### PR TITLE
feat(api): add user meetings endpoint with registration filtering

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -153,7 +153,6 @@ export class MyMeetingsComponent {
         switchMap((project) => {
           // If no project/foundation selected, return empty array
           if (!project?.uid) {
-            this.loading.set(false);
             return of([]);
           }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -7,10 +7,10 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { DashboardMeetingCardComponent } from '@app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { getActiveOccurrences } from '@lfx-one/shared';
-import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, finalize, of, switchMap } from 'rxjs';
+import { catchError, finalize, of, switchMap, tap } from 'rxjs';
 
 import type { MeetingWithOccurrence } from '@lfx-one/shared/interfaces';
 
@@ -22,11 +22,11 @@ import type { MeetingWithOccurrence } from '@lfx-one/shared/interfaces';
   styleUrl: './my-meetings.component.scss',
 })
 export class MyMeetingsComponent {
-  private readonly meetingService = inject(MeetingService);
+  private readonly userService = inject(UserService);
   private readonly projectContextService = inject(ProjectContextService);
 
   protected readonly loading = signal(true);
-  private readonly project = computed(() => this.projectContextService.selectedProject() || this.projectContextService.selectedFoundation());
+  private readonly selectedProject = computed(() => this.projectContextService.selectedProject() || this.projectContextService.selectedFoundation());
   private readonly allMeetings = this.initializeAllMeetings();
   protected readonly todayMeetings = this.initializeTodayMeetings();
   protected readonly upcomingMeetings = this.initializeUpcomingMeetings();
@@ -144,20 +144,22 @@ export class MyMeetingsComponent {
   }
 
   private initializeAllMeetings() {
-    const project$ = toObservable(this.project);
+    // Convert project signal to observable to react to project changes
+    const project$ = toObservable(this.selectedProject);
 
     return toSignal(
       project$.pipe(
+        tap(() => this.loading.set(true)),
         switchMap((project) => {
+          // If no project/foundation selected, return empty array
           if (!project?.uid) {
             this.loading.set(false);
             return of([]);
           }
-          this.loading.set(true);
-          return this.meetingService.getMeetingsByProject(project.uid).pipe(
+
+          return this.userService.getUserMeetings(project.uid).pipe(
             catchError((error) => {
-              console.error('Failed to load meetings:', error);
-              this.loading.set(false);
+              console.error('Failed to load user meetings:', error);
               return of([]);
             }),
             finalize(() => this.loading.set(false))

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -10,13 +10,14 @@ import {
   CreateUserPermissionRequest,
   EmailManagementData,
   EmailPreferences,
+  Meeting,
   ProfileUpdateRequest,
   TwoFactorSettings,
   UpdateEmailPreferencesRequest,
   User,
   UserEmail,
 } from '@lfx-one/shared/interfaces';
-import { Observable, take } from 'rxjs';
+import { catchError, Observable, of, take } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -122,5 +123,19 @@ export class UserService {
    */
   public getDeveloperTokenInfo(): Observable<{ token: string; type: string }> {
     return this.http.get<{ token: string; type: string }>('/api/profile/developer').pipe(take(1));
+  }
+
+  /**
+   * Gets all meetings for the current authenticated user filtered by project
+   * Returns meetings the user is registered for or has access to
+   * @param projectUid - Project UID to filter meetings by
+   */
+  public getUserMeetings(projectUid: string): Observable<Meeting[]> {
+    return this.http.get<Meeting[]>('/api/user/meetings', { params: { projectUid } }).pipe(
+      catchError((error) => {
+        console.error('Failed to load user meetings:', error);
+        return of([]);
+      })
+    );
   }
 }

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -147,7 +147,6 @@ export class UserController {
       const meetings = await this.userService.getUserMeetings(req, userEmail, projectUid);
 
       Logger.success(req, 'get_user_meetings', startTime, {
-        email: userEmail,
         project_uid: projectUid,
         meeting_count: meetings.length,
       });

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -144,7 +144,8 @@ export class UserController {
       }
 
       // Get user's meetings from service
-      const meetings = await this.userService.getUserMeetings(req, userEmail, projectUid);
+      const query = { tags_all: `project_uid:${projectUid}` };
+      const meetings = await this.userService.getUserMeetings(req, userEmail, projectUid, query);
 
       Logger.success(req, 'get_user_meetings', startTime, {
         project_uid: projectUid,

--- a/apps/lfx-one/src/server/routes/user.route.ts
+++ b/apps/lfx-one/src/server/routes/user.route.ts
@@ -11,4 +11,7 @@ const userController = new UserController();
 // GET /api/user/pending-actions - Get all pending actions for the authenticated user
 router.get('/pending-actions', (req, res, next) => userController.getPendingActions(req, res, next));
 
+// GET /api/user/meetings - Get all meetings for the authenticated user
+router.get('/meetings', (req, res, next) => userController.getUserMeetings(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -587,8 +587,8 @@ export class UserService {
       req.log.error(
         {
           operation: 'get_user_meetings',
-          email,
           err: error,
+          project_uid: projectUid,
         },
         'Failed to get user meetings'
       );


### PR DESCRIPTION
## Summary
- Add new `/api/user/meetings` endpoint that returns meetings the authenticated user is registered for or has access to
- Update my-meetings component to use user-specific endpoint instead of project-wide meetings
- Filter public meetings by checking registration status via M2M token

## Changes
- **Backend UserService**: Add `getUserMeetings()` method that fetches meetings and filters by visibility/registration
- **Backend UserController**: Add `getUserMeetings` endpoint handler with proper validation and logging
- **User Routes**: Add `/api/user/meetings` GET endpoint
- **Frontend UserService**: Add `getUserMeetings()` method to call the new API
- **MyMeetingsComponent**: Switch from `MeetingService` to `UserService` for user-specific meetings

## Note
This implementation is marked as DEMO - needs optimization review post-demo as it makes multiple API calls for registration checks.

LFXV2-833

🤖 Generated with [Claude Code](https://claude.ai/code)