### PR TITLE
fix(ui): align training & certifications cards with app design system

### DIFF
--- a/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="bg-white rounded-xl border shadow-sm hover:border-blue-400 transition-all" data-testid="certification-card">
+<lfx-card styleClass="hover:border-blue-400 transition-all" data-testid="certification-card">
   <div class="p-5 flex items-start gap-5">
     <!-- Col 1: Logo -->
     <div
@@ -74,4 +74,4 @@
       </div>
     </div>
   </div>
-</div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card styleClass="hover:border-blue-400 transition-all" data-testid="certification-card">
+<lfx-card data-testid="certification-card">
   <div class="p-5 flex items-start gap-5">
     <!-- Col 1: Logo -->
     <div

--- a/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.ts
@@ -8,12 +8,13 @@ import { ChangeDetectionStrategy, Component, computed, input, Signal } from '@an
 import { Certification } from '@lfx-one/shared/interfaces';
 
 import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
 
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
 @Component({
   selector: 'lfx-certification-card',
-  imports: [ButtonComponent, DatePipe],
+  imports: [ButtonComponent, CardComponent, DatePipe],
   templateUrl: './certification-card.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="bg-white rounded-xl border shadow-sm hover:border-blue-400 transition-all" data-testid="training-card">
+<lfx-card styleClass="hover:border-blue-400 transition-all" data-testid="training-card">
   <div class="p-5 flex items-start gap-5">
     <!-- Col 1: Logo -->
     <div
@@ -83,4 +83,4 @@
       </div>
     </div>
   </div>
-</div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card styleClass="hover:border-blue-400 transition-all" data-testid="training-card">
+<lfx-card data-testid="training-card">
   <div class="p-5 flex items-start gap-5">
     <!-- Col 1: Logo -->
     <div

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.ts
@@ -9,10 +9,11 @@ import { Certification, TrainingEnrollment } from '@lfx-one/shared/interfaces';
 import { CONTINUE_LEARNING_URL, COURSE_URL_PREFIX } from '@lfx-one/shared/constants';
 
 import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
 
 @Component({
   selector: 'lfx-training-card',
-  imports: [ButtonComponent, DatePipe, NgClass],
+  imports: [ButtonComponent, CardComponent, DatePipe, NgClass],
   templateUrl: './training-card.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -70,16 +70,16 @@
           <!-- Loading state -->
           <div class="flex flex-col gap-4" data-testid="certs-loading">
             @for (i of [1, 2, 3]; track i) {
-              <div class="bg-white rounded-xl border shadow-sm p-5 animate-pulse">
-                <div class="flex items-start gap-5">
-                  <div class="w-14 h-14 bg-gray-200 rounded-xl"></div>
+              <lfx-card>
+                <div class="p-5 flex items-start gap-5">
+                  <p-skeleton width="3.5rem" height="3.5rem" borderRadius="12px" />
                   <div class="flex-1 flex flex-col gap-3">
-                    <div class="h-4 bg-gray-200 rounded w-1/3"></div>
-                    <div class="h-3 bg-gray-200 rounded w-2/3"></div>
-                    <div class="h-3 bg-gray-200 rounded w-1/2"></div>
+                    <p-skeleton width="33%" height="1rem" />
+                    <p-skeleton width="66%" height="0.75rem" />
+                    <p-skeleton width="50%" height="0.75rem" />
                   </div>
                 </div>
-              </div>
+              </lfx-card>
             }
           </div>
         } @else if (certifications()!.length === 0) {
@@ -118,16 +118,16 @@
           <!-- Loading state -->
           <div class="flex flex-col gap-4" data-testid="trainings-loading">
             @for (i of [1, 2, 3]; track i) {
-              <div class="bg-white rounded-xl border shadow-sm p-5 animate-pulse">
-                <div class="flex items-start gap-5">
-                  <div class="w-14 h-14 bg-gray-200 rounded-xl"></div>
+              <lfx-card>
+                <div class="p-5 flex items-start gap-5">
+                  <p-skeleton width="3.5rem" height="3.5rem" borderRadius="12px" />
                   <div class="flex-1 flex flex-col gap-3">
-                    <div class="h-4 bg-gray-200 rounded w-1/3"></div>
-                    <div class="h-3 bg-gray-200 rounded w-2/3"></div>
-                    <div class="h-3 bg-gray-200 rounded w-1/2"></div>
+                    <p-skeleton width="33%" height="1rem" />
+                    <p-skeleton width="66%" height="0.75rem" />
+                    <p-skeleton width="50%" height="0.75rem" />
                   </div>
                 </div>
-              </div>
+              </lfx-card>
             }
           </div>
         } @else if ((enrollments()?.length ?? 0) === 0 && (completedTrainings()?.length ?? 0) === 0) {

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
@@ -8,6 +8,8 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { Certification, FilterPillOption, TrainingEnrollment } from '@lfx-one/shared/interfaces';
 import { CERTIFICATION_PRODUCT_TYPE, TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
 
+import { Skeleton } from 'primeng/skeleton';
+
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
@@ -43,7 +45,7 @@ const USEFUL_LINKS = [
 
 @Component({
   selector: 'lfx-trainings-dashboard',
-  imports: [ButtonComponent, CardComponent, CertificationCardComponent, FilterPillsComponent, TrainingCardComponent],
+  imports: [ButtonComponent, CardComponent, CertificationCardComponent, FilterPillsComponent, Skeleton, TrainingCardComponent],
   templateUrl: './trainings-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
@@ -8,7 +8,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { Certification, FilterPillOption, TrainingEnrollment } from '@lfx-one/shared/interfaces';
 import { CERTIFICATION_PRODUCT_TYPE, TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
 
-import { Skeleton } from 'primeng/skeleton';
+import { SkeletonModule } from 'primeng/skeleton';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -45,7 +45,7 @@ const USEFUL_LINKS = [
 
 @Component({
   selector: 'lfx-trainings-dashboard',
-  imports: [ButtonComponent, CardComponent, CertificationCardComponent, FilterPillsComponent, Skeleton, TrainingCardComponent],
+  imports: [ButtonComponent, CardComponent, CertificationCardComponent, FilterPillsComponent, SkeletonModule, TrainingCardComponent],
   templateUrl: './trainings-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## Summary

- Replace hand-rolled card divs (`bg-white rounded-xl border shadow-sm`) on training and certification cards with the `lfx-card` wrapper component — consistent with every other module in the app (badges, committees, meetings)
- Replace `animate-pulse` skeleton divs in the trainings dashboard loading states with `p-skeleton` components — matches the pattern used in the badges dashboard and elsewhere
- Remove redundant `styleClass="hover:border-blue-400 transition-all"` from both cards — `lfx-card` already applies `hover:border-blue-500 transition-colors` via its component stylesheet

## Files changed

- `certification-card.component.html/ts` — wrap with `lfx-card`, import `CardComponent`
- `training-card.component.html/ts` — wrap with `lfx-card`, import `CardComponent`
- `trainings-dashboard.component.html/ts` — swap two skeleton blocks to `p-skeleton`, import `SkeletonModule`

## Test plan

- [ ] Navigate to Training & Certifications page — cards render correctly with consistent border/shadow/radius
- [ ] Trigger loading state (slow network / dev tools) — skeleton animation renders using PrimeNG p-skeleton
- [ ] Verify no visual regressions on certification cards, training cards, and the stats row

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
