### PR TITLE
fix(project-context): root-writer canWrite + pin project_uid in urls

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -44,8 +44,7 @@ export class CommitteeManageComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
-  // Pin project context from URL when present (set by dashboard quicklinks). Snapshot read so
-  // context is stable for the entire create flow regardless of project-selector changes.
+  // Snapshot read — stable for the entire create flow.
   private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -44,6 +44,9 @@ export class CommitteeManageComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
+  // Pin project context from URL when present (set by dashboard quicklinks). Snapshot read so
+  // context is stable for the entire create flow regardless of project-selector changes.
+  private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
   public committeeId = signal<string | null>(null);
@@ -192,7 +195,7 @@ export class CommitteeManageComponent {
       },
       display_name: this.form.value.display_name || this.form.value.name,
       website: this.form.value.website || null,
-      project_uid: this.committee()?.project_uid || this.project()?.uid || null,
+      project_uid: this.committee()?.project_uid || this.projectUidFromUrl || this.project()?.uid || null,
     };
 
     const committeeData = this.cleanFormData(formValue);
@@ -285,7 +288,7 @@ export class CommitteeManageComponent {
       },
       display_name: this.form.value.display_name || this.form.value.name,
       website: this.form.value.website || null,
-      project_uid: this.committee()?.project_uid || this.project()?.uid || null,
+      project_uid: this.committee()?.project_uid || this.projectUidFromUrl || this.project()?.uid || null,
     };
 
     const committeeData = this.cleanFormData(formValue);

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -5,7 +5,11 @@
   <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
     <span class="text-surface-400 font-medium">Quick links:</span>
     @for (link of links; track link.testId; let last = $last) {
-      <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+      <a
+        [routerLink]="link.route"
+        [queryParams]="contextQueryParams()"
+        class="flex items-center gap-1.5 text-primary hover:underline"
+        [attr.data-testid]="'dashboard-quicklink-' + link.testId">
         <i [class]="link.icon" aria-hidden="true"></i>
         {{ link.label }}
       </a>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, Signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DashboardQuickLink } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
@@ -21,4 +21,18 @@ export class DashboardQuicklinksComponent {
   ];
 
   protected readonly canWrite = this.projectContextService.canWrite;
+
+  /**
+   * When the active context has a project UID, pin it to the create-flow URL so the form
+   * binds to that project regardless of subsequent project-selector changes (mirrors how
+   * committee → Schedule Meeting pins `committee_uid`).
+   */
+  protected readonly contextQueryParams: Signal<Record<string, string>> = this.initContextQueryParams();
+
+  private initContextQueryParams(): Signal<Record<string, string>> {
+    return computed(() => {
+      const uid = this.projectContextService.activeContextUid();
+      return uid ? { project_uid: uid } : {};
+    });
+  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, Signal } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Params, RouterLink } from '@angular/router';
 import { DashboardQuickLink } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 
@@ -27,9 +27,9 @@ export class DashboardQuicklinksComponent {
    * binds to that project regardless of subsequent project-selector changes (mirrors how
    * committee → Schedule Meeting pins `committee_uid`).
    */
-  protected readonly contextQueryParams: Signal<Record<string, string>> = this.initContextQueryParams();
+  protected readonly contextQueryParams: Signal<Params> = this.initContextQueryParams();
 
-  private initContextQueryParams(): Signal<Record<string, string>> {
+  private initContextQueryParams(): Signal<Params> {
     return computed(() => {
       const uid = this.projectContextService.activeContextUid();
       return uid ? { project_uid: uid } : {};

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -22,11 +22,6 @@ export class DashboardQuicklinksComponent {
 
   protected readonly canWrite = this.projectContextService.canWrite;
 
-  /**
-   * When the active context has a project UID, pin it to the create-flow URL so the form
-   * binds to that project regardless of subsequent project-selector changes (mirrors how
-   * committee → Schedule Meeting pins `committee_uid`).
-   */
   protected readonly contextQueryParams: Signal<Params> = this.initContextQueryParams();
 
   private initContextQueryParams(): Signal<Params> {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { COMMITTEE_LABEL, MAILING_LIST_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import { GroupsIOServiceType, MailingListAudienceAccess, MailingListType } from '@lfx-one/shared/enums';
-import { CommitteeReference, CreateGroupsIOServiceRequest, CreateMailingListRequest, GroupsIOMailingList, GroupsIOService } from '@lfx-one/shared/interfaces';
+import { CommitteeReference, CreateGroupsIOServiceRequest, CreateMailingListRequest, GroupsIOMailingList, GroupsIOService, ProjectContext } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { announcementVisibilityValidator, htmlMaxLengthValidator, htmlMinLengthValidator, htmlRequiredValidator } from '@lfx-one/shared/validators';
 import { MailingListService } from '@services/mailing-list.service';
@@ -17,7 +17,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, filter, Observable, of, switchMap, tap, throwError } from 'rxjs';
+import { catchError, filter, map, Observable, of, switchMap, tap, throwError } from 'rxjs';
 
 import { MailingListBasicInfoComponent } from '../components/mailing-list-basic-info/mailing-list-basic-info.component';
 import { MailingListSettingsComponent } from '../components/mailing-list-settings/mailing-list-settings.component';
@@ -224,6 +224,23 @@ export class MailingListManageComponent {
   }
 
   private initProject(): Signal<ReturnType<typeof this.projectContextService.selectedProject>> {
+    // If a project_uid is pinned in the URL (e.g. from dashboard quicklinks), lock the
+    // project signal to that project for the entire create flow. Otherwise fall back to the
+    // reactive active-context signal. The URL pin prevents downstream consumers
+    // (availableServices, selectedService, servicePrefix, createSharedService) from
+    // following project-selector changes mid-form, which would otherwise move the new
+    // mailing list to a different project than the user originally chose.
+    if (this.projectUidFromUrl) {
+      // Backend's /api/projects/:slug accepts UUIDs too — dispatches to getProjectById
+      // when the param looks like a UUID (see project.controller.ts isUuid check).
+      return toSignal(
+        this.projectService.getProject(this.projectUidFromUrl, false).pipe(
+          map((p) => (p ? ({ uid: p.uid, name: p.name, slug: p.slug, parent_uid: p.parent_uid } as ProjectContext) : null)),
+          catchError(() => of(this.projectContextService.activeContext()))
+        ),
+        { initialValue: this.projectContextService.activeContext() }
+      );
+    }
     return computed(() => this.projectContextService.activeContext());
   }
 
@@ -454,7 +471,7 @@ export class MailingListManageComponent {
     const serviceData: CreateGroupsIOServiceRequest = {
       type: GroupsIOServiceType.SHARED,
       prefix: `${this.cleanSlug(project.slug)}`,
-      project_uid: this.projectUidFromUrl || project.uid,
+      project_uid: project.uid,
       domain: parent.domain,
     };
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -44,6 +44,9 @@ export class MailingListManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
+  // Pin project context from URL when present (set by dashboard quicklinks). Snapshot read so
+  // context is stable for the entire create flow regardless of project-selector changes.
+  private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
 
   // Protected constants
   public readonly totalSteps = MAILING_LIST_TOTAL_STEPS;
@@ -451,7 +454,7 @@ export class MailingListManageComponent {
     const serviceData: CreateGroupsIOServiceRequest = {
       type: GroupsIOServiceType.SHARED,
       prefix: `${this.cleanSlug(project.slug)}`,
-      project_uid: project.uid,
+      project_uid: this.projectUidFromUrl || project.uid,
       domain: parent.domain,
     };
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -9,7 +9,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { COMMITTEE_LABEL, MAILING_LIST_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import { GroupsIOServiceType, MailingListAudienceAccess, MailingListType } from '@lfx-one/shared/enums';
-import { CommitteeReference, CreateGroupsIOServiceRequest, CreateMailingListRequest, GroupsIOMailingList, GroupsIOService, ProjectContext } from '@lfx-one/shared/interfaces';
+import {
+  CommitteeReference,
+  CreateGroupsIOServiceRequest,
+  CreateMailingListRequest,
+  GroupsIOMailingList,
+  GroupsIOService,
+  ProjectContext,
+} from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { announcementVisibilityValidator, htmlMaxLengthValidator, htmlMinLengthValidator, htmlRequiredValidator } from '@lfx-one/shared/validators';
 import { MailingListService } from '@services/mailing-list.service';
@@ -44,8 +51,7 @@ export class MailingListManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
-  // Pin project context from URL when present (set by dashboard quicklinks). Snapshot read so
-  // context is stable for the entire create flow regardless of project-selector changes.
+  // Snapshot read — stable for the entire create flow.
   private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
 
   // Protected constants
@@ -224,18 +230,12 @@ export class MailingListManageComponent {
   }
 
   private initProject(): Signal<ReturnType<typeof this.projectContextService.selectedProject>> {
-    // If a project_uid is pinned in the URL (e.g. from dashboard quicklinks), lock the
-    // project signal to that project for the entire create flow. Otherwise fall back to the
-    // reactive active-context signal. The URL pin prevents downstream consumers
-    // (availableServices, selectedService, servicePrefix, createSharedService) from
-    // following project-selector changes mid-form, which would otherwise move the new
-    // mailing list to a different project than the user originally chose.
     if (this.projectUidFromUrl) {
-      // Backend's /api/projects/:slug accepts UUIDs too — dispatches to getProjectById
-      // when the param looks like a UUID (see project.controller.ts isUuid check).
       return toSignal(
         this.projectService.getProject(this.projectUidFromUrl, false).pipe(
-          map((p) => (p ? ({ uid: p.uid, name: p.name, slug: p.slug, parent_uid: p.parent_uid } as ProjectContext) : null)),
+          map((p) =>
+            p ? ({ uid: p.uid, name: p.name, slug: p.slug, parent_uid: p.parent_uid } as ProjectContext) : this.projectContextService.activeContext()
+          ),
           catchError(() => of(this.projectContextService.activeContext()))
         ),
         { initialValue: this.projectContextService.activeContext() }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -91,6 +91,10 @@ export class MeetingManageComponent {
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
   private readonly committeeUidFromUrl = this.route.snapshot.queryParamMap.get('committee_uid');
+  // Pin project context from URL when present (set by dashboard quicklinks). Falls back
+  // to ProjectContextService.activeContextUid() if absent. Snapshot read so context is
+  // stable for the entire create flow regardless of project-selector changes.
+  private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
 
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
@@ -478,7 +482,7 @@ export class MeetingManageComponent {
     }
 
     return {
-      project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid(),
+      project_uid: this.meeting()?.project_uid || this.projectUidFromUrl || this.projectContextService.activeContextUid(),
       title: formValue.title,
       description: formValue.description || '',
       start_time: startDateTime,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -91,9 +91,7 @@ export class MeetingManageComponent {
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
   private readonly committeeUidFromUrl = this.route.snapshot.queryParamMap.get('committee_uid');
-  // Pin project context from URL when present (set by dashboard quicklinks). Falls back
-  // to ProjectContextService.activeContextUid() if absent. Snapshot read so context is
-  // stable for the entire create flow regardless of project-selector changes.
+  // Snapshot read — stable for the entire create flow.
   private readonly projectUidFromUrl = this.route.snapshot.queryParamMap.get('project_uid');
 
   // Mode and state signals

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -102,7 +102,7 @@ export class ProjectContextService {
   }
 
   private initCanWrite(): Signal<boolean> {
-    return toSignal(
+    const projectWriter = toSignal(
       toObservable(this.activeContext).pipe(
         switchMap((ctx) => {
           if (!ctx?.slug) {
@@ -116,5 +116,10 @@ export class ProjectContextService {
       ),
       { initialValue: false }
     );
+
+    // Root writers (writers on the TLF pseudo-project) bypass the per-project FGA check —
+    // they're treated as writers everywhere, mirroring lens-visibility behavior in
+    // lens.service.ts (showFoundation/showProject already OR-in isRootWriter).
+    return computed(() => this.personaService.isRootWriter() || projectWriter());
   }
 }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -117,9 +117,7 @@ export class ProjectContextService {
       { initialValue: false }
     );
 
-    // Root writers (writers on the TLF pseudo-project) bypass the per-project FGA check —
-    // they're treated as writers everywhere, mirroring lens-visibility behavior in
-    // lens.service.ts (showFoundation/showProject already OR-in isRootWriter).
+    // Root writers are treated as writers on all projects.
     return computed(() => this.personaService.isRootWriter() || projectWriter());
   }
 }


### PR DESCRIPTION
> **Tracking ticket**: [LFXV2-1636](https://linuxfoundation.atlassian.net/browse/LFXV2-1636) — filed 2026-05-04
>
> ⚠️ **Branch name caveat**: `claude/festive-hermann-b17e04` is the Claude Code worktree default. Per @MRashad26's feedback, the convention is `fix/LFXV2-1636`. Rename was attempted via the GitHub API and blocked by an org ruleset (admin-only). Needs an org admin to rename server-side, or close+reopen if required for merge.

---

## Summary

Two related gaps in how project context flows to "Create" actions in the dashboards:

### 1. Root-writers now see Create actions on every project dashboard

`ProjectContextService.canWrite()` was checking only per-project FGA writer tuples (`project.writer === true`). Root-writers (writer on the TLF/ROOT pseudo-project, tracked as `personaService.isRootWriter`) already get persona/lens bypasses in `lens.service.ts` (`showFoundation || isRootWriter`, `showProject || isRootWriter`), but the `canWrite` gate did not honor it.

Effect: users with TLF-level write access didn't see Create quicklinks on six dashboards (meetings, votes, committees, surveys, mailing lists, project dashboard). `canWrite()` now ORs in `isRootWriter()`, mirroring the existing pattern in `lens.service.ts`.

### 2. Create flows pin project context to the URL

Dashboard quicklinks (Create meeting / group / mailing list) navigated to their create routes with no `project_uid` queryParam. The create forms read `project_uid` reactively from `activeContext()` — so changing the project selector mid-form silently moved the new resource to a different project.

Now mirrors the committee → Schedule Meeting pattern (`?committee_uid=`):

- `dashboard-quicklinks` adds `[queryParams]="contextQueryParams()"` returning `{ project_uid: <uid> }` when a context is active.
- `meeting-manage`, `committee-manage`, `mailing-list-manage` each read a snapshot of `?project_uid=` on construction and prefer it over the reactive `activeContext` fallback.

Snapshot reads (not reactive) — context is stable for the entire create flow.

## Files changed (6 files, 2 commits, +43/-10)

| Area | File | Change |
| --- | --- | --- |
| canWrite gate | `shared/services/project-context.service.ts` | OR-in `personaService.isRootWriter()` |
| Quicklinks | `dashboards/components/dashboard-quicklinks/{ts,html}` | `contextQueryParams` computed + `[queryParams]` binding |
| Meetings | `meetings/meeting-manage/meeting-manage.component.ts` | URL-pinned `projectUidFromUrl` preferred over activeContext |
| Committees | `committees/committee-manage/committee-manage.component.ts` | Same pattern, both create + update call sites |
| Mailing lists | `mailing-lists/mailing-list-manage/mailing-list-manage.component.ts` | Same pattern in `createSharedService()` |

## Verification

- `yarn build` clean (Angular SSR + types)
- `yarn lint:check` clean
- `yarn check-types` clean
- Mirrors existing `committeeUidFromUrl` pattern at `meeting-manage.component.ts:93`
- Component-organization compliant (complex computed via private init function per `.claude/rules/component-organization.md`)
- License headers preserved
- `personaService` and `route` were already injected — no new DI

## Commits

1. `a40262fa` — main fix (canWrite + URL pin across 6 files)
2. `a299a640` — TS type-fix follow-up: `Signal<Record<string, string>>` → `Signal<Params>` (Angular's queryParams type) so the empty-object branch type-checks. Caught by pre-push `yarn build`.

## Follow-ups (NOT in this PR)

- **`.husky/commit-msg` bug** — `yarn commitlint --edit $1` doesn't quote `$1`, breaks on worktree paths with spaces (`/Users/.../LFX Self Serve/...`). Used `--no-verify` for these commits with explicit owner permission. 1-character fix in a protected file; needs code-owner review.
- **mailing-list `createSharedService()` prefix** — now pins `project_uid` from URL but still reads `project.slug` reactively for the `prefix`. Cosmetic impact only if user changes project mid-form AND a shared service needs to be created.
- **Committee-level edit gates** — `committee.writer` checks (`canEdit`, `canManageMembers` in committee-view, etc.) have the same root-writer gap. Out of scope here — likely needs a `canEditResource()` helper or upstream FGA inheritance.

## Risk flags

- No `LFXV2-XXXX` JIRA ticket — discovered via research thread, not a tracked ticket. Happy to file one before merge if required.
- `--no-verify` was used on both commits to bypass the broken `commit-msg` hook (path-with-spaces). Pre-commit (lint/format/types) ran successfully on the first commit; pre-push (`yarn build`) ran successfully on the second. The skipped hook was commitlint, which would have passed anyway — both messages are conventional-commit compliant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1636]: https://linuxfoundation.atlassian.net/browse/LFXV2-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ