### PR TITLE
fix(dashboard): align engaged community channel names with chart labels

### DIFF
--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -895,7 +895,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'memberships',
       testId: 'ed-evo-engaged-community',
-      description: 'Unique individuals active across 7 channels — Slack, Discord, GitHub, mailing lists, training, web, and code — in the last 90 days.',
+      description:
+        'Unique individuals active across 7 channels — community, working groups, newsletter, training, code, web, and certified — in the last 90 days.',
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
@@ -905,7 +906,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         lfxColors.blue[500]
       ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Unique individuals active across Slack, Discord, GitHub, mailing lists, training, web, and code in the last 90 days.',
+      tooltipText: 'Unique individuals active across community, working groups, newsletter, training, code, web, and certified in the last 90 days.',
       drawerType: DashboardDrawerType.NorthStarEngagedCommunity,
     } as DashboardMetricCard,
     {


### PR DESCRIPTION
## Summary
- Update the Engaged Community card description and tooltip to match the actual Community Breakdown chart axis labels
- Card previously referenced "Slack, Discord, GitHub, mailing lists" but chart shows "Community, Working Groups, Newsletter, Certified"
- Two string edits in `dashboard-metrics.constants.ts`

## JIRA
[LFXV2-1623](https://linuxfoundation.atlassian.net/browse/LFXV2-1623)

## Test plan
- [ ] Open ED dashboard → Marketing Overview → Engaged Community card
- [ ] Verify card description reads "community, working groups, newsletter, training, code, web, and certified"
- [ ] Click into Engaged Community drawer → verify chart axis labels match the card description channels

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1623]: https://linuxfoundation.atlassian.net/browse/LFXV2-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ