### PR TITLE
fix(dashboard): cap sponsorship percentage label at 999%

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/events-card/events-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/events-card/events-card.component.ts
@@ -71,7 +71,7 @@ export class EventsCardComponent {
 
   protected readonly formattedProgressLabel = computed(() => {
     const pct = Math.round(this.summaryData().sponsorshipProgressPct);
-    return `${pct}% of goal`;
+    return pct > 999 ? '>999% of goal' : `${pct}% of goal`;
   });
 
   protected readonly formattedRevenue = computed(() => {


### PR DESCRIPTION
## Summary
- Cap the sponsorship vs goal text label at ">999% of goal" when the percentage exceeds 999%
- The progress bar already caps at 100% visually, but the text label was showing raw uncapped values (e.g. "61365% of goal")
- Defensive UI measure while the upstream Snowflake goal target is corrected
- One-line change in `events-card.component.ts`

## JIRA
[LFXV2-1619](https://linuxfoundation.atlassian.net/browse/LFXV2-1619)

## Test plan
- [ ] Open Health Metrics → Events card on AAIF foundation
- [ ] Verify sponsorship label shows ">999% of goal" instead of "61365% of goal"
- [ ] Verify progress bar still fills to 100% (no visual regression)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1619]: https://linuxfoundation.atlassian.net/browse/LFXV2-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ