### PR TITLE
fix(dashboard): clarify events change indicator with past/upcoming split

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/events-card/events-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/events-card/events-card.component.ts
@@ -52,12 +52,13 @@ export class EventsCardComponent {
   });
 
   protected readonly formattedChange = computed(() => {
-    const diff = this.summaryData().eventCountDiff;
-    const abs = Math.abs(diff);
+    const { eventCountDiff, pastEvents, upcomingEvents } = this.summaryData();
+    const abs = Math.abs(eventCountDiff);
     let prefix = '';
-    if (diff > 0) prefix = '+';
-    else if (diff < 0) prefix = '-';
-    return `${prefix}${abs} vs prev period`;
+    if (eventCountDiff > 0) prefix = '+';
+    else if (eventCountDiff < 0) prefix = '-';
+    const breakdown = upcomingEvents > 0 ? ` (${pastEvents} past · ${upcomingEvents} upcoming)` : '';
+    return `${prefix}${abs} vs prev period${breakdown}`;
   });
 
   protected readonly showChangeIndicator = computed(() => {


### PR DESCRIPTION
## Summary
- The events change indicator showed "+10 vs prev period" without context, misleading users when most events are upcoming
- Now appends a breakdown "(2 past · 8 upcoming)" when upcoming events exist
- One computed signal change in `events-card.component.ts`

## JIRA
[LFXV2-1626](https://linuxfoundation.atlassian.net/browse/LFXV2-1626)

## Test plan
- [ ] Open Health Metrics → Events card on AAIF foundation (YTD range)
- [ ] Verify change indicator shows "+N vs prev period (X past · Y upcoming)"
- [ ] Switch to a non-YTD range → verify breakdown still appears when upcoming > 0
- [ ] Foundation with 0 upcoming events → verify no breakdown suffix

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1626]: https://linuxfoundation.atlassian.net/browse/LFXV2-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ