### PR TITLE
fix(dashboard): add past/upcoming tag to event growth drawer rows

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -198,10 +198,10 @@
           </div>
           @for (event of sortedTopEvents(); track event.id) {
             <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
-              <span class="flex-1 flex items-center gap-2 text-sm font-medium text-gray-900">
-                {{ event.name }}
+              <span class="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium text-gray-900">
+                <span class="truncate">{{ event.name }}</span>
                 <span
-                  class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
                   [class]="event.isPast ? 'bg-gray-100 text-gray-500' : 'bg-blue-50 text-blue-600'">
                   {{ event.isPast ? 'Past' : 'Upcoming' }}
                 </span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -198,7 +198,14 @@
           </div>
           @for (event of sortedTopEvents(); track event.id) {
             <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
-              <span class="flex-1 text-sm font-medium text-gray-900">{{ event.name }}</span>
+              <span class="flex-1 flex items-center gap-2 text-sm font-medium text-gray-900">
+                {{ event.name }}
+                <span
+                  class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+                  [class]="event.isPast ? 'bg-gray-100 text-gray-500' : 'bg-blue-50 text-blue-600'">
+                  {{ event.isPast ? 'Past' : 'Upcoming' }}
+                </span>
+              </span>
               <span class="w-24 text-right text-sm text-gray-500">{{ event.date | date: 'MMM d' : 'UTC' }}</span>
               <span class="w-28 text-right text-sm font-semibold text-gray-900">{{ event.registrants | number }}</span>
               <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.attendees | number }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -102,11 +102,16 @@ export class EventGrowthDrawerComponent {
   }
 
   private initSortedTopEvents(): Signal<EventGrowthTopEventView[]> {
-    return computed(() =>
-      [...this.data().topEvents]
+    return computed(() => {
+      const today = new Date().toISOString().slice(0, 10);
+      return [...this.data().topEvents]
         .sort((a, b) => a.date.localeCompare(b.date))
-        .map((event) => ({ ...event, formattedRevenue: EventGrowthDrawerComponent.formatMoney(event.revenue) }))
-    );
+        .map((event) => ({
+          ...event,
+          formattedRevenue: EventGrowthDrawerComponent.formatMoney(event.revenue),
+          isPast: event.date < today,
+        }));
+    });
   }
 
   private initMonthlyChartData(): Signal<ChartData<'bar'>> {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -109,7 +109,7 @@ export class EventGrowthDrawerComponent {
         .map((event) => ({
           ...event,
           formattedRevenue: EventGrowthDrawerComponent.formatMoney(event.revenue),
-          isPast: event.date < today,
+          isPast: !!event.date && event.date < today,
         }));
     });
   }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2983,6 +2983,7 @@ export interface EventGrowthTopEvent {
  */
 export interface EventGrowthTopEventView extends EventGrowthTopEvent {
   formattedRevenue: string;
+  isPast: boolean;
 }
 
 /**

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2978,8 +2978,8 @@ export interface EventGrowthTopEvent {
 }
 
 /**
- * Presentation-ready event row with pre-formatted revenue string
- * Used by the drawer component to avoid calling formatters from templates
+ * Presentation-ready event row with pre-formatted revenue and past/upcoming status.
+ * Used by the drawer component to avoid calling formatters from templates.
  */
 export interface EventGrowthTopEventView extends EventGrowthTopEvent {
   formattedRevenue: string;


### PR DESCRIPTION
## Summary
- Event rows in the Event Growth drawer mixed realized and forecast revenue without visual distinction
- Add a "Past" (gray) or "Upcoming" (blue) tag next to each event name, computed from the event date
- Adds `isPast` to `EventGrowthTopEventView` interface
- 3 files changed: interface, drawer TS, drawer HTML

## JIRA
[LFXV2-1622](https://linuxfoundation.atlassian.net/browse/LFXV2-1622)

## Test plan
- [ ] Open ED dashboard → Marketing Overview → Event Growth card → click into drawer
- [ ] Verify each event row has a "Past" or "Upcoming" tag next to the name
- [ ] Past events show gray tag, upcoming events show blue tag
- [ ] Tags correctly reflect whether event date is before or after today

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1622]: https://linuxfoundation.atlassian.net/browse/LFXV2-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ