### PR TITLE
fix(dashboard): label health scores as "projects scored"

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -530,12 +530,13 @@ export class FoundationHealthComponent {
 
   private transformProjectHealthScores(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.healthScoresData();
+    const scored = data.excellent + data.healthy + data.stable + data.unsteady + data.critical;
 
     return {
       ...metric,
       loading: this.healthScoresLoading(),
       value: '',
-      subtitle: '',
+      subtitle: scored > 0 ? `${scored} projects scored` : '',
       healthScores: data,
     };
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -20,7 +20,7 @@
       <!-- Total Projects Badge -->
       @if (hasData()) {
         <div class="flex items-center gap-1.5 px-3 py-1 bg-gray-100 rounded-full" data-testid="project-health-scores-drawer-total">
-          <span class="text-sm font-medium text-gray-700">{{ totalProjects().toLocaleString() }} projects</span>
+          <span class="text-sm font-medium text-gray-700">{{ totalProjects().toLocaleString() }} projects scored</span>
         </div>
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -17,7 +17,7 @@
         <p class="text-sm text-gray-500">Board Member · Organization view</p>
       </div>
 
-      <!-- Total Projects Badge -->
+      <!-- Projects Scored Badge -->
       @if (hasData()) {
         <div class="flex items-center gap-1.5 px-3 py-1 bg-gray-100 rounded-full" data-testid="project-health-scores-drawer-total">
           <span class="text-sm font-medium text-gray-700">{{ totalProjects().toLocaleString() }} projects scored</span>


### PR DESCRIPTION
## Summary
- Health score buckets can sum to a different number than Total Projects because not all projects have a Crowd.dev health score
- Add "N projects scored" subtitle on the Foundation Health card so users don't confuse the bucket sum with total project count
- Update drawer badge from "N projects" to "N projects scored"
- 2 files changed, ~3 lines

## JIRA
[LFXV2-1618](https://linuxfoundation.atlassian.net/browse/LFXV2-1618)

## Test plan
- [ ] Open ED dashboard → Foundation Health → Project Health Scores card
- [ ] Verify card subtitle says "N projects scored"
- [ ] Click into drawer → verify badge says "N projects scored"
- [ ] Compare with Total Projects card — numbers may differ and that's expected

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1618]: https://linuxfoundation.atlassian.net/browse/LFXV2-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ