### PR TITLE
perf(ssr): route SSR API calls over loopback

### DIFF
--- a/apps/lfx-one/src/app/app.config.ts
+++ b/apps/lfx-one/src/app/app.config.ts
@@ -11,6 +11,7 @@ import { lfxPreset } from '@linuxfoundation/lfx-ui-core';
 import { definePreset } from '@primeuix/themes';
 import Aura from '@primeuix/themes/aura';
 import { authenticationInterceptor } from '@shared/interceptors/authentication.interceptor';
+import { ssrBaseUrlInterceptor } from '@shared/interceptors/ssr-base-url.interceptor';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { providePrimeNG } from 'primeng/config';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -36,7 +37,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes, withPreloading(CustomPreloadingStrategy), withInMemoryScrolling({ scrollPositionRestoration: 'top' })),
     provideClientHydration(withEventReplay(), withIncrementalHydration(), withHttpTransferCacheOptions({ includeHeaders: ['Authorization'] })),
-    provideHttpClient(withFetch(), withInterceptors([authenticationInterceptor])),
+    provideHttpClient(withFetch(), withInterceptors([ssrBaseUrlInterceptor, authenticationInterceptor])),
     provideAnimationsAsync(),
     providePrimeNG({
       theme: {

--- a/apps/lfx-one/src/app/app.config.ts
+++ b/apps/lfx-one/src/app/app.config.ts
@@ -37,7 +37,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes, withPreloading(CustomPreloadingStrategy), withInMemoryScrolling({ scrollPositionRestoration: 'top' })),
     provideClientHydration(withEventReplay(), withIncrementalHydration(), withHttpTransferCacheOptions({ includeHeaders: ['Authorization'] })),
-    provideHttpClient(withFetch(), withInterceptors([ssrBaseUrlInterceptor, authenticationInterceptor])),
+    provideHttpClient(withFetch(), withInterceptors([authenticationInterceptor, ssrBaseUrlInterceptor])),
     provideAnimationsAsync(),
     providePrimeNG({
       theme: {

--- a/apps/lfx-one/src/app/shared/interceptors/ssr-base-url.interceptor.ts
+++ b/apps/lfx-one/src/app/shared/interceptors/ssr-base-url.interceptor.ts
@@ -5,6 +5,12 @@ import { isPlatformServer } from '@angular/common';
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject, PLATFORM_ID } from '@angular/core';
 
+/**
+ * Rewrites relative `/api/*` and `/public/api/*` URLs to `http://127.0.0.1:$PORT`
+ * during SSR so the Node process talks to the in-process Express server directly
+ * instead of routing through the public load balancer. Browser-side requests are
+ * passed through unchanged.
+ */
 export const ssrBaseUrlInterceptor: HttpInterceptorFn = (req, next) => {
   const platformId = inject(PLATFORM_ID);
 

--- a/apps/lfx-one/src/app/shared/interceptors/ssr-base-url.interceptor.ts
+++ b/apps/lfx-one/src/app/shared/interceptors/ssr-base-url.interceptor.ts
@@ -1,0 +1,22 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformServer } from '@angular/common';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject, PLATFORM_ID } from '@angular/core';
+
+export const ssrBaseUrlInterceptor: HttpInterceptorFn = (req, next) => {
+  const platformId = inject(PLATFORM_ID);
+
+  if (!isPlatformServer(platformId)) {
+    return next(req);
+  }
+
+  if (!req.url.startsWith('/api/') && !req.url.startsWith('/public/api/')) {
+    return next(req);
+  }
+
+  const port = process.env['PORT'] || '4000';
+  const internalBase = `http://127.0.0.1:${port}`;
+  return next(req.clone({ url: `${internalBase}${req.url}` }));
+};


### PR DESCRIPTION
## Summary

- Adds `ssrBaseUrlInterceptor` that rewrites relative `/api/*` and `/public/api/*` URLs to `http://127.0.0.1:$PORT/...` when running on the server platform, so the SSR Node process talks to its own Express server directly instead of going out through Cloudflare → Traefik → backend pods via `app.lfx.dev`.
- Browser-side behavior is unchanged — interceptor is gated on `isPlatformServer`.

## Context

Datadog APM trace `b40ef136d08d7f7740c34d90b0ddf006` showed an SSR-emitted `POST /public/api/meetings/:id/join-url` taking **160 seconds**. The actual upstream meeting service responded in <200 ms; the rest was Cloudflare/LB/connection-queueing time on the SSR's call to itself via the public hostname. Loopback eliminates the round trip entirely.

Trace: https://app.datadoghq.com/apm/trace/b40ef136d08d7f7740c34d90b0ddf006

Tracking: LFXV2-1634