### PR TITLE
fix(dashboard): add info-icon tooltip to ED metric cards

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -40,11 +40,12 @@
     @switch (card.customContentType) {
       @case ('dual-signal') {
         <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
-        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+        <div class="flex-shrink-0">
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
             [description]="card.description"
+            [infoTooltip]="card.tooltipText"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
@@ -96,11 +97,12 @@
       }
       @case ('funnel') {
         <!-- Funnel Card (Flywheel Conversion) -->
-        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+        <div class="flex-shrink-0">
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
             [description]="card.description"
+            [infoTooltip]="card.tooltipText"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
@@ -147,11 +149,12 @@
       }
       @default {
         <!-- Standard Single-Signal Card -->
-        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+        <div class="flex-shrink-0">
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
             [description]="card.description"
+            [infoTooltip]="card.tooltipText"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [chartData]="card.chartData"

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -39,10 +39,15 @@
         }
         <h5 class="text-sm font-medium flex-1">{{ title() }}</h5>
         @if (infoTooltip()) {
-          <i
-            class="fa-light fa-circle-info text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             [pTooltip]="infoTooltip()!"
-            tooltipPosition="top"></i>
+            tooltipPosition="top"
+            aria-label="Methodology info"
+            (click)="$event.stopPropagation()">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         }
       </div>
 

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -38,6 +38,12 @@
           <i [class]="icon() + ' w-4 h-4 text-gray-500 flex-shrink-0'"></i>
         }
         <h5 class="text-sm font-medium flex-1">{{ title() }}</h5>
+        @if (infoTooltip()) {
+          <i
+            class="fa-light fa-circle-info text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            [pTooltip]="infoTooltip()!"
+            tooltipPosition="top"></i>
+        }
       </div>
 
       <!-- Description -->

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
@@ -21,6 +21,7 @@ export class MetricCardComponent {
   public readonly title = input.required<string>();
   public readonly icon = input<string>();
   public readonly description = input<string>();
+  public readonly infoTooltip = input<string>();
   public readonly testId = input<string>();
 
   // Chart inputs


### PR DESCRIPTION
## Summary
- Add visible (i) info icon next to ED metric card titles that shows methodology tooltip on hover
- Previously tooltips were only accessible by hovering the entire card with no visual indicator
- Addresses Mazin's feedback that Flywheel Conversion is "opaque, no calc shown" (Confluence item #13)

## Changes
- `metric-card.component.ts` — add optional `infoTooltip` input
- `metric-card.component.html` — render `fa-circle-info` icon when `infoTooltip` is provided
- `marketing-overview.component.html` — move tooltip from wrapper div to `[infoTooltip]` binding on all 3 card variants (dual-signal, funnel, default)

## Test plan
- [ ] Navigate to ED Marketing Overview as an ED persona
- [ ] Verify (i) icon appears next to each card title
- [ ] Hover (i) icon on Flywheel card — should show "Percentage of event attendees who re-engage..."
- [ ] Verify other cards (Brand Reach, Brand Health, etc.) also show their methodology tooltips
- [ ] Verify no regression on non-ED dashboards that use metric-card without infoTooltip

LFXV2-1623

🤖 Generated with [Claude Code](https://claude.ai/claude-code)