### PR TITLE
perf(ssr): defer meeting join URL fetch to client

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, OnInit, signal, Signal, WritableSignal } from '@angular/core';
+import { DatePipe, isPlatformServer, NgClass } from '@angular/common';
+import { Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -117,6 +117,7 @@ export class MeetingJoinComponent implements OnInit {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
 
   // Class variables with types
   public authenticated: WritableSignal<boolean>;
@@ -765,6 +766,11 @@ export class MeetingJoinComponent implements OnInit {
 
           // Reset error state
           this.joinUrlError.set(null);
+
+          if (isPlatformServer(this.platformId)) {
+            this.isLoadingJoinUrl.set(false);
+            return of(undefined);
+          }
 
           // Only fetch when meeting is joinable and we have necessary user info
           if (!canJoin || !meeting?.id) {


### PR DESCRIPTION
## Summary

- Short-circuits `MeetingJoinComponent.initializeFetchedJoinUrl` on the server platform so the `POST /public/api/meetings/:id/join-url` is only issued after client hydration.
- The Zoom join URL is only consumed by `window.open(...)` in the browser; fetching it during SSR provided no user-visible content while blocking TTFB on an upstream call.
- Browser-side behavior is unchanged — guard is gated on `isPlatformServer`.

## Context

Follow-up to #632. That PR fixed the routing of the SSR call (loopback instead of public domain). This PR removes the call from SSR entirely.

Datadog APM trace `b40ef136d08d7f7740c34d90b0ddf006` showed the SSR-emitted `POST /public/api/meetings/:id/join-url` taking up to **160 seconds**, which contributed to a 56s SSR TTFB and an HTTP 499. With this change, the page renders immediately with all SSR-resolvable content; the Join button populates once client hydration runs the fetch.

Trace: https://app.datadoghq.com/apm/trace/b40ef136d08d7f7740c34d90b0ddf006

Tracking: LFXV2-1634