### PR TITLE
perf(observability): tag APM spans with matched Express route

### DIFF
--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -121,11 +121,9 @@ if (!otlpEndpoint) {
 
           const url = (req.originalUrl || req.url || '').split('?')[0];
           const segments = url.split('/').filter(Boolean);
-          if (segments.length > 0) {
-            const bucket = `/${segments[0]}/*`;
-            span.setAttribute('http.route', bucket);
-            span.updateName(`${request.method} ${bucket}`);
-          }
+          const bucket = segments.length > 0 ? `/${segments[0]}/*` : '/';
+          span.setAttribute('http.route', bucket);
+          span.updateName(`${request.method} ${bucket}`);
         },
       }),
       new ExpressInstrumentation(),

--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -107,6 +107,26 @@ if (!otlpEndpoint) {
           const url = req.url || '';
           return url === '/health' || url === '/api/health' || url.startsWith('/.well-known');
         },
+        applyCustomAttributesOnSpan: (span, request, response) => {
+          const req = 'req' in response ? response.req : undefined;
+          if (!req) return;
+
+          if (req.route?.path) {
+            const baseUrl = req.baseUrl || '';
+            const fullRoute = `${baseUrl}${req.route.path}`;
+            span.setAttribute('http.route', fullRoute);
+            span.updateName(`${request.method} ${fullRoute}`);
+            return;
+          }
+
+          const url = (req.originalUrl || req.url || '').split('?')[0];
+          const segments = url.split('/').filter(Boolean);
+          if (segments.length > 0) {
+            const bucket = `/${segments[0]}/*`;
+            span.setAttribute('http.route', bucket);
+            span.updateName(`${request.method} ${bucket}`);
+          }
+        },
       }),
       new ExpressInstrumentation(),
       new UndiciInstrumentation({

--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -111,9 +111,18 @@ if (!otlpEndpoint) {
           const req = 'req' in response ? response.req : undefined;
           if (!req) return;
 
-          if (req.route?.path) {
+          const routePath = req.route?.path;
+          // Skip pure wildcard route paths ('**', '*', '/*', '/**') leaked from
+          // static-asset fallthrough — they collapse SSR traffic into a single bucket.
+          const isWildcardOnly = typeof routePath === 'string' && /^\/?\*+$/.test(routePath);
+
+          if (routePath && !isWildcardOnly) {
             const baseUrl = req.baseUrl || '';
-            const fullRoute = `${baseUrl}${req.route.path}`;
+            let fullRoute = `${baseUrl}${routePath}`;
+            // Strip trailing slash from mounted router root (e.g. `/api/meetings/` → `/api/meetings`).
+            if (fullRoute.length > 1 && fullRoute.endsWith('/')) {
+              fullRoute = fullRoute.slice(0, -1);
+            }
             span.setAttribute('http.route', fullRoute);
             span.updateName(`${request.method} ${fullRoute}`);
             return;
@@ -121,7 +130,15 @@ if (!otlpEndpoint) {
 
           const url = (req.originalUrl || req.url || '').split('?')[0];
           const segments = url.split('/').filter(Boolean);
-          const bucket = segments.length > 0 ? `/${segments[0]}/*` : '/';
+          let bucket;
+          if (segments.length === 0) {
+            bucket = '/';
+          } else if (segments.length === 1) {
+            // Single-segment URLs (e.g. `/login`) are concrete endpoints, not prefixes.
+            bucket = `/${segments[0]}`;
+          } else {
+            bucket = `/${segments[0]}/*`;
+          }
           span.setAttribute('http.route', bucket);
           span.updateName(`${request.method} ${bucket}`);
         },


### PR DESCRIPTION
## Summary

- Adds `applyCustomAttributesOnSpan` hook on `HttpInstrumentation` in `apps/lfx-one/otel.mjs`.
- For matched Express routes: sets `http.route = req.baseUrl + req.route.path` and updates the span name to `METHOD ROUTE`.
- For SSR catch-all routes: falls back to bucketing by first URL segment.

## Context

Datadog's OTLP receiver computes `resource_name` from `http.method + http.route` for HTTP server spans. Without `http.route` it falls back to bare `http.method` — which is what's happening today. Recent investigation showed `service:lfx-v2-ui` had ~19k spans bucketed under just `resource_name:GET` and ~10k under `resource_name:POST`, making per-endpoint analysis impossible.

## Verification

After deploy, query Datadog:

```
aggregate_spans service:lfx-v2-ui group_by:[resource_name]
```

Should show buckets like `GET /api/meetings/:id`, `POST /public/api/meetings/:id/join-url`, `GET /meetings/*` instead of just `GET` and `POST`.

Tracking: LFXV2-1637