### PR TITLE
fix(meetings): match registrant by username for restricted join

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -142,6 +142,7 @@ export class MeetingJoinComponent implements OnInit {
   public fetchedJoinUrl: Signal<string | undefined>;
   public isLoadingJoinUrl: WritableSignal<boolean> = signal<boolean>(false);
   public joinUrlError: WritableSignal<string | null> = signal<string | null>(null);
+  public joinUrlErrorCode: WritableSignal<string | null> = signal<string | null>(null);
   public attachments: Signal<MeetingAttachment[]>;
   public messageSeverity: Signal<'success' | 'info' | 'warn'>;
   public messageIcon: Signal<string>;
@@ -346,6 +347,7 @@ export class MeetingJoinComponent implements OnInit {
 
   public onEmailErrorClick(): void {
     this.joinUrlError.set(null);
+    this.joinUrlErrorCode.set(null);
     this.showGuestForm.set(true);
   }
 
@@ -766,6 +768,7 @@ export class MeetingJoinComponent implements OnInit {
 
           // Reset error state
           this.joinUrlError.set(null);
+          this.joinUrlErrorCode.set(null);
 
           if (isPlatformServer(this.platformId)) {
             this.isLoadingJoinUrl.set(false);
@@ -833,6 +836,7 @@ export class MeetingJoinComponent implements OnInit {
       catchError((error) => {
         this.isLoadingJoinUrl.set(false);
         this.joinUrlError.set(error?.error?.error || 'Failed to load meeting join URL. Please try again.');
+        this.joinUrlErrorCode.set(error?.error?.code ?? null);
         return of(undefined);
       })
     );
@@ -1005,9 +1009,7 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   private initializeEmailError(): Signal<boolean> {
-    return computed(() => {
-      return this.joinUrlError()?.toLowerCase().includes('email address is not registered for this restricted meeting') ?? false;
-    });
+    return computed(() => this.joinUrlErrorCode() === 'NOT_REGISTERED_FOR_MEETING');
   }
 
   private initializeIsPastMeeting(): Signal<boolean> {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -535,10 +535,13 @@ export class PublicMeetingController {
     }
 
     if (registrants.length === 0) {
+      // Specific code so the frontend can show the "join with a different email" affordance
+      // without coupling to the human-readable message text.
       throw new AuthorizationError('You are not registered for this restricted meeting', {
         operation: 'post_meeting_link',
         service: 'public_meeting_controller',
         path: `/itx/meetings/${id}`,
+        code: 'NOT_REGISTERED_FOR_MEETING',
       });
     }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -3,7 +3,7 @@
 
 import { Meeting } from '@lfx-one/shared';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
-import { CreateMeetingRegistrantRequest } from '@lfx-one/shared/interfaces';
+import { CreateMeetingRegistrantRequest, MeetingRegistrant } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -13,7 +13,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
-import { getEffectiveEmail } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { ProjectService } from '../services/project.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { validatePassword } from '../utils/security.util';
@@ -253,6 +253,7 @@ export class PublicMeetingController {
     const { password } = req.query;
     const bodyEmail = typeof req.body.email === 'string' ? req.body.email.trim() : '';
     const email: string = bodyEmail || getEffectiveEmail(req) || '';
+    const username = getEffectiveUsername(req);
     const startTime = logger.startOperation(req, 'post_meeting_link', {
       meeting_id: id,
     });
@@ -292,18 +293,23 @@ export class PublicMeetingController {
         return;
       }
 
-      // Check that the user has access to the meeting by validating they were invited to the meeting
-      // Restricted meetings require an email to be provided
+      // For restricted meetings, validate the user is registered. Match by email OR username
+      // so accounts whose auth email differs from their invited registrant email still resolve.
+      // The matched registrant's stored email is then used for the upstream join_link call.
+      let joinEmail = email;
       if (meeting.restricted) {
-        await this.restrictedMeetingCheck(req, next, email, id);
+        const matchedRegistrant = await this.restrictedMeetingCheck(req, email, username, id);
+        if (matchedRegistrant.email) {
+          joinEmail = matchedRegistrant.email;
+        }
       }
 
-      const joinUrlData = await this.meetingService.getMeetingJoinUrl(req, id, email);
+      const joinUrlData = await this.meetingService.getMeetingJoinUrl(req, id, joinEmail);
 
       // Log the success
       logger.success(req, 'post_meeting_link', startTime, {
         meeting_id: id,
-        email: email,
+        email: joinEmail,
         project_uid: meeting.project_uid,
         title: meeting.title,
       });
@@ -495,40 +501,53 @@ export class PublicMeetingController {
     return now >= earliestJoinTime;
   }
 
-  private async restrictedMeetingCheck(req: Request, next: NextFunction, email: string, id: string): Promise<void> {
+  private async restrictedMeetingCheck(req: Request, email: string, username: string | null, id: string): Promise<MeetingRegistrant> {
     const helperStartTime = logger.startOperation(req, 'restricted_meeting_check', {
       meeting_id: id,
       has_email: !!email,
+      has_username: !!username,
     });
 
-    // Check that the user has access to the meeting by validating they were invited to the meeting
-    if (!email) {
-      // Create a validation error (error handler will log)
-      const validationError = ServiceValidationError.forField('email', 'Email is required', {
+    if (!email && !username) {
+      throw ServiceValidationError.forField('email', 'Email is required', {
         operation: 'post_meeting_link',
         service: 'public_meeting_controller',
         path: req.path,
       });
-
-      next(validationError);
-      return;
     }
 
-    // Query the meeting registrants filtered by the user's email to validate if the user was invited to the meeting
-    const registrants = await this.meetingService.getMeetingRegistrantsByEmail(req, id, email);
+    // Username is the primary check — it's the auth-provider-verified identity and survives
+    // accounts with multiple emails. Email is the fallback for unauthenticated flows or when
+    // no username is available.
+    let registrants: MeetingRegistrant[] = [];
+    let matchedBy: 'username' | 'email' | null = null;
+    if (username) {
+      registrants = await this.meetingService.getMeetingRegistrantsByUsername(req, id, username);
+      if (registrants.length > 0) {
+        matchedBy = 'username';
+      }
+    }
+    if (registrants.length === 0 && email) {
+      registrants = await this.meetingService.getMeetingRegistrantsByEmail(req, id, email);
+      if (registrants.length > 0) {
+        matchedBy = 'email';
+      }
+    }
+
     if (registrants.length === 0) {
-      const authError = new AuthorizationError('The email address is not registered for this restricted meeting', {
+      throw new AuthorizationError('The email address is not registered for this restricted meeting', {
         operation: 'post_meeting_link',
         service: 'public_meeting_controller',
         path: `/itx/meetings/${id}`,
       });
-      throw authError;
     }
 
     logger.success(req, 'restricted_meeting_check', helperStartTime, {
       meeting_id: id,
-      email,
       registrant_count: registrants.length,
+      matched_by: matchedBy,
     });
+
+    return registrants[0];
   }
 }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -509,7 +509,7 @@ export class PublicMeetingController {
     });
 
     if (!email && !username) {
-      throw ServiceValidationError.forField('email', 'Email is required', {
+      throw ServiceValidationError.forField('email', 'Email or authenticated user identity is required', {
         operation: 'post_meeting_link',
         service: 'public_meeting_controller',
         path: req.path,
@@ -535,7 +535,7 @@ export class PublicMeetingController {
     }
 
     if (registrants.length === 0) {
-      throw new AuthorizationError('The email address is not registered for this restricted meeting', {
+      throw new AuthorizationError('You are not registered for this restricted meeting', {
         operation: 'post_meeting_link',
         service: 'public_meeting_controller',
         path: `/itx/meetings/${id}`,

--- a/apps/lfx-one/src/server/errors/authentication.error.ts
+++ b/apps/lfx-one/src/server/errors/authentication.error.ts
@@ -28,8 +28,10 @@ export class AuthorizationError extends BaseApiError {
       operation?: string;
       service?: string;
       path?: string;
+      code?: string;
     } = {}
   ) {
-    super(message, 403, 'AUTHORIZATION_REQUIRED', options);
+    const { code, ...rest } = options;
+    super(message, 403, code ?? 'AUTHORIZATION_REQUIRED', rest);
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -39,7 +39,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
@@ -889,11 +889,13 @@ export class MeetingService {
     });
 
     try {
-      // Resolve the user's registrant first — handles accounts with multiple emails where the
+      // Resolve the user's registrant(s) first — handles accounts with multiple emails where the
       // RSVP record's email differs from the auth email. RSVPs reliably carry registrant_id,
       // unlike username which is often null on RSVP records.
+      // Use getEffectiveUsername (returns LFID nickname) rather than getUsernameFromAuth
+      // (returns OIDC `sub`) since registrant.username stores the plain LFID.
       const email = getEffectiveEmail(req) ?? undefined;
-      const username = (await getUsernameFromAuth(req)) ?? undefined;
+      const username = getEffectiveUsername(req) ?? undefined;
 
       if (!email && !username) {
         logger.warning(req, 'get_meeting_rsvp_for_current_user', 'No email or username in auth context, returning null', {
@@ -906,10 +908,13 @@ export class MeetingService {
       if (registrants.length === 0) {
         return null;
       }
-      const registrantId = registrants[0].uid;
+      // A user can have multiple registrant rows for the same meeting (occurrence-specific
+      // invites or re-registrations). Match RSVPs against any of them so all the user's
+      // responses are visible.
+      const registrantIds = new Set(registrants.map((r) => r.uid));
 
       const allRsvps = await this.getMeetingRsvps(req, meetingUid);
-      const userRsvps = allRsvps.filter((rsvp) => rsvp.registrant_id === registrantId);
+      const userRsvps = allRsvps.filter((rsvp) => registrantIds.has(rsvp.registrant_id));
 
       if (occurrenceId) {
         // First try to find an occurrence-specific RSVP (takes precedence)

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -39,7 +39,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix, usernameMatches } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
@@ -889,26 +889,27 @@ export class MeetingService {
     });
 
     try {
-      // Match by email first (always populated on RSVP records); fall back to username for safety.
-      const normalizedEmail = getEffectiveEmail(req)?.toLowerCase() ?? null;
-      const username = await getUsernameFromAuth(req);
+      // Resolve the user's registrant first — handles accounts with multiple emails where the
+      // RSVP record's email differs from the auth email. RSVPs reliably carry registrant_id,
+      // unlike username which is often null on RSVP records.
+      const email = getEffectiveEmail(req) ?? undefined;
+      const username = (await getUsernameFromAuth(req)) ?? undefined;
 
-      if (!normalizedEmail && !username) {
+      if (!email && !username) {
         logger.warning(req, 'get_meeting_rsvp_for_current_user', 'No email or username in auth context, returning null', {
           meeting_id: meetingUid,
         });
         return null;
       }
 
-      // Fetch all RSVPs for this meeting via query service
-      const allRsvps = await this.getMeetingRsvps(req, meetingUid);
+      const registrants = await this.getMeetingRegistrantsForUser(req, meetingUid, email, username);
+      if (registrants.length === 0) {
+        return null;
+      }
+      const registrantId = registrants[0].uid;
 
-      // Filter RSVPs for current user — RSVP records carry email reliably; username is often absent.
-      const userRsvps = allRsvps.filter((rsvp) => {
-        if (normalizedEmail && rsvp.email?.toLowerCase() === normalizedEmail) return true;
-        if (username && rsvp.username && usernameMatches(username, rsvp.username)) return true;
-        return false;
-      });
+      const allRsvps = await this.getMeetingRsvps(req, meetingUid);
+      const userRsvps = allRsvps.filter((rsvp) => rsvp.registrant_id === registrantId);
 
       if (occurrenceId) {
         // First try to find an occurrence-specific RSVP (takes precedence)


### PR DESCRIPTION
## Summary

Public meeting join and *my RSVP* lookups now identify the user by their **registrant** instead of relying solely on their auth email. Resolves the case where an account has multiple emails on file — the OIDC primary email differs from the email used to invite them — which previously caused a false "not registered" denial on join and a missing RSVP on the meeting page.

### What changed

- **Restricted-meeting access check** (`postMeetingJoinUrl` / `restrictedMeetingCheck`) — matches by username first, falls back to email. The matched registrant's stored email is used for the upstream `/itx/meetings/:id/join_link` call so Zoom resolves the correct invitee.
- **Current-user RSVP lookup** (`getMeetingRsvpForCurrentUser`) — resolves the registrant via the existing email-or-username helper, then filters RSVPs by `registrant_id`. RSVP records carry `registrant_id` reliably, while their `username` field is often `null`.

### Why this matters

Validated against production for meeting `99417859585` (a restricted meeting):

| Lookup | Result |
|---|---|
| Registrant by `username:lewisoj` | ✅ 1 record (email `lojile@contractor.linuxfoundation.org`) |
| Registrant by `email:steveokon2016@gmail.com` (auth primary) | ❌ 0 records — would deny join |
| RSVP records with `username` populated | 0 of 2 — username-based RSVP match would fail |
| RSVP filter by `registrant_id` | ✅ Finds the right record regardless of email mismatch |

JIRA: LFXV2-1634