### PR TITLE
fix(dashboards): rename marketing metrics heading to marketing overview

### DIFF
--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -66,13 +66,13 @@ test.describe('Marketing Overview Section', () => {
     await expect(section).toBeVisible();
 
     const heading = section.locator('h2');
-    await expect(heading).toContainText('Marketing Metrics');
+    await expect(heading).toContainText('Marketing Overview');
 
     const subtitle = section.locator('p');
     await expect(subtitle).toContainText('North Star KPIs');
   });
 
-  test('renders Foundation Health before Marketing Metrics', async ({ page }) => {
+  test('renders Foundation Health before Marketing Overview', async ({ page }) => {
     const healthSection = page.locator('[data-testid="foundation-health-section"]');
     const edSection = page.locator('[data-testid="ed-evolution-section"]');
 
@@ -80,7 +80,7 @@ test.describe('Marketing Overview Section', () => {
     await expect(healthSection).toBeVisible();
     await expect(edSection).toBeVisible();
 
-    // Foundation Health should appear before Marketing Metrics in the DOM
+    // Foundation Health should appear before Marketing Overview in the DOM
     const healthBox = await healthSection.boundingBox();
     const edBox = await edSection.boundingBox();
     expect(healthBox!.y).toBeLessThan(edBox!.y);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -6,7 +6,7 @@
   <div class="flex items-center gap-3 mb-3">
     <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
       <i class="fa-light fa-chart-line-up text-lg" aria-hidden="true"></i>
-      Marketing Metrics
+      Marketing Overview
     </h2>
     <div class="flex-1 border-t border-gray-200 self-center"></div>
     <!-- Carousel Controls -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
@@ -49,7 +49,7 @@
       </section>
     }
 
-    <!-- Marketing Metrics -->
+    <!-- Marketing Overview -->
     @defer (on idle) {
       <lfx-marketing-overview />
     } @placeholder {

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2829,10 +2829,11 @@ export interface EmailCtrResponse {
 
 // ============================================
 // Marketing Overview Card (Executive Director Dashboard)
+// Interface names retain the "MarketingMetrics" prefix for backwards compatibility.
 // ============================================
 
 /**
- * Email campaign section data for the Marketing Overview card
+ * Email campaign section data for the Marketing Overview (formerly "Marketing Metrics") card.
  */
 export interface MarketingMetricsEmailSection {
   ctr: string;
@@ -2846,7 +2847,7 @@ export interface MarketingMetricsEmailSection {
 }
 
 /**
- * Paid campaign section data for the Marketing Overview card
+ * Paid campaign section data for the Marketing Overview (formerly "Marketing Metrics") card.
  */
 export interface MarketingMetricsPaidSection {
   impressions: string;
@@ -2860,7 +2861,7 @@ export interface MarketingMetricsPaidSection {
 }
 
 /**
- * Composite data for the Marketing Overview card.
+ * Composite data for the Marketing Overview (formerly "Marketing Metrics") card.
  * Pre-formatted for template binding — no formatting in the template.
  */
 export interface MarketingMetricsCardData {

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2828,11 +2828,11 @@ export interface EmailCtrResponse {
 }
 
 // ============================================
-// Marketing Metrics Card (Executive Director Dashboard)
+// Marketing Overview Card (Executive Director Dashboard)
 // ============================================
 
 /**
- * Email campaign section data for the Marketing Metrics card
+ * Email campaign section data for the Marketing Overview card
  */
 export interface MarketingMetricsEmailSection {
   ctr: string;
@@ -2846,7 +2846,7 @@ export interface MarketingMetricsEmailSection {
 }
 
 /**
- * Paid campaign section data for the Marketing Metrics card
+ * Paid campaign section data for the Marketing Overview card
  */
 export interface MarketingMetricsPaidSection {
   impressions: string;
@@ -2860,7 +2860,7 @@ export interface MarketingMetricsPaidSection {
 }
 
 /**
- * Composite data for the Marketing Metrics card.
+ * Composite data for the Marketing Overview card.
  * Pre-formatted for template binding — no formatting in the template.
  */
 export interface MarketingMetricsCardData {


### PR DESCRIPTION
## Summary
- Renames the "Marketing Metrics" section heading to "Marketing Overview" on the ED dashboard
- Updates e2e test assertions and HTML comments to match

## Test plan
- [ ] Verify the ED dashboard shows "Marketing Overview" as the section heading
- [ ] Verify e2e tests pass with updated assertion text

🤖 Generated with [Claude Code](https://claude.ai/claude-code)