### PR TITLE
feat(sidebar): use best_match sort for project search

### DIFF
--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -197,7 +197,9 @@ export class NavigationService {
 
   private buildQuery(lens: NavLens, pageToken: string | undefined, name: string | undefined): LensItemsQuery {
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
-    const base: LensItemsQuery = { type: 'project', filters: [], sort: 'name_asc' };
+    // Switch to relevance ordering whenever the user is searching — alphabetical sort would bury
+    // an exact match (e.g. "LF Products") under every other prefix-matching project.
+    const base: LensItemsQuery = { type: 'project', filters: [], sort: name ? 'best_match' : 'name_asc' };
     if (lens === 'foundation') {
       // Funding + membership required (AND); Active or Formation - Engaged accepted (OR).
       // This ensures pre-launch foundations appear in the dropdown before they go Active.

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -196,10 +196,13 @@ export class NavigationService {
   }
 
   private buildQuery(lens: NavLens, pageToken: string | undefined, name: string | undefined): LensItemsQuery {
+    // Normalize once: whitespace-only `name` (e.g. ?name=%20) shouldn't flip sort to best_match
+    // or forward a meaningless query upstream. Treat empty-after-trim as no search.
+    const trimmedName = name?.trim();
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
     // Switch to relevance ordering whenever the user is searching — alphabetical sort would bury
     // an exact match (e.g. "LF Products") under every other prefix-matching project.
-    const base: LensItemsQuery = { type: 'project', filters: [], sort: name ? 'best_match' : 'name_asc' };
+    const base: LensItemsQuery = { type: 'project', filters: [], sort: trimmedName ? 'best_match' : 'name_asc' };
     if (lens === 'foundation') {
       // Funding + membership required (AND); Active or Formation - Engaged accepted (OR).
       // This ensures pre-launch foundations appear in the dropdown before they go Active.
@@ -212,7 +215,7 @@ export class NavigationService {
     }
 
     if (pageToken) base.page_token = pageToken;
-    if (name) base.name = name;
+    if (trimmedName) base.name = trimmedName;
 
     return base;
   }

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -56,7 +56,8 @@ export interface LensItemsQuery {
   filters: string[];
   /** OR — at least one term must match (e.g. `['stage:Active', 'stage:Formation - Engaged']`). Combined with `filters` via AND. */
   filters_or?: string[];
-  sort: 'name_asc';
+  /** `best_match` opts into upstream `_score` (TF/IDF + bool_prefix) ordering — meaningful only with `name`. */
+  sort: 'name_asc' | 'best_match';
   page_token?: string;
   name?: string;
 }


### PR DESCRIPTION
## Summary

The sidebar foundation/project lens dropdown calls `/query/resources` with `sort=name_asc`. When users type a name to search, OpenSearch returns results alphabetically rather than by relevance — burying exact matches (e.g. typing "LF Products" returned every other "LF *" project before the actual match).

This PR opts into the new upstream `sort=best_match` value (TF/IDF + bool_prefix `_score`) whenever a `name` term is present. Default browsing (no search term) keeps `name_asc` so the alphabetical ordering of the open dropdown is preserved.

## Changes

- `packages/shared/src/interfaces/navigation.interface.ts` — widened `LensItemsQuery.sort` to `'name_asc' | 'best_match'`.
- `apps/lfx-one/src/server/services/navigation.service.ts` — `buildQuery` switches to `best_match` when `name` is provided. Subsequent paginated pages of an active search inherit it automatically because each page rebuilds the query with the same `name`.

## Upstream dependency

- [linuxfoundation/lfx-v2-query-service#49](https://github.com/linuxfoundation/lfx-v2-query-service/pull/49) — adds the `best_match` enum value. **Already deployed.**

## JIRA

LFXV2-1639