### PR TITLE
feat(observability): add UX readiness health check endpoint

### DIFF
--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -105,7 +105,7 @@ if (!otlpEndpoint) {
       new HttpInstrumentation({
         ignoreIncomingRequestHook: (req) => {
           const url = req.url || '';
-          return url === '/health' || url === '/api/health' || url.startsWith('/.well-known');
+          return url === '/livez' || url === '/readyz' || url.startsWith('/.well-known');
         },
         applyCustomAttributesOnSpan: (span, request, response) => {
           const req = 'req' in response ? response.req : undefined;

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -17,8 +17,9 @@ const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
  * Ordered by specificity - more specific patterns should come first
  */
 const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
-  // Health check - completely public
-  { pattern: '/health', type: 'api', auth: 'public' },
+  // Liveness and readiness probes - completely public
+  { pattern: '/livez', type: 'api', auth: 'public' },
+  { pattern: '/readyz', type: 'api', auth: 'public' },
 
   // Public API routes - optional authentication with token benefits
   { pattern: '/public/api', type: 'api', auth: 'optional', tokenRequired: false },

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -95,9 +95,9 @@ app.get('/health', (_req: Request, res: Response) => {
 // though many SSR pages render fine without them. Per-feature dependency
 // failures are handled at the route level, not by pulling the whole pod out
 // of the Service endpoints list.
-// Registered before pino-http so probes don't pollute request logs. Auth is
-// covered by the existing '/health' public entry in auth.middleware.ts via
-// the startsWith matcher. No rate-limit changes needed (not under /api/).
+// Registered before pino-http, auth, and rate-limit middleware so probes don't
+// pollute request logs and the endpoint is always reachable unauthenticated.
+// (No rate-limit changes needed — /health/* is not under /api/.)
 app.get('/health/ready', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ready' });
 });

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -86,6 +86,22 @@ app.get('/health', (_req: Request, res: Response) => {
   res.send('OK');
 });
 
+// Readiness endpoint for Kubernetes (LFXV2-1640).
+// Signals that this pod can accept HTTP traffic: Express is listening and the
+// Angular SSR engine loaded successfully (constructed at module load above —
+// a load failure crashes the process before reaching this point).
+// Intentionally does NOT probe NATS / Snowflake / microservice-proxy: those
+// clients are lazy-initialized and report not-connected at startup even
+// though many SSR pages render fine without them. Per-feature dependency
+// failures are handled at the route level, not by pulling the whole pod out
+// of the Service endpoints list.
+// Registered before pino-http so probes don't pollute request logs. Auth is
+// covered by the existing '/health' public entry in auth.middleware.ts via
+// the startsWith matcher. No rate-limit changes needed (not under /api/).
+app.get('/health/ready', (_req: Request, res: Response) => {
+  res.status(200).json({ status: 'ready' });
+});
+
 const httpLogger = pinoHttp({
   logger: serverLogger,
   serializers: {

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -81,8 +81,11 @@ app.get(
   })
 );
 
-// Health endpoint before logger middleware so health checks aren't logged.
-app.get('/health', (_req: Request, res: Response) => {
+// Liveness and readiness endpoints registered before logger middleware so
+// Kubernetes probe traffic is not request-logged. Both are also registered
+// before auth and rate-limit middleware so they are always reachable
+// unauthenticated. auth.middleware.ts lists /livez and /readyz as public.
+app.get('/livez', (_req: Request, res: Response) => {
   res.send('OK');
 });
 
@@ -95,10 +98,7 @@ app.get('/health', (_req: Request, res: Response) => {
 // though many SSR pages render fine without them. Per-feature dependency
 // failures are handled at the route level, not by pulling the whole pod out
 // of the Service endpoints list.
-// Registered before pino-http, auth, and rate-limit middleware so probes don't
-// pollute request logs and the endpoint is always reachable unauthenticated.
-// (No rate-limit changes needed — /health/* is not under /api/.)
-app.get('/health/ready', (_req: Request, res: Response) => {
+app.get('/readyz', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ready' });
 });
 

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -73,18 +73,13 @@ app.use(
 app.use(express.json({ limit: '15mb' }));
 app.use(express.urlencoded({ extended: true, limit: '15mb' }));
 
-app.get(
-  '**',
-  express.static(browserDistFolder, {
-    maxAge: '1y',
-    index: false,
-  })
-);
-
-// Liveness and readiness endpoints registered before logger middleware so
-// Kubernetes probe traffic is not request-logged. Both are also registered
-// before auth and rate-limit middleware so they are always reachable
-// unauthenticated. auth.middleware.ts lists /livez and /readyz as public.
+// Liveness and readiness endpoints registered before the static handler,
+// logger, auth, and rate-limit middleware so:
+//   - probes are served directly with no filesystem lookup (no I/O overhead
+//     on frequent Kubernetes probe traffic)
+//   - probe traffic is not request-logged
+//   - endpoints are always reachable unauthenticated
+// auth.middleware.ts lists /livez and /readyz as public.
 app.get('/livez', (_req: Request, res: Response) => {
   res.send('OK');
 });
@@ -101,6 +96,14 @@ app.get('/livez', (_req: Request, res: Response) => {
 app.get('/readyz', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ready' });
 });
+
+app.get(
+  '**',
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: false,
+  })
+);
 
 const httpLogger = pinoHttp({
   logger: serverLogger,

--- a/charts/lfx-v2-ui/templates/deployment.yaml
+++ b/charts/lfx-v2-ui/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               {{- toYaml $config.valueFrom | nindent 14 }}
             {{- end }}
           {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/lfx-v2-ui/templates/deployment.yaml
+++ b/charts/lfx-v2-ui/templates/deployment.yaml
@@ -53,3 +53,11 @@ spec:
               {{- toYaml $config.valueFrom | nindent 14 }}
             {{- end }}
           {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -153,12 +153,12 @@ resources:
     memory: 512Mi
 
 # Liveness probe — restarts the pod if the process becomes unresponsive.
-# Targets GET /health (plain text "OK"), registered before logging, auth, and
+# Targets GET /livez (plain text "OK"), registered before logging, auth, and
 # rate-limit middleware so it is always reachable if the process is alive.
 # Set to null to disable: livenessProbe: null
 livenessProbe:
   httpGet:
-    path: /health
+    path: /livez
     port: http
   initialDelaySeconds: 30
   periodSeconds: 30
@@ -166,16 +166,16 @@ livenessProbe:
   failureThreshold: 3
 
 # Readiness probe — controls when the pod receives traffic from the Service.
-# Targets GET /health/ready (JSON {"status":"ready"}) which is registered
-# before pino-http so probes don't pollute request logs. The endpoint confirms
-# that Express is listening and the Angular SSR engine loaded; it intentionally
+# Targets GET /readyz (JSON {"status":"ready"}) which is registered before
+# pino-http so probes don't pollute request logs. The endpoint confirms that
+# Express is listening and the Angular SSR engine loaded; it intentionally
 # does not probe lazy-initialized clients (NATS, Snowflake) because those
 # report not-connected at startup even when most SSR pages render fine without
 # them. See apps/lfx-one/src/server/server.ts for implementation details.
 # Set to null to disable: readinessProbe: null
 readinessProbe:
   httpGet:
-    path: /health/ready
+    path: /readyz
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -153,8 +153,8 @@ resources:
     memory: 512Mi
 
 # Liveness probe — restarts the pod if the process becomes unresponsive.
-# Targets GET /health (plain text "OK") which Express serves before all
-# middleware, so it is always available if the process is alive.
+# Targets GET /health (plain text "OK"), registered before logging, auth, and
+# rate-limit middleware so it is always reachable if the process is alive.
 # Set to null to disable: livenessProbe: null
 livenessProbe:
   httpGet:

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -152,6 +152,37 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# Liveness probe — restarts the pod if the process becomes unresponsive.
+# Targets GET /health (plain text "OK") which Express serves before all
+# middleware, so it is always available if the process is alive.
+# Set to null to disable: livenessProbe: null
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Readiness probe — controls when the pod receives traffic from the Service.
+# Targets GET /health/ready (JSON {"status":"ready"}) which is registered
+# before pino-http so probes don't pollute request logs. The endpoint confirms
+# that Express is listening and the Angular SSR engine loaded; it intentionally
+# does not probe lazy-initialized clients (NATS, Snowflake) because those
+# report not-connected at startup even when most SSR pages render fine without
+# them. See apps/lfx-one/src/server/server.ts for implementation details.
+# Set to null to disable: readinessProbe: null
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+  successThreshold: 1
+
 # Environment variables for the application
 # Uses map/object format for deep merging support
 environment:

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -152,7 +152,22 @@ resources:
     cpu: 500m
     memory: 512Mi
 
-# Liveness probe — restarts the pod if the process becomes unresponsive.
+# Startup probe — gates liveness and readiness during the initial startup window.
+# Once it succeeds, Kubernetes hands off to livenessProbe and readinessProbe.
+# Budget: 10s initial delay + (10s × 30 failures) = 310s (~5 min) maximum,
+# giving headroom over the observed ~4 min cold-start time.
+# Set to null to disable: startupProbe: null
+startupProbe:
+  httpGet:
+    path: /livez
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 30
+
+# Liveness probe — restarts the pod if it becomes unresponsive at runtime.
+# startupProbe handles the startup window, so initialDelaySeconds is 0 here.
 # Targets GET /livez (plain text "OK"), registered before logging, auth, and
 # rate-limit middleware so it is always reachable if the process is alive.
 # Set to null to disable: livenessProbe: null
@@ -160,12 +175,13 @@ livenessProbe:
   httpGet:
     path: /livez
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 30
+  initialDelaySeconds: 0
+  periodSeconds: 15
   timeoutSeconds: 5
   failureThreshold: 3
 
 # Readiness probe — controls when the pod receives traffic from the Service.
+# startupProbe handles the startup window, so initialDelaySeconds is 0 here.
 # Targets GET /readyz (JSON {"status":"ready"}) which is registered before
 # pino-http so probes don't pollute request logs. The endpoint confirms that
 # Express is listening and the Angular SSR engine loaded; it intentionally
@@ -177,7 +193,7 @@ readinessProbe:
   httpGet:
     path: /readyz
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 3
   failureThreshold: 3

--- a/docs/architecture/backend/ai-service.md
+++ b/docs/architecture/backend/ai-service.md
@@ -321,8 +321,8 @@ serverLogger.error('Failed to generate meeting agenda', { error });
 ### Health Monitoring
 
 ```typescript
-// Health check integration
-app.get('/api/health', (req, res) => {
+// Readiness check integration
+app.get('/readyz', (req, res) => {
   const healthStatus = {
     ai_service: {
       configured: !!process.env['AI_PROXY_URL'] && !!process.env['AI_API_KEY'],

--- a/docs/architecture/backend/logging-monitoring.md
+++ b/docs/architecture/backend/logging-monitoring.md
@@ -672,22 +672,25 @@ logger.success(req, 'user_login', startTime, {
 
 ## 📊 Health Check Filtering
 
-Health check endpoints are excluded from automatic HTTP logging:
+Liveness and readiness endpoints are excluded from automatic HTTP logging by being registered before the `pino-http` middleware:
 
 ```typescript
-// Health check endpoint (added before logger middleware)
-app.get('/health', (_req: Request, res: Response) => {
+// Liveness and readiness endpoints (registered before logger middleware)
+app.get('/livez', (_req: Request, res: Response) => {
   res.send('OK');
 });
+app.get('/readyz', (_req: Request, res: Response) => {
+  res.status(200).json({ status: 'ready' });
+});
 
-// HTTP logger middleware (added after health endpoint)
+// HTTP logger middleware (added after probe endpoints)
 app.use(httpLogger);
 ```
 
 URLs excluded from logging:
 
-- `/health`
-- `/api/health`
+- `/livez`
+- `/readyz`
 - `/.well-known/*`
 
 ## 🎯 Best Practices

--- a/docs/architecture/backend/nats-integration.md
+++ b/docs/architecture/backend/nats-integration.md
@@ -245,8 +245,8 @@ logger.info(undefined, 'nats_connect', 'Connecting to NATS server on demand', { 
 ### Health Check Integration
 
 ```typescript
-// Health endpoint includes NATS status
-app.get('/api/health', (req, res) => {
+// Readiness endpoint includes NATS status
+app.get('/readyz', (req, res) => {
   const healthStatus = {
     nats: {
       connected: natsService.isConnected(),

--- a/docs/architecture/backend/observability.md
+++ b/docs/architecture/backend/observability.md
@@ -40,7 +40,7 @@ Tracing activates only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — leaving it 
 
 ## What gets instrumented
 
-- **HTTP** (`HttpInstrumentation`) — incoming and outgoing HTTP requests, with `/health`, `/api/health`, and `/.well-known/*` excluded so health checks don't flood spans.
+- **HTTP** (`HttpInstrumentation`) — incoming and outgoing HTTP requests, with `/livez`, `/readyz`, and `/.well-known/*` excluded so health checks don't flood spans.
 - **Express** (`ExpressInstrumentation`) — per-middleware spans so you can see which middleware runs for a given request.
 - **Undici** (`UndiciInstrumentation`) — spans for `fetch` / `undici` calls (used by `api-client.service.ts` for microservice calls). Content-type headers are captured.
 - **Propagators** — W3C Trace Context + W3C Baggage (`traceparent`, `tracestate`, `baggage` headers) so spans correlate across the NATS boundary and into downstream microservices.

--- a/docs/architecture/backend/snowflake-integration.md
+++ b/docs/architecture/backend/snowflake-integration.md
@@ -774,8 +774,8 @@ Track these metrics for operational visibility:
 ### Health Check Integration
 
 ```typescript
-// Add to server health endpoint
-app.get('/health', (req, res) => {
+// Add to server liveness endpoint
+app.get('/livez', (req, res) => {
   const snowflakeStats = snowflakeService.getPoolStats();
   const lockStats = snowflakeService.getLockStats();
 

--- a/docs/architecture/backend/ssr-server.md
+++ b/docs/architecture/backend/ssr-server.md
@@ -205,7 +205,7 @@ The server supports distributed tracing via OpenTelemetry. Tracing is **opt-in**
 
 ### Instrumentations
 
-- **HTTP** — traces incoming requests (excludes `/health`, `/api/health`, `/.well-known`)
+- **HTTP** — traces incoming requests (excludes `/livez`, `/readyz`, `/.well-known`)
 - **Express** — traces Express route and middleware execution
 - **Undici** — traces outgoing `fetch()` requests with header propagation
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,8 +118,8 @@ yarn build
 # Check server logs
 yarn start:server
 
-# Test health endpoint (SSR server defaults to PORT 4000; override via $PORT)
-curl http://localhost:4000/health
+# Test liveness endpoint (SSR server defaults to PORT 4000; override via $PORT)
+curl http://localhost:4000/livez
 
 # Check environment variables
 echo $NODE_ENV
@@ -301,7 +301,7 @@ pm2 restart lfx-one
 
 ```bash
 # Application health
-curl http://localhost:4200/health
+curl http://localhost:4200/livez
 
 # Check Angular build
 yarn build
@@ -415,7 +415,7 @@ yarn start
 
 ```bash
 # Check microservice connectivity
-curl -I $LFX_V2_SERVICE/health
+curl -I $LFX_V2_SERVICE/livez
 
 # Test NATS connection
 # Check NATS_URL environment variable

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -300,8 +300,8 @@ pm2 restart lfx-one
 ### Health Checks
 
 ```bash
-# Application health
-curl http://localhost:4000/livez
+# Application health (yarn start serves on 4200; production SSR server on 4000)
+curl http://localhost:4200/livez
 
 # Check Angular build
 yarn build

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -301,7 +301,7 @@ pm2 restart lfx-one
 
 ```bash
 # Application health
-curl http://localhost:4200/livez
+curl http://localhost:4000/livez
 
 # Check Angular build
 yarn build


### PR DESCRIPTION
## Summary

- Adds `GET /livez` (liveness) to the Express server — returns plain text `OK` once Express is listening.
- Adds `GET /readyz` (readiness) to the Express server, registered before the static handler, `pino-http`, auth, and rate-limit middleware so probe traffic incurs no filesystem I/O, is not request-logged, and is always reachable unauthenticated. Returns HTTP 200 `{"status":"ready"}` once Express is listening and the Angular SSR engine has loaded.
- The readiness check is process-alive only — NATS, Snowflake, and the microservice proxy are intentionally excluded because those clients are lazy-initialized and would falsely report not-ready at pod startup, while most SSR pages render fine without them.
- Both endpoints are listed as public in `auth.middleware.ts` and sit outside the rate-limit prefixes (`/api/`, `/public/api/`).
- Adds three probes to `charts/lfx-v2-ui` — the chart previously had none:
  - **`startupProbe`** (`/livez`) — gates liveness and readiness during the initial startup window. Budget: 10s delay + 10s × 30 failures = **310s (~5 min)**, sized for the observed ~4 min cold-start time. Once it passes, Kubernetes hands off to the probes below.
  - **`livenessProbe`** (`/livez`) — restarts the pod if it becomes unresponsive at runtime. 0s initial delay (startupProbe handles the wait), 15s period, 3 failures → pod restarted within 45s.
  - **`readinessProbe`** (`/readyz`) — controls when the pod receives Service traffic. 0s initial delay, 10s period, 3 failures → traffic withheld within 30s.
- Updated `otel.mjs` to exclude `/livez` and `/readyz` from OpenTelemetry `HttpInstrumentation` spans (replacing the old `/health` exclusion).
- Updated all documentation references from `/health` to `/livez`/`/readyz`.

> **Note:** Endpoint naming follows platform conventions for liveness (`/livez`) and readiness (`/readyz`) checks. Any probe can be disabled by setting it to `null` in your environment values file — e.g. `startupProbe: null`, `livenessProbe: null`, or `readinessProbe: null`.

## Changes

```
 apps/lfx-one/otel.mjs                                 |  2 +-
 apps/lfx-one/src/server/middleware/auth.middleware.ts  |  5 ++-
 apps/lfx-one/src/server/server.ts                      | 29 ++++++++++---
 charts/lfx-v2-ui/templates/deployment.yaml             | 12 ++++++
 charts/lfx-v2-ui/values.yaml                           | 47 ++++++++++++++++++++++
 docs/architecture/backend/ai-service.md                |  4 +-
 docs/architecture/backend/logging-monitoring.md        | 15 ++++---
 docs/architecture/backend/nats-integration.md          |  4 +-
 docs/architecture/backend/observability.md             |  2 +-
 docs/architecture/backend/snowflake-integration.md     |  4 +-
 docs/architecture/backend/ssr-server.md                |  2 +-
 docs/troubleshooting.md                                | 10 ++---
```

Jira: LFXV2-1640

🤖 Generated with [Claude Code](https://claude.ai/code)