### PR TITLE
feat(dashboards): add marketing impact page with attributed revenue kpi

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -33,6 +33,13 @@ export const routes: Routes = [
         canActivate: [executiveDirectorGuard],
         loadComponent: () => import('./modules/dashboards/health-metrics/health-metrics.component').then((m) => m.HealthMetricsComponent),
       },
+      // Foundation Lens — Marketing Impact page (ED-only)
+      {
+        path: 'foundation/marketing-impact',
+        data: { lens: 'foundation' },
+        canActivate: [executiveDirectorGuard],
+        loadComponent: () => import('./modules/dashboards/marketing-impact/marketing-impact.component').then((m) => m.MarketingImpactComponent),
+      },
       // Foundation Lens — Projects page
       {
         path: 'foundation/projects',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -272,6 +272,12 @@ export class MainLayoutComponent {
             routerLink: '/foundation/health-metrics',
             testId: 'sidebar-metrics-health-metrics',
           },
+          {
+            label: 'Marketing Impact',
+            icon: 'fa-light fa-bullhorn',
+            routerLink: '/foundation/marketing-impact',
+            testId: 'sidebar-metrics-marketing-impact',
+          },
         ],
       });
     }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -118,7 +118,7 @@
                   } @else {
                     <i class="fa-solid fa-minus text-xs text-gray-400" aria-hidden="true"></i>
                   }
-                  <span class="text-xs font-medium" [class]="kpi.trend === 'up' ? 'text-green-600' : kpi.trend === 'down' ? 'text-red-600' : 'text-gray-500'">
+                  <span class="text-xs font-medium" [class]="kpi.trendClass">
                     {{ kpi.momChange }}
                   </span>
                   <span class="text-xs text-gray-400">{{ kpi.previousLabel }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -26,6 +26,8 @@
         [options]="monthOptions"
         optionLabel="label"
         optionValue="value"
+        placeholder="Select month"
+        ariaLabel="Select reporting month"
         styleClass="w-[180px]"
         data-testid="marketing-impact-month-picker" />
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -31,12 +31,39 @@
     </div>
   </div>
 
-  <!-- Content placeholder -->
   @if (!hasFoundation()) {
     <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 p-12">
       <p class="text-sm text-gray-500">Select a foundation to view marketing impact.</p>
     </div>
   } @else {
+    <!-- Focus filter bar -->
+    <div class="flex items-center gap-3" data-testid="marketing-impact-focus-bar">
+      <span class="text-xs font-semibold tracking-wide text-gray-500">FOCUS</span>
+      <lfx-filter-pills
+        [options]="focusOptions"
+        [selectedFilter]="selectedFocus()"
+        (filterChange)="onFocusChange($event)"
+        data-testid="marketing-impact-focus-pills" />
+    </div>
+
+    <!-- Section tabs -->
+    <div class="flex gap-6 border-b border-gray-200" data-testid="marketing-impact-tabs">
+      @for (tab of tabs; track tab.id) {
+        <button
+          type="button"
+          (click)="onTabChange(tab.id)"
+          [class]="
+            selectedTab() === tab.id
+              ? 'pb-2 text-sm font-medium text-blue-600 border-b-2 border-blue-600 -mb-px'
+              : 'pb-2 text-sm font-medium text-gray-500 hover:text-gray-700 -mb-px'
+          "
+          [attr.data-testid]="'marketing-impact-tab-' + tab.id">
+          {{ tab.label }}
+        </button>
+      }
+    </div>
+
+    <!-- Content placeholder -->
     <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16" data-testid="marketing-impact-placeholder">
       <div class="flex flex-col items-center gap-2 text-center">
         <i class="fa-light fa-chart-mixed text-3xl text-gray-400"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -1,0 +1,47 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-6" data-testid="marketing-impact-page">
+  <!-- Header -->
+  <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+    <div class="flex flex-col gap-1">
+      <h2 class="text-xl font-semibold text-gray-900" data-testid="marketing-impact-title">Marketing Impact</h2>
+      <p class="text-sm text-gray-500">How are we helping grow and engage?</p>
+      @if (hasFoundation() && contextLabel()) {
+        <p class="text-xs text-gray-400" data-testid="marketing-impact-context">{{ contextLabel() }}</p>
+      }
+    </div>
+    <div class="flex items-center gap-3">
+      <lfx-button
+        label="Export PDF"
+        icon="fa-light fa-file-pdf"
+        severity="secondary"
+        [outlined]="true"
+        [disabled]="true"
+        ariaLabel="Export report as PDF (coming soon)"
+        data-testid="marketing-impact-export-pdf" />
+      <lfx-select
+        [form]="headerForm"
+        control="month"
+        [options]="monthOptions"
+        optionLabel="label"
+        optionValue="value"
+        styleClass="w-[180px]"
+        data-testid="marketing-impact-month-picker" />
+    </div>
+  </div>
+
+  <!-- Content placeholder -->
+  @if (!hasFoundation()) {
+    <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 p-12">
+      <p class="text-sm text-gray-500">Select a foundation to view marketing impact.</p>
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16" data-testid="marketing-impact-placeholder">
+      <div class="flex flex-col items-center gap-2 text-center">
+        <i class="fa-light fa-chart-mixed text-3xl text-gray-400"></i>
+        <p class="text-sm text-gray-500">Marketing impact data coming soon.</p>
+      </div>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -116,7 +116,7 @@
                   } @else if (kpi.trend === 'down') {
                     <i class="fa-solid fa-arrow-down text-xs text-red-600" aria-hidden="true"></i>
                   } @else {
-                    <i class="fa-solid fa-minus text-xs text-gray-400" aria-hidden="true"></i>
+                    <i class="fa-solid fa-minus text-xs text-gray-500" aria-hidden="true"></i>
                   }
                   <span class="text-xs font-medium" [class]="kpi.trendClass">
                     {{ kpi.momChange }}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -34,7 +34,7 @@
   </div>
 
   @if (!hasFoundation()) {
-    <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 p-12">
+    <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 p-12" data-testid="marketing-impact-empty-state">
       <p class="text-sm text-gray-500">Select a foundation to view marketing impact.</p>
     </div>
   } @else {
@@ -49,11 +49,13 @@
     </div>
 
     <!-- Section tabs -->
-    <div class="flex gap-6 border-b border-gray-200" role="tablist" data-testid="marketing-impact-tabs">
+    <div class="flex gap-6 border-b border-gray-200" role="tablist" aria-label="Marketing impact sections" data-testid="marketing-impact-tabs">
       @for (tab of tabs; track tab.id) {
         <button
           type="button"
           role="tab"
+          [attr.id]="'mi-tab-' + tab.id"
+          [attr.aria-controls]="'mi-panel-' + tab.id"
           (click)="onTabChange(tab.id)"
           [attr.aria-selected]="selectedTab() === tab.id"
           [attr.tabindex]="selectedTab() === tab.id ? 0 : -1"
@@ -69,71 +71,73 @@
     </div>
 
     <!-- Tab content -->
-    @if (selectedTab() === 'overview') {
-      <!-- Performance summary header -->
-      <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between" data-testid="marketing-impact-summary-header">
-        <div class="flex flex-col gap-0.5">
-          <h3 class="text-base font-semibold text-gray-900">Performance summary</h3>
-          <p class="text-xs text-gray-500">Linear attribution · all LF projects</p>
-        </div>
-        <lfx-button
-          label="View executive summary"
-          icon="fa-light fa-file-lines"
-          severity="secondary"
-          [outlined]="true"
-          [disabled]="true"
-          ariaLabel="View executive summary (coming soon)"
-          data-testid="marketing-impact-exec-summary-btn" />
-      </div>
-
-      <!-- KPI cards grid -->
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="marketing-impact-kpi-grid">
-        @if (loading()) {
-          <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="marketing-impact-kpi-skeleton">
-            <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
-            <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
-            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
+    <div class="flex flex-col gap-6" role="tabpanel" [attr.id]="'mi-panel-' + selectedTab()" [attr.aria-labelledby]="'mi-tab-' + selectedTab()">
+      @if (selectedTab() === 'overview') {
+        <!-- Performance summary header -->
+        <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between" data-testid="marketing-impact-summary-header">
+          <div class="flex flex-col gap-0.5">
+            <h3 class="text-base font-semibold text-gray-900">Performance summary</h3>
+            <p class="text-xs text-gray-500">Linear attribution · {{ foundationName() }}</p>
           </div>
-        } @else {
-          @for (kpi of performanceSummaryKpis(); track kpi.id) {
-            <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" [attr.data-testid]="'marketing-impact-kpi-' + kpi.id">
-              <!-- Label row -->
-              <div class="flex items-center gap-2">
-                <div class="flex h-7 w-7 items-center justify-center rounded-full" [class]="kpi.iconClass">
-                  <i [class]="kpi.icon + ' text-sm'" aria-hidden="true"></i>
-                </div>
-                <span class="text-sm font-medium text-gray-600">{{ kpi.label }}</span>
-              </div>
-              <!-- Value -->
-              <span class="text-2xl font-semibold text-gray-900">{{ kpi.value }}</span>
-              <!-- MoM change -->
-              <div class="flex items-center gap-1.5">
-                @if (kpi.trend === 'up') {
-                  <i class="fa-solid fa-arrow-up text-xs text-green-600" aria-hidden="true"></i>
-                } @else if (kpi.trend === 'down') {
-                  <i class="fa-solid fa-arrow-down text-xs text-red-600" aria-hidden="true"></i>
-                } @else {
-                  <i class="fa-solid fa-minus text-xs text-gray-400" aria-hidden="true"></i>
-                }
-                <span class="text-xs font-medium" [class]="kpi.trend === 'up' ? 'text-green-600' : kpi.trend === 'down' ? 'text-red-600' : 'text-gray-500'">
-                  {{ kpi.momChange }}
-                </span>
-                <span class="text-xs text-gray-400">{{ kpi.previousLabel }}</span>
-              </div>
-            </div>
-          }
-        }
-      </div>
-    } @else {
-      <!-- Non-overview tab placeholder -->
-      <div
-        class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"
-        data-testid="marketing-impact-tab-placeholder">
-        <div class="flex flex-col items-center gap-2 text-center">
-          <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
-          <p class="text-sm text-gray-500">{{ selectedTabLabel() }} data coming soon.</p>
+          <lfx-button
+            label="View executive summary"
+            icon="fa-light fa-file-lines"
+            severity="secondary"
+            [outlined]="true"
+            [disabled]="true"
+            ariaLabel="View executive summary (coming soon)"
+            data-testid="marketing-impact-exec-summary-btn" />
         </div>
-      </div>
-    }
+
+        <!-- KPI cards grid -->
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="marketing-impact-kpi-grid">
+          @if (loading()) {
+            <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="marketing-impact-kpi-skeleton">
+              <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+              <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+              <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
+            </div>
+          } @else {
+            @for (kpi of performanceSummaryKpis(); track kpi.id) {
+              <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" [attr.data-testid]="'marketing-impact-kpi-' + kpi.id">
+                <!-- Label row -->
+                <div class="flex items-center gap-2">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full" [class]="kpi.iconClass">
+                    <i [class]="kpi.icon + ' text-sm'" aria-hidden="true"></i>
+                  </div>
+                  <span class="text-sm font-medium text-gray-600">{{ kpi.label }}</span>
+                </div>
+                <!-- Value -->
+                <span class="text-2xl font-semibold text-gray-900">{{ kpi.value }}</span>
+                <!-- MoM change -->
+                <div class="flex items-center gap-1.5">
+                  @if (kpi.trend === 'up') {
+                    <i class="fa-solid fa-arrow-up text-xs text-green-600" aria-hidden="true"></i>
+                  } @else if (kpi.trend === 'down') {
+                    <i class="fa-solid fa-arrow-down text-xs text-red-600" aria-hidden="true"></i>
+                  } @else {
+                    <i class="fa-solid fa-minus text-xs text-gray-400" aria-hidden="true"></i>
+                  }
+                  <span class="text-xs font-medium" [class]="kpi.trend === 'up' ? 'text-green-600' : kpi.trend === 'down' ? 'text-red-600' : 'text-gray-500'">
+                    {{ kpi.momChange }}
+                  </span>
+                  <span class="text-xs text-gray-400">{{ kpi.previousLabel }}</span>
+                </div>
+              </div>
+            }
+          }
+        </div>
+      } @else {
+        <!-- Non-overview tab placeholder -->
+        <div
+          class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"
+          data-testid="marketing-impact-tab-placeholder">
+          <div class="flex flex-col items-center gap-2 text-center">
+            <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
+            <p class="text-sm text-gray-500">{{ selectedTabLabel() }} data coming soon.</p>
+          </div>
+        </div>
+      }
+    </div>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -49,11 +49,14 @@
     </div>
 
     <!-- Section tabs -->
-    <div class="flex gap-6 border-b border-gray-200" data-testid="marketing-impact-tabs">
+    <div class="flex gap-6 border-b border-gray-200" role="tablist" data-testid="marketing-impact-tabs">
       @for (tab of tabs; track tab.id) {
         <button
           type="button"
+          role="tab"
           (click)="onTabChange(tab.id)"
+          [attr.aria-selected]="selectedTab() === tab.id"
+          [attr.tabindex]="selectedTab() === tab.id ? 0 : -1"
           [class]="
             selectedTab() === tab.id
               ? 'pb-2 text-sm font-medium text-blue-600 border-b-2 border-blue-600 -mb-px'
@@ -65,12 +68,72 @@
       }
     </div>
 
-    <!-- Content placeholder -->
-    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16" data-testid="marketing-impact-placeholder">
-      <div class="flex flex-col items-center gap-2 text-center">
-        <i class="fa-light fa-chart-mixed text-3xl text-gray-400"></i>
-        <p class="text-sm text-gray-500">Marketing impact data coming soon.</p>
+    <!-- Tab content -->
+    @if (selectedTab() === 'overview') {
+      <!-- Performance summary header -->
+      <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between" data-testid="marketing-impact-summary-header">
+        <div class="flex flex-col gap-0.5">
+          <h3 class="text-base font-semibold text-gray-900">Performance summary</h3>
+          <p class="text-xs text-gray-500">Linear attribution · all LF projects</p>
+        </div>
+        <lfx-button
+          label="View executive summary"
+          icon="fa-light fa-file-lines"
+          severity="secondary"
+          [outlined]="true"
+          [disabled]="true"
+          ariaLabel="View executive summary (coming soon)"
+          data-testid="marketing-impact-exec-summary-btn" />
       </div>
-    </div>
+
+      <!-- KPI cards grid -->
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="marketing-impact-kpi-grid">
+        @if (loading()) {
+          <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="marketing-impact-kpi-skeleton">
+            <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+            <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
+          </div>
+        } @else {
+          @for (kpi of performanceSummaryKpis(); track kpi.id) {
+            <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" [attr.data-testid]="'marketing-impact-kpi-' + kpi.id">
+              <!-- Label row -->
+              <div class="flex items-center gap-2">
+                <div class="flex h-7 w-7 items-center justify-center rounded-full" [class]="kpi.iconClass">
+                  <i [class]="kpi.icon + ' text-sm'" aria-hidden="true"></i>
+                </div>
+                <span class="text-sm font-medium text-gray-600">{{ kpi.label }}</span>
+              </div>
+              <!-- Value -->
+              <span class="text-2xl font-semibold text-gray-900">{{ kpi.value }}</span>
+              <!-- MoM change -->
+              <div class="flex items-center gap-1.5">
+                @if (kpi.trend === 'up') {
+                  <i class="fa-solid fa-arrow-up text-xs text-green-600" aria-hidden="true"></i>
+                } @else if (kpi.trend === 'down') {
+                  <i class="fa-solid fa-arrow-down text-xs text-red-600" aria-hidden="true"></i>
+                } @else {
+                  <i class="fa-solid fa-minus text-xs text-gray-400" aria-hidden="true"></i>
+                }
+                <span class="text-xs font-medium" [class]="kpi.trend === 'up' ? 'text-green-600' : kpi.trend === 'down' ? 'text-red-600' : 'text-gray-500'">
+                  {{ kpi.momChange }}
+                </span>
+                <span class="text-xs text-gray-400">{{ kpi.previousLabel }}</span>
+              </div>
+            </div>
+          }
+        }
+      </div>
+    } @else {
+      <!-- Non-overview tab placeholder -->
+      <div
+        class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"
+        data-testid="marketing-impact-tab-placeholder">
+        <div class="flex flex-col items-center gap-2 text-center">
+          <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
+          <p class="text-sm text-gray-500">{{ selectedTabLabel() }} data coming soon.</p>
+        </div>
+      </div>
+    }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.scss
@@ -1,0 +1,6 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -97,7 +97,10 @@ export class MarketingImpactComponent {
     return toSignal(
       foundation$.pipe(
         switchMap((slug) => {
-          if (!slug) return of(null);
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
           this.loading.set(true);
           return this.analyticsService.getRevenueImpact(slug).pipe(
             tap(() => this.loading.set(false)),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -16,7 +16,7 @@ import {
 import { formatCurrency } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { catchError, map, of, startWith, switchMap, tap } from 'rxjs';
+import { map, of, startWith, switchMap, tap } from 'rxjs';
 
 import type {
   FilterPillOption,
@@ -67,7 +67,9 @@ export class MarketingImpactComponent {
   protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
 
   protected onFocusChange(focusId: string): void {
-    this.selectedFocus.set(focusId as MarketingImpactFocusProgram);
+    if (this.focusOptions.some((o) => o.id === focusId)) {
+      this.selectedFocus.set(focusId as MarketingImpactFocusProgram);
+    }
   }
 
   protected onTabChange(tabId: MarketingImpactTab): void {
@@ -102,13 +104,7 @@ export class MarketingImpactComponent {
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getRevenueImpact(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
-          );
+          return this.analyticsService.getRevenueImpact(slug).pipe(tap(() => this.loading.set(false)));
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -1,0 +1,57 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectComponent } from '@components/select/select.component';
+import { buildMarketingImpactMonthOptions, getDefaultMarketingImpactMonth } from '@lfx-one/shared/constants';
+import { ProjectContextService } from '@services/project-context.service';
+import { startWith } from 'rxjs';
+
+import type { MarketingImpactMonthOption } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-marketing-impact',
+  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent],
+  templateUrl: './marketing-impact.component.html',
+  styleUrl: './marketing-impact.component.scss',
+})
+export class MarketingImpactComponent {
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly fb = inject(FormBuilder);
+
+  // Form
+  protected readonly headerForm = this.fb.group({
+    month: [getDefaultMarketingImpactMonth()],
+  });
+
+  // Static data
+  protected readonly monthOptions: MarketingImpactMonthOption[] = buildMarketingImpactMonthOptions();
+
+  // Signals
+  protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
+  protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
+
+  // Complex computed signals
+  protected readonly selectedMonth: Signal<string | null> = this.initSelectedMonth();
+  protected readonly contextLabel: Signal<string> = this.initContextLabel();
+
+  private initSelectedMonth(): Signal<string | null> {
+    return toSignal(this.headerForm.get('month')!.valueChanges.pipe(startWith(getDefaultMarketingImpactMonth())), {
+      initialValue: getDefaultMarketingImpactMonth(),
+    });
+  }
+
+  private initContextLabel(): Signal<string> {
+    return computed(() => {
+      const name = this.foundationName();
+      const monthValue = this.selectedMonth();
+      const option = this.monthOptions.find((o) => o.value === monthValue);
+      const monthLabel = option?.label ?? '';
+      if (!name || !monthLabel) return '';
+      return `Cross-channel performance for ${name} \u00B7 ${monthLabel}`;
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -40,27 +40,22 @@ export class MarketingImpactComponent {
   private readonly fb = inject(FormBuilder);
   private readonly defaultMonth = getDefaultMarketingImpactMonth();
 
-  // Form
   protected readonly headerForm = this.fb.nonNullable.group({
     month: [this.defaultMonth],
   });
 
-  // Static data
   protected readonly monthOptions: MarketingImpactMonthOption[] = buildMarketingImpactMonthOptions();
   protected readonly focusOptions: FilterPillOption[] = MARKETING_IMPACT_FOCUS_OPTIONS;
   protected readonly tabs: MarketingImpactTabOption[] = MARKETING_IMPACT_TABS;
 
-  // WritableSignals
   protected readonly selectedFocus = signal<MarketingImpactFocusProgram>('all');
   protected readonly selectedTab = signal<MarketingImpactTab>('overview');
   protected readonly loading = signal(false);
 
-  // Computed signals
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
   protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
   protected readonly selectedTabLabel = computed(() => this.tabs.find((t) => t.id === this.selectedTab())?.label ?? '');
 
-  // Complex computed signals
   protected readonly selectedMonth: Signal<string> = this.initSelectedMonth();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
   protected readonly revenueImpactData: Signal<RevenueImpactResponse | null> = this.initRevenueImpactData();
@@ -118,8 +113,14 @@ export class MarketingImpactComponent {
 
       const change = data.changePercentage;
       let trend: PerformanceSummaryKpi['trend'] = 'neutral';
-      if (change > 0) trend = 'up';
-      else if (change < 0) trend = 'down';
+      let trendClass = 'text-gray-500';
+      if (change > 0) {
+        trend = 'up';
+        trendClass = 'text-green-600';
+      } else if (change < 0) {
+        trend = 'down';
+        trendClass = 'text-red-600';
+      }
 
       return [
         {
@@ -130,6 +131,7 @@ export class MarketingImpactComponent {
           value: formatCurrency(data.revenueAttributed),
           momChange: `${change >= 0 ? '+' : ''}${change.toFixed(1)}%`,
           trend,
+          trendClass,
           previousLabel: 'vs prior period',
         },
       ];

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
@@ -13,10 +13,20 @@ import {
   MARKETING_IMPACT_FOCUS_OPTIONS,
   MARKETING_IMPACT_TABS,
 } from '@lfx-one/shared/constants';
+import { formatCurrency } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { startWith } from 'rxjs';
+import { catchError, map, of, startWith, switchMap, tap } from 'rxjs';
 
-import type { FilterPillOption, MarketingImpactFocusProgram, MarketingImpactMonthOption, MarketingImpactTab } from '@lfx-one/shared/interfaces';
+import type {
+  FilterPillOption,
+  MarketingImpactFocusProgram,
+  MarketingImpactMonthOption,
+  MarketingImpactTab,
+  MarketingImpactTabOption,
+  PerformanceSummaryKpi,
+  RevenueImpactResponse,
+} from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-marketing-impact',
@@ -26,27 +36,35 @@ import type { FilterPillOption, MarketingImpactFocusProgram, MarketingImpactMont
 })
 export class MarketingImpactComponent {
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly analyticsService = inject(AnalyticsService);
   private readonly fb = inject(FormBuilder);
+  private readonly defaultMonth = getDefaultMarketingImpactMonth();
 
   // Form
-  protected readonly headerForm = this.fb.group({
-    month: [getDefaultMarketingImpactMonth()],
+  protected readonly headerForm = this.fb.nonNullable.group({
+    month: [this.defaultMonth],
   });
 
   // Static data
   protected readonly monthOptions: MarketingImpactMonthOption[] = buildMarketingImpactMonthOptions();
   protected readonly focusOptions: FilterPillOption[] = MARKETING_IMPACT_FOCUS_OPTIONS;
-  protected readonly tabs = MARKETING_IMPACT_TABS;
+  protected readonly tabs: MarketingImpactTabOption[] = MARKETING_IMPACT_TABS;
 
-  // Signals
-  protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
-  protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
+  // WritableSignals
   protected readonly selectedFocus = signal<MarketingImpactFocusProgram>('all');
   protected readonly selectedTab = signal<MarketingImpactTab>('overview');
+  protected readonly loading = signal(false);
+
+  // Computed signals
+  protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
+  protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
+  protected readonly selectedTabLabel = computed(() => this.tabs.find((t) => t.id === this.selectedTab())?.label ?? '');
 
   // Complex computed signals
-  protected readonly selectedMonth: Signal<string | null> = this.initSelectedMonth();
+  protected readonly selectedMonth: Signal<string> = this.initSelectedMonth();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
+  protected readonly revenueImpactData: Signal<RevenueImpactResponse | null> = this.initRevenueImpactData();
+  protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
 
   protected onFocusChange(focusId: string): void {
     this.selectedFocus.set(focusId as MarketingImpactFocusProgram);
@@ -56,9 +74,9 @@ export class MarketingImpactComponent {
     this.selectedTab.set(tabId);
   }
 
-  private initSelectedMonth(): Signal<string | null> {
-    return toSignal(this.headerForm.get('month')!.valueChanges.pipe(startWith(getDefaultMarketingImpactMonth())), {
-      initialValue: getDefaultMarketingImpactMonth(),
+  private initSelectedMonth(): Signal<string> {
+    return toSignal(this.headerForm.controls.month.valueChanges.pipe(startWith(this.defaultMonth)), {
+      initialValue: this.defaultMonth,
     });
   }
 
@@ -70,6 +88,52 @@ export class MarketingImpactComponent {
       const monthLabel = option?.label ?? '';
       if (!name || !monthLabel) return '';
       return `Cross-channel performance for ${name} \u00B7 ${monthLabel}`;
+    });
+  }
+
+  private initRevenueImpactData(): Signal<RevenueImpactResponse | null> {
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug));
+
+    return toSignal(
+      foundation$.pipe(
+        switchMap((slug) => {
+          if (!slug) return of(null);
+          this.loading.set(true);
+          return this.analyticsService.getRevenueImpact(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initPerformanceSummaryKpis(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.revenueImpactData();
+      if (!data) return [];
+
+      const change = data.changePercentage;
+      let trend: PerformanceSummaryKpi['trend'] = 'neutral';
+      if (change > 0) trend = 'up';
+      else if (change < 0) trend = 'down';
+
+      return [
+        {
+          id: 'attributed-revenue',
+          label: 'Attributed Revenue',
+          icon: 'fa-light fa-dollar-sign',
+          iconClass: 'bg-green-100 text-green-600',
+          value: formatCurrency(data.revenueAttributed),
+          momChange: `${change >= 0 ? '+' : ''}${change.toFixed(1)}%`,
+          trend,
+          previousLabel: 'vs prior period',
+        },
+      ];
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -7,13 +7,8 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { SelectComponent } from '@components/select/select.component';
-import {
-  buildMarketingImpactMonthOptions,
-  getDefaultMarketingImpactMonth,
-  MARKETING_IMPACT_FOCUS_OPTIONS,
-  MARKETING_IMPACT_TABS,
-} from '@lfx-one/shared/constants';
-import { formatCurrency } from '@lfx-one/shared/utils';
+import { MARKETING_IMPACT_FOCUS_OPTIONS, MARKETING_IMPACT_TABS } from '@lfx-one/shared/constants';
+import { buildMarketingImpactMonthOptions, formatCurrency, getDefaultMarketingImpactMonth } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { map, of, startWith, switchMap, tap } from 'rxjs';

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -1,20 +1,26 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { SelectComponent } from '@components/select/select.component';
-import { buildMarketingImpactMonthOptions, getDefaultMarketingImpactMonth } from '@lfx-one/shared/constants';
+import {
+  buildMarketingImpactMonthOptions,
+  getDefaultMarketingImpactMonth,
+  MARKETING_IMPACT_FOCUS_OPTIONS,
+  MARKETING_IMPACT_TABS,
+} from '@lfx-one/shared/constants';
 import { ProjectContextService } from '@services/project-context.service';
 import { startWith } from 'rxjs';
 
-import type { MarketingImpactMonthOption } from '@lfx-one/shared/interfaces';
+import type { FilterPillOption, MarketingImpactFocusProgram, MarketingImpactMonthOption, MarketingImpactTab } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-marketing-impact',
-  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent],
+  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent, FilterPillsComponent],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',
 })
@@ -29,14 +35,26 @@ export class MarketingImpactComponent {
 
   // Static data
   protected readonly monthOptions: MarketingImpactMonthOption[] = buildMarketingImpactMonthOptions();
+  protected readonly focusOptions: FilterPillOption[] = MARKETING_IMPACT_FOCUS_OPTIONS;
+  protected readonly tabs = MARKETING_IMPACT_TABS;
 
   // Signals
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
   protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
+  protected readonly selectedFocus = signal<MarketingImpactFocusProgram>('all');
+  protected readonly selectedTab = signal<MarketingImpactTab>('overview');
 
   // Complex computed signals
   protected readonly selectedMonth: Signal<string | null> = this.initSelectedMonth();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
+
+  protected onFocusChange(focusId: string): void {
+    this.selectedFocus.set(focusId as MarketingImpactFocusProgram);
+  }
+
+  protected onTabChange(tabId: MarketingImpactTab): void {
+    this.selectedTab.set(tabId);
+  }
 
   private initSelectedMonth(): Signal<string | null> {
     return toSignal(this.headerForm.get('month')!.valueChanges.pipe(startWith(getDefaultMarketingImpactMonth())), {

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -51,3 +51,4 @@ export * from './transaction.constants';
 export * from './rewards.constants';
 export * from './regex.constants';
 export * from './foundation-projects.constants';
+export * from './marketing-impact.constants';

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { MarketingImpactMonthOption } from '../interfaces/marketing-impact.interface';
+import { FilterPillOption } from '../interfaces/dashboard-metric.interface';
+import type { MarketingImpactMonthOption, MarketingImpactTab } from '../interfaces/marketing-impact.interface';
 
 /** Number of past months to show in the Marketing Impact month picker. */
 const MONTH_COUNT = 12;
@@ -33,3 +34,23 @@ export function getDefaultMarketingImpactMonth(): string {
   const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
   return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
 }
+
+/** Focus program filter options for the Marketing Impact FOCUS bar. */
+export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
+  { id: 'all', label: 'All programs' },
+  { id: 'events', label: 'Events' },
+  { id: 'newsletters', label: 'Newsletters' },
+  { id: 'surveys', label: 'Surveys' },
+  { id: 'trainings', label: 'Trainings' },
+];
+
+/** Tab definitions for the Marketing Impact section tabs. */
+export const MARKETING_IMPACT_TABS: { id: MarketingImpactTab; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'attribution', label: 'Attribution' },
+  { id: 'performance-marketing', label: 'Performance Marketing' },
+  { id: 'email', label: 'Email' },
+  { id: 'web-activity', label: 'Web Activity' },
+  { id: 'social-accounts', label: 'Social Accounts' },
+  { id: 'social-listening', label: 'Social Listening' },
+];

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -2,32 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { FilterPillOption } from '../interfaces/dashboard-metric.interface';
-import type { MarketingImpactMonthOption, MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
-
-/** Number of past months to show in the Marketing Impact month picker. */
-const MONTH_COUNT = 12;
-
-/** Builds the last 12 month options in descending order for the month picker. */
-export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[] {
-  const now = new Date();
-  const options: MarketingImpactMonthOption[] = [];
-
-  for (let i = 1; i <= MONTH_COUNT; i++) {
-    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-    options.push({ label, value });
-  }
-
-  return options;
-}
-
-/** Returns the default reporting month (previous calendar month). */
-export function getDefaultMarketingImpactMonth(): string {
-  const now = new Date();
-  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
-}
+import type { MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
 
 /** Focus program filter options for the Marketing Impact FOCUS bar. */
 export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MarketingImpactMonthOption } from '../interfaces/marketing-impact.interface';
+
+/** Number of past months to show in the Marketing Impact month picker. */
+const MONTH_COUNT = 12;
+
+/**
+ * Builds month options for the Marketing Impact page.
+ * Returns the last 12 months in descending order (most recent first).
+ * The current month is excluded because its data is incomplete.
+ */
+export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[] {
+  const now = new Date();
+  const options: MarketingImpactMonthOption[] = [];
+
+  for (let i = 1; i <= MONTH_COUNT; i++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    options.push({ label, value });
+  }
+
+  return options;
+}
+
+/**
+ * Returns the default month value (previous month) for the Marketing Impact page.
+ */
+export function getDefaultMarketingImpactMonth(): string {
+  const now = new Date();
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
+}

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -2,16 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { FilterPillOption } from '../interfaces/dashboard-metric.interface';
-import type { MarketingImpactMonthOption, MarketingImpactTab } from '../interfaces/marketing-impact.interface';
+import type { MarketingImpactMonthOption, MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
 
 /** Number of past months to show in the Marketing Impact month picker. */
 const MONTH_COUNT = 12;
 
-/**
- * Builds month options for the Marketing Impact page.
- * Returns the last 12 months in descending order (most recent first).
- * The current month is excluded because its data is incomplete.
- */
+/** Builds the last 12 month options in descending order for the month picker. */
 export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[] {
   const now = new Date();
   const options: MarketingImpactMonthOption[] = [];
@@ -26,9 +22,7 @@ export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[]
   return options;
 }
 
-/**
- * Returns the default month value (previous month) for the Marketing Impact page.
- */
+/** Returns the default reporting month (previous calendar month). */
 export function getDefaultMarketingImpactMonth(): string {
   const now = new Date();
   const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
@@ -45,7 +39,7 @@ export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
 ];
 
 /** Tab definitions for the Marketing Impact section tabs. */
-export const MARKETING_IMPACT_TABS: { id: MarketingImpactTab; label: string }[] = [
+export const MARKETING_IMPACT_TABS: MarketingImpactTabOption[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'attribution', label: 'Attribution' },
   { id: 'performance-marketing', label: 'Performance Marketing' },

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -147,3 +147,6 @@ export * from './stat-card.interface';
 
 // Changelog interfaces
 export * from './changelog.interface';
+
+// Marketing Impact interfaces
+export * from './marketing-impact.interface';

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -1,9 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * Month option for the Marketing Impact page month picker.
- */
+/** Month option for the Marketing Impact page month picker. */
 export interface MarketingImpactMonthOption {
   /** Display label (e.g., "April 2026") */
   label: string;
@@ -11,8 +9,29 @@ export interface MarketingImpactMonthOption {
   value: string;
 }
 
+/** Tab option for the Marketing Impact section tabs. */
+export interface MarketingImpactTabOption {
+  id: MarketingImpactTab;
+  label: string;
+}
+
 /** Focus program identifiers for the Marketing Impact FOCUS filter bar. */
 export type MarketingImpactFocusProgram = 'all' | 'events' | 'newsletters' | 'surveys' | 'trainings';
 
 /** Tab identifiers for the Marketing Impact section tabs. */
 export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';
+
+/**
+ * Pre-formatted KPI card data for the Marketing Impact performance summary.
+ * All display values are pre-formatted strings so the template has zero logic.
+ */
+export interface PerformanceSummaryKpi {
+  id: string;
+  label: string;
+  icon: string;
+  iconClass: string;
+  value: string;
+  momChange: string;
+  trend: 'up' | 'down' | 'neutral';
+  previousLabel: string;
+}

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Month option for the Marketing Impact page month picker.
+ */
+export interface MarketingImpactMonthOption {
+  /** Display label (e.g., "April 2026") */
+  label: string;
+  /** ISO-style value for API use (e.g., "2026-04") */
+  value: string;
+}

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -10,3 +10,9 @@ export interface MarketingImpactMonthOption {
   /** ISO-style value for API use (e.g., "2026-04") */
   value: string;
 }
+
+/** Focus program identifiers for the Marketing Impact FOCUS filter bar. */
+export type MarketingImpactFocusProgram = 'all' | 'events' | 'newsletters' | 'surveys' | 'trainings';
+
+/** Tab identifiers for the Marketing Impact section tabs. */
+export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -21,10 +21,7 @@ export type MarketingImpactFocusProgram = 'all' | 'events' | 'newsletters' | 'su
 /** Tab identifiers for the Marketing Impact section tabs. */
 export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';
 
-/**
- * Pre-formatted KPI card data for the Marketing Impact performance summary.
- * All display values are pre-formatted strings so the template has zero logic.
- */
+/** Pre-formatted KPI card data for the Marketing Impact performance summary. */
 export interface PerformanceSummaryKpi {
   id: string;
   label: string;
@@ -33,5 +30,6 @@ export interface PerformanceSummaryKpi {
   value: string;
   momChange: string;
   trend: 'up' | 'down' | 'neutral';
+  trendClass: string;
   previousLabel: string;
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from './platform.utils';
 export * from './project.utils';
 export * from './badge.utils';
 export * from './marketing.utils';
+export * from './marketing-impact.utils';
 export * from './flywheel.utils';
 export * from './rewards.utils';
 export * from './insights.utils';

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MarketingImpactMonthOption } from '../interfaces/marketing-impact.interface';
+
+/** Number of past months to show in the Marketing Impact month picker. */
+const MONTH_COUNT = 12;
+
+/** Builds the last 12 month options in descending order for the month picker. */
+export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[] {
+  const now = new Date();
+  const options: MarketingImpactMonthOption[] = [];
+
+  for (let i = 1; i <= MONTH_COUNT; i++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    options.push({ label, value });
+  }
+
+  return options;
+}
+
+/** Returns the default reporting month (previous calendar month). */
+export function getDefaultMarketingImpactMonth(): string {
+  const now = new Date();
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- Add Marketing Impact page shell under Foundation lens with route `foundation/marketing-impact`
- Page includes header with subtitle, month picker (last 12 months), and disabled Export PDF button
- Focus filter bar with program pills (All, Events, Newsletters, Surveys, Trainings)
- Section tabs with proper `role="tablist"`/`role="tab"` semantics and keyboard accessibility
- Attributed Revenue KPI card on the Overview tab — wired to real data from the existing `revenue-impact` endpoint
- Sidebar nav item added under the Metrics section (ED-only, below Health Metrics)
- Route protected by `executiveDirectorGuard` — only visible to executive directors
- Shared package additions: `MarketingImpactMonthOption`, `MarketingImpactTabOption`, `PerformanceSummaryKpi` interfaces; `buildMarketingImpactMonthOptions()`, `getDefaultMarketingImpactMonth()`, `MARKETING_IMPACT_TABS`, `MARKETING_IMPACT_FOCUS_OPTIONS` constants

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)