### PR TITLE
feat(sidebar): list permitted projects with persona-priority default

### DIFF
--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -111,16 +111,28 @@ export class NavigationService {
     }
   }
 
-  /** Prefer items where the user holds an in-priority persona; fall back to the first item. */
+  /** Prefer items where the user holds an in-priority persona, in persona-array order; fall back to the first item. */
   private pickItemByPersonaPriority(items: LensItem[], priority: readonly PersonaType[]): LensItem {
     const personaProjects = this.personaService.personaProjects();
     for (const persona of priority) {
-      const personaUids = new Set((personaProjects[persona] ?? []).map((p) => p.projectUid));
-      if (personaUids.size === 0) continue;
-      const match = items.find((item) => personaUids.has(item.uid));
-      if (match) return match;
+      const projects = personaProjects[persona] ?? [];
+      for (const project of projects) {
+        const match = items.find((item) => item.uid === project.projectUid);
+        if (match) return match;
+      }
     }
     return items[0];
+  }
+
+  /** First project UID of the highest-priority persona the user holds for this lens, or null. */
+  private getPriorityUid(lens: NavLens): string | null {
+    const priority = lens === 'foundation' ? BOARD_SCOPED_PERSONA_PRIORITY : PROJECT_SCOPED_PERSONA_PRIORITY;
+    const personaProjects = this.personaService.personaProjects();
+    for (const persona of priority) {
+      const projects = personaProjects[persona] ?? [];
+      if (projects.length > 0) return projects[0].projectUid;
+    }
+    return null;
   }
 
   private handleEmptyLensResponse(lens: NavLens, page: LensPage): void {
@@ -274,7 +286,7 @@ export class NavigationService {
 
   private getSelectedUidForLens(lens: NavLens): string | null {
     const context = lens === 'foundation' ? this.projectContextService.selectedFoundation() : this.projectContextService.selectedProject();
-    return context?.uid ?? null;
+    return context?.uid ?? this.getPriorityUid(lens);
   }
 
   private toLensPage(response: LensItemsResponse, reset: boolean): LensPage {

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -5,8 +5,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { BOARD_SCOPED_PERSONA_PRIORITY, LENS_DEFAULT_ROUTES, NAV_SEARCH_DEBOUNCE_MS } from '@lfx-one/shared/constants';
-import { LensItem, LensItemsResponse, LensPage, LensState, NavLens, TaggedLensPage } from '@lfx-one/shared/interfaces';
+import { BOARD_SCOPED_PERSONA_PRIORITY, LENS_DEFAULT_ROUTES, NAV_SEARCH_DEBOUNCE_MS, PROJECT_SCOPED_PERSONA_PRIORITY } from '@lfx-one/shared/constants';
+import { LensItem, LensItemsResponse, LensPage, LensState, NavLens, PersonaType, TaggedLensPage } from '@lfx-one/shared/interfaces';
 import { lensItemToProjectContext } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { catchError, debounceTime, distinctUntilChanged, EMPTY, filter, map, merge, Observable, of, scan, skip, Subject, switchMap, tap } from 'rxjs';
@@ -61,14 +61,6 @@ export class NavigationService {
     return this.getState(lens).searchTerm;
   }
 
-  public bypassActive(lens: NavLens): Signal<boolean> {
-    return this.getState(lens).bypassActive;
-  }
-
-  public personaFetchFailed(lens: NavLens): Signal<boolean> {
-    return this.getState(lens).personaFetchFailed;
-  }
-
   public setSearchTerm(lens: NavLens, term: string): void {
     this.getState(lens).searchTerm.set(term);
   }
@@ -109,7 +101,8 @@ export class NavigationService {
       return;
     }
 
-    const defaultItem = lens === 'foundation' ? this.pickFoundationByPersonaPriority(page.items) : page.items[0];
+    const priority = lens === 'foundation' ? BOARD_SCOPED_PERSONA_PRIORITY : PROJECT_SCOPED_PERSONA_PRIORITY;
+    const defaultItem = this.pickItemByPersonaPriority(page.items, priority);
     const context = lensItemToProjectContext(defaultItem);
     if (lens === 'foundation') {
       this.projectContextService.setFoundation(context);
@@ -118,10 +111,10 @@ export class NavigationService {
     }
   }
 
-  /** Prefer a foundation the user is ED of, then Board Member of; fall back to the first item. */
-  private pickFoundationByPersonaPriority(items: LensItem[]): LensItem {
+  /** Prefer items where the user holds an in-priority persona; fall back to the first item. */
+  private pickItemByPersonaPriority(items: LensItem[], priority: readonly PersonaType[]): LensItem {
     const personaProjects = this.personaService.personaProjects();
-    for (const persona of BOARD_SCOPED_PERSONA_PRIORITY) {
+    for (const persona of priority) {
       const personaUids = new Set((personaProjects[persona] ?? []).map((p) => p.projectUid));
       if (personaUids.size === 0) continue;
       const match = items.find((item) => personaUids.has(item.uid));
@@ -131,8 +124,7 @@ export class NavigationService {
   }
 
   private handleEmptyLensResponse(lens: NavLens, page: LensPage): void {
-    const upstreamFailure = page.upstreamFailed || page.personaFetchFailed;
-    const toast = upstreamFailure
+    const toast = page.upstreamFailed
       ? { severity: 'error', summary: 'Unable to load', detail: 'We were unable to load your data. Please try again in a moment.' }
       : {
           severity: 'info',
@@ -150,26 +142,12 @@ export class NavigationService {
     const loading = signal<boolean>(false);
     const loaded = signal<boolean>(false);
     const nextPageToken = signal<string | null>(null);
-    const bypassActive = signal<boolean>(false);
-    const personaFetchFailed = signal<boolean>(false);
     const pendingDefaultSelection = signal<boolean>(false);
     const generation = signal<number>(0);
     const loadMore$ = new Subject<string>();
     const reload$ = new Subject<void>();
 
-    const items = this.initItems(
-      lens,
-      searchTerm,
-      loading,
-      loaded,
-      nextPageToken,
-      bypassActive,
-      personaFetchFailed,
-      pendingDefaultSelection,
-      generation,
-      loadMore$,
-      reload$
-    );
+    const items = this.initItems(lens, searchTerm, loading, loaded, nextPageToken, pendingDefaultSelection, generation, loadMore$, reload$);
     const hasMore = computed(() => nextPageToken() !== null);
 
     return {
@@ -179,8 +157,6 @@ export class NavigationService {
       loaded,
       nextPageToken,
       hasMore,
-      bypassActive,
-      personaFetchFailed,
       pendingDefaultSelection,
       generation,
       loadMore$,
@@ -194,8 +170,6 @@ export class NavigationService {
     loading: WritableSignal<boolean>,
     loaded: WritableSignal<boolean>,
     nextPageToken: WritableSignal<string | null>,
-    bypassActive: WritableSignal<boolean>,
-    personaFetchFailed: WritableSignal<boolean>,
     pendingDefaultSelection: WritableSignal<boolean>,
     generation: WritableSignal<number>,
     loadMore$: Subject<string>,
@@ -234,8 +208,6 @@ export class NavigationService {
         map(({ page }) => page),
         tap((page) => {
           nextPageToken.set(page.nextPageToken);
-          bypassActive.set(page.bypassActive);
-          personaFetchFailed.set(page.personaFetchFailed);
           loaded.set(true);
           if (page.reset && pendingDefaultSelection()) {
             pendingDefaultSelection.set(false);
@@ -277,7 +249,7 @@ export class NavigationService {
         clearLoadingIfActive();
         if (reset) {
           return of({
-            page: { items: [], nextPageToken: null, bypassActive: false, personaFetchFailed: false, upstreamFailed: true, reset: true },
+            page: { items: [], nextPageToken: null, upstreamFailed: true, reset: true },
             generation,
           });
         }
@@ -309,8 +281,6 @@ export class NavigationService {
     return {
       items: response.items,
       nextPageToken: response.next_page_token,
-      bypassActive: response.bypass_active,
-      personaFetchFailed: response.persona_fetch_failed,
       upstreamFailed: response.upstream_failed,
       reset,
     };

--- a/apps/lfx-one/src/server/controllers/navigation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/navigation.controller.ts
@@ -44,8 +44,6 @@ export class NavigationController {
       logger.success(req, 'get_lens_items', startTime, {
         lens: result.lens,
         item_count: result.items.length,
-        bypass_active: result.bypass_active,
-        persona_fetch_failed: result.persona_fetch_failed,
       });
 
       res.json(result);

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -1,31 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { LENS_PERSONA_MAP, NAV_MAX_UPSTREAM_ITERATIONS, NAV_MIN_ITEMS_PER_RESPONSE } from '@lfx-one/shared/constants';
 import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
-import {
-  EnrichedPersonaProject,
-  GetLensItemsParams,
-  LensItem,
-  LensItemsQuery,
-  LensItemsResponse,
-  NavLens,
-  PersonaApiResponse,
-  PersonaType,
-  Project,
-  QueryServiceResponse,
-} from '@lfx-one/shared/interfaces';
+import { GetLensItemsParams, LensItem, LensItemsQuery, LensItemsResponse, NavLens, Project, QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { personaDetectionService } from '../utils/persona-helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /** Stages eligible for the project lens — Active plus supported pre-launch formation stages. */
 const PROJECT_LENS_ALLOWED_STAGES = new Set<string>([ProjectStage.Active, ProjectStage.FormationEngaged, ProjectStage.FormationExploratory]);
 
-/** Powers the foundation/project lens dropdown. Root writers bypass the persona filter. */
+/** Powers the foundation/project lens dropdown. Access is gated entirely by the user's bearer token via the query service. */
 export class NavigationService {
   private readonly microserviceProxy: MicroserviceProxyService;
 
@@ -36,114 +23,45 @@ export class NavigationService {
   public async getLensItems(req: Request, params: GetLensItemsParams): Promise<LensItemsResponse> {
     const { lens, pageToken, name, selectedUid } = params;
 
-    // Parallel: root-writer check + first upstream page. Deferring persona fetch saves the
-    // NATS roundtrip for admins (the hot path).
-    const [bypassActive, firstPage] = await Promise.all([personaDetectionService.checkRootWriter(req), this.fetchUpstreamPage(req, lens, pageToken, name)]);
+    const firstPage = await this.fetchUpstreamPage(req, lens, pageToken, name);
 
-    let persona: PersonaApiResponse | null = null;
-    let personaFetchFailed = false;
-    if (!bypassActive) {
-      const personaResult = await this.fetchPersona(req);
-      persona = personaResult.persona;
-      personaFetchFailed = personaResult.failed;
-    }
-
-    // Fail closed: a persona-fetch failure must not fall through to unfiltered lens items.
-    // The frontend surfaces the "Unable to load" toast when items is empty + persona_fetch_failed.
-    if (!bypassActive && personaFetchFailed) {
-      logger.warning(req, 'build_lens_items', 'Persona fetch failed, returning empty lens items to fail closed', { lens });
+    if (firstPage.failed || !firstPage.response) {
       return {
         items: [],
         next_page_token: null,
-        bypass_active: false,
-        persona_fetch_failed: true,
-        upstream_failed: firstPage.failed,
+        upstream_failed: true,
         lens,
       };
     }
 
-    const shouldFilter = !bypassActive && !!persona;
-    const eligibleUids = shouldFilter && persona ? this.collectEligibleProjectUids(persona.projects, LENS_PERSONA_MAP[lens]) : null;
-
-    // targetCount=0 when filtering with no eligible projects skips the loop body entirely.
-    const targetCount = eligibleUids ? eligibleUids.size : NAV_MIN_ITEMS_PER_RESPONSE;
-
-    const accumulated: LensItem[] = [];
-    let iterations = 0;
-    let lastToken: string | null = null;
-    let upstreamFailed = firstPage.failed;
-    let currentResponse: QueryServiceResponse<Project> | null = firstPage.response;
-
-    while (currentResponse && accumulated.length < targetCount && iterations < NAV_MAX_UPSTREAM_ITERATIONS) {
-      iterations += 1;
-      const pageItems = this.filterPageResources(currentResponse.resources, lens, eligibleUids);
-      accumulated.push(...pageItems.map((p) => this.toLensItem(p)));
-      lastToken = currentResponse.page_token ?? null;
-
-      if (!lastToken || accumulated.length >= targetCount) break;
-
-      const next = await this.fetchUpstreamPage(req, lens, lastToken, name);
-      if (next.failed) {
-        upstreamFailed = true;
-        lastToken = null;
-        break;
-      }
-      currentResponse = next.response;
-    }
-
-    // With persona filtering, only suppress next-page token when we've proven completeness.
-    // If the loop exited due to the iteration cap, keep the token so the client can continue.
-    if (eligibleUids) {
-      const fullyCollected = accumulated.length >= eligibleUids.size;
-      if (fullyCollected || upstreamFailed) {
-        lastToken = null;
-      }
-    }
+    const projects = this.filterPageResources(firstPage.response.resources, lens);
+    const items: LensItem[] = projects.map((p) => this.toLensItem(p));
+    const nextPageToken: string | null = firstPage.response.page_token ?? null;
 
     // Ensure the selected project is in the first-page response so navigation from
     // other lenses (e.g., Me → Open) doesn't get overridden by the default picker.
     if (selectedUid && !pageToken) {
-      const alreadyIncluded = accumulated.some((item) => item.uid === selectedUid);
+      const alreadyIncluded = items.some((item) => item.uid === selectedUid);
       if (!alreadyIncluded) {
         const selectedItem = await this.fetchSelectedItem(req, lens, selectedUid);
         if (selectedItem) {
-          accumulated.unshift(selectedItem);
+          items.unshift(selectedItem);
         }
       }
     }
 
     logger.debug(req, 'build_lens_items', 'Built lens items', {
       lens,
-      item_count: accumulated.length,
-      upstream_iterations: iterations,
-      bypass_active: bypassActive,
-      persona_fetch_failed: personaFetchFailed,
-      upstream_failed: upstreamFailed,
-      has_next_page: !!lastToken,
+      item_count: items.length,
+      has_next_page: !!nextPageToken,
     });
 
     return {
-      items: accumulated,
-      next_page_token: lastToken,
-      bypass_active: bypassActive,
-      persona_fetch_failed: personaFetchFailed,
-      upstream_failed: upstreamFailed,
+      items,
+      next_page_token: nextPageToken,
+      upstream_failed: false,
       lens,
     };
-  }
-
-  private async fetchPersona(req: Request): Promise<{ persona: PersonaApiResponse | null; failed: boolean }> {
-    try {
-      const persona = await personaDetectionService.getPersonas(req);
-      if (persona.error) {
-        logger.warning(req, 'fetch_persona', 'Persona fetch returned error, falling back to lens-scoped results only', { error: persona.error });
-        return { persona: null, failed: true };
-      }
-      return { persona, failed: false };
-    } catch (error) {
-      logger.warning(req, 'fetch_persona', 'Persona fetch failed, falling back to lens-scoped results only', { err: error });
-      return { persona: null, failed: true };
-    }
   }
 
   private async fetchUpstreamPage(
@@ -183,14 +101,11 @@ export class NavigationService {
     }
   }
 
-  private filterPageResources(resources: QueryServiceResponse<Project>['resources'], lens: NavLens, eligibleUids: Set<string> | null): Project[] {
+  private filterPageResources(resources: QueryServiceResponse<Project>['resources'], lens: NavLens): Project[] {
     let projects = resources.map((r) => r.data);
     // legal_entity_type negation isn't supported by the filter grammar — re-check locally.
     if (lens === 'foundation') {
       projects = projects.filter((p) => computeIsFoundation(p));
-    }
-    if (eligibleUids) {
-      projects = projects.filter((p) => eligibleUids.has(p.uid));
     }
     return projects;
   }
@@ -210,7 +125,7 @@ export class NavigationService {
       base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
     } else {
       // Include active projects plus supported pre-launch formation stages so
-      // persona-eligible pre-launch projects appear in the project dropdown.
+      // pre-launch projects appear in the project dropdown.
       base.filters_or = [...PROJECT_LENS_ALLOWED_STAGES].map((stage) => `stage:${stage}`);
     }
 
@@ -218,16 +133,6 @@ export class NavigationService {
     if (trimmedName) base.name = trimmedName;
 
     return base;
-  }
-
-  private collectEligibleProjectUids(projects: EnrichedPersonaProject[], allowedPersonas: readonly PersonaType[]): Set<string> {
-    const uids = new Set<string>();
-    for (const project of projects) {
-      if (project.personas.some((p) => allowedPersonas.includes(p))) {
-        uids.add(project.projectUid);
-      }
-    }
-    return uids;
   }
 
   private toLensItem(project: Project): LensItem {

--- a/packages/shared/src/constants/lens.constants.ts
+++ b/packages/shared/src/constants/lens.constants.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { Lens, LensOption, NavLens } from '../interfaces';
-import type { PersonaType } from '../interfaces/persona.interface';
 
 export const LENS_COOKIE_KEY = 'lfx-active-lens';
 
@@ -61,11 +60,4 @@ export const DUAL_SCOPED_LENSES: readonly Lens[] = ['me', 'foundation', 'project
 /** Lenses backed by the nav API (me/org are not). */
 export const NAV_LENSES: readonly NavLens[] = ['foundation', 'project'] as const;
 
-export const LENS_PERSONA_MAP: Readonly<Record<NavLens, readonly PersonaType[]>> = {
-  foundation: ['board-member', 'executive-director'],
-  project: ['contributor', 'maintainer', 'executive-director'],
-} as const;
-
-export const NAV_MIN_ITEMS_PER_RESPONSE = 15;
-export const NAV_MAX_UPSTREAM_ITERATIONS = 10;
 export const NAV_SEARCH_DEBOUNCE_MS = 300;

--- a/packages/shared/src/constants/persona.constants.ts
+++ b/packages/shared/src/constants/persona.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { BOARD_SCOPED_PERSONAS, DevPersonaPreset, PersonaOption, PersonaType } from '../interfaces';
+import { BOARD_SCOPED_PERSONAS, DevPersonaPreset, PersonaOption, PersonaType, PROJECT_SCOPED_PERSONAS } from '../interfaces';
 
 export const PERSONA_COOKIE_KEY = 'lfx-active-persona-preset';
 
@@ -15,6 +15,9 @@ export const PERSONA_PRIORITY: readonly PersonaType[] = ['executive-director', '
 
 /** Board-scoped personas in priority order. Used to pick a default foundation on lens entry. */
 export const BOARD_SCOPED_PERSONA_PRIORITY: readonly PersonaType[] = PERSONA_PRIORITY.filter((p) => BOARD_SCOPED_PERSONAS.has(p));
+
+/** Project-scoped personas in priority order. Used to pick a default project on lens entry. */
+export const PROJECT_SCOPED_PERSONA_PRIORITY: readonly PersonaType[] = PERSONA_PRIORITY.filter((p) => PROJECT_SCOPED_PERSONAS.has(p));
 
 /** Role label priority for dashboard sorting, highest first. */
 export const ROLE_PRIORITY: readonly string[] = [

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -19,8 +19,6 @@ export interface LensItem {
 export interface LensItemsResponse {
   items: LensItem[];
   next_page_token: string | null;
-  bypass_active: boolean;
-  persona_fetch_failed: boolean;
   upstream_failed: boolean;
   lens: NavLens;
 }
@@ -29,8 +27,6 @@ export interface LensItemsResponse {
 export interface LensPage {
   items: LensItem[];
   nextPageToken: string | null;
-  bypassActive: boolean;
-  personaFetchFailed: boolean;
   upstreamFailed: boolean;
   reset: boolean;
 }
@@ -70,8 +66,6 @@ export interface LensState {
   loaded: WritableSignal<boolean>;
   nextPageToken: WritableSignal<string | null>;
   hasMore: Signal<boolean>;
-  bypassActive: WritableSignal<boolean>;
-  personaFetchFailed: WritableSignal<boolean>;
   loadMore$: Subject<string>;
   reload$: Subject<void>;
   pendingDefaultSelection: WritableSignal<boolean>;


### PR DESCRIPTION
## Summary

- Drop the in-app persona filter on the foundation/project lens dropdown so the sidebar lists every project the user can access via the query service. The query service (gated by the user's bearer token) is now the single source of truth for access.
- Reintroduce default selection by persona priority on lens entry: foundation lens prefers ED → board member → first item; project lens prefers maintainer → contributor → first item. When multiple items match a persona, the first one in the displayed list wins.

## Changes

- **Backend `NavigationService.getLensItems`** simplified to a single upstream call. Removed root-writer bypass, persona fetch + fail-closed, eligible-UID collection, and the iterate-until-target-count loop. Foundation post-filter (`computeIsFoundation`) and selected-UID injection are kept.
- **Shared interfaces** drop `bypass_active`/`persona_fetch_failed` from the response and per-lens state.
- **Shared constants** drop `LENS_PERSONA_MAP`, `NAV_MIN_ITEMS_PER_RESPONSE`, `NAV_MAX_UPSTREAM_ITERATIONS`. Add `PROJECT_SCOPED_PERSONA_PRIORITY` derived from existing `PERSONA_PRIORITY`.
- **Frontend `NavigationService`** drops the persona-failure signals and replaces `pickFoundationByPersonaPriority` with a generic `pickItemByPersonaPriority(items, priority)` used by both lenses.

LFXV2-1650