### PR TITLE
feat(events): add registration open tab to foundation events

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -38,6 +38,11 @@ export const routes: Routes = [
         data: { lens: 'foundation' },
         loadComponent: () => import('./modules/dashboards/foundation-projects/foundation-projects.component').then((m) => m.FoundationProjectsComponent),
       },
+      {
+        path: 'foundation/events',
+        data: { lens: 'foundation' },
+        loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
+      },
       // Project Lens dashboard (placeholder — reuses DashboardComponent for now)
       {
         path: 'project/overview',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -440,13 +440,13 @@ export class MainLayoutComponent {
    */
   private syncLensFromRoute(): void {
     let currentRoute = this.route;
-    let lens: unknown = currentRoute.snapshot.data['lens'];
+    let lens: Lens | undefined = currentRoute.snapshot.data['lens'];
     while (currentRoute.firstChild) {
       currentRoute = currentRoute.firstChild;
       lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
-    if (typeof lens === 'string' && lens in ALL_LENSES) {
-      this.lensService.setLens(lens as Lens);
+    if (lens && lens in ALL_LENSES) {
+      this.lensService.setLens(lens);
     }
   }
 }

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -215,7 +215,7 @@ export class MainLayoutComponent {
       {
         label: 'Events',
         icon: 'fa-light fa-ticket',
-        routerLink: '/events',
+        routerLink: '/foundation/events',
       },
       {
         label: MAILING_LIST_LABEL.plural,
@@ -440,11 +440,12 @@ export class MainLayoutComponent {
    */
   private syncLensFromRoute(): void {
     let currentRoute = this.route;
+    let lens: unknown = currentRoute.snapshot.data['lens'];
     while (currentRoute.firstChild) {
       currentRoute = currentRoute.firstChild;
+      lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
-    const lens = currentRoute.snapshot.data['lens'];
-    if (lens && lens in ALL_LENSES) {
+    if (typeof lens === 'string' && lens in ALL_LENSES) {
       this.lensService.setLens(lens as Lens);
     }
   }

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
@@ -56,15 +56,17 @@
   }
 
   <!-- Status Filter Dropdown -->
-  <div class="w-full sm:w-40">
-    <lfx-select
-      [form]="searchForm"
-      control="status"
-      size="small"
-      [options]="statusOptions()"
-      placeholder="Status"
-      [showClear]="true"
-      styleClass="w-full"
-      data-testid="events-status-filter"></lfx-select>
-  </div>
+  @if (showStatusFilter()) {
+    <div class="w-full sm:w-40">
+      <lfx-select
+        [form]="searchForm"
+        control="status"
+        size="small"
+        [options]="statusOptions()"
+        placeholder="Status"
+        [showClear]="true"
+        styleClass="w-full"
+        data-testid="events-status-filter"></lfx-select>
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -21,6 +21,7 @@ export class EventsTopBarComponent {
 
   public readonly isFoundationFilter = input<boolean>(false);
   public readonly showRoleFilter = input<boolean>(true);
+  public readonly showStatusFilter = input<boolean>(true);
   public readonly projectName = input<string | undefined>(undefined);
   /** When true, foundation options are scoped to the user's registered past events */
   public readonly isPast = input<boolean>(false);
@@ -81,6 +82,16 @@ export class EventsTopBarComponent {
       .subscribe((show) => {
         if (!show) {
           this.searchForm.get('role')?.setValue(null);
+        }
+      });
+
+    // Clear status when the status filter is hidden so a stale selection
+    // doesn't continue to filter the active tab once it's no longer visible.
+    toObservable(this.showStatusFilter)
+      .pipe(skip(1), takeUntilDestroyed())
+      .subscribe((show) => {
+        if (!show) {
+          this.searchForm.get('status')?.setValue(null);
         }
       });
 

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.html
@@ -15,7 +15,7 @@
         }"
         [attr.data-testid]="'foundation-events-tab-' + tab.id">
         {{ tab.label }}
-        @if (tab.countKey && !upcomingEventsLoading() && !pastEventsLoading()) {
+        @if (tab.countKey && !eventsStatsLoading()) {
           <span>({{ tabCounts()[tab.countKey] }})</span>
         }
       </button>
@@ -32,6 +32,15 @@
       (pageChange)="onUpcomingPageChange($event)"
       (sortChange)="onUpcomingSortChange($event)"
       data-testid="foundation-events-upcoming-table" />
+  } @else if (activeTab() === 'registration-open') {
+    <lfx-foundation-events-table
+      [eventsResponse]="registrationOpenEvents()"
+      [loading]="registrationOpenEventsLoading()"
+      [sortField]="registrationOpenSortField()"
+      [sortOrder]="registrationOpenSortOrder()"
+      (pageChange)="onRegistrationOpenPageChange($event)"
+      (sortChange)="onRegistrationOpenSortChange($event)"
+      data-testid="foundation-events-registration-open-table" />
   } @else {
     <lfx-foundation-events-table
       [eventsResponse]="pastEvents()"

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.html
@@ -15,7 +15,7 @@
         }"
         [attr.data-testid]="'foundation-events-tab-' + tab.id">
         {{ tab.label }}
-        @if (tab.countKey && !eventsStatsLoading()) {
+        @if (tab.countKey && !countLoading()[tab.countKey]) {
           <span>({{ tabCounts()[tab.countKey] }})</span>
         }
       </button>

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -57,7 +57,13 @@ export class EventsListComponent {
     past: this.pastEvents().total,
   }));
 
-  public readonly eventsStatsLoading = computed(() => this.upcomingEventsLoading() || this.registrationOpenEventsLoading() || this.pastEventsLoading());
+  // Per-count loading so each tab/stat reveals its number as soon as its own
+  // request finishes — a slow tab no longer blocks the others.
+  public readonly countLoading = computed(() => ({
+    upcoming: this.upcomingEventsLoading(),
+    registrationOpen: this.registrationOpenEventsLoading(),
+    past: this.pastEventsLoading(),
+  }));
 
   public constructor() {
     // Reset every tab to page 1 when foundation/search filters change.

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -24,7 +24,7 @@ export class EventsListComponent {
   public readonly searchQuery = input<string>('');
   public readonly status = input<string | null>(null);
 
-  protected readonly activeTab = signal<EventTabId>('upcoming');
+  public readonly activeTab = signal<EventTabId>('upcoming');
 
   public readonly upcomingEventsLoading = signal(true);
   public readonly registrationOpenEventsLoading = signal(true);
@@ -60,12 +60,22 @@ export class EventsListComponent {
   public readonly eventsStatsLoading = computed(() => this.upcomingEventsLoading() || this.registrationOpenEventsLoading() || this.pastEventsLoading());
 
   public constructor() {
-    // Reset both tabs to page 1 when shared filters change
-    combineLatest([toObservable(this.foundation), toObservable(this.searchQuery), toObservable(this.status)])
+    // Reset every tab to page 1 when foundation/search filters change.
+    combineLatest([toObservable(this.foundation), toObservable(this.searchQuery)])
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
         this.registrationOpenEventsPage.set({ offset: 0, pageSize: this.registrationOpenEventsPage().pageSize });
+        this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
+      });
+
+    // Status changes only affect tabs that honor the user-selected status —
+    // the Registration Open tab forces 'Active' and ignores the dropdown,
+    // so don't reset its page (avoids a wasted refetch).
+    toObservable(this.status)
+      .pipe(skip(1), takeUntilDestroyed())
+      .subscribe(() => {
+        this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
         this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
       });
   }

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -27,30 +27,37 @@ export class EventsListComponent {
   protected readonly activeTab = signal<EventTabId>('upcoming');
 
   public readonly upcomingEventsLoading = signal(true);
+  public readonly registrationOpenEventsLoading = signal(true);
   public readonly pastEventsLoading = signal(true);
 
   protected readonly upcomingEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
+  protected readonly registrationOpenEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
   protected readonly pastEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
 
   protected readonly upcomingSortField = signal('EVENT_START_DATE');
   protected readonly upcomingSortOrder = signal<'ASC' | 'DESC'>('ASC');
+  protected readonly registrationOpenSortField = signal('EVENT_START_DATE');
+  protected readonly registrationOpenSortOrder = signal<'ASC' | 'DESC'>('ASC');
   protected readonly pastSortField = signal('EVENT_START_DATE');
   protected readonly pastSortOrder = signal<'ASC' | 'DESC'>('DESC');
 
   protected readonly upcomingEvents: Signal<EventsResponse> = this.initializeUpcomingEvents();
+  protected readonly registrationOpenEvents: Signal<EventsResponse> = this.initializeRegistrationOpenEvents();
   protected readonly pastEvents: Signal<EventsResponse> = this.initializePastEvents();
 
   protected readonly tabs: EventTab[] = [
     { id: 'upcoming', label: 'Upcoming', countKey: 'upcoming' },
+    { id: 'registration-open', label: 'Registration Open', countKey: 'registrationOpen' },
     { id: 'past', label: 'Past', countKey: 'past' },
   ];
 
   public readonly tabCounts = computed(() => ({
     upcoming: this.upcomingEvents().total,
+    registrationOpen: this.registrationOpenEvents().total,
     past: this.pastEvents().total,
   }));
 
-  public readonly eventsStatsLoading = computed(() => this.upcomingEventsLoading() || this.pastEventsLoading());
+  public readonly eventsStatsLoading = computed(() => this.upcomingEventsLoading() || this.registrationOpenEventsLoading() || this.pastEventsLoading());
 
   public constructor() {
     // Reset both tabs to page 1 when shared filters change
@@ -58,6 +65,7 @@ export class EventsListComponent {
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
+        this.registrationOpenEventsPage.set({ offset: 0, pageSize: this.registrationOpenEventsPage().pageSize });
         this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
       });
   }
@@ -69,6 +77,11 @@ export class EventsListComponent {
   protected onUpcomingPageChange(event: PageChangeEvent): void {
     this.upcomingEventsLoading.set(true);
     this.upcomingEventsPage.set(event);
+  }
+
+  protected onRegistrationOpenPageChange(event: PageChangeEvent): void {
+    this.registrationOpenEventsLoading.set(true);
+    this.registrationOpenEventsPage.set(event);
   }
 
   protected onPastPageChange(event: PageChangeEvent): void {
@@ -86,6 +99,16 @@ export class EventsListComponent {
     this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
   }
 
+  protected onRegistrationOpenSortChange(event: SortChangeEvent): void {
+    if (this.registrationOpenSortField() === event.field) {
+      this.registrationOpenSortOrder.set(this.registrationOpenSortOrder() === 'ASC' ? 'DESC' : 'ASC');
+    } else {
+      this.registrationOpenSortField.set(event.field);
+      this.registrationOpenSortOrder.set('ASC');
+    }
+    this.registrationOpenEventsPage.set({ offset: 0, pageSize: this.registrationOpenEventsPage().pageSize });
+  }
+
   protected onPastSortChange(event: SortChangeEvent): void {
     if (this.pastSortField() === event.field) {
       this.pastSortOrder.set(this.pastSortOrder() === 'ASC' ? 'DESC' : 'ASC');
@@ -100,6 +123,17 @@ export class EventsListComponent {
     return this.initializeEvents(false, this.upcomingEventsPage, this.upcomingEventsLoading, this.upcomingSortField, this.upcomingSortOrder);
   }
 
+  private initializeRegistrationOpenEvents(): Signal<EventsResponse> {
+    return this.initializeEvents(
+      false,
+      this.registrationOpenEventsPage,
+      this.registrationOpenEventsLoading,
+      this.registrationOpenSortField,
+      this.registrationOpenSortOrder,
+      'Active'
+    );
+  }
+
   private initializePastEvents(): Signal<EventsResponse> {
     return this.initializeEvents(true, this.pastEventsPage, this.pastEventsLoading, this.pastSortField, this.pastSortOrder);
   }
@@ -109,7 +143,8 @@ export class EventsListComponent {
     pageSignal: WritableSignal<PageChangeEvent>,
     loadingSignal: WritableSignal<boolean>,
     sortFieldSignal: WritableSignal<string>,
-    sortOrderSignal: WritableSignal<'ASC' | 'DESC'>
+    sortOrderSignal: WritableSignal<'ASC' | 'DESC'>,
+    forcedStatus?: EventStatusFilter
   ): Signal<EventsResponse> {
     return toSignal(
       toObservable(
@@ -117,7 +152,7 @@ export class EventsListComponent {
           ...pageSignal(),
           foundation: this.foundation(),
           searchQuery: this.searchQuery() || undefined,
-          status: (this.status() ?? undefined) as EventStatusFilter | undefined,
+          status: forcedStatus ?? ((this.status() ?? undefined) as EventStatusFilter | undefined),
           sortField: sortFieldSignal(),
           sortOrder: sortOrderSignal(),
         }))

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
@@ -43,12 +43,11 @@
           Location <i [class]="sortIcons()['EVENT_CITY']"></i>
         </button>
       </th>
+      <th scope="col" data-testid="header-status">Registration Status</th>
       @if (isPastEvents()) {
         <th scope="col" data-testid="header-attendees">Attendees</th>
-      } @else {
-        <th scope="col" data-testid="header-status">Status</th>
       }
-      <th>Action</th>
+      <th scope="col">Action</th>
     </tr>
   </ng-template>
 
@@ -80,19 +79,24 @@
         <span class="text-xs text-gray-700">{{ event.location }}</span>
       </td>
 
+      <!-- Registration Status -->
+      <td>
+        @if (event.displayStatus) {
+          <lfx-tag
+            [value]="event.displayStatus"
+            [severity]="statusSeverityMap[event.displayStatus] ?? 'secondary'"
+            [attr.data-testid]="'event-status-' + event.id" />
+        } @else {
+          <span class="text-xs text-gray-400">—</span>
+        }
+      </td>
+
       <!-- Attendees -->
       @if (isPastEvents()) {
         <td>
           <span class="text-xs text-gray-700" [attr.data-testid]="'event-attendees-' + event.id">
             {{ event.attendees !== null ? (event.attendees | number) : '—' }}
           </span>
-        </td>
-      } @else {
-        <td>
-          <lfx-tag
-            [value]="event.displayStatus"
-            [severity]="statusSeverityMap[event.displayStatus] ?? 'secondary'"
-            [attr.data-testid]="'event-status-' + event.id" />
         </td>
       }
 
@@ -102,7 +106,7 @@
           [label]="event.actionLabel"
           severity="primary"
           [outlined]="event.isOutlined"
-          [href]="isPastEvents() ? event.url : (event.registrationUrl ?? event.url)"
+          [href]="event.url"
           target="_blank"
           rel="noopener noreferrer"
           size="small"
@@ -114,7 +118,7 @@
 
   <ng-template #emptymessage>
     <tr>
-      <td [attr.colspan]="6" class="text-center py-10">
+      <td [attr.colspan]="isPastEvents() ? 7 : 6" class="text-center py-10">
         <div class="flex items-center justify-center p-16">
           <div class="text-center max-w-md">
             <div class="text-gray-400 mb-4">

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
@@ -48,8 +48,8 @@ export class EventsTableComponent {
       return {
         ...event,
         displayStatus,
-        actionLabel: isPast ? 'View Recap' : this.resolveActionLabel(displayStatus),
-        isOutlined: !isPast && displayStatus === FoundationEventStatus.COMING_SOON,
+        actionLabel: isPast ? 'View Recap' : 'View Details',
+        isOutlined: !isPast,
       };
     });
   });
@@ -60,17 +60,6 @@ export class EventsTableComponent {
 
   protected onHeaderClick(field: string): void {
     this.sortChange.emit({ field });
-  }
-
-  private resolveActionLabel(displayStatus: string | null): string {
-    switch (displayStatus) {
-      case FoundationEventStatus.COMING_SOON:
-        return 'Notify Me';
-      case FoundationEventStatus.COMPLETED:
-        return 'View Recap';
-      default:
-        return 'Register';
-    }
   }
 
   private mapFoundationEventStatus(raw: string | null): string | null {

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
@@ -7,9 +7,10 @@
     <div class="flex items-start justify-between mt-3">
       <div class="flex flex-col gap-1">
         <h1 class="font-display font-light text-2xl" data-testid="foundation-event-page-title">Foundation Events</h1>
+        @let foundation = userFoundation();
         <p class="text-sm text-gray-500" data-testid="foundation-event-page-subtitle">
-          @if (userFoundation()) {
-            Events hosted by {{ userFoundation() }} and its ecosystem.
+          @if (foundation) {
+            Events hosted by {{ foundation }} and its ecosystem.
           } @else {
             Events hosted across this foundation portfolio.
           }
@@ -82,6 +83,7 @@
     <div class="bg-white rounded-lg border border-gray-200 p-4">
       <lfx-events-top-bar
         [showRoleFilter]="false"
+        [showStatusFilter]="eventsList.activeTab() !== 'registration-open'"
         [statusOptions]="foundationStatusOptions"
         searchPlaceholder="Search foundation events..."
         (searchQueryChange)="onSearchQueryChange($event)"

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
@@ -28,7 +28,7 @@
               <i class="fa-light fa-ticket text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
-              @if (eventsList.eventsStatsLoading()) {
+              @if (eventsList.upcomingEventsLoading() || eventsList.pastEventsLoading()) {
                 <p class="text-xl font-medium text-gray-400">&mdash;</p>
               } @else {
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().upcoming + eventsList.tabCounts().past }}</p>
@@ -41,7 +41,7 @@
               <i class="fa-light fa-calendar-plus text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
-              @if (eventsList.eventsStatsLoading()) {
+              @if (eventsList.upcomingEventsLoading()) {
                 <p class="text-xl font-medium text-gray-400">&mdash;</p>
               } @else {
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().upcoming }}</p>
@@ -54,7 +54,7 @@
               <i class="fa-light fa-ticket text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
-              @if (eventsList.eventsStatsLoading()) {
+              @if (eventsList.registrationOpenEventsLoading()) {
                 <p class="text-xl font-medium text-gray-400">&mdash;</p>
               } @else {
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().registrationOpen }}</p>
@@ -67,7 +67,7 @@
               <i class="fa-light fa-calendar-check text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
-              @if (eventsList.eventsStatsLoading()) {
+              @if (eventsList.pastEventsLoading()) {
                 <p class="text-xl font-medium text-gray-400">&mdash;</p>
               } @else {
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().past }}</p>

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
@@ -6,17 +6,24 @@
     <!-- Page Header -->
     <div class="flex items-start justify-between mt-3">
       <div class="flex flex-col gap-1">
-        <h1 class="font-display font-light text-2xl" data-testid="foundation-event-page-title">Events</h1>
+        <h1 class="font-display font-light text-2xl" data-testid="foundation-event-page-title">Foundation Events</h1>
+        <p class="text-sm text-gray-500" data-testid="foundation-event-page-subtitle">
+          @if (userFoundation()) {
+            Events hosted by {{ userFoundation() }} and its ecosystem.
+          } @else {
+            Events hosted across this foundation portfolio.
+          }
+        </p>
       </div>
       <lfx-discover-events-button testId="foundation-event-discover-button" />
     </div>
 
     <!-- Summary Stat Cards -->
     <div data-testid="foundation-events-stats">
-      <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-        <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+      <lfx-card styleClass="foundation-events-stats-card [&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+        <div class="grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
           <div class="flex items-center gap-3 p-4">
-            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-indigo-100 text-indigo-600 flex-shrink-0">
               <i class="fa-light fa-ticket text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
@@ -29,20 +36,7 @@
             </div>
           </div>
           <div class="flex items-center gap-3 p-4">
-            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-              <i class="fa-light fa-calendar-check text-xl"></i>
-            </div>
-            <div class="flex flex-col gap-0.5">
-              @if (eventsList.eventsStatsLoading()) {
-                <p class="text-xl font-medium text-gray-400">&mdash;</p>
-              } @else {
-                <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().past }}</p>
-              }
-              <p class="text-sm font-normal text-gray-900">Past Events</p>
-            </div>
-          </div>
-          <div class="flex items-center gap-3 p-4">
-            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
               <i class="fa-light fa-calendar-plus text-xl"></i>
             </div>
             <div class="flex flex-col gap-0.5">
@@ -54,6 +48,32 @@
               <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
             </div>
           </div>
+          <div class="flex items-center gap-3 p-4">
+            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
+              <i class="fa-light fa-ticket text-xl"></i>
+            </div>
+            <div class="flex flex-col gap-0.5">
+              @if (eventsList.eventsStatsLoading()) {
+                <p class="text-xl font-medium text-gray-400">&mdash;</p>
+              } @else {
+                <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().registrationOpen }}</p>
+              }
+              <p class="text-sm font-normal text-gray-900">Registration Open</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-3 p-4">
+            <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+              <i class="fa-light fa-calendar-check text-xl"></i>
+            </div>
+            <div class="flex flex-col gap-0.5">
+              @if (eventsList.eventsStatsLoading()) {
+                <p class="text-xl font-medium text-gray-400">&mdash;</p>
+              } @else {
+                <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().past }}</p>
+              }
+              <p class="text-sm font-normal text-gray-900">Past Events</p>
+            </div>
+          </div>
         </div>
       </lfx-card>
     </div>
@@ -63,6 +83,7 @@
       <lfx-events-top-bar
         [showRoleFilter]="false"
         [statusOptions]="foundationStatusOptions"
+        searchPlaceholder="Search foundation events..."
         (searchQueryChange)="onSearchQueryChange($event)"
         (statusChange)="onStatusChange($event)" />
     </div>

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-:host ::ng-deep [data-testid='foundation-events-stats'] .foundation-events-stats-card.p-card {
+:host ::ng-deep .foundation-events-stats-card.p-card {
   @apply hover:border-gray-200;
 }

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-::ng-deep .foundation-events-stats-card.p-card {
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+:host ::ng-deep [data-testid='foundation-events-stats'] .foundation-events-stats-card.p-card {
   @apply hover:border-gray-200;
 }

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.scss
@@ -1,2 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
+
+::ng-deep .foundation-events-stats-card.p-card {
+  @apply hover:border-gray-200;
+}

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -168,7 +168,7 @@ export interface PageChangeEvent {
 /**
  * Tab identifier for the events list component
  */
-export type EventTabId = 'upcoming' | 'past' | 'visa-letters' | 'travel-funding';
+export type EventTabId = 'upcoming' | 'registration-open' | 'past' | 'visa-letters' | 'travel-funding';
 
 /**
  * Tab definition for the events list component
@@ -176,7 +176,7 @@ export type EventTabId = 'upcoming' | 'past' | 'visa-letters' | 'travel-funding'
 export interface EventTab {
   id: EventTabId;
   label: string;
-  countKey?: 'upcoming' | 'past';
+  countKey?: 'upcoming' | 'registrationOpen' | 'past';
 }
 
 /**


### PR DESCRIPTION
**Tracking:** [LFXV2-1653](https://linuxfoundation.atlassian.net/browse/LFXV2-1653)

## Summary

- Adds a **Registration Open** tab to `/foundation/events` (filters by raw event status `Active`); the stats grid grows from 3 cards (Total / Past / Upcoming) to 4 (adds Registration Open).
- The action button on the foundation events table now shows **"View Details"** (or **"View Recap"** for past events) and always links to `event.url`. Previously it cycled through "Register" / "Notify Me" / "View Recap" with `event.registrationUrl` as a fallback for upcoming events.
- Foundation events page gains a dynamic subtitle that reflects the active foundation lens.
- Sidebar **Events** entry now routes to `/foundation/events` (was `/events`).
- Lens detection now walks to the deepest activated child route so child routes inheriting `data: { lens }` are honored.
- Status dropdown is hidden on the Registration Open tab so the filter doesn't appear to work when the tab forces `status='Active'`.

## Behavior changes worth flagging in review

- The action button no longer surfaces "Register" / "Notify Me" labels or a `registrationUrl` deep link. Reviewers may want to confirm the desired CTA on upcoming events.
- The Registration Status column is always shown; the previous "Status" column for upcoming events is gone (column name unified).

## Protected file touched

- `apps/lfx-one/src/app/app.routes.ts` — adds the `/foundation/events` lazy-loaded route under the foundation lens. Code-owner review required.

## Files changed

- `apps/lfx-one/src/app/app.routes.ts`
- `apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts`
- `apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.{html,scss}`
- `apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.{ts,html}`
- `apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.{ts,html}`
- `apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.{ts,html}`
- `packages/shared/src/interfaces/events.interface.ts`

## Remaining cleanup (tracked on LFXV2-1653)

Follow-up PRs against the same ticket can close these out — they were intentionally left out of this PR:

- `registrationUrl` field cleanup (drop from interface + `my-events` table consumer).
- `finalize()` → `tap()` in `events-list.component.ts:159–184` (pre-existing bug; canceled requests clear the loading flag).
- Optional: consolidate per-tab Snowflake fetches into a counts-or-multi-status endpoint.

## Test plan

- [ ] Navigate to `/foundation/events` while on the foundation lens — page title reads "Foundation Events", subtitle reflects the selected foundation, four stat cards render.
- [ ] Click the **Registration Open** tab — table populates with events whose raw status is `Active`; tab count matches; the Status dropdown is hidden.
- [ ] Confirm Upcoming and Past tabs still load correctly, the Status dropdown reappears, and counts are accurate.
- [ ] Confirm Registration Status column renders in all three tabs and "Attendees" column appears only on Past.
- [ ] Click the action button on an upcoming/registration-open event — opens `event.url` in a new tab. Past events open the same way with "View Recap" label.
- [ ] Sidebar Events item navigates to `/foundation/events`.
- [ ] Lens indicator stays in sync when navigating between `/foundation/projects`, `/foundation/events`, and lens-less routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1653]: https://linuxfoundation.atlassian.net/browse/LFXV2-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ