### PR TITLE
fix(meetings): deduplicate past meeting participants by email

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -662,11 +662,27 @@ export class MeetingService {
 
     const seen = new Map<string, PastMeetingParticipant>();
     for (const participant of raw) {
-      const key = participant.email?.toLowerCase() ?? participant.uid;
+      const normalizedEmail = participant.email?.trim().toLowerCase();
+      const key = normalizedEmail || participant.uid;
       const existing = seen.get(key);
-      if (!existing || (!existing.is_attended && participant.is_attended)) {
+      if (!existing) {
         seen.set(key, participant);
+        continue;
       }
+      const preferred = participant.is_attended && !existing.is_attended ? participant : existing;
+      const other = preferred === participant ? existing : participant;
+      seen.set(key, {
+        ...preferred,
+        is_attended: existing.is_attended || participant.is_attended,
+        is_invited: existing.is_invited || participant.is_invited,
+        host: existing.host || participant.host,
+        org_is_member: existing.org_is_member || participant.org_is_member,
+        org_is_project_member: existing.org_is_project_member || participant.org_is_project_member,
+        avatar_url: preferred.avatar_url ?? other.avatar_url,
+        job_title: preferred.job_title ?? other.job_title,
+        org_name: preferred.org_name ?? other.org_name,
+        username: preferred.username ?? other.username,
+      });
     }
 
     return [...seen.values()];

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -641,9 +641,7 @@ export class MeetingService {
 
   /**
    * Fetches past meeting participants by past meeting UID.
-   * Deduplicates by email (case-insensitive), preferring the attended record when both exist.
-   * The query service can emit multiple records per person (e.g. one for the invitation and one
-   * for the Zoom join event), causing doubled rows on the past-meeting attendee list (LFXV2-1649).
+   * Deduplicates by email — the query service can emit multiple records per person.
    */
   public async getPastMeetingParticipants(req: Request, pastMeetingUid: string): Promise<PastMeetingParticipant[]> {
     logger.debug(req, 'get_past_meeting_participants', 'Fetching past meeting participants', {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -640,7 +640,10 @@ export class MeetingService {
   }
 
   /**
-   * Fetches past meeting participants by past meeting UID
+   * Fetches past meeting participants by past meeting UID.
+   * Deduplicates by email (case-insensitive), preferring the attended record when both exist.
+   * The query service can emit multiple records per person (e.g. one for the invitation and one
+   * for the Zoom join event), causing doubled rows on the past-meeting attendee list (LFXV2-1649).
    */
   public async getPastMeetingParticipants(req: Request, pastMeetingUid: string): Promise<PastMeetingParticipant[]> {
     logger.debug(req, 'get_past_meeting_participants', 'Fetching past meeting participants', {
@@ -652,12 +655,33 @@ export class MeetingService {
       tags: `meeting_and_occurrence_id:${pastMeetingUid}`,
     };
 
-    return fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
+    const raw = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         ...params,
         ...(pageToken && { page_token: pageToken }),
       })
     );
+
+    const seen = new Map<string, PastMeetingParticipant>();
+    for (const participant of raw) {
+      const key = participant.email?.toLowerCase() ?? participant.uid;
+      const existing = seen.get(key);
+      if (!existing || (!existing.is_attended && participant.is_attended)) {
+        seen.set(key, participant);
+      }
+    }
+
+    const deduplicated = [...seen.values()];
+
+    if (deduplicated.length !== raw.length) {
+      logger.warning(req, 'get_past_meeting_participants', 'Deduplicated participant records', {
+        past_meeting_id: pastMeetingUid,
+        raw_count: raw.length,
+        deduplicated_count: deduplicated.length,
+      });
+    }
+
+    return deduplicated;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -669,17 +669,7 @@ export class MeetingService {
       }
     }
 
-    const deduplicated = [...seen.values()];
-
-    if (deduplicated.length !== raw.length) {
-      logger.warning(req, 'get_past_meeting_participants', 'Deduplicated participant records', {
-        past_meeting_id: pastMeetingUid,
-        raw_count: raw.length,
-        deduplicated_count: deduplicated.length,
-      });
-    }
-
-    return deduplicated;
+    return [...seen.values()];
   }
 
   /**


### PR DESCRIPTION
## Summary

- Deduplicates `v1_past_meeting_participant` records by normalised email in `getPastMeetingParticipants()` before returning to the client
- Uses `trim().toLowerCase() || uid` as the dedup key so blank/whitespace emails fall back to `uid` instead of collapsing distinct participants
- Merges boolean status flags (`is_attended`, `is_invited`, `host`, `org_is_member`, `org_is_project_member`) via OR when collapsing duplicates so counts derived downstream remain correct; prefers the attended row for descriptive fields

Fixes https://linuxfoundation.atlassian.net/browse/LFXV2-1649

🤖 Generated with [Claude Code](https://claude.ai/code)