### PR TITLE
fix(meetings): fix repeat_interval sent as string instead of number

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/about-me-form/about-me-form.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/about-me-form/about-me-form.component.html
@@ -176,12 +176,11 @@
         How many nights of accommodation do you need? <span class="text-red-500">*</span>
       </label>
       <div class="flex items-center gap-2">
-        <lfx-input-text
+        <lfx-input-number
           [form]="form"
           control="accommodationNumberOfNights"
           id="about-me-accommodation-nights"
           placeholder="no. of nights"
-          type="number"
           size="small"
           styleClass="w-20"
           dataTest="about-me-accommodation-nights" />

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/about-me-form/about-me-form.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/about-me-form/about-me-form.component.ts
@@ -6,6 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { UserService } from '@app/shared/services/user.service';
 import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
@@ -16,7 +17,7 @@ import { OrgSearchFieldComponent } from '../org-search-field/org-search-field.co
 
 @Component({
   selector: 'lfx-about-me-form',
-  imports: [ReactiveFormsModule, InputTextComponent, SelectComponent, TextareaComponent, CheckboxComponent, OrgSearchFieldComponent],
+  imports: [ReactiveFormsModule, InputNumberComponent, InputTextComponent, SelectComponent, TextareaComponent, CheckboxComponent, OrgSearchFieldComponent],
   templateUrl: './about-me-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-expenses-form/travel-expenses-form.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-expenses-form/travel-expenses-form.component.html
@@ -25,7 +25,7 @@
       </div>
       <div class="flex items-center gap-1">
         <span class="text-sm text-gray-500">$</span>
-        <lfx-input-text [form]="form" control="airfareCost" type="number" size="small" styleClass="w-full" dataTest="expenses-airfare-cost" />
+        <lfx-input-number [form]="form" control="airfareCost" size="small" styleClass="w-full" dataTest="expenses-airfare-cost" />
       </div>
       <lfx-input-text
         [form]="form"
@@ -44,7 +44,7 @@
       </div>
       <div class="flex items-center gap-1">
         <span class="text-sm text-gray-500">$</span>
-        <lfx-input-text [form]="form" control="hotelCost" type="number" size="small" styleClass="w-full" dataTest="expenses-hotel-cost" />
+        <lfx-input-number [form]="form" control="hotelCost" size="small" styleClass="w-full" dataTest="expenses-hotel-cost" />
       </div>
       <lfx-input-text
         [form]="form"
@@ -63,7 +63,7 @@
       </div>
       <div class="flex items-center gap-1">
         <span class="text-sm text-gray-500">$</span>
-        <lfx-input-text [form]="form" control="groundTransportCost" type="number" size="small" styleClass="w-full" dataTest="expenses-ground-transport-cost" />
+        <lfx-input-number [form]="form" control="groundTransportCost" size="small" styleClass="w-full" dataTest="expenses-ground-transport-cost" />
       </div>
       <lfx-input-text
         [form]="form"

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-expenses-form/travel-expenses-form.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-expenses-form/travel-expenses-form.component.ts
@@ -6,13 +6,14 @@ import { ChangeDetectionStrategy, Component, computed, inject, output } from '@a
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { startWith } from 'rxjs';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MessageComponent } from '@components/message/message.component';
 import { TravelFundExpenses } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-travel-expenses-form',
-  imports: [ReactiveFormsModule, InputTextComponent, MessageComponent, CurrencyPipe],
+  imports: [ReactiveFormsModule, InputNumberComponent, InputTextComponent, MessageComponent, CurrencyPipe],
   templateUrl: './travel-expenses-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
@@ -191,14 +191,13 @@
       @if (form().get('duration')?.value === 'custom') {
         <div>
           <label for="custom-duration" class="block text-neutral-950 mb-2"> Custom Duration (minutes) <span class="text-red-500">*</span> </label>
-          <lfx-input-text
+          <lfx-input-number
             [form]="form()"
             control="customDuration"
             id="custom-duration"
             placeholder="Enter minutes (5-480)"
-            type="number"
             styleClass="w-full"
-            data-testid="meeting-details-custom-duration"></lfx-input-text>
+            data-testid="meeting-details-custom-duration"></lfx-input-number>
           @if (form().get('customDuration')?.errors?.['required'] && form().get('customDuration')?.touched) {
             <p class="mt-1 text-sm text-red-600">Custom duration is required</p>
           }
@@ -238,15 +237,14 @@
             tooltipPosition="right"
             tooltipStyleClass="text-xs max-w-xs"></i>
         </label>
-        <lfx-input-text
+        <lfx-input-number
           [form]="form()"
           control="early_join_time_minutes"
           size="small"
           id="early-join-time"
           placeholder="10"
-          type="number"
           styleClass="w-full"
-          data-testid="meeting-details-early-join"></lfx-input-text>
+          data-testid="meeting-details-early-join"></lfx-input-number>
         @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
           <p class="mt-1 text-sm text-red-600">Early join time must be at least 10 minutes</p>
         }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -8,6 +8,7 @@ import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { CalendarComponent } from '@components/calendar/calendar.component';
 import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggle.component';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
@@ -32,6 +33,7 @@ import { MeetingRecurrencePatternComponent } from '../meeting-recurrence-pattern
     ButtonComponent,
     CalendarComponent,
     FeatureToggleComponent,
+    InputNumberComponent,
     InputTextComponent,
     SelectComponent,
     TextareaComponent,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
@@ -17,14 +17,13 @@
       <div class="flex items-center gap-3 flex-wrap">
         <span class="text-sm text-gray-600">Repeat every</span>
 
-        <lfx-input-text
+        <lfx-input-number
           [form]="recurrenceForm()"
           control="repeat_interval"
-          type="number"
           placeholder="1"
           styleClass="w-20"
           data-testid="recurrence-interval-input">
-        </lfx-input-text>
+        </lfx-input-number>
 
         <lfx-select [form]="form()" control="patternTypeUI" [options]="patternTypeOptions" styleClass="min-w-24" data-testid="recurrence-pattern-type-select">
         </lfx-select>
@@ -70,14 +69,13 @@
           @if (monthlyType() === 'dayOfMonth') {
             <div class="flex items-center gap-2 flex-wrap pl-6">
               <span class="text-sm text-gray-600">On day</span>
-              <lfx-input-text
+              <lfx-input-number
                 [form]="recurrenceForm()"
                 control="monthly_day"
-                type="number"
                 placeholder="1"
                 styleClass="w-16"
                 data-testid="recurrence-monthly-day">
-              </lfx-input-text>
+              </lfx-input-number>
               <span class="text-sm text-gray-600">of the month</span>
             </div>
           }
@@ -146,14 +144,13 @@
       @if (endType() === 'occurrences') {
         <div class="flex items-center gap-2 flex-wrap pl-6">
           <span class="text-sm text-gray-600">After</span>
-          <lfx-input-text
+          <lfx-input-number
             [form]="recurrenceForm()"
             control="end_times"
-            type="number"
             placeholder="10"
             styleClass="w-20"
             data-testid="recurrence-end-occurrences">
-          </lfx-input-text>
+          </lfx-input-number>
           <span class="text-sm text-gray-600">occurrence(s)</span>
         </div>
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, DestroyRef, inject, input, OnInit, signal, Signal 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalendarComponent } from '@components/calendar/calendar.component';
-import { InputTextComponent } from '@components/input-text/input-text.component';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
 import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
@@ -19,7 +19,7 @@ import { getWeekOfMonth } from '@lfx-one/shared/utils';
 
 @Component({
   selector: 'lfx-meeting-recurrence-pattern',
-  imports: [ReactiveFormsModule, CalendarComponent, InputTextComponent, RadioButtonComponent, SelectComponent],
+  imports: [ReactiveFormsModule, CalendarComponent, InputNumberComponent, RadioButtonComponent, SelectComponent],
   templateUrl: './meeting-recurrence-pattern.component.html',
 })
 export class MeetingRecurrencePatternComponent implements OnInit {

--- a/apps/lfx-one/src/app/shared/components/input-number/input-number.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-number/input-number.component.html
@@ -7,10 +7,10 @@
       <p-inputicon [class]="icon()" />
       <input
         pInputText
+        type="number"
         [id]="id()"
         [formControlName]="control()"
         [pSize]="size()!"
-        [type]="type()"
         [placeholder]="placeholder()"
         [class]="styleClass()"
         class="w-full"
@@ -20,10 +20,10 @@
   } @else {
     <input
       pInputText
+      type="number"
       [id]="id()"
       [formControlName]="control()"
       [pSize]="size()!"
-      [type]="type()"
       [placeholder]="placeholder()"
       [class]="styleClass()"
       class="w-full"

--- a/apps/lfx-one/src/app/shared/components/input-number/input-number.component.ts
+++ b/apps/lfx-one/src/app/shared/components/input-number/input-number.component.ts
@@ -1,0 +1,26 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+import { Component, input } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { InputTextModule } from 'primeng/inputtext';
+
+@Component({
+  selector: 'lfx-input-number',
+  imports: [InputTextModule, ReactiveFormsModule, IconFieldModule, InputIconModule],
+  templateUrl: './input-number.component.html',
+})
+export class InputNumberComponent {
+  public form = input.required<FormGroup>();
+  public control = input.required<string>();
+  public id = input<string>();
+  public size = input<'large' | 'small'>();
+  public placeholder = input<string>();
+  public autocomplete = input<string>();
+  public dataTest = input<string>();
+  public icon = input<string>();
+  public styleClass = input<string>();
+}

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
@@ -5,6 +5,46 @@
   @if (icon()) {
     <p-iconfield>
       <p-inputicon [class]="icon()" />
+      @if (type() === 'number') {
+        <input
+          pInputText
+          type="number"
+          [id]="id()"
+          [formControlName]="control()"
+          [pSize]="size()!"
+          [placeholder]="placeholder()"
+          [class]="styleClass()"
+          class="w-full"
+          [autocomplete]="autocomplete()"
+          [attr.data-test]="dataTest()" />
+      } @else {
+        <input
+          pInputText
+          [id]="id()"
+          [formControlName]="control()"
+          [pSize]="size()!"
+          [type]="type()"
+          [placeholder]="placeholder()"
+          [class]="styleClass()"
+          class="w-full"
+          [autocomplete]="autocomplete()"
+          [attr.data-test]="dataTest()" />
+      }
+    </p-iconfield>
+  } @else {
+    @if (type() === 'number') {
+      <input
+        pInputText
+        type="number"
+        [id]="id()"
+        [formControlName]="control()"
+        [pSize]="size()!"
+        [placeholder]="placeholder()"
+        [class]="styleClass()"
+        class="w-full"
+        [autocomplete]="autocomplete()"
+        [attr.data-test]="dataTest()" />
+    } @else {
       <input
         pInputText
         [id]="id()"
@@ -16,18 +56,6 @@
         class="w-full"
         [autocomplete]="autocomplete()"
         [attr.data-test]="dataTest()" />
-    </p-iconfield>
-  } @else {
-    <input
-      pInputText
-      [id]="id()"
-      [formControlName]="control()"
-      [pSize]="size()!"
-      [type]="type()"
-      [placeholder]="placeholder()"
-      [class]="styleClass()"
-      class="w-full"
-      [autocomplete]="autocomplete()"
-      [attr.data-test]="dataTest()" />
+    }
   }
 </ng-container>


### PR DESCRIPTION
## Summary

- Add a dedicated `lfx-input-number` component that declares `type=\"number\"` as a static attribute, activating Angular's `NumberValueAccessor` directive so FormControls receive `number` values instead of strings
- Angular's `NumberValueAccessor` selector (`input[type=number][formControlName]`) requires a static attribute — the previous dynamic `[type]` binding on `lfx-input-text` prevented the directive from matching at compile time
- Primary fix: meeting recurrence fields (`repeat_interval`, `monthly_day`, `end_times`) were submitted as strings to the Go service which expects `int`, causing an unmarshal error on bi-weekly (and other custom-schedule) meeting creation
- Silent secondary fix: `normalizeRecurrence` guards with `typeof recurrence.end_times === 'number'` — a string value caused user-selected "end after N occurrences" to silently become infinite recurrence
- Also updates `meeting-details`, `travel-expenses-form`, and `about-me-form` which had the same latent type coercion issue

## Example Request Payload

```json
{"project_uid":"1e225827-<redacted>","title":"LFX Self Serve - Platform Engineering Discussions","description":"Quick sync on LFX Self Serve development, architecture, and platform discussions covering best practices, new services, troubleshooting, etc.","start_time":"2026-05-18T17:00:00.000Z","duration":30,"timezone":"America/Los_Angeles","meeting_type":"Technical","early_join_time_minutes":10,"visibility":"private","restricted":false,"recording_enabled":true,"transcript_enabled":true,"youtube_upload_enabled":false,"show_meeting_attendees":false,"zoom_config":{"ai_companion_enabled":true,"ai_summary_require_approval":false},"artifact_visibility":"meeting_participants","recurrence":{"type":2,"repeat_interval":"2","weekly_days":"2"},"platform":"Zoom","committees":[]}
```

## Example Response

Returns 400 Bad Request error:

```json
{
    "error": "json: cannot unmarshal string into Go struct field RecurrenceRequestBody.recurrence.repeat_interval of type int",
    "code": "BAD_REQUEST",
    "service": "api_client_service",
    "path": "/"
}
```

## Changes

```
 apps/lfx-one/src/app/shared/components/input-number/input-number.component.html  | 33 ++++++++++++++++++++++
 apps/lfx-one/src/app/shared/components/input-number/input-number.component.ts    | 26 +++++++++++++++++
 .../meeting-recurrence-pattern/meeting-recurrence-pattern.component.html          | 15 ++++------
 .../meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts            |  4 +--
 .../meeting-details/meeting-details.component.html                                | 10 +++----
 .../meeting-details/meeting-details.component.ts                                  |  2 ++
 .../travel-expenses-form/travel-expenses-form.component.html                      |  6 ++--
 .../travel-expenses-form/travel-expenses-form.component.ts                        |  3 +-
 .../about-me-form/about-me-form.component.html                                    |  3 +-
 .../about-me-form/about-me-form.component.ts                                      |  3 +-
 10 files changed, 81 insertions(+), 24 deletions(-)
```

Jira: [LFXV2-1688](https://linuxfoundation.atlassian.net/browse/LFXV2-1688)

Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1688]: https://linuxfoundation.atlassian.net/browse/LFXV2-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ