### PR TITLE
feat(dashboards): add org involvement carousel to /org/overview (LFXV2-1674)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.html
@@ -1,0 +1,68 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section data-testid="dashboard-organization-involvement-section">
+  <!-- Title row -->
+  <div class="flex items-center gap-3 mb-3">
+    <div class="flex items-center gap-2 shrink-0">
+      <h2 class="text-base font-medium text-gray-900">{{ accountName() }}'s Involvement</h2>
+      <span class="text-sm text-gray-500">{{ subtitleText() }}</span>
+    </div>
+    <div class="flex-1 border-t border-gray-200 self-center"></div>
+    <!-- Carousel Controls -->
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        (click)="scrollShadowDirective()?.scrollLeft()"
+        class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+        data-testid="dashboard-involvement-scroll-left"
+        aria-label="Scroll left">
+        <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
+      </button>
+      <button
+        type="button"
+        (click)="scrollShadowDirective()?.scrollRight()"
+        class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+        data-testid="dashboard-involvement-scroll-right"
+        aria-label="Scroll right">
+        <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+  <!-- Filter Pills row -->
+  <div class="flex flex-wrap items-center gap-2 mb-4">
+    <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="handleFilterChange($event)"></lfx-filter-pills>
+  </div>
+
+  <div class="relative overflow-hidden">
+    <div lfxScrollShadow class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="dashboard-involvement-carousel">
+      @for (metric of primaryMetrics(); track metric.testId) {
+        <lfx-metric-card
+          [title]="metric.title"
+          [icon]="metric.icon"
+          [testId]="metric.testId"
+          [chartType]="metric.chartType"
+          [chartData]="metric.chartData"
+          [chartOptions]="metric.chartOptions"
+          [value]="metric.value"
+          [subtitle]="metric.subtitle"
+          [loading]="metric.loading"
+          [clickable]="false"></lfx-metric-card>
+      }
+    </div>
+
+    <!-- Right shadow fade -->
+    <div
+      class="absolute top-0 bottom-0 right-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_right,transparent,#f9fafb)] transition-opacity duration-200"
+      [class.opacity-0]="!scrollShadowDirective()?.showRightShadow()"
+      data-testid="dashboard-involvement-shadow-right"
+      aria-hidden="true"></div>
+
+    <!-- Left shadow fade -->
+    <div
+      class="absolute top-0 bottom-0 left-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_left,transparent,#f9fafb)] transition-opacity duration-200"
+      [class.opacity-0]="!scrollShadowDirective()?.showLeftShadow()"
+      data-testid="dashboard-involvement-shadow-left"
+      aria-hidden="true"></div>
+  </div>
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.scss
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+.hide-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari and Opera */
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-overview-involvement/org-overview-involvement.component.ts
@@ -1,0 +1,496 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, signal, viewChild } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { MetricCardComponent } from '@components/metric-card/metric-card.component';
+import { BASE_BAR_CHART_OPTIONS, BASE_LINE_CHART_OPTIONS, lfxColors, ORG_INVOLVEMENT_METRICS } from '@lfx-one/shared/constants';
+import { hexToRgba } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgInvolvementAnalyticsService } from '@services/org-involvement-analytics.service';
+import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
+
+import type {
+  OrgInvolvementCertifiedEmployeesMonthlyResponse,
+  OrgInvolvementContributorsMonthlyResponse,
+  OrgInvolvementEventAttendanceMonthlyResponse,
+  OrgFoundationCoverageResponse,
+  OrgInvolvementMaintainersMonthlyResponse,
+  OrgTrainingEnrollmentsResponse,
+} from '@lfx-one/shared/interfaces/org-involvement.interface';
+import type { DashboardMetricCard, FilterPillOption } from '@lfx-one/shared/interfaces';
+import type { ChartOptions, ChartType } from 'chart.js';
+
+@Component({
+  selector: 'lfx-org-overview-involvement',
+  imports: [
+    FilterPillsComponent,
+    MetricCardComponent,
+    ScrollShadowDirective,
+  ],
+  templateUrl: './org-overview-involvement.component.html',
+  styleUrl: './org-overview-involvement.component.scss',
+})
+export class OrgOverviewInvolvementComponent {
+  public readonly scrollShadowDirective = viewChild(ScrollShadowDirective);
+
+  private readonly analyticsService = inject(OrgInvolvementAnalyticsService);
+  private readonly accountContextService = inject(AccountContextService);
+
+  private readonly maintainersLoading = signal(true);
+  private readonly contributorsLoading = signal(true);
+  private readonly certifiedEmployeesLoading = signal(true);
+  private readonly trainingEnrollmentsLoading = signal(true);
+  private readonly eventsLoading = signal(true);
+  private readonly coverageLoading = signal(true);
+
+  private readonly selectedAccountId$ = toObservable(this.accountContextService.selectedAccount).pipe(map((account) => account.accountId));
+
+  private readonly coverageData = this.initializeCoverageData();
+  private readonly maintainersData = this.initializeMaintainersData();
+  private readonly contributorsData = this.initializeContributorsData();
+  private readonly certifiedEmployeesData = this.initializeCertifiedEmployeesData();
+  private readonly trainingEnrollmentsData = this.initializeTrainingEnrollmentsData();
+  private readonly eventAttendanceMonthlyData = this.initializeEventAttendanceMonthlyData();
+
+  public readonly selectedFilter = signal<string>('all');
+  public readonly accountName = computed<string>(() => this.accountContextService.selectedAccount().accountName || 'Organization');
+
+  public readonly subtitleText = computed<string>(() => {
+    const coverage = this.coverageData();
+    if (this.coverageLoading()) {
+      return '';
+    }
+    return coverage.foundationCount > 0 ? `across ${coverage.foundationCount} LF foundations` : 'No engagement yet';
+  });
+
+  public readonly filterOptions: FilterPillOption[] = [
+    { id: 'all', label: 'All' },
+    { id: 'contributions', label: 'Contribution' },
+    { id: 'events', label: 'Event' },
+    { id: 'education', label: 'Education' },
+  ];
+
+  private readonly activeContributorsCard = this.initializeActiveContributorsCard();
+  private readonly maintainersCard = this.initializeMaintainersCard();
+  private readonly eventAttendeesCard = this.initializeEventAttendeesCard();
+  private readonly eventSpeakersCard = this.initializeEventSpeakersCard();
+  private readonly certifiedEmployeesCard = this.initializeCertifiedEmployeesCard();
+  private readonly trainingEnrollmentsCard = this.initializeTrainingEnrollmentsCard();
+
+  public readonly primaryMetrics = this.initializePrimaryMetrics();
+
+  public handleFilterChange(filter: string): void {
+    this.selectedFilter.set(filter);
+  }
+
+  private getMetricConfig(title: string): DashboardMetricCard {
+    return ORG_INVOLVEMENT_METRICS.find((m) => m.title === title)!;
+  }
+
+  private initializeActiveContributorsCard() {
+    return computed(() => this.transformActiveContributors(this.contributorsData(), this.getMetricConfig('Active Contributors')));
+  }
+
+  private initializeMaintainersCard() {
+    return computed(() => this.transformMaintainers(this.maintainersData(), this.getMetricConfig('Maintainers')));
+  }
+
+  private initializeEventAttendeesCard() {
+    return computed(() => this.transformEventAttendees(this.eventAttendanceMonthlyData(), this.getMetricConfig('Event Attendees')));
+  }
+
+  private initializeEventSpeakersCard() {
+    return computed(() => this.transformEventSpeakers(this.eventAttendanceMonthlyData(), this.getMetricConfig('Event Speakers')));
+  }
+
+  private initializeCertifiedEmployeesCard() {
+    return computed(() => this.transformCertifiedEmployees(this.certifiedEmployeesData(), this.getMetricConfig('Certified Employees')));
+  }
+
+  private initializeTrainingEnrollmentsCard() {
+    return computed(() => this.transformTrainingEnrollments(this.trainingEnrollmentsData(), this.getMetricConfig('Training Enrollments')));
+  }
+
+  private initializePrimaryMetrics() {
+    return computed<DashboardMetricCard[]>(() => {
+      const filter = this.selectedFilter();
+
+      const allCards = [
+        { card: this.activeContributorsCard(), category: 'contributions' },
+        { card: this.maintainersCard(), category: 'contributions' },
+        { card: this.eventAttendeesCard(), category: 'events' },
+        { card: this.eventSpeakersCard(), category: 'events' },
+        { card: this.certifiedEmployeesCard(), category: 'education' },
+        { card: this.trainingEnrollmentsCard(), category: 'education' },
+      ];
+
+      if (filter === 'all') {
+        return allCards.map((item) => item.card);
+      }
+
+      return allCards.filter((item) => item.category === filter).map((item) => item.card);
+    });
+  }
+
+  private initializeCoverageData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.coverageLoading.set(true);
+          return this.analyticsService.getFoundationCoverage(accountId).pipe(
+            tap(() => this.coverageLoading.set(false)),
+            catchError(() => {
+              this.coverageLoading.set(false);
+              return of({ accountId: '', foundationCount: 0, foundations: [] } as OrgFoundationCoverageResponse);
+            })
+          );
+        })
+      ),
+      { initialValue: { accountId: '', foundationCount: 0, foundations: [] } as OrgFoundationCoverageResponse }
+    );
+  }
+
+  private initializeMaintainersData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.maintainersLoading.set(true);
+          return this.analyticsService.getMaintainersMonthly(accountId).pipe(
+            tap(() => this.maintainersLoading.set(false)),
+            catchError(() => {
+              this.maintainersLoading.set(false);
+              return of({
+                accountId: '',
+                accountName: '',
+                totalMaintainersYearly: 0,
+                totalProjectsYearly: 0,
+                monthlyData: [],
+                monthlyLabels: [],
+              } as OrgInvolvementMaintainersMonthlyResponse);
+            })
+          );
+        })
+      ),
+      {
+        initialValue: {
+          accountId: '',
+          accountName: '',
+          totalMaintainersYearly: 0,
+          totalProjectsYearly: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        } as OrgInvolvementMaintainersMonthlyResponse,
+      }
+    );
+  }
+
+  private initializeContributorsData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.contributorsLoading.set(true);
+          return this.analyticsService.getContributorsMonthly(accountId).pipe(
+            tap(() => this.contributorsLoading.set(false)),
+            catchError(() => {
+              this.contributorsLoading.set(false);
+              return of({
+                accountId: '',
+                totalActiveContributors: 0,
+                monthlyData: [],
+                monthlyLabels: [],
+              } as OrgInvolvementContributorsMonthlyResponse);
+            })
+          );
+        })
+      ),
+      {
+        initialValue: {
+          accountId: '',
+          totalActiveContributors: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        } as OrgInvolvementContributorsMonthlyResponse,
+      }
+    );
+  }
+
+  private initializeCertifiedEmployeesData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.certifiedEmployeesLoading.set(true);
+          return this.analyticsService.getCertifiedEmployeesMonthly(accountId).pipe(
+            tap(() => this.certifiedEmployeesLoading.set(false)),
+            catchError(() => {
+              this.certifiedEmployeesLoading.set(false);
+              return of({
+                accountId: '',
+                totalCertifications: 0,
+                totalCertifiedEmployees: 0,
+                monthlyData: [],
+                monthlyLabels: [],
+              } as OrgInvolvementCertifiedEmployeesMonthlyResponse);
+            })
+          );
+        })
+      ),
+      {
+        initialValue: {
+          accountId: '',
+          totalCertifications: 0,
+          totalCertifiedEmployees: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        } as OrgInvolvementCertifiedEmployeesMonthlyResponse,
+      }
+    );
+  }
+
+  private initializeTrainingEnrollmentsData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.trainingEnrollmentsLoading.set(true);
+          return this.analyticsService.getTrainingEnrollments(accountId).pipe(
+            tap(() => this.trainingEnrollmentsLoading.set(false)),
+            catchError(() => {
+              this.trainingEnrollmentsLoading.set(false);
+              return of({ accountId: '', totalEnrollments: 0, dailyData: [] } as OrgTrainingEnrollmentsResponse);
+            })
+          );
+        })
+      ),
+      { initialValue: { accountId: '', totalEnrollments: 0, dailyData: [] } as OrgTrainingEnrollmentsResponse }
+    );
+  }
+
+  private initializeEventAttendanceMonthlyData() {
+    return toSignal(
+      this.selectedAccountId$.pipe(
+        switchMap((accountId) => {
+          this.eventsLoading.set(true);
+          return this.analyticsService.getEventAttendanceMonthly(accountId).pipe(
+            tap(() => this.eventsLoading.set(false)),
+            catchError(() => {
+              this.eventsLoading.set(false);
+              return of({
+                accountId: '',
+                accountName: '',
+                totalAttended: 0,
+                totalSpeakers: 0,
+                attendeesMonthlyData: [],
+                speakersMonthlyData: [],
+                monthlyLabels: [],
+              } as OrgInvolvementEventAttendanceMonthlyResponse);
+            })
+          );
+        })
+      ),
+      {
+        initialValue: {
+          accountId: '',
+          accountName: '',
+          totalAttended: 0,
+          totalSpeakers: 0,
+          attendeesMonthlyData: [],
+          speakersMonthlyData: [],
+          monthlyLabels: [],
+        } as OrgInvolvementEventAttendanceMonthlyResponse,
+      }
+    );
+  }
+
+  private transformActiveContributors(data: OrgInvolvementContributorsMonthlyResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    return {
+      ...metric,
+      loading: this.contributorsLoading(),
+      value: data.totalActiveContributors.toString(),
+      subtitle: 'Employees actively contributing to projects',
+      chartOptions: this.createBarChartOptions('Active contributors'),
+      chartData:
+        data.monthlyData.length > 0
+          ? {
+              labels: data.monthlyLabels,
+              datasets: [
+                {
+                  data: data.monthlyData,
+                  borderColor: lfxColors.blue[500],
+                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.5),
+                  borderWidth: 0,
+                  borderRadius: 4,
+                },
+              ],
+            }
+          : metric.chartData,
+    };
+  }
+
+  private transformMaintainers(data: OrgInvolvementMaintainersMonthlyResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    const projectLabel = data.totalProjectsYearly === 1 ? 'project' : 'projects';
+    return {
+      ...metric,
+      loading: this.maintainersLoading(),
+      value: data.totalMaintainersYearly.toString(),
+      subtitle: `Employees stewarding ${projectLabel} across foundations`,
+      chartOptions: this.createBarChartOptions('Maintainers'),
+      chartData:
+        data.monthlyData.length > 0
+          ? {
+              labels: data.monthlyLabels,
+              datasets: [
+                {
+                  data: data.monthlyData,
+                  borderColor: lfxColors.blue[500],
+                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.5),
+                  borderWidth: 0,
+                  borderRadius: 4,
+                },
+              ],
+            }
+          : metric.chartData,
+    };
+  }
+
+  private transformEventAttendees(data: OrgInvolvementEventAttendanceMonthlyResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    return {
+      ...metric,
+      loading: this.eventsLoading(),
+      value: data.totalAttended.toString(),
+      subtitle: 'Employees at foundation events',
+      chartOptions: this.createLineChartOptions('Event attendees'),
+      chartData:
+        data.attendeesMonthlyData.length > 0
+          ? {
+              labels: data.monthlyLabels,
+              datasets: [
+                {
+                  data: data.attendeesMonthlyData,
+                  borderColor: lfxColors.emerald[500],
+                  backgroundColor: hexToRgba(lfxColors.emerald[500], 0.1),
+                  fill: true,
+                  tension: 0,
+                  borderWidth: 2,
+                  pointRadius: 0,
+                },
+              ],
+            }
+          : metric.chartData,
+    };
+  }
+
+  private transformEventSpeakers(data: OrgInvolvementEventAttendanceMonthlyResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    return {
+      ...metric,
+      loading: this.eventsLoading(),
+      value: data.totalSpeakers.toString(),
+      subtitle: 'Employee speakers at events',
+      chartOptions: this.createLineChartOptions('Event speakers'),
+      chartData:
+        data.speakersMonthlyData.length > 0
+          ? {
+              labels: data.monthlyLabels,
+              datasets: [
+                {
+                  data: data.speakersMonthlyData,
+                  borderColor: lfxColors.amber[500],
+                  backgroundColor: hexToRgba(lfxColors.amber[500], 0.1),
+                  fill: true,
+                  tension: 0,
+                  borderWidth: 2,
+                  pointRadius: 0,
+                },
+              ],
+            }
+          : metric.chartData,
+    };
+  }
+
+  private transformCertifiedEmployees(data: OrgInvolvementCertifiedEmployeesMonthlyResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    return {
+      ...metric,
+      loading: this.certifiedEmployeesLoading(),
+      value: `${data.totalCertifiedEmployees} employees`,
+      subtitle: `${data.totalCertifications} total certifications`,
+      chartOptions: this.createLineChartOptions('Certifications'),
+      chartData:
+        data.monthlyData.length > 0
+          ? {
+              labels: data.monthlyLabels,
+              datasets: [
+                {
+                  data: data.monthlyData,
+                  borderColor: lfxColors.violet[500],
+                  backgroundColor: hexToRgba(lfxColors.violet[500], 0.1),
+                  fill: true,
+                  tension: 0,
+                  borderWidth: 2,
+                  pointRadius: 0,
+                },
+              ],
+            }
+          : metric.chartData,
+    };
+  }
+
+  private transformTrainingEnrollments(data: OrgTrainingEnrollmentsResponse, metric: DashboardMetricCard): DashboardMetricCard {
+    return {
+      ...metric,
+      loading: this.trainingEnrollmentsLoading(),
+      value: data.totalEnrollments.toString(),
+      subtitle: 'Training courses enrolled this year',
+      chartOptions: this.createLineChartOptions('Training enrollments'),
+      chartData: {
+        labels: data.dailyData.map((row) => {
+          const date = new Date(row.date);
+          return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }),
+        datasets: [
+          {
+            data: data.dailyData.map((row) => row.cumulativeCount),
+            borderColor: lfxColors.blue[500],
+            backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+            fill: true,
+            tension: 0,
+            borderWidth: 2,
+            pointRadius: 0,
+          },
+        ],
+      },
+    };
+  }
+
+  private createBarChartOptions(label: string): ChartOptions<ChartType> {
+    return {
+      ...BASE_BAR_CHART_OPTIONS,
+      plugins: {
+        ...BASE_BAR_CHART_OPTIONS.plugins,
+        tooltip: {
+          ...(BASE_BAR_CHART_OPTIONS.plugins?.tooltip ?? {}),
+          callbacks: {
+            title: (context) => context[0]?.label ?? '',
+            label: (context) => `${label}: ${context.parsed.y ?? 0}`,
+          },
+        },
+      },
+    };
+  }
+
+  private createLineChartOptions(label: string): ChartOptions<ChartType> {
+    return {
+      ...BASE_LINE_CHART_OPTIONS,
+      plugins: {
+        ...BASE_LINE_CHART_OPTIONS.plugins,
+        tooltip: {
+          ...(BASE_LINE_CHART_OPTIONS.plugins?.tooltip ?? {}),
+          callbacks: {
+            title: (context) => context[0]?.label ?? '',
+            label: (context) => `${label}: ${context.parsed.y ?? 0}`,
+          },
+        },
+      },
+    };
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.html
@@ -15,8 +15,40 @@
     }
   </header>
 
-  <p class="text-sm text-gray-500">
-    A summary of your organization&rsquo;s engagement, membership, and activity across the Linux Foundation. Detailed sections are being built and
-    will appear here as part of the Org Lens.
-  </p>
+  <!-- Organization Involvement Section -->
+  @defer (on viewport) {
+    <lfx-org-overview-involvement />
+  } @placeholder {
+    <section data-testid="organization-involvement-placeholder">
+      <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
+        <div class="flex flex-col gap-3">
+          <p-skeleton width="14rem" height="1.5rem" />
+          <p-skeleton width="16rem" height="1.5rem" />
+        </div>
+        <div class="flex items-center gap-2">
+          <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+          <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+        </div>
+      </div>
+      <div class="flex gap-4 overflow-hidden">
+        @for (i of [1, 2, 3]; track i) {
+          <div class="p-4 bg-white border border-gray-200 rounded-lg flex-shrink-0 w-[calc(100vw-3rem)] md:w-80">
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-2">
+                <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
+                <p-skeleton width="6rem" height="0.875rem" />
+              </div>
+              <div class="mt-3 w-full h-16">
+                <p-skeleton width="100%" height="100%" borderRadius="8px" />
+              </div>
+              <div class="flex flex-col gap-1 mt-auto">
+                <p-skeleton width="3rem" height="1.75rem" />
+                <p-skeleton width="70%" height="0.75rem" />
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    </section>
+  }
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.ts
@@ -3,11 +3,14 @@
 
 import { Component, computed, inject, Signal } from '@angular/core';
 import { TagComponent } from '@components/tag/tag.component';
+import { SkeletonModule } from 'primeng/skeleton';
 import { AccountContextService } from '@services/account-context.service';
+
+import { OrgOverviewInvolvementComponent } from '../components/org-overview-involvement/org-overview-involvement.component';
 
 @Component({
   selector: 'lfx-org-overview',
-  imports: [TagComponent],
+  imports: [TagComponent, SkeletonModule, OrgOverviewInvolvementComponent],
   templateUrl: './org-overview.component.html',
 })
 export class OrgOverviewComponent {

--- a/apps/lfx-one/src/app/shared/services/org-involvement-analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-involvement-analytics.service.ts
@@ -1,0 +1,104 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { catchError, Observable, of } from 'rxjs';
+
+import type {
+  OrgFoundationCoverageResponse,
+  OrgInvolvementCertifiedEmployeesMonthlyResponse,
+  OrgInvolvementContributorsMonthlyResponse,
+  OrgInvolvementEventAttendanceMonthlyResponse,
+  OrgInvolvementMaintainersMonthlyResponse,
+  OrgTrainingEnrollmentsResponse,
+} from '@lfx-one/shared/interfaces/org-involvement.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgInvolvementAnalyticsService {
+  private readonly http = inject(HttpClient);
+
+  public getFoundationCoverage(accountId: string): Observable<OrgFoundationCoverageResponse> {
+    return this.http.get<OrgFoundationCoverageResponse>('/api/analytics/org-foundation-coverage', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          foundationCount: 0,
+          foundations: [],
+        })
+      )
+    );
+  }
+
+  public getContributorsMonthly(accountId: string): Observable<OrgInvolvementContributorsMonthlyResponse> {
+    return this.http.get<OrgInvolvementContributorsMonthlyResponse>('/api/analytics/org-involvement-contributors-monthly', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          totalActiveContributors: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        })
+      )
+    );
+  }
+
+  public getMaintainersMonthly(accountId: string): Observable<OrgInvolvementMaintainersMonthlyResponse> {
+    return this.http.get<OrgInvolvementMaintainersMonthlyResponse>('/api/analytics/org-involvement-maintainers-monthly', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          accountName: '',
+          totalMaintainersYearly: 0,
+          totalProjectsYearly: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        })
+      )
+    );
+  }
+
+  public getEventAttendanceMonthly(accountId: string): Observable<OrgInvolvementEventAttendanceMonthlyResponse> {
+    return this.http.get<OrgInvolvementEventAttendanceMonthlyResponse>('/api/analytics/org-involvement-event-attendance-monthly', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          accountName: '',
+          totalAttended: 0,
+          totalSpeakers: 0,
+          attendeesMonthlyData: [],
+          speakersMonthlyData: [],
+          monthlyLabels: [],
+        })
+      )
+    );
+  }
+
+  public getCertifiedEmployeesMonthly(accountId: string): Observable<OrgInvolvementCertifiedEmployeesMonthlyResponse> {
+    return this.http.get<OrgInvolvementCertifiedEmployeesMonthlyResponse>('/api/analytics/org-involvement-certified-employees-monthly', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          totalCertifications: 0,
+          totalCertifiedEmployees: 0,
+          monthlyData: [],
+          monthlyLabels: [],
+        })
+      )
+    );
+  }
+
+  public getTrainingEnrollments(accountId: string): Observable<OrgTrainingEnrollmentsResponse> {
+    return this.http.get<OrgTrainingEnrollmentsResponse>('/api/analytics/org-involvement-training-enrollments', { params: { accountId } }).pipe(
+      catchError(() =>
+        of({
+          accountId: '',
+          totalEnrollments: 0,
+          dailyData: [],
+        })
+      )
+    );
+  }
+}

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -6,6 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 import { AuthenticationError, ServiceValidationError } from '../errors';
 import { assertHealthMetricsRange, getStringQueryParam, parseEntityType } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
+import { OrgInvolvementService } from '../services/org-involvement.service';
 import { OrganizationService } from '../services/organization.service';
 import { ProjectService } from '../services/project.service';
 import { UserService } from '../services/user.service';
@@ -24,11 +25,13 @@ const NAME_MAX_LENGTH = 200;
 export class AnalyticsController {
   private readonly userService: UserService;
   private readonly organizationService: OrganizationService;
+  private readonly orgInvolvementService: OrgInvolvementService;
   private readonly projectService: ProjectService;
 
   public constructor() {
     this.userService = new UserService();
     this.organizationService = new OrganizationService();
+    this.orgInvolvementService = new OrgInvolvementService();
     this.projectService = new ProjectService();
   }
 
@@ -1743,6 +1746,196 @@ export class AnalyticsController {
         account_id: accountId,
         foundation_slug: foundationSlug,
         program_count: response.programs.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // Organization Involvement Endpoints (cross-foundation, accountId only)
+
+  /**
+   * GET /api/analytics/org-foundation-coverage
+   * Get foundation coverage for an organization across all LF foundations
+   * Query params: accountId (required)
+   */
+  public async orgFoundationCoverage(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_foundation_coverage');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_foundation_coverage',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getFoundationCoverage(accountId);
+
+      logger.success(req, 'get_org_foundation_coverage', startTime, {
+        account_id: accountId,
+        foundation_count: response.foundationCount,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/org-involvement-contributors-monthly
+   * Get cross-foundation active contributors monthly for an organization
+   * Query params: accountId (required)
+   */
+  public async orgContributorsMonthly(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_involvement_contributors_monthly');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_involvement_contributors_monthly',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getContributorsMonthly(accountId);
+
+      logger.success(req, 'get_org_involvement_contributors_monthly', startTime, {
+        account_id: accountId,
+        total_active_contributors: response.totalActiveContributors,
+        monthly_data_points: response.monthlyData.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/org-involvement-maintainers-monthly
+   * Get cross-foundation maintainers monthly for an organization
+   * Query params: accountId (required)
+   */
+  public async orgMaintainersMonthly(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_involvement_maintainers_monthly');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_involvement_maintainers_monthly',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getMaintainersMonthly(accountId);
+
+      logger.success(req, 'get_org_involvement_maintainers_monthly', startTime, {
+        account_id: accountId,
+        total_maintainers: response.totalMaintainersYearly,
+        total_projects: response.totalProjectsYearly,
+        monthly_data_points: response.monthlyData.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/org-involvement-event-attendance-monthly
+   * Get cross-foundation event attendance monthly for an organization
+   * Query params: accountId (required)
+   */
+  public async orgEventAttendanceMonthly(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_involvement_event_attendance_monthly');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_involvement_event_attendance_monthly',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getEventAttendanceMonthly(accountId);
+
+      logger.success(req, 'get_org_involvement_event_attendance_monthly', startTime, {
+        account_id: accountId,
+        total_attended: response.totalAttended,
+        total_speakers: response.totalSpeakers,
+        monthly_data_points: response.monthlyLabels.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/org-involvement-certified-employees-monthly
+   * Get cross-foundation certified employees monthly for an organization
+   * Query params: accountId (required)
+   */
+  public async orgCertifiedEmployeesMonthly(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_involvement_certified_employees_monthly');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_involvement_certified_employees_monthly',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getCertifiedEmployeesMonthly(accountId);
+
+      logger.success(req, 'get_org_involvement_certified_employees_monthly', startTime, {
+        account_id: accountId,
+        total_certifications: response.totalCertifications,
+        total_certified_employees: response.totalCertifiedEmployees,
+        monthly_data_points: response.monthlyData.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/org-involvement-training-enrollments
+   * Get cross-foundation training enrollments YTD for an organization
+   * Query params: accountId (required)
+   */
+  public async orgTrainingEnrollments(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_involvement_training_enrollments');
+
+    try {
+      const accountId = getStringQueryParam(req, 'accountId');
+
+      if (!accountId) {
+        throw ServiceValidationError.forField('accountId', 'accountId query parameter is required', {
+          operation: 'get_org_involvement_training_enrollments',
+        });
+      }
+
+      const response = await this.orgInvolvementService.getTrainingEnrollments(accountId);
+
+      logger.success(req, 'get_org_involvement_training_enrollments', startTime, {
+        account_id: accountId,
+        total_enrollments: response.totalEnrollments,
+        daily_data_points: response.dailyData.length,
       });
 
       res.json(response);

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -129,6 +129,14 @@ router.get('/org-training-enrollments-distribution', (req, res, next) => analyti
 router.get('/org-certified-employees-monthly', (req, res, next) => analyticsController.getOrgCertifiedEmployeesMonthly(req, res, next));
 router.get('/org-certified-employees-distribution', (req, res, next) => analyticsController.getOrgCertifiedEmployeesDistribution(req, res, next));
 
+// Organization involvement endpoints (cross-foundation, accountId only — org overview page)
+router.get('/org-foundation-coverage', (req, res, next) => analyticsController.orgFoundationCoverage(req, res, next));
+router.get('/org-involvement-contributors-monthly', (req, res, next) => analyticsController.orgContributorsMonthly(req, res, next));
+router.get('/org-involvement-maintainers-monthly', (req, res, next) => analyticsController.orgMaintainersMonthly(req, res, next));
+router.get('/org-involvement-event-attendance-monthly', (req, res, next) => analyticsController.orgEventAttendanceMonthly(req, res, next));
+router.get('/org-involvement-certified-employees-monthly', (req, res, next) => analyticsController.orgCertifiedEmployeesMonthly(req, res, next));
+router.get('/org-involvement-training-enrollments', (req, res, next) => analyticsController.orgTrainingEnrollments(req, res, next));
+
 // Web activities summary endpoint (marketing dashboard)
 router.get('/web-activities-summary', (req, res, next) => analyticsController.getWebActivitiesSummary(req, res, next));
 

--- a/apps/lfx-one/src/server/services/org-involvement.service.ts
+++ b/apps/lfx-one/src/server/services/org-involvement.service.ts
@@ -1,0 +1,282 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  OrgInvolvementCertifiedEmployeesMonthlyResponse,
+  OrgInvolvementContributorsMonthlyResponse,
+  OrgInvolvementEventAttendanceMonthlyResponse,
+  OrgFoundationCoverageResponse,
+  OrgInvolvementMaintainersMonthlyResponse,
+  OrgTrainingEnrollmentsResponse,
+} from '@lfx-one/shared';
+
+import { ResourceNotFoundError } from '../errors';
+import { SnowflakeService } from './snowflake.service';
+
+interface FoundationCoverageRow {
+  ACCOUNT_ID: string;
+  FOUNDATION_ID: string;
+  FOUNDATION_SLUG: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_COUNT: number;
+}
+
+interface ContributorsMonthlyRow {
+  ACCOUNT_ID: string;
+  MONTH_START_DATE: Date;
+  UNIQUE_CONTRIBUTORS: number;
+  CUMULATIVE_CONTRIBUTORS: number;
+  TOTAL_ACTIVE_CONTRIBUTORS: number;
+}
+
+interface MaintainersMonthlyRow {
+  ACCOUNT_ID: string;
+  ACCOUNT_NAME: string;
+  MONTH_START_DATE: Date;
+  ACTIVE_MAINTAINERS: number;
+  ACTIVE_PROJECTS: number;
+  CUMULATIVE_MAINTAINERS: number;
+  TOTAL_MAINTAINERS_YEARLY: number;
+  TOTAL_PROJECTS_YEARLY: number;
+}
+
+interface EventAttendanceMonthlyRow {
+  ACCOUNT_ID: string;
+  ACCOUNT_NAME: string;
+  MONTH_START_DATE: Date;
+  ATTENDED_COUNT: number;
+  SPEAKER_COUNT: number;
+  CUMULATIVE_ATTENDED: number;
+  CUMULATIVE_SPEAKERS: number;
+  TOTAL_ATTENDED: number;
+  TOTAL_SPEAKERS: number;
+}
+
+interface CertifiedEmployeesMonthlyRow {
+  ACCOUNT_ID: string;
+  MONTH_START_DATE: Date;
+  MONTHLY_CERTIFICATIONS: number;
+  MONTHLY_CERTIFIED_EMPLOYEES: number;
+  CUMULATIVE_CERTIFICATIONS: number;
+  TOTAL_CERTIFICATIONS: number;
+  TOTAL_CERTIFIED_EMPLOYEES: number;
+}
+
+interface TrainingEnrollmentRow {
+  ACCOUNT_ID: string;
+  ENROLLMENT_DATE: string;
+  DAILY_COUNT: number;
+  CUMULATIVE_COUNT: number;
+  TOTAL_ENROLLMENTS: number;
+}
+
+/**
+ * Service for cross-foundation organization involvement analytics.
+ * Queries the org_* platinum tables (account-level, no foundation filter).
+ */
+export class OrgInvolvementService {
+  private snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  public async getFoundationCoverage(accountId: string): Promise<OrgFoundationCoverageResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        FOUNDATION_ID,
+        FOUNDATION_SLUG,
+        FOUNDATION_NAME,
+        FOUNDATION_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_FOUNDATION_COVERAGE
+      WHERE ACCOUNT_ID = ?
+      ORDER BY FOUNDATION_NAME ASC
+    `;
+
+    const result = await this.snowflakeService.execute<FoundationCoverageRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
+      throw new ResourceNotFoundError('Foundation coverage data', accountId, {
+        operation: 'get_foundation_coverage',
+      });
+    }
+
+    return {
+      accountId: result.rows[0].ACCOUNT_ID,
+      foundationCount: result.rows[0].FOUNDATION_COUNT || 0,
+      foundations: result.rows.map((row) => ({
+        foundationId: row.FOUNDATION_ID,
+        foundationSlug: row.FOUNDATION_SLUG,
+        foundationName: row.FOUNDATION_NAME,
+      })),
+    };
+  }
+
+  public async getContributorsMonthly(accountId: string): Promise<OrgInvolvementContributorsMonthlyResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        MONTH_START_DATE,
+        UNIQUE_CONTRIBUTORS,
+        CUMULATIVE_CONTRIBUTORS,
+        TOTAL_ACTIVE_CONTRIBUTORS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_CONTRIBUTORS_MONTHLY
+      WHERE ACCOUNT_ID = ?
+      ORDER BY MONTH_START_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<ContributorsMonthlyRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
+      throw new ResourceNotFoundError('Contributors monthly data', accountId, {
+        operation: 'get_contributors_monthly',
+      });
+    }
+
+    const firstRow = result.rows[0];
+
+    return {
+      accountId: firstRow.ACCOUNT_ID,
+      totalActiveContributors: firstRow.TOTAL_ACTIVE_CONTRIBUTORS || 0,
+      monthlyData: result.rows.map((row) => row.UNIQUE_CONTRIBUTORS || 0),
+      monthlyLabels: result.rows.map((row) => row.MONTH_START_DATE.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })),
+    };
+  }
+
+  public async getMaintainersMonthly(accountId: string): Promise<OrgInvolvementMaintainersMonthlyResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        ACCOUNT_NAME,
+        MONTH_START_DATE,
+        ACTIVE_MAINTAINERS,
+        ACTIVE_PROJECTS,
+        CUMULATIVE_MAINTAINERS,
+        TOTAL_MAINTAINERS_YEARLY,
+        TOTAL_PROJECTS_YEARLY
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_MAINTAINERS_MONTHLY
+      WHERE ACCOUNT_ID = ?
+      ORDER BY MONTH_START_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<MaintainersMonthlyRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
+      throw new ResourceNotFoundError('Maintainers monthly data', accountId, {
+        operation: 'get_maintainers_monthly',
+      });
+    }
+
+    const firstRow = result.rows[0];
+
+    return {
+      accountId: firstRow.ACCOUNT_ID,
+      accountName: firstRow.ACCOUNT_NAME,
+      totalMaintainersYearly: firstRow.TOTAL_MAINTAINERS_YEARLY || 0,
+      totalProjectsYearly: firstRow.TOTAL_PROJECTS_YEARLY || 0,
+      monthlyData: result.rows.map((row) => row.ACTIVE_MAINTAINERS || 0),
+      monthlyLabels: result.rows.map((row) => row.MONTH_START_DATE.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })),
+    };
+  }
+
+  public async getEventAttendanceMonthly(accountId: string): Promise<OrgInvolvementEventAttendanceMonthlyResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        ACCOUNT_NAME,
+        MONTH_START_DATE,
+        ATTENDED_COUNT,
+        SPEAKER_COUNT,
+        CUMULATIVE_ATTENDED,
+        CUMULATIVE_SPEAKERS,
+        TOTAL_ATTENDED,
+        TOTAL_SPEAKERS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENT_ATTENDANCE_MONTHLY
+      WHERE ACCOUNT_ID = ?
+      ORDER BY MONTH_START_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<EventAttendanceMonthlyRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
+      throw new ResourceNotFoundError('Event attendance monthly data', accountId, {
+        operation: 'get_event_attendance_monthly',
+      });
+    }
+
+    const firstRow = result.rows[0];
+
+    return {
+      accountId: firstRow.ACCOUNT_ID,
+      accountName: firstRow.ACCOUNT_NAME,
+      totalAttended: firstRow.TOTAL_ATTENDED || 0,
+      totalSpeakers: firstRow.TOTAL_SPEAKERS || 0,
+      attendeesMonthlyData: result.rows.map((row) => row.ATTENDED_COUNT || 0),
+      speakersMonthlyData: result.rows.map((row) => row.SPEAKER_COUNT || 0),
+      monthlyLabels: result.rows.map((row) => row.MONTH_START_DATE.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })),
+    };
+  }
+
+  public async getCertifiedEmployeesMonthly(accountId: string): Promise<OrgInvolvementCertifiedEmployeesMonthlyResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        MONTH_START_DATE,
+        MONTHLY_CERTIFICATIONS,
+        MONTHLY_CERTIFIED_EMPLOYEES,
+        CUMULATIVE_CERTIFICATIONS,
+        TOTAL_CERTIFICATIONS,
+        TOTAL_CERTIFIED_EMPLOYEES
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_CERTIFIED_EMPLOYEES_MONTHLY
+      WHERE ACCOUNT_ID = ?
+      ORDER BY MONTH_START_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<CertifiedEmployeesMonthlyRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
+      throw new ResourceNotFoundError('Certified employees monthly data', accountId, {
+        operation: 'get_certified_employees_monthly',
+      });
+    }
+
+    const firstRow = result.rows[0];
+
+    return {
+      accountId: firstRow.ACCOUNT_ID,
+      totalCertifications: firstRow.TOTAL_CERTIFICATIONS || 0,
+      totalCertifiedEmployees: firstRow.TOTAL_CERTIFIED_EMPLOYEES || 0,
+      monthlyData: result.rows.map((row) => row.MONTHLY_CERTIFICATIONS || 0),
+      monthlyLabels: result.rows.map((row) => row.MONTH_START_DATE.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })),
+    };
+  }
+
+  public async getTrainingEnrollments(accountId: string): Promise<OrgTrainingEnrollmentsResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        ENROLLMENT_DATE,
+        DAILY_COUNT,
+        CUMULATIVE_COUNT,
+        TOTAL_ENROLLMENTS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_TRAINING_ENROLLMENTS
+      WHERE ACCOUNT_ID = ?
+      ORDER BY ENROLLMENT_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<TrainingEnrollmentRow>(query, [accountId]);
+
+    const totalEnrollments = result.rows.length > 0 ? result.rows[result.rows.length - 1].TOTAL_ENROLLMENTS || 0 : 0;
+
+    return {
+      accountId,
+      totalEnrollments,
+      dailyData: result.rows.map((row) => ({
+        date: row.ENROLLMENT_DATE,
+        count: row.DAILY_COUNT,
+        cumulativeCount: row.CUMULATIVE_COUNT,
+      })),
+    };
+  }
+}

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -319,6 +319,59 @@ export const PRIMARY_INVOLVEMENT_METRICS: DashboardMetricCard[] = [
 ];
 
 // ============================================
+// Org Overview Involvement Metrics (cross-foundation, non-clickable)
+// ============================================
+
+/**
+ * Engagement card configuration for the /org/overview involvement section.
+ * 6 cards aggregated across all LF foundations. Cards are NOT clickable — no drawerType.
+ */
+export const ORG_INVOLVEMENT_METRICS: DashboardMetricCard[] = [
+  {
+    title: 'Active Contributors',
+    icon: 'fa-light fa-code',
+    chartType: 'bar',
+    category: 'contributors',
+    testId: 'org-overview-involvement-card-active-contributors',
+  },
+  {
+    title: 'Maintainers',
+    icon: 'fa-light fa-user-check',
+    chartType: 'bar',
+    category: 'contributors',
+    testId: 'org-overview-involvement-card-maintainers',
+  },
+  {
+    title: 'Event Attendees',
+    icon: 'fa-light fa-user-group',
+    chartType: 'line',
+    category: 'events',
+    testId: 'org-overview-involvement-card-event-attendees',
+  },
+  {
+    title: 'Event Speakers',
+    icon: 'fa-light fa-award-simple',
+    chartType: 'line',
+    category: 'events',
+    testId: 'org-overview-involvement-card-event-speakers',
+  },
+  {
+    title: 'Certified Employees',
+    icon: 'fa-light fa-graduation-cap',
+    chartType: 'line',
+    category: 'education',
+    testId: 'org-overview-involvement-card-certified-employees',
+  },
+  {
+    title: 'Training Enrollments',
+    icon: 'fa-light fa-graduation-cap',
+    chartType: 'line',
+    category: 'education',
+    testId: 'org-overview-involvement-card-training-enrollments',
+  },
+];
+
+// ============================================
 // Marketing Overview Metrics (Executive Director)
 // ============================================
 

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -144,3 +144,6 @@ export * from './supabase.interface';
 
 // Stat card interfaces
 export * from './stat-card.interface';
+
+// Org involvement interfaces (cross-foundation org overview)
+export * from './org-involvement.interface';

--- a/packages/shared/src/interfaces/org-involvement.interface.ts
+++ b/packages/shared/src/interfaces/org-involvement.interface.ts
@@ -1,0 +1,90 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Foundation entry in the org foundation coverage response
+ */
+export interface OrgFoundationCoverageFoundation {
+  foundationId: string;
+  foundationSlug: string;
+  foundationName: string;
+}
+
+/**
+ * GET /api/analytics/org-foundation-coverage
+ * How many LF foundations this organization is involved in
+ */
+export interface OrgFoundationCoverageResponse {
+  accountId: string;
+  foundationCount: number;
+  foundations: OrgFoundationCoverageFoundation[];
+}
+
+/**
+ * GET /api/analytics/org-contributors-monthly
+ * Cross-foundation active contributors aggregated monthly (12-month window)
+ */
+export interface OrgInvolvementContributorsMonthlyResponse {
+  accountId: string;
+  totalActiveContributors: number;
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * GET /api/analytics/org-maintainers-monthly
+ * Cross-foundation maintainers aggregated monthly (12-month window)
+ */
+export interface OrgInvolvementMaintainersMonthlyResponse {
+  accountId: string;
+  accountName: string;
+  totalMaintainersYearly: number;
+  totalProjectsYearly: number;
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * GET /api/analytics/org-event-attendance-monthly
+ * Cross-foundation event attendance aggregated monthly (12-month window)
+ */
+export interface OrgInvolvementEventAttendanceMonthlyResponse {
+  accountId: string;
+  accountName: string;
+  totalAttended: number;
+  totalSpeakers: number;
+  attendeesMonthlyData: number[];
+  speakersMonthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * GET /api/analytics/org-certified-employees-monthly
+ * Cross-foundation certified employees aggregated monthly (12-month window)
+ */
+export interface OrgInvolvementCertifiedEmployeesMonthlyResponse {
+  accountId: string;
+  totalCertifications: number;
+  totalCertifiedEmployees: number;
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * Daily data point for training enrollments
+ */
+export interface OrgTrainingEnrollmentDailyDataPoint {
+  date: string;
+  count: number;
+  cumulativeCount: number;
+}
+
+/**
+ * GET /api/analytics/org-training-enrollments
+ * Cross-foundation training enrollments YTD (daily grain)
+ */
+export interface OrgTrainingEnrollmentsResponse {
+  accountId: string;
+  totalEnrollments: number;
+  dailyData: OrgTrainingEnrollmentDailyDataPoint[];
+}


### PR DESCRIPTION
## Summary

- Add a cross-foundation involvement carousel to `/org/overview` showing 6 read-only engagement metric cards
- Cards aggregate across **all LF foundations** per `account_id` (no foundation picker needed)
- Cards are **not clickable** (no drill-down drawers) — Membership Tier is excluded (surfaced via page header tier badge)

## Changes

### Shared Types (`packages/shared/`)
- `org-involvement.interface.ts` — 7 response interfaces for 6 API endpoints
- `dashboard-metrics.constants.ts` — `ORG_INVOLVEMENT_METRICS` constant (6 cards, no `drawerType`)
- `interfaces/index.ts` — barrel export

### Backend (`apps/lfx-one/src/server/`)
- `org-involvement.service.ts` — 6 Snowflake query methods (accountId only, no foundationSlug)
- `analytics.controller.ts` — 6 new controller methods with validation + structured logging
- `analytics.route.ts` — 6 new `org-involvement-*` routes (prefixed to avoid collision with existing per-foundation `org-*` drill-down routes)

### Frontend (`apps/lfx-one/src/app/`)
- `org-involvement-analytics.service.ts` — 6 HTTP methods with `catchError` zeroed fallbacks
- `org-overview-involvement.component.ts/html/scss` — Signal-based component, `switchMap` on `accountContextService.selectedAccount`, all 6 cards via `<lfx-metric-card [clickable]="false">`, filter pills (All/Contribution/Event/Education), scroll shadow + arrows, no Data Copilot button
- `org-overview.component.ts/html` — Mount via `@defer (on viewport)` with skeleton placeholder

## Validation

- `yarn check-types`: PASS
- `yarn lint:check`: PASS (1 pre-existing error in `account-context.service.ts` from conglomerate PR — not introduced here)
- `yarn build`: PASS (28.9s)
- E2E tests: 6/6 PASS (section rendering, filter pills, scroll controls, API URL alignment, error resilience, page header)

## Dependency

Requires [lf-dbt#2390](https://github.com/linuxfoundation/lf-dbt/pull/2390) to be merged and deployed for the Snowflake platinum tables to exist. Until then, APIs return 500 (table not found) and the carousel shows zeroed cards — this is the expected pre-deploy behavior per FR-006/FR-022.

## Test plan

- [ ] Navigate to `/org/overview` → 6 engagement cards render below the header
- [ ] Switch organization in sidebar → all 6 cards refresh
- [ ] Click filter pills → carousel reflows (All=6, Contribution=2, Event=2, Education=2)
- [ ] Verify cards are NOT clickable (no drawer opens)
- [ ] Verify no Membership Tier card and no Ask LFX Lens button
- [ ] Verify board-member and ED dashboards still work (regression)

Resolves [LFXV2-1674](https://linuxfoundation.atlassian.net/browse/LFXV2-1674)

Made with [Cursor](https://cursor.com)

[LFXV2-1674]: https://linuxfoundation.atlassian.net/browse/LFXV2-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ