### PR TITLE
feat(votes): add proxy endpoint for submitting vote responses

### DIFF
--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -284,18 +284,36 @@ export class VoteController {
         });
       }
 
-      if (!payload.abstain && (!Array.isArray(payload.user_vote_content) || payload.user_vote_content.length === 0)) {
-        throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        });
-      }
+      if (payload.abstain) {
+        payload.user_vote_content = undefined;
+      } else {
+        if (!Array.isArray(payload.user_vote_content) || payload.user_vote_content.length === 0) {
+          throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', {
+            operation: 'create_vote_response',
+            service: 'vote_controller',
+          });
+        }
 
-      if (payload.abstain && payload.user_vote_content !== undefined) {
-        throw ServiceValidationError.forField('user_vote_content', 'user_vote_content must not be provided when abstaining', {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        });
+        for (const [index, answer] of payload.user_vote_content.entries()) {
+          if (!answer.question_id || typeof answer.question_id !== 'string') {
+            throw ServiceValidationError.forField(
+              `user_vote_content[${index}].question_id`,
+              'question_id is required for each answer',
+              { operation: 'create_vote_response', service: 'vote_controller' }
+            );
+          }
+
+          const hasChoiceIds = Array.isArray(answer.choice_ids) && answer.choice_ids.length > 0;
+          const hasRankedChoices = Array.isArray(answer.ranked_choices) && answer.ranked_choices.length > 0;
+
+          if (!hasChoiceIds && !hasRankedChoices) {
+            throw ServiceValidationError.forField(
+              `user_vote_content[${index}]`,
+              'Each answer must include either choice_ids or ranked_choices',
+              { operation: 'create_vote_response', service: 'vote_controller' }
+            );
+          }
+        }
       }
 
       await this.voteService.createVoteResponse(req, payload);

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -291,6 +291,13 @@ export class VoteController {
         });
       }
 
+      if (payload.abstain && Array.isArray(payload.user_vote_content) && payload.user_vote_content.length > 0) {
+        throw ServiceValidationError.forField('user_vote_content', 'user_vote_content must not be provided when abstaining', {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+        });
+      }
+
       await this.voteService.createVoteResponse(req, payload);
 
       logger.success(req, 'create_vote_response', startTime, {

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -266,8 +266,16 @@ export class VoteController {
         throw ServiceValidationError.forField('abstain', 'abstain is required and must be a boolean', validationContext);
       }
 
+      // Build the upstream payload immutably: when abstaining we drop user_vote_content entirely;
+      // when not abstaining we validate each answer and forward the original content.
+      let upstreamPayload: CreateVoteResponseRequest;
+
       if (payload.abstain) {
-        payload.user_vote_content = undefined;
+        upstreamPayload = {
+          vote_uid: payload.vote_uid,
+          vote_response_uid: payload.vote_response_uid,
+          abstain: true,
+        };
       } else {
         if (!Array.isArray(payload.user_vote_content) || payload.user_vote_content.length === 0) {
           throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', validationContext);
@@ -293,14 +301,16 @@ export class VoteController {
             );
           }
         }
+
+        upstreamPayload = payload;
       }
 
-      await this.voteService.createVoteResponse(req, payload);
+      await this.voteService.createVoteResponse(req, upstreamPayload);
 
       logger.success(req, 'create_vote_response', startTime, {
-        vote_uid: payload.vote_uid,
-        vote_response_uid: payload.vote_response_uid,
-        abstain: payload.abstain,
+        vote_uid: upstreamPayload.vote_uid,
+        vote_response_uid: upstreamPayload.vote_response_uid,
+        abstain: upstreamPayload.abstain,
         status_code: 204,
       });
 

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -5,7 +5,7 @@ import { CreateVoteRequest, CreateVoteResponseRequest, UpdateVoteRequest } from 
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
-import { validateRequestBody, validateUidParameter } from '../helpers/validation.helper';
+import { validateRequestBody, validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { VoteService } from '../services/vote.service';
 
@@ -258,20 +258,18 @@ export class VoteController {
       }
 
       if (
-        !validateUidParameter(payload.vote_uid, req, next, {
+        !validateRequiredParameter(payload.vote_uid, 'vote_uid', req, next, {
           operation: 'create_vote_response',
           service: 'vote_controller',
-          fieldName: 'vote_uid',
         })
       ) {
         return;
       }
 
       if (
-        !validateUidParameter(payload.vote_response_uid, req, next, {
+        !validateRequiredParameter(payload.vote_response_uid, 'vote_response_uid', req, next, {
           operation: 'create_vote_response',
           service: 'vote_controller',
-          fieldName: 'vote_response_uid',
         })
       ) {
         return;

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -248,56 +248,45 @@ export class VoteController {
     });
 
     try {
-      if (
-        !validateRequestBody(payload, req, next, {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        })
-      ) {
+      const validationContext = { operation: 'create_vote_response', service: 'vote_controller' } as const;
+
+      if (!validateRequestBody(payload, req, next, validationContext)) {
         return;
       }
 
-      if (
-        !validateRequiredParameter(payload.vote_uid, 'vote_uid', req, next, {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        })
-      ) {
+      if (!validateRequiredParameter(payload.vote_uid, 'vote_uid', req, next, validationContext)) {
         return;
       }
 
-      if (
-        !validateRequiredParameter(payload.vote_response_uid, 'vote_response_uid', req, next, {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        })
-      ) {
+      if (!validateRequiredParameter(payload.vote_response_uid, 'vote_response_uid', req, next, validationContext)) {
         return;
       }
 
       if (typeof payload.abstain !== 'boolean') {
-        throw ServiceValidationError.forField('abstain', 'abstain is required and must be a boolean', {
-          operation: 'create_vote_response',
-          service: 'vote_controller',
-        });
+        throw ServiceValidationError.forField('abstain', 'abstain is required and must be a boolean', validationContext);
       }
 
       if (payload.abstain) {
         payload.user_vote_content = undefined;
       } else {
         if (!Array.isArray(payload.user_vote_content) || payload.user_vote_content.length === 0) {
-          throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', {
-            operation: 'create_vote_response',
-            service: 'vote_controller',
-          });
+          throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', validationContext);
         }
 
         for (const [index, answer] of payload.user_vote_content.entries()) {
+          if (!answer || typeof answer !== 'object') {
+            throw ServiceValidationError.forField(
+              `user_vote_content[${index}]`,
+              'Each answer must be a non-null object',
+              validationContext
+            );
+          }
+
           if (!answer.question_id || typeof answer.question_id !== 'string') {
             throw ServiceValidationError.forField(
               `user_vote_content[${index}].question_id`,
               'question_id is required for each answer',
-              { operation: 'create_vote_response', service: 'vote_controller' }
+              validationContext
             );
           }
 
@@ -308,7 +297,7 @@ export class VoteController {
             throw ServiceValidationError.forField(
               `user_vote_content[${index}]`,
               'Each answer must include either choice_ids or ranked_choices',
-              { operation: 'create_vote_response', service: 'vote_controller' }
+              validationContext
             );
           }
         }

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -291,7 +291,7 @@ export class VoteController {
         });
       }
 
-      if (payload.abstain && Array.isArray(payload.user_vote_content) && payload.user_vote_content.length > 0) {
+      if (payload.abstain && payload.user_vote_content !== undefined) {
         throw ServiceValidationError.forField('user_vote_content', 'user_vote_content must not be provided when abstaining', {
           operation: 'create_vote_response',
           service: 'vote_controller',

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -1,10 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CreateVoteRequest, UpdateVoteRequest } from '@lfx-one/shared/interfaces';
+import { CreateVoteRequest, CreateVoteResponseRequest, UpdateVoteRequest } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { validateUidParameter } from '../helpers/validation.helper';
+import { ServiceValidationError } from '../errors';
+import { validateRequestBody, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { VoteService } from '../services/vote.service';
 
@@ -230,6 +231,76 @@ export class VoteController {
       });
 
       res.json(results);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /votes/responses
+   */
+  public async createVoteResponse(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const payload: CreateVoteResponseRequest = req.body;
+    const startTime = logger.startOperation(req, 'create_vote_response', {
+      vote_uid: payload?.vote_uid,
+      vote_response_uid: payload?.vote_response_uid,
+      abstain: payload?.abstain,
+    });
+
+    try {
+      if (
+        !validateRequestBody(payload, req, next, {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+        })
+      ) {
+        return;
+      }
+
+      if (
+        !validateUidParameter(payload.vote_uid, req, next, {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+          fieldName: 'vote_uid',
+        })
+      ) {
+        return;
+      }
+
+      if (
+        !validateUidParameter(payload.vote_response_uid, req, next, {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+          fieldName: 'vote_response_uid',
+        })
+      ) {
+        return;
+      }
+
+      if (typeof payload.abstain !== 'boolean') {
+        throw ServiceValidationError.forField('abstain', 'abstain is required and must be a boolean', {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+        });
+      }
+
+      if (!payload.abstain && (!Array.isArray(payload.user_vote_content) || payload.user_vote_content.length === 0)) {
+        throw ServiceValidationError.forField('user_vote_content', 'user_vote_content is required when not abstaining', {
+          operation: 'create_vote_response',
+          service: 'vote_controller',
+        });
+      }
+
+      await this.voteService.createVoteResponse(req, payload);
+
+      logger.success(req, 'create_vote_response', startTime, {
+        vote_uid: payload.vote_uid,
+        vote_response_uid: payload.vote_response_uid,
+        abstain: payload.abstain,
+        status_code: 204,
+      });
+
+      res.status(204).send();
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -275,19 +275,11 @@ export class VoteController {
 
         for (const [index, answer] of payload.user_vote_content.entries()) {
           if (!answer || typeof answer !== 'object') {
-            throw ServiceValidationError.forField(
-              `user_vote_content[${index}]`,
-              'Each answer must be a non-null object',
-              validationContext
-            );
+            throw ServiceValidationError.forField(`user_vote_content[${index}]`, 'Each answer must be a non-null object', validationContext);
           }
 
           if (!answer.question_id || typeof answer.question_id !== 'string') {
-            throw ServiceValidationError.forField(
-              `user_vote_content[${index}].question_id`,
-              'question_id is required for each answer',
-              validationContext
-            );
+            throw ServiceValidationError.forField(`user_vote_content[${index}].question_id`, 'question_id is required for each answer', validationContext);
           }
 
           const hasChoiceIds = Array.isArray(answer.choice_ids) && answer.choice_ids.length > 0;

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -34,8 +34,8 @@ interface ValidationOptions {
  *   multiple UIDs in the same request to disambiguate the validation error)
  * @returns true if validation passes, false if validation fails (error sent to next)
  */
-export function validateUidParameter(uid: string | undefined, req: Request, next: NextFunction, options: ValidationOptions): uid is string {
-  if (!uid || uid.trim() === '') {
+export function validateUidParameter(uid: unknown, req: Request, next: NextFunction, options: ValidationOptions): uid is string {
+  if (typeof uid !== 'string' || uid.trim() === '') {
     const fieldName = options.fieldName ?? 'uid';
     const message = options.fieldName ? `${fieldName} is required` : 'UID is required';
     const validationError = ServiceValidationError.forField(fieldName, message, {

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -21,24 +21,15 @@ import type { HealthMetricsRange } from '@lfx-one/shared/interfaces';
 interface ValidationOptions {
   operation: string;
   service?: string;
-  fieldName?: string;
 }
 
 /**
- * Validates that a UID parameter exists and is not empty
- * @param uid The UID value to validate
- * @param req Express request object
- * @param next Express next function for error handling
- * @param options Validation options including operation name and optional fieldName
- *   (defaults to 'uid'; pass a specific name like 'vote_uid' when validating
- *   multiple UIDs in the same request to disambiguate the validation error)
- * @returns true if validation passes, false if validation fails (error sent to next)
+ * Validates that a UID route parameter exists and is not empty.
+ * For validating named body/query fields, use validateRequiredParameter instead.
  */
 export function validateUidParameter(uid: unknown, req: Request, next: NextFunction, options: ValidationOptions): uid is string {
   if (typeof uid !== 'string' || uid.trim() === '') {
-    const fieldName = options.fieldName ?? 'uid';
-    const message = options.fieldName ? `${fieldName} is required` : 'UID is required';
-    const validationError = ServiceValidationError.forField(fieldName, message, {
+    const validationError = ServiceValidationError.forField('uid', 'UID is required', {
       operation: options.operation,
       service: options.service || 'controller',
       path: req.path,

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -21,6 +21,7 @@ import type { HealthMetricsRange } from '@lfx-one/shared/interfaces';
 interface ValidationOptions {
   operation: string;
   service?: string;
+  fieldName?: string;
 }
 
 /**
@@ -28,12 +29,16 @@ interface ValidationOptions {
  * @param uid The UID value to validate
  * @param req Express request object
  * @param next Express next function for error handling
- * @param options Validation options including operation name
+ * @param options Validation options including operation name and optional fieldName
+ *   (defaults to 'uid'; pass a specific name like 'vote_uid' when validating
+ *   multiple UIDs in the same request to disambiguate the validation error)
  * @returns true if validation passes, false if validation fails (error sent to next)
  */
 export function validateUidParameter(uid: string | undefined, req: Request, next: NextFunction, options: ValidationOptions): uid is string {
   if (!uid || uid.trim() === '') {
-    const validationError = ServiceValidationError.forField('uid', 'UID is required', {
+    const fieldName = options.fieldName ?? 'uid';
+    const message = options.fieldName ? `${fieldName} is required` : 'UID is required';
+    const validationError = ServiceValidationError.forField(fieldName, message, {
       operation: options.operation,
       service: options.service || 'controller',
       path: req.path,

--- a/apps/lfx-one/src/server/routes/votes.route.ts
+++ b/apps/lfx-one/src/server/routes/votes.route.ts
@@ -18,6 +18,11 @@ router.get('/count', (req, res, next) => voteController.getVotesCount(req, res, 
 // GET /votes/my-votes - get votes the current user has been invited to
 router.get('/my-votes', (req, res, next) => voteController.getMyVotes(req, res, next));
 
+// POST /votes/responses - submit a vote response (ballot)
+// Note: literal-segment routes must precede '/:uid' handlers so Express
+// doesn't accidentally match 'responses' as a uid for any future POST /:uid/* route.
+router.post('/responses', (req, res, next) => voteController.createVoteResponse(req, res, next));
+
 // GET /votes/:uid/results - get vote results
 router.get('/:uid/results', (req, res, next) => voteController.getVoteResults(req, res, next));
 

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1103,13 +1103,13 @@ export class UserService {
       { failOnPartial: true }
     );
 
-    // `vote_uid` is the v2 parent poll UID (what `/votes/{uid}` expects); `poll_id` is the v1
-    // fallback per the upstream indexer contract. Neither is the individual-response id.
+    // `vote_uid` is the v2 parent poll UID (what `/votes/{uid}` expects); `vote_id` and `poll_id`
+    // are v1 fallbacks per the upstream indexer contract. None of these is the individual-response id.
     const pendingVoteUids = Array.from(
       new Set(
         responses
           .filter((r) => r.vote_status !== 'submitted' && !r.voter_removed)
-          .map((r) => r.vote_uid ?? r.poll_id)
+          .map((r) => r.vote_uid ?? r.vote_id ?? r.poll_id)
           .filter((uid): uid is string => !!uid)
       )
     );

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -14,6 +14,7 @@ import {
   ActiveWeeksStreakResponse,
   ActiveWeeksStreakRow,
   ApiGatewayUserProfile,
+  IndexedVoteResponse,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
@@ -1088,21 +1089,12 @@ export class UserService {
    * `end_time`, and `status` — everything the `transformVotesToActions` consumer needs.
    */
   private async fetchPendingVotes(req: Request, projectUid?: string): Promise<Vote[]> {
-    interface VoteResponseRow {
-      vote_uid?: string;
-      vote_id?: string;
-      poll_id?: string;
-      project_uid?: string;
-      vote_status?: string;
-      voter_removed?: boolean;
-    }
-
     // failOnPartial: completeness matters — a truncated response can silently miss a pending
     // invitation. The caller already catches and degrades, so fail closed here.
-    const responses = await fetchAllQueryResources<VoteResponseRow>(
+    const responses = await fetchAllQueryResources<IndexedVoteResponse>(
       req,
       (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<VoteResponseRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVoteResponse>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote_response',
           filter_grants: 'direct',
           ...(projectUid && { filters: [`project_uid:${projectUid}`] }),

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -264,7 +264,7 @@ export class VoteService {
       ['X-Sync']: 'true',
     });
 
-    logger.info(req, 'create_vote_response', 'Ballot accepted by upstream voting service', {
+    logger.debug(req, 'create_vote_response', 'Ballot accepted by upstream voting service, polling query service', {
       vote_uid: payload.vote_uid,
       vote_response_uid: payload.vote_response_uid,
     });

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -3,7 +3,9 @@
 
 import {
   CreateVoteRequest,
+  CreateVoteResponseRequest,
   IndexedVote,
+  IndexedVoteResponse,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateVoteRequest,
@@ -244,6 +246,50 @@ export class VoteService {
     });
 
     return results;
+  }
+
+  /**
+   * Submits a ballot via POST /vote_responses using the user's bearer token (no M2M),
+   * then polls until the query service indexes the response as 'submitted'.
+   */
+  public async createVoteResponse(req: Request, payload: CreateVoteResponseRequest): Promise<void> {
+    logger.debug(req, 'create_vote_response', 'Submitting vote response', {
+      vote_uid: payload.vote_uid,
+      vote_response_uid: payload.vote_response_uid,
+      abstain: payload.abstain,
+      answer_count: payload.user_vote_content?.length ?? 0,
+    });
+
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', '/vote_responses', 'POST', undefined, payload);
+
+    const resolved = await pollEndpoint({
+      req,
+      operation: 'create_vote_response_poll',
+      pollFn: async () => {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVoteResponse>>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          {
+            type: 'vote_response',
+            filter_grants: 'direct',
+            filters: [`vote_uid:${payload.vote_uid}`],
+          }
+        );
+        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === 'submitted');
+      },
+      maxRetries: 5,
+      retryDelayMs: 1000,
+      metadata: { vote_uid: payload.vote_uid, vote_response_uid: payload.vote_response_uid },
+    });
+
+    if (!resolved) {
+      logger.warning(req, 'create_vote_response', 'Vote response not yet indexed, client may see stale state', {
+        vote_uid: payload.vote_uid,
+        vote_response_uid: payload.vote_response_uid,
+      });
+    }
   }
 
   // ============================================

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -260,7 +260,14 @@ export class VoteService {
       answer_count: payload.user_vote_content?.length ?? 0,
     });
 
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', '/vote_responses', 'POST', undefined, payload);
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', '/vote_responses', 'POST', undefined, payload, {
+      ['X-Sync']: 'true',
+    });
+
+    logger.info(req, 'create_vote_response', 'Ballot accepted by upstream voting service', {
+      vote_uid: payload.vote_uid,
+      vote_response_uid: payload.vote_response_uid,
+    });
 
     const resolved = await pollEndpoint({
       req,

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -228,6 +228,29 @@ export interface IndexedVote extends Omit<Vote, 'uid'> {
 }
 
 /**
+ * Vote response row from the query service indexer (`lfx.index.vote_response`).
+ * Tagged by `vote_uid` (not `vote_response_uid`); use `filter_grants=direct` to
+ * scope to the current user's rows. `vote_status` is `string` — the indexer's
+ * vocabulary is broader than the UI enums.
+ */
+export interface IndexedVoteResponse {
+  /** Vote response (ballot) identifier — the row's own primary key */
+  uid?: string;
+  /** Parent poll identifier (v2). Indexer tag key. */
+  vote_uid?: string;
+  /** V1 fallback for the parent poll identifier */
+  vote_id?: string;
+  /** V1 alias for `vote_id` carried by older indexer versions */
+  poll_id?: string;
+  /** V2 project UID the response belongs to */
+  project_uid?: string;
+  /** Upstream submission status (e.g. `'submitted'`, `'awaiting_response'`) */
+  vote_status?: string;
+  /** Whether the voter has been removed from the poll's eligible list */
+  voter_removed?: boolean;
+}
+
+/**
  * Individual Vote entity from query service
  * @description Represents a user's participation record from lfx.index.individual_vote
  */
@@ -561,6 +584,48 @@ export interface CreateVoteRequest {
   quorum_percentage?: number;
   /** Winning threshold percentage required */
   winning_threshold_percentage?: number;
+}
+
+/**
+ * Ranked choice submission for a single choice in a ranked-choice question
+ * @description Aligns with upstream RankedChoiceInput
+ * @see https://github.com/linuxfoundation/lfx-v2-voting-service
+ */
+export interface RankedChoiceInput {
+  /** Choice identifier (UUID) */
+  choice_id: string;
+  /** 1-based rank assigned to the choice */
+  choice_rank: number;
+}
+
+/**
+ * Voter's answer to a single question on a ballot submission
+ * @description Aligns with upstream VoteAnswerInput
+ * @see https://github.com/linuxfoundation/lfx-v2-voting-service
+ */
+export interface VoteAnswerInput {
+  /** Question identifier (UUID) */
+  question_id: string;
+  /** Selected choice IDs for generic / single-choice / multi-choice questions */
+  choice_ids?: string[];
+  /** Ranked choices for ranked-choice voting questions */
+  ranked_choices?: RankedChoiceInput[];
+}
+
+/**
+ * Request body for submitting a vote response (ballot)
+ * @description Aligns with upstream POST /vote_responses
+ * @see https://github.com/linuxfoundation/lfx-v2-voting-service
+ */
+export interface CreateVoteResponseRequest {
+  /** Client-generated vote response identifier (UUID) */
+  vote_response_uid: string;
+  /** Vote/poll identifier this response belongs to (UUID) */
+  vote_uid: string;
+  /** Whether the voter is abstaining */
+  abstain: boolean;
+  /** Voter's answers — required when not abstaining */
+  user_vote_content?: VoteAnswerInput[];
 }
 
 /**


### PR DESCRIPTION
# Summary

This pull request introduces a new endpoint for submitting vote responses (ballots) and adds supporting types and logic throughout the codebase. The main changes include the addition of the `POST /votes/responses` route, implementation of the corresponding controller and service logic, and the introduction of new shared interfaces to represent vote responses and their structure. There are also improvements to validation logic to support multiple UID fields in a single request.

**New vote response submission endpoint:**

- Added `POST /votes/responses` route in `votes.route.ts` to allow users to submit their ballot responses. The route is placed before parameterized routes to avoid routing conflicts.
- Implemented `createVoteResponse` method in `VoteController` to handle the new endpoint, including validation for all required fields and abstention logic.
- Added `createVoteResponse` method to `VoteService` to submit the ballot to the upstream service, then poll the query service until the response is indexed as 'submitted'.

**Shared interface and type additions:**

- Introduced `CreateVoteResponseRequest`, `VoteAnswerInput`, `RankedChoiceInput`, and `IndexedVoteResponse` interfaces in `poll.interface.ts` to strongly type the structure of vote responses and their answers. [[1]](diffhunk://#diff-609b2b535f632b58108dfa006787fb5eca8e2cc6dfb5524385d2f4423164461cR589-R630) [[2]](diffhunk://#diff-609b2b535f632b58108dfa006787fb5eca8e2cc6dfb5524385d2f4423164461cR230-R252)
- Updated imports and usage of these new types in relevant files. [[1]](diffhunk://#diff-5e2f7bdd4fc128c2e660bd384a9f63981e28c84e85ea7fdd76e6ff83ae00a374L4-R8) [[2]](diffhunk://#diff-1fd3f0a3d18da132ca5fd10941839176e1ed91c503ecf2354b0950f8ab0f0146R17) [[3]](diffhunk://#diff-18c155558dc67592a24e987f4cacba24250d9f76d07126b74ceee8cb6e4c7933R6-R8) [[4]](diffhunk://#diff-1fd3f0a3d18da132ca5fd10941839176e1ed91c503ecf2354b0950f8ab0f0146L1091-R1097)

**Validation improvements:**

- Enhanced `validateUidParameter` to accept an optional `fieldName`, allowing for more precise validation error messages when multiple UIDs are present in a request.

**Other updates:**

- Updated `UserService` and related queries to use the new `IndexedVoteResponse` type for consistency and type safety.

These changes collectively enable secure and robust submission of user ballots, with strong validation and type safety across the backend.

**References:**  
[[1]](diffhunk://#diff-46cddfa036b4d4461523a6dde77f5fc21bde92443ac64b106df20d09dca8b685R21-R25) [[2]](diffhunk://#diff-5e2f7bdd4fc128c2e660bd384a9f63981e28c84e85ea7fdd76e6ff83ae00a374R239-R308) [[3]](diffhunk://#diff-18c155558dc67592a24e987f4cacba24250d9f76d07126b74ceee8cb6e4c7933R251-R294) [[4]](diffhunk://#diff-609b2b535f632b58108dfa006787fb5eca8e2cc6dfb5524385d2f4423164461cR589-R630) [[5]](diffhunk://#diff-609b2b535f632b58108dfa006787fb5eca8e2cc6dfb5524385d2f4423164461cR230-R252) [[6]](diffhunk://#diff-c6fbc59cb68b31539137bee166f151b0833034250f3333df52f0232f5b86ae0cR24-R41) [[7]](diffhunk://#diff-1fd3f0a3d18da132ca5fd10941839176e1ed91c503ecf2354b0950f8ab0f0146R17) [[8]](diffhunk://#diff-1fd3f0a3d18da132ca5fd10941839176e1ed91c503ecf2354b0950f8ab0f0146L1091-R1097) [[9]](diffhunk://#diff-18c155558dc67592a24e987f4cacba24250d9f76d07126b74ceee8cb6e4c7933R6-R8) [[10]](diffhunk://#diff-5e2f7bdd4fc128c2e660bd384a9f63981e28c84e85ea7fdd76e6ff83ae00a374L4-R8)