### PR TITLE
fix(committees): forward folder_uid on document upload

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -133,14 +133,13 @@ export class CommitteeDocumentsComponent {
       data: {
         mode: 'file',
         committeeId: this.committee().uid,
+        defaultParentUid: this.currentFolderUid(),
       },
     });
 
     dialogRef?.onClose.pipe(take(1)).subscribe({
       next: (result: boolean | undefined) => {
         if (result) {
-          // Upload API doesn't accept folder_uid yet — pop to root so the new file is visible.
-          this.currentFolderUid.set(null);
           this.refreshTrigger.update((v) => v + 1);
         }
       },

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -133,6 +133,7 @@ export class CommitteeDocumentsComponent {
       data: {
         mode: 'file',
         committeeId: this.committee().uid,
+        folders: this.folderOptions(),
         defaultParentUid: this.currentFolderUid(),
       },
     });

--- a/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.html
@@ -56,7 +56,7 @@
     </div>
 
     <!-- Folder (optional) -->
-    @if (folderOptions.length > 0) {
+    @if (folderOptions?.length > 0) {
       <div>
         <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Folder (optional)</label>
         <lfx-select
@@ -105,7 +105,7 @@
     </div>
 
     <!-- Folder (optional) -->
-    @if (folderOptions.length > 0) {
+    @if (folderOptions?.length > 0) {
       <div>
         <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Folder (optional)</label>
         <lfx-select

--- a/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.html
@@ -54,6 +54,23 @@
         <p class="mt-1 text-xs text-red-600">Name is required</p>
       }
     </div>
+
+    <!-- Folder (optional) -->
+    @if (folderOptions.length > 0) {
+      <div>
+        <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Folder (optional)</label>
+        <lfx-select
+          size="small"
+          [form]="form"
+          control="parent_uid"
+          [options]="folderOptions"
+          placeholder="No folder"
+          [showClear]="true"
+          styleClass="w-full"
+          data-testid="document-form-folder"></lfx-select>
+        <p class="mt-1 text-[11px] text-gray-400">Place this file inside a folder</p>
+      </div>
+    }
   } @else if (isLink()) {
     <!-- Link URL -->
     <div>

--- a/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.ts
@@ -89,6 +89,7 @@ export class DocumentFormComponent {
         .uploadCommitteeDocument(this.committeeId, file, {
           name: formValue.name,
           description: formValue.description || undefined,
+          folder_uid: this.defaultParentUid ?? undefined,
         })
         .subscribe({
           next: () => {

--- a/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/document-form/document-form.component.ts
@@ -89,7 +89,7 @@ export class DocumentFormComponent {
         .uploadCommitteeDocument(this.committeeId, file, {
           name: formValue.name,
           description: formValue.description || undefined,
-          folder_uid: this.defaultParentUid ?? undefined,
+          folder_uid: formValue.parent_uid || undefined,
         })
         .subscribe({
           next: () => {
@@ -211,6 +211,7 @@ export class DocumentFormComponent {
       return new FormGroup({
         name: new FormControl('', [Validators.required]),
         description: new FormControl(''),
+        parent_uid: new FormControl<string | null>(this.defaultParentUid),
       });
     }
 

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -136,7 +136,11 @@ export class CommitteeService {
    * with metadata as query params. The BFF forwards as multipart/form-data to the
    * upstream committee service.
    */
-  public uploadCommitteeDocument(committeeId: string, file: File, metadata: { name: string; description?: string }): Observable<CommitteeDocument> {
+  public uploadCommitteeDocument(
+    committeeId: string,
+    file: File,
+    metadata: { name: string; description?: string; folder_uid?: string }
+  ): Observable<CommitteeDocument> {
     let params = new HttpParams()
       .set('name', metadata.name)
       .set('file_name', file.name)
@@ -145,6 +149,9 @@ export class CommitteeService {
 
     if (metadata.description) {
       params = params.set('description', metadata.description);
+    }
+    if (metadata.folder_uid) {
+      params = params.set('folder_uid', metadata.folder_uid);
     }
 
     return this.http

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -37,6 +37,8 @@ function contentDispositionAttachment(fileName: string): string {
   return `attachment; filename="${safeAscii}"; filename*=UTF-8''${encoded}`;
 }
 
+const FOLDER_UID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Controller for handling committee HTTP requests
  */
@@ -746,18 +748,16 @@ export class CommitteeController {
       }
 
       // Validate folder_uid shape so upstream can't be sent a malformed identifier.
-      if (folderUid !== undefined) {
-        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidPattern.test(folderUid)) {
-          next(
-            ServiceValidationError.forField('folder_uid', 'folder_uid must be a valid UUID', {
-              operation: 'upload_committee_document',
-              service: 'committee_controller',
-              path: req.path,
-            })
-          );
-          return;
-        }
+      const trimmedFolderUid = folderUid?.trim();
+      if (trimmedFolderUid && !FOLDER_UID_PATTERN.test(trimmedFolderUid)) {
+        next(
+          ServiceValidationError.forField('folder_uid', 'folder_uid must be a valid UUID', {
+            operation: 'upload_committee_document',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
       }
 
       const uploadData: UploadCommitteeDocumentRequest = {
@@ -766,7 +766,7 @@ export class CommitteeController {
         content_type: contentType!,
         file_size: fileSizeNum,
         ...(description && { description }),
-        ...(folderUid && { folder_uid: folderUid }),
+        ...(trimmedFolderUid && { folder_uid: trimmedFolderUid }),
       };
 
       const result = await this.committeeService.uploadCommitteeDocument(req, id, fileBuffer, uploadData);

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -634,12 +634,14 @@ export class CommitteeController {
     const contentType = getStringQueryParam(req, 'content_type');
     const fileSize = getStringQueryParam(req, 'file_size');
     const description = getStringQueryParam(req, 'description');
+    const folderUid = getStringQueryParam(req, 'folder_uid');
 
     const startTime = logger.startOperation(req, 'upload_committee_document', {
       committee_id: id,
       file_name: fileName,
       file_size: fileSize,
       content_type: contentType,
+      folder_uid: folderUid,
     });
 
     try {
@@ -743,12 +745,28 @@ export class CommitteeController {
         return;
       }
 
+      // Validate folder_uid shape so upstream can't be sent a malformed identifier.
+      if (folderUid !== undefined) {
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidPattern.test(folderUid)) {
+          next(
+            ServiceValidationError.forField('folder_uid', 'folder_uid must be a valid UUID', {
+              operation: 'upload_committee_document',
+              service: 'committee_controller',
+              path: req.path,
+            })
+          );
+          return;
+        }
+      }
+
       const uploadData: UploadCommitteeDocumentRequest = {
         name: trimmedName!,
         file_name: trimmedFileName!,
         content_type: contentType!,
         file_size: fileSizeNum,
         ...(description && { description }),
+        ...(folderUid && { folder_uid: folderUid }),
       };
 
       const result = await this.committeeService.uploadCommitteeDocument(req, id, fileBuffer, uploadData);

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -22,6 +22,7 @@ import { Request } from 'express';
 import FormData from 'form-data';
 
 import { ResourceNotFoundError } from '../errors';
+import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
@@ -93,6 +94,7 @@ interface CommitteeDocumentQueryResult {
   content_type?: string;
   description?: string;
   committee_uid?: string;
+  folder_uid?: string;
   created_at?: string;
   updated_at?: string;
   uploaded_by_username?: string;
@@ -792,6 +794,7 @@ export class CommitteeService {
       created_at: f.created_at,
       updated_at: f.updated_at,
       uploaded_by: f.uploaded_by_username,
+      parent_uid: f.folder_uid,
       committee_uid: f.committee_uid,
     }));
 
@@ -906,13 +909,16 @@ export class CommitteeService {
       formData.append('folder_uid', uploadData.folder_uid);
     }
 
+    // X-Sync=true makes the upstream wait for the indexer-publish ACK so the freshly
+    // uploaded document is visible in the next /query/resources fetch without a race.
     const result = await this.microserviceProxy.proxyRequest<CommitteeDocumentUpstreamResponse>(
       req,
       'LFX_V2_SERVICE',
       `/committees/${committeeId}/documents`,
       'POST',
       undefined,
-      formData
+      formData,
+      { 'X-Sync': 'true' }
     );
 
     logger.info(req, 'upload_committee_document', 'Committee document uploaded successfully', {
@@ -920,6 +926,29 @@ export class CommitteeService {
       document_uid: result.uid,
       file_name: result.file_name,
       file_size: result.file_size,
+    });
+
+    // Wait until the indexer has picked up the new doc so the next list-fetch sees it.
+    // Without this, the user has to manually refresh — indexer is async to upstream write.
+    await pollEndpoint({
+      req,
+      operation: 'upload_committee_document_index_poll',
+      pollFn: async () => {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string }>>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          {
+            type: 'committee_document',
+            tags: `committee_document_uid:${result.uid}`,
+          }
+        );
+        return (resources?.length ?? 0) > 0;
+      },
+      maxRetries: 5,
+      retryDelayMs: 400,
+      metadata: { committee_uid: committeeId, document_uid: result.uid },
     });
 
     return {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -891,7 +891,6 @@ export class CommitteeService {
     // file_size is intentionally omitted — upstream UploadCommitteeDocumentRequestBody
     // only declares name, file_name, content_type, file, description. Goa silently
     // drops unknown multipart fields.
-    // TODO: append folder_uid once upstream accepts it (LFXV2-1632).
     const formData = new FormData();
     formData.append('file', fileBuffer, {
       filename: uploadData.file_name,
@@ -902,6 +901,9 @@ export class CommitteeService {
     formData.append('content_type', uploadData.content_type);
     if (uploadData.description) {
       formData.append('description', uploadData.description);
+    }
+    if (uploadData.folder_uid) {
+      formData.append('folder_uid', uploadData.folder_uid);
     }
 
     const result = await this.microserviceProxy.proxyRequest<CommitteeDocumentUpstreamResponse>(

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -891,9 +891,8 @@ export class CommitteeService {
       file_size: uploadData.file_size,
     });
 
-    // file_size is intentionally omitted — upstream UploadCommitteeDocumentRequestBody
-    // only declares name, file_name, content_type, file, description. Goa silently
-    // drops unknown multipart fields.
+    // file_size is intentionally omitted — upstream UploadCommitteeDocumentRequestBody declares
+    // name, file_name, content_type, file, description, folder_uid. Goa drops unknown fields.
     const formData = new FormData();
     formData.append('file', fileBuffer, {
       filename: uploadData.file_name,
@@ -909,8 +908,7 @@ export class CommitteeService {
       formData.append('folder_uid', uploadData.folder_uid);
     }
 
-    // X-Sync=true makes the upstream wait for the indexer-publish ACK so the freshly
-    // uploaded document is visible in the next /query/resources fetch without a race.
+    // X-Sync=true blocks until the upstream indexer ACKs the publish, preventing stale list reads.
     const result = await this.microserviceProxy.proxyRequest<CommitteeDocumentUpstreamResponse>(
       req,
       'LFX_V2_SERVICE',
@@ -928,8 +926,7 @@ export class CommitteeService {
       file_size: result.file_size,
     });
 
-    // Wait until the indexer has picked up the new doc so the next list-fetch sees it.
-    // Without this, the user has to manually refresh — indexer is async to upstream write.
+    // Poll until the query service sees the new doc — indexer is async to the upstream write.
     await pollEndpoint({
       req,
       operation: 'upload_committee_document_index_poll',

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -544,8 +544,8 @@ export interface UploadCommitteeDocumentRequest {
   /** Optional description (max 2000 chars) */
   description?: string;
   /**
-   * TODO: add once upstream `POST /committees/{uid}/documents` accepts `folder_uid`.
-   * Until then, all uploaded files land at the committee root.
+   * Optional folder UID to nest the file inside a committee folder.
+   * When omitted, the file lands at the committee root.
    */
   folder_uid?: string;
 }


### PR DESCRIPTION
## Summary

Wire `folder_uid` end-to-end on committee file upload so files dropped from inside a folder view land in that folder instead of the committee root, and surface a folder selector in the Upload File dialog.

- **Forward `folder_uid` on upload** — BFF appends it to the multipart form data; controller validates UUID shape; shared interface and Angular HTTP service extended; component passes the current folder UID into the dialog.
- **Show files in their folder** — fixes a pre-existing gap in the BFF documents list normalizer where files weren't mapped from upstream `folder_uid` to frontend `parent_uid`, so previously-uploaded files inside folders also surface correctly now.
- **Match Add Link UX** — Upload File dialog now has a "Folder (optional)" selector pre-seeded to the current folder.
- **No more manual refresh** — pass `X-Sync=true` on upload and poll the indexer (`pollEndpoint`, max 5×400ms) until the new doc is queryable, so the next list-fetch is guaranteed to see it.

Linked: [LFXV2-1630](https://linuxfoundation.atlassian.net/browse/LFXV2-1630)

## External References

Upstream `lfx-v2-committee-service` already accepts `folder_uid` on `POST /committees/{uid}/documents` — verified via `gen/http/openapi3.yaml` (`UploadCommitteeDocumentRequestBody.folder_uid`). No upstream service deploy is required for this PR; both dev and prod clusters have it.

## Test plan

- [ ] Upload a file from the committee root — lands at root (existing behavior).
- [ ] Drill into a folder, click **Upload File** — dialog opens with that folder pre-selected; uploaded file appears inside the folder without manual refresh.
- [ ] Upload a file from root with a folder picked in the selector — file appears in the chosen folder.
- [ ] Upload a file from inside a folder, then clear the selector before submit — file lands at root.
- [ ] Pass an invalid `folder_uid` directly to the BFF endpoint — returns 400 with a `folder_uid must be a valid UUID` validation error.

[LFXV2-1630]: https://linuxfoundation.atlassian.net/browse/LFXV2-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ