### PR TITLE
feat(changelog): add changelog drawer in lens navigation

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -137,3 +137,10 @@ API_GW_AUDIENCE=https://api-gw.dev.platform.linuxfoundation.org/
 CREDLY_API_URL=https://api.credly.com/v1
 CREDLY_ORG_ID=your-credly-org-id
 CREDLY_API_TOKEN=your-credly-api-token
+
+# Changelog Integration
+# API key (lfx_...) with `changelogs:read` scope from the lfx-changelog admin
+# Product ID is the UUID of the "self-serve" product (per environment)
+CHANGELOG_API_URL=https://changelog.lfx.dev
+CHANGELOG_API_KEY=your-changelog-api-key
+CHANGELOG_PRODUCT_ID=your-changelog-product-uuid

--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -40,7 +40,7 @@
     "@fullcalendar/daygrid": "6.1.20",
     "@fullcalendar/timegrid": "6.1.20",
     "@lfx-one/shared": "workspace:*",
-    "@linuxfoundation/lfx-ui-core": "^0.1.0",
+    "@linuxfoundation/lfx-ui-core": "^0.2.0",
     "@openfeature/core": "^1.9.1",
     "@openfeature/launchdarkly-client-provider": "^0.3.3",
     "@openfeature/web-sdk": "1.7.2",

--- a/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.html
+++ b/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.html
@@ -1,0 +1,33 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  (onShow)="onShow()"
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
+  data-testid="changelog-drawer">
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="changelog-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="changelog-drawer-title">What's New</h2>
+        <p class="text-sm text-gray-500">Latest updates and improvements to LFX Self-Serve</p>
+      </div>
+
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors flex-shrink-0"
+        aria-label="Close panel"
+        data-testid="changelog-drawer-close">
+        <i class="fa-light fa-xmark text-xl"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="changelog-host" data-testid="changelog-drawer-content">
+    <lfx-changelog product="self-serve" limit="10"></lfx-changelog>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.scss
+++ b/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.scss
@@ -1,55 +1,42 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Theme the embedded <lfx-changelog> web component to match the drawer.
-// The widget exposes CSS custom properties via :host AND ::part() selectors
-// (see @linuxfoundation/lfx-ui-core/dist/components/changelog/changelog.style.js).
-//
-// IMPORTANT: variables must be set on the host element itself (`lfx-changelog`)
-// rather than an ancestor, because the widget's internal `:host { --foo: ... }`
-// rule sets default values directly on the host and beats inherited values.
-// Targeting `lfx-changelog` from outside has equal specificity but wins via
-// document-cascade ordering.
+// Selectors target `lfx-changelog` directly so the variables override the widget's
+// internal `:host` defaults via document-cascade ordering (inheritance loses to `:host`).
 .changelog-host lfx-changelog {
-  // Brand + drawer typography
   --lfx-changelog-font-family: inherit;
-  --lfx-changelog-font-size-base: 0.8125rem; // 13px (down from 14px)
-  --lfx-changelog-font-size-sm: 0.6875rem; // 11px (down from 12px)
-  --lfx-changelog-font-size-lg: 0.875rem; // 14px (down from 16px) — entry titles
-  --lfx-changelog-font-size-xl: 1rem; // 16px (down from 20px) — section headings
+  --lfx-changelog-font-size-base: 0.8125rem;
+  --lfx-changelog-font-size-sm: 0.6875rem;
+  --lfx-changelog-font-size-lg: 0.875rem;
+  --lfx-changelog-font-size-xl: 1rem;
   --lfx-changelog-line-height: 1.5;
-  --lfx-changelog-text-primary: #0f172b; // gray-900
-  --lfx-changelog-text-secondary: #45556c; // gray-600
-  --lfx-changelog-text-muted: #62748e; // gray-500
-  --lfx-changelog-text-link: #0082d9; // blue-600
-  --lfx-changelog-text-link-hover: #0061a3; // blue-700
-  --lfx-changelog-accent: #0082d9; // blue-600
-  --lfx-changelog-accent-bg: #ecf4ff; // blue-100
+  --lfx-changelog-text-primary: #0f172b;
+  --lfx-changelog-text-secondary: #45556c;
+  --lfx-changelog-text-muted: #62748e;
+  --lfx-changelog-text-link: #0082d9;
+  --lfx-changelog-text-link-hover: #0061a3;
+  --lfx-changelog-accent: #0082d9;
+  --lfx-changelog-accent-bg: #ecf4ff;
 
-  // Flatten the widget's outer card chrome — the drawer body already provides
-  // surface and padding, so we don't want a card-in-card effect.
+  // Flatten the widget's outer card chrome so it doesn't double-card with the drawer body.
   --lfx-changelog-bg-surface: transparent;
   --lfx-changelog-bg-surface-alt: transparent;
   --lfx-changelog-border-color: transparent;
   --lfx-changelog-border-radius: 0;
   --lfx-changelog-card-padding: 0;
 
-  // Hide the widget's own header — the drawer's header already renders the title.
+  // Drawer header already renders the title.
   &::part(header) {
     display: none;
   }
 
-  // Re-introduce a subtle separator between entries (the shared border-color is
-  // transparent so the outer container border vanishes). Only takes effect when
-  // multiple entries render.
+  // Re-introduce entry separators (the shared border-color is now transparent).
   &::part(card) {
     padding-bottom: 1.25rem;
     margin-bottom: 1.25rem;
-    border-bottom: 1px solid #e2e8f0; // gray-200
+    border-bottom: 1px solid #e2e8f0;
   }
 
-  // Drop redundant footer chrome — keep the link itself (surface-alt and border
-  // are already transparent via the variables above).
   &::part(footer) {
     padding-top: 1rem;
   }

--- a/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.scss
+++ b/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.scss
@@ -1,0 +1,56 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Theme the embedded <lfx-changelog> web component to match the drawer.
+// The widget exposes CSS custom properties via :host AND ::part() selectors
+// (see @linuxfoundation/lfx-ui-core/dist/components/changelog/changelog.style.js).
+//
+// IMPORTANT: variables must be set on the host element itself (`lfx-changelog`)
+// rather than an ancestor, because the widget's internal `:host { --foo: ... }`
+// rule sets default values directly on the host and beats inherited values.
+// Targeting `lfx-changelog` from outside has equal specificity but wins via
+// document-cascade ordering.
+.changelog-host lfx-changelog {
+  // Brand + drawer typography
+  --lfx-changelog-font-family: inherit;
+  --lfx-changelog-font-size-base: 0.8125rem; // 13px (down from 14px)
+  --lfx-changelog-font-size-sm: 0.6875rem; // 11px (down from 12px)
+  --lfx-changelog-font-size-lg: 0.875rem; // 14px (down from 16px) — entry titles
+  --lfx-changelog-font-size-xl: 1rem; // 16px (down from 20px) — section headings
+  --lfx-changelog-line-height: 1.5;
+  --lfx-changelog-text-primary: #0f172b; // gray-900
+  --lfx-changelog-text-secondary: #45556c; // gray-600
+  --lfx-changelog-text-muted: #62748e; // gray-500
+  --lfx-changelog-text-link: #0082d9; // blue-600
+  --lfx-changelog-text-link-hover: #0061a3; // blue-700
+  --lfx-changelog-accent: #0082d9; // blue-600
+  --lfx-changelog-accent-bg: #ecf4ff; // blue-100
+
+  // Flatten the widget's outer card chrome — the drawer body already provides
+  // surface and padding, so we don't want a card-in-card effect.
+  --lfx-changelog-bg-surface: transparent;
+  --lfx-changelog-bg-surface-alt: transparent;
+  --lfx-changelog-border-color: transparent;
+  --lfx-changelog-border-radius: 0;
+  --lfx-changelog-card-padding: 0;
+
+  // Hide the widget's own header — the drawer's header already renders the title.
+  &::part(header) {
+    display: none;
+  }
+
+  // Re-introduce a subtle separator between entries (the shared border-color is
+  // transparent so the outer container border vanishes). Only takes effect when
+  // multiple entries render.
+  &::part(card) {
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.25rem;
+    border-bottom: 1px solid #e2e8f0; // gray-200
+  }
+
+  // Drop redundant footer chrome — keep the link itself (surface-alt and border
+  // are already transparent via the variables above).
+  &::part(footer) {
+    padding-top: 1rem;
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.ts
+++ b/apps/lfx-one/src/app/shared/components/changelog-drawer/changelog-drawer.component.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, model } from '@angular/core';
+import { ChangelogService } from '@services/changelog.service';
+import { DrawerModule } from 'primeng/drawer';
+
+@Component({
+  selector: 'lfx-changelog-drawer',
+  imports: [DrawerModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  templateUrl: './changelog-drawer.component.html',
+  styleUrl: './changelog-drawer.component.scss',
+})
+export class ChangelogDrawerComponent {
+  private readonly changelogService = inject(ChangelogService);
+
+  public readonly visible = model<boolean>(false);
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  protected onShow(): void {
+    this.changelogService.markViewed();
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -97,6 +97,28 @@
 
     <!-- Footer -->
     <div class="flex flex-col items-center gap-3 mt-auto">
+      <!-- Changelog (What's New) -->
+      <button
+        type="button"
+        (click)="openChangelogDrawer()"
+        data-testid="lens-changelog-button"
+        aria-label="What's new"
+        pTooltip="What's New"
+        tooltipPosition="right"
+        class="group flex flex-col items-center gap-1 w-full transition-colors text-blue-200/70 hover:text-white">
+        <div class="relative flex items-center justify-center w-10 h-10 rounded-xl transition-colors group-hover:bg-white/10">
+          <i class="fa-light fa-clock-rotate-left text-xl"></i>
+          @if (unseenChangelogCount() > 0) {
+            <lfx-badge
+              [value]="unseenChangelogCount().toString()"
+              severity="danger"
+              size="small"
+              styleClass="!absolute -top-1 -right-1"
+              data-testid="lens-changelog-badge" />
+          }
+        </div>
+      </button>
+
       <!-- LFX Insights -->
       <a
         [href]="insightsUrl"
@@ -166,15 +188,6 @@
           <span>My profile</span>
         </button>
         <a
-          [href]="changelogUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="lens-changelog"
-          class="flex items-center gap-2.5 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-          <i class="fa-light fa-clock-rotate-left w-4 text-gray-400"></i>
-          <span>Changelog</span>
-        </a>
-        <a
           href="https://jira.linuxfoundation.org/servicedesk/customer/portal/4"
           target="_blank"
           rel="noopener noreferrer"
@@ -194,4 +207,7 @@
       </div>
     </ng-template>
   </p-popover>
+
+  <!-- Changelog Drawer -->
+  <lfx-changelog-drawer [(visible)]="changelogDrawerVisible" />
 }

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -110,7 +110,7 @@
           <i class="fa-light fa-clock-rotate-left text-xl"></i>
           @if (unseenChangelogCount() > 0) {
             <lfx-badge
-              [value]="unseenChangelogCount().toString()"
+              [value]="unseenChangelogCount()"
               severity="danger"
               size="small"
               styleClass="!absolute -top-1 -right-1"

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -102,7 +102,7 @@
         type="button"
         (click)="openChangelogDrawer()"
         data-testid="lens-changelog-button"
-        aria-label="What's new"
+        aria-label="What's New"
         pTooltip="What's New"
         tooltipPosition="right"
         class="group flex flex-col items-center gap-1 w-full transition-colors text-blue-200/70 hover:text-white">

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, inject, input, viewChild } from '@angular/core';
+import { afterNextRender, Component, inject, input, signal, viewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { BadgeComponent } from '@components/badge/badge.component';
 import { ButtonComponent } from '@components/button/button.component';
+import { ChangelogDrawerComponent } from '@components/changelog-drawer/changelog-drawer.component';
 import { ImpersonationDialogComponent } from '@components/impersonation-dialog/impersonation-dialog.component';
-import { environment } from '@environments/environment';
 import { LENS_DEFAULT_ROUTES } from '@lfx-one/shared/constants';
 import { Lens } from '@lfx-one/shared/interfaces';
 import { buildInsightsUrl } from '@lfx-one/shared/utils';
+import { ChangelogService } from '@services/changelog.service';
 import { LensService } from '@services/lens.service';
 import { UserService } from '@services/user.service';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -19,7 +21,7 @@ import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-lens-switcher',
-  imports: [NgClass, RouterLink, TooltipModule, PopoverModule, AvatarComponent, ButtonComponent],
+  imports: [NgClass, RouterLink, TooltipModule, PopoverModule, AvatarComponent, BadgeComponent, ButtonComponent, ChangelogDrawerComponent],
   providers: [DialogService],
   templateUrl: './lens-switcher.component.html',
   styleUrl: './lens-switcher.component.scss',
@@ -29,19 +31,33 @@ export class LensSwitcherComponent {
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
   private readonly dialogService = inject(DialogService);
+  private readonly changelogService = inject(ChangelogService);
 
   public readonly mobile = input<boolean>(false);
 
   protected readonly activeLens = this.lensService.activeLens;
   protected readonly lenses = this.lensService.availableLenses;
   protected readonly user = this.userService.user;
-  protected readonly changelogUrl = environment.urls.changelog;
   protected readonly insightsUrl = buildInsightsUrl();
   protected readonly userMenu = viewChild<Popover>('userMenu');
 
   protected readonly userInitials = this.userService.userInitials;
   protected readonly canImpersonate = this.userService.canImpersonate;
   protected readonly isImpersonating = this.userService.impersonating;
+  protected readonly unseenChangelogCount = this.changelogService.unseenChangelogCount;
+  protected readonly changelogDrawerVisible = signal(false);
+
+  public constructor() {
+    // Fetch after first browser render so SSR doesn't issue an upstream call we
+    // can't display, and so input bindings have settled (the `[mobile]="true"`
+    // duplicate instance correctly skips the load).
+    afterNextRender(() => {
+      if (this.mobile()) {
+        return;
+      }
+      this.changelogService.loadUnseenCount();
+    });
+  }
 
   protected setLens(lens: Lens): void {
     this.userMenu()?.hide();
@@ -67,5 +83,9 @@ export class LensSwitcherComponent {
       draggable: false,
       resizable: false,
     });
+  }
+
+  protected openChangelogDrawer(): void {
+    this.changelogDrawerVisible.set(true);
   }
 }

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -48,9 +48,7 @@ export class LensSwitcherComponent {
   protected readonly changelogDrawerVisible = signal(false);
 
   public constructor() {
-    // Fetch after first browser render so SSR doesn't issue an upstream call we
-    // can't display, and so input bindings have settled (the `[mobile]="true"`
-    // duplicate instance correctly skips the load).
+    // afterNextRender so input bindings have settled — the duplicate `[mobile]="true"` instance correctly skips.
     afterNextRender(() => {
       if (this.mobile()) {
         return;

--- a/apps/lfx-one/src/app/shared/services/changelog.service.ts
+++ b/apps/lfx-one/src/app/shared/services/changelog.service.ts
@@ -14,16 +14,10 @@ export class ChangelogService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = '/api/changelog';
 
-  // Triggers — `next()` from public methods to drive the unified reactive pipeline below.
   private readonly loadTrigger$ = new Subject<void>();
   private readonly markViewedTrigger$ = new Subject<void>();
 
-  /**
-   * Unseen changelog count — derived from a merged stream of:
-   *   - load events (GET /unseen → unseenCount)
-   *   - mark-viewed events (optimistically 0, then fires POST /mark-viewed)
-   * Errors are swallowed so the badge keeps its last known value (best-effort UX hint).
-   */
+  // Errors swallowed so the badge keeps its last known value (best-effort UX hint).
   public readonly unseenChangelogCount: Signal<number> = toSignal(
     merge(
       this.loadTrigger$.pipe(
@@ -35,8 +29,7 @@ export class ChangelogService {
         )
       ),
       this.markViewedTrigger$.pipe(
-        // Emit 0 immediately for an optimistic badge clear, then fire the POST in
-        // the background and ignore its outcome (success → already 0; failure → keep 0).
+        // Optimistic 0 first, then the POST in the background.
         switchMap(() =>
           merge(
             of(0),

--- a/apps/lfx-one/src/app/shared/services/changelog.service.ts
+++ b/apps/lfx-one/src/app/shared/services/changelog.service.ts
@@ -1,0 +1,61 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ChangelogViewMarkViewedResponse, ChangelogViewUnseenResponse } from '@lfx-one/shared/interfaces';
+import { catchError, EMPTY, map, merge, of, Subject, switchMap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ChangelogService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/changelog';
+
+  // Triggers — `next()` from public methods to drive the unified reactive pipeline below.
+  private readonly loadTrigger$ = new Subject<void>();
+  private readonly markViewedTrigger$ = new Subject<void>();
+
+  /**
+   * Unseen changelog count — derived from a merged stream of:
+   *   - load events (GET /unseen → unseenCount)
+   *   - mark-viewed events (optimistically 0, then fires POST /mark-viewed)
+   * Errors are swallowed so the badge keeps its last known value (best-effort UX hint).
+   */
+  public readonly unseenChangelogCount: Signal<number> = toSignal(
+    merge(
+      this.loadTrigger$.pipe(
+        switchMap(() =>
+          this.http.get<ChangelogViewUnseenResponse>(`${this.baseUrl}/unseen`).pipe(
+            map((res) => res.data.unseenCount),
+            catchError(() => EMPTY)
+          )
+        )
+      ),
+      this.markViewedTrigger$.pipe(
+        // Emit 0 immediately for an optimistic badge clear, then fire the POST in
+        // the background and ignore its outcome (success → already 0; failure → keep 0).
+        switchMap(() =>
+          merge(
+            of(0),
+            this.http.post<ChangelogViewMarkViewedResponse>(`${this.baseUrl}/mark-viewed`, {}).pipe(
+              map(() => 0),
+              catchError(() => EMPTY)
+            )
+          )
+        )
+      )
+    ),
+    { initialValue: 0 }
+  );
+
+  public loadUnseenCount(): void {
+    this.loadTrigger$.next();
+  }
+
+  public markViewed(): void {
+    this.markViewedTrigger$.next();
+  }
+}

--- a/apps/lfx-one/src/server/controllers/changelog.controller.ts
+++ b/apps/lfx-one/src/server/controllers/changelog.controller.ts
@@ -9,11 +9,6 @@ import { logger } from '../services/logger.service';
 export class ChangelogController {
   private readonly changelogService = new ChangelogService();
 
-  /**
-   * GET /api/changelog/unseen
-   * Returns the unseen changelog count for the authenticated user against the
-   * self-serve product.
-   */
   public async getUnseenCount(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_changelog_unseen');
 
@@ -30,10 +25,6 @@ export class ChangelogController {
     }
   }
 
-  /**
-   * POST /api/changelog/mark-viewed
-   * Marks the self-serve product's changelog as viewed for the authenticated user.
-   */
   public async markViewed(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'mark_changelog_viewed');
 

--- a/apps/lfx-one/src/server/controllers/changelog.controller.ts
+++ b/apps/lfx-one/src/server/controllers/changelog.controller.ts
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { ChangelogService } from '../services/changelog.service';
+import { logger } from '../services/logger.service';
+
+export class ChangelogController {
+  private readonly changelogService = new ChangelogService();
+
+  /**
+   * GET /api/changelog/unseen
+   * Returns the unseen changelog count for the authenticated user against the
+   * self-serve product.
+   */
+  public async getUnseenCount(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_changelog_unseen');
+
+    try {
+      const result = await this.changelogService.getUnseenCount(req);
+
+      logger.success(req, 'get_changelog_unseen', startTime, {
+        unseen_count: result.data.unseenCount,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /api/changelog/mark-viewed
+   * Marks the self-serve product's changelog as viewed for the authenticated user.
+   */
+  public async markViewed(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'mark_changelog_viewed');
+
+    try {
+      const result = await this.changelogService.markViewed(req);
+
+      logger.success(req, 'mark_changelog_viewed', startTime, {
+        product_id: result.data.productId,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/changelog.route.ts
+++ b/apps/lfx-one/src/server/routes/changelog.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { ChangelogController } from '../controllers/changelog.controller';
+
+const router = Router();
+const changelogController = new ChangelogController();
+
+router.get('/unseen', (req, res, next) => changelogController.getUnseenCount(req, res, next));
+router.post('/mark-viewed', (req, res, next) => changelogController.markViewed(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -20,6 +20,7 @@ import { apiErrorHandler } from './middleware/error-handler.middleware';
 import { apiRateLimiter, authRateLimiter, publicApiRateLimiter } from './middleware/rate-limit.middleware';
 import analyticsRouter from './routes/analytics.route';
 import badgesRouter from './routes/badges.route';
+import changelogRouter from './routes/changelog.route';
 import committeesRouter from './routes/committees.route';
 import copilotRouter from './routes/copilot.route';
 import documentsRouter from './routes/documents.route';
@@ -194,6 +195,7 @@ app.use('/api/impersonate', impersonationRouter);
 app.use('/api/training', trainingRouter);
 app.use('/api/rewards', rewardsRouter);
 app.use('/api/transactions', transactionRouter);
+app.use('/api/changelog', changelogRouter);
 
 app.use('/api/*', apiErrorHandler);
 

--- a/apps/lfx-one/src/server/services/changelog.service.ts
+++ b/apps/lfx-one/src/server/services/changelog.service.ts
@@ -1,0 +1,131 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CHANGELOG_CONFIG } from '@lfx-one/shared/constants';
+import { ChangelogViewMarkViewedResponse, ChangelogViewUnseenResponse } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { getEffectiveSub } from '../utils/auth-helper';
+import { logger } from './logger.service';
+
+/**
+ * Service for the LFX Changelog "views" tracking API.
+ * Authenticates server-to-server with an API key (changelogs:read scope) and identifies
+ * the viewer via the Auth0 `sub` so unread counts and read-receipts are scoped per user.
+ */
+export class ChangelogService {
+  // Resolved lazily on first access so dotenv has finished loading,
+  // then memoized — env is stable after startup.
+  private _apiUrl: string | undefined;
+  private _apiKey: string | undefined;
+  private _productId: string | undefined;
+
+  private get apiUrl(): string {
+    return (this._apiUrl ??= (process.env['CHANGELOG_API_URL'] || CHANGELOG_CONFIG.DEFAULT_API_URL).replace(/\/+$/, ''));
+  }
+
+  private get apiKey(): string {
+    return (this._apiKey ??= process.env['CHANGELOG_API_KEY'] || '');
+  }
+
+  private get productId(): string {
+    return (this._productId ??= process.env['CHANGELOG_PRODUCT_ID'] || '');
+  }
+
+  /**
+   * Get unseen changelog count for the authenticated user against the configured product.
+   */
+  public async getUnseenCount(req: Request): Promise<ChangelogViewUnseenResponse> {
+    const viewerId = getEffectiveSub(req);
+    if (!viewerId) {
+      throw new MicroserviceError('User authentication required', 401, 'CHANGELOG_UNAUTHENTICATED', {
+        operation: 'get_changelog_unseen',
+        service: 'changelog_service',
+      });
+    }
+
+    const url = new URL(CHANGELOG_CONFIG.ENDPOINTS.UNSEEN, this.apiUrl);
+    url.searchParams.set('viewerId', viewerId);
+    url.searchParams.set('productId', this.productId);
+
+    logger.debug(req, 'get_changelog_unseen', 'Fetching unseen changelog count', { product_id: this.productId });
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new MicroserviceError(`Changelog unseen request failed: ${response.statusText}`, response.status, 'CHANGELOG_UNSEEN_ERROR', {
+        operation: 'get_changelog_unseen',
+        service: 'changelog_service',
+        errorBody: errorText,
+      });
+    }
+
+    return this.parseJson<ChangelogViewUnseenResponse>(response, 'get_changelog_unseen', 'CHANGELOG_UNSEEN_ERROR');
+  }
+
+  /**
+   * Mark the configured product's changelog as viewed for the authenticated user.
+   */
+  public async markViewed(req: Request): Promise<ChangelogViewMarkViewedResponse> {
+    const viewerId = getEffectiveSub(req);
+    if (!viewerId) {
+      throw new MicroserviceError('User authentication required', 401, 'CHANGELOG_UNAUTHENTICATED', {
+        operation: 'mark_changelog_viewed',
+        service: 'changelog_service',
+      });
+    }
+
+    const url = new URL(CHANGELOG_CONFIG.ENDPOINTS.MARK_VIEWED, this.apiUrl).toString();
+
+    logger.debug(req, 'mark_changelog_viewed', 'Marking changelog as viewed', { product_id: this.productId });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({ viewerId, productId: this.productId }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new MicroserviceError(`Changelog mark-viewed request failed: ${response.statusText}`, response.status, 'CHANGELOG_MARK_VIEWED_ERROR', {
+        operation: 'mark_changelog_viewed',
+        service: 'changelog_service',
+        errorBody: errorText,
+      });
+    }
+
+    return this.parseJson<ChangelogViewMarkViewedResponse>(response, 'mark_changelog_viewed', 'CHANGELOG_MARK_VIEWED_ERROR');
+  }
+
+  /**
+   * Parse a fetch Response as JSON, but first verify the Content-Type is JSON.
+   * If the upstream returns HTML (e.g. an SPA fallback or an auth challenge page)
+   * we want a clear MicroserviceError instead of a cryptic JSON.parse failure.
+   */
+  private async parseJson<T>(response: Response, operation: string, code: string): Promise<T> {
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      const bodyPreview = (await response.text()).slice(0, 200);
+      throw new MicroserviceError(`Changelog API returned non-JSON response (content-type: ${contentType || 'unknown'})`, 502, code, {
+        operation,
+        service: 'changelog_service',
+        errorBody: bodyPreview,
+      });
+    }
+    return (await response.json()) as T;
+  }
+}

--- a/apps/lfx-one/src/server/services/changelog.service.ts
+++ b/apps/lfx-one/src/server/services/changelog.service.ts
@@ -9,17 +9,13 @@ import { MicroserviceError } from '../errors';
 import { getEffectiveSub } from '../utils/auth-helper';
 import { logger } from './logger.service';
 
-/**
- * Service for the LFX Changelog "views" tracking API.
- * Authenticates server-to-server with an API key (changelogs:read scope) and identifies
- * the viewer via the Auth0 `sub` so unread counts and read-receipts are scoped per user.
- */
 export class ChangelogService {
-  // Resolved lazily on first access so dotenv has finished loading,
-  // then memoized — env is stable after startup.
+  // Resolved lazily on first access so dotenv has finished loading, then memoized.
   private _apiUrl: string | undefined;
   private _apiKey: string | undefined;
   private _productId: string | undefined;
+
+  private static readonly errorBodyPreviewLimit = 200;
 
   private get apiUrl(): string {
     return (this._apiUrl ??= (process.env['CHANGELOG_API_URL'] || CHANGELOG_CONFIG.DEFAULT_API_URL).replace(/\/+$/, ''));
@@ -33,10 +29,9 @@ export class ChangelogService {
     return (this._productId ??= process.env['CHANGELOG_PRODUCT_ID'] || '');
   }
 
-  /**
-   * Get unseen changelog count for the authenticated user against the configured product.
-   */
   public async getUnseenCount(req: Request): Promise<ChangelogViewUnseenResponse> {
+    this.assertConfigured('get_changelog_unseen');
+
     const viewerId = getEffectiveSub(req);
     if (!viewerId) {
       throw new MicroserviceError('User authentication required', 401, 'CHANGELOG_UNAUTHENTICATED', {
@@ -61,21 +56,19 @@ export class ChangelogService {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
       throw new MicroserviceError(`Changelog unseen request failed: ${response.statusText}`, response.status, 'CHANGELOG_UNSEEN_ERROR', {
         operation: 'get_changelog_unseen',
         service: 'changelog_service',
-        errorBody: errorText,
+        errorBody: await this.previewErrorBody(response),
       });
     }
 
     return this.parseJson<ChangelogViewUnseenResponse>(response, 'get_changelog_unseen', 'CHANGELOG_UNSEEN_ERROR');
   }
 
-  /**
-   * Mark the configured product's changelog as viewed for the authenticated user.
-   */
   public async markViewed(req: Request): Promise<ChangelogViewMarkViewedResponse> {
+    this.assertConfigured('mark_changelog_viewed');
+
     const viewerId = getEffectiveSub(req);
     if (!viewerId) {
       throw new MicroserviceError('User authentication required', 401, 'CHANGELOG_UNAUTHENTICATED', {
@@ -100,32 +93,44 @@ export class ChangelogService {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
       throw new MicroserviceError(`Changelog mark-viewed request failed: ${response.statusText}`, response.status, 'CHANGELOG_MARK_VIEWED_ERROR', {
         operation: 'mark_changelog_viewed',
         service: 'changelog_service',
-        errorBody: errorText,
+        errorBody: await this.previewErrorBody(response),
       });
     }
 
     return this.parseJson<ChangelogViewMarkViewedResponse>(response, 'mark_changelog_viewed', 'CHANGELOG_MARK_VIEWED_ERROR');
   }
 
-  /**
-   * Parse a fetch Response as JSON, but first verify the Content-Type is JSON.
-   * If the upstream returns HTML (e.g. an SPA fallback or an auth challenge page)
-   * we want a clear MicroserviceError instead of a cryptic JSON.parse failure.
-   */
+  // Short-circuit when env vars are missing so misconfigured deployments fail fast with a clear error
+  // instead of generating noisy 401/400 logs from upstream calls with empty bearer tokens.
+  private assertConfigured(operation: string): void {
+    const missing: string[] = [];
+    if (!this.apiKey) missing.push('CHANGELOG_API_KEY');
+    if (!this.productId) missing.push('CHANGELOG_PRODUCT_ID');
+    if (missing.length === 0) return;
+
+    throw new MicroserviceError(`Changelog API not configured (missing: ${missing.join(', ')})`, 503, 'CHANGELOG_NOT_CONFIGURED', {
+      operation,
+      service: 'changelog_service',
+    });
+  }
+
+  // Guard against HTML responses (SPA fallback, auth challenge) so callers see a clear error instead of a JSON.parse failure.
   private async parseJson<T>(response: Response, operation: string, code: string): Promise<T> {
     const contentType = response.headers.get('content-type') ?? '';
     if (!contentType.includes('application/json')) {
-      const bodyPreview = (await response.text()).slice(0, 200);
       throw new MicroserviceError(`Changelog API returned non-JSON response (content-type: ${contentType || 'unknown'})`, 502, code, {
         operation,
         service: 'changelog_service',
-        errorBody: bodyPreview,
+        errorBody: await this.previewErrorBody(response),
       });
     }
     return (await response.json()) as T;
+  }
+
+  private async previewErrorBody(response: Response): Promise<string> {
+    return (await response.text()).slice(0, ChangelogService.errorBodyPreviewLimit);
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-angular": "^20.0.0",
-    "@linuxfoundation/lfx-ui-core": "^0.0.22",
+    "@linuxfoundation/lfx-ui-core": "^0.2.0",
     "@types/node": "^24.2.1",
     "@typescript-eslint/eslint-plugin": "^8.39.1",
     "@typescript-eslint/parser": "^8.39.1",

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -51,6 +51,19 @@ export const NATS_CONFIG = {
 } as const;
 
 /**
+ * Changelog (lfx-changelog) configuration constants
+ * @description Configuration for the LFX Changelog API used for unread tracking against
+ * the self-serve product changelog feed.
+ */
+export const CHANGELOG_CONFIG = {
+  DEFAULT_API_URL: 'https://changelog.lfx.dev',
+  ENDPOINTS: {
+    UNSEEN: '/api/changelogs/views/unseen',
+    MARK_VIEWED: '/api/changelogs/views/mark-viewed',
+  },
+} as const;
+
+/**
  * CDP (Community Data Platform) configuration constants
  * @description Configuration for CDP API used for identity and work history data
  */

--- a/packages/shared/src/interfaces/changelog.interface.ts
+++ b/packages/shared/src/interfaces/changelog.interface.ts
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface ChangelogViewUnseen {
+  productId: string;
+  unseenCount: number;
+  lastViewedAt: string | null;
+}
+
+export interface ChangelogViewUnseenResponse {
+  success: boolean;
+  data: ChangelogViewUnseen;
+}
+
+export interface ChangelogViewMarkViewedData {
+  productId: string;
+  lastViewedAt: string;
+}
+
+export interface ChangelogViewMarkViewedResponse {
+  success: boolean;
+  data: ChangelogViewMarkViewedData;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -144,3 +144,6 @@ export * from './supabase.interface';
 
 // Stat card interfaces
 export * from './stat-card.interface';
+
+// Changelog interfaces
+export * from './changelog.interface';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,27 +4283,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@linuxfoundation/lfx-ui-core@npm:^0.0.22":
-  version: 0.0.22
-  resolution: "@linuxfoundation/lfx-ui-core@npm:0.0.22"
+"@linuxfoundation/lfx-ui-core@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@linuxfoundation/lfx-ui-core@npm:0.2.0"
+  dependencies:
+    dompurify: "npm:3.3.3"
+    marked: "npm:17.0.5"
   peerDependencies:
     prettier: ">=3.0.0"
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 10c0/0cab9673f5c5b67082d1e5632955c0ce47d5ceb029e0e934688106028e1a72e034aaf0f37f01a50a5644ef9d9a4c9a6560de4b05f87cbcb8f35ed4c27b23e5d5
-  languageName: node
-  linkType: hard
-
-"@linuxfoundation/lfx-ui-core@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@linuxfoundation/lfx-ui-core@npm:0.1.0"
-  peerDependencies:
-    prettier: ">=3.0.0"
-  peerDependenciesMeta:
-    prettier:
-      optional: true
-  checksum: 10c0/b8d7759201276c9c6b7cca55e8406c197a63af80ff6bbed9ebfff0a10f1f98d397a3cc495cee11231313186469bf4d2d28c53b6903c77b09b58fd03ee4ebea81
+  checksum: 10c0/857fec3b1be0b65f9b3c2189730ff27f51d89e101c10b139b8286823fca7a8acba4f01ca2334b06dff459ad0261358a5fca458d83020c935f694d02d54e9cf89
   languageName: node
   linkType: hard
 
@@ -7031,6 +7022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
@@ -9487,6 +9485,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:3.3.3":
+  version: 3.3.3
+  resolution: "dompurify@npm:3.3.3"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
   languageName: node
   linkType: hard
 
@@ -12549,7 +12559,7 @@ __metadata:
     "@fullcalendar/daygrid": "npm:6.1.20"
     "@fullcalendar/timegrid": "npm:6.1.20"
     "@lfx-one/shared": "workspace:*"
-    "@linuxfoundation/lfx-ui-core": "npm:^0.1.0"
+    "@linuxfoundation/lfx-ui-core": "npm:^0.2.0"
     "@openfeature/core": "npm:^1.9.1"
     "@openfeature/launchdarkly-client-provider": "npm:^0.3.3"
     "@openfeature/web-sdk": "npm:1.7.2"
@@ -12607,7 +12617,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": "npm:^20.1.0"
     "@commitlint/config-angular": "npm:^20.0.0"
-    "@linuxfoundation/lfx-ui-core": "npm:^0.0.22"
+    "@linuxfoundation/lfx-ui-core": "npm:^0.2.0"
     "@types/node": "npm:^24.2.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.39.1"
     "@typescript-eslint/parser": "npm:^8.39.1"
@@ -13086,6 +13096,15 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^12.0.0"
   checksum: 10c0/c40efb5e5296e7feb8e37155bde8eb70bc57d731b1f7d90e35a092fde403d7697c56fb49334d92d330d6f1ca29a98142036d6480a12681133a0a1453164cb2f0
+  languageName: node
+  linkType: hard
+
+"marked@npm:17.0.5":
+  version: 17.0.5
+  resolution: "marked@npm:17.0.5"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/a044c59cfa14662fefa37bc840200c1f0899214fb677da779112284d49cd5b277806f9a28398195b2031b1e2c80d8daef218e8ad588d7bfa9bc8041cac777ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds a "What's New" icon to the lens navigation (above LFX Insights) that opens a right-side drawer embedding the `<lfx-changelog>` web component for the `self-serve` product. Includes an unread-count badge driven by the changelog `views` API.
- Backend proxy at `/api/changelog/{unseen,mark-viewed}` calls `changelog.lfx.dev/api/changelogs/views/*` server-to-server with an API key, attaching the user's Auth0 `sub` (via `getEffectiveSub`, so impersonation is honored) as `viewerId`.
- Bumps `@linuxfoundation/lfx-ui-core` to `^0.2.0` (the version that ships the `lfx-changelog` web component) at the workspace root and in `apps/lfx-one`.

## Implementation notes

- **Service pattern**: aligned with `cdp.service.ts` / `credly.service.ts` — lazy env getters, inline `fetch` per method, `MicroserviceError` with specific error codes (`CHANGELOG_UNSEEN_ERROR`, `CHANGELOG_MARK_VIEWED_ERROR`), and a `parseJson()` content-type guard so non-JSON upstream responses surface a clear error instead of a `JSON.parse` stack trace. Endpoint paths and the default API URL live in `CHANGELOG_CONFIG` in `@lfx-one/shared/constants` (mirrors `CDP_CONFIG`).
- **Frontend reactive**: `unseenChangelogCount` is a `Signal<number>` produced by `toSignal()` over a merged Subject pipeline (load + mark-viewed events drive a single reactive stream). No `.subscribe()` in components. Mark-viewed emits `0` optimistically, then fires the POST in the background.
- **Drawer rendering**: embeds `<lfx-changelog product="self-serve" limit="10">`. The widget's outer card chrome is flattened via CSS variables (`--lfx-changelog-bg-surface: transparent`, etc.) targeted at `lfx-changelog` directly so they win over the widget's internal `:host` defaults; redundant header/footer chrome is hidden via `::part(header)` and the brand accent is themed to LFX blue. Card separators are re-introduced via `::part(card)` with a subtle gray border-bottom.
- **SSR-safe**: the unseen fetch fires inside `afterNextRender` so SSR doesn't issue an upstream call we can't display, and so the duplicate `<lfx-lens-switcher [mobile]="true">` instance correctly skips the load (constructor-time inputs hadn't settled).

## Configuration

Three new env vars (added to `apps/lfx-one/.env.example`):

- `CHANGELOG_API_URL` — defaults to `https://changelog.lfx.dev`
- `CHANGELOG_API_KEY` — `lfx_…` key with `changelogs:read` scope
- `CHANGELOG_PRODUCT_ID` — UUID of the self-serve product (per environment)

Pull values from 1Password before the PR is deployed.

## Related

- JIRA: [LFXV2-1702](https://linuxfoundation.atlassian.net/browse/LFXV2-1702)
- Pattern reference: lfx-pcc's `PCCService` / `pcc.controller.ts` (PCC ships a routed page; this PR ships a drawer instead).
- Upstream API: `linuxfoundation/lfx-changelog` — `apps/lfx-changelog/src/server/setup/routes.ts` mounts `/api/changelogs` (which exposes `/views/unseen` and `/views/mark-viewed`).


[LFXV2-1702]: https://linuxfoundation.atlassian.net/browse/LFXV2-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ