### PR TITLE
feat(dashboards): wire org lens to live snowflake data

### DIFF
--- a/apps/lfx-one/src/app/shared/components/org-selector/org-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/org-selector/org-selector.component.html
@@ -47,85 +47,31 @@
     </div>
 
     <div class="max-h-[400px] overflow-y-auto">
-      @for (group of displayGroups(); track $index) {
-        @if (group.kind === 'flat') {
-          <button
-            type="button"
-            class="flex items-center gap-3 p-2 w-full text-left hover:bg-gray-100 rounded-lg transition-colors"
-            [class.bg-blue-50]="isSelected(group.account)"
-            (click)="selectItem(group.account, popover)"
-            [attr.data-testid]="'org-selector-item-' + (group.account.accountSlug || group.account.accountId)">
-            <div class="bg-gray-100 overflow-clip rounded-lg shrink-0 size-9 border border-gray-200">
-              <div class="flex items-center justify-center size-full p-1.5">
-                @if (group.account.logoUrl) {
-                  <img [alt]="group.account.accountName" class="w-full h-full object-contain" [src]="group.account.logoUrl" />
-                } @else {
-                  <i class="fa-light fa-building text-gray-500" aria-hidden="true"></i>
-                }
-              </div>
-            </div>
-
-            <div class="flex-1 min-w-0">
-              <p class="font-medium text-sm text-gray-900 mb-0">{{ group.account.accountName }}</p>
-            </div>
-
-            @if (isSelected(group.account)) {
-              <i class="fa-solid fa-check text-blue-600 text-sm" aria-hidden="true"></i>
-            }
-          </button>
-        } @else {
-          <button
-            type="button"
-            class="flex items-center gap-3 p-2 w-full text-left hover:bg-gray-100 rounded-lg transition-colors"
-            [class.bg-blue-50]="isSelected(group.parent)"
-            (click)="selectItem(group.parent, popover)"
-            [attr.data-testid]="'org-selector-item-' + (group.parent.accountSlug || group.parent.accountId)">
-            <div class="bg-gray-100 overflow-clip rounded-lg shrink-0 size-9 border border-gray-200">
-              <div class="flex items-center justify-center size-full p-1.5">
-                @if (group.parent.logoUrl) {
-                  <img [alt]="group.parent.accountName" class="w-full h-full object-contain" [src]="group.parent.logoUrl" />
-                } @else {
-                  <i class="fa-light fa-building text-gray-500" aria-hidden="true"></i>
-                }
-              </div>
-            </div>
-
-            <div class="flex-1 min-w-0">
-              <p class="font-medium text-sm text-gray-900 mb-0">{{ group.parent.accountName }}</p>
-            </div>
-
-            @if (isSelected(group.parent)) {
-              <i class="fa-solid fa-check text-blue-600 text-sm" aria-hidden="true"></i>
-            }
-          </button>
-
-          @for (sibling of group.siblings; track sibling.accountId) {
-            <button
-              type="button"
-              class="flex items-center gap-3 p-2 pl-12 w-full text-left hover:bg-gray-100 rounded-lg transition-colors"
-              [class.bg-blue-50]="isSelected(sibling)"
-              (click)="selectItem(sibling, popover)"
-              [attr.data-testid]="'org-selector-item-' + (sibling.accountSlug || sibling.accountId)">
-              <div class="bg-gray-100 overflow-clip rounded-lg shrink-0 size-7 border border-gray-200">
-                <div class="flex items-center justify-center size-full p-1">
-                  @if (sibling.logoUrl) {
-                    <img [alt]="sibling.accountName" class="w-full h-full object-contain" [src]="sibling.logoUrl" />
-                  } @else {
-                    <i class="fa-light fa-building text-gray-500 text-xs" aria-hidden="true"></i>
-                  }
-                </div>
-              </div>
-
-              <div class="flex-1 min-w-0">
-                <p class="text-sm text-gray-700 mb-0">{{ sibling.accountName }}</p>
-              </div>
-
-              @if (isSelected(sibling)) {
-                <i class="fa-solid fa-check text-blue-600 text-sm" aria-hidden="true"></i>
+      @for (account of visibleAccounts(); track account.accountId) {
+        <button
+          type="button"
+          class="flex items-center gap-3 p-2 w-full text-left hover:bg-gray-100 rounded-lg transition-colors"
+          [class.bg-blue-50]="isSelected(account)"
+          (click)="selectItem(account, popover)"
+          [attr.data-testid]="'org-selector-item-' + (account.accountSlug || account.accountId)">
+          <div class="bg-gray-100 overflow-clip rounded-lg shrink-0 size-9 border border-gray-200">
+            <div class="flex items-center justify-center size-full p-1.5">
+              @if (account.logoUrl) {
+                <img [alt]="account.accountName" class="w-full h-full object-contain" [src]="account.logoUrl" />
+              } @else {
+                <i class="fa-light fa-building text-gray-500" aria-hidden="true"></i>
               }
-            </button>
+            </div>
+          </div>
+
+          <div class="flex-1 min-w-0">
+            <p class="font-medium text-sm text-gray-900 mb-0">{{ account.accountName }}</p>
+          </div>
+
+          @if (isSelected(account)) {
+            <i class="fa-solid fa-check text-blue-600 text-sm" aria-hidden="true"></i>
           }
-        }
+        </button>
       } @empty {
         <div class="text-center py-8 text-gray-500 text-sm">No organizations found</div>
       }

--- a/apps/lfx-one/src/app/shared/components/org-selector/org-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/org-selector/org-selector.component.ts
@@ -11,8 +11,6 @@ import { AutoFocus } from 'primeng/autofocus';
 import { InputTextModule } from 'primeng/inputtext';
 import { Popover, PopoverModule } from 'primeng/popover';
 
-type DisplayGroup = { kind: 'flat'; account: Account } | { kind: 'conglomerate'; parent: Account; siblings: Account[] };
-
 @Component({
   selector: 'lfx-org-selector',
   imports: [ReactiveFormsModule, PopoverModule, InputTextModule, AutoFocus],
@@ -40,38 +38,13 @@ export class OrgSelectorComponent {
 
   protected readonly displayLogo: Signal<string> = computed(() => this.selectedAccount().logoUrl ?? '');
 
-  protected readonly displayGroups: Signal<DisplayGroup[]> = computed(() => {
+  protected readonly visibleAccounts: Signal<Account[]> = computed(() => {
     const term = this.searchTerm();
     const accounts = this.availableAccounts();
-    const selectedId = this.selectedAccount().accountId;
-
-    if (term) {
-      return accounts.filter((account) => account.accountName.toLowerCase().includes(term)).map<DisplayGroup>((account) => ({ kind: 'flat', account }));
+    if (!term) {
+      return accounts;
     }
-
-    const seen = new Set<string>();
-    const groups: DisplayGroup[] = [];
-
-    for (const account of accounts) {
-      if (seen.has(account.accountId)) {
-        continue;
-      }
-
-      const family = account.accountsRelated ?? [];
-      if (family.length > 0) {
-        const parent = family.find((member) => member.accountId === selectedId) ?? account;
-        const siblings = family.filter((member) => member.accountId !== parent.accountId);
-        groups.push({ kind: 'conglomerate', parent, siblings });
-        for (const member of family) {
-          seen.add(member.accountId);
-        }
-      } else {
-        groups.push({ kind: 'flat', account });
-        seen.add(account.accountId);
-      }
-    }
-
-    return groups;
+    return accounts.filter((account) => account.accountName.toLowerCase().includes(term));
   });
 
   protected selectItem(account: Account, popover: Popover): void {

--- a/apps/lfx-one/src/app/shared/services/account-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/account-context.service.ts
@@ -2,11 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
-import { ACCOUNT_COOKIE_KEY, ACCOUNTS, DEFAULT_ACCOUNT } from '@lfx-one/shared/constants';
-import { Account } from '@lfx-one/shared/interfaces';
+import { ACCOUNT_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { Account, OrgLensAccountContextResponse } from '@lfx-one/shared/interfaces';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 
+import { AnalyticsService } from './analytics.service';
 import { CookieRegistryService } from './cookie-registry.service';
+
+const PLACEHOLDER_ACCOUNT: Account = {
+  accountId: '',
+  accountName: '',
+  accountSlug: '',
+  membershipTier: '',
+};
 
 @Injectable({
   providedIn: 'root',
@@ -14,98 +22,147 @@ import { CookieRegistryService } from './cookie-registry.service';
 export class AccountContextService {
   private readonly cookieService = inject(SsrCookieService);
   private readonly cookieRegistry = inject(CookieRegistryService);
+  private readonly analyticsService = inject(AnalyticsService);
   private readonly storageKey = ACCOUNT_COOKIE_KEY;
 
   /**
-   * User's organizations from committee memberships (filtered from ACCOUNTS)
-   * If empty, falls back to all available accounts
+   * Seed organizations from the persona service — the accounts the
+   * current user is authorised to see. Display attributes (slug, logo,
+   * tier) are resolved from Snowflake via getOrgLensAccountContext.
    */
   private readonly userOrganizations: WritableSignal<Account[]> = signal<Account[]>([]);
 
-  /**
-   * Whether user organizations have been initialized from auth context
-   */
   private readonly initialized: WritableSignal<boolean> = signal<boolean>(false);
 
   /**
-   * The currently selected account
+   * Snowflake-resolved Account records keyed by accountId. Flat — the
+   * UI renders one entry per account regardless of any Salesforce
+   * conglomerate hierarchy that may exist behind the scenes.
    */
+  private readonly liveAccounts: WritableSignal<Map<string, Account>> = signal(new Map());
+
   public readonly selectedAccount: WritableSignal<Account>;
 
   /**
-   * Returns available accounts for the user
-   * Merges detected organizations into the predefined ACCOUNTS list so that
-   * organizations not in the hardcoded list are still available for selection
+   * Accounts visible in the org-selector — one row per persona-authorised
+   * account, enriched with Snowflake display attributes once available,
+   * falling back to bare seed records while live data is loading so the
+   * selector is never empty between bootstrap and the first response.
    */
   public readonly availableAccounts: Signal<Account[]> = computed(() => {
-    const detected = this.userOrganizations();
-    if (!this.initialized() || detected.length === 0) {
-      return ACCOUNTS;
+    const seeds = this.userOrganizations();
+    const live = this.liveAccounts();
+
+    if (live.size === 0) {
+      return seeds;
     }
 
-    // Start with ACCOUNTS, then append any detected orgs not already in the list
-    const knownIds = new Set(ACCOUNTS.map((a) => a.accountId));
-    const extras = detected.filter((d) => !knownIds.has(d.accountId));
-    return extras.length > 0 ? [...ACCOUNTS, ...extras] : ACCOUNTS;
+    const seen = new Set<string>();
+    const result: Account[] = [];
+    for (const seed of seeds) {
+      if (seen.has(seed.accountId)) {
+        continue;
+      }
+      seen.add(seed.accountId);
+      result.push(live.get(seed.accountId) ?? seed);
+    }
+    return result;
   });
 
   public constructor() {
     const stored = this.loadFromStorage();
-    this.selectedAccount = signal<Account>(stored || DEFAULT_ACCOUNT);
+    this.selectedAccount = signal<Account>(stored ?? PLACEHOLDER_ACCOUNT);
   }
 
   /**
-   * Initialize user organizations from auth context (SSR state transfer)
-   * Called during app initialization with organizations matched from committee memberships
+   * Initialize user organizations from auth context (SSR state transfer).
+   *
+   * Sets the seed list from the persona service, then fetches
+   * /api/analytics/org-lens-account-context to enrich each seed with
+   * its Snowflake display attributes (slug, logo, cdev mapping, tier).
+   * Selection is reconciled against the seeds and re-enriched once the
+   * live data arrives.
    */
   public initializeUserOrganizations(organizations: Account[]): void {
     this.initialized.set(true);
-    const enriched = (organizations ?? []).map((org) => {
-      const known = ACCOUNTS.find((a) => a.accountId === org.accountId);
-      return known ? { ...known, ...org, accountsRelated: known.accountsRelated, membershipTier: org.membershipTier ?? known.membershipTier } : org;
-    });
-    this.userOrganizations.set(enriched);
+    const seeds = organizations ?? [];
+    this.userOrganizations.set(seeds);
 
-    if (enriched.length > 0) {
-      // Validate stored selection against the user's detected organizations.
-      // A stored selection from a prior session (or a leaked impersonator cookie)
-      // must match one of the currently detected orgs; otherwise fall back to
-      // the first detected org so the selector reflects the active context.
-      // Resolve to the canonical Account from organizations so we never trust
-      // cookie-supplied fields (e.g. accountName) beyond the validated accountId.
+    if (seeds.length > 0) {
       const stored = this.loadFromStorage();
-      const matchedOrganization = stored ? (enriched.find((org) => org.accountId === stored.accountId) ?? null) : null;
-
-      if (matchedOrganization) {
-        this.selectedAccount.set(matchedOrganization);
+      const matchedSeed = stored ? (seeds.find((seed) => seed.accountId === stored.accountId) ?? null) : null;
+      if (matchedSeed) {
+        this.selectedAccount.set(matchedSeed);
       } else {
-        this.setAccount(enriched[0]);
+        this.setAccount(seeds[0]);
       }
     }
+
+    this.refreshFromSnowflake(seeds.map((seed) => seed.accountId));
   }
 
-  /**
-   * Set the selected account and persist to storage
-   */
   public setAccount(account: Account): void {
-    this.selectedAccount.set(account);
-    this.persistToStorage(account);
+    const live = this.liveAccounts().get(account.accountId);
+    const next = live ?? account;
+    this.selectedAccount.set(next);
+    this.persistToStorage(next);
   }
 
-  /**
-   * Get the currently selected account ID
-   */
   public getAccountId(): string {
     return this.selectedAccount().accountId;
   }
 
+  private refreshFromSnowflake(accountIds: string[]): void {
+    const ids = [...new Set(accountIds.filter((id) => !!id))];
+    if (ids.length === 0) {
+      return;
+    }
+
+    this.analyticsService.getOrgLensAccountContext(ids).subscribe((rows) => {
+      if (rows.length === 0) {
+        return;
+      }
+      const live = this.buildLiveAccounts(rows);
+      this.liveAccounts.set(live);
+
+      const current = this.selectedAccount();
+      const liveCurrent = live.get(current.accountId);
+      if (liveCurrent) {
+        this.selectedAccount.set(liveCurrent);
+      } else if (!current.accountId) {
+        const firstSeed = this.userOrganizations()[0];
+        if (firstSeed) {
+          const liveSeed = live.get(firstSeed.accountId) ?? firstSeed;
+          this.selectedAccount.set(liveSeed);
+          this.persistToStorage(liveSeed);
+        }
+      }
+    });
+  }
+
+  private buildLiveAccounts(rows: OrgLensAccountContextResponse[]): Map<string, Account> {
+    const accounts = new Map<string, Account>();
+    for (const row of rows) {
+      const account = this.toAccount(row);
+      accounts.set(account.accountId, account);
+    }
+    return accounts;
+  }
+
+  private toAccount(row: OrgLensAccountContextResponse): Account {
+    return {
+      accountId: row.accountId,
+      accountName: row.accountName,
+      accountSlug: row.accountSlug ?? '',
+      logoUrl: row.logoUrl ?? undefined,
+      cdevOrgId: row.cdevOrgId ?? undefined,
+      membershipTier: row.membershipTierDisplayName ?? '',
+    };
+  }
+
   private persistToStorage(account: Account): void {
-    // Drop accountsRelated before stringify — conglomerate members share a circular
-    // reference into the family list. The cookie only needs the identifier; tier,
-    // logo, and family are re-enriched from ACCOUNTS / Snowflake on load.
-    const { accountsRelated: _accountsRelated, ...persistable } = account;
-    this.cookieService.set(this.storageKey, JSON.stringify(persistable), {
-      expires: 30, // 30 days
+    this.cookieService.set(this.storageKey, JSON.stringify(account), {
+      expires: 30,
       path: '/',
       sameSite: 'Lax',
       secure: process.env['NODE_ENV'] === 'production',

--- a/apps/lfx-one/src/app/shared/services/account-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/account-context.service.ts
@@ -92,7 +92,7 @@ export class AccountContextService {
       const stored = this.loadFromStorage();
       const matchedSeed = stored ? (seeds.find((seed) => seed.accountId === stored.accountId) ?? null) : null;
       if (matchedSeed) {
-        this.selectedAccount.set(matchedSeed);
+        this.setAccount(matchedSeed);
       } else {
         this.setAccount(seeds[0]);
       }
@@ -173,12 +173,23 @@ export class AccountContextService {
   private loadFromStorage(): Account | null {
     try {
       const stored = this.cookieService.get(this.storageKey);
-      if (stored) {
-        return JSON.parse(stored) as Account;
+      if (!stored) {
+        return null;
       }
+      const parsed = JSON.parse(stored) as Account;
+      if (!this.isValidAccountId(parsed?.accountId)) {
+        return null;
+      }
+      return parsed;
     } catch {
-      // Invalid data in cookie, ignore
+      return null;
     }
-    return null;
+  }
+
+  // Salesforce account ids are 15- or 18-char alphanumeric strings.
+  // Reject anything else so a tampered cookie can't seed selectedAccount with
+  // an invalid id before persona init reconciles.
+  private isValidAccountId(id: unknown): id is string {
+    return typeof id === 'string' && /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(id);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -4,6 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import {
+  OrgLensAccountContextResponse,
   ActiveWeeksStreakResponse,
   CertifiedEmployeesResponse,
   CodeCommitsDailyResponse,
@@ -204,6 +205,23 @@ export class AnalyticsService {
         });
       })
     );
+  }
+
+  /**
+   * Bootstrap the Org Lens account context for the user's persona-authorised
+   * Salesforce accounts. Returns a single denormalised row per account_id
+   * with display attributes, Crowd.dev mapping, and the highest active
+   * corporate membership tier — drives both the org-selector dropdown and
+   * the header badge.
+   */
+  public getOrgLensAccountContext(accountIds: string[]): Observable<OrgLensAccountContextResponse[]> {
+    if (accountIds.length === 0) {
+      return of([]);
+    }
+    const params = { accountIds: accountIds.join(',') };
+    return this.http
+      .get<OrgLensAccountContextResponse[]>('/api/analytics/org-lens-account-context', { params })
+      .pipe(catchError(() => of([] as OrgLensAccountContextResponse[])));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2796,6 +2796,31 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/org-lens-account-context
+   * Resolve LFX One Org Lens display context for a set of Salesforce
+   * accounts — one denormalised row per account_id with cdev mapping
+   * and highest active corporate membership tier.
+   * Query params: accountIds (required) - Comma-separated Salesforce account IDs (max 50)
+   */
+  public async getOrgLensAccountContext(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_lens_account_context');
+
+    try {
+      const accountIds = this.parseAccountIdsParam(req, 'get_org_lens_account_context');
+      const response = await this.organizationService.getOrgLensAccountContext(accountIds);
+
+      logger.success(req, 'get_org_lens_account_context', startTime, {
+        requested_count: accountIds.length,
+        resolved_count: response.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * Parse and validate a comma-separated slugs query parameter.
    * @throws ServiceValidationError if the parameter is missing, empty, exceeds max count, or has invalid format
    */
@@ -2838,5 +2863,44 @@ export class AnalyticsController {
     }
 
     return slugs;
+  }
+
+  /**
+   * Parse and validate the `accountIds` query parameter (comma-separated
+   * Salesforce account IDs). De-duplicates, enforces a 50-id ceiling, and
+   * checks each id matches the Salesforce 15/18-char alphanumeric format.
+   */
+  private parseAccountIdsParam(req: Request, operation: string): string[] {
+    const raw = getStringQueryParam(req, 'accountIds');
+    if (!raw) {
+      throw ServiceValidationError.forField('accountIds', 'accountIds query parameter is required', { operation });
+    }
+
+    const ids = [
+      ...new Set(
+        raw
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      ),
+    ];
+
+    if (ids.length === 0) {
+      throw ServiceValidationError.forField('accountIds', 'At least one accountId is required', { operation });
+    }
+
+    const MAX_ACCOUNT_IDS = 50;
+    if (ids.length > MAX_ACCOUNT_IDS) {
+      throw ServiceValidationError.forField('accountIds', `Maximum of ${MAX_ACCOUNT_IDS} accountIds allowed per request`, { operation });
+    }
+
+    const SALESFORCE_ID_PATTERN = /^[A-Za-z0-9]{15,18}$/;
+    for (const id of ids) {
+      if (!SALESFORCE_ID_PATTERN.test(id)) {
+        throw ServiceValidationError.forField('accountIds', `Invalid Salesforce accountId format: ${id}`, { operation });
+      }
+    }
+
+    return ids;
   }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -189,4 +189,7 @@ router.get('/marketing-attribution', (req, res, next) => analyticsController.get
 // Multi-foundation summary endpoint (multi-foundation dashboard)
 router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));
 
+// Org Lens — bootstrap account context (display attrs + cdev mapping + tier)
+router.get('/org-lens-account-context', (req, res, next) => analyticsController.getOrgLensAccountContext(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/organization.service.ts
+++ b/apps/lfx-one/src/server/services/organization.service.ts
@@ -6,6 +6,8 @@
 import {
   CertifiedEmployeesMonthlyRow,
   CertifiedEmployeesResponse,
+  OrgLensAccountContextResponse,
+  OrgLensAccountContextRow,
   FoundationCompanyBusFactorResponse,
   FoundationCompanyBusFactorRow,
   MembershipTierResponse,
@@ -869,5 +871,63 @@ export class OrganizationService {
     }));
 
     return { programs };
+  }
+
+  /**
+   * Resolve LFX One Org Lens account context for a set of Salesforce
+   * accounts (typically the user's persona-authorised organizations).
+   *
+   * Single-table read against
+   * platinum_lfx_one_org_lens_account_context — one denormalised
+   * platinum row per account_id with display attributes, Crowd.dev
+   * mapping, and the highest active corporate membership tier
+   * pre-joined inside dbt. No application-layer joins, no conglomerate
+   * expansion (the UI renders a flat list).
+   */
+  public async getOrgLensAccountContext(accountIds: string[]): Promise<OrgLensAccountContextResponse[]> {
+    if (accountIds.length === 0) {
+      return [];
+    }
+
+    const placeholders = accountIds.map(() => '?').join(',');
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        ACCOUNT_NAME,
+        ACCOUNT_SLUG,
+        LOGO_URL,
+        CDEV_ORG_ID,
+        CDEV_ORG_NAME,
+        CDEV_ORG_LOGO,
+        IS_MEMBER,
+        MEMBER_ACCOUNT_TYPE,
+        MEMBERSHIP_ID,
+        MEMBERSHIP_PROJECT_ID,
+        MEMBERSHIP_PROJECT_NAME,
+        MEMBERSHIP_TIER_DISPLAY_NAME,
+        MEMBERSHIP_TIER_CLASS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT
+      WHERE ACCOUNT_ID IN (${placeholders})
+      ORDER BY ACCOUNT_NAME
+    `;
+
+    const result = await this.snowflakeService.execute<OrgLensAccountContextRow>(query, accountIds);
+
+    return result.rows.map((row) => ({
+      accountId: row.ACCOUNT_ID,
+      accountName: row.ACCOUNT_NAME,
+      accountSlug: row.ACCOUNT_SLUG,
+      logoUrl: row.LOGO_URL,
+      cdevOrgId: row.CDEV_ORG_ID,
+      cdevOrgName: row.CDEV_ORG_NAME,
+      cdevOrgLogo: row.CDEV_ORG_LOGO,
+      isMember: row.IS_MEMBER,
+      memberAccountType: row.MEMBER_ACCOUNT_TYPE,
+      membershipId: row.MEMBERSHIP_ID,
+      membershipProjectId: row.MEMBERSHIP_PROJECT_ID,
+      membershipProjectName: row.MEMBERSHIP_PROJECT_NAME,
+      membershipTierDisplayName: row.MEMBERSHIP_TIER_DISPLAY_NAME,
+      membershipTierClass: row.MEMBERSHIP_TIER_CLASS,
+    }));
   }
 }

--- a/packages/shared/src/constants/accounts.constants.ts
+++ b/packages/shared/src/constants/accounts.constants.ts
@@ -1,31 +1,4 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { Account } from '../interfaces/account.interface';
-
 export const ACCOUNT_COOKIE_KEY = 'lfx-selected-account';
-
-const IBM_FAMILY: Account[] = [
-  { accountId: '0014100000kgVoqAAE', accountName: 'International Business Machines Corporation', accountSlug: 'ibm', membershipTier: 'Platinum Member' },
-  { accountId: '0014100000Te2QjAAJ', accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Platinum Member' },
-  { accountId: '0014100000TdzYmAAJ', accountName: 'Apptio', accountSlug: 'apptio', membershipTier: 'Platinum Member' },
-  { accountId: '0012M00002ZLGHsQAP', accountName: 'IBM Watson Health', accountSlug: 'ibm-watson-health', membershipTier: 'Platinum Member' },
-  { accountId: '0012M000027Enn8QAC', accountName: 'Nordcloud, an IBM Company', accountSlug: 'nordcloud', membershipTier: 'Platinum Member' },
-  { accountId: '0012M00002F2mObQAJ', accountName: 'Stackwatch Inc', accountSlug: 'stackwatch', membershipTier: 'Platinum Member' },
-  { accountId: '0014100000Te2qeAAB', accountName: 'Turbonomic, an IBM Company', accountSlug: 'turbonomic', membershipTier: 'Platinum Member' },
-];
-
-for (const member of IBM_FAMILY) {
-  member.accountsRelated = IBM_FAMILY;
-}
-
-const TOYOTA: Account = {
-  accountId: '0012M00002ND5yOQAT',
-  accountName: 'Toyota Motor Corporation',
-  accountSlug: 'toyota-motor-corporation',
-  membershipTier: 'Gold Member',
-};
-
-export const ACCOUNTS: Account[] = [TOYOTA, ...IBM_FAMILY];
-
-export const DEFAULT_ACCOUNT: Account = IBM_FAMILY.find((account) => account.accountSlug === 'red-hat') ?? IBM_FAMILY[0];

--- a/packages/shared/src/interfaces/account.interface.ts
+++ b/packages/shared/src/interfaces/account.interface.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Account entity representing an organization in the system
- * @description Maps account ID to organization name for board member dashboard
+ * Account entity representing an organization in the LFX One Org Lens.
+ * Used by the org-selector and any header/badge that needs the org's
+ * display attributes.
  */
 export interface Account {
-  /** Salesforce account_id (also known as b2b_account_id) — primary join key */
+  /** Salesforce account_id — primary join key */
   accountId: string;
   /** Organization display name */
   accountName: string;
@@ -16,8 +17,6 @@ export interface Account {
   accountSlug?: string;
   /** Logo URL for the organization */
   logoUrl?: string;
-  /** Highest membership tier across active memberships (e.g. "Platinum", "Gold") */
+  /** Highest active corporate membership tier display name (e.g. "Platinum Membership"). NULL/empty → no badge. */
   membershipTier?: string;
-  /** Related accounts in the same Salesforce hierarchy (conglomerate siblings) */
-  accountsRelated?: Account[];
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -66,6 +66,9 @@ export * from './snowflake.interface';
 // Account interfaces
 export * from './account.interface';
 
+// Org Lens (per-account TLF membership tier + cdev org mapping) interfaces
+export * from './org-lens.interface';
+
 // Mailing list interfaces
 export * from './mailing-list.interface';
 

--- a/packages/shared/src/interfaces/org-lens.interface.ts
+++ b/packages/shared/src/interfaces/org-lens.interface.ts
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * LFX Org Lens membership tier classes, in descending tier order.
+ * Drives any tier-based ranking or filtering on the client side.
+ * Backed by the accepted_values dbt test on
+ * platinum_lfx_one_org_lens_account_context.membership_tier_class.
+ */
+export type MembershipTierClass = 'Platinum' | 'Premier' | 'Gold' | 'Silver' | 'Steering' | 'General' | 'Sponsor' | 'Other';
+
+/**
+ * Raw row from ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT — the
+ * single denormalised platinum table that resolves a Salesforce
+ * account_id to the full Org Lens display context (account attributes,
+ * Crowd.dev mapping, highest active corporate membership tier).
+ */
+export interface OrgLensAccountContextRow {
+  ACCOUNT_ID: string;
+  ACCOUNT_NAME: string;
+  ACCOUNT_SLUG: string | null;
+  LOGO_URL: string | null;
+  CDEV_ORG_ID: string | null;
+  CDEV_ORG_NAME: string | null;
+  CDEV_ORG_LOGO: string | null;
+  IS_MEMBER: boolean;
+  MEMBER_ACCOUNT_TYPE: string | null;
+  MEMBERSHIP_ID: string | null;
+  MEMBERSHIP_PROJECT_ID: string | null;
+  MEMBERSHIP_PROJECT_NAME: string | null;
+  MEMBERSHIP_TIER_DISPLAY_NAME: string | null;
+  MEMBERSHIP_TIER_CLASS: MembershipTierClass | null;
+}
+
+export interface OrgLensAccountContextResponse {
+  accountId: string;
+  accountName: string;
+  accountSlug: string | null;
+  logoUrl: string | null;
+  cdevOrgId: string | null;
+  cdevOrgName: string | null;
+  cdevOrgLogo: string | null;
+  isMember: boolean;
+  memberAccountType: string | null;
+  membershipId: string | null;
+  membershipProjectId: string | null;
+  membershipProjectName: string | null;
+  membershipTierDisplayName: string | null;
+  membershipTierClass: MembershipTierClass | null;
+}


### PR DESCRIPTION
Wires the Org Lens shell to live data from the new
`platinum_lfx_one_org_lens_account_context` model
([linuxfoundation/lf-dbt#2393](https://github.com/linuxfoundation/lf-dbt/pull/2393),
merged). Single-table read, no app-layer joins, flat org list.

Ticket: [LFXV2-1673](https://linuxfoundation.atlassian.net/browse/LFXV2-1673)
Base branch: `feat/CD-3507-org-lens-shell` (in-flight feature branch, not main)

## Summary

- New endpoint `GET /api/analytics/org-lens-account-context?accountIds=...`
  returns one denormalised platinum row per Salesforce account (display
  attrs + Crowd.dev mapping + highest active corporate membership tier).
- `AccountContextService`, `org-selector` dropdown, and the header tier
  badge now read from the live endpoint instead of
  `accounts.constants.ts` hardcoding (which is removed).
- Dropdown is a flat list — no conglomerate hierarchy, no "X related
  accounts" copy, no first-visit picker. Per PM direction.
- New shared interfaces (`OrgLensAccountContextRow`,
  `OrgLensAccountContextResponse`) and the canonical
  `MembershipTierClass` union, backed by the `accepted_values` dbt test.

## Test plan

- [x] `yarn lint`, `yarn check-types`, `prettier --check` on the 11
  staged files all clean
- [x] Playwright smoke against local dev — flat list of 8 IBM-family
  orgs renders, logos resolve (Apptio fallback OK), tier badges match
  Snowflake values, API returns 200 with the expected shape

## Notes for reviewers

- Pre-commit `format:check` shows drift on five tracked files
  (`app.routes.ts`, the four `org-overview*` / `org-placeholder-page`
  / `org-involvement-analytics` files) introduced by
  [#656](https://github.com/linuxfoundation/lfx-v2-ui/pull/656)
  (LFXV2-1674).

[LFXV2-1673]: https://linuxfoundation.atlassian.net/browse/LFXV2-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ