### PR TITLE
docs(claude-md): extend with session conventions and ssr safety

### DIFF
--- a/.claude/rules/commit-workflow.md
+++ b/.claude/rules/commit-workflow.md
@@ -1,6 +1,7 @@
 ---
-description: Commit conventions, branch naming, PR format, PR size guidelines, and JIRA tracking workflow
-globs: '*'
+description: Commit conventions, branch naming, PR format, PR size guidelines, sign-off + GPG signing, and JIRA tracking workflow
+paths:
+  - '*'
 ---
 
 # Commit & PR Workflow

--- a/.claude/rules/component-organization.md
+++ b/.claude/rules/component-organization.md
@@ -1,6 +1,7 @@
 ---
-description: Angular component organization pattern — signal initialization, structure order, model signals
-globs: '**/*.component.ts'
+description: Angular component organization pattern — signal initialization, structure order, model signals, DELETE → CREATE rule
+paths:
+  - '**/*.component.ts'
 ---
 
 # Component Organization Pattern
@@ -117,3 +118,15 @@ import { RelativeDateInfo } from '@lfx-one/shared/interfaces';
 
 - **`ChangeDetectionStrategy.OnPush`** is NOT required. With zoneless change detection and signals, OnPush is unnecessary. Do not flag its absence.
 - **`standalone: true`** is NOT required on components, directives, or pipes. Angular defaults components, directives, and pipes to standalone. Do not flag its absence.
+
+## 7. DELETE → CREATE for full component replacement
+
+When _fully replacing_ a component (architectural rewrite, breaking API change, or change in core responsibilities), delete the old file and create the new one. The intent change is clearer in review than a sprawling in-place rewrite.
+
+Does **not** apply to:
+
+- Small tweaks, bug fixes, or cosmetic changes — edit in place
+- Refactors that preserve the public API — edit in place
+- Renames or moves — use `git mv` (preserves blame continuity), then edit
+
+For borderline cases, prefer in-place edits — they keep `git blame` and review history more useful.

--- a/.claude/rules/development-rules.md
+++ b/.claude/rules/development-rules.md
@@ -1,6 +1,7 @@
 ---
 description: General development rules — shared package conventions, license headers, testing, formatting, layout patterns
-globs: '*'
+paths:
+  - '*'
 ---
 
 # Development Rules

--- a/.claude/rules/logging-patterns.md
+++ b/.claude/rules/logging-patterns.md
@@ -1,6 +1,7 @@
 ---
 description: Pino structured logging patterns — logger service API, layer responsibilities, log levels, code examples
-globs: '**/server/**'
+paths:
+  - '**/server/**'
 ---
 
 # Logging System

--- a/.claude/rules/skill-guidance.md
+++ b/.claude/rules/skill-guidance.md
@@ -1,6 +1,7 @@
 ---
 description: Guides Claude to suggest the right skill based on user intent
-globs: '*'
+paths:
+  - '*'
 ---
 
 # Available Skills

--- a/.claude/rules/ssr-safety.md
+++ b/.claude/rules/ssr-safety.md
@@ -1,0 +1,49 @@
+---
+description: SSR safety rules — isPlatformBrowser guard, browser-only API handling, lazy-loading third-party libs
+paths:
+  - '**/*.component.ts'
+  - '**/*.service.ts'
+  - '**/*.directive.ts'
+  - '**/server/**'
+---
+
+# SSR Safety
+
+Angular 20 SSR is strict. Static HTML prototypes and dev-mode hot reload hide SSR-only failures — they only surface during `yarn build` or production runtime.
+
+## Never reference browser-only APIs outside an isPlatformBrowser guard
+
+`window`, `document`, `localStorage`, `navigator`, `IntersectionObserver`, `ResizeObserver`, `MutationObserver`, and similar browser globals must be gated:
+
+```typescript
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, PLATFORM_ID } from '@angular/core';
+
+constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
+ngOnInit() {
+  if (isPlatformBrowser(this.platformId)) {
+    // browser-only code here
+  }
+}
+```
+
+## Third-party libraries that touch the browser
+
+Libraries that reference `window` at import time (charting libs, drag-and-drop libs, some UI kits) must be loaded lazily _inside_ the guard:
+
+```typescript
+ngOnInit() {
+  if (isPlatformBrowser(this.platformId)) {
+    import('some-browser-only-lib').then(({ default: lib }) => {
+      // use lib here
+    });
+  }
+}
+```
+
+A static top-level `import` of such a library will crash SSR even if the code path that uses it is browser-only.
+
+## Catching failures
+
+`yarn build` exercises the SSR bundle and is the fastest local way to catch SSR violations. `yarn start` (dev server) does not.

--- a/.claude/rules/ssr-safety.md
+++ b/.claude/rules/ssr-safety.md
@@ -17,9 +17,9 @@ Angular 20 SSR is strict. Static HTML prototypes and dev-mode hot reload hide SS
 
 ```typescript
 import { isPlatformBrowser } from '@angular/common';
-import { Inject, PLATFORM_ID } from '@angular/core';
+import { inject, PLATFORM_ID } from '@angular/core';
 
-constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+private readonly platformId = inject(PLATFORM_ID);
 
 ngOnInit() {
   if (isPlatformBrowser(this.platformId)) {

--- a/.claude/rules/styling.md
+++ b/.claude/rules/styling.md
@@ -1,0 +1,34 @@
+---
+description: Styling and brand-color rules — lfxColors scales, Tailwind config, no hard-coded hex
+paths:
+  - '**/*.html'
+  - '**/*.scss'
+  - '**/*.component.ts'
+---
+
+# Styling
+
+## Brand colors
+
+Brand palette lives in `@linuxfoundation/lfx-ui-core`, exported via `packages/shared/src/constants/colors.constants.ts` as `lfxColors`. Tailwind picks scales up automatically via `apps/lfx-one/tailwind.config.js` (there is no root-level Tailwind config).
+
+Available scales:
+
+- `blue` — primary
+- `gray` — neutral
+- `emerald` — success
+- `red` — error
+- `amber` — warning
+- `violet` — accent
+
+**Never hard-code hex values.** Reference scale names so brand updates propagate without code changes.
+
+## Layout primitives
+
+- Use `flex + flex-col + gap-*` for vertical stacking, never `space-y-*`
+- Never nest ternary expressions inside templates — extract a computed or pipe instead
+
+## Tailwind & PrimeNG wrappers
+
+- Tailwind first; reach for custom SCSS only for PrimeNG overrides, complex animations, or pseudo-elements
+- All PrimeNG components are accessed through LFX wrapper components in `shared/components/` — don't reach for raw `<p-*>` components directly in feature module templates if a wrapper exists

--- a/.claude/skills/dco/SKILL.md
+++ b/.claude/skills/dco/SKILL.md
@@ -38,8 +38,8 @@ Then interactively rebase from one commit _before_ that:
 
 ```bash
 git rebase -i <parent-of-unsigned-commit>
-# In the editor, change `pick` to `reword` for each unsigned commit
-# Save and exit; for each commit reword shown, just save (no message change)
+# In the editor, change `pick` to `edit` for each unsigned commit
+# Save and exit; the rebase stops at each `edit` line so you can amend
 ```
 
 For each commit in the rebase, replace it with a signed version:

--- a/.claude/skills/dco/SKILL.md
+++ b/.claude/skills/dco/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: dco
+description: >
+  Recover from missing DCO sign-off on commits. Handles the single-commit
+  amend, older-commit recovery via interactive rebase or cherry-pick,
+  and explains the Probot DCO check that blocks PRs without sign-off.
+  Use when a PR fails the DCO check, when a commit needs a Signed-off-by
+  trailer added retroactively, or when sign-off was forgotten during
+  rebase / cherry-pick / amend.
+allowed-tools: Bash, Read, Edit
+---
+
+# DCO Sign-off Recovery
+
+All commits in this repo must carry a `Signed-off-by:` trailer (Developer Certificate of Origin). The Probot DCO check on PRs blocks merge until every commit is signed.
+
+The standard way to add it is with `--signoff` at commit time. This skill handles the cases where that was missed.
+
+## Case 1: Last commit only
+
+```bash
+git commit --amend --signoff -S --no-edit
+git push --force-with-lease
+```
+
+`--force-with-lease` is preferred over plain `--force` — it refuses if someone else has pushed to the branch since you last fetched.
+
+## Case 2: Older commit on the same branch
+
+Find the commit hash of the oldest unsigned commit:
+
+```bash
+git log --pretty='%h %s %(trailers:key=Signed-off-by,valueonly)' origin/main..HEAD
+# Any line with an empty trailing field is unsigned
+```
+
+Then interactively rebase from one commit _before_ that:
+
+```bash
+git rebase -i <parent-of-unsigned-commit>
+# In the editor, change `pick` to `reword` for each unsigned commit
+# Save and exit; for each commit reword shown, just save (no message change)
+```
+
+For each commit in the rebase, replace it with a signed version:
+
+```bash
+git commit --amend --signoff -S --no-edit
+git rebase --continue
+```
+
+When done, force-push:
+
+```bash
+git push --force-with-lease
+```
+
+## Case 3: Cherry-pick / merge brought in unsigned commits
+
+When cherry-picking commits authored by others (or your own older commits) without `--signoff`, the picked commits won't carry the trailer.
+
+Cherry-pick with sign-off baked in:
+
+```bash
+git cherry-pick --signoff <sha>
+```
+
+If you already cherry-picked without it, fall back to Case 1 or Case 2 above.
+
+## Verifying the whole branch
+
+Before pushing, verify every commit ahead of origin/main has both DCO and GPG:
+
+```bash
+git log --format='%G? %(trailers:key=Signed-off-by,valueonly,separator=%x20) %h %s' origin/main..HEAD
+```
+
+Each line must start with `G` or `U` (good GPG signature) AND carry a non-empty `Signed-off-by` value before the SHA. Codes `N` / `B` / `E` need investigation. See `.claude/rules/commit-workflow.md` for the canonical signing policy.
+
+## What the Probot DCO check looks for
+
+The check passes when every commit message includes a `Signed-off-by: Name <email>` trailer matching the commit author's email. The `--signoff` (or `-s`) flag adds this trailer automatically using your `user.name` and `user.email` git config.
+
+A failing DCO check on a PR will show a "Details" link explaining which commits are missing sign-off.

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -14,6 +14,16 @@ You are helping a contributor build within the LFX One codebase. This skill hand
 
 **Important:** You are integrating features within existing architecture — not making architectural decisions. If the work requires changes to routing, auth, middleware, or infrastructure, flag it for a code owner.
 
+## Pre-edit hygiene
+
+Before every meaningful edit:
+
+1. **Re-read the file with `view`** — do not trust prior conversation history. Files change; context drifts.
+2. **Run `yarn check-types` after multi-file changes** to catch type drift early.
+3. **Stop and ask** if the request conflicts with conventions in `CLAUDE.md` or `.claude/rules/`.
+
+Default to small, atomic changes. If a request spans more than one module or touches both client and SSR server, surface that and ask whether to split.
+
 ## Step 1: Start from Latest Main & Track Work
 
 Follow the "Starting New Work" rule in `development-rules.md` — checkout `main`, pull latest, and create a feature branch before writing any code.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -108,6 +108,22 @@ If the contributor encounters issues, help them debug:
 - **Missing dependencies:** Run `yarn install` again
 - **Corepack issues:** Run `corepack enable && corepack prepare yarn@4.9.2 --activate`
 
+### Local auth gotchas (Authelia)
+
+The local stack uses **Authelia** at `https://auth.k8s.orb.local` (not Auth0 — Auth0 is prod/staging only).
+
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` is required for local Authelia because the cert is self-signed. See README.
+- Local-mode detection: the server checks `issuerBaseUrl.includes('auth.k8s.orb.local')` in `m2m-token.util.ts`, `auth.middleware.ts`, and `profile.controller.ts`.
+- **Login broken?** Most common cause is stale cookies or a rotated client secret. Clear browser cookies for `localhost:4200`, then re-fetch the Authelia client secret and update `.env`:
+
+  ```bash
+  kubectl get secrets authelia-clients -n lfx \
+    -o jsonpath='{.data.lfx}' | base64 --decode
+  ```
+
+- **Inspect the current session** (after login): `http://localhost:4200/api/auth/me`
+- If the `lfx` Authelia client doesn't exist in the cluster, the `authelia-clients` secret will be missing — the local k8s stack needs `helmfile sync` to recreate it.
+
 ## Done
 
 Once the app loads successfully, the contributor is ready to start development.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -121,7 +121,7 @@ The local stack uses **Authelia** at `https://auth.k8s.orb.local` (not Auth0 —
     -o jsonpath='{.data.lfx}' | base64 --decode
   ```
 
-- **Inspect the current session** (after login): `http://localhost:4200/api/auth/me`
+- **Inspect the current session** (after login): `http://localhost:4200/api/profile` (the server-registered route backed by `profileController.getCurrentUserProfile` — there is no `/api/auth/me`)
 - If the `lfx` Authelia client doesn't exist in the cluster, the `authelia-clients` secret will be missing — the local k8s stack needs `helmfile sync` to recreate it.
 
 ## Done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 > Auto-loaded by Claude Code at session start. Read this first.
 
 ## Project Overview
@@ -61,7 +63,7 @@ All commands run from the repo root via Turborepo:
 
 ```bash
 ng cache clean             # Angular CLI cache
-npx turbo clean            # Turborepo build cache
+yarn turbo clean           # Turborepo build cache (turbo is a local devDep)
 rm -rf node_modules && yarn install   # nuclear
 ```
 
@@ -183,9 +185,17 @@ Older commits, cherry-picks, rebases → invoke the `dco` skill. PR is blocked u
 - Use `flex + flex-col + gap-*`, not `space-y-*`, for vertical stacking.
 - All shared constants and interfaces live in `@lfx-one/shared` — no module-level consts or local `interface Foo {}` inside `apps/lfx-one/`.
 
-### DELETE → CREATE for component replacement
+### DELETE → CREATE for full component replacement
 
-When replacing a component or pattern, delete the old file and create a new one. Never modify in place. Git history captures the change; reviewers see a clean diff. Team convention.
+When _fully replacing_ a component (architectural rewrite, breaking API change, or change in core responsibilities), delete the old file and create the new one. The intent change is clearer in review than a sprawling in-place rewrite.
+
+Does **not** apply to:
+
+- Small tweaks, bug fixes, or cosmetic changes — edit in place
+- Refactors that preserve the public API — edit in place
+- Renames or moves — use `git mv` (preserves blame continuity), then edit
+
+For borderline cases, prefer in-place edits — they keep `git blame` and review history more useful.
 
 ### Architecture
 
@@ -220,7 +230,7 @@ Third-party libs that touch `window` → load lazily inside the guard.
 
 ## Brand colors
 
-Brand palette lives in `@linuxfoundation/lfx-ui-core`, exported via `packages/shared/src/constants/colors.constants.ts` as `lfxColors`. Tailwind picks scales up automatically via `tailwind.config.js`.
+Brand palette lives in `@linuxfoundation/lfx-ui-core`, exported via `packages/shared/src/constants/colors.constants.ts` as `lfxColors`. Tailwind picks scales up automatically via `apps/lfx-one/tailwind.config.js` (there is no root-level Tailwind config).
 
 Available scales:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,7 @@ LFX One is a Turborepo monorepo containing an Angular 20 SSR application with st
 
 ## Working mode
 
-You have full file-edit authority in this session — different from a Cowork session where you generate prompts for someone else to execute.
-
-Before every meaningful edit:
-
-1. Re-read the file with `view` — do not trust prior conversation history. Files change; context drifts.
-2. Run `yarn check-types` after multi-file changes to catch type drift early.
-3. Stop and ask if the request conflicts with the conventions in this file or in `.claude/rules/`.
-
-Default to small, atomic changes. If a request spans more than one module or touches both client and SSR server, surface that and ask whether to split.
+You have full file-edit authority in this session — different from a Cowork session where you generate prompts for someone else to execute. For pre-edit hygiene checks (re-read files, type-check after multi-file changes, etc.) invoke the `/develop` skill.
 
 ## Domain language
 
@@ -168,15 +160,7 @@ Utilities split into **generic** helpers (date/time, string, url, file, form, ht
 - Pre-commit runs `./check-headers.sh`, `npx lint-staged` (prettier + lint on staged files), then repo-wide `yarn format:check`, `yarn lint:check`, and `yarn check-types`. Only `lint-staged` is scoped to staged files — the rest run on the whole repo. You don't need to run `yarn format` manually; `lint-staged` already prettifies staged files. If a commit fails, fix the reported issue and retry.
 - See `.claude/rules/commit-workflow.md` for PR title / sizing / JIRA details.
 
-**Recovery for missing sign-off:**
-
-Last commit only:
-
-```bash
-git commit --amend --signoff -S --no-edit
-```
-
-Older commits, cherry-picks, rebases → invoke the `dco` skill. PR is blocked until every commit is signed.
+For missing sign-off recovery (single-commit amend, or older commits / cherry-picks / rebases), invoke the `dco` skill.
 
 ### Source hygiene
 
@@ -184,18 +168,6 @@ Older commits, cherry-picks, rebases → invoke the `dco` skill. PR is blocked u
 - Never nest ternary expressions.
 - Use `flex + flex-col + gap-*`, not `space-y-*`, for vertical stacking.
 - All shared constants and interfaces live in `@lfx-one/shared` — no module-level consts or local `interface Foo {}` inside `apps/lfx-one/`.
-
-### DELETE → CREATE for full component replacement
-
-When _fully replacing_ a component (architectural rewrite, breaking API change, or change in core responsibilities), delete the old file and create the new one. The intent change is clearer in review than a sprawling in-place rewrite.
-
-Does **not** apply to:
-
-- Small tweaks, bug fixes, or cosmetic changes — edit in place
-- Refactors that preserve the public API — edit in place
-- Renames or moves — use `git mv` (preserves blame continuity), then edit
-
-For borderline cases, prefer in-place edits — they keep `git blame` and review history more useful.
 
 ### Architecture
 
@@ -206,42 +178,6 @@ For borderline cases, prefer in-place edits — they keep `git blame` and review
 ### Dev server
 
 - Don't restart the dev server on code changes — hot reload handles it. Check logs instead.
-
-## SSR safety
-
-Angular 20 SSR is strict. Static HTML prototypes and dev-mode hot reload hide these — they only surface during `yarn build` or production runtime.
-
-Never reference `window`, `document`, `localStorage`, `navigator`, or `IntersectionObserver` outside an `isPlatformBrowser` guard:
-
-```typescript
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, PLATFORM_ID } from '@angular/core';
-
-constructor(@Inject(PLATFORM_ID) private platformId: object) {}
-
-ngOnInit() {
-  if (isPlatformBrowser(this.platformId)) {
-    // browser-only code here
-  }
-}
-```
-
-Third-party libs that touch `window` → load lazily inside the guard.
-
-## Brand colors
-
-Brand palette lives in `@linuxfoundation/lfx-ui-core`, exported via `packages/shared/src/constants/colors.constants.ts` as `lfxColors`. Tailwind picks scales up automatically via `apps/lfx-one/tailwind.config.js` (there is no root-level Tailwind config).
-
-Available scales:
-
-- `blue` — primary
-- `gray` — neutral
-- `emerald` — success
-- `red` — error
-- `amber` — warning
-- `violet` — accent
-
-**Never hard-code hex values.** Reference scale names so brand updates propagate without code changes.
 
 ## Design source of truth
 
@@ -261,34 +197,7 @@ When implementing from a design:
 
 The HTML is the **visual** spec. Behavior needs explicit input.
 
-## Local auth gotchas
-
-- Local auth: **Authelia** at `https://auth.k8s.orb.local`
-- `NODE_TLS_REJECT_UNAUTHORIZED=0` required for local Authelia (see README)
-- Detection logic: server checks `issuerBaseUrl.includes('auth.k8s.orb.local')` in `m2m-token.util.ts`, `auth.middleware.ts`, `profile.controller.ts`
-- Login breaking? Clear cookies, re-fetch client secret:
-
-  ```bash
-  kubectl get secrets authelia-clients -n lfx -o jsonpath='{.data.lfx}' | base64 --decode
-  ```
-
-- Inspect session: `http://localhost:4200/api/auth/me`
-
-## Session hygiene
-
-### When context feels stale
-
-- Re-read files before editing — don't trust history
-- Run `git status` and `git diff` to ground in disk reality
-- If session has been running >30 min on one task, suggest `/compact` or fresh session
-
-### When delegating sub-investigations
-
-Use the Task tool for "find all usages of X" or "audit module Y for pattern Z" — fresh subagent context, main session stays focused.
-
-### When unsure
-
-Stop and ask. Convention: **clarify, then act.** One well-executed change beats three drifting ones.
+For local auth issues (Authelia at `auth.k8s.orb.local`, broken cookies, client-secret fetch, session inspection), invoke the `/setup` skill.
 
 ## Source of truth, in order
 
@@ -300,15 +209,17 @@ Stop and ask. Convention: **clarify, then act.** One well-executed change beats 
 
 ## Rule Files
 
-Detailed patterns are in `.claude/rules/` and loaded contextually based on file globs:
+Detailed patterns are in `.claude/rules/` and loaded contextually based on the `paths:` frontmatter in each file:
 
-| Rule File                   | Glob                | Topics                                                                      |
-| --------------------------- | ------------------- | --------------------------------------------------------------------------- |
-| `component-organization.md` | `**/*.component.ts` | Signal initialization, component structure order, model signals, interfaces |
-| `logging-patterns.md`       | `**/server/**`      | Logger service API, layer responsibilities, log levels, code examples       |
-| `development-rules.md`      | `*`                 | Shared package, license headers, testing, formatting, doc maintenance       |
-| `commit-workflow.md`        | `*`                 | Commit conventions, branch naming, PR format, PR sizing, JIRA tracking      |
-| `skill-guidance.md`         | `*`                 | Guides Claude to suggest `/setup`, `/develop`, `/preflight` skills          |
+| Rule File                   | Paths                                                                       | Topics                                                                                                |
+| --------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `component-organization.md` | `**/*.component.ts`                                                         | Signal initialization, component structure order, model signals, interfaces, DELETE → CREATE rule     |
+| `logging-patterns.md`       | `**/server/**`                                                              | Logger service API, layer responsibilities, log levels, code examples                                 |
+| `ssr-safety.md`             | `**/*.component.ts`, `**/*.service.ts`, `**/*.directive.ts`, `**/server/**` | `isPlatformBrowser` guard, browser-only API rules, lazy-loading third-party libs                      |
+| `styling.md`                | `**/*.html`, `**/*.scss`, `**/*.component.ts`                               | Brand color scales (`lfxColors`), Tailwind config, no hard-coded hex                                  |
+| `development-rules.md`      | `*`                                                                         | Shared package, license headers, testing, formatting, doc maintenance                                 |
+| `commit-workflow.md`        | `*`                                                                         | Commit conventions, branch naming, PR format, PR sizing, JIRA tracking, sign-off + GPG signing policy |
+| `skill-guidance.md`         | `*`                                                                         | Guides Claude to suggest `/setup`, `/develop`, `/preflight` skills                                    |
 
 ## Architecture Documentation
 
@@ -340,7 +251,7 @@ Detailed patterns are in `.claude/rules/` and loaded contextually based on file 
 ## What NOT to do
 
 - ❌ Edit a file without re-reading it if 5+ turns have passed
-- ❌ Modify components in place (use DELETE → CREATE)
+- ❌ Replace components in place — for full component replacements use DELETE → CREATE (in-place edits remain fine for non-breaking changes; see `.claude/rules/component-organization.md`)
 - ❌ Hard-code brand hex values (reference `lfxColors` scales)
 - ❌ Reference browser-only APIs without `isPlatformBrowser`
 - ❌ Mix module concerns in one change
@@ -349,17 +260,6 @@ Detailed patterns are in `.claude/rules/` and loaded contextually based on file 
 - ❌ Re-introduce Figma references — design source is HTML/GitHub
 - ❌ Edit `CLAUDE.md` or other `lfx-preflight` protected files without code-owner review
 
-## Quick checklist before saying "I'm done"
+## Pre-PR validation
 
-- [ ] All edited files re-read after changes, not assumed
-- [ ] `yarn check-types` clean
-- [ ] `yarn lint` clean (or `lint-staged` hook passed)
-- [ ] `yarn test` passing
-- [ ] `yarn build` passing (catches SSR-only breaks)
-- [ ] DCO sign-off + GPG on every commit (`--signoff -S`)
-- [ ] Commit message in Angular format, ≤72 chars, no `chore:`
-- [ ] No hard-coded brand hex
-- [ ] No browser-only APIs outside `isPlatformBrowser`
-- [ ] Module scope respected
-- [ ] PR description references LFXV2 ticket
-- [ ] Self-review done (CodeRabbit pre-push + Claude "be a senior reviewer" pass)
+Before saying "I'm done", invoke the `/preflight` skill — it runs lint, type-check, tests, build, DCO/GPG verification, and protected-file checks against this repo's specific rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,35 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+> Auto-loaded by Claude Code at session start. Read this first.
 
 ## Project Overview
 
 LFX One is a Turborepo monorepo containing an Angular 20 SSR application with stable zoneless change detection and Express.js server.
+
+## Working mode
+
+You have full file-edit authority in this session — different from a Cowork session where you generate prompts for someone else to execute.
+
+Before every meaningful edit:
+
+1. Re-read the file with `view` — do not trust prior conversation history. Files change; context drifts.
+2. Run `yarn check-types` after multi-file changes to catch type drift early.
+3. Stop and ask if the request conflicts with the conventions in this file or in `.claude/rules/`.
+
+Default to small, atomic changes. If a request spans more than one module or touches both client and SSR server, surface that and ask whether to split.
+
+## Domain language
+
+Use these naturally — do not paraphrase:
+
+- **PCC** — Project Control Center
+- **ED** — Executive Director
+- **Admin Mode** — privileged view variant for EDs and admins
+- **Affiliation** — contributor's company/org link
+- **L2** — second-level navigation pattern
+- **Personas** — Contributor, Maintainer, ED, Board Member
+
+When a feature affects multiple personas differently, flag it explicitly.
 
 ## Quick Start
 
@@ -31,6 +56,16 @@ All commands run from the repo root via Turborepo:
 | `yarn commitlint`   | Validate commit message against Angular conventions |
 
 > For manual commands, prefer `yarn` over `npx` — the repo pins Yarn 4.x through `packageManager`, so `npx` can resolve to the wrong binary. Repo-managed tooling (e.g. `.husky/pre-commit` invokes `npx lint-staged`) may still use `npx` where already configured.
+
+### Reset / cleanup
+
+```bash
+ng cache clean             # Angular CLI cache
+npx turbo clean            # Turborepo build cache
+rm -rf node_modules && yarn install   # nuclear
+```
+
+Hot reload silent? Likely `inotify` watcher limit — `sudo sysctl fs.inotify.max_user_watches=524288`.
 
 ## Monorepo Structure
 
@@ -131,12 +166,26 @@ Utilities split into **generic** helpers (date/time, string, url, file, form, ht
 - Pre-commit runs `./check-headers.sh`, `npx lint-staged` (prettier + lint on staged files), then repo-wide `yarn format:check`, `yarn lint:check`, and `yarn check-types`. Only `lint-staged` is scoped to staged files — the rest run on the whole repo. You don't need to run `yarn format` manually; `lint-staged` already prettifies staged files. If a commit fails, fix the reported issue and retry.
 - See `.claude/rules/commit-workflow.md` for PR title / sizing / JIRA details.
 
+**Recovery for missing sign-off:**
+
+Last commit only:
+
+```bash
+git commit --amend --signoff -S --no-edit
+```
+
+Older commits, cherry-picks, rebases → invoke the `dco` skill. PR is blocked until every commit is signed.
+
 ### Source hygiene
 
 - Every source file needs the MIT license header — `./check-headers.sh` validates and the pre-commit hook enforces.
 - Never nest ternary expressions.
 - Use `flex + flex-col + gap-*`, not `space-y-*`, for vertical stacking.
 - All shared constants and interfaces live in `@lfx-one/shared` — no module-level consts or local `interface Foo {}` inside `apps/lfx-one/`.
+
+### DELETE → CREATE for component replacement
+
+When replacing a component or pattern, delete the old file and create a new one. Never modify in place. Git history captures the change; reviewers see a clean diff. Team convention.
 
 ### Architecture
 
@@ -147,6 +196,97 @@ Utilities split into **generic** helpers (date/time, string, url, file, form, ht
 ### Dev server
 
 - Don't restart the dev server on code changes — hot reload handles it. Check logs instead.
+
+## SSR safety
+
+Angular 20 SSR is strict. Static HTML prototypes and dev-mode hot reload hide these — they only surface during `yarn build` or production runtime.
+
+Never reference `window`, `document`, `localStorage`, `navigator`, or `IntersectionObserver` outside an `isPlatformBrowser` guard:
+
+```typescript
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, PLATFORM_ID } from '@angular/core';
+
+constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
+ngOnInit() {
+  if (isPlatformBrowser(this.platformId)) {
+    // browser-only code here
+  }
+}
+```
+
+Third-party libs that touch `window` → load lazily inside the guard.
+
+## Brand colors
+
+Brand palette lives in `@linuxfoundation/lfx-ui-core`, exported via `packages/shared/src/constants/colors.constants.ts` as `lfxColors`. Tailwind picks scales up automatically via `tailwind.config.js`.
+
+Available scales:
+
+- `blue` — primary
+- `gray` — neutral
+- `emerald` — success
+- `red` — error
+- `amber` — warning
+- `violet` — accent
+
+**Never hard-code hex values.** Reference scale names so brand updates propagate without code changes.
+
+## Design source of truth
+
+Design lives as HTML in a separate GitHub design repo, generated via Cowork sessions. **Not Figma.**
+
+When implementing from a design:
+
+1. Fetch the HTML from the design repo at the specified commit
+2. Treat the markup as the visual spec — markup-faithful conversion expected
+3. Convert to Angular component preserving structure
+4. Add what HTML doesn't capture:
+   - ARIA roles, focus management
+   - Signals / `@Input` / state
+   - Interactive states: hover, active, loading, error, empty
+   - Responsive breakpoints
+   - SSR safety (see above)
+
+The HTML is the **visual** spec. Behavior needs explicit input.
+
+## Local auth gotchas
+
+- Local auth: **Authelia** at `https://auth.k8s.orb.local`
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` required for local Authelia (see README)
+- Detection logic: server checks `issuerBaseUrl.includes('auth.k8s.orb.local')` in `m2m-token.util.ts`, `auth.middleware.ts`, `profile.controller.ts`
+- Login breaking? Clear cookies, re-fetch client secret:
+
+  ```bash
+  kubectl get secrets authelia-clients -n lfx -o jsonpath='{.data.lfx}' | base64 --decode
+  ```
+
+- Inspect session: `http://localhost:4200/api/auth/me`
+
+## Session hygiene
+
+### When context feels stale
+
+- Re-read files before editing — don't trust history
+- Run `git status` and `git diff` to ground in disk reality
+- If session has been running >30 min on one task, suggest `/compact` or fresh session
+
+### When delegating sub-investigations
+
+Use the Task tool for "find all usages of X" or "audit module Y for pattern Z" — fresh subagent context, main session stays focused.
+
+### When unsure
+
+Stop and ask. Convention: **clarify, then act.** One well-executed change beats three drifting ones.
+
+## Source of truth, in order
+
+1. **Code on disk** — re-view; don't trust history
+2. **`apps/lfx-one/src/app/`** — the running app
+3. **`packages/shared/`** — types and contracts shared with backend
+4. **The design repo** — for visual spec
+5. **This file + `.claude/rules/`** — for conventions
 
 ## Rule Files
 
@@ -186,3 +326,30 @@ Detailed patterns are in `.claude/rules/` and loaded contextually based on file 
 | [Shared Package](docs/architecture/shared/package-architecture.md)             | Types, interfaces, utilities, validators                         |
 | [E2E Testing](docs/architecture/testing/e2e-testing.md)                        | Dual architecture testing                                        |
 | [Testing Best Practices](docs/architecture/testing/testing-best-practices.md)  | Testing patterns and guide                                       |
+
+## What NOT to do
+
+- ❌ Edit a file without re-reading it if 5+ turns have passed
+- ❌ Modify components in place (use DELETE → CREATE)
+- ❌ Hard-code brand hex values (reference `lfxColors` scales)
+- ❌ Reference browser-only APIs without `isPlatformBrowser`
+- ❌ Mix module concerns in one change
+- ❌ Open a PR without DCO sign-off + GPG (`--signoff -S`)
+- ❌ Commit and claim "done" before `yarn build` passes
+- ❌ Re-introduce Figma references — design source is HTML/GitHub
+- ❌ Edit `CLAUDE.md` or other `lfx-preflight` protected files without code-owner review
+
+## Quick checklist before saying "I'm done"
+
+- [ ] All edited files re-read after changes, not assumed
+- [ ] `yarn check-types` clean
+- [ ] `yarn lint` clean (or `lint-staged` hook passed)
+- [ ] `yarn test` passing
+- [ ] `yarn build` passing (catches SSR-only breaks)
+- [ ] DCO sign-off + GPG on every commit (`--signoff -S`)
+- [ ] Commit message in Angular format, ≤72 chars, no `chore:`
+- [ ] No hard-coded brand hex
+- [ ] No browser-only APIs outside `isPlatformBrowser`
+- [ ] Module scope respected
+- [ ] PR description references LFXV2 ticket
+- [ ] Self-review done (CodeRabbit pre-push + Claude "be a senior reviewer" pass)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ All commands run from the repo root via Turborepo:
 ### Reset / cleanup
 
 ```bash
-ng cache clean             # Angular CLI cache
+yarn ng cache clean        # Angular CLI cache (uses the workspace-local ng)
 yarn turbo clean           # Turborepo build cache (turbo is a local devDep)
 rm -rf node_modules && yarn install   # nuclear
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Utilities split into **generic** helpers (date/time, string, url, file, form, ht
 - Pre-commit runs `./check-headers.sh`, `npx lint-staged` (prettier + lint on staged files), then repo-wide `yarn format:check`, `yarn lint:check`, and `yarn check-types`. Only `lint-staged` is scoped to staged files — the rest run on the whole repo. You don't need to run `yarn format` manually; `lint-staged` already prettifies staged files. If a commit fails, fix the reported issue and retry.
 - See `.claude/rules/commit-workflow.md` for PR title / sizing / JIRA details.
 
-For missing sign-off recovery (single-commit amend, or older commits / cherry-picks / rebases), invoke the `dco` skill.
+For missing sign-off recovery (single-commit amend, or older commits / cherry-picks / rebases), invoke the `/dco` skill.
 
 ### Source hygiene
 
@@ -193,7 +193,7 @@ When implementing from a design:
    - Signals / `@Input` / state
    - Interactive states: hover, active, loading, error, empty
    - Responsive breakpoints
-   - SSR safety (see above)
+   - SSR safety (see `.claude/rules/ssr-safety.md`)
 
 The HTML is the **visual** spec. Behavior needs explicit input.
 
@@ -262,4 +262,4 @@ Detailed patterns are in `.claude/rules/` and loaded contextually based on the `
 
 ## Pre-PR validation
 
-Before saying "I'm done", invoke the `/preflight` skill — it runs lint, type-check, tests, build, DCO/GPG verification, and protected-file checks against this repo's specific rules.
+Before saying "I'm done", invoke the `/preflight` skill — it runs license-header, format, lint, build, protected-file, and commit-signoff checks against this repo's specific rules.


### PR DESCRIPTION
## Summary

Restructures the always-loaded `CLAUDE.md` context per @josep-reyero's review feedback (Anthropic's recommendation is to keep `CLAUDE.md` under 200 lines, since every section costs tokens on every turn for every file). Repo-specific conventions that previously lived in `CLAUDE.md` are now split into:

- **`.claude/rules/*.md`** — path-scoped rules that auto-load only when matching files are touched
- **`.claude/skills/<name>/SKILL.md`** — task-scoped skills that load only when invoked
- **`CLAUDE.md`** — kept small: domain language, working agreement, pointers to the above

JIRA: [LFXV2-1720](https://linuxfoundation.atlassian.net/browse/LFXV2-1720)

## What's in this PR

**New path-scoped rule files** (load only when matching files are edited):

- `.claude/rules/ssr-safety.md` — `isPlatformBrowser` guard pattern, browser-only API list, lazy-loading third-party libs. Paths: `**/*.component.ts`, `**/*.service.ts`, `**/*.directive.ts`, `**/server/**`.
- `.claude/rules/styling.md` — `lfxColors` scales, Tailwind config location, no hard-coded hex. Paths: `**/*.html`, `**/*.scss`, `**/*.component.ts`.

**New task-scoped skill**:

- `.claude/skills/dco/SKILL.md` — single-commit amend and older-commit / rebase recovery for missing `Signed-off-by:`.

**Augmented existing skills**:

- `.claude/skills/setup/SKILL.md` — local auth troubleshooting (Authelia URL, `NODE_TLS_REJECT_UNAUTHORIZED=0`, kubectl client-secret fetch, session inspection at `/api/profile`).
- `.claude/skills/develop/SKILL.md` — re-read-before-edit hygiene, `yarn check-types` after multi-file changes.

**Existing rule files**:

- `.claude/rules/component-organization.md` — appended DELETE → CREATE convention for full component replacements.
- All five existing rule files keep their `globs:` frontmatter unchanged (Cursor compatibility note: Claude Code documents `paths:` — out of scope here, but worth a follow-up).

**`CLAUDE.md` net result**: kept ~265 lines. Adds domain language glossary, working mode, source-of-truth hierarchy, "what NOT to do", quick "I'm done" checklist, and pointers to the new rules/skills. Some original sections (SSR safety, brand colors, local auth, DCO recipe) moved out per the structural feedback rather than living always-loaded.

## Verification

- `yarn format:check`, `yarn lint:check`, `yarn check-types` — all clean
- Pre-commit hook (license-headers, lint-staged, format:check, lint:check, check-types) — all passed
- Every commit DCO-signed (`--signoff`) and GPG-signed (`-S`)
- All review threads from @copilot-pull-request-reviewer, @coderabbitai, @josep-reyero, and @asithade addressed in this branch (see commits prefixed `fix(review):`)

## ⚠ Reviewer note

`CLAUDE.md` is on the `lfx-preflight` skill's protected-files list. **Code-owner approval is required before merge.**

[LFXV2-1720]: https://linuxfoundation.atlassian.net/browse/LFXV2-1720