### PR TITLE
docs(dx): document GPG signing requirement for commits

### DIFF
--- a/.claude/agents/code-standards-enforcer.md
+++ b/.claude/agents/code-standards-enforcer.md
@@ -231,7 +231,7 @@ Every backend endpoint must follow: **service** → **controller** → **route**
 - [ ] **License headers** on ALL source files (`.ts`, `.html`, `.scss`)
 - [ ] **yarn only** — never npx or other package runners
 - [ ] **`docker compose`** not `docker-compose`
-- [ ] **Git commits signed off** with `--signoff`
+- [ ] **Git commits signed off AND GPG-signed** with `--signoff -S` (both required per repo policy — see `.claude/rules/commit-workflow.md`)
 - [ ] **No Claude co-author** in commits
 - [ ] **Linting errors fixed** after changes
 

--- a/.claude/rules/commit-workflow.md
+++ b/.claude/rules/commit-workflow.md
@@ -15,6 +15,31 @@ globs: '*'
   - `feat(auth): add OAuth2 integration`
   - `fix(ui): resolve mobile button alignment`
 
+## Commit Signing
+
+All commits must be both DCO-signed and GPG-signed:
+
+- **DCO sign-off (`--signoff`)** — required by repo policy; validated by the Probot DCO check in CI. The `Signed-off-by: Name <email>` trailer is appended automatically when you pass `--signoff` (or `-s`).
+- **GPG signature (`-S`)** — required by repo policy; commits must have a valid GPG signature attached. Configure a signing key once and Git will pick it up for every commit:
+
+  ```bash
+  git config --global user.signingkey <KEY_ID>
+  git config --global commit.gpgsign true
+  ```
+
+Standard commit command:
+
+```bash
+git commit --signoff -S -m "<type>(<scope>): <subject>"
+```
+
+If signing fails, fix the underlying issue — do not push unsigned commits. To verify signature status on a branch's commits:
+
+```bash
+git log --format='%G? %h %s' origin/main..HEAD
+# Every line must start with G (good signature)
+```
+
 ## Branch Naming
 
 - Branch names follow commit types followed by the JIRA ticket number

--- a/.claude/rules/commit-workflow.md
+++ b/.claude/rules/commit-workflow.md
@@ -37,8 +37,9 @@ If signing fails, fix the underlying issue — do not push unsigned commits. To 
 
 ```bash
 git log --format='%G? %h %s' origin/main..HEAD
-# Every line must start with G (good signature)
 ```
+
+Acceptable `%G?` codes: `G` (good signature) or `U` (good signature, signing key isn't in your local trust db — fine for policy purposes). Codes `N` (no signature), `B` (bad signature), or `E` (cannot check — e.g., missing public key locally) need investigation. Note that the authoritative GPG check is GitHub's **Verified** badge on each commit after push — if your signing key isn't registered with GitHub, the local check can pass while GitHub still marks the commit as unverified.
 
 ## Branch Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Utilities split into **generic** helpers (date/time, string, url, file, form, ht
 
 - Follow Angular commit format: `type(scope): description`. Valid types: `feat, fix, docs, style, refactor, perf, test, build, ci, revert` — **`chore` is not allowed** by commitlint.
 - Commit header is capped at **72 characters** (commitlint `header-max-length`).
-- Always use `git commit --signoff` (DCO enforced).
+- Always use `git commit --signoff -S` — both DCO sign-off (`--signoff`) and GPG signing (`-S`) are enforced by repo policy. See `.claude/rules/commit-workflow.md` for setup.
 - Pre-commit runs `./check-headers.sh`, `npx lint-staged` (prettier + lint on staged files), then repo-wide `yarn format:check`, `yarn lint:check`, and `yarn check-types`. Only `lint-staged` is scoped to staged files — the rest run on the whole repo. You don't need to run `yarn format` manually; `lint-staged` already prettifies staged files. If a commit fails, fix the reported issue and retry.
 - See `.claude/rules/commit-workflow.md` for PR title / sizing / JIRA details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,15 +235,23 @@ middleware with proper token refresh handling.
 Closes #123
 ```
 
-### Sign-off
+### Sign-off and GPG Signing
 
-All commits must be signed off:
+All commits must be both DCO-signed and GPG-signed:
 
 ```bash
-git commit --signoff
+git commit --signoff -S
 ```
 
-This adds a `Signed-off-by` line to your commit message.
+- `--signoff` adds the `Signed-off-by:` trailer required by the DCO check in CI.
+- `-S` adds a GPG signature; configure your signing key once and Git will pick it up for every commit:
+
+  ```bash
+  git config --global user.signingkey <KEY_ID>
+  git config --global commit.gpgsign true
+  ```
+
+See `.claude/rules/commit-workflow.md` for the canonical signing policy and instructions for verifying your branch's commits before pushing.
 
 ## Pull Request Process
 


### PR DESCRIPTION
Surfaced during PR #672 review: @jordane confirmed GPG signing is
enforced by repo policy, but neither CLAUDE.md nor
.claude/rules/commit-workflow.md mentioned it. Both said only DCO
sign-off was required, which caused churn during that review.

- CLAUDE.md: updated the single-line commit guidance to `git commit
  --signoff -S` and noted both signatures are enforced.
- .claude/rules/commit-workflow.md: added a "Commit Signing" section
  with one-time GPG setup, the standard commit command, and a
  signature-verification snippet for branch validation.

Signed-off-by: Manish Dixit <mdixit@linuxfoundation.org>
