### PR TITLE
fix(committees): clickable Parent Project link and lens-aware back label

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -141,10 +141,23 @@
               </div>
               <div class="flex items-center gap-4 flex-wrap">
                 @if (committee()?.project_name || committee()?.foundation_name) {
-                  <div class="flex items-center gap-1.5">
-                    <span class="text-xs font-medium text-gray-500">Parent Project:</span>
-                    <span class="text-xs text-gray-700">{{ committee()?.project_name || committee()?.foundation_name }}</span>
-                  </div>
+                  @if (committee()?.project_slug) {
+                    <button
+                      type="button"
+                      class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
+                      (click)="navigateToParentProject()"
+                      data-testid="committee-view-parent-project-link">
+                      <i class="fa-light fa-diagram-project text-[11px]"></i>
+                      <span>Parent Project:</span>
+                      <span>{{ committee()?.project_name || committee()?.foundation_name }}</span>
+                      <i class="fa-light fa-chevron-right text-[10px]"></i>
+                    </button>
+                  } @else {
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-xs font-medium text-gray-500">Parent Project:</span>
+                      <span class="text-xs text-gray-700">{{ committee()?.project_name || committee()?.foundation_name }}</span>
+                    </div>
+                  }
                 }
                 @if (parentGroup(); as parent) {
                   <button

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -141,7 +141,7 @@
               </div>
               <div class="flex items-center gap-4 flex-wrap">
                 @if (committee()?.project_name || committee()?.foundation_name) {
-                  @if (committee()?.project_slug) {
+                  @if (committee()?.project_uid && committee()?.project_slug) {
                     <button
                       type="button"
                       class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -22,11 +22,13 @@ import {
   getCommitteeCategorySeverity,
   TagSeverity,
 } from '@lfx-one/shared';
-import { GroupsIOMailingList, TabConfigEntry } from '@lfx-one/shared/interfaces';
+import { GroupsIOMailingList, ProjectContext, TabConfigEntry } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_VALID_TABS } from '@lfx-one/shared/constants';
 import { getChatPlatformIcon, getChatPlatformLabel, getRepoPlatformIcon, getRepoPlatformLabel } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
+import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { CategoryAvatarColorPipe } from '@pipes/category-avatar-color.pipe';
 import { InitialsPipe } from '@pipes/initials.pipe';
@@ -86,6 +88,8 @@ export class CommitteeViewComponent {
   private readonly messageService = inject(MessageService);
   private readonly dialogService = inject(DialogService);
   private readonly userService = inject(UserService);
+  private readonly lensService = inject(LensService);
+  private readonly projectContextService = inject(ProjectContextService);
 
   private readonly navBackLabel: string | null = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
 
@@ -127,7 +131,7 @@ export class CommitteeViewComponent {
     return getCommitteeCategorySeverity(category || '');
   });
 
-  public backLabel: Signal<string> = computed(() => this.navBackLabel ?? (this.myRole() !== null ? 'My Groups' : 'Groups'));
+  public backLabel: Signal<string> = computed(() => this.navBackLabel ?? (this.lensService.activeLens() === 'me' ? 'My Groups' : 'Groups'));
 
   public canEdit: Signal<boolean> = computed(() => !!this.committee()?.writer);
 
@@ -348,6 +352,25 @@ export class CommitteeViewComponent {
     const parent = this.parentGroup();
     if (parent?.uid) {
       this.router.navigate(['/', 'groups', parent.uid]);
+    }
+  }
+
+  public navigateToParentProject(): void {
+    const c = this.committee();
+    if (!c?.project_uid || !c.project_slug) return;
+    const context: ProjectContext = {
+      uid: c.project_uid,
+      name: c.project_name || c.foundation_name || c.project_slug,
+      slug: c.project_slug,
+    };
+    if (c.is_foundation) {
+      this.projectContextService.setFoundation(context);
+      this.lensService.setLens('foundation');
+      this.router.navigate(['/foundation/overview']);
+    } else {
+      this.projectContextService.setProject(context);
+      this.lensService.setLens('project');
+      this.router.navigate(['/project/overview']);
     }
   }
 

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -122,8 +122,10 @@ export class CommitteeController {
       }
 
       // Get the committee by ID — include caller membership so the UI can render
-      // visitor / member / chair states without a second round-trip.
-      const committee = await this.committeeService.getCommitteeById(req, id, { includeMembership: true });
+      // visitor / member / chair states without a second round-trip, and enrich with
+      // project metadata so the detail page's Parent Project link can resolve project_uid
+      // -> project_slug for navigation.
+      const committee = await this.committeeService.getCommitteeById(req, id, { includeMembership: true, enrichProject: true });
 
       // Log the success
       logger.success(req, 'get_committee_by_id', startTime, {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -125,7 +125,7 @@ export class CommitteeController {
       // visitor / member / chair states without a second round-trip, and enrich with
       // project metadata so the detail page's Parent Project link can resolve project_uid
       // -> project_slug for navigation.
-      const committee = await this.committeeService.getCommitteeById(req, id, { includeMembership: true, enrichProject: true });
+      const committee = await this.committeeService.getCommitteeById(req, id, { includeMembership: true, includeProjectMetadata: true });
 
       // Log the success
       logger.success(req, 'get_committee_by_id', startTime, {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -239,11 +239,15 @@ export class CommitteeService {
       this.accessCheckService.addAccessToResource(req, committee, 'committee'),
     ]);
 
-    return {
+    const merged = {
       ...withAccess,
       ...settings,
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
     };
+
+    // Enrich with project metadata so the UI can resolve project_uid -> project_slug for navigation.
+    const [enriched] = await this.projectService.enrichWithProjectData(req, [merged]);
+    return enriched;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -220,7 +220,7 @@ export class CommitteeService {
    *   so default is `false`. Enable only on user-facing reads (e.g. the GET /committees/:id
    *   controller), not on internal validation reads (member CRUD, meeting fan-out) where
    *   the caller-membership fields are unused.
-   * @param options.enrichProject When true, enriches the response with `project_name`,
+   * @param options.includeProjectMetadata When true, enriches the response with `project_name`,
    *   `project_slug`, `is_foundation`, and `parent_project_uid` via
    *   `ProjectService.enrichWithProjectData`. Costs one extra upstream project fetch
    *   (de-duplicated/batched), so default is `false`. Enable only on user-facing reads
@@ -228,7 +228,11 @@ export class CommitteeService {
    *   detail page's Parent Project link). Internal callers (existence checks, meeting
    *   fan-out, member CRUD) should leave this off — they don't use these fields.
    */
-  public async getCommitteeById(req: Request, committeeId: string, options: { includeMembership?: boolean; enrichProject?: boolean } = {}): Promise<Committee> {
+  public async getCommitteeById(
+    req: Request,
+    committeeId: string,
+    options: { includeMembership?: boolean; includeProjectMetadata?: boolean } = {}
+  ): Promise<Committee> {
     const committee = await this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
 
     if (!committee) {
@@ -252,7 +256,7 @@ export class CommitteeService {
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
     };
 
-    if (!options.enrichProject) {
+    if (!options.includeProjectMetadata) {
       return merged;
     }
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -220,8 +220,15 @@ export class CommitteeService {
    *   so default is `false`. Enable only on user-facing reads (e.g. the GET /committees/:id
    *   controller), not on internal validation reads (member CRUD, meeting fan-out) where
    *   the caller-membership fields are unused.
+   * @param options.enrichProject When true, enriches the response with `project_name`,
+   *   `project_slug`, `is_foundation`, and `parent_project_uid` via
+   *   `ProjectService.enrichWithProjectData`. Costs one extra upstream project fetch
+   *   (de-duplicated/batched), so default is `false`. Enable only on user-facing reads
+   *   that need slug-based navigation (e.g. the GET /committees/:id controller for the
+   *   detail page's Parent Project link). Internal callers (existence checks, meeting
+   *   fan-out, member CRUD) should leave this off — they don't use these fields.
    */
-  public async getCommitteeById(req: Request, committeeId: string, options: { includeMembership?: boolean } = {}): Promise<Committee> {
+  public async getCommitteeById(req: Request, committeeId: string, options: { includeMembership?: boolean; enrichProject?: boolean } = {}): Promise<Committee> {
     const committee = await this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
 
     if (!committee) {
@@ -244,6 +251,10 @@ export class CommitteeService {
       ...settings,
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
     };
+
+    if (!options.enrichProject) {
+      return merged;
+    }
 
     // Enrich with project metadata so the UI can resolve project_uid -> project_slug for navigation.
     const [enriched] = await this.projectService.enrichWithProjectData(req, [merged]);


### PR DESCRIPTION
## Summary

Fixes two related defects on the committee detail page (`/groups/<uid>`):

- **Parent Project becomes a clickable link.** Previously rendered as plain text; it now renders as a button (when a `project_slug` is available) that switches to the parent's Foundation or Project lens via `ProjectContextService` + `LensService` and lands on its overview page — mirroring the existing Parent Group link pattern. Falls back to plain text when no slug is present so we never render a broken link.
- **Back-label respects the active lens, not the user's role.** The fallback was `myRole() !== null ? 'My Groups' : 'Groups'` — so any user with a role on the committee saw "My Groups" even on Foundation/Project lens deep links or refreshes. It now uses `LensService.activeLens()`, so "My Groups" only appears in Me lens and "Groups" appears everywhere else.
- **Single-fetch enrichment.** `getCommitteeById` in the Express proxy now wraps the merged committee result in `ProjectService.enrichWithProjectData([...])` so `project_slug`, `project_name`, `is_foundation`, and `parent_project_uid` are consistently populated, matching what the list endpoints already do. This is what makes the new link's slug-based navigation possible.

JIRA: [LFXV2-1723](https://linuxfoundation.atlassian.net/browse/LFXV2-1723)

## Test plan

- [ ] Foundation lens > Groups > click into a committee → back button says "Groups"
- [ ] Refresh / deep-link to a committee whose member you are, while still in Foundation lens → back button still says "Groups" (regression of the bug fixed here)
- [ ] Me lens > My Groups > click into a committee → back button says "My Groups"
- [ ] Refresh on a Me-lens committee → back button still says "My Groups"
- [ ] On a committee whose parent is a **foundation** → Parent Project link → switches to Foundation lens with that foundation selected, lands on `/foundation/overview`
- [ ] On a committee whose parent is a **sub-project** → Parent Project link → switches to Project lens, lands on `/project/overview`
- [ ] Parent Group link still works as before (no regression)
- [ ] Sub-Group(s) chip / dropdown still works as before (no regression)
- [ ] On a committee where the API does not return a `project_slug`, Parent Project still renders as plain text (no broken link)

## Notes for reviewers

- `CommitteeViewComponent` now has 9 `inject()` calls (was 7 pre-change) — added `LensService` and `ProjectContextService` so navigation can set the correct lens + context. The component was already a large detail page; not introducing a new responsibility, but worth flagging for future refactor consideration.
- The "Parent Project" button styling mirrors the existing "Parent Group" button in the same file for visual consistency (same Tailwind classes, with a `fa-diagram-project` icon to distinguish project vs. group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1723]: https://linuxfoundation.atlassian.net/browse/LFXV2-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ