### PR TITLE
feat(shared): add Associate and Academic tiers to MembershipTierClass

### DIFF
--- a/packages/shared/src/interfaces/org-lens.interface.ts
+++ b/packages/shared/src/interfaces/org-lens.interface.ts
@@ -6,8 +6,21 @@
  * Drives any tier-based ranking or filtering on the client side.
  * Backed by the accepted_values dbt test on
  * platinum_lfx_one_org_lens_account_context.membership_tier_class.
+ *
+ * Rank: Platinum(1) > Premier(2) > Steering(3) > Gold(4) > Silver(5) >
+ *       General(6) > Sponsor(7) > Associate(8) > Academic(9) > Other(10)
  */
-export type MembershipTierClass = 'Platinum' | 'Premier' | 'Gold' | 'Silver' | 'Steering' | 'General' | 'Sponsor' | 'Other';
+export type MembershipTierClass =
+  | 'Platinum'
+  | 'Premier'
+  | 'Steering'
+  | 'Gold'
+  | 'Silver'
+  | 'General'
+  | 'Sponsor'
+  | 'Associate'
+  | 'Academic'
+  | 'Other';
 
 /**
  * Raw row from ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT — the


### PR DESCRIPTION
> **WIP / Draft.**

Ticket: [LFXV2-1721](https://linuxfoundation.atlassian.net/browse/LFXV2-1721)

## Summary
- Extends `MembershipTierClass` union with `Associate` and `Academic` tier values to match all `accepted_values` in the dbt platinum model
- Reorders `Steering` to rank 3 (after `Premier`, before `Gold`) to reflect the canonical tier ladder
- Adds rank-order documentation in the JSDoc comment so downstream client code can reason about tier precedence without consulting the dbt model
- Reformats the union to multi-line for readability

## Out of scope (intentionally)
- Runtime tier-rank logic / comparator utilities (separate ticket)
- UI badge / label changes for the new tiers

## Test plan
- [ ] `yarn build` passes (verified by pre-push hook)
- [ ] TypeScript consumers of `MembershipTierClass` compile without error
- [ ] Verify `Associate` and `Academic` values appear in dbt `accepted_values` test on `platinum_lfx_one_org_lens_account_context.membership_tier_class`

[LFXV2-1721]: https://linuxfoundation.atlassian.net/browse/LFXV2-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ