### PR TITLE
feat(profile): surface CDP identity type field

### DIFF
--- a/apps/lfx-one/e2e/profile-identities-verify.spec.ts
+++ b/apps/lfx-one/e2e/profile-identities-verify.spec.ts
@@ -27,7 +27,10 @@ test.describe('Identities Verify Flow', () => {
 
       // Unverified identities
       await expect(page.getByTestId('identity-row-idf-2')).toContainText('jdoe@company.org');
-      await expect(page.getByTestId('identity-row-idf-6')).toContainText('john-doe-engineer');
+      // LinkedIn identifier now comes from Auth0 profileData.email (the pd.name
+      // fallback was removed). Assert email-shape rather than a literal value
+      // so the test isn't brittle to the test user's specific LinkedIn email.
+      await expect(page.getByTestId('identity-row-idf-6')).toContainText(/[^\s@]+@[^\s@.]+\.[^\s@]+/);
     });
 
     test('should show unverified identities in unverified section', async ({ page }) => {
@@ -84,7 +87,8 @@ test.describe('Identities Verify Flow', () => {
       await expect(dialog).toBeVisible({ timeout: 5000 });
 
       await expect(dialog).toContainText('LinkedIn');
-      await expect(dialog).toContainText('john-doe-engineer');
+      // Identifier is now the LinkedIn pd.email value, not the dropped pd.name.
+      await expect(dialog).toContainText(/[^\s@]+@[^\s@.]+\.[^\s@]+/);
     });
 
     test('should show "Verify identity" as dialog header', async ({ page }) => {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1894,7 +1894,9 @@ export class ProfileController {
       case 'google-oauth2':
         return pd.email ?? null;
       case 'linkedin':
-        return pd.email ?? pd.name ?? null;
+        // No name fallback: with type='email' on POST, persisting pd.name (a display name,
+        // not an email) would corrupt CDP. Skip the identity if Auth0 didn't give us an email.
+        return pd.email ?? null;
       default:
         return null;
     }

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -681,7 +681,7 @@ export class ProfileController {
 
       // Reconcile CDP identities with auth-service identities and filter to the
       // (platform, type) combos LFX One can surface for verification via Auth0.
-      const { enriched, notInCdpCount } = this.reconcileIdentities(req, cdpIdentities, auth0Identities, lfid);
+      const { enriched, cdpPostsQueued } = this.reconcileIdentities(req, cdpIdentities, auth0Identities, lfid);
       const displayIdentities = enriched.filter((id) => CDP_DISPLAYABLE_IDENTITY_COMBOS.has(`${id.platform}+${id.type}`));
 
       logger.success(req, 'get_identities', startTime, {
@@ -690,7 +690,7 @@ export class ProfileController {
         auth_service_count: auth0Identities.length,
         display_count: displayIdentities.length,
         hidden_count: enriched.filter((i) => i.displayState === 'hidden').length,
-        not_in_cdp_count: notInCdpCount,
+        cdp_posts_queued: cdpPostsQueued,
       });
 
       res.json(displayIdentities);
@@ -1701,7 +1701,7 @@ export class ProfileController {
    * 2. In auth-service AND CDP, verified=false OR verifiedBy≠lfid → VERIFIED (auto-verify via PATCH)
    * 3. In auth-service but NOT in CDP → VERIFIED (synthetic entry + fire-and-forget POST to CDP,
    *    skipping the POST when a `custom` row for the same email value has already been written
-   *    in this loop or already exists as a manually-verified custom-email row)
+   *    in this loop or already exists as a CDP custom-email row owned by this user (verifiedBy=lfid))
    * 4. In CDP but NOT in auth-service, multi-LFID + verifiedBy=lfxOne → HIDDEN
    * 5. In CDP but NOT in auth-service (all other) → UNVERIFIED
    */
@@ -1710,7 +1710,7 @@ export class ProfileController {
     cdpIdentities: CdpIdentity[],
     authServiceIdentities: Auth0Identity[],
     lfid: string
-  ): { enriched: EnrichedIdentity[]; notInCdpCount: number } {
+  ): { enriched: EnrichedIdentity[]; cdpPostsQueued: number } {
     // Build a map of "platform:value" → Auth0Identity for matching
     const authServiceMap = new Map<string, Auth0Identity>();
     for (const authId of authServiceIdentities) {
@@ -1799,7 +1799,7 @@ export class ProfileController {
     });
 
     // Process auth-service identities NOT in CDP — create synthetic entries
-    let notInCdpCount = 0;
+    let cdpPostsQueued = 0;
     // Tracks values we've POSTed to CDP as platform='custom' within this loop.
     // Google + email auth-service providers both POST as platform='custom' for
     // back-compat, so a user with BOTH providers for the same email would
@@ -1839,7 +1839,7 @@ export class ProfileController {
         (postedCustomEmails.has(value) || enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid));
 
       if (!wouldDuplicateCustomEmail) {
-        notInCdpCount++;
+        cdpPostsQueued++;
         if (cdpPostPlatform === 'custom') {
           postedCustomEmails.add(value);
         }
@@ -1879,7 +1879,7 @@ export class ProfileController {
       });
     }
 
-    return { enriched, notInCdpCount };
+    return { enriched, cdpPostsQueued };
   }
 
   private normalizeProfileReturnTo(raw: unknown): string {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1,7 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { AUTH0_TO_CDP_PROVIDER_MAP, CDP_PLATFORM_ICONS, CDP_TO_AUTH0_PROVIDER_MAP, IDENTITY_DISPLAY_PLATFORMS } from '@lfx-one/shared/constants';
+import {
+  AUTH0_TO_CDP_PROVIDER_MAP,
+  CDP_DISPLAYABLE_IDENTITY_COMBOS,
+  CDP_PLATFORM_ICONS,
+  CDP_PLATFORM_TO_TYPE_MAP,
+  CDP_TO_AUTH0_PROVIDER_MAP,
+} from '@lfx-one/shared/constants';
 import {
   Auth0Identity,
   CdpIdentity,
@@ -673,9 +679,10 @@ export class ProfileController {
         auth_service_identities: auth0Identities,
       });
 
-      // Reconcile CDP identities with auth-service identities and filter to display platforms
+      // Reconcile CDP identities with auth-service identities and filter to the
+      // (platform, type) combos LFX One can surface for verification via Auth0.
       const { enriched, notInCdpCount } = this.reconcileIdentities(req, cdpIdentities, auth0Identities, lfid);
-      const displayIdentities = enriched.filter((id) => IDENTITY_DISPLAY_PLATFORMS.includes(id.platform));
+      const displayIdentities = enriched.filter((id) => CDP_DISPLAYABLE_IDENTITY_COMBOS.has(`${id.platform}+${id.type}`));
 
       logger.success(req, 'get_identities', startTime, {
         lfid,
@@ -1775,8 +1782,9 @@ export class ProfileController {
       const isCdpVerifiedWithOwner = cdp.verified && !!cdp.verifiedBy;
       let displayState: IdentityDisplayState;
 
-      if (cdp.platform === 'linkedin') {
-        // LinkedIn identities must be linked via auth-service — ignore CDP-only entries
+      if (!CDP_DISPLAYABLE_IDENTITY_COMBOS.has(`${cdp.platform}+${cdp.type}`)) {
+        // Combo not surfaceable via Auth0 (e.g. linkedin+username, gitlab+username) —
+        // we have no way to help the user verify it, so hide.
         displayState = 'hidden';
       } else if (isCdpVerifiedWithOwner && hasMultiLfid) {
         // Multi-LFID merged profile — hide identities verified by another LFID
@@ -1802,29 +1810,26 @@ export class ProfileController {
         continue;
       }
 
-      // Skip non-display platforms (e.g., lfid, gitlab)
-      if (!IDENTITY_DISPLAY_PLATFORMS.includes(cdpPlatform)) {
+      const type = CDP_PLATFORM_TO_TYPE_MAP[cdpPlatform] ?? 'username';
+
+      // Skip combos LFX One can't surface for verification (e.g. lfid, gitlab)
+      if (!CDP_DISPLAYABLE_IDENTITY_COMBOS.has(`${cdpPlatform}+${type}`)) {
         continue;
       }
-
-      notInCdpCount++;
 
       // Google uses email as its value — skip CDP create if the same email is already a verified email identity
       const isEmailAlreadyVerified = enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid);
 
-      // Skip CDP create for LinkedIn — Auth0 returns the user's email as the identity value,
-      // but CDP expects a vanity username, so a synthetic POST would write bad data.
-      const skipCdpCreate = cdpPlatform === 'linkedin';
-
-      if (!isEmailAlreadyVerified && !skipCdpCreate) {
-        // Fire-and-forget: persist auth-service identity to CDP
-        const isEmailType = cdpPlatform === 'email' || cdpPlatform === 'google';
-        const cdpPostPlatform = isEmailType ? 'custom' : cdpPlatform;
+      if (!isEmailAlreadyVerified) {
+        notInCdpCount++;
+        // Email/google still POST as platform='custom' for back-compat with existing CDP rows.
+        // LinkedIn now posts as platform='linkedin' (with type='email') so CDP can categorize correctly.
+        const cdpPostPlatform = cdpPlatform === 'email' || cdpPlatform === 'google' ? 'custom' : cdpPlatform;
         this.cdpService
           .createIdentityForUser(req, [lfid], {
             value,
             platform: cdpPostPlatform,
-            type: isEmailType ? 'email' : 'username',
+            type,
             source: 'lfxOne',
             verified: true,
             verifiedBy: lfid,
@@ -1842,6 +1847,7 @@ export class ProfileController {
       enriched.push({
         id: `auth0:${authId.user_id}`,
         platform: cdpPlatform,
+        type,
         value,
         verified: true,
         verifiedBy: lfid,

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1817,10 +1817,16 @@ export class ProfileController {
         continue;
       }
 
-      // Google uses email as its value — skip CDP create if the same email is already a verified email identity
-      const isEmailAlreadyVerified = enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid);
+      // Google/email POST to CDP as platform='custom' — suppress the create if
+      // the user already has a manually-verified custom-email row with the same
+      // value (would otherwise produce a duplicate CDP row). LinkedIn POSTs as
+      // platform='linkedin', which is a distinct row from an email identity
+      // with the same value, so don't suppress it.
+      const wouldDuplicateCustomEmail =
+        (cdpPlatform === 'email' || cdpPlatform === 'google') &&
+        enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid);
 
-      if (!isEmailAlreadyVerified) {
+      if (!wouldDuplicateCustomEmail) {
         notInCdpCount++;
         // Email/google still POST as platform='custom' for back-compat with existing CDP rows.
         // LinkedIn now posts as platform='linkedin' (with type='email') so CDP can categorize correctly.

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1699,7 +1699,9 @@ export class ProfileController {
    * Truth table:
    * 1. In auth-service AND CDP, verified=true & verifiedBy=lfid → VERIFIED (already reconciled)
    * 2. In auth-service AND CDP, verified=false OR verifiedBy≠lfid → VERIFIED (auto-verify via PATCH)
-   * 3. In auth-service but NOT in CDP → VERIFIED (synthetic entry, TODO: POST to CDP)
+   * 3. In auth-service but NOT in CDP → VERIFIED (synthetic entry + fire-and-forget POST to CDP,
+   *    skipping the POST when a `custom` row for the same email value has already been written
+   *    in this loop or already exists as a manually-verified custom-email row)
    * 4. In CDP but NOT in auth-service, multi-LFID + verifiedBy=lfxOne → HIDDEN
    * 5. In CDP but NOT in auth-service (all other) → UNVERIFIED
    */
@@ -1798,6 +1800,14 @@ export class ProfileController {
 
     // Process auth-service identities NOT in CDP — create synthetic entries
     let notInCdpCount = 0;
+    // Tracks values we've POSTed to CDP as platform='custom' within this loop.
+    // Google + email auth-service providers both POST as platform='custom' for
+    // back-compat, so a user with BOTH providers for the same email would
+    // otherwise generate two duplicate custom rows. Iteration order of
+    // authServiceMap is not guaranteed to put 'email' first, and synthetic
+    // entries pushed for the first iter use platform='google'|'email' (not
+    // 'custom'), so the enriched-array-only check below misses them.
+    const postedCustomEmails = new Set<string>();
     for (const [, authId] of authServiceMap) {
       const cdpPlatform = AUTH0_TO_CDP_PROVIDER_MAP[authId.provider];
       const value = this.getAuth0IdentityValue(authId);
@@ -1817,20 +1827,22 @@ export class ProfileController {
         continue;
       }
 
-      // Google/email POST to CDP as platform='custom' — suppress the create if
-      // the user already has a manually-verified custom-email row with the same
-      // value (would otherwise produce a duplicate CDP row). LinkedIn POSTs as
-      // platform='linkedin', which is a distinct row from an email identity
-      // with the same value, so don't suppress it.
+      // Google/email POST to CDP as platform='custom'. Suppress the create when
+      // it would duplicate an existing CDP custom-email row (either a manually-
+      // verified one already in `enriched`, or one we POSTed earlier in this
+      // same loop for the other provider). LinkedIn POSTs as platform='linkedin',
+      // a distinct row from an email identity with the same value — never
+      // suppressed by this guard.
+      const cdpPostPlatform = cdpPlatform === 'email' || cdpPlatform === 'google' ? 'custom' : cdpPlatform;
       const wouldDuplicateCustomEmail =
-        (cdpPlatform === 'email' || cdpPlatform === 'google') &&
-        enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid);
+        cdpPostPlatform === 'custom' &&
+        (postedCustomEmails.has(value) || enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid));
 
       if (!wouldDuplicateCustomEmail) {
         notInCdpCount++;
-        // Email/google still POST as platform='custom' for back-compat with existing CDP rows.
-        // LinkedIn now posts as platform='linkedin' (with type='email') so CDP can categorize correctly.
-        const cdpPostPlatform = cdpPlatform === 'email' || cdpPlatform === 'google' ? 'custom' : cdpPlatform;
+        if (cdpPostPlatform === 'custom') {
+          postedCustomEmails.add(value);
+        }
         this.cdpService
           .createIdentityForUser(req, [lfid], {
             value,

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CDP_CONFIG } from '@lfx-one/shared/constants';
+import { isEmailShape } from '@lfx-one/shared/utils';
 import {
   CdpCreateIdentityRequest,
   CdpIdentity,
@@ -344,14 +345,12 @@ export class CdpService {
       const identities: CdpIdentity[] = rawIdentities.map((raw) => {
         const platform = raw.platform === 'custom' ? 'email' : raw.platform;
         // CDP rows that pre-date the `type` field fall back to inferring from
-        // the value's shape: matches a local@host.tld pattern → email, else
-        // username. Inferring from platform alone would misclassify legacy
-        // LinkedIn vanity rows as email (since CDP_PLATFORM_TO_TYPE_MAP
-        // ['linkedin'] = 'email' is the POST default, reflecting that Auth0
-        // gives us emails — not a guarantee about what's stored in any given
-        // row).
-        const isEmailShape = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw.value.trim());
-        const type = raw.type ?? (isEmailShape ? 'email' : 'username');
+        // the value's shape via the shared isEmailShape util — a strict
+        // local@host.tld match → 'email', otherwise 'username'. Platform
+        // alone is not a reliable signal here: CDP_PLATFORM_TO_TYPE_MAP is
+        // the POST default per platform (reflecting what Auth0 gives us),
+        // not a guarantee about what's stored in any given row.
+        const type = raw.type ?? (isEmailShape(raw.value) ? 'email' : 'username');
         return {
           id: raw.id,
           platform,

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CDP_CONFIG } from '@lfx-one/shared/constants';
+import { CDP_CONFIG, CDP_PLATFORM_TO_TYPE_MAP } from '@lfx-one/shared/constants';
 import {
   CdpCreateIdentityRequest,
   CdpIdentity,
@@ -343,9 +343,13 @@ export class CdpService {
 
       const identities: CdpIdentity[] = rawIdentities.map((raw) => {
         const platform = raw.platform === 'custom' ? 'email' : raw.platform;
+        // CDP rows that pre-date the `type` field fall back to the platform
+        // default; new rows return `type` directly from the API.
+        const type = raw.type ?? CDP_PLATFORM_TO_TYPE_MAP[raw.platform] ?? 'username';
         return {
           id: raw.id,
           platform,
+          type,
           value: raw.value,
           verified: raw.verified,
           verifiedBy: raw.verifiedBy ?? null,

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CDP_CONFIG, CDP_PLATFORM_TO_TYPE_MAP } from '@lfx-one/shared/constants';
+import { CDP_CONFIG } from '@lfx-one/shared/constants';
 import {
   CdpCreateIdentityRequest,
   CdpIdentity,
@@ -343,9 +343,15 @@ export class CdpService {
 
       const identities: CdpIdentity[] = rawIdentities.map((raw) => {
         const platform = raw.platform === 'custom' ? 'email' : raw.platform;
-        // CDP rows that pre-date the `type` field fall back to the platform
-        // default; new rows return `type` directly from the API.
-        const type = raw.type ?? CDP_PLATFORM_TO_TYPE_MAP[raw.platform] ?? 'username';
+        // CDP rows that pre-date the `type` field fall back to inferring from
+        // the value's shape: matches a local@host.tld pattern → email, else
+        // username. Inferring from platform alone would misclassify legacy
+        // LinkedIn vanity rows as email (since CDP_PLATFORM_TO_TYPE_MAP
+        // ['linkedin'] = 'email' is the POST default, reflecting that Auth0
+        // gives us emails — not a guarantee about what's stored in any given
+        // row).
+        const isEmailShape = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw.value.trim());
+        const type = raw.type ?? (isEmailShape ? 'email' : 'username');
         return {
           id: raw.id,
           platform,

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -94,7 +94,7 @@ export const CDP_TO_AUTH0_PROVIDER_MAP: Record<string, string> = Object.fromEntr
  * when CDP returns an identity without `type`, and (b) to derive `type` when
  * LFX One POSTs new identities to CDP from auth-service.
  */
-export const CDP_PLATFORM_TO_TYPE_MAP: Record<string, CdpIdentityType> = {
+export const CDP_PLATFORM_TO_TYPE_MAP: Readonly<Record<string, CdpIdentityType | undefined>> = {
   github: 'username',
   gitlab: 'username',
   lfid: 'username',

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { IdentityProvider, IdentityProviderOption, ProfileTab } from '../interfaces';
+import { CdpIdentityType, IdentityProvider, IdentityProviderOption, ProfileTab } from '../interfaces';
 
 /**
  * Profile tab configuration
@@ -67,12 +67,6 @@ export const IDENTITY_PROVIDER_OPTIONS: IdentityProviderOption[] = [
 ];
 
 /**
- * Platforms that the UI supports verification for.
- * Only identities on these platforms are returned to the frontend.
- */
-export const IDENTITY_DISPLAY_PLATFORMS: readonly string[] = ['github', 'google', 'linkedin', 'email'];
-
-/**
  * Maps Auth0 identity provider names to CDP platform names
  * Used to cross-reference Auth0 linked identities with CDP identities
  */
@@ -94,6 +88,35 @@ export const AUTH0_TO_CDP_PROVIDER_MAP: Record<string, string> = {
 export const CDP_TO_AUTH0_PROVIDER_MAP: Record<string, string> = Object.fromEntries(
   Object.entries(AUTH0_TO_CDP_PROVIDER_MAP).map(([auth0, cdp]) => [cdp, auth0])
 );
+
+/**
+ * Default mapping from CDP platform → identity type. Used (a) as a fallback
+ * when CDP returns an identity without `type`, and (b) to derive `type` when
+ * LFX One POSTs new identities to CDP from auth-service.
+ */
+export const CDP_PLATFORM_TO_TYPE_MAP: Record<string, CdpIdentityType> = {
+  github: 'username',
+  gitlab: 'username',
+  lfid: 'username',
+  google: 'email',
+  linkedin: 'email',
+  email: 'email',
+  custom: 'email',
+};
+
+/**
+ * Allowlist of (platform, type) combos that LFX One supports surfacing in the
+ * profile identities UI and syncing to CDP from auth-service. Applied AFTER
+ * the `custom → email` remap in cdp.service.ts, so email-style entries appear
+ * here as `email + email`. LFID is handled by a dedicated auto-verify branch
+ * and intentionally excluded from this allowlist.
+ */
+export const CDP_DISPLAYABLE_IDENTITY_COMBOS: ReadonlySet<string> = new Set([
+  'github+username',
+  'linkedin+email',
+  'email+email',
+  'google+email',
+]);
 
 /**
  * CDP platform to icon class mapping

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -111,12 +111,7 @@ export const CDP_PLATFORM_TO_TYPE_MAP: Record<string, CdpIdentityType> = {
  * here as `email + email`. LFID is handled by a dedicated auto-verify branch
  * and intentionally excluded from this allowlist.
  */
-export const CDP_DISPLAYABLE_IDENTITY_COMBOS: ReadonlySet<string> = new Set([
-  'github+username',
-  'linkedin+email',
-  'email+email',
-  'google+email',
-]);
+export const CDP_DISPLAYABLE_IDENTITY_COMBOS: ReadonlySet<string> = new Set(['github+username', 'linkedin+email', 'email+email', 'google+email']);
 
 /**
  * CDP platform to icon class mapping

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -90,9 +90,12 @@ export const CDP_TO_AUTH0_PROVIDER_MAP: Record<string, string> = Object.fromEntr
 );
 
 /**
- * Default mapping from CDP platform → identity type. Used (a) as a fallback
- * when CDP returns an identity without `type`, and (b) to derive `type` when
- * LFX One POSTs new identities to CDP from auth-service.
+ * Default mapping from CDP platform → identity type, used when LFX One POSTs
+ * new identities to CDP from auth-service (where the value's shape is known
+ * because we control it — Auth0 always gives us email for LinkedIn, nickname
+ * for GitHub, etc.). NOT used as a GET-side fallback for legacy CDP rows
+ * missing `type`; that path infers from the value's shape directly (see
+ * cdp.service.ts).
  */
 export const CDP_PLATFORM_TO_TYPE_MAP: Readonly<Record<string, CdpIdentityType | undefined>> = {
   github: 'username',

--- a/packages/shared/src/interfaces/profile.interface.ts
+++ b/packages/shared/src/interfaces/profile.interface.ts
@@ -466,7 +466,8 @@ export interface CdpIdentityRaw {
   value: string;
   platform: string;
   // Optional to tolerate legacy CDP rows that pre-date the field; backend
-  // derives a fallback via CDP_PLATFORM_TO_TYPE_MAP when absent.
+  // derives a fallback by inspecting the value's shape (email vs username)
+  // in cdp.service.ts when absent.
   type?: CdpIdentityType;
   verified: boolean;
   verifiedBy?: string | null;

--- a/packages/shared/src/interfaces/profile.interface.ts
+++ b/packages/shared/src/interfaces/profile.interface.ts
@@ -452,12 +452,22 @@ export interface CdpResolveResponse {
 }
 
 /**
+ * CDP identity type — distinguishes whether the identity's value is an email
+ * address or a platform username/handle. Returned by the CDP identities API
+ * and required on create.
+ */
+export type CdpIdentityType = 'email' | 'username';
+
+/**
  * Raw identity from CDP API response
  */
 export interface CdpIdentityRaw {
   id: string;
   value: string;
   platform: string;
+  // Optional to tolerate legacy CDP rows that pre-date the field; backend
+  // derives a fallback via CDP_PLATFORM_TO_TYPE_MAP when absent.
+  type?: CdpIdentityType;
   verified: boolean;
   verifiedBy?: string | null;
   source: string;
@@ -478,7 +488,7 @@ export interface CdpIdentitiesResponse {
 export interface CdpCreateIdentityRequest {
   value: string;
   platform: string;
-  type: string;
+  type: CdpIdentityType;
   source: string;
   verified: boolean;
   verifiedBy: string;
@@ -490,6 +500,7 @@ export interface CdpCreateIdentityRequest {
 export interface CdpIdentity {
   id: string;
   platform: string;
+  type: CdpIdentityType;
   value: string;
   verified: boolean;
   verifiedBy?: string | null;

--- a/packages/shared/src/utils/identity.utils.ts
+++ b/packages/shared/src/utils/identity.utils.ts
@@ -8,8 +8,14 @@
  * default (e.g. CDP_PLATFORM_TO_TYPE_MAP) is intentionally not consulted
  * here — POST defaults reflect what Auth0 gives us, not a guarantee about
  * what is stored in any given row.
+ *
+ * The middle character class excludes `.` so the greedy `+` deterministically
+ * stops at the first dot in the host portion, eliminating the polynomial
+ * backtracking that would otherwise occur on pathological inputs like
+ * `x@x.x.x.x.…`. The trailing class still allows `.` so the TLD/subdomain
+ * tail (e.g. `co.uk`, `users.noreply.github.com`) can contain dots.
  */
-export const EMAIL_SHAPE_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const EMAIL_SHAPE_REGEX = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
 
 /**
  * Returns true if the value matches a strict `local@host.tld` email shape

--- a/packages/shared/src/utils/identity.utils.ts
+++ b/packages/shared/src/utils/identity.utils.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Strict `local@host.tld` shape detection. Used to distinguish email vs
+ * username CDP identity values when the platform doesn't carry that
+ * information (legacy CDP rows without a `type` field). The platform
+ * default (e.g. CDP_PLATFORM_TO_TYPE_MAP) is intentionally not consulted
+ * here — POST defaults reflect what Auth0 gives us, not a guarantee about
+ * what is stored in any given row.
+ */
+export const EMAIL_SHAPE_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Returns true if the value matches a strict `local@host.tld` email shape
+ * after trimming surrounding whitespace.
+ */
+export function isEmailShape(value: string): boolean {
+  return EMAIL_SHAPE_REGEX.test(value.trim());
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -24,3 +24,4 @@ export * from './rewards.utils';
 export * from './insights.utils';
 export * from './pagination.utils';
 export * from './project-counts.utils';
+export * from './identity.utils';


### PR DESCRIPTION
## Summary

- Add `CdpIdentityType` union (`'email' | 'username'`) and surface `type` on `CdpIdentityRaw`, `CdpIdentity`, and `CdpCreateIdentityRequest`.
- Introduce `CDP_PLATFORM_TO_TYPE_MAP` (fallback for legacy CDP rows without `type`) and `CDP_DISPLAYABLE_IDENTITY_COMBOS` allowlist: `github+username`, `linkedin+email`, `email+email`, `google+email`.
- Replace `IDENTITY_DISPLAY_PLATFORMS` platform-only filter with the combo allowlist at all three filter points in `profile.controller.ts` — final response filter, unverified-vs-hidden decision, and the auth-service-to-CDP sync gate.
- Remove the LinkedIn POST skip — LinkedIn now syncs to CDP as \`platform='linkedin', type='email'\`, so the legacy "LinkedIn must come from auth-service only" hide rule is no longer needed.
- Drop the unused \`IDENTITY_DISPLAY_PLATFORMS\` constant.

The existing \`email/google → custom\` POST mapping and \`custom → email\` GET remap are preserved for back-compat with pre-existing CDP rows.

LFXV2-1697