### PR TITLE
feat(surveys): show per-user response status on me lens

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -299,7 +299,7 @@ export class CommitteeMeetingsComponent {
     return {
       id: `survey-${survey.uid}`,
       title: `Survey: ${survey.survey_title}`,
-      start: survey.survey_cutoff_date,
+      start: survey.survey_cutoff_date ?? undefined,
       allDay: true,
       backgroundColor: SURVEY_COLOR.bg,
       borderColor: SURVEY_COLOR.border,

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -158,10 +158,10 @@ export class CommitteeOverviewComponent {
 
   public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));
   public pendingSurveys: Signal<Survey[]> = computed(() =>
-    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status !== 'responded')
+    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status?.toLowerCase() !== 'responded')
   );
   public respondedSurveys: Signal<Survey[]> = computed(() =>
-    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status === 'responded')
+    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status?.toLowerCase() === 'responded')
   );
   public hasPendingActions: Signal<boolean> = computed(() => this.pendingVotes().length > 0 || this.pendingSurveys().length > 0);
 
@@ -390,11 +390,14 @@ export class CommitteeOverviewComponent {
         text: survey.survey_title,
         icon: 'fa-light fa-circle-check',
         severity: PENDING_ACTION_SEVERITY.Submitted,
-        // Survey is still open — the user may change their answer until it closes,
-        // so the action remains the survey link, not a results view. The 'Submitted'
-        // type + green check icon communicate that a response is already on file.
-        buttonText: 'Update',
-        buttonLink: survey.survey_link,
+        // No buttonLink: the committee surveys query does not populate the per-user
+        // SurveyMonkey link (survey_link is Me-lens-only data on /api/surveys/my-surveys),
+        // and handlePendingActionClick falls through to tabNavigated('surveys') for
+        // non-Vote items. The label reflects what actually happens on click — navigation
+        // to the surveys tab. To re-enable an in-place "Update" CTA, the committee
+        // surveys endpoint would need to enrich each row with the current user's
+        // survey_response.survey_link.
+        buttonText: 'View',
         date: undefined,
       }));
       return [...voteItems, ...surveyItems, ...respondedSurveyItems].map((item, index) => {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -157,7 +157,12 @@ export class CommitteeOverviewComponent {
   });
 
   public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));
-  public pendingSurveys: Signal<Survey[]> = computed(() => this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN));
+  public pendingSurveys: Signal<Survey[]> = computed(() =>
+    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status !== 'responded')
+  );
+  public respondedSurveys: Signal<Survey[]> = computed(() =>
+    this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status === 'responded')
+  );
   public hasPendingActions: Signal<boolean> = computed(() => this.pendingVotes().length > 0 || this.pendingSurveys().length > 0);
 
   public pendingActionItems: Signal<CommitteePendingActionRow[]> = this.initPendingActionItems();
@@ -360,18 +365,39 @@ export class CommitteeOverviewComponent {
           ? `Deadline: ${new Date(vote.end_time).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
           : undefined,
       }));
-      const surveyItems: PendingActionItem[] = this.pendingSurveys().map((survey) => ({
-        type: 'Survey',
+      const surveyItems: PendingActionItem[] = this.pendingSurveys().map((survey) => {
+        const sentDate = survey.created_at ? new Date(survey.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : null;
+        const dueDate = survey.survey_cutoff_date
+          ? new Date(survey.survey_cutoff_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+          : null;
+        const dateParts: string[] = [];
+        if (sentDate) dateParts.push(`Sent: ${sentDate}`);
+        if (dueDate) dateParts.push(`Due: ${dueDate}`);
+
+        return {
+          type: 'Survey',
+          badge: this.committee().name,
+          text: survey.survey_title,
+          icon: 'fa-light fa-chart-simple',
+          severity: PENDING_ACTION_SEVERITY.Survey,
+          buttonText: 'Submit Survey',
+          date: dateParts.length > 0 ? dateParts.join(' · ') : undefined,
+        };
+      });
+      const respondedSurveyItems: PendingActionItem[] = this.respondedSurveys().map((survey) => ({
+        type: 'Submitted',
         badge: this.committee().name,
         text: survey.survey_title,
-        icon: 'fa-light fa-chart-simple',
-        severity: PENDING_ACTION_SEVERITY.Survey,
-        buttonText: 'Submit Survey',
-        date: survey.survey_cutoff_date
-          ? `Deadline: ${new Date(survey.survey_cutoff_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
-          : undefined,
+        icon: 'fa-light fa-circle-check',
+        severity: PENDING_ACTION_SEVERITY.Submitted,
+        // Survey is still open — the user may change their answer until it closes,
+        // so the action remains the survey link, not a results view. The 'Submitted'
+        // type + green check icon communicate that a response is already on file.
+        buttonText: 'Update',
+        buttonLink: survey.survey_link,
+        date: undefined,
       }));
-      return [...voteItems, ...surveyItems].map((item, index) => {
+      return [...voteItems, ...surveyItems, ...respondedSurveyItems].map((item, index) => {
         const rowKey = item.buttonLink ? `${item.type}-${item.buttonLink}` : `${item.type}-${item.text}-${index}`;
         // Parity from `rowKey` (not list index) so future row removals (e.g., a vote closing)
         // don't flip following rows' stripes mid-`transition-colors`.

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
@@ -29,7 +29,7 @@
     </div>
   </ng-template>
 
-  <div class="flex flex-col gap-5 p-4 sm:p-6">
+  <div class="flex flex-col gap-5">
     @if (loading()) {
       <div class="flex flex-col gap-3">
         <p-skeleton height="2.5rem" width="60%"></p-skeleton>
@@ -79,10 +79,26 @@
           </a>
         </div>
       }
+    } @else if (isOpenUnresponded()) {
+      <div class="flex flex-col gap-2 p-5 bg-slate-50 rounded-lg" data-testid="my-response-drawer-open-unresponded">
+        <span class="text-sm font-medium text-slate-900">You haven't responded yet.</span>
+        <span class="text-xs text-slate-500">This survey is still accepting responses.</span>
+        @if (surveyLink(); as link) {
+          <a
+            [href]="link"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-[#0061A3] hover:underline font-medium mt-2"
+            data-testid="my-response-drawer-take-link">
+            Take the survey
+            <i class="fa-light fa-arrow-up-right-from-square ml-1" aria-hidden="true"></i>
+          </a>
+        }
+      </div>
     } @else {
       <div class="flex flex-col gap-2 p-5 bg-slate-50 rounded-lg" data-testid="my-response-drawer-empty">
         <span class="text-sm font-medium text-slate-900">You didn't respond to this survey.</span>
-        <span class="text-xs text-slate-500"> You were invited but didn't submit a response before the survey closed. </span>
+        <span class="text-xs text-slate-500">You were invited but didn't submit a response before the survey closed.</span>
       </div>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
@@ -21,9 +21,10 @@
       <button
         type="button"
         (click)="onClose()"
+        aria-label="Close"
         class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors flex-shrink-0"
         data-testid="my-response-drawer-close">
-        <i class="fa-light fa-xmark text-xl"></i>
+        <i class="fa-light fa-xmark text-xl" aria-hidden="true"></i>
       </button>
     </div>
   </ng-template>
@@ -44,7 +45,7 @@
         </div>
       } @else if (hasQuestionAnswers()) {
         <div class="flex flex-col gap-4" data-testid="my-response-drawer-questions">
-          @for (qa of resp.survey_monkey_question_answers; track qa.question_id) {
+          @for (qa of resp.survey_monkey_question_answers; track qa.question_id ?? $index) {
             <div class="flex flex-col gap-2 p-4 border border-slate-200 rounded-lg">
               <span class="text-sm font-medium text-slate-900">{{ qa.question_text }}</span>
               @if ((qa.answers?.length ?? 0) === 0) {
@@ -52,7 +53,7 @@
               } @else {
                 <ul class="flex flex-col gap-1 list-disc list-inside">
                   @for (a of qa.answers; track $index) {
-                    <li class="text-sm text-slate-700">{{ a.text }}</li>
+                    <li class="text-sm text-slate-700">{{ a.text ?? a.choice_id ?? '—' }}</li>
                   }
                 </ul>
               }

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.html
@@ -1,0 +1,88 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full my-response-drawer"
+  data-testid="my-response-drawer">
+  <ng-template #header>
+    <div class="flex items-center justify-between gap-2 w-full pr-4">
+      <div class="flex flex-col gap-1 flex-1 min-w-0">
+        <h1 class="text-lg sm:text-xl font-semibold text-slate-900 truncate" data-testid="my-response-drawer-title">
+          {{ survey()?.survey_title ?? 'Your Response' }}
+        </h1>
+        @if (response()?.response_datetime; as submitted) {
+          <span class="text-xs text-slate-500" data-testid="my-response-drawer-submitted-at"> Submitted {{ submitted | date: 'MMM d, y, h:mm a' }} </span>
+        }
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors flex-shrink-0"
+        data-testid="my-response-drawer-close">
+        <i class="fa-light fa-xmark text-xl"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-5 p-4 sm:p-6">
+    @if (loading()) {
+      <div class="flex flex-col gap-3">
+        <p-skeleton height="2.5rem" width="60%"></p-skeleton>
+        <p-skeleton height="1.5rem" width="80%"></p-skeleton>
+        <p-skeleton height="1.5rem" width="70%"></p-skeleton>
+      </div>
+    } @else if (response(); as resp) {
+      @if (isNps()) {
+        <div class="flex flex-col gap-2 p-5 bg-slate-50 rounded-lg" data-testid="my-response-drawer-nps">
+          <span class="text-sm text-slate-600">Your score</span>
+          <span class="text-5xl font-semibold text-slate-900">{{ resp.nps_value }}</span>
+          <span class="text-xs text-slate-500">on a scale of 0–10</span>
+        </div>
+      } @else if (hasQuestionAnswers()) {
+        <div class="flex flex-col gap-4" data-testid="my-response-drawer-questions">
+          @for (qa of resp.survey_monkey_question_answers; track qa.question_id) {
+            <div class="flex flex-col gap-2 p-4 border border-slate-200 rounded-lg">
+              <span class="text-sm font-medium text-slate-900">{{ qa.question_text }}</span>
+              @if ((qa.answers?.length ?? 0) === 0) {
+                <span class="text-sm text-slate-400 italic">No answer</span>
+              } @else {
+                <ul class="flex flex-col gap-1 list-disc list-inside">
+                  @for (a of qa.answers; track $index) {
+                    <li class="text-sm text-slate-700">{{ a.text }}</li>
+                  }
+                </ul>
+              }
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="text-sm text-slate-500" data-testid="my-response-drawer-no-answers">
+          Your response is on file but the detailed answers aren't available yet. Try again later or use the survey link to review your submission.
+        </div>
+      }
+
+      @if (canUpdate()) {
+        <div class="flex justify-end pt-2 border-t border-slate-200">
+          <a
+            [href]="resp.survey_link"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-[#0061A3] hover:underline font-medium"
+            data-testid="my-response-drawer-update-link">
+            Update your response
+            <i class="fa-light fa-arrow-up-right-from-square ml-1"></i>
+          </a>
+        </div>
+      }
+    } @else {
+      <div class="flex flex-col gap-2 p-5 bg-slate-50 rounded-lg" data-testid="my-response-drawer-empty">
+        <span class="text-sm font-medium text-slate-900">You didn't respond to this survey.</span>
+        <span class="text-xs text-slate-500"> You were invited but didn't submit a response before the survey closed. </span>
+      </div>
+    }
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.scss
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+::ng-deep {
+  .my-response-drawer {
+    .p-drawer-header {
+      @apply border-b border-slate-200 bg-white pb-4;
+    }
+
+    .p-drawer-content {
+      @apply px-4 sm:px-6 py-4 overflow-y-auto;
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
@@ -28,7 +28,11 @@ export class MyResponseDrawerComponent {
   protected readonly loading = signal<boolean>(false);
   protected readonly response: Signal<MySurveyResponse | null> = this.initResponse();
 
-  protected readonly isNps: Signal<boolean> = computed(() => this.survey()?.is_nps_survey ?? false);
+  // Prefer the survey's is_nps_survey flag, but fall back to inspecting the response
+  // payload. Stub survey rows (rendered when the upstream /surveys/{uid} detail fetch
+  // fails) default is_nps_survey to false even for genuinely NPS surveys; without this
+  // fallback the drawer would mis-render the NPS score as a "no answers" state.
+  protected readonly isNps: Signal<boolean> = computed(() => this.survey()?.is_nps_survey === true || this.response()?.nps_value != null);
   protected readonly hasQuestionAnswers: Signal<boolean> = computed(() => (this.response()?.survey_monkey_question_answers?.length ?? 0) > 0);
   protected readonly canUpdate: Signal<boolean> = computed(() => {
     // While the survey is still accepting responses the user may change their answer.

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
@@ -45,6 +45,19 @@ export class MyResponseDrawerComponent {
     return !!this.response()?.survey_link;
   });
 
+  // True when the drawer is opened for an open-but-unresponded survey. The empty-state
+  // copy needs to differ from the closed-survey case ("haven't responded yet" vs
+  // "didn't respond before the survey closed").
+  protected readonly isOpenUnresponded: Signal<boolean> = computed(() => {
+    const s = this.survey();
+    return !!s && getSurveyDisplayStatus(s) === SurveyStatus.OPEN;
+  });
+
+  // The personalized SurveyMonkey link on the parent Survey (Me-lens-only).
+  // Surfaced through a computed so the empty-state template can offer a "Take Survey"
+  // CTA when applicable without re-evaluating the access pattern inline.
+  protected readonly surveyLink: Signal<string | undefined> = computed(() => this.survey()?.survey_link);
+
   protected onClose(): void {
     this.visible.set(false);
   }

--- a/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/my-response-drawer/my-response-drawer.component.ts
@@ -1,0 +1,63 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { Component, computed, inject, input, model, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { SurveyStatus } from '@lfx-one/shared/enums';
+import { MySurveyResponse, Survey } from '@lfx-one/shared/interfaces';
+import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { SurveyService } from '@services/survey.service';
+import { DrawerModule } from 'primeng/drawer';
+import { SkeletonModule } from 'primeng/skeleton';
+import { finalize, of, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-my-response-drawer',
+  imports: [DrawerModule, DatePipe, SkeletonModule],
+  templateUrl: './my-response-drawer.component.html',
+  styleUrl: './my-response-drawer.component.scss',
+})
+export class MyResponseDrawerComponent {
+  private readonly surveyService = inject(SurveyService);
+
+  public readonly surveyId = input<string | null>(null);
+  public readonly survey = input<Survey | null>(null);
+  public readonly visible = model<boolean>(false);
+
+  protected readonly loading = signal<boolean>(false);
+  protected readonly response: Signal<MySurveyResponse | null> = this.initResponse();
+
+  protected readonly isNps: Signal<boolean> = computed(() => this.survey()?.is_nps_survey ?? false);
+  protected readonly hasQuestionAnswers: Signal<boolean> = computed(() => (this.response()?.survey_monkey_question_answers?.length ?? 0) > 0);
+  protected readonly canUpdate: Signal<boolean> = computed(() => {
+    // While the survey is still accepting responses the user may change their answer.
+    // Use displayStatus (not raw survey_status) so a survey whose cutoff date has
+    // passed is treated as closed even when the upstream survey_status is still
+    // 'OPEN'/'SENT'. The personalized survey_link is also required.
+    const s = this.survey();
+    if (!s) return false;
+    if (getSurveyDisplayStatus(s) !== SurveyStatus.OPEN) return false;
+    return !!this.response()?.survey_link;
+  });
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  private initResponse(): Signal<MySurveyResponse | null> {
+    return toSignal(
+      toObservable(this.surveyId).pipe(
+        switchMap((id) => {
+          if (!id) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.surveyService.getMyResponse(id).pipe(finalize(() => this.loading.set(false)));
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -84,13 +84,13 @@
           data-testid="surveys-table">
           <ng-template #header>
             <tr>
-              <th class="w-[23%]">{{ surveyLabel.singular }} Name</th>
+              <th class="w-[26%]">{{ surveyLabel.singular }} Name</th>
               <th class="w-[15%]">Survey Type</th>
               <th class="w-[16%]">Group</th>
               <th class="w-[11%]">Responses</th>
               <th class="w-[12%]">Due</th>
-              <th class="w-[11%]">Status</th>
-              <th class="w-[12%]"></th>
+              <th class="w-[8%] text-right">Status</th>
+              <th class="w-[12%] whitespace-nowrap"></th>
             </tr>
           </ng-template>
 
@@ -146,8 +146,12 @@
                 }
               </td>
 
-              <td>
-                <lfx-tag [value]="survey | surveyStatusLabel" [severity]="survey | surveyStatusSeverity"></lfx-tag>
+              <td class="text-right">
+                @let openResponded = survey.displayStatus === SurveyStatus.OPEN && survey.response_status === 'responded';
+                @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && survey.response_status !== 'responded';
+                <lfx-tag
+                  [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
+                  [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>
               </td>
 
               <td>
@@ -167,19 +171,29 @@
                     </lfx-button>
                   } @else if (!hasPMOAccess() && survey.displayStatus === SurveyStatus.OPEN && survey.survey_link) {
                     <lfx-button
-                      label="Take Survey"
-                      severity="primary"
+                      [label]="survey.response_status === 'responded' ? 'Update' : 'Take Survey'"
+                      [severity]="survey.response_status === 'responded' ? 'secondary' : 'primary'"
                       size="small"
                       [text]="true"
                       [href]="survey.survey_link"
                       target="_blank"
                       rel="noopener noreferrer"
-                      [attr.data-testid]="'surveys-take-' + survey.uid">
+                      [attr.data-testid]="(survey.response_status === 'responded' ? 'surveys-update-' : 'surveys-take-') + survey.uid">
                     </lfx-button>
-                  } @else if (survey.displayStatus === SurveyStatus.OPEN || survey.displayStatus === SurveyStatus.CLOSED) {
+                  } @else if (isMeLens() && survey.displayStatus === SurveyStatus.CLOSED) {
+                    <lfx-button
+                      label="View"
+                      severity="secondary"
+                      size="small"
+                      [text]="true"
+                      styleClass=""
+                      (onClick)="onViewResults(survey.uid)"
+                      [attr.data-testid]="'surveys-view-' + survey.uid">
+                    </lfx-button>
+                  } @else if (!isMeLens() && (survey.displayStatus === SurveyStatus.OPEN || survey.displayStatus === SurveyStatus.CLOSED)) {
                     <lfx-button
                       label="Results"
-                      severity="primary"
+                      severity="secondary"
                       size="small"
                       [text]="true"
                       styleClass=""

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -147,8 +147,9 @@
               </td>
 
               <td class="text-right">
-                @let openResponded = survey.displayStatus === SurveyStatus.OPEN && survey.response_status === 'responded';
-                @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && survey.response_status !== 'responded';
+                @let isResponded = survey.response_status?.toLowerCase() === 'responded';
+                @let openResponded = survey.displayStatus === SurveyStatus.OPEN && isResponded;
+                @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && !isResponded;
                 <lfx-tag
                   [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
                   [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>
@@ -170,15 +171,16 @@
                       [attr.data-testid]="'surveys-delete-' + survey.uid">
                     </lfx-button>
                   } @else if (!hasPMOAccess() && survey.displayStatus === SurveyStatus.OPEN && survey.survey_link) {
+                    @let actionIsResponded = survey.response_status?.toLowerCase() === 'responded';
                     <lfx-button
-                      [label]="survey.response_status === 'responded' ? 'Update' : 'Take Survey'"
-                      [severity]="survey.response_status === 'responded' ? 'secondary' : 'primary'"
+                      [label]="actionIsResponded ? 'Update' : 'Take Survey'"
+                      [severity]="actionIsResponded ? 'secondary' : 'primary'"
                       size="small"
                       [text]="true"
                       [href]="survey.survey_link"
                       target="_blank"
                       rel="noopener noreferrer"
-                      [attr.data-testid]="(survey.response_status === 'responded' ? 'surveys-update-' : 'surveys-take-') + survey.uid">
+                      [attr.data-testid]="(actionIsResponded ? 'surveys-update-' : 'surveys-take-') + survey.uid">
                     </lfx-button>
                   } @else if (isMeLens() && survey.displayStatus === SurveyStatus.CLOSED) {
                     <lfx-button

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -67,6 +67,7 @@ export class SurveysTableComponent {
   public readonly projectOptions = input<{ label: string; value: string | null }[]>([]);
   public readonly showFoundationFilter = input<boolean>(false);
   public readonly showProjectFilter = input<boolean>(false);
+  public readonly isMeLens = input<boolean>(false);
 
   // === Outputs ===
   public readonly viewResults = output<string>();

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -48,6 +48,7 @@
       [surveys]="isMeLens() ? filteredMySurveys() : surveys()"
       [hasPMOAccess]="!isMeLens() && canWrite()"
       [loading]="isMeLens() ? mySurveysLoading() : loading()"
+      [isMeLens]="isMeLens()"
       [foundationOptions]="foundationOptions()"
       [projectOptions]="projectOptions()"
       [showFoundationFilter]="showFoundationFilter()"
@@ -72,3 +73,7 @@
   (closeSurvey)="onCloseSurvey($event)"
   data-testid="survey-results-drawer">
 </lfx-survey-results-drawer>
+
+<!-- My Response Drawer (Me lens) -->
+<lfx-my-response-drawer [(visible)]="myResponseDrawerVisible" [surveyId]="selectedSurveyId()" [survey]="selectedListSurvey()" data-testid="my-response-drawer">
+</lfx-my-response-drawer>

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -15,12 +15,13 @@ import { SurveyService } from '@services/survey.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { MyResponseDrawerComponent } from '../components/my-response-drawer/my-response-drawer.component';
 import { SurveyResultsDrawerComponent } from '../components/survey-results-drawer/survey-results-drawer.component';
 import { SurveysTableComponent } from '../components/surveys-table/surveys-table.component';
 
 @Component({
   selector: 'lfx-surveys-dashboard',
-  imports: [LowerCasePipe, ButtonComponent, SurveysTableComponent, RouterLink, SurveyResultsDrawerComponent, EmptyStateComponent],
+  imports: [LowerCasePipe, ButtonComponent, SurveysTableComponent, RouterLink, SurveyResultsDrawerComponent, MyResponseDrawerComponent, EmptyStateComponent],
   templateUrl: './surveys-dashboard.component.html',
   styleUrl: './surveys-dashboard.component.scss',
 })
@@ -42,6 +43,7 @@ export class SurveysDashboardComponent {
   protected readonly loading = signal<boolean>(true);
   protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly resultsDrawerVisible = signal<boolean>(false);
+  protected readonly myResponseDrawerVisible = signal<boolean>(false);
   protected readonly selectedSurveyId = signal<string | null>(null);
   protected readonly mySurveysLoading = signal<boolean>(true);
   protected readonly foundationFilter = signal<string | null>(null);
@@ -63,7 +65,13 @@ export class SurveysDashboardComponent {
 
   protected onViewResults(surveyId: string): void {
     this.selectedSurveyId.set(surveyId);
-    this.resultsDrawerVisible.set(true);
+    // Me lens: open the per-user drawer (response data scoped to the current user).
+    // All other lenses: open the aggregate results drawer (gated by participant access upstream).
+    if (this.isMeLens()) {
+      this.myResponseDrawerVisible.set(true);
+    } else {
+      this.resultsDrawerVisible.set(true);
+    }
   }
 
   protected onRowClick(survey: Survey): void {

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -67,9 +67,13 @@ export class SurveysDashboardComponent {
     this.selectedSurveyId.set(surveyId);
     // Me lens: open the per-user drawer (response data scoped to the current user).
     // All other lenses: open the aggregate results drawer (gated by participant access upstream).
+    // Explicitly close the non-target drawer so a mid-session lens switch can't leave both
+    // visibility signals set to true at the same time.
     if (this.isMeLens()) {
+      this.resultsDrawerVisible.set(false);
       this.myResponseDrawerVisible.set(true);
     } else {
+      this.myResponseDrawerVisible.set(false);
       this.resultsDrawerVisible.set(true);
     }
   }

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { CreateSurveyRequest, Survey } from '@lfx-one/shared/interfaces';
+import { CreateSurveyRequest, MySurveyResponse, Survey } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of, take, throwError } from 'rxjs';
 
 @Injectable({
@@ -40,6 +40,20 @@ export class SurveyService {
   /** Returns surveys for the current user; foundation/project filtering is applied client-side. */
   public getMySurveys(): Observable<Survey[]> {
     return this.http.get<Survey[]>('/api/surveys/my-surveys').pipe(catchError(() => of([])));
+  }
+
+  /** Returns the current user's submitted response for a survey, or null if none. Used by the Me lens "View My Response" drawer. */
+  public getMyResponse(surveyUid: string): Observable<MySurveyResponse | null> {
+    return this.http.get<MySurveyResponse>(`/api/surveys/${surveyUid}/my-response`).pipe(
+      catchError((error) => {
+        // 404 here means "no response on file" — that's a normal empty state, not an error.
+        // Log non-404s so transient backend issues surface in DevTools without breaking the drawer.
+        if (error?.status !== 404) {
+          console.error(`Failed to load my-response for survey ${surveyUid}:`, error);
+        }
+        return of(null);
+      })
+    );
   }
 
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -4,6 +4,7 @@
 import { CreateSurveyRequest } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
+import { ResourceNotFoundError } from '../errors';
 import { validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { SurveyService } from '../services/survey.service';
@@ -99,8 +100,16 @@ export class SurveyController {
       const response = await this.surveyService.getMyResponse(req, surveyUid);
 
       if (!response) {
-        res.status(404).json({ message: 'No response found for the current user.' });
-        return;
+        // Throw ResourceNotFoundError so apiErrorHandler emits a structured
+        // 404 with request_id correlation and consistent error logging,
+        // matching the pattern used elsewhere (e.g. public-meeting.controller).
+        return next(
+          new ResourceNotFoundError('Survey response', surveyUid, {
+            operation: 'get_my_response',
+            service: 'survey_controller',
+            path: `/surveys/${surveyUid}/my-response`,
+          })
+        );
       }
 
       logger.success(req, 'get_my_response', startTime, { survey_uid: surveyUid });

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -86,6 +86,31 @@ export class SurveyController {
   }
 
   /**
+   * GET /surveys/:uid/my-response — returns the current user's submitted response, or 404 if none.
+   */
+  public async getMyResponse(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const surveyUid = req.params['uid'];
+    const startTime = logger.startOperation(req, 'get_my_response', { survey_uid: surveyUid });
+
+    try {
+      const validationContext = { operation: 'get_my_response', service: 'survey_controller' };
+      if (!validateUidParameter(surveyUid, req, next, validationContext)) return;
+
+      const response = await this.surveyService.getMyResponse(req, surveyUid);
+
+      if (!response) {
+        res.status(404).json({ message: 'No response found for the current user.' });
+        return;
+      }
+
+      logger.success(req, 'get_my_response', startTime, { survey_uid: surveyUid });
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /surveys/:uid
    */
   public async getSurveyById(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/surveys.route.ts
+++ b/apps/lfx-one/src/server/routes/surveys.route.ts
@@ -18,6 +18,9 @@ router.get('/', (req, res, next) => surveyController.getSurveys(req, res, next))
 // GET /surveys/my-surveys - get surveys the current user has been invited to
 router.get('/my-surveys', (req, res, next) => surveyController.getMySurveys(req, res, next));
 
+// GET /surveys/:uid/my-response - current user's submitted response (Me lens drawer)
+router.get('/:uid/my-response', (req, res, next) => surveyController.getMyResponse(req, res, next));
+
 // GET /surveys/:uid - get a single survey
 router.get('/:uid', (req, res, next) => surveyController.getSurveyById(req, res, next));
 

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -3,7 +3,7 @@
 
 import { SURVEY_LINK_ALLOWLIST } from '@lfx-one/shared/constants';
 import { SurveyStatus } from '@lfx-one/shared/enums';
-import { CreateSurveyRequest, QueryServiceResponse, Survey } from '@lfx-one/shared/interfaces';
+import { CreateSurveyRequest, MySurveyResponse, QueryServiceResponse, Survey } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
@@ -49,18 +49,29 @@ export class SurveyService {
       type: 'survey',
     };
 
-    const surveys = await fetchAllQueryResources<Survey>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
-    );
+    // Fetch surveys and the current user's survey_responses in parallel so the
+    // join (used to stamp response_status='responded') does not add a sequential
+    // round-trip. fetchRespondedSurveyUidsForUser returns an empty set when the
+    // user cannot be identified or the lookup fails, so callers degrade gracefully.
+    const [surveys, respondedSurveyUids] = await Promise.all([
+      fetchAllQueryResources<Survey>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          ...params,
+          ...(pageToken && { page_token: pageToken }),
+        })
+      ),
+      this.fetchRespondedSurveyUidsForUser(req),
+    ]);
+
+    const enriched =
+      respondedSurveyUids.size > 0 ? surveys.map((s) => (s.uid && respondedSurveyUids.has(s.uid) ? { ...s, response_status: 'responded' } : s)) : surveys;
 
     logger.debug(req, 'get_surveys', 'Completed survey fetch', {
-      final_count: surveys.length,
+      final_count: enriched.length,
+      responded_count: respondedSurveyUids.size,
     });
 
-    return surveys;
+    return enriched;
   }
 
   /**
@@ -199,9 +210,10 @@ export class SurveyService {
       filtersOr.push(`username:${username}`);
     }
 
-    // Query survey_response records using filters_or (OR logic on data fields)
-    const responses = await fetchAllQueryResources<{ survey_uid: string; survey_link?: string }>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ survey_uid: string; survey_link?: string }>>(
+    // Query survey_response records using filters_or (OR logic on data fields).
+    // response_datetime distinguishes invited-only (empty) from submitted (populated).
+    const responses = await fetchAllQueryResources<{ survey_uid: string; survey_link?: string; response_datetime?: string }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ survey_uid: string; survey_link?: string; response_datetime?: string }>>(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
@@ -215,13 +227,17 @@ export class SurveyService {
     );
 
     const surveyLinkMap = new Map<string, string>();
+    const respondedSurveyUids = new Set<string>();
     for (const r of responses) {
-      if (!r.survey_uid || !r.survey_link || surveyLinkMap.has(r.survey_uid)) {
-        continue;
+      if (!r.survey_uid) continue;
+      if (r.response_datetime && r.response_datetime.trim() !== '') {
+        respondedSurveyUids.add(r.survey_uid);
       }
-      const validatedLink = validateAndSanitizeUrl(r.survey_link.trim(), SURVEY_LINK_ALLOWLIST);
-      if (validatedLink) {
-        surveyLinkMap.set(r.survey_uid, validatedLink);
+      if (r.survey_link && !surveyLinkMap.has(r.survey_uid)) {
+        const validatedLink = validateAndSanitizeUrl(r.survey_link.trim(), SURVEY_LINK_ALLOWLIST);
+        if (validatedLink) {
+          surveyLinkMap.set(r.survey_uid, validatedLink);
+        }
       }
     }
 
@@ -237,17 +253,42 @@ export class SurveyService {
       unique_survey_count: surveyUids.length,
     });
 
-    // Fetch survey details in parallel via the survey microservice
+    // Fetch survey details in parallel via the survey microservice, then stamp
+    // response_status based on whether the user's survey_response row has a populated
+    // response_datetime. The UI uses this to switch "Take Survey" to "Results".
+    // When the detail fetch fails (404 / transient upstream error), keep the row in
+    // the list with a stub Survey built from the response record so the user can still
+    // see they were invited — silently dropping invited surveys hides the user's history.
     const surveys = await Promise.all(
       surveyUids.map(async (uid) => {
         try {
-          return await this.microserviceProxy.proxyRequest<Survey>(req, 'LFX_V2_SERVICE', `/surveys/${uid}`, 'GET');
+          const survey = await this.microserviceProxy.proxyRequest<Survey>(req, 'LFX_V2_SERVICE', `/surveys/${uid}`, 'GET');
+          if (survey && respondedSurveyUids.has(uid)) {
+            return { ...survey, response_status: 'responded' };
+          }
+          return survey;
         } catch (error) {
-          logger.warning(req, 'get_my_surveys', 'Failed to fetch survey details, skipping', {
+          logger.warning(req, 'get_my_surveys', 'Survey detail unavailable — rendering stub', {
             survey_uid: uid,
             error: error instanceof Error ? error.message : 'Unknown error',
           });
-          return null;
+          const stub: Survey = {
+            uid,
+            survey_title: 'Survey (details unavailable)',
+            survey_status: 'closed',
+            survey_cutoff_date: '',
+            is_nps_survey: false,
+            is_project_survey: false,
+            committees: [],
+            committee_category: '',
+            total_responses: 0,
+            total_recipients: 0,
+            created_at: '',
+            last_modified_at: '',
+            creator_name: '',
+          };
+          if (respondedSurveyUids.has(uid)) stub.response_status = 'responded';
+          return stub;
         }
       })
     );
@@ -292,5 +333,88 @@ export class SurveyService {
     });
 
     return this.projectService.enrichWithProjectData(req, withProjectUid);
+  }
+
+  /**
+   * Returns the current user's submitted response for a survey, or null if no response exists.
+   * Used by the Me lens "View My Response" drawer. Queries type=survey_response filtered by
+   * the user's email/username (via filters_or) and the survey_uid (client-side filter on the
+   * page since the index has no native survey_uid filter on this resource type). Only returns
+   * a record whose response_datetime is populated — invitation-only rows are treated as
+   * "not yet responded" and return null.
+   */
+  public async getMyResponse(req: Request, surveyUid: string): Promise<MySurveyResponse | null> {
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = getEffectiveEmail(req);
+
+    if (!username && !email) return null;
+
+    const filtersOr: string[] = [];
+    if (email) filtersOr.push(`email:${email}`);
+    if (username) filtersOr.push(`username:${username}`);
+
+    const responses = await fetchAllQueryResources<MySurveyResponse>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MySurveyResponse>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'survey_response',
+        filters_or: filtersOr,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    const match = responses.find((r) => r?.survey_uid === surveyUid && r.response_datetime && r.response_datetime.trim() !== '');
+    return match ?? null;
+  }
+
+  /**
+   * Returns the set of survey UIDs the current user has responded to. Queries
+   * type=survey_response by username/email via filters_or and dedupes to a Set
+   * of survey_uid values. Returns an empty Set when the user cannot be
+   * identified or the query fails — callers treat this as "no responses known"
+   * and surveys render as not-yet-responded (the safer default).
+   */
+  private async fetchRespondedSurveyUidsForUser(req: Request): Promise<Set<string>> {
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = getEffectiveEmail(req);
+
+    if (!username && !email) {
+      return new Set<string>();
+    }
+
+    const filtersOr: string[] = [];
+    if (email) filtersOr.push(`email:${email}`);
+    if (username) filtersOr.push(`username:${username}`);
+
+    try {
+      const responses = await fetchAllQueryResources<{ survey_uid?: string; response_datetime?: string }>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<{ survey_uid?: string; response_datetime?: string }>>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          {
+            type: 'survey_response',
+            filters_or: filtersOr,
+            ...(pageToken && { page_token: pageToken }),
+          }
+        )
+      );
+      // A survey_response row exists when the user is invited; response_datetime is only
+      // populated once they actually submit. Filter on the populated datetime so invitations
+      // don't get misreported as responded.
+      const uids = new Set<string>();
+      for (const r of responses) {
+        if (r.survey_uid && r.response_datetime && r.response_datetime.trim() !== '') {
+          uids.add(r.survey_uid);
+        }
+      }
+      return uids;
+    } catch (err) {
+      logger.warning(req, 'get_surveys', 'Failed to fetch user survey responses for response_status enrichment, returning empty set', {
+        err,
+      });
+      return new Set<string>();
+    }
   }
 }

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -63,12 +63,24 @@ export class SurveyService {
       this.fetchRespondedSurveyUidsForUser(req),
     ]);
 
+    // Count the responded UIDs that intersect with this result set so the log
+    // metric is meaningful — respondedSurveyUids covers all of the user's
+    // responses (across committees/projects) and would otherwise be > final_count.
+    let respondedInResult = 0;
     const enriched =
-      respondedSurveyUids.size > 0 ? surveys.map((s) => (s.uid && respondedSurveyUids.has(s.uid) ? { ...s, response_status: 'responded' } : s)) : surveys;
+      respondedSurveyUids.size > 0
+        ? surveys.map((s) => {
+            if (s.uid && respondedSurveyUids.has(s.uid)) {
+              respondedInResult++;
+              return { ...s, response_status: 'responded' };
+            }
+            return s;
+          })
+        : surveys;
 
     logger.debug(req, 'get_surveys', 'Completed survey fetch', {
       final_count: enriched.length,
-      responded_count: respondedSurveyUids.size,
+      responded_in_result: respondedInResult,
     });
 
     return enriched;
@@ -278,7 +290,9 @@ export class SurveyService {
             uid,
             survey_title: 'Survey (details unavailable)',
             survey_status: 'closed',
-            survey_cutoff_date: '',
+            // null instead of '' so Angular's DatePipe doesn't choke on an
+            // invalid empty-string input when the table renders the Due column.
+            survey_cutoff_date: null,
             is_nps_survey: false,
             is_project_survey: false,
             committees: [],
@@ -303,7 +317,7 @@ export class SurveyService {
     const decorated = surveys
       .filter((s): s is Survey => s !== null)
       .map((survey) => {
-        const parsedCutoff = new Date(survey.survey_cutoff_date).getTime();
+        const parsedCutoff = survey.survey_cutoff_date ? new Date(survey.survey_cutoff_date).getTime() : NaN;
 
         return {
           survey,
@@ -340,10 +354,10 @@ export class SurveyService {
   /**
    * Returns the current user's submitted response for a survey, or null if no response exists.
    * Used by the Me lens "View My Response" drawer. Queries type=survey_response filtered by
-   * the user's email/username (via filters_or) and the survey_uid (client-side filter on the
-   * page since the index has no native survey_uid filter on this resource type). Only returns
-   * a record whose response_datetime is populated — invitation-only rows are treated as
-   * "not yet responded" and return null.
+   * the user's email/username (via filters_or) and matches survey_uid in-memory after the
+   * query returns, since the index has no native survey_uid filter on this resource type.
+   * Only returns a record whose response_datetime is populated — invitation-only rows are
+   * treated as "not yet responded" and return null.
    */
   public async getMyResponse(req: Request, surveyUid: string): Promise<MySurveyResponse | null> {
     const rawUsername = await getUsernameFromAuth(req);

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -255,7 +255,9 @@ export class SurveyService {
 
     // Fetch survey details in parallel via the survey microservice, then stamp
     // response_status based on whether the user's survey_response row has a populated
-    // response_datetime. The UI uses this to switch "Take Survey" to "Results".
+    // response_datetime. The UI consumes response_status to open the per-user response
+    // drawer on the Me lens and switch the action button to 'Update' (vs 'Take Survey')
+    // while the survey is still open.
     // When the detail fetch fails (404 / transient upstream error), keep the row in
     // the list with a stub Survey built from the response record so the user can still
     // see they were invited — silently dropping invited surveys hides the user's history.
@@ -363,7 +365,13 @@ export class SurveyService {
     );
 
     const match = responses.find((r) => r?.survey_uid === surveyUid && r.response_datetime && r.response_datetime.trim() !== '');
-    return match ?? null;
+    if (!match) return null;
+
+    // Defense-in-depth: validate survey_link against the same allowlist getMySurveys uses
+    // before propagating the URL to the UI. Drops the field if validation fails — the rest
+    // of the payload (answers, nps_value, response_datetime) is still useful for the drawer.
+    const sanitizedLink = match.survey_link ? validateAndSanitizeUrl(match.survey_link.trim(), SURVEY_LINK_ALLOWLIST) : undefined;
+    return { ...match, survey_link: sanitizedLink ?? undefined };
   }
 
   /**

--- a/packages/shared/src/constants/pending-action.constants.ts
+++ b/packages/shared/src/constants/pending-action.constants.ts
@@ -13,4 +13,5 @@ export const PENDING_ACTION_SEVERITY: Record<PendingActionType, TagSeverity> = {
   Vote: 'info', // blue
   Survey: 'success', // green
   Agenda: 'secondary', // gray — informational read-before-meeting cue
+  Submitted: 'success', // green — completed survey/feedback acknowledgement
 };

--- a/packages/shared/src/constants/pending-action.constants.ts
+++ b/packages/shared/src/constants/pending-action.constants.ts
@@ -11,7 +11,7 @@ import { PendingActionType, TagSeverity } from '../interfaces/components.interfa
 export const PENDING_ACTION_SEVERITY: Record<PendingActionType, TagSeverity> = {
   RSVP: 'warn', // amber — most common row + matches the row's amber background tint
   Vote: 'info', // blue
-  Survey: 'success', // green
+  Survey: 'warn', // amber — pending survey, action needed
   Agenda: 'secondary', // gray — informational read-before-meeting cue
-  Submitted: 'success', // green — completed survey/feedback acknowledgement
+  Submitted: 'success', // green — completed survey/feedback acknowledgement, distinguishes from pending Survey
 };

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -473,7 +473,7 @@ export interface ProgressItemWithChart extends ProgressItem {
  * Pending-action row discriminator. String union (not enum) so it round-trips through JSON
  * without value-vs-key reverse-mapping footguns.
  */
-export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda';
+export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda' | 'Submitted';
 
 /**
  * Pending action item for task list

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -130,6 +130,42 @@ export interface Survey {
 }
 
 /**
+ * A single choice/free-text answer selected by the respondent for a question.
+ * @description Shape mirrors the v2-indexed SurveyMonkeyAnswer published by lfx-v2-survey-service.
+ */
+export interface MySurveyAnswer {
+  choice_id?: string;
+  text?: string;
+}
+
+/**
+ * A question + the respondent's answers for that question.
+ */
+export interface MySurveyQuestionAnswer {
+  question_id?: string;
+  question_text?: string;
+  question_family?: string;
+  question_subtype?: string;
+  answers?: MySurveyAnswer[];
+}
+
+/**
+ * The current user's submitted response to a survey. Read-only payload backing
+ * the "View My Response" drawer on the Me lens.
+ */
+export interface MySurveyResponse {
+  uid: string;
+  survey_uid: string;
+  response_datetime?: string;
+  /** Personalized SurveyMonkey link — used for "Update Response" on an open survey */
+  survey_link?: string;
+  /** Populated for NPS surveys */
+  nps_value?: number;
+  /** Populated for standard SurveyMonkey surveys */
+  survey_monkey_question_answers?: MySurveyQuestionAnswer[];
+}
+
+/**
  * NPS breakdown data
  * @description Breakdown of NPS responses into promoters, passives, and detractors
  */

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -85,8 +85,9 @@ export interface Survey {
   survey_title: string;
   /** Current status of the survey */
   survey_status: string;
-  /** Survey deadline/cutoff date */
-  survey_cutoff_date: string;
+  /** Survey deadline/cutoff date. May be null when the upstream detail fetch
+   * fails and the row is rendered from a stub (see getMySurveys fallback). */
+  survey_cutoff_date: string | null;
   /** Whether this is an NPS survey */
   is_nps_survey: boolean;
   /** Whether this is a project-level survey */


### PR DESCRIPTION
## Summary

- Joins indexed `survey_response` records (by user email/username) against the surveys list so each row on the Me lens reflects whether the current user has actually submitted. `response_status='responded'` is stamped only when `survey_response.response_datetime` is populated — distinguishing invited-only rows from real submissions.
- New `GET /api/surveys/:uid/my-response` endpoint plus a new `lfx-my-response-drawer` for per-user response viewing on the Me lens. The aggregate Results drawer is no longer reachable from Me lens (Stephan/Jim feedback — most takers shouldn't see aggregate).
- My Surveys table status badge is now informative: amber **Open** for action-needed, green **Submitted** for done, gray **Closed**. Actions: **Take Survey** (primary CTA) only when open and not responded; **Update** (same SurveyMonkey link) when open + responded; **View** on every closed survey.
- Committee Overview pending actions filter out responded surveys and show a green **Submitted** card with an **Update** link instead.
- `getMySurveys` now renders a stub Survey when the upstream `/surveys/{uid}` detail fetch fails, so invited rows are not silently dropped.

JIRA: [LFXV2-1726](https://linuxfoundation.atlassian.net/browse/LFXV2-1726)

### Shared package changes

- New `MySurveyResponse` / `MySurveyQuestionAnswer` / `MySurveyAnswer` interfaces.
- `PendingActionType` union extended with `'Submitted'`; matching green severity added to `PENDING_ACTION_SEVERITY`.

### Behavior changes worth calling out

- Aggregate Results drawer is no longer reachable from the Me lens (survey name, row click, and Results action all route to the per-user drawer instead). Foundation/Project lens behavior is unchanged.
- `getSurveys` now makes one extra parallel query to `type=survey_response` to compute `response_status` for the requesting user. Returns an empty set on failure — surveys still render as not-responded.

## Test plan

- [ ] My Surveys page: open survey you haven't taken → amber **Open** badge + blue **Take Survey** button
- [ ] My Surveys page: open survey you submitted → green **Submitted** badge + gray **Update** link (opens SurveyMonkey to edit)
- [ ] My Surveys page: closed survey → gray **Closed** badge + gray **View** link
- [ ] Click survey name or row on Me lens → per-user drawer opens (not aggregate)
- [ ] Per-user drawer (NPS survey) → shows your score with `0–10` caption
- [ ] Per-user drawer (Standard survey) → shows each question with your selected answers
- [ ] Per-user drawer (closed + no response) → friendly "you didn't respond" empty state
- [ ] Foundation lens / Project lens: aggregate Results drawer still opens (admins/participants)
- [ ] Committee Overview: responded surveys show as green "Submitted" cards with "Update" link; unresponded surveys still appear in the amber "Survey" pending action cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1726]: https://linuxfoundation.atlassian.net/browse/LFXV2-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ