### PR TITLE
fix(dashboards): show no-data state instead of performing well

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -102,14 +102,14 @@
       @if (hasNoData()) {
         <div
           class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          role="status"
+          aria-live="polite"
           data-testid="email-ctr-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">No active campaigns detected</span>
-              <p class="text-sm text-gray-500">
-                No email, paid, or attribution activity found for this foundation — engage with marketing ops to get campaigns going
-              </p>
+              <p class="text-sm text-gray-500">No email, paid, or attribution activity is currently available for this foundation</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -99,6 +99,22 @@
         </div>
       }
 
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          data-testid="email-ctr-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">No active campaigns detected</span>
+              <p class="text-sm text-gray-500">
+                No email, paid, or attribution activity found for this foundation — engage with marketing ops to get campaigns going
+              </p>
+            </div>
+          </div>
+        </div>
+      }
+
       @if (attributionData().channels.length > 0) {
         <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-attribution-section">
           <div class="flex items-center gap-2">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -101,14 +101,13 @@
 
       @if (hasNoData()) {
         <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
           role="status"
-          aria-live="polite"
           data-testid="email-ctr-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">No active campaigns detected</span>
+              <h3 class="text-sm font-semibold text-gray-900">No active campaigns detected</h3>
               <p class="text-sm text-gray-500">No email, paid, or attribution activity is currently available for this foundation</p>
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -58,20 +58,7 @@ export class EmailCtrDrawerComponent {
   // True once all three data sources have resolved (not still loading)
   private readonly dataResolved: Signal<boolean> = computed(() => !this.drawerLoading() && this.paidDataResolved() && this.attributionDataResolved());
 
-  protected readonly hasNoData: Signal<boolean> = computed(() => {
-    if (!this.dataResolved()) {
-      return false;
-    }
-    const email = this.drawerData();
-    const paid = this.paidData();
-    const attribution = this.attributionData();
-    const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
-    const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
-    const hasAttributionActivity =
-      attribution.channels.length > 0 &&
-      attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0 || c.firstTouchRevenue > 0 || c.lastTouchRevenue > 0 || c.timeDecayRevenue > 0);
-    return !hasEmailActivity && !hasPaidActivity && !hasAttributionActivity;
-  });
+  protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   protected readonly expandedTypes = signal<Set<string>>(new Set());
 
@@ -229,6 +216,23 @@ export class EmailCtrDrawerComponent {
 
   protected revPerSession(channel: MarketingAttributionChannel): string {
     return channel.sessions > 0 ? `$${(channel.linearRevenue / channel.sessions).toFixed(2)}` : '—';
+  }
+
+  private initHasNoData(): Signal<boolean> {
+    return computed(() => {
+      if (!this.dataResolved()) {
+        return false;
+      }
+      const email = this.drawerData();
+      const paid = this.paidData();
+      const attribution = this.attributionData();
+      const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
+      const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
+      const hasAttributionActivity =
+        attribution.channels.length > 0 &&
+        attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0 || c.firstTouchRevenue > 0 || c.lastTouchRevenue > 0 || c.timeDecayRevenue > 0);
+      return !hasEmailActivity && !hasPaidActivity && !hasAttributionActivity;
+    });
   }
 
   private initDrawerData(): Signal<EmailCtrResponse> {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -55,8 +55,11 @@ export class EmailCtrDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
+  // True once all three data sources have resolved (not still loading)
+  private readonly dataResolved: Signal<boolean> = computed(() => !this.drawerLoading() && this.paidDataResolved() && this.attributionDataResolved());
+
   protected readonly hasNoData: Signal<boolean> = computed(() => {
-    if (this.drawerLoading() || !this.paidDataResolved() || !this.attributionDataResolved()) {
+    if (!this.dataResolved()) {
       return false;
     }
     const email = this.drawerData();
@@ -271,7 +274,7 @@ export class EmailCtrDrawerComponent {
     return computed(() => {
       // Gate on all three data sources having resolved — avoid misleading
       // "Maintain current momentum" while paid/attribution are still in-flight.
-      if (this.drawerLoading() || !this.paidDataResolved() || !this.attributionDataResolved()) {
+      if (!this.dataResolved()) {
         return [];
       }
 
@@ -424,7 +427,7 @@ export class EmailCtrDrawerComponent {
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
       // Gate on all three data sources — same rationale as initRecommendedActions.
-      if (this.drawerLoading() || !this.paidDataResolved() || !this.attributionDataResolved()) {
+      if (!this.dataResolved()) {
         return [];
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -400,7 +400,7 @@ export class EmailCtrDrawerComponent {
         if (!hasEmailActivity && !hasPaidActivity && !hasAttributionActivity) {
           actions.push({
             title: 'No active campaigns detected',
-            description: 'No email, paid, or attribution activity found for this foundation — data will appear once campaigns are running',
+            description: 'No email, paid, or attribution activity found for this foundation — reach out to marketing ops to set up campaign tracking',
             priority: 'medium',
             actionType: 'investigate',
           });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -54,6 +54,20 @@ export class EmailCtrDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+
+  protected readonly hasNoData: Signal<boolean> = computed(() => {
+    if (this.drawerLoading() || !this.paidDataResolved() || !this.attributionDataResolved()) {
+      return false;
+    }
+    const email = this.drawerData();
+    const paid = this.paidData();
+    const attribution = this.attributionData();
+    const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
+    const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
+    const hasAttributionActivity = attribution.channels.length > 0 && attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0);
+    return !hasEmailActivity && !hasPaidActivity && !hasAttributionActivity;
+  });
+
   protected readonly expandedTypes = signal<Set<string>>(new Set());
 
   protected readonly emailTotalSends: Signal<string> = computed(() => {
@@ -392,26 +406,13 @@ export class EmailCtrDrawerComponent {
       // Combine — 1 per section, max 3
       const actions = [...attrActions.slice(0, 1), ...paidActions.slice(0, 1), ...emailActions.slice(0, 1)];
 
-      if (actions.length === 0) {
-        const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
-        const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
-        const hasAttributionActivity = attribution.channels.length > 0 && attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0);
-
-        if (!hasEmailActivity && !hasPaidActivity && !hasAttributionActivity) {
-          actions.push({
-            title: 'No active campaigns detected',
-            description: 'No email, paid, or attribution activity found for this foundation — engage with marketing ops to get campaigns going',
-            priority: 'medium',
-            actionType: 'investigate',
-          });
-        } else {
-          actions.push({
-            title: 'Maintain current momentum',
-            description: 'All channels performing well — continue current strategy and monitor for shifts',
-            priority: 'low',
-            actionType: 'growth',
-          });
-        }
+      if (actions.length === 0 && !this.hasNoData()) {
+        actions.push({
+          title: 'Maintain current momentum',
+          description: 'All channels performing well — continue current strategy and monitor for shifts',
+          priority: 'low',
+          actionType: 'growth',
+        });
       }
 
       return actions;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -64,7 +64,9 @@ export class EmailCtrDrawerComponent {
     const attribution = this.attributionData();
     const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
     const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
-    const hasAttributionActivity = attribution.channels.length > 0 && attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0);
+    const hasAttributionActivity =
+      attribution.channels.length > 0 &&
+      attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0 || c.firstTouchRevenue > 0 || c.lastTouchRevenue > 0 || c.timeDecayRevenue > 0);
     return !hasEmailActivity && !hasPaidActivity && !hasAttributionActivity;
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -393,12 +393,25 @@ export class EmailCtrDrawerComponent {
       const actions = [...attrActions.slice(0, 1), ...paidActions.slice(0, 1), ...emailActions.slice(0, 1)];
 
       if (actions.length === 0) {
-        actions.push({
-          title: 'Maintain current momentum',
-          description: 'All channels performing well — continue current strategy and monitor for shifts',
-          priority: 'low',
-          actionType: 'growth',
-        });
+        const hasEmailActivity = email.currentCtr > 0 || email.monthlySends.some((s) => s > 0);
+        const hasPaidActivity = paid.totalReach > 0 || paid.totalSpend > 0;
+        const hasAttributionActivity = attribution.channels.length > 0 && attribution.channels.some((c) => c.sessions > 0 || c.linearRevenue > 0);
+
+        if (!hasEmailActivity && !hasPaidActivity && !hasAttributionActivity) {
+          actions.push({
+            title: 'No active campaigns detected',
+            description: 'No email, paid, or attribution activity found for this foundation — data will appear once campaigns are running',
+            priority: 'medium',
+            actionType: 'investigate',
+          });
+        } else {
+          actions.push({
+            title: 'Maintain current momentum',
+            description: 'All channels performing well — continue current strategy and monitor for shifts',
+            priority: 'low',
+            actionType: 'growth',
+          });
+        }
       }
 
       return actions;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -400,7 +400,7 @@ export class EmailCtrDrawerComponent {
         if (!hasEmailActivity && !hasPaidActivity && !hasAttributionActivity) {
           actions.push({
             title: 'No active campaigns detected',
-            description: 'No email, paid, or attribution activity found for this foundation — reach out to marketing ops to set up campaign tracking',
+            description: 'No email, paid, or attribution activity found for this foundation — engage with marketing ops to get campaigns going',
             priority: 'medium',
             actionType: 'investigate',
           });


### PR DESCRIPTION
## Summary

- Show a neutral blue info card instead of misleading green "Performing Well" section when the email-ctr drawer has no data
- Extract `dataResolved` signal to DRY the triple-gate check across `hasNoData`, `initRecommendedActions`, and `initKeyInsights`
- Add `role="status"` and `aria-live="polite"` to the no-data card for screen reader announcements
- Use neutral copy (no actionable CTA language)

## What changed

- `hasNoData` computed signal checks all three data sources (email, paid, attribution) after they've resolved
- When `hasNoData()` is true, a standalone blue-bordered info card renders between the Performing Well section and the attribution section
- The attention/performing sections naturally empty out (early returns in `initRecommendedActions`/`initKeyInsights`) so no misleading green card appears

## Test plan

- [ ] Select a foundation with no email/paid/attribution data (e.g., a small project)
- [ ] Verify the blue no-data card appears instead of a green "Performing Well" card
- [ ] Verify the card has appropriate ARIA attributes for screen readers
- [ ] Verify foundations with data still show attention/performing sections normally

🤖 Generated with [Claude Code](https://claude.ai/code)