### PR TITLE
fix(dashboards): show no-data state in social media drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -131,6 +131,20 @@
         </div>
       }
 
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          data-testid="social-media-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">No social media activity detected</span>
+              <p class="text-sm text-gray-500">No follower or engagement data found for this foundation — engage with marketing ops to build social presence</p>
+            </div>
+          </div>
+        </div>
+      }
+
       <!-- Platform Breakdown Table -->
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="social-media-drawer-platforms-section">
         <div class="flex flex-col gap-1">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -134,12 +134,14 @@
       @if (hasNoData()) {
         <div
           class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          role="status"
+          aria-live="polite"
           data-testid="social-media-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">No social media activity detected</span>
-              <p class="text-sm text-gray-500">No follower or engagement data found for this foundation — engage with marketing ops to build social presence</p>
+              <p class="text-sm text-gray-500">No follower or engagement data is currently available for this foundation</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -133,14 +133,13 @@
 
       @if (hasNoData()) {
         <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
           role="status"
-          aria-live="polite"
           data-testid="social-media-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">No social media activity detected</span>
+              <h3 class="text-sm font-semibold text-gray-900">No social media activity detected</h3>
               <p class="text-sm text-gray-500">No follower or engagement data is currently available for this foundation</p>
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -249,13 +249,23 @@ export class SocialMediaDrawerComponent {
       }
 
       if (actions.length === 0) {
-        actions.push({
-          title: 'Continue growth strategy',
-          description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
-          priority: 'low',
+        const hasActivity = totalFollowers > 0 || platforms.some((p) => p.postsLast30Days > 0 || p.engagementRate > 0);
 
-          actionType: 'growth',
-        });
+        if (!hasActivity) {
+          actions.push({
+            title: 'No social media activity detected',
+            description: 'No follower or engagement data found for this foundation — reach out to marketing ops to set up social tracking',
+            priority: 'medium',
+            actionType: 'investigate',
+          });
+        } else {
+          actions.push({
+            title: 'Continue growth strategy',
+            description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
+            priority: 'low',
+            actionType: 'growth',
+          });
+        }
       }
 
       return actions;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -70,7 +70,7 @@ export class SocialMediaDrawerComponent {
 
   protected readonly hasNoData: Signal<boolean> = computed(() => {
     const { platforms, totalFollowers } = this.drawerData();
-    return totalFollowers === 0 && !platforms.some((p) => p.postsLast30Days > 0 || p.engagementRate > 0);
+    return totalFollowers === 0 && !platforms.some((p) => p.followers > 0 || p.postsLast30Days > 0 || p.engagementRate > 0);
   });
 
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -68,10 +68,7 @@ export class SocialMediaDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
-  protected readonly hasNoData: Signal<boolean> = computed(() => {
-    const { platforms, totalFollowers } = this.drawerData();
-    return totalFollowers === 0 && !platforms.some((p) => p.followers > 0 || p.postsLast30Days > 0 || p.engagementRate > 0 || p.impressions > 0);
-  });
+  protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();
   protected readonly platformChartData: Signal<ChartData<'bar'>> = this.initPlatformChartData();
@@ -164,6 +161,13 @@ export class SocialMediaDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initHasNoData(): Signal<boolean> {
+    return computed(() => {
+      const { platforms, totalFollowers } = this.drawerData();
+      return totalFollowers === 0 && !platforms.some((p) => p.followers > 0 || p.postsLast30Days > 0 || p.engagementRate > 0 || p.impressions > 0);
+    });
+  }
+
   private initDrawerData(): Signal<SocialMediaResponse> {
     const defaultValue: SocialMediaResponse = {
       totalFollowers: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -70,7 +70,7 @@ export class SocialMediaDrawerComponent {
 
   protected readonly hasNoData: Signal<boolean> = computed(() => {
     const { platforms, totalFollowers } = this.drawerData();
-    return totalFollowers === 0 && !platforms.some((p) => p.followers > 0 || p.postsLast30Days > 0 || p.engagementRate > 0);
+    return totalFollowers === 0 && !platforms.some((p) => p.followers > 0 || p.postsLast30Days > 0 || p.engagementRate > 0 || p.impressions > 0);
   });
 
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -254,7 +254,7 @@ export class SocialMediaDrawerComponent {
         if (!hasActivity) {
           actions.push({
             title: 'No social media activity detected',
-            description: 'No follower or engagement data found for this foundation — reach out to marketing ops to set up social tracking',
+            description: 'No follower or engagement data found for this foundation — engage with marketing ops to build social presence',
             priority: 'medium',
             actionType: 'investigate',
           });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -67,6 +67,12 @@ export class SocialMediaDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+
+  protected readonly hasNoData: Signal<boolean> = computed(() => {
+    const { platforms, totalFollowers } = this.drawerData();
+    return totalFollowers === 0 && !platforms.some((p) => p.postsLast30Days > 0 || p.engagementRate > 0);
+  });
+
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();
   protected readonly platformChartData: Signal<ChartData<'bar'>> = this.initPlatformChartData();
 
@@ -248,24 +254,13 @@ export class SocialMediaDrawerComponent {
         }
       }
 
-      if (actions.length === 0) {
-        const hasActivity = totalFollowers > 0 || platforms.some((p) => p.postsLast30Days > 0 || p.engagementRate > 0);
-
-        if (!hasActivity) {
-          actions.push({
-            title: 'No social media activity detected',
-            description: 'No follower or engagement data found for this foundation — engage with marketing ops to build social presence',
-            priority: 'medium',
-            actionType: 'investigate',
-          });
-        } else {
-          actions.push({
-            title: 'Continue growth strategy',
-            description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
-            priority: 'low',
-            actionType: 'growth',
-          });
-        }
+      if (actions.length === 0 && !this.hasNoData()) {
+        actions.push({
+          title: 'Continue growth strategy',
+          description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
+          priority: 'low',
+          actionType: 'growth',
+        });
       }
 
       return actions;


### PR DESCRIPTION
## Summary
- When all social media data (followers, posts, engagement, impressions) is zero, the Social Media drawer's catch-all showed "Continue growth strategy" under "Performing Well" which is misleading
- Now detects zero activity and shows a neutral blue info card: "No social media activity detected — No follower or engagement data found for this foundation — engage with marketing ops to build social presence"
- The legitimate "Performing Well" state is preserved for foundations with real data but no actionable issues
- Includes `impressions` in the activity predicate to correctly handle platforms with view-only activity

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)