### PR TITLE
fix(dashboards): show no-data state in brand health drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -146,14 +146,14 @@
     @if (hasNoData()) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
         data-testid="brand-health-drawer-no-data">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
             <span class="text-sm font-semibold text-gray-900">No brand mention data available</span>
-            <p class="text-sm text-gray-500">
-              No brand mentions found for this foundation — engage with marketing ops to build brand awareness and get momentum going
-            </p>
+            <p class="text-sm text-gray-500">No brand mentions are currently available for this foundation</p>
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -143,6 +143,22 @@
       </div>
     }
 
+    @if (hasNoData()) {
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        data-testid="brand-health-drawer-no-data">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <span class="text-sm font-semibold text-gray-900">No brand mention data available</span>
+            <p class="text-sm text-gray-500">
+              No brand mentions found for this foundation — engage with marketing ops to build brand awareness and get momentum going
+            </p>
+          </div>
+        </div>
+      </div>
+    }
+
     <!-- Mentions Trend -->
     <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-mentions-trend">
       <div class="flex flex-col gap-1">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -82,6 +82,8 @@ export class BrandHealthDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
+  protected readonly hasNoData: Signal<boolean> = computed(() => this.data().totalMentions === 0);
+
   protected readonly formattedSentimentMom: Signal<string> = computed(() => {
     const v = this.data().sentimentMomChangePp;
     return (v > 0 ? '+' : '') + v.toFixed(1);
@@ -118,12 +120,6 @@ export class BrandHealthDrawerComponent {
       const actions: MarketingRecommendedAction[] = [];
 
       if (totalMentions === 0) {
-        actions.push({
-          title: 'No brand mention data available',
-          description: 'No brand mentions found for this foundation — engage with marketing ops to build brand awareness and get momentum going',
-          priority: 'medium',
-          actionType: 'investigate',
-        });
         return actions;
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -120,7 +120,7 @@ export class BrandHealthDrawerComponent {
       if (totalMentions === 0) {
         actions.push({
           title: 'No brand mention data available',
-          description: 'No brand mentions found for this foundation — reach out to marketing ops to set up brand monitoring',
+          description: 'No brand mentions found for this foundation — engage with marketing ops to build brand awareness and get momentum going',
           priority: 'medium',
           actionType: 'investigate',
         });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -118,6 +118,12 @@ export class BrandHealthDrawerComponent {
       const actions: MarketingRecommendedAction[] = [];
 
       if (totalMentions === 0) {
+        actions.push({
+          title: 'No brand mention data available',
+          description: 'No brand mentions found for this foundation — reach out to marketing ops to set up brand monitoring',
+          priority: 'medium',
+          actionType: 'investigate',
+        });
         return actions;
       }
 


### PR DESCRIPTION
## Summary
- When brand mention data is zero, the Brand Health drawer showed empty actions with no guidance
- Now shows a neutral blue info card: **"No brand mention data available"** with description *"No brand mentions found for this foundation — engage with marketing ops to build brand awareness and get momentum going"*
- The legitimate "Performing Well" state is preserved for foundations with real mention data

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)