### PR TITLE
fix(dashboards): show no-data state in website visits drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -116,6 +116,20 @@
         </div>
       }
 
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          data-testid="website-visits-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">No website traffic data available</span>
+              <p class="text-sm text-gray-500">No web sessions found for this foundation — engage with marketing ops to drive website traffic</p>
+            </div>
+          </div>
+        </div>
+      }
+
       <!-- Daily Trend Chart -->
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-trend-section">
         <div class="flex flex-col gap-1">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -118,14 +118,13 @@
 
       @if (hasNoData()) {
         <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
           role="status"
-          aria-live="polite"
           data-testid="website-visits-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">No website traffic data available</span>
+              <h3 class="text-sm font-semibold text-gray-900">No website traffic data available</h3>
               <p class="text-sm text-gray-500">No web session data is currently available for this foundation</p>
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -119,12 +119,14 @@
       @if (hasNoData()) {
         <div
           class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          role="status"
+          aria-live="polite"
           data-testid="website-visits-drawer-no-data">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">No website traffic data available</span>
-              <p class="text-sm text-gray-500">No web sessions found for this foundation — engage with marketing ops to drive website traffic</p>
+              <p class="text-sm text-gray-500">No web session data is currently available for this foundation</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -53,6 +53,12 @@ export class WebsiteVisitsDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+
+  protected readonly hasNoData: Signal<boolean> = computed(() => {
+    const { totalSessions, dailyData } = this.drawerData();
+    return totalSessions === 0 && dailyData.length === 0;
+  });
+
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly domainChartData: Signal<ChartData<'bar'>> = this.initDomainChartData();
 
@@ -226,12 +232,11 @@ export class WebsiteVisitsDrawerComponent {
         }
       }
 
-      if (actions.length === 0) {
+      if (actions.length === 0 && !this.hasNoData()) {
         actions.push({
           title: 'Continue current strategy',
           description: `${formatNumber(totalSessions)} sessions with healthy traffic distribution`,
           priority: 'low',
-
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -54,10 +54,7 @@ export class WebsiteVisitsDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
-  protected readonly hasNoData: Signal<boolean> = computed(() => {
-    const { totalSessions, dailyData } = this.drawerData();
-    return totalSessions === 0 && (dailyData.length === 0 || dailyData.every((v) => v === 0));
-  });
+  protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly domainChartData: Signal<ChartData<'bar'>> = this.initDomainChartData();
@@ -140,6 +137,13 @@ export class WebsiteVisitsDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initHasNoData(): Signal<boolean> {
+    return computed(() => {
+      const { totalSessions, dailyData } = this.drawerData();
+      return totalSessions === 0 && (dailyData.length === 0 || dailyData.every((v) => v === 0));
+    });
+  }
+
   private initDrawerData(): Signal<WebActivitiesSummaryResponse> {
     const defaultValue: WebActivitiesSummaryResponse = {
       totalSessions: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -56,7 +56,7 @@ export class WebsiteVisitsDrawerComponent {
 
   protected readonly hasNoData: Signal<boolean> = computed(() => {
     const { totalSessions, dailyData } = this.drawerData();
-    return totalSessions === 0 && dailyData.length === 0;
+    return totalSessions === 0 && (dailyData.length === 0 || dailyData.every((v) => v === 0));
   });
 
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
@@ -181,7 +181,7 @@ export class WebsiteVisitsDrawerComponent {
       const { totalSessions, totalPageViews, domainGroups, dailyData } = this.drawerData();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (totalSessions === 0 && dailyData.length === 0) {
+      if (this.hasNoData()) {
         return actions;
       }
 
@@ -250,7 +250,7 @@ export class WebsiteVisitsDrawerComponent {
       const { totalSessions, totalPageViews, domainGroups, dailyData } = this.drawerData();
       const insights: MarketingKeyInsight[] = [];
 
-      if (totalSessions === 0 && dailyData.length === 0) {
+      if (this.hasNoData()) {
         return insights;
       }
 


### PR DESCRIPTION
## Summary
- When website session data is zero, the drawer showed "Continue current strategy" under "Performing Well" which is misleading
- Now skips both attention and performing sections, shows a neutral blue info card: "No website traffic data available — engage with marketing ops to drive website traffic"

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)