### PR TITLE
fix(dashboards): show neutral card when member acquisition has no data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -144,6 +144,23 @@
       </div>
     }
 
+    <!-- No Data Card -->
+    @if (hasNoData()) {
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        data-testid="member-acquisition-drawer-no-data">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <span class="text-sm font-semibold text-gray-900">No membership activity detected</span>
+            <p class="text-sm text-gray-500">
+              No acquisition or retention data available for this foundation — engage with marketing ops to drive membership growth
+            </p>
+          </div>
+        </div>
+      </div>
+    }
+
     <!-- Sales Pipeline -->
     @if (
       revenueImpactData().pipelineInfluenced > 0 ||

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -148,14 +148,14 @@
     @if (hasNoData()) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
         data-testid="member-acquisition-drawer-no-data">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
             <span class="text-sm font-semibold text-gray-900">No membership activity detected</span>
-            <p class="text-sm text-gray-500">
-              No acquisition or retention data available for this foundation — engage with marketing ops to drive membership growth
-            </p>
+            <p class="text-sm text-gray-500">No member acquisition data is currently available for this foundation</p>
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -144,17 +144,15 @@
       </div>
     }
 
-    <!-- No Data Card -->
     @if (hasNoData()) {
       <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        aria-live="polite"
         data-testid="member-acquisition-drawer-no-data">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <span class="text-sm font-semibold text-gray-900">No membership activity detected</span>
+            <h3 class="text-sm font-semibold text-gray-900">No membership activity detected</h3>
             <p class="text-sm text-gray-500">No member acquisition data is currently available for this foundation</p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -84,8 +84,10 @@ export class MemberAcquisitionDrawerComponent {
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly hasNoData: Signal<boolean> = computed(() => {
     const { totalMembers, newMembersThisQuarter, quarterlyData } = this.data();
-    const { renewalRate, monthlyData } = this.retentionData();
-    return totalMembers === 0 && newMembersThisQuarter === 0 && quarterlyData.length === 0 && renewalRate === 0 && monthlyData.length === 0;
+    const { renewalRate, netRevenueRetention, monthlyData } = this.retentionData();
+    const hasQuarterlyActivity = quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0);
+    const hasMonthlyActivity = monthlyData.some((m) => m.value > 0);
+    return totalMembers === 0 && newMembersThisQuarter === 0 && !hasQuarterlyActivity && renewalRate === 0 && netRevenueRetention === 0 && !hasMonthlyActivity;
   });
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();
 
@@ -165,7 +167,7 @@ export class MemberAcquisitionDrawerComponent {
       const { newMembersThisQuarter, changePercentage, quarterlyData } = this.data();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (newMembersThisQuarter === 0 && quarterlyData.length === 0) {
+      if (newMembersThisQuarter === 0 && !quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0)) {
         return actions;
       }
 
@@ -225,7 +227,7 @@ export class MemberAcquisitionDrawerComponent {
       const { newMembersThisQuarter, newMemberRevenue, changePercentage, quarterlyData } = this.data();
       const insights: MarketingKeyInsight[] = [];
 
-      if (newMembersThisQuarter === 0 && quarterlyData.length === 0) {
+      if (newMembersThisQuarter === 0 && !quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0)) {
         return insights;
       }
 
@@ -299,7 +301,7 @@ export class MemberAcquisitionDrawerComponent {
       const { renewalRate, netRevenueRetention, monthlyData } = this.retentionData();
       const insights: MarketingKeyInsight[] = [];
 
-      if (renewalRate === 0 && monthlyData.length === 0) {
+      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
         return insights;
       }
 
@@ -331,7 +333,7 @@ export class MemberAcquisitionDrawerComponent {
       const { renewalRate, netRevenueRetention, changePercentage, monthlyData } = this.retentionData();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (renewalRate === 0 && monthlyData.length === 0) {
+      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
         return actions;
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -82,13 +82,7 @@ export class MemberAcquisitionDrawerComponent {
   protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
-  protected readonly hasNoData: Signal<boolean> = computed(() => {
-    const { totalMembers, newMembersThisQuarter, quarterlyData } = this.data();
-    const { renewalRate, netRevenueRetention, monthlyData } = this.retentionData();
-    const hasQuarterlyActivity = quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0);
-    const hasMonthlyActivity = monthlyData.some((m) => m.value > 0);
-    return totalMembers === 0 && newMembersThisQuarter === 0 && !hasQuarterlyActivity && renewalRate === 0 && netRevenueRetention === 0 && !hasMonthlyActivity;
-  });
+  protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();
 
   protected readonly acquisitionChartOptions: ChartOptions<'bar'> = createBarChartOptions({
@@ -141,6 +135,18 @@ export class MemberAcquisitionDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initHasNoData(): Signal<boolean> {
+    return computed(() => {
+      const { totalMembers, newMembersThisQuarter, quarterlyData } = this.data();
+      const { renewalRate, netRevenueRetention, monthlyData } = this.retentionData();
+      const hasQuarterlyActivity = quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0);
+      const hasMonthlyActivity = monthlyData.some((m) => m.value > 0);
+      return (
+        totalMembers === 0 && newMembersThisQuarter === 0 && !hasQuarterlyActivity && renewalRate === 0 && netRevenueRetention === 0 && !hasMonthlyActivity
+      );
+    });
+  }
+
   private initTotalMembersChartData(): Signal<ChartData<'line'>> {
     return computed(() => {
       const { totalMembersMonthlyData, totalMembersMonthlyLabels } = this.data();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -82,6 +82,11 @@ export class MemberAcquisitionDrawerComponent {
   protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+  protected readonly hasNoData: Signal<boolean> = computed(() => {
+    const { totalMembers, newMembersThisQuarter, quarterlyData } = this.data();
+    const { renewalRate, monthlyData } = this.retentionData();
+    return totalMembers === 0 && newMembersThisQuarter === 0 && quarterlyData.length === 0 && renewalRate === 0 && monthlyData.length === 0;
+  });
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();
 
   protected readonly acquisitionChartOptions: ChartOptions<'bar'> = createBarChartOptions({
@@ -358,7 +363,7 @@ export class MemberAcquisitionDrawerComponent {
         });
       }
 
-      if (actions.length === 0) {
+      if (actions.length === 0 && !this.hasNoData()) {
         actions.push({
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,


### PR DESCRIPTION
## Summary
- When member acquisition & retention data is all zero, skip both "Needs Your Attention" and "Performing Well" sections
- Show a neutral blue info card guiding EDs to engage with marketing ops to drive membership growth
- Follows the same pattern applied in PRs #682, #683, #685, #686

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)