### PR TITLE
fix(dashboards): show neutral card when member retention has no data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -119,5 +119,22 @@
         }
       </div>
     }
+
+    <!-- No Data Card -->
+    @if (hasNoData()) {
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        data-testid="member-retention-drawer-no-data">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <span class="text-sm font-semibold text-gray-900">No retention data available</span>
+            <p class="text-sm text-gray-500">
+              No renewal or retention activity found for this foundation — engage with marketing ops to strengthen member retention
+            </p>
+          </div>
+        </div>
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -124,14 +124,14 @@
     @if (hasNoData()) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
         data-testid="member-retention-drawer-no-data">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
             <span class="text-sm font-semibold text-gray-900">No retention data available</span>
-            <p class="text-sm text-gray-500">
-              No renewal or retention activity found for this foundation — engage with marketing ops to strengthen member retention
-            </p>
+            <p class="text-sm text-gray-500">No member retention data is currently available for this foundation</p>
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -120,17 +120,15 @@
       </div>
     }
 
-    <!-- No Data Card -->
     @if (hasNoData()) {
       <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        aria-live="polite"
         data-testid="member-retention-drawer-no-data">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <span class="text-sm font-semibold text-gray-900">No retention data available</span>
+            <h3 class="text-sm font-semibold text-gray-900">No retention data available</h3>
             <p class="text-sm text-gray-500">No member retention data is currently available for this foundation</p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -45,8 +45,8 @@ export class MemberRetentionDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly hasNoData: Signal<boolean> = computed(() => {
-    const { renewalRate, monthlyData } = this.data();
-    return renewalRate === 0 && monthlyData.length === 0;
+    const { renewalRate, netRevenueRetention, monthlyData } = this.data();
+    return renewalRate === 0 && netRevenueRetention === 0 && (monthlyData.length === 0 || monthlyData.every((m) => m.value === 0));
   });
 
   // === Protected Methods ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -60,7 +60,7 @@ export class MemberRetentionDrawerComponent {
       const { renewalRate, netRevenueRetention, changePercentage, monthlyData } = this.data();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (renewalRate === 0 && monthlyData.length === 0) {
+      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
         return actions;
       }
 
@@ -113,7 +113,7 @@ export class MemberRetentionDrawerComponent {
       const { renewalRate, netRevenueRetention, monthlyData } = this.data();
       const insights: MarketingKeyInsight[] = [];
 
-      if (renewalRate === 0 && monthlyData.length === 0) {
+      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
         return insights;
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -44,10 +44,7 @@ export class MemberRetentionDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
-  protected readonly hasNoData: Signal<boolean> = computed(() => {
-    const { renewalRate, netRevenueRetention, monthlyData } = this.data();
-    return renewalRate === 0 && netRevenueRetention === 0 && (monthlyData.length === 0 || monthlyData.every((m) => m.value === 0));
-  });
+  protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   // === Protected Methods ===
   protected onClose(): void {
@@ -55,12 +52,19 @@ export class MemberRetentionDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initHasNoData(): Signal<boolean> {
+    return computed(() => {
+      const { renewalRate, netRevenueRetention, monthlyData } = this.data();
+      return renewalRate === 0 && netRevenueRetention === 0 && (monthlyData.length === 0 || monthlyData.every((m) => m.value === 0));
+    });
+  }
+
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { renewalRate, netRevenueRetention, changePercentage, monthlyData } = this.data();
+      const { renewalRate, netRevenueRetention, changePercentage } = this.data();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
+      if (this.hasNoData()) {
         return actions;
       }
 
@@ -110,10 +114,10 @@ export class MemberRetentionDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { renewalRate, netRevenueRetention, monthlyData } = this.data();
+      const { netRevenueRetention, monthlyData } = this.data();
       const insights: MarketingKeyInsight[] = [];
 
-      if (renewalRate === 0 && netRevenueRetention === 0 && !monthlyData.some((m) => m.value > 0)) {
+      if (this.hasNoData()) {
         return insights;
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -44,6 +44,10 @@ export class MemberRetentionDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+  protected readonly hasNoData: Signal<boolean> = computed(() => {
+    const { renewalRate, monthlyData } = this.data();
+    return renewalRate === 0 && monthlyData.length === 0;
+  });
 
   // === Protected Methods ===
   protected onClose(): void {
@@ -90,7 +94,7 @@ export class MemberRetentionDrawerComponent {
         });
       }
 
-      if (actions.length === 0) {
+      if (actions.length === 0 && !this.hasNoData()) {
         actions.push({
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,


### PR DESCRIPTION
## Summary
- When member retention data is all zero, skip both "Needs Your Attention" and "Performing Well" sections
- Show a neutral blue info card guiding EDs to engage with marketing ops to strengthen member retention
- Follows the same pattern applied in PRs #682, #683, #685, #686, #687

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)