### PR TITLE
feat(committees): add iCal Subscribe modal on Meetings tab (LFXV2-1714)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -133,19 +133,23 @@ export class CommitteeMeetingsComponent {
   /** Opens the iCal Subscribe modal — copy URL + Google/Outlook/Apple deep links. */
   public onSubscribe(): void {
     const committee = this.committee();
-    if (!committee?.uid) return;
+    if (!committee?.uid) {
+      console.warn('Subscribe clicked with no committee uid; aborting dialog open');
+      return;
+    }
 
     const feedUrl = `${environment.urls.home}/public/api/committees/${committee.uid}/calendar.ics`;
+    const committeeName = committee.name ?? 'Committee';
 
     this.dialogService.open(IcalSubscribeDialogComponent, {
-      header: 'Subscribe to Calendar',
+      header: `Subscribe — ${committeeName}`,
       width: '480px',
       modal: true,
       closable: true,
       dismissableMask: true,
       data: {
         feedUrl,
-        committeeName: committee.name ?? 'Committee',
+        committeeName,
       },
     });
   }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, linkedSignal, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -20,17 +19,18 @@ import { addMinutesToDate } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
 import { VoteService } from '@services/vote.service';
-import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { getCurrentOrNextOccurrence, hasMeetingEnded } from '@lfx-one/shared/utils';
 import { catchError, debounceTime, distinctUntilChanged, filter, finalize, forkJoin, map, of, startWith, switchMap, tap } from 'rxjs';
+
+import { IcalSubscribeDialogComponent } from '../ical-subscribe-dialog/ical-subscribe-dialog.component';
 
 @Component({
   selector: 'lfx-committee-meetings',
   imports: [
     ReactiveFormsModule,
     RouterLink,
-    ClipboardModule,
     ButtonComponent,
     CardComponent,
     InputTextComponent,
@@ -39,6 +39,7 @@ import { catchError, debounceTime, distinctUntilChanged, filter, finalize, forkJ
     MeetingCardComponent,
     FullCalendarComponent,
   ],
+  providers: [DialogService],
   templateUrl: './committee-meetings.component.html',
   styleUrl: './committee-meetings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -48,8 +49,7 @@ export class CommitteeMeetingsComponent {
   private readonly voteService = inject(VoteService);
   private readonly surveyService = inject(SurveyService);
   private readonly router = inject(Router);
-  private readonly clipboard = inject(Clipboard);
-  private readonly messageService = inject(MessageService);
+  private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
 
   // Inputs
@@ -130,16 +130,23 @@ export class CommitteeMeetingsComponent {
       .subscribe((v) => this.searchForm.get('timeFilter')?.setValue(v, { emitEvent: false }));
   }
 
-  /** Copies the committee's calendar subscribe URL to clipboard and shows a confirmation toast. */
+  /** Opens the iCal Subscribe modal — copy URL + Google/Outlook/Apple deep links. */
   public onSubscribe(): void {
-    const uid = this.committee().uid;
-    const url = `${environment.urls.home}/public/api/committees/${uid}/calendar.ics`;
-    this.clipboard.copy(url);
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Subscribe URL copied!',
-      detail: 'Add this to Google Calendar, Outlook, or Apple Calendar.',
-      life: 5000,
+    const committee = this.committee();
+    if (!committee?.uid) return;
+
+    const feedUrl = `${environment.urls.home}/public/api/committees/${committee.uid}/calendar.ics`;
+
+    this.dialogService.open(IcalSubscribeDialogComponent, {
+      header: 'Subscribe to Calendar',
+      width: '480px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: {
+        feedUrl,
+        committeeName: committee.name ?? 'Committee',
+      },
     });
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
@@ -3,7 +3,6 @@
 
 <div class="flex flex-col gap-5 p-2" data-testid="ical-subscribe-dialog">
   @if (feedUrl) {
-    <!-- Feed URL with copy -->
     <div class="flex flex-col gap-2">
       <span class="text-sm font-medium text-gray-700">Calendar Feed URL</span>
       <div class="flex items-center gap-2">
@@ -21,7 +20,6 @@
       </div>
     </div>
 
-    <!-- Calendar app buttons -->
     <div class="flex flex-col gap-2">
       <span class="text-sm font-medium text-gray-700">Add to your calendar</span>
       <div class="flex flex-col gap-2">
@@ -66,7 +64,6 @@
       </div>
     </div>
 
-    <!-- Hint text -->
     <p class="text-xs text-gray-400 mt-1">Subscribing keeps your calendar automatically updated when meetings are added or changed.</p>
   } @else {
     <div class="flex flex-col items-center py-8 text-center" data-testid="ical-empty-state">

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
@@ -1,0 +1,59 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5 p-2" data-testid="ical-subscribe-dialog">
+  <!-- Feed URL with copy -->
+  <div class="flex flex-col gap-2">
+    <label class="text-sm font-medium text-gray-700">Calendar Feed URL</label>
+    <div class="flex items-center gap-2">
+      <div class="flex-1 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-600 truncate font-mono" data-testid="ical-feed-url">
+        {{ feedUrl }}
+      </div>
+      <lfx-button
+        [icon]="copied() ? 'fa-light fa-check' : 'fa-light fa-copy'"
+        [severity]="copied() ? 'success' : 'secondary'"
+        size="small"
+        [label]="copied() ? 'Copied' : 'Copy'"
+        (onClick)="copyFeedUrl()"
+        data-testid="ical-copy-btn">
+      </lfx-button>
+    </div>
+  </div>
+
+  <!-- Calendar app buttons -->
+  <div class="flex flex-col gap-2">
+    <label class="text-sm font-medium text-gray-700">Add to your calendar</label>
+    <div class="flex flex-col gap-2">
+      <a
+        [href]="googleCalendarUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+        data-testid="ical-google-btn">
+        <i class="fa-brands fa-google text-base" aria-hidden="true"></i>
+        Google Calendar
+        <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
+      </a>
+      <a
+        [href]="outlookUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+        data-testid="ical-outlook-btn">
+        <i class="fa-brands fa-microsoft text-base" aria-hidden="true"></i>
+        Outlook
+        <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
+      </a>
+      <a
+        [href]="webcalUrl"
+        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+        data-testid="ical-apple-btn">
+        <i class="fa-brands fa-apple text-base" aria-hidden="true"></i>
+        Apple Calendar
+      </a>
+    </div>
+  </div>
+
+  <!-- Hint text -->
+  <p class="text-xs text-gray-400 mt-1">Subscribing keeps your calendar automatically updated when meetings are added or changed.</p>
+</div>

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
@@ -5,7 +5,7 @@
   @if (feedUrl) {
     <!-- Feed URL with copy -->
     <div class="flex flex-col gap-2">
-      <label class="text-sm font-medium text-gray-700">Calendar Feed URL</label>
+      <span class="text-sm font-medium text-gray-700">Calendar Feed URL</span>
       <div class="flex items-center gap-2">
         <div class="flex-1 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-600 truncate font-mono" data-testid="ical-feed-url">
           {{ feedUrl }}
@@ -23,7 +23,7 @@
 
     <!-- Calendar app buttons -->
     <div class="flex flex-col gap-2">
-      <label class="text-sm font-medium text-gray-700">Add to your calendar</label>
+      <span class="text-sm font-medium text-gray-700">Add to your calendar</span>
       <div class="flex flex-col gap-2">
         <a
           [href]="googleCalendarUrl"

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.html
@@ -2,58 +2,77 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-5 p-2" data-testid="ical-subscribe-dialog">
-  <!-- Feed URL with copy -->
-  <div class="flex flex-col gap-2">
-    <label class="text-sm font-medium text-gray-700">Calendar Feed URL</label>
-    <div class="flex items-center gap-2">
-      <div class="flex-1 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-600 truncate font-mono" data-testid="ical-feed-url">
-        {{ feedUrl }}
-      </div>
-      <lfx-button
-        [icon]="copied() ? 'fa-light fa-check' : 'fa-light fa-copy'"
-        [severity]="copied() ? 'success' : 'secondary'"
-        size="small"
-        [label]="copied() ? 'Copied' : 'Copy'"
-        (onClick)="copyFeedUrl()"
-        data-testid="ical-copy-btn">
-      </lfx-button>
-    </div>
-  </div>
-
-  <!-- Calendar app buttons -->
-  <div class="flex flex-col gap-2">
-    <label class="text-sm font-medium text-gray-700">Add to your calendar</label>
+  @if (feedUrl) {
+    <!-- Feed URL with copy -->
     <div class="flex flex-col gap-2">
-      <a
-        [href]="googleCalendarUrl"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
-        data-testid="ical-google-btn">
-        <i class="fa-brands fa-google text-base" aria-hidden="true"></i>
-        Google Calendar
-        <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
-      </a>
-      <a
-        [href]="outlookUrl"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
-        data-testid="ical-outlook-btn">
-        <i class="fa-brands fa-microsoft text-base" aria-hidden="true"></i>
-        Outlook
-        <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
-      </a>
-      <a
-        [href]="webcalUrl"
-        class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
-        data-testid="ical-apple-btn">
-        <i class="fa-brands fa-apple text-base" aria-hidden="true"></i>
-        Apple Calendar
-      </a>
+      <label class="text-sm font-medium text-gray-700">Calendar Feed URL</label>
+      <div class="flex items-center gap-2">
+        <div class="flex-1 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-600 truncate font-mono" data-testid="ical-feed-url">
+          {{ feedUrl }}
+        </div>
+        <lfx-button
+          [icon]="copied() ? 'fa-light fa-check' : 'fa-light fa-copy'"
+          [severity]="copied() ? 'success' : 'secondary'"
+          size="small"
+          [label]="copied() ? 'Copied' : 'Copy'"
+          (onClick)="copyFeedUrl()"
+          data-testid="ical-copy-btn">
+        </lfx-button>
+      </div>
     </div>
-  </div>
 
-  <!-- Hint text -->
-  <p class="text-xs text-gray-400 mt-1">Subscribing keeps your calendar automatically updated when meetings are added or changed.</p>
+    <!-- Calendar app buttons -->
+    <div class="flex flex-col gap-2">
+      <label class="text-sm font-medium text-gray-700">Add to your calendar</label>
+      <div class="flex flex-col gap-2">
+        <a
+          [href]="googleCalendarUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+          data-testid="ical-google-btn">
+          <i class="fa-brands fa-google text-base" aria-hidden="true"></i>
+          Google Calendar
+          <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
+        </a>
+        <a
+          [href]="outlookLiveUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+          data-testid="ical-outlook-live-btn">
+          <i class="fa-brands fa-microsoft text-base" aria-hidden="true"></i>
+          Outlook.com
+          <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
+        </a>
+        <a
+          [href]="outlook365Url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+          data-testid="ical-outlook-365-btn">
+          <i class="fa-brands fa-microsoft text-base" aria-hidden="true"></i>
+          Outlook 365 / Office
+          <i class="fa-light fa-arrow-up-right-from-square text-xs text-gray-400 ml-auto" aria-hidden="true"></i>
+        </a>
+        <!-- No target="_blank" — webcal:// hands off to the OS calendar handler -->
+        <a
+          [href]="webcalUrl"
+          class="flex items-center gap-3 px-4 py-3 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700 no-underline"
+          data-testid="ical-apple-btn">
+          <i class="fa-brands fa-apple text-base" aria-hidden="true"></i>
+          Apple Calendar
+        </a>
+      </div>
+    </div>
+
+    <!-- Hint text -->
+    <p class="text-xs text-gray-400 mt-1">Subscribing keeps your calendar automatically updated when meetings are added or changed.</p>
+  } @else {
+    <div class="flex flex-col items-center py-8 text-center" data-testid="ical-empty-state">
+      <i class="fa-light fa-calendar-xmark text-2xl text-gray-300 mb-2" aria-hidden="true"></i>
+      <p class="text-sm font-medium text-gray-500">Calendar feed unavailable</p>
+      <p class="text-xs text-gray-400 mt-1">No subscription URL was provided for this committee.</p>
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
@@ -4,8 +4,15 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
+import { IcalSubscribeDialogData } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig } from 'primeng/dynamicdialog';
+
+const COPIED_STATE_RESET_MS = 2000;
+
+function toWebcal(url: string): string {
+  return url.replace(/^https?:\/\//i, 'webcal://');
+}
 
 @Component({
   selector: 'lfx-ical-subscribe-dialog',
@@ -16,11 +23,21 @@ import { DynamicDialogConfig } from 'primeng/dynamicdialog';
 export class IcalSubscribeDialogComponent {
   private readonly clipboard = inject(Clipboard);
   private readonly messageService = inject(MessageService);
-  private readonly dialogConfig = inject(DynamicDialogConfig);
+  private readonly dialogConfig = inject<DynamicDialogConfig<IcalSubscribeDialogData>>(DynamicDialogConfig);
   private readonly destroyRef = inject(DestroyRef);
 
-  public readonly feedUrl = (this.dialogConfig.data?.feedUrl as string) ?? '';
-  public readonly committeeName = (this.dialogConfig.data?.committeeName as string) ?? 'Committee';
+  public readonly feedUrl = this.dialogConfig.data?.feedUrl ?? '';
+  public readonly committeeName = this.dialogConfig.data?.committeeName ?? 'Committee';
+
+  public readonly googleCalendarUrl = this.feedUrl ? `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(toWebcal(this.feedUrl))}` : '';
+  public readonly outlookLiveUrl = this.feedUrl
+    ? `https://outlook.live.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`
+    : '';
+  public readonly outlook365Url = this.feedUrl
+    ? `https://outlook.office.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`
+    : '';
+  public readonly webcalUrl = this.feedUrl ? toWebcal(this.feedUrl) : '';
+
   public copied = signal(false);
 
   private copiedResetTimer: ReturnType<typeof setTimeout> | null = null;
@@ -31,22 +48,6 @@ export class IcalSubscribeDialogComponent {
         clearTimeout(this.copiedResetTimer);
       }
     });
-  }
-
-  public get googleCalendarUrl(): string {
-    return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(this.toWebcal(this.feedUrl))}`;
-  }
-
-  public get outlookLiveUrl(): string {
-    return `https://outlook.live.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`;
-  }
-
-  public get outlook365Url(): string {
-    return `https://outlook.office.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`;
-  }
-
-  public get webcalUrl(): string {
-    return this.toWebcal(this.feedUrl);
   }
 
   public copyFeedUrl(): void {
@@ -64,7 +65,7 @@ export class IcalSubscribeDialogComponent {
       this.copiedResetTimer = setTimeout(() => {
         this.copied.set(false);
         this.copiedResetTimer = null;
-      }, 2000);
+      }, COPIED_STATE_RESET_MS);
     } else {
       this.messageService.add({
         severity: 'error',
@@ -72,9 +73,5 @@ export class IcalSubscribeDialogComponent {
         detail: 'Failed to copy URL to clipboard',
       });
     }
-  }
-
-  private toWebcal(url: string): string {
-    return url.replace(/^https?:\/\//i, 'webcal://');
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Clipboard } from '@angular/cdk/clipboard';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { MessageService } from 'primeng/api';
+import { DynamicDialogConfig } from 'primeng/dynamicdialog';
+
+@Component({
+  selector: 'lfx-ical-subscribe-dialog',
+  imports: [ButtonComponent],
+  templateUrl: './ical-subscribe-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class IcalSubscribeDialogComponent {
+  private readonly clipboard = inject(Clipboard);
+  private readonly messageService = inject(MessageService);
+  private readonly dialogConfig = inject(DynamicDialogConfig);
+
+  public readonly feedUrl = this.dialogConfig.data.feedUrl as string;
+  public readonly committeeName = this.dialogConfig.data.committeeName as string;
+  public copied = signal(false);
+
+  public get googleCalendarUrl(): string {
+    return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(this.feedUrl.replace('https://', 'webcal://'))}`;
+  }
+
+  public get outlookUrl(): string {
+    return `https://outlook.live.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`;
+  }
+
+  public get webcalUrl(): string {
+    return this.feedUrl.replace('https://', 'webcal://');
+  }
+
+  public copyFeedUrl(): void {
+    const success = this.clipboard.copy(this.feedUrl);
+    if (success) {
+      this.copied.set(true);
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Copied',
+        detail: 'Calendar feed URL copied to clipboard',
+      });
+      setTimeout(() => this.copied.set(false), 2000);
+    } else {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to copy URL to clipboard',
+      });
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
@@ -37,8 +37,12 @@ export class IcalSubscribeDialogComponent {
     return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(this.toWebcal(this.feedUrl))}`;
   }
 
-  public get outlookUrl(): string {
+  public get outlookLiveUrl(): string {
     return `https://outlook.live.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`;
+  }
+
+  public get outlook365Url(): string {
+    return `https://outlook.office.com/calendar/0/addfromweb?url=${encodeURIComponent(this.feedUrl)}&name=${encodeURIComponent(this.committeeName)}`;
   }
 
   public get webcalUrl(): string {

--- a/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard } from '@angular/cdk/clipboard';
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig } from 'primeng/dynamicdialog';
@@ -17,13 +17,24 @@ export class IcalSubscribeDialogComponent {
   private readonly clipboard = inject(Clipboard);
   private readonly messageService = inject(MessageService);
   private readonly dialogConfig = inject(DynamicDialogConfig);
+  private readonly destroyRef = inject(DestroyRef);
 
-  public readonly feedUrl = this.dialogConfig.data.feedUrl as string;
-  public readonly committeeName = this.dialogConfig.data.committeeName as string;
+  public readonly feedUrl = (this.dialogConfig.data?.feedUrl as string) ?? '';
+  public readonly committeeName = (this.dialogConfig.data?.committeeName as string) ?? 'Committee';
   public copied = signal(false);
 
+  private copiedResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  public constructor() {
+    this.destroyRef.onDestroy(() => {
+      if (this.copiedResetTimer !== null) {
+        clearTimeout(this.copiedResetTimer);
+      }
+    });
+  }
+
   public get googleCalendarUrl(): string {
-    return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(this.feedUrl.replace('https://', 'webcal://'))}`;
+    return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(this.toWebcal(this.feedUrl))}`;
   }
 
   public get outlookUrl(): string {
@@ -31,7 +42,7 @@ export class IcalSubscribeDialogComponent {
   }
 
   public get webcalUrl(): string {
-    return this.feedUrl.replace('https://', 'webcal://');
+    return this.toWebcal(this.feedUrl);
   }
 
   public copyFeedUrl(): void {
@@ -43,7 +54,13 @@ export class IcalSubscribeDialogComponent {
         summary: 'Copied',
         detail: 'Calendar feed URL copied to clipboard',
       });
-      setTimeout(() => this.copied.set(false), 2000);
+      if (this.copiedResetTimer !== null) {
+        clearTimeout(this.copiedResetTimer);
+      }
+      this.copiedResetTimer = setTimeout(() => {
+        this.copied.set(false);
+        this.copiedResetTimer = null;
+      }, 2000);
     } else {
       this.messageService.add({
         severity: 'error',
@@ -51,5 +68,9 @@ export class IcalSubscribeDialogComponent {
         detail: 'Failed to copy URL to clipboard',
       });
     }
+  }
+
+  private toWebcal(url: string): string {
+    return url.replace(/^https?:\/\//i, 'webcal://');
   }
 }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -689,6 +689,11 @@ export interface DescriptionDialogData {
   description: string;
 }
 
+export interface IcalSubscribeDialogData {
+  feedUrl: string;
+  committeeName: string;
+}
+
 export interface EditChairsDialogData {
   members: { label: string; value: string }[];
   currentChairUid: string | null;


### PR DESCRIPTION
## Summary
- Replaces the Meetings tab Subscribe button's direct clipboard copy with a DynamicDialog modal.
- Modal exposes the calendar feed URL with a copy control, plus deep-links for Google Calendar, Outlook, and Apple Calendar.
- Feed URL points at `/public/api/committees/:uid/calendar.ics` — the backend is delivered separately by LFXV2-1705.

## Behavioral change
Previous behavior: clicking **Subscribe** copied the iCal URL to the clipboard and surfaced a toast.
New behavior: clicking **Subscribe** opens a modal that lets the user copy the URL or jump straight into Google / Outlook / Apple Calendar.

The Subscribe button remains visible to all users (read-only action — not gated by `canEdit`). Button placement is unchanged (top-right of the Meetings tab, next to the List/Calendar toggle).

## Files
- `apps/lfx-one/src/app/modules/committees/components/ical-subscribe-dialog/` *(new)* — DynamicDialog component with copy + calendar app deep-links
- `apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts` — swaps `Clipboard` + `MessageService` injections for `DialogService`; `onSubscribe()` now opens the dialog

## Test plan
- [ ] Navigate to a committee → Meetings tab and verify the Subscribe button is visible to all users (List view + Calendar view)
- [ ] Click Subscribe; modal opens with the feed URL pre-filled
- [ ] Click Copy → URL is in the clipboard, button label flips to "Copied" for ~2s, success toast appears
- [ ] Click Google Calendar → opens `https://calendar.google.com/calendar/r?cid=webcal://...` in a new tab
- [ ] Click Outlook → opens `https://outlook.live.com/calendar/0/addfromweb?url=...` in a new tab
- [ ] Click Apple Calendar → triggers `webcal://` handler
- [ ] Dismiss the modal by clicking outside (dismissableMask) and via the X
- [ ] Once LFXV2-1705 backend ships, verify the URL returns a valid `text/calendar` payload

## Related
- Backend (separate PR): LFXV2-1705 — `/public/api/committees/:uid/calendar.ics`