### PR TITLE
feat(committees): behavioral class chips and table column [LFXV2-1715]

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -44,6 +44,38 @@
       <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
     }
 
+    <!-- Behavioral Class Filter Chips -->
+    @let totalForChips = isMeLens() ? myCommittees().length : committees().length;
+    @if (totalForChips > 0) {
+      <div class="flex flex-wrap items-center gap-2" data-testid="groups-behavioral-class-chips">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+          [class]="behavioralClassFilter() === null ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
+          (click)="selectBehavioralClass(null)"
+          data-testid="groups-chip-all">
+          All ({{ totalForChips }})
+        </button>
+        @for (key of behavioralClassKeys; track key) {
+          @if (behavioralClassCounts()[key] > 0) {
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+              [class]="
+                behavioralClassFilter() === key
+                  ? 'bg-blue-600 text-white'
+                  : behavioralClassConfig[key].bgColor + ' ' + behavioralClassConfig[key].color + ' hover:opacity-80'
+              "
+              (click)="selectBehavioralClass(key)"
+              [attr.data-testid]="'groups-chip-' + key">
+              <i [class]="behavioralClassConfig[key].icon" aria-hidden="true"></i>
+              {{ behavioralClassConfig[key].label }} ({{ behavioralClassCounts()[key] }})
+            </button>
+          }
+        }
+      </div>
+    }
+
     <!-- My Groups Table (Me lens) -->
     @if (isMeLens()) {
       @if (myCommitteesLoading()) {
@@ -69,7 +101,6 @@
           [hasItems]="myCommittees().length > 0"
           [myCommitteeUids]="myCommitteeUids()"
           [searchForm]="searchForm"
-          [categoryOptions]="categories()"
           [votingStatusOptions]="votingStatusOptions()"
           [showFoundationFilter]="showFoundationFilter()"
           [showProjectFilter]="showProjectFilter()"
@@ -87,29 +118,18 @@
     @if (!isMeLens()) {
       <!-- All Groups Section -->
       @if (committeesLoading()) {
-        <div class="flex flex-col gap-4">
-          <div class="flex items-center gap-2">
-            <p-skeleton width="6rem" height="1.25rem" borderRadius="4px" />
-            <p-skeleton width="1.5rem" height="1.25rem" borderRadius="1rem" />
+        <lfx-card>
+          <div class="flex flex-col gap-4 p-4">
+            @for (_ of [1, 2, 3, 4, 5]; track _) {
+              <div class="flex items-center gap-6">
+                <p-skeleton width="25%" height="0.875rem" />
+                <p-skeleton width="20%" height="0.875rem" />
+                <p-skeleton width="15%" height="0.875rem" />
+                <p-skeleton width="10%" height="0.875rem" />
+              </div>
+            }
           </div>
-          <lfx-card>
-            <div class="flex flex-col gap-4 p-4">
-              @for (_ of [1, 2, 3, 4, 5]; track _) {
-                <div class="flex items-center gap-6">
-                  <p-skeleton width="25%" height="0.875rem" />
-                  <p-skeleton width="20%" height="0.875rem" />
-                  <p-skeleton width="15%" height="0.875rem" />
-                  <p-skeleton width="10%" height="0.875rem" />
-                </div>
-              }
-            </div>
-          </lfx-card>
-        </div>
-      } @else if (committees().length > 0) {
-        <div class="flex items-center gap-2">
-          <h2 class="text-lg font-semibold text-gray-900">All {{ committeeLabel.plural }}</h2>
-          <span class="text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">{{ totalCommittees() }}</span>
-        </div>
+        </lfx-card>
       }
 
       <!-- Content Area - Table or Cards -->
@@ -130,7 +150,6 @@
               [canManageCommittee]="canWrite()"
               [myCommitteeUids]="myCommitteeUids()"
               [searchForm]="searchForm"
-              [categoryOptions]="categories()"
               [votingStatusOptions]="votingStatusOptions()"
               (refresh)="refreshCommittees()"
               (rowClick)="onCommitteeClick($event)">

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -44,7 +44,6 @@
       <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
     }
 
-    <!-- Behavioral Class Filter Chips -->
     @let totalForChips = isMeLens() ? myCommittees().length : committees().length;
     @if (totalForChips > 0) {
       <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Filter groups by behavioral class" data-testid="groups-behavioral-class-chips">

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -47,11 +47,12 @@
     <!-- Behavioral Class Filter Chips -->
     @let totalForChips = isMeLens() ? myCommittees().length : committees().length;
     @if (totalForChips > 0) {
-      <div class="flex flex-wrap items-center gap-2" data-testid="groups-behavioral-class-chips">
+      <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Filter groups by behavioral class" data-testid="groups-behavioral-class-chips">
         <button
           type="button"
           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
           [class]="behavioralClassFilter() === null ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
+          [attr.aria-pressed]="behavioralClassFilter() === null"
           (click)="selectBehavioralClass(null)"
           data-testid="groups-chip-all">
           All ({{ totalForChips }})
@@ -66,6 +67,7 @@
                   ? 'bg-blue-600 text-white'
                   : behavioralClassConfig[key].bgColor + ' ' + behavioralClassConfig[key].color + ' hover:opacity-80'
               "
+              [attr.aria-pressed]="behavioralClassFilter() === key"
               (click)="selectBehavioralClass(key)"
               [attr.data-testid]="'groups-chip-' + key">
               <i [class]="behavioralClassConfig[key].icon" aria-hidden="true"></i>
@@ -108,6 +110,7 @@
           [projectOptions]="projectOptions()"
           (foundationFilterChange)="onFoundationFilterChange($event)"
           (projectFilterChange)="onProjectFilterChange($event)"
+          (resetRequested)="selectBehavioralClass(null)"
           (refresh)="refreshCommittees()"
           (rowClick)="onCommitteeClick($event)"
           data-testid="committees-me-table">
@@ -151,6 +154,7 @@
               [myCommitteeUids]="myCommitteeUids()"
               [searchForm]="searchForm"
               [votingStatusOptions]="votingStatusOptions()"
+              (resetRequested)="selectBehavioralClass(null)"
               (refresh)="refreshCommittees()"
               (rowClick)="onCommitteeClick($event)">
             </lfx-committee-table>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -8,8 +8,8 @@ import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
-import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
-import { Committee, MyCommittee, ProjectContext, StatCardItem } from '@lfx-one/shared/interfaces';
+import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL, getGroupBehavioralClass } from '@lfx-one/shared/constants';
+import { Committee, GroupBehavioralClass, MyCommittee, ProjectContext, StatCardItem } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
@@ -45,6 +45,19 @@ export class CommitteeDashboardComponent {
   public refresh = signal(0);
   public foundationFilter = signal<string | null>(null);
   public projectFilter = signal<string | null>(null);
+  public behavioralClassFilter = signal<GroupBehavioralClass | null>(null);
+
+  // Behavioral class display config + helper exposed to template
+  protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
+  protected readonly getGroupBehavioralClass = getGroupBehavioralClass;
+  protected readonly behavioralClassKeys: GroupBehavioralClass[] = [
+    'governing-board',
+    'oversight-committee',
+    'working-group',
+    'special-interest-group',
+    'ambassador-program',
+    'other',
+  ];
 
   // ── Forms ─────────────────────────────────────────────────────────────────
   public searchForm: FormGroup;
@@ -54,10 +67,8 @@ export class CommitteeDashboardComponent {
   public myCommittees: Signal<MyCommittee[]>;
   public filteredMyCommittees: Signal<MyCommittee[]>;
   public myCommitteeUids: Signal<Set<string>>;
-  public categories: Signal<{ label: string; value: string | null }[]>;
   public votingStatusOptions: Signal<{ label: string; value: string | null }[]>;
   public filteredCommittees: Signal<Committee[]>;
-  public categoryFilter: Signal<string | null>;
   public votingStatusFilter: Signal<string | null>;
 
   // Foundation and project filter options (separate dropdowns)
@@ -82,6 +93,9 @@ export class CommitteeDashboardComponent {
   public myPublicGroups: Signal<number>;
   public myActiveVoting: Signal<number>;
 
+  // Behavioral class counts (per-class totals across the active lens)
+  public behavioralClassCounts!: Signal<Record<GroupBehavioralClass, number>>;
+
   // Stat card arrays for the shared <lfx-stat-card-grid> component
   public foundationStatCards: Signal<StatCardItem[]>;
   public myStatCards: Signal<StatCardItem[]>;
@@ -100,11 +114,9 @@ export class CommitteeDashboardComponent {
     // Initialize search form
     this.searchForm = this.initializeSearchForm();
     this.searchTerm = this.initializeSearchTerm();
-    this.categoryFilter = this.initializeCategoryFilter();
     this.votingStatusFilter = this.initializeVotingStatusFilter();
 
     // Initialize filters
-    this.categories = this.initializeCategories();
     this.votingStatusOptions = this.initializeVotingStatusOptions();
     this.filteredCommittees = this.initializeFilteredCommittees();
     this.filteredMyCommittees = this.initializeFilteredMyCommittees();
@@ -136,6 +148,23 @@ export class CommitteeDashboardComponent {
         iconContainerClass: 'bg-emerald-100 text-emerald-600',
       },
     ]);
+
+    // Behavioral class counts — lens-aware source so chips reflect the visible group set
+    this.behavioralClassCounts = computed(() => {
+      const source = this.isMeLens() ? this.myCommittees() : this.committees();
+      const counts: Record<GroupBehavioralClass, number> = {
+        'governing-board': 0,
+        'oversight-committee': 0,
+        'working-group': 0,
+        'special-interest-group': 0,
+        'ambassador-program': 0,
+        other: 0,
+      };
+      source.forEach((c) => {
+        counts[getGroupBehavioralClass(c.category)]++;
+      });
+      return counts;
+    });
   }
 
   public openCreateDialog(): void {
@@ -161,6 +190,10 @@ export class CommitteeDashboardComponent {
     this.router.navigate(['/groups', committee.uid], {
       state: { backLabel: this.isMeLens() ? 'My Groups' : 'Groups' },
     });
+  }
+
+  public selectBehavioralClass(cls: GroupBehavioralClass | null): void {
+    this.behavioralClassFilter.set(cls);
   }
 
   public onFoundationFilterChange(value: string | null): void {
@@ -224,7 +257,6 @@ export class CommitteeDashboardComponent {
   private initializeSearchForm(): FormGroup {
     return new FormGroup({
       search: new FormControl<string>(''),
-      category: new FormControl<string | null>(null),
       votingStatus: new FormControl<string | null>(null),
       foundationFilter: new FormControl<string | null>(null),
       projectFilter: new FormControl<string | null>(null),
@@ -233,10 +265,6 @@ export class CommitteeDashboardComponent {
 
   private initializeSearchTerm(): Signal<string> {
     return toSignal(this.searchForm.get('search')!.valueChanges.pipe(startWith(''), debounceTime(300), distinctUntilChanged()), { initialValue: '' });
-  }
-
-  private initializeCategoryFilter(): Signal<string | null> {
-    return toSignal(this.searchForm.get('category')!.valueChanges.pipe(startWith(null), distinctUntilChanged()), { initialValue: null });
   }
 
   private initializeVotingStatusFilter(): Signal<string | null> {
@@ -268,30 +296,6 @@ export class CommitteeDashboardComponent {
       ),
       { initialValue: [] }
     );
-  }
-
-  private initializeCategories(): Signal<{ label: string; value: string | null }[]> {
-    return computed(() => {
-      const committeesData = this.isMeLens() ? this.myCommittees() : this.committees();
-
-      // Count committees by category, falling back to 'Other' when category is absent
-      const categoryCounts = new Map<string, number>();
-      committeesData.forEach((committee) => {
-        const cat = committee.category || 'Other';
-        categoryCounts.set(cat, (categoryCounts.get(cat) || 0) + 1);
-      });
-
-      // Get unique categories and sort them
-      const uniqueCategories = Array.from(categoryCounts.keys()).sort((a, b) => a.localeCompare(b));
-
-      // Create options with counts
-      const categoryOptions = uniqueCategories.map((cat) => ({
-        label: `${cat} (${categoryCounts.get(cat)})`,
-        value: cat,
-      }));
-
-      return [{ label: 'All', value: null }, ...categoryOptions];
-    });
   }
 
   private initializeVotingStatusOptions(): Signal<{ label: string; value: string | null }[]> {
@@ -357,10 +361,10 @@ export class CommitteeDashboardComponent {
         );
       }
 
-      // Apply category filter
-      const category = this.categoryFilter();
-      if (category) {
-        filtered = filtered.filter((committee) => (committee.category || 'Other') === category);
+      // Apply behavioral class filter
+      const behavioralClass = this.behavioralClassFilter();
+      if (behavioralClass) {
+        filtered = filtered.filter((committee) => getGroupBehavioralClass(committee.category) === behavioralClass);
       }
 
       // Apply voting status filter
@@ -402,10 +406,10 @@ export class CommitteeDashboardComponent {
         );
       }
 
-      // Apply category filter
-      const category = this.categoryFilter();
-      if (category) {
-        filtered = filtered.filter((c) => (c.category || 'Other') === category);
+      // Apply behavioral class filter
+      const behavioralClass = this.behavioralClassFilter();
+      if (behavioralClass) {
+        filtered = filtered.filter((c) => getGroupBehavioralClass(c.category) === behavioralClass);
       }
 
       // Apply voting status filter

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -92,6 +92,10 @@ export class CommitteeDashboardComponent {
 
   private searchTerm: Signal<string>;
 
+  // Decorated source signals — depend only on the raw committees lists, so decoration runs once per source change rather than on every filter change.
+  private decoratedCommittees: Signal<Committee[]>;
+  private decoratedMyCommittees: Signal<MyCommittee[]>;
+
   public constructor() {
     // Initialize project context
     this.project = computed(() => this.projectContextService.activeContext());
@@ -100,6 +104,8 @@ export class CommitteeDashboardComponent {
     this.committees = this.initializeCommittees();
     this.myCommittees = this.initializeMyCommittees();
     this.myCommitteeUids = computed(() => new Set(this.myCommittees().map((c) => c.uid)));
+    this.decoratedCommittees = this.initializeDecoratedCommittees();
+    this.decoratedMyCommittees = this.initializeDecoratedMyCommittees();
 
     // Initialize search form
     this.searchForm = this.initializeSearchForm();
@@ -184,6 +190,7 @@ export class CommitteeDashboardComponent {
   private resetScopeFilters(): void {
     this.foundationFilter.set(null);
     this.projectFilter.set(null);
+    this.behavioralClassFilter.set(null);
     this.searchForm?.get('foundationFilter')?.setValue(null, { emitEvent: false });
     this.searchForm?.get('projectFilter')?.setValue(null, { emitEvent: false });
   }
@@ -321,10 +328,17 @@ export class CommitteeDashboardComponent {
     });
   }
 
+  private initializeDecoratedCommittees(): Signal<Committee[]> {
+    return computed(() => this.committees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) })));
+  }
+
+  private initializeDecoratedMyCommittees(): Signal<MyCommittee[]> {
+    return computed(() => this.myCommittees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) })));
+  }
+
   private initializeFilteredCommittees(): Signal<Committee[]> {
     return computed(() => {
-      // Decorate up-front so downstream filters and the table template can read committee.behavioralClass without per-row function calls.
-      let filtered: Committee[] = this.committees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) }));
+      let filtered: Committee[] = this.decoratedCommittees();
 
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
       if (searchTerm) {
@@ -354,7 +368,7 @@ export class CommitteeDashboardComponent {
 
   private initializeFilteredMyCommittees(): Signal<MyCommittee[]> {
     return computed(() => {
-      let filtered: MyCommittee[] = this.myCommittees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) }));
+      let filtered: MyCommittee[] = this.decoratedMyCommittees();
 
       const project = this.projectFilter();
       const foundation = this.foundationFilter();
@@ -393,7 +407,7 @@ export class CommitteeDashboardComponent {
 
   private initializeBehavioralClassCounts(): Signal<Record<GroupBehavioralClass, number>> {
     return computed(() => {
-      const source = this.isMeLens() ? this.myCommittees() : this.committees();
+      const source = this.isMeLens() ? this.decoratedMyCommittees() : this.decoratedCommittees();
       const counts: Record<GroupBehavioralClass, number> = {
         'governing-board': 0,
         'oversight-committee': 0,
@@ -403,7 +417,7 @@ export class CommitteeDashboardComponent {
         other: 0,
       };
       source.forEach((c) => {
-        counts[getGroupBehavioralClass(c.category)]++;
+        counts[c.behavioralClass ?? 'other']++;
       });
       return counts;
     });

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -47,11 +47,7 @@ export class CommitteeDashboardComponent {
   public projectFilter = signal<string | null>(null);
   public behavioralClassFilter = signal<GroupBehavioralClass | null>(null);
 
-  // Behavioral class display config + helper exposed to template.
-  // Keys are derived from the config so the chip list stays in sync if the taxonomy changes.
-  // Object.keys preserves insertion order per ES2015+, which keeps the chip display order matching the config.
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
-  protected readonly getGroupBehavioralClass = getGroupBehavioralClass;
   protected readonly behavioralClassKeys = Object.keys(BEHAVIORAL_CLASS_CONFIG) as GroupBehavioralClass[];
 
   // ── Forms ─────────────────────────────────────────────────────────────────
@@ -88,8 +84,7 @@ export class CommitteeDashboardComponent {
   public myPublicGroups: Signal<number>;
   public myActiveVoting: Signal<number>;
 
-  // Behavioral class counts (per-class totals across the active lens)
-  public behavioralClassCounts!: Signal<Record<GroupBehavioralClass, number>>;
+  public behavioralClassCounts: Signal<Record<GroupBehavioralClass, number>>;
 
   // Stat card arrays for the shared <lfx-stat-card-grid> component
   public foundationStatCards: Signal<StatCardItem[]>;
@@ -144,22 +139,7 @@ export class CommitteeDashboardComponent {
       },
     ]);
 
-    // Behavioral class counts — lens-aware source so chips reflect the visible group set
-    this.behavioralClassCounts = computed(() => {
-      const source = this.isMeLens() ? this.myCommittees() : this.committees();
-      const counts: Record<GroupBehavioralClass, number> = {
-        'governing-board': 0,
-        'oversight-committee': 0,
-        'working-group': 0,
-        'special-interest-group': 0,
-        'ambassador-program': 0,
-        other: 0,
-      };
-      source.forEach((c) => {
-        counts[getGroupBehavioralClass(c.category)]++;
-      });
-      return counts;
-    });
+    this.behavioralClassCounts = this.initializeBehavioralClassCounts();
   }
 
   public openCreateDialog(): void {
@@ -343,9 +323,9 @@ export class CommitteeDashboardComponent {
 
   private initializeFilteredCommittees(): Signal<Committee[]> {
     return computed(() => {
-      let filtered = this.committees();
+      // Decorate up-front so downstream filters and the table template can read committee.behavioralClass without per-row function calls.
+      let filtered: Committee[] = this.committees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) }));
 
-      // Apply search filter
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
       if (searchTerm) {
         filtered = filtered.filter(
@@ -356,20 +336,16 @@ export class CommitteeDashboardComponent {
         );
       }
 
-      // Apply behavioral class filter
       const behavioralClass = this.behavioralClassFilter();
       if (behavioralClass) {
-        filtered = filtered.filter((committee) => getGroupBehavioralClass(committee.category) === behavioralClass);
+        filtered = filtered.filter((committee) => committee.behavioralClass === behavioralClass);
       }
 
-      // Apply voting status filter
       const votingStatus = this.votingStatusFilter();
-      if (votingStatus) {
-        if (votingStatus === 'enabled') {
-          filtered = filtered.filter((committee) => committee.enable_voting === true);
-        } else if (votingStatus === 'disabled') {
-          filtered = filtered.filter((committee) => committee.enable_voting === false);
-        }
+      if (votingStatus === 'enabled') {
+        filtered = filtered.filter((committee) => committee.enable_voting === true);
+      } else if (votingStatus === 'disabled') {
+        filtered = filtered.filter((committee) => committee.enable_voting === false);
       }
 
       return filtered;
@@ -378,9 +354,8 @@ export class CommitteeDashboardComponent {
 
   private initializeFilteredMyCommittees(): Signal<MyCommittee[]> {
     return computed(() => {
-      let filtered: MyCommittee[] = this.myCommittees();
+      let filtered: MyCommittee[] = this.myCommittees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) }));
 
-      // Apply foundation/project filter (client-side)
       const project = this.projectFilter();
       const foundation = this.foundationFilter();
       if (project) {
@@ -389,7 +364,6 @@ export class CommitteeDashboardComponent {
         filtered = filtered.filter((c) => c.project_uid === foundation || (c.parent_project_uid === foundation && !c.is_foundation));
       }
 
-      // Apply search filter
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
       if (searchTerm) {
         filtered = filtered.filter(
@@ -401,13 +375,11 @@ export class CommitteeDashboardComponent {
         );
       }
 
-      // Apply behavioral class filter
       const behavioralClass = this.behavioralClassFilter();
       if (behavioralClass) {
-        filtered = filtered.filter((c) => getGroupBehavioralClass(c.category) === behavioralClass);
+        filtered = filtered.filter((c) => c.behavioralClass === behavioralClass);
       }
 
-      // Apply voting status filter
       const votingStatus = this.votingStatusFilter();
       if (votingStatus === 'enabled') {
         filtered = filtered.filter((c) => c.enable_voting === true);
@@ -416,6 +388,24 @@ export class CommitteeDashboardComponent {
       }
 
       return filtered;
+    });
+  }
+
+  private initializeBehavioralClassCounts(): Signal<Record<GroupBehavioralClass, number>> {
+    return computed(() => {
+      const source = this.isMeLens() ? this.myCommittees() : this.committees();
+      const counts: Record<GroupBehavioralClass, number> = {
+        'governing-board': 0,
+        'oversight-committee': 0,
+        'working-group': 0,
+        'special-interest-group': 0,
+        'ambassador-program': 0,
+        other: 0,
+      };
+      source.forEach((c) => {
+        counts[getGroupBehavioralClass(c.category)]++;
+      });
+      return counts;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -329,11 +329,21 @@ export class CommitteeDashboardComponent {
   }
 
   private initializeDecoratedCommittees(): Signal<Committee[]> {
-    return computed(() => this.committees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) })));
+    return computed(() =>
+      this.committees().map((c) => {
+        const behavioralClass = getGroupBehavioralClass(c.category);
+        return { ...c, behavioralClass, classDisplay: BEHAVIORAL_CLASS_CONFIG[behavioralClass] };
+      })
+    );
   }
 
   private initializeDecoratedMyCommittees(): Signal<MyCommittee[]> {
-    return computed(() => this.myCommittees().map((c) => ({ ...c, behavioralClass: getGroupBehavioralClass(c.category) })));
+    return computed(() =>
+      this.myCommittees().map((c) => {
+        const behavioralClass = getGroupBehavioralClass(c.category);
+        return { ...c, behavioralClass, classDisplay: BEHAVIORAL_CLASS_CONFIG[behavioralClass] };
+      })
+    );
   }
 
   private initializeFilteredCommittees(): Signal<Committee[]> {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -47,17 +47,12 @@ export class CommitteeDashboardComponent {
   public projectFilter = signal<string | null>(null);
   public behavioralClassFilter = signal<GroupBehavioralClass | null>(null);
 
-  // Behavioral class display config + helper exposed to template
+  // Behavioral class display config + helper exposed to template.
+  // Keys are derived from the config so the chip list stays in sync if the taxonomy changes.
+  // Object.keys preserves insertion order per ES2015+, which keeps the chip display order matching the config.
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
   protected readonly getGroupBehavioralClass = getGroupBehavioralClass;
-  protected readonly behavioralClassKeys: GroupBehavioralClass[] = [
-    'governing-board',
-    'oversight-committee',
-    'working-group',
-    'special-interest-group',
-    'ambassador-program',
-    'other',
-  ];
+  protected readonly behavioralClassKeys = Object.keys(BEHAVIORAL_CLASS_CONFIG) as GroupBehavioralClass[];
 
   // ── Forms ─────────────────────────────────────────────────────────────────
   public searchForm: FormGroup;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -124,12 +124,11 @@
                 <lfx-tag [value]="category" styleClass="tag-neutral"></lfx-tag>
               </td>
               <td>
-                @let cls = readBehavioralClass(committee);
                 <span
                   class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full"
-                  [class]="behavioralClassConfig[cls].bgColor + ' ' + behavioralClassConfig[cls].color">
-                  <i [class]="behavioralClassConfig[cls].icon + ' text-[10px]'" aria-hidden="true"></i>
-                  {{ behavioralClassConfig[cls].label }}
+                  [class]="committee.classDisplay.bgColor + ' ' + committee.classDisplay.color">
+                  <i [class]="committee.classDisplay.icon + ' text-[10px]'" aria-hidden="true"></i>
+                  {{ committee.classDisplay.label }}
                 </span>
               </td>
               <td class="min-w-[200px]">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -2,16 +2,6 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-  <!-- Type Tabs (hidden when no categories are recognized) -->
-  @if (categoryTabOptions().length > 1) {
-    <lfx-card-tabs-bar
-      [options]="categoryTabOptions()"
-      [selectedFilter]="categoryTab()"
-      (filterChange)="onCategoryTabChange($event)"
-      data-testid="committee-type-tabs">
-    </lfx-card-tabs-bar>
-  }
-
   <!-- Filter Bar -->
   @if (hasItems()) {
     <div class="px-5 pt-4 pb-3">
@@ -102,6 +92,7 @@
             <tr>
               <th>Name</th>
               <th>Type</th>
+              <th>Class</th>
               <th class="min-w-[200px]">Description</th>
               <th>Members</th>
               <th>Channels</th>
@@ -131,6 +122,15 @@
               <td>
                 @let category = committee.category || 'Other';
                 <lfx-tag [value]="category" styleClass="tag-neutral"></lfx-tag>
+              </td>
+              <td>
+                @let cls = getGroupBehavioralClass(committee.category);
+                <span
+                  class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full"
+                  [class]="behavioralClassConfig[cls].bgColor + ' ' + behavioralClassConfig[cls].color">
+                  <i [class]="behavioralClassConfig[cls].icon + ' text-[10px]'" aria-hidden="true"></i>
+                  {{ behavioralClassConfig[cls].label }}
+                </span>
               </td>
               <td class="min-w-[200px]">
                 <div class="max-w-[300px] line-clamp-2 text-sm text-gray-700">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -124,7 +124,7 @@
                 <lfx-tag [value]="category" styleClass="tag-neutral"></lfx-tag>
               </td>
               <td>
-                @let cls = getGroupBehavioralClass(committee.category);
+                @let cls = readBehavioralClass(committee);
                 <span
                   class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full"
                   [class]="behavioralClassConfig[cls].bgColor + ' ' + behavioralClassConfig[cls].color">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -13,8 +13,6 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { Committee, COMMITTEE_LABEL } from '@lfx-one/shared';
-import { BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
-import { GroupBehavioralClass } from '@lfx-one/shared/interfaces';
 import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
 import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
 import { PersonaService } from '@services/persona.service';
@@ -66,13 +64,8 @@ export class CommitteeTableComponent {
   public readonly projectFilterChange = output<string | null>();
   public readonly resetRequested = output<void>();
 
-  protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
   protected readonly isBoardMember = computed(() => this.personaService.currentPersona() === 'board-member');
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.committees().length > 10 ? [10, 25, 50] : undefined));
-
-  protected readBehavioralClass(committee: Committee): GroupBehavioralClass {
-    return committee.behavioralClass ?? 'other';
-  }
 
   protected onRowSelect(event: { data: Committee }): void {
     this.rowClick.emit(event.data);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -63,6 +63,7 @@ export class CommitteeTableComponent {
   public readonly rowClick = output<Committee>();
   public readonly foundationFilterChange = output<string | null>();
   public readonly projectFilterChange = output<string | null>();
+  public readonly resetRequested = output<void>();
 
   // Behavioral class config + helper exposed to template
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
@@ -81,5 +82,6 @@ export class CommitteeTableComponent {
     this.searchForm().patchValue({ search: '', votingStatus: null, foundationFilter: null, projectFilter: null });
     this.foundationFilterChange.emit(null);
     this.projectFilterChange.emit(null);
+    this.resetRequested.emit();
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -13,7 +13,8 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { Committee, COMMITTEE_LABEL } from '@lfx-one/shared';
-import { BEHAVIORAL_CLASS_CONFIG, getGroupBehavioralClass } from '@lfx-one/shared/constants';
+import { BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
+import { GroupBehavioralClass } from '@lfx-one/shared/interfaces';
 import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
 import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
 import { PersonaService } from '@services/persona.service';
@@ -65,14 +66,13 @@ export class CommitteeTableComponent {
   public readonly projectFilterChange = output<string | null>();
   public readonly resetRequested = output<void>();
 
-  // Behavioral class config + helper exposed to template
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
-  protected readonly getGroupBehavioralClass = getGroupBehavioralClass;
-
-  // State
   protected readonly isBoardMember = computed(() => this.personaService.currentPersona() === 'board-member');
-
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.committees().length > 10 ? [10, 25, 50] : undefined));
+
+  protected readBehavioralClass(committee: Committee): GroupBehavioralClass {
+    return committee.behavioralClass ?? 'other';
+  }
 
   protected onRowSelect(event: { data: Committee }): void {
     this.rowClick.emit(event.data);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -2,21 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe, DecimalPipe } from '@angular/common';
-import { Component, computed, inject, input, output, signal } from '@angular/core';
-import { toSignal, toObservable } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, input, output } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { switchMap, startWith } from 'rxjs';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
-import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { Committee, COMMITTEE_LABEL } from '@lfx-one/shared';
-import { FilterPillOption } from '@lfx-one/shared/interfaces';
+import { BEHAVIORAL_CLASS_CONFIG, getGroupBehavioralClass } from '@lfx-one/shared/constants';
 import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
 import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
 import { PersonaService } from '@services/persona.service';
@@ -31,7 +28,6 @@ import { TooltipModule } from 'primeng/tooltip';
     ReactiveFormsModule,
     RouterLink,
     CardComponent,
-    CardTabsBarComponent,
     ButtonComponent,
     TableComponent,
     TagComponent,
@@ -56,7 +52,6 @@ export class CommitteeTableComponent {
   public myCommitteeUids = input<Set<string>>(new Set());
   public readonly committeeLabel = COMMITTEE_LABEL;
   public searchForm = input.required<FormGroup>();
-  public categoryOptions = input.required<{ label: string; value: string | null }[]>();
   public votingStatusOptions = input.required<{ label: string; value: string | null }[]>();
   public showFoundationFilter = input<boolean>(false);
   public showProjectFilter = input<boolean>(false);
@@ -69,56 +64,22 @@ export class CommitteeTableComponent {
   public readonly foundationFilterChange = output<string | null>();
   public readonly projectFilterChange = output<string | null>();
 
-  // Writable signals
-  protected readonly categoryTab = signal<string>('all');
+  // Behavioral class config + helper exposed to template
+  protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
+  protected readonly getGroupBehavioralClass = getGroupBehavioralClass;
 
   // State
   protected readonly isBoardMember = computed(() => this.personaService.currentPersona() === 'board-member');
 
-  private readonly formValue = toSignal(toObservable(this.searchForm).pipe(switchMap((form) => form.valueChanges.pipe(startWith(form.value)))), {
-    initialValue: {} as Record<string, unknown>,
-  });
-
-  protected readonly isFiltered = computed(() => {
-    const v = this.formValue();
-    return !!v['search'] || !!v['category'] || !!v['votingStatus'] || !!v['foundationFilter'] || !!v['projectFilter'];
-  });
-
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.committees().length > 10 ? [10, 25, 50] : undefined));
-
-  protected readonly categoryTabOptions = computed<FilterPillOption[]>(() =>
-    this.categoryOptions().map((opt) => {
-      const fullLabel = opt.label ?? 'All';
-      const truncatedLabel = this.truncateTabLabel(fullLabel);
-      return {
-        id: opt.value ?? 'all',
-        label: truncatedLabel,
-        fullLabel: truncatedLabel !== fullLabel ? fullLabel : undefined,
-      };
-    })
-  );
 
   protected onRowSelect(event: { data: Committee }): void {
     this.rowClick.emit(event.data);
   }
 
-  protected onCategoryTabChange(tab: string): void {
-    this.categoryTab.set(tab);
-    this.searchForm().patchValue({ category: tab === 'all' ? null : tab });
-  }
-
   protected resetFilters(): void {
-    this.categoryTab.set('all');
-    this.searchForm().patchValue({ search: '', category: null, votingStatus: null, foundationFilter: null, projectFilter: null });
+    this.searchForm().patchValue({ search: '', votingStatus: null, foundationFilter: null, projectFilter: null });
     this.foundationFilterChange.emit(null);
     this.projectFilterChange.emit(null);
-  }
-
-  private truncateTabLabel(label: string): string {
-    const match = label.match(/^(.+) \((\d+)\)$/);
-    if (!match) return label;
-    const [, name, count] = match;
-    if (name.length <= 20) return label;
-    return `${name.slice(0, 20)}...(${count})`;
   }
 }

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberAppointedBy, CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
+import { BehavioralClassDisplayConfig, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
 import { lfxColors } from './colors.constants';
 
 // Re-export helper functions from utils for backward compatibility
@@ -554,11 +554,7 @@ export const CATEGORY_BEHAVIORAL_CLASS: Record<string, GroupBehavioralClass> = {
   Committee: 'other',
 };
 
-/**
- * Display configuration for behavioral classes.
- * Used by the Groups List page for filter chips and badges.
- */
-export const BEHAVIORAL_CLASS_CONFIG: Record<GroupBehavioralClass, { label: string; icon: string; color: string; bgColor: string }> = {
+export const BEHAVIORAL_CLASS_CONFIG: Record<GroupBehavioralClass, BehavioralClassDisplayConfig> = {
   'governing-board': {
     label: 'Boards',
     icon: 'fa-light fa-gavel',

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -553,3 +553,46 @@ export const CATEGORY_BEHAVIORAL_CLASS: Record<string, GroupBehavioralClass> = {
   Other: 'other',
   Committee: 'other',
 };
+
+/**
+ * Display configuration for behavioral classes.
+ * Used by the Groups List page for filter chips and badges.
+ */
+export const BEHAVIORAL_CLASS_CONFIG: Record<GroupBehavioralClass, { label: string; icon: string; color: string; bgColor: string }> = {
+  'governing-board': {
+    label: 'Boards',
+    icon: 'fa-light fa-gavel',
+    color: 'text-violet-700',
+    bgColor: 'bg-violet-50',
+  },
+  'oversight-committee': {
+    label: 'Oversight',
+    icon: 'fa-light fa-shield-check',
+    color: 'text-emerald-700',
+    bgColor: 'bg-emerald-50',
+  },
+  'working-group': {
+    label: 'Working Groups',
+    icon: 'fa-light fa-users-gear',
+    color: 'text-amber-700',
+    bgColor: 'bg-amber-50',
+  },
+  'special-interest-group': {
+    label: 'SIGs',
+    icon: 'fa-light fa-comments',
+    color: 'text-blue-700',
+    bgColor: 'bg-blue-50',
+  },
+  'ambassador-program': {
+    label: 'Ambassadors',
+    icon: 'fa-light fa-megaphone',
+    color: 'text-rose-700',
+    bgColor: 'bg-rose-50',
+  },
+  other: {
+    label: 'Other',
+    icon: 'fa-light fa-layer-group',
+    color: 'text-gray-700',
+    bgColor: 'bg-gray-50',
+  },
+};

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -30,6 +30,14 @@ export type OversightSubType = 'governance' | 'advisory';
  */
 export type GroupBehavioralClass = 'governing-board' | 'oversight-committee' | 'working-group' | 'special-interest-group' | 'ambassador-program' | 'other';
 
+/** Display metadata for a behavioral class — used by filter chips and badges. */
+export interface BehavioralClassDisplayConfig {
+  label: string;
+  icon: string;
+  color: string;
+  bgColor: string;
+}
+
 // ── Join & Invite Types (Phase 1) ───────────────────────────────────────────
 
 /**
@@ -128,6 +136,8 @@ export interface Committee {
   writer?: boolean;
   /** Committee category/type (e.g., "Technical", "Legal", "Board") */
   category: string;
+  /** Behavioral class derived from category — populated by the UI before binding to list views to avoid per-row function calls in templates. */
+  behavioralClass?: GroupBehavioralClass;
   /** Optional description of the committee's purpose */
   description?: string;
   /** UID of parent committee for hierarchical structures */

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -138,6 +138,8 @@ export interface Committee {
   category: string;
   /** Behavioral class derived from category — populated by the UI before binding to list views to avoid per-row function calls in templates. */
   behavioralClass?: GroupBehavioralClass;
+  /** Resolved display metadata for behavioralClass — populated by the UI alongside behavioralClass so templates read pure properties. */
+  classDisplay?: BehavioralClassDisplayConfig;
   /** Optional description of the committee's purpose */
   description?: string;
   /** UID of parent committee for hierarchical structures */


### PR DESCRIPTION
## Summary

- Adds behavioral class filter chips above the Groups table — six classes (Boards / Oversight / Working Groups / SIGs / Ambassadors / Other) that roll up the 20 raw PCC categories. One-click filtering, lens-aware counts.
- Adds a **Class** column to the Groups table with a colored badge per row.
- Retires the prior raw-category filter UI (tab strip + dropdown). The category form control, `categories` signal, `initializeCategories` method, and matching filter blocks are removed since the chips cover the same need at the right granularity.
- Exposes `BEHAVIORAL_CLASS_CONFIG` from `@lfx-one/shared/constants` for reuse by other surfaces.

Ticket: [LFXV2-1715](https://linuxfoundation.atlassian.net/browse/LFXV2-1715)

## Behavioral notes for reviewers

- Chip counts source from `myCommittees()` on Me lens, `committees()` on project/foundation lens — matches the pattern used by the voting-status filter.
- Empty classes don't render chips (`@if (behavioralClassCounts()[key] > 0)`), so the row stays compact for projects with narrow group mixes.
- The behavioral class taxonomy is single-sourced from `CATEGORY_BEHAVIORAL_CLASS` in `committees.constants.ts`; `getGroupBehavioralClass()` falls back to substring matching for unknown PCC categories.

## Test plan

- [ ] **Me lens** (`/me/groups`): chips render with class counts summing to total, clicking a chip filters the table, "All" returns to unfiltered state
- [ ] **Project lens** (`/groups`): same chip behavior, plus the Class column appears in the table next to Type
- [ ] **Foundation lens** (`/foundation/groups`): chips reflect the foundation's group mix
- [ ] Search + Voting Status filters still compose with the class chip
- [ ] Empty class (e.g. no Ambassadors in a project) → chip hidden
- [ ] Class badges render with the correct icon + color per class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1715]: https://linuxfoundation.atlassian.net/browse/LFXV2-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ