### PR TITLE
feat(org-lens): seed demo accounts when persona detection returns none

### DIFF
--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -4,6 +4,7 @@
 import {
   AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS,
   DETECTION_SOURCE_MAP,
+  ORG_LENS_DEMO_SEED_ACCOUNTS,
   PERSONA_PRIORITY,
   PERSONAS_CACHE_TTL_MS,
   ROOT_PROJECT_SLUG,
@@ -203,7 +204,7 @@ export class PersonaDetectionService {
         personaProjects: {},
         personas: ['contributor'],
         projects: [],
-        organizations: [],
+        organizations: this.withDemoSeedFallback(req, []),
         error: detectionResponse.error.message,
       };
     }
@@ -215,7 +216,7 @@ export class PersonaDetectionService {
         personaProjects: {},
         personas: ['contributor'],
         projects: [],
-        organizations: [],
+        organizations: this.withDemoSeedFallback(req, []),
         error: null,
       };
     }
@@ -235,9 +236,34 @@ export class PersonaDetectionService {
       personaProjects,
       personas,
       projects,
-      organizations: this.extractOrganizations(req, projects),
+      organizations: this.withDemoSeedFallback(req, this.extractOrganizations(req, projects)),
       error: null,
     };
+  }
+
+  /**
+   * Org Lens demo seed fallback.
+   *
+   * Until the upstream persona service returns user-scoped organizations
+   * directly (blocked on persona-service work), the only path that
+   * populates `organizations` today is `extractOrganizations`, which
+   * scrapes `board_member` detection extras. Users without board
+   * memberships — i.e. most engineering accounts on the dev cluster —
+   * would see an empty selector.
+   *
+   * Returns the demo seed (`ORG_LENS_DEMO_SEED_ACCOUNTS`) only when the
+   * real extraction produced nothing, so real board members still see
+   * their actual orgs first. Replace this fallback with a live source
+   * once the persona contract delivers organizations.
+   */
+  private withDemoSeedFallback(req: Request, accounts: Account[]): Account[] {
+    if (accounts.length > 0) {
+      return accounts;
+    }
+    logger.debug(req, 'extract_organizations', 'No detected orgs — returning Org Lens demo seed', {
+      seed_count: ORG_LENS_DEMO_SEED_ACCOUNTS.length,
+    });
+    return ORG_LENS_DEMO_SEED_ACCOUNTS.map((account) => ({ ...account }));
   }
 
   private async fetchAndResolveAffiliatedSlugs(req: Request, username: string, email: string): Promise<string[]> {

--- a/packages/shared/src/constants/accounts.constants.ts
+++ b/packages/shared/src/constants/accounts.constants.ts
@@ -1,4 +1,29 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { Account } from '../interfaces/account.interface';
+
 export const ACCOUNT_COOKIE_KEY = 'lfx-selected-account';
+
+/**
+ * Demo seed for the Org Lens feature branch. Used as a fallback in
+ * PersonaDetectionService when the upstream persona service doesn't yet
+ * return user-scoped { accountId, cdevOrgId } pairs (blocked on upstream
+ * persona-service work). Only identifier + display name live here —
+ * tier, slug, and logo are intentionally resolved from Snowflake via
+ * getOrgLensAccountContext, so the demo exercises the real enrichment
+ * path end-to-end.
+ *
+ * Remove (or replace with a live source) once the persona service
+ * delivers organizations directly.
+ */
+export const ORG_LENS_DEMO_SEED_ACCOUNTS: Account[] = [
+  { accountId: '0012M00002ND5yOQAT', accountName: 'Toyota Motor Corporation' },
+  { accountId: '0014100000kgVoqAAE', accountName: 'International Business Machines Corporation' },
+  { accountId: '0014100000Te2QjAAJ', accountName: 'Red Hat, Inc.' },
+  { accountId: '0014100000TdzYmAAJ', accountName: 'Apptio' },
+  { accountId: '0012M00002ZLGHsQAP', accountName: 'IBM Watson Health' },
+  { accountId: '0012M000027Enn8QAC', accountName: 'Nordcloud, an IBM Company' },
+  { accountId: '0012M00002F2mObQAJ', accountName: 'Stackwatch Inc' },
+  { accountId: '0014100000Te2qeAAB', accountName: 'Turbonomic, an IBM Company' },
+];


### PR DESCRIPTION
> **WIP / Draft.** Demo overlay stacked on top of [#646](https://github.com/linuxfoundation/lfx-self-serve/pull/646) so the org lens shell's preview URL has a populated org selector for the CD-3507 stakeholder demo. Intended to be reverted from the shell branch before #646 merges to `main`.

Ticket: [CD-3507](https://linuxfoundation.atlassian.net/browse/CD-3507)

## Summary
- Add `ORG_LENS_DEMO_SEED_ACCOUNTS` (8 orgs: Toyota + IBM family) in `packages/shared/src/constants/accounts.constants.ts`. Each entry carries only `accountId` + `accountName` so tier, slug, and logo continue to resolve live from `platinum_lfx_one_org_lens_account_context` via `getOrgLensAccountContext`.
- Add private `withDemoSeedFallback(req, accounts)` helper in `PersonaDetectionService` that returns the seed only when the input list is empty, so real `board_member` detections are never displaced.
- Apply the helper to all three return paths of `computePersonaDetections`: persona-service error, no detections, and the success path's `extractOrganizations` output.

## Why
The persona-service contract for user-scoped `organizations` is still blocked upstream (Prabodh's work). Today the only path that populates `organizations` is `extractOrganizations`, which scrapes `board_member` detection extras — so engineering accounts on the dev cluster see an empty selector. The seed unblocks the stakeholder demo without faking enrichment data: tier badges, logos, and slugs all come from the real Snowflake context.

## Out of scope (intentionally)
- Real persona-service `organizations` integration. Will replace this fallback once the upstream contract is in.
- UI changes. The selector, tier badge, and downstream pages are unchanged.
- Mocking enrichment fields (tier/slug/logo). Those keep flowing through `getOrgLensAccountContext` so the demo exercises the live path.

## Test plan
- [ ] From this branch, `make nats-forward` + `make start`, log in, visit `http://localhost:4200/org/overview`
- [ ] Org selector trigger and dropdown show all 8 seeded orgs with Snowflake-resolved logos/names
- [ ] Tier badge resolves live: Toyota → Platinum Membership; IBM Watson Health → Contributor
- [ ] `yarn check-types` passes
- [ ] Verify a real board-member account still sees its detected org first (not displaced by seed)

## Follow-ups
- Delete `ORG_LENS_DEMO_SEED_ACCOUNTS` and `withDemoSeedFallback` once the upstream persona service returns user-scoped organizations.

Generated with [Cursor Composer](https://cursor.com/composer)