### PR TITLE
refactor(repo): rename lfx-v2-ui to lfx-self-serve throughout

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -28,7 +28,7 @@ If not already cloned:
 
 ```bash
 git clone <repository-url>
-cd lfx-v2-ui
+cd lfx-self-serve
 ```
 
 If already in the repo, confirm the working directory:

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -4,5 +4,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/linuxfoundation/lfx-v2-ui/blob/main/SECURITY.md
+    url: https://github.com/linuxfoundation/lfx-self-serve/blob/main/SECURITY.md
     about: Please review our security policy for more details

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 name: Feature request
-description: Suggest a new feature for lfx-v2-ui
+description: Suggest a new feature for lfx-self-serve
 labels: ["type:enhancement"]
 body:
   - type: textarea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ All commands run from the repo root via Turborepo:
 ## Monorepo Structure
 
 ```text
-lfx-v2-ui/
+lfx-self-serve/
 ├── apps/
 │   └── lfx-one/              # Angular 20 SSR application with stable zoneless change detection
 │       ├── src/app/

--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -43,7 +43,7 @@ if (!otlpEndpoint) {
     diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
   }
 
-  const serviceName = process.env['OTEL_SERVICE_NAME'] || 'lfx-v2-ui';
+  const serviceName = process.env['OTEL_SERVICE_NAME'] || 'lfx-self-serve';
   const serviceVersion = process.env['APP_VERSION'] || 'development';
 
   const resource = resourceFromAttributes({

--- a/apps/lfx-one/src/server/server-tracer.ts
+++ b/apps/lfx-one/src/server/server-tracer.ts
@@ -3,6 +3,6 @@
 
 import { trace } from '@opentelemetry/api';
 
-export const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] || 'lfx-v2-ui';
+export const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] || 'lfx-self-serve';
 
 export const tracer = trace.getTracer(SERVICE_NAME);

--- a/charts/lfx-self-serve/Chart.yaml
+++ b/charts/lfx-self-serve/Chart.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 apiVersion: v2
-name: lfx-v2-ui
-description: A Helm chart for LFX v2 UI - Angular SSR application with Express backend
+name: lfx-self-serve
+description: A Helm chart for LFX Self Serve - Angular SSR application with Express backend
 type: application
 # This version should not be incremented, as it is dynamically replaced with the release version during the chart build
 # job.
@@ -13,6 +13,6 @@ keywords:
   - lfx
   - project-control-center
   - ui
-home: https://github.com/linuxfoundation/lfx-v2-ui
+home: https://github.com/linuxfoundation/lfx-self-serve
 sources:
-  - https://github.com/linuxfoundation/lfx-v2-ui
+  - https://github.com/linuxfoundation/lfx-self-serve

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -99,14 +99,14 @@ environment:
 
 ### Application Parameters
 
-| Parameter           | Description        | Default                             |
-| ------------------- | ------------------ | ----------------------------------- |
-| `replicaCount`      | Number of replicas | `1`                                 |
-| `image.registry`    | Image registry     | `""`                                |
-| `image.repository`  | Image repository   | `ghcr.io/linuxfoundation/lfx-v2-ui` |
-| `image.tag`         | Image tag          | `"latest"`                          |
-| `image.pullPolicy`  | Image pull policy  | `IfNotPresent`                      |
-| `image.pullSecrets` | Image pull secrets | `[]`                                |
+| Parameter           | Description        | Default                                  |
+| ------------------- | ------------------ | ---------------------------------------- |
+| `replicaCount`      | Number of replicas | `1`                                      |
+| `image.registry`    | Image registry     | `""`                                     |
+| `image.repository`  | Image repository   | `ghcr.io/linuxfoundation/lfx-self-serve` |
+| `image.tag`         | Image tag          | `"latest"`                               |
+| `image.pullPolicy`  | Image pull policy  | `IfNotPresent`                           |
+| `image.pullSecrets` | Image pull secrets | `[]`                                     |
 
 ### Environment Variables
 
@@ -323,13 +323,13 @@ externalSecrets:
       auth:
         jwt:
           serviceAccountRef:
-            name: lfx-v2-ui-sa # ServiceAccount with IRSA annotation
+            name: lfx-self-serve-sa # ServiceAccount with IRSA annotation
   target:
-    name: lfx-v2-ui
+    name: lfx-self-serve
   dataFrom:
     - find:
         tags:
-          service: lfx-v2-ui
+          service: lfx-self-serve
       rewrite:
         - merge: {}
 ```
@@ -349,6 +349,6 @@ environment:
   PCC_AUTH0_CLIENT_SECRET:
     valueFrom:
       secretKeyRef:
-        name: lfx-v2-ui # Or your custom target name
+        name: lfx-self-serve # Or your custom target name
         key: PCC_AUTH0_CLIENT_SECRET
 ```

--- a/charts/lfx-self-serve/templates/_helpers.tpl
+++ b/charts/lfx-self-serve/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "lfx-v2-ui.name" -}}
+{{- define "lfx-self-serve.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -13,7 +13,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "lfx-v2-ui.fullname" -}}
+{{- define "lfx-self-serve.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -29,16 +29,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "lfx-v2-ui.chart" -}}
+{{- define "lfx-self-serve.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "lfx-v2-ui.labels" -}}
-helm.sh/chart: {{ include "lfx-v2-ui.chart" . }}
-{{ include "lfx-v2-ui.selectorLabels" . }}
+{{- define "lfx-self-serve.labels" -}}
+helm.sh/chart: {{ include "lfx-self-serve.chart" . }}
+{{ include "lfx-self-serve.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -51,17 +51,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "lfx-v2-ui.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "lfx-v2-ui.name" . }}
+{{- define "lfx-self-serve.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lfx-self-serve.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "lfx-v2-ui.serviceAccountName" -}}
+{{- define "lfx-self-serve.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "lfx-v2-ui.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "lfx-self-serve.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -70,7 +70,7 @@ Create the name of the service account to use
 {{/*
 Create the image name with tag
 */}}
-{{- define "lfx-v2-ui.image" -}}
+{{- define "lfx-self-serve.image" -}}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
@@ -78,7 +78,7 @@ Create the image name with tag
 {{/*
 Common annotations
 */}}
-{{- define "lfx-v2-ui.annotations" -}}
+{{- define "lfx-self-serve.annotations" -}}
 {{- with .Values.annotations }}
 {{ toYaml . }}
 {{- end }}
@@ -87,7 +87,7 @@ Common annotations
 {{/*
 Pod annotations
 */}}
-{{- define "lfx-v2-ui.podAnnotations" -}}
+{{- define "lfx-self-serve.podAnnotations" -}}
 {{- with .Values.podAnnotations }}
 {{ toYaml . }}
 {{- end }}
@@ -99,15 +99,15 @@ Pod annotations
 {{/*
 Create the name of the external secrets secretstore to use
 */}}
-{{- define "lfx-v2-ui.secretStoreName" -}}
-{{- default (include "lfx-v2-ui.fullname" .) .Values.externalSecrets.secretStore.name }}
+{{- define "lfx-self-serve.secretStoreName" -}}
+{{- default (include "lfx-self-serve.fullname" .) .Values.externalSecrets.secretStore.name }}
 {{- end }}
 
 {{/*
 Create the name of the external secret to use
 */}}
-{{- define "lfx-v2-ui.externalSecretName" -}}
-{{- default (include "lfx-v2-ui.fullname" .) .Values.externalSecrets.name }}
+{{- define "lfx-self-serve.externalSecretName" -}}
+{{- default (include "lfx-self-serve.fullname" .) .Values.externalSecrets.name }}
 {{- end }}
 
 {{/*
@@ -115,7 +115,7 @@ SecretStore annotations
 Merges global annotations with externalSecrets.secretStore.annotations
 SecretStore-specific annotations override global ones on key conflicts
 */}}
-{{- define "lfx-v2-ui.secretStoreAnnotations" -}}
+{{- define "lfx-self-serve.secretStoreAnnotations" -}}
 {{- $notations := dict -}}
 {{- if .Values.annotations }}
 {{- $notations = merge $notations .Values.annotations }}
@@ -136,7 +136,7 @@ ExternalSecret annotations
 Merges global annotations with externalSecrets.annotations
 ExternalSecret-specific annotations override global ones on key conflicts
 */}}
-{{- define "lfx-v2-ui.externalSecretAnnotations" -}}
+{{- define "lfx-self-serve.externalSecretAnnotations" -}}
 {{- $notations := dict -}}
 {{- if .Values.annotations }}
 {{- $notations = merge $notations .Values.annotations }}

--- a/charts/lfx-self-serve/templates/deployment.yaml
+++ b/charts/lfx-self-serve/templates/deployment.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "lfx-v2-ui.fullname" . }}
+  name: {{ include "lfx-self-serve.fullname" . }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
-  {{- with (include "lfx-v2-ui.annotations" .) }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
+  {{- with (include "lfx-self-serve.annotations" .) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
@@ -15,13 +15,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "lfx-v2-ui.selectorLabels" . | nindent 6 }}
+      {{- include "lfx-self-serve.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        {{- include "lfx-v2-ui.podAnnotations" . | nindent 8 }}
+        {{- include "lfx-self-serve.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "lfx-v2-ui.labels" . | nindent 8 }}
+        {{- include "lfx-self-serve.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,10 +30,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccount.name | default (include "lfx-v2-ui.serviceAccountName" .) }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "lfx-self-serve.serviceAccountName" .) }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ include "lfx-v2-ui.image" . }}
+          image: {{ include "lfx-self-serve.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/lfx-self-serve/templates/externalsecret.yaml
+++ b/charts/lfx-self-serve/templates/externalsecret.yaml
@@ -7,18 +7,18 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{ include "lfx-v2-ui.externalSecretName" . }}
+  name: {{ include "lfx-self-serve.externalSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
-  {{- with (include "lfx-v2-ui.externalSecretAnnotations" .) }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
+  {{- with (include "lfx-self-serve.externalSecretAnnotations" .) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
   secretStoreRef:
-    name: {{ include "lfx-v2-ui.secretStoreName" . }}
+    name: {{ include "lfx-self-serve.secretStoreName" . }}
     kind: SecretStore
   target:
     name: {{ $targetName }}

--- a/charts/lfx-self-serve/templates/ingress.yaml
+++ b/charts/lfx-self-serve/templates/ingress.yaml
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "lfx-v2-ui.fullname" . -}}
+{{- $fullName := include "lfx-self-serve.fullname" . -}}
 {{- $svcPort := .Values.service.port }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/lfx-self-serve/templates/pdb.yaml
+++ b/charts/lfx-self-serve/templates/pdb.yaml
@@ -13,14 +13,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "lfx-v2-ui.fullname" . }}
+  name: {{ include "lfx-self-serve.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "lfx-v2-ui.selectorLabels" . | nindent 6 }}
+      {{- include "lfx-self-serve.selectorLabels" . | nindent 6 }}
   {{- if $hasMin }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}

--- a/charts/lfx-self-serve/templates/secretstore.yaml
+++ b/charts/lfx-self-serve/templates/secretstore.yaml
@@ -6,11 +6,11 @@
 apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
-  name: {{ include "lfx-v2-ui.secretStoreName" . }}
+  name: {{ include "lfx-self-serve.secretStoreName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
-  {{- with (include "lfx-v2-ui.secretStoreAnnotations" .) }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
+  {{- with (include "lfx-self-serve.secretStoreAnnotations" .) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}

--- a/charts/lfx-self-serve/templates/service.yaml
+++ b/charts/lfx-self-serve/templates/service.yaml
@@ -4,9 +4,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lfx-v2-ui.fullname" . }}
+  name: {{ include "lfx-self-serve.fullname" . }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,4 +19,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "lfx-v2-ui.selectorLabels" . | nindent 4 }}
+    {{- include "lfx-self-serve.selectorLabels" . | nindent 4 }}

--- a/charts/lfx-self-serve/templates/serviceaccount.yaml
+++ b/charts/lfx-self-serve/templates/serviceaccount.yaml
@@ -5,9 +5,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name | default (include "lfx-v2-ui.serviceAccountName" .) }}
+  name: {{ .Values.serviceAccount.name | default (include "lfx-self-serve.serviceAccountName" .) }}
   labels:
-    {{- include "lfx-v2-ui.labels" . | nindent 4 }}
+    {{- include "lfx-self-serve.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -11,7 +11,7 @@ podDisruptionBudget:
   # maxUnavailable: 1
 
 image:
-  repository: ghcr.io/linuxfoundation/lfx-v2-ui
+  repository: ghcr.io/linuxfoundation/lfx-self-serve
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -40,7 +40,7 @@ externalSecrets:
   #     auth:
   #       jwt:
   #         serviceAccountRef:
-  #           name: lfx-v2-ui-sa
+  #           name: lfx-self-serve-sa
   provider: {}
 
   # Annotations to add to ExternalSecret resources
@@ -92,7 +92,7 @@ externalSecrets:
   #   dataFrom:
   #     - find:
   #         tags:
-  #           service: "lfx-v2-ui"
+  #           service: "lfx-self-serve"
   #       rewrite:
   #         - merge: {}
   dataFrom:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ Each subtopic owns one file under `docs/architecture/`. Start there for patterns
 ## Directory Structure
 
 ```text
-lfx-v2-ui/
+lfx-self-serve/
 ├── apps/
 │   └── lfx-one/          # Angular 20 SSR application
 │       ├── src/app/      # Feature modules, layouts, shared components/services

--- a/docs/architecture/backend/observability.md
+++ b/docs/architecture/backend/observability.md
@@ -18,7 +18,7 @@ The LFX One backend ships with OpenTelemetry-based distributed tracing that acti
 
 ```typescript
 // apps/lfx-one/src/server/server-tracer.ts
-export const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] || 'lfx-v2-ui';
+export const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] || 'lfx-self-serve';
 export const tracer = trace.getTracer(SERVICE_NAME);
 ```
 
@@ -29,7 +29,7 @@ The `SERVICE_NAME` constant is also consumed by `server-logger.ts` so log entrie
 | Env var                       | Default                                          | Purpose                                                                                                         |
 | ----------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset → tracing off)_                          | Required to turn tracing on. Points at the OTLP collector (HTTP or gRPC).                                       |
-| `OTEL_SERVICE_NAME`           | `lfx-v2-ui`                                      | Identifier that appears on every span and in log metadata.                                                      |
+| `OTEL_SERVICE_NAME`           | `lfx-self-serve`                                 | Identifier that appears on every span and in log metadata.                                                      |
 | `APP_VERSION`                 | `development` (otel.mjs) / `1.0.0` (pino logger) | Tagged onto the `service.version` resource attribute (otel.mjs) and the log `version` field (server-logger.ts). |
 | `NODE_ENV`                    | `development`                                    | Drives `deployment.environment` resource attribute (`dev`, `stage`, `prod`).                                    |
 | `OTEL_LOG_LEVEL`              | `info`                                           | Passed through to the OTel SDK diagnostics logger.                                                              |

--- a/docs/architecture/backend/ssr-server.md
+++ b/docs/architecture/backend/ssr-server.md
@@ -197,7 +197,7 @@ The server supports distributed tracing via OpenTelemetry. Tracing is **opt-in**
 | Variable                      | Default                      | Description                                                                                                                                |
 | ----------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset — tracing disabled)_ | OTLP collector endpoint (e.g., `http://localhost:4318`)                                                                                    |
-| `OTEL_SERVICE_NAME`           | `lfx-v2-ui`                  | Service name reported in traces                                                                                                            |
+| `OTEL_SERVICE_NAME`           | `lfx-self-serve`             | Service name reported in traces                                                                                                            |
 | `OTEL_TRACES_SAMPLER`         | `parentbased_always_on`      | Sampler strategy: `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_traceidratio` |
 | `OTEL_TRACES_SAMPLER_ARG`     | `1.0`                        | Sampling ratio (0.0–1.0), clamped and validated                                                                                            |
 | `OTEL_LOG_LEVEL`              | `info`                       | Diagnostic log level: `none`, `error`, `warn`, `info`, `debug`, `verbose`, `all`                                                           |

--- a/docs/architecture/frontend/feature-flags.md
+++ b/docs/architecture/frontend/feature-flags.md
@@ -661,7 +661,7 @@ docker run \
   -e LD_CLIENT_ID=prod-client-id \
   -e DD_RUM_CLIENT_ID=prod-rum-token \
   -e DD_RUM_APPLICATION_ID=prod-rum-app-id \
-  ghcr.io/linuxfoundation/lfx-v2-ui:latest
+  ghcr.io/linuxfoundation/lfx-self-serve:latest
 ```
 
 **Kubernetes Deployment:**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -241,7 +241,7 @@ AI_API_KEY=your-ai-api-key
 # OpenTelemetry Tracing (Optional)
 # Set OTEL_EXPORTER_OTLP_ENDPOINT to enable tracing; omit to disable
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-OTEL_SERVICE_NAME=lfx-v2-ui
+OTEL_SERVICE_NAME=lfx-self-serve
 OTEL_TRACES_SAMPLER=parentbased_always_on             # Sampler: always_on, always_off, traceidratio, parentbased_*
 OTEL_TRACES_SAMPLER_ARG=1.0                         # Sampling ratio 0.0-1.0, clamped (default: 1.0)
 OTEL_LOG_LEVEL=info                                 # Log level: none, error, warn, info, debug, verbose, all

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -186,7 +186,7 @@ docker run \
   -e LD_CLIENT_ID=prod-client-id \
   -e DD_RUM_CLIENT_ID=prod-rum-token \
   -e DD_RUM_APPLICATION_ID=prod-rum-app-id \
-  ghcr.io/linuxfoundation/lfx-v2-ui:latest
+  ghcr.io/linuxfoundation/lfx-self-serve:latest
 ```
 
 ### Kubernetes Deployment

--- a/packages/shared/src/interfaces/my-document.interface.ts
+++ b/packages/shared/src/interfaces/my-document.interface.ts
@@ -128,7 +128,7 @@ export interface MyDocumentItem {
   /** Number of items inside this folder — shown next to the folder name when isFolder is true */
   childCount?: number;
   /**
-   * Direct BFF download endpoint for files served by lfx-v2-ui itself (with proper
+   * Direct BFF download endpoint for files served by lfx-self-serve itself (with proper
    * Content-Disposition). When set, the download button navigates here instead of routing
    * through the generic /api/documents/download proxy that fetches external URLs.
    */


### PR DESCRIPTION
## Summary

- Renames `charts/lfx-v2-ui/` → `charts/lfx-self-serve/` and updates chart name, template helper prefixes, GitHub URLs, and GHCR image path
- Updates OTEL service name default (`lfx-v2-ui` → `lfx-self-serve`) in `otel.mjs` and `server-tracer.ts`
- Updates all doc references to the old repo name (GHCR image paths, OTEL defaults, directory trees, setup instructions, issue templates)

`lfx-one` app/package names are unchanged — they are the application identity, separate from the repo name. GitHub Actions workflows required no changes (they use `${{ github.repository }}`).

Closes LFXV2-1763

🤖 Generated with [Claude Code](https://claude.ai/code)