### PR TITLE
fix(profile): unblock linkedin add identity flow

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -216,6 +216,13 @@ export class ProfileIdentitiesComponent implements OnInit {
   }
 
   private initIdentitiesState(): Signal<IdentitiesState> {
+    // Skip the fetch during SSR. The server's HTTP call doesn't carry the user's
+    // session cookie reliably, so it tends to fail and renders the load-error
+    // banner into the SSR HTML — producing a red-banner flash on hydration
+    // before the browser's authenticated fetch resolves.
+    if (!isPlatformBrowser(this.platformId)) {
+      return signal({ identities: [] as EnrichedIdentity[], loaded: false });
+    }
     return toSignal(
       this.refreshTrigger$.pipe(
         startWith(undefined),

--- a/apps/lfx-one/src/server/services/profile-auth.service.ts
+++ b/apps/lfx-one/src/server/services/profile-auth.service.ts
@@ -22,22 +22,42 @@ interface TokenResponse {
  * update:current_user_metadata and update:current_user_identities scopes.
  */
 export class ProfileAuthService {
-  private readonly clientId: string;
-  private readonly clientSecret: string;
-  private readonly audience: string;
-  private readonly scope: string;
-  private readonly issuerBaseUrl: string;
-  private readonly baseUrl: string;
-  private readonly redirectUri: string;
+  // Resolved lazily on first access so dotenv has finished loading,
+  // then memoized — env is stable after startup.
+  private _clientId: string | undefined;
+  private _clientSecret: string | undefined;
+  private _audience: string | undefined;
+  private _scope: string | undefined;
+  private _issuerBaseUrl: string | undefined;
+  private _baseUrl: string | undefined;
+  private _redirectUri: string | undefined;
 
-  public constructor() {
-    this.clientId = process.env['PROFILE_CLIENT_ID'] || '';
-    this.clientSecret = process.env['PROFILE_CLIENT_SECRET'] || '';
-    this.audience = process.env['PROFILE_AUDIENCE'] || '';
-    this.scope = process.env['PROFILE_SCOPE'] || '';
-    this.issuerBaseUrl = (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, '');
-    this.baseUrl = process.env['PCC_BASE_URL'] || 'http://localhost:4000';
-    this.redirectUri = process.env['PROFILE_REDIRECT_URI'] || `${this.baseUrl}/passwordless/callback`;
+  private get clientId(): string {
+    return (this._clientId ??= process.env['PROFILE_CLIENT_ID'] || '');
+  }
+
+  private get clientSecret(): string {
+    return (this._clientSecret ??= process.env['PROFILE_CLIENT_SECRET'] || '');
+  }
+
+  private get audience(): string {
+    return (this._audience ??= process.env['PROFILE_AUDIENCE'] || '');
+  }
+
+  private get scope(): string {
+    return (this._scope ??= process.env['PROFILE_SCOPE'] || '');
+  }
+
+  private get issuerBaseUrl(): string {
+    return (this._issuerBaseUrl ??= (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, ''));
+  }
+
+  private get baseUrl(): string {
+    return (this._baseUrl ??= process.env['PCC_BASE_URL'] || 'http://localhost:4000');
+  }
+
+  private get redirectUri(): string {
+    return (this._redirectUri ??= process.env['PROFILE_REDIRECT_URI'] || `${this.baseUrl}/passwordless/callback`);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/social-verification.service.ts
+++ b/apps/lfx-one/src/server/services/social-verification.service.ts
@@ -30,20 +30,34 @@ interface SocialTokenResponse {
  * - The `github`, `google-oauth2`, and `linkedin` social connections must be enabled on the Auth0 tenant
  */
 export class SocialVerificationService {
-  private readonly clientId: string;
-  private readonly clientSecret: string;
-  private readonly issuerBaseUrl: string;
-  private readonly baseUrl: string;
-  private readonly redirectUri: string;
+  // Resolved lazily on first access so dotenv has finished loading,
+  // then memoized — env is stable after startup.
+  private _clientId: string | undefined;
+  private _clientSecret: string | undefined;
+  private _issuerBaseUrl: string | undefined;
+  private _baseUrl: string | undefined;
+  private _redirectUri: string | undefined;
 
   private static readonly validProviders: readonly SocialProvider[] = ['github', 'google', 'linkedin'];
 
-  public constructor() {
-    this.clientId = process.env['PROFILE_CLIENT_ID'] || '';
-    this.clientSecret = process.env['PROFILE_CLIENT_SECRET'] || '';
-    this.issuerBaseUrl = (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, '');
-    this.baseUrl = process.env['PCC_BASE_URL'] || 'http://localhost:4000';
-    this.redirectUri = process.env['SOCIAL_REDIRECT_URI'] || `${this.baseUrl}/social/callback`;
+  private get clientId(): string {
+    return (this._clientId ??= process.env['PROFILE_CLIENT_ID'] || '');
+  }
+
+  private get clientSecret(): string {
+    return (this._clientSecret ??= process.env['PROFILE_CLIENT_SECRET'] || '');
+  }
+
+  private get issuerBaseUrl(): string {
+    return (this._issuerBaseUrl ??= (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, ''));
+  }
+
+  private get baseUrl(): string {
+    return (this._baseUrl ??= process.env['PCC_BASE_URL'] || 'http://localhost:4000');
+  }
+
+  private get redirectUri(): string {
+    return (this._redirectUri ??= process.env['SOCIAL_REDIRECT_URI'] || `${this.baseUrl}/social/callback`);
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Lazy env getters in `ProfileAuthService` and `SocialVerificationService`** — both services previously read their env vars (`PROFILE_CLIENT_ID`, `PROFILE_CLIENT_SECRET`, etc.) into `readonly` instance fields inside their constructors. Both are instantiated by `ProfileController` during ESM import resolution, which runs before `dotenv.config()` in `server.ts`, so the fields were captured as empty strings. `isProfileAuthConfigured()` returned `false` and the Flow C redirect silently bounced back to `/profile/identities?error=profile_auth_not_configured`. Converts both services to the lazy-getter pattern already used by `CdpService` / `CredlyService` so env vars are read on first access (after dotenv has loaded).
- **Skip identities fetch during SSR** in `profile-identities.component.ts` — the server-side HTTP call to `/api/profile/identities` doesn't reliably carry the user's session cookie, the fetch tended to fail, and the SSR HTML rendered the "Identity service unavailable" banner. That caused a red-banner flash on hydration before the browser's authenticated fetch resolved. Gates the observable inside `initIdentitiesState()` with `isPlatformBrowser(this.platformId)` so SSR renders a loading state and the browser owns the request.

LFXV2-1762

## Test plan

- [ ] Restart the dev server (mandatory — the dotenv race only manifests on cold start with stale instance fields).
- [ ] Click **Add Identity → LinkedIn** on `/profile/identities` and confirm the browser redirects to Auth0 `/authorize` (URL changes to `linuxfoundation-dev.auth0.com/authorize?…`) instead of bouncing back with `?error=profile_auth_not_configured`.
- [ ] Server log shows `profile_auth_start` success, not `WARN: Profile auth not configured`.
- [ ] Hard-reload `/profile/identities` and confirm no red "Identity service unavailable" banner flash on initial load.
- [ ] Regression: existing email OTP verification flow (`/profile/emails`) still works.
- [ ] Regression: existing password change flow (`/profile/password`) still works.
- [ ] Negative test: temporarily blank `PROFILE_CLIENT_ID` in `.env`, restart, confirm the `Profile auth not configured` warning still fires for genuinely unconfigured environments.
- [ ] `yarn format:check && yarn lint:check && yarn check-types && yarn build` pass.