### PR TITLE
fix(meetings): hide private meeting details from unverified viewers

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -195,48 +195,50 @@
                   </div>
                 }
 
-                <!-- Feature Badges Row -->
-                <div class="flex flex-wrap gap-2 items-center">
-                  <!-- Recording Badge -->
-                  @if (meeting().recording_enabled) {
-                    <lfx-tag
-                      value="Recording"
-                      severity="secondary"
-                      icon="fa-light fa-video"
-                      styleClass="!text-red-500"
-                      data-testid="meeting-badge-recording"></lfx-tag>
-                  }
+                <!-- Feature Badges Row (private meetings: shown only to verified attendees) -->
+                @if (showPrivateDetails()) {
+                  <div class="flex flex-wrap gap-2 items-center">
+                    <!-- Recording Badge -->
+                    @if (meeting().recording_enabled) {
+                      <lfx-tag
+                        value="Recording"
+                        severity="secondary"
+                        icon="fa-light fa-video"
+                        styleClass="!text-red-500"
+                        data-testid="meeting-badge-recording"></lfx-tag>
+                    }
 
-                  <!-- Transcripts Badge -->
-                  @if (meeting().transcript_enabled) {
-                    <lfx-tag
-                      value="Transcripts"
-                      severity="secondary"
-                      icon="fa-light fa-file-lines"
-                      styleClass="!text-teal-600"
-                      data-testid="meeting-badge-transcripts"></lfx-tag>
-                  }
+                    <!-- Transcripts Badge -->
+                    @if (meeting().transcript_enabled) {
+                      <lfx-tag
+                        value="Transcripts"
+                        severity="secondary"
+                        icon="fa-light fa-file-lines"
+                        styleClass="!text-teal-600"
+                        data-testid="meeting-badge-transcripts"></lfx-tag>
+                    }
 
-                  <!-- YouTube Upload Badge -->
-                  @if (meeting().youtube_upload_enabled) {
-                    <lfx-tag
-                      value="YouTube Upload"
-                      severity="secondary"
-                      icon="fa-light fa-upload"
-                      styleClass="!text-amber-600"
-                      data-testid="meeting-badge-youtube"></lfx-tag>
-                  }
+                    <!-- YouTube Upload Badge -->
+                    @if (meeting().youtube_upload_enabled) {
+                      <lfx-tag
+                        value="YouTube Upload"
+                        severity="secondary"
+                        icon="fa-light fa-upload"
+                        styleClass="!text-amber-600"
+                        data-testid="meeting-badge-youtube"></lfx-tag>
+                    }
 
-                  <!-- AI Summary Badge -->
-                  @if (hasAiCompanion()) {
-                    <lfx-tag
-                      value="AI Summary"
-                      severity="secondary"
-                      icon="fa-light fa-sparkles"
-                      styleClass="!text-purple-500"
-                      data-testid="meeting-badge-ai-summary"></lfx-tag>
-                  }
-                </div>
+                    <!-- AI Summary Badge -->
+                    @if (hasAiCompanion()) {
+                      <lfx-tag
+                        value="AI Summary"
+                        severity="secondary"
+                        icon="fa-light fa-sparkles"
+                        styleClass="!text-purple-500"
+                        data-testid="meeting-badge-ai-summary"></lfx-tag>
+                    }
+                  </div>
+                }
 
                 <!-- RSVP Summary -->
                 @if (hasRsvpData()) {
@@ -486,7 +488,7 @@
             }
           </div>
 
-          @if (!(isPastMeeting() && !pastMeetingFullAccess())) {
+          @if (showPrivateDetails() && !(isPastMeeting() && !pastMeetingFullAccess())) {
             <!-- Divider -->
             <hr class="border-gray-200 my-4" />
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -39,6 +39,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
+import { MeetingVisibility } from '@lfx-one/shared/enums';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -163,6 +164,12 @@ export class MeetingJoinComponent implements OnInit {
   // time-based fallback for non-hyphenated URLs where past-ness is only knowable from the clock.
   protected loadedViaPastMeetingId = signal(false);
   protected pastMeetingFullAccess = signal(false);
+  protected showPrivateDetails = computed(() => {
+    const m = this.meeting();
+    if (!m) return false;
+    if (m.visibility === MeetingVisibility.PUBLIC && !m.restricted) return true;
+    return this.authenticated() && (m.organizer === true || m.invited === true);
+  });
   private refreshTrigger$ = new BehaviorSubject<void>(undefined);
   public emailError: Signal<boolean>;
 


### PR DESCRIPTION
## Summary

- Agenda, meeting materials card, and feature pills (Recording, Transcripts, YouTube, AI Summary) are now hidden on the public meeting details page (`/meetings/:id`) when the viewer is not verified as an organizer or invited registrant of a private meeting
- Adds a `showPrivateDetails` computed on `MeetingJoinComponent` that short-circuits to `true` for public non-restricted meetings and checks `authenticated && (organizer || invited)` for private ones
- The `invited` flag is already populated by the controller via the existing `addInvitedStatusToMeeting` helper — no backend changes required

## Test plan

- [ ] Private meeting, unauthenticated viewer: title, "Private" badge, date/time, sign-in/guest form visible; agenda, Meeting Materials card, all feature pills **hidden**
- [ ] Private meeting, authenticated invited registrant: all sections render normally
- [ ] Private meeting, authenticated organizer: all sections render normally
- [ ] Private meeting, authenticated but uninvited user: sections hidden
- [ ] Public, non-restricted meeting: no change — agenda/materials/pills all render (regression check)
- [ ] Past private meeting: existing `pastMeetingFullAccess` behavior preserved by the AND in the wrapper condition