### PR TITLE
refactor(claude): prune protected-files hook and PR review checks

### DIFF
--- a/.claude/hooks/guard-protected-files.sh
+++ b/.claude/hooks/guard-protected-files.sh
@@ -58,8 +58,6 @@ case "$FILE_PATH" in
     warn "Supabase service — changes affect user profile data management." ;;
   apps/lfx-one/src/server/services/ai.service.ts)
     warn "AI integration service — changes affect AI-powered features." ;;
-  apps/lfx-one/src/server/services/project.service.ts)
-    warn "Project service — core business logic for project management." ;;
   apps/lfx-one/src/server/services/etag.service.ts)
     warn "ETag caching service — changes affect HTTP caching behavior." ;;
   apps/lfx-one/src/server/helpers/error-serializer.ts)
@@ -70,12 +68,6 @@ esac
 if [[ "$FILE_PATH" == apps/lfx-one/src/server/middleware/* ]]; then
   warn "Middleware files — changes affect request processing for all routes."
 fi
-
-# ── Frontend App Configuration ─────────────────────────────────
-case "$FILE_PATH" in
-  apps/lfx-one/src/app/app.routes.ts)
-    warn "Main app routing — changes affect navigation for the entire application." ;;
-esac
 
 # ── Build & Config Files ──────────────────────────────────────
 if [[ "$FILE_PATH" == .husky/* ]]; then
@@ -89,7 +81,7 @@ case "$FILE_PATH" in
     warn "Prettier configuration — changes affect code formatting standards." ;;
   turbo.json)
     warn "Turborepo config — changes affect monorepo build pipeline." ;;
-  angular.json)
+  apps/lfx-one/angular.json)
     warn "Angular CLI config — changes affect build, serve, and test configuration." ;;
   CLAUDE.md)
     warn "Project instructions — changes affect AI assistant behavior for all users." ;;

--- a/.claude/skills/lfx-review-pr/SKILL.md
+++ b/.claude/skills/lfx-review-pr/SKILL.md
@@ -184,7 +184,6 @@ Construct the Agent prompt with the full context below. The enforcer runs in par
 > - Missing `ChangeDetectionStrategy.OnPush` — not required; the app uses stable zoneless change detection
 > - Missing `standalone: true` — Angular 20+ defaults to standalone
 > - `provideZonelessChangeDetection()` as experimental — it is stable in Angular 20
-> - Suggesting that the PR add a "Test plan" section — the user's global config explicitly disables this
 >
 > **Cross-check every finding against the actual rule text before emitting it.** If you cannot quote the rule from one of the loaded rule files, hook, checklist, or architecture doc, drop the finding. Hallucinated rules are worse than missed ones.
 
@@ -232,9 +231,7 @@ Validates PR metadata against `commit-workflow.md` and the project's global conv
 
 4. **External repo references** — if the PR touches new or modified upstream proxy calls under `apps/lfx-one/src/server/`, the PR body should link to the corresponding upstream PR / commit in the microservice repo. Flag SHOULD FIX if an upstream endpoint looks new but no external link is given.
 
-5. **No test plans in PR body** — if the PR body contains `## Test plan`, `## Testing`, or `Test plan:` sections, flag as NIT (the project convention is no test plans in PR descriptions).
-
-6. **Branch rebased on main** — check whether the PR branch includes `origin/main`:
+5. **Branch rebased on main** — check whether the PR branch includes `origin/main`:
 
    ```bash
    git merge-base --is-ancestor origin/main origin/<headRefName>
@@ -242,7 +239,7 @@ Validates PR metadata against `commit-workflow.md` and the project's global conv
 
    If the exit code is non-zero, flag SHOULD FIX: the branch needs a rebase.
 
-7. **PR size** — if `additions > 1000`, emit a review-body note per `commit-workflow.md`'s 1000-line target. (Also covered in Additional Rules below.)
+6. **PR size** — if `additions > 1000`, emit a review-body note per `commit-workflow.md`'s 1000-line target. (Also covered in Additional Rules below.)
 
 Build a findings table like:
 
@@ -253,7 +250,6 @@ Build a findings table like:
 | Branch name     | PASS   | `feat/LFXV2-1234`                  |
 | JIRA ticket     | PASS   | Found LFXV2-1234 in commits        |
 | External refs   | N/A    | No new upstream endpoints          |
-| No test plan    | FAIL   | PR body contains `## Test plan`    |
 | Branch rebased  | PASS   | origin/main is an ancestor         |
 | PR size         | PASS   | 342 additions                      |
 ```
@@ -330,7 +326,6 @@ Before passing any finding to `/review`, drop it if it matches any of these know
 - **Missing `ChangeDetectionStrategy.OnPush`** — not required; the app uses stable zoneless change detection.
 - **Missing `standalone: true`** — Angular 20+ defaults to standalone.
 - **`provideZonelessChangeDetection()` flagged as experimental** — it is stable in Angular 20.
-- **Suggesting the PR add a "Test plan" section** — the project's global config explicitly disables this.
 - **Hallucinated rules** — if the finding's `rule` field cannot be located by string match in the loaded rule files, hook, or checklists, drop it.
 
 ---


### PR DESCRIPTION
## Summary

- **`.claude/hooks/guard-protected-files.sh`** — three corrections to bring the protected-files list in line with the current codebase:
  - Fixed stale `angular.json` rule: it was matching only repo root, but the file actually lives at `apps/lfx-one/angular.json` (the rule has been silently inert since the monorepo restructure).
  - Removed `project.service.ts` — it was the only domain service in the list, inconsistent with peer services (`meeting.service.ts`, `committee.service.ts`, `persona-detection.service.ts`) which all carry equally core logic and aren't gated.
  - Removed `app.routes.ts` — the most common change here is a routine route addition, which doesn't warrant a code-owner nit. Sensitive bits (auth, lens, ED guards) already live in their own files under `shared/guards/` and are protected via PR review, not this hook.
- **`.claude/skills/lfx-review-pr/SKILL.md`** — removed all four test-plan touchpoints. This is the source of the recurring "PR description has test plans" nit appearing on reviews. Specifically dropped: the active NIT in Phase 4 (item 5), the example findings-table row, and both passive false-positive filter mentions in Phases 2 and 6.

Smoke-tested the hook locally: `app.routes.ts` and `project.service.ts` now exit silently; `auth.middleware.ts`, `logger.service.ts`, and `apps/lfx-one/angular.json` still warn correctly.