### PR TITLE
feat(layout): add manage cookie preferences link to footer

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -101,6 +101,6 @@
       <router-outlet />
     </div>
     <!-- Footer Component -->
-    <lfx-footer class="md:ml-8 p-8 mt-auto"></lfx-footer>
+    <lfx-footer class="md:ml-8 p-8 mt-auto" cookie-tracking="true"></lfx-footer>
   </main>
 </div>


### PR DESCRIPTION
## Summary

- Enable the built-in Osano cookie-consent integration on the existing `<lfx-footer>` web component by setting `cookie-tracking="true"`
- Renders a "Manage cookie preferences" link in the footer, centered below the copyright line
- Injects the Osano consent script which drives the "Storage Preferences" right-side drawer (Essential, Targeted Advertising, Personalization, Analytics, Do Not Sell or Share toggles + "Powered by Osano")
- No new Angular components, services, or backend changes required — functionality is fully implemented in the vendored `@linuxfoundation/lfx-ui-core` `<lfx-footer>` web component

## Changes

 apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Verification

1. Sign in to the app and navigate to any authenticated route
2. Scroll to the footer — confirm "Manage cookie preferences." link appears centered below the copyright line
3. Click the link — confirm the "Storage Preferences" right-side drawer opens with consent toggles
4. Toggle a non-Essential category, click Save, and confirm drawer closes without errors

Jira: LFXV2-1786

<img width="2029" height="1340" alt="image" src="https://github.com/user-attachments/assets/4c9fa943-ce94-4b1f-9dcd-9927e2a1e4cc" />

<img width="2020" height="1337" alt="image" src="https://github.com/user-attachments/assets/7dc708ab-9dfb-453b-b743-188e28bc8817" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code)