### PR TITLE
feat(analytics): tag Plausible pageviews with foundation/project/lens

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -33,6 +33,7 @@ import {
   PastMeetingParticipant,
   PastMeetingRecording,
   PastMeetingSummary,
+  PlausiblePageviewContext,
   Project,
   PublicPastMeetingResponse,
   ROOT_PROJECT_SLUG,
@@ -44,6 +45,7 @@ import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
+import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
@@ -115,6 +117,7 @@ export class MeetingJoinComponent implements OnInit {
   private readonly userService = inject(UserService);
   private readonly clipboard = inject(Clipboard);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly plausibleService = inject(PlausibleService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
@@ -297,6 +300,7 @@ export class MeetingJoinComponent implements OnInit {
     this.registrants = this.initializeRegistrants();
     this.parentProject = this.initializeParentProject();
     this.initializeAutoJoin();
+    this.initializePublicMeetingPageviewTracking();
   }
 
   public ngOnInit(): void {
@@ -1126,6 +1130,70 @@ export class MeetingJoinComponent implements OnInit {
       ),
       { initialValue: null }
     );
+  }
+
+  /**
+   * Fire one enriched Plausible pageview for this public meeting page once
+   * the project (and parent foundation, when relevant) have resolved. The
+   * PlausibleService skips the auto NavigationEnd pageview for /meetings/:id
+   * paths so we land exactly one event per visit carrying foundation/project
+   * custom props. Anonymous viewers of private meetings receive a redacted
+   * `project: null` payload and intentionally fall through without firing.
+   */
+  private initializePublicMeetingPageviewTracking(): void {
+    if (isPlatformServer(this.platformId)) {
+      return;
+    }
+    toObservable(this.project)
+      .pipe(
+        filter((p): p is Partial<Project> => !!p?.slug),
+        switchMap((project) => {
+          // No parent_uid → project is itself a top-level foundation; fire immediately.
+          if (!project.parent_uid) {
+            return of({ project, parent: null as Project | null });
+          }
+          // Wait for the parent foundation lookup; race a 2s fallback so a slow
+          // upstream (or a parent that resolves to ROOT and is mapped to null)
+          // never blocks the pageview indefinitely.
+          return merge(
+            toObservable(this.parentProject).pipe(
+              filter((parent): parent is Project => !!parent),
+              map((parent) => ({ project, parent: parent as Project | null }))
+            ),
+            timer(2000).pipe(map(() => ({ project, parent: null as Project | null })))
+          );
+        }),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ project, parent }) => {
+        this.plausibleService.trackPage(this.buildMeetingPageviewProps(project, parent));
+      });
+  }
+
+  /**
+   * Build the Plausible pageview props payload for a public meeting page.
+   * When the meeting's project has a parent, that parent IS the foundation
+   * and the meeting's project is the sub-project. Otherwise the project is
+   * itself a foundation and only the foundation_* keys are populated.
+   */
+  private buildMeetingPageviewProps(project: Partial<Project>, parent: Project | null): Record<string, unknown> {
+    const context: PlausiblePageviewContext = {};
+    if (parent) {
+      if (parent.slug) context.foundation = parent.slug;
+      if (parent.name) context.foundation_name = parent.name;
+      if (project.slug) context.project = project.slug;
+      if (project.name) context.project_name = project.name;
+    } else {
+      if (project.slug) context.foundation = project.slug;
+      if (project.name) context.foundation_name = project.name;
+    }
+    return {
+      path: window.location.pathname,
+      url: `${window.location.origin}${window.location.pathname}`,
+      title: document.title,
+      ...context,
+    };
   }
 
   private initializeRegistrants(): Signal<MeetingRegistrant[]> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -1173,18 +1173,24 @@ export class MeetingJoinComponent implements OnInit {
 
   /**
    * Build the Plausible pageview props payload for a public meeting page.
-   * When the meeting's project has a parent, that parent IS the foundation
-   * and the meeting's project is the sub-project. Otherwise the project is
-   * itself a foundation and only the foundation_* keys are populated.
+   *
+   * Branches on `project.parent_uid` rather than on whether `parent` resolved,
+   * so a slow parent fetch (or an ROOT_PROJECT_SLUG mapping that resolves to
+   * null) does not roll a sub-project up into the `foundation_*` keys. When
+   * the parent is expected but unresolved we leave foundation empty — honest
+   * gap vs. misattribution of the dashboard dimensions this is enriching.
    */
   private buildMeetingPageviewProps(project: Partial<Project>, parent: Project | null): Record<string, unknown> {
     const context: PlausiblePageviewContext = {};
-    if (parent) {
-      if (parent.slug) context.foundation = parent.slug;
-      if (parent.name) context.foundation_name = parent.name;
+    if (project.parent_uid) {
+      // Sub-project under a foundation. Attribute the project correctly even
+      // if the parent fetch hasn't (or won't) resolve.
       if (project.slug) context.project = project.slug;
       if (project.name) context.project_name = project.name;
+      if (parent?.slug) context.foundation = parent.slug;
+      if (parent?.name) context.foundation_name = parent.name;
     } else {
+      // Top-level project IS the foundation — only foundation_* keys populated.
       if (project.slug) context.foundation = project.slug;
       if (project.name) context.foundation_name = project.name;
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -33,7 +33,6 @@ import {
   PastMeetingParticipant,
   PastMeetingRecording,
   PastMeetingSummary,
-  PlausiblePageviewContext,
   Project,
   PublicPastMeetingResponse,
   ROOT_PROJECT_SLUG,
@@ -1132,74 +1131,44 @@ export class MeetingJoinComponent implements OnInit {
     );
   }
 
-  /**
-   * Fire one enriched Plausible pageview for this public meeting page once
-   * the project (and parent foundation, when relevant) have resolved. The
-   * PlausibleService skips the auto NavigationEnd pageview for /meetings/:id
-   * paths so we land exactly one event per visit carrying foundation/project
-   * custom props. Anonymous viewers of private meetings receive a redacted
-   * `project: null` payload and intentionally fall through without firing.
-   */
+  // PlausibleService defers the auto-pageview for /meetings/:id — fire it here once context lands.
   private initializePublicMeetingPageviewTracking(): void {
     if (isPlatformServer(this.platformId)) {
       return;
     }
+    // Caps the parent foundation fetch so ROOT_PROJECT_SLUG → null (mapped in initializeParentProject)
+    // doesn't block the pageview forever. Sub-projects whose parent doesn't land in time record
+    // project_* correctly and leave foundation_* empty (see buildPageviewContext callsite below).
+    const PARENT_FETCH_TIMEOUT_MS = 2000;
     toObservable(this.project)
       .pipe(
         filter((p): p is Partial<Project> => !!p?.slug),
         switchMap((project) => {
-          // No parent_uid → project is itself a top-level foundation; fire immediately.
           if (!project.parent_uid) {
             return of({ project, parent: null as Project | null });
           }
-          // Wait for the parent foundation lookup; race a 2s fallback so a slow
-          // upstream (or a parent that resolves to ROOT and is mapped to null)
-          // never blocks the pageview indefinitely.
           return merge(
             toObservable(this.parentProject).pipe(
               filter((parent): parent is Project => !!parent),
               map((parent) => ({ project, parent: parent as Project | null }))
             ),
-            timer(2000).pipe(map(() => ({ project, parent: null as Project | null })))
+            timer(PARENT_FETCH_TIMEOUT_MS).pipe(map(() => ({ project, parent: null as Project | null })))
           );
         }),
         take(1),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(({ project, parent }) => {
-        this.plausibleService.trackPage(this.buildMeetingPageviewProps(project, parent));
+        const isTopLevel = !project.parent_uid;
+        this.plausibleService.trackPage(
+          PlausibleService.buildPageviewContext({
+            foundationSlug: isTopLevel ? project.slug : parent?.slug,
+            foundationName: isTopLevel ? project.name : parent?.name,
+            projectSlug: isTopLevel ? undefined : project.slug,
+            projectName: isTopLevel ? undefined : project.name,
+          })
+        );
       });
-  }
-
-  /**
-   * Build the Plausible pageview props payload for a public meeting page.
-   *
-   * Branches on `project.parent_uid` rather than on whether `parent` resolved,
-   * so a slow parent fetch (or an ROOT_PROJECT_SLUG mapping that resolves to
-   * null) does not roll a sub-project up into the `foundation_*` keys. When
-   * the parent is expected but unresolved we leave foundation empty — honest
-   * gap vs. misattribution of the dashboard dimensions this is enriching.
-   */
-  private buildMeetingPageviewProps(project: Partial<Project>, parent: Project | null): Record<string, unknown> {
-    const context: PlausiblePageviewContext = {};
-    if (project.parent_uid) {
-      // Sub-project under a foundation. Attribute the project correctly even
-      // if the parent fetch hasn't (or won't) resolve.
-      if (project.slug) context.project = project.slug;
-      if (project.name) context.project_name = project.name;
-      if (parent?.slug) context.foundation = parent.slug;
-      if (parent?.name) context.foundation_name = parent.name;
-    } else {
-      // Top-level project IS the foundation — only foundation_* keys populated.
-      if (project.slug) context.foundation = project.slug;
-      if (project.name) context.foundation_name = project.name;
-    }
-    return {
-      path: window.location.pathname,
-      url: `${window.location.origin}${window.location.pathname}`,
-      title: document.title,
-      ...context,
-    };
   }
 
   private initializeRegistrants(): Signal<MeetingRegistrant[]> {

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -29,7 +29,10 @@ export class PlausibleService {
   // project data from the API after navigation). The auto-pageview is skipped
   // for these and the owning component fires `trackPage()` once data settles,
   // so we record one enriched event per visit instead of a context-free hit.
-  private static readonly deferredPageviewPattern = /^\/meetings\/\d+$/;
+  // Matches both upcoming-meeting URLs (`/meetings/<id>`) and past-meeting
+  // occurrence URLs (`/meetings/<id>-<13-digit-timestamp>`); both forms route
+  // to MeetingJoinComponent — see isPastMeetingOccurrenceId in that file.
+  private static readonly deferredPageviewPattern = /^\/meetings\/\d+(-\d{13})?$/;
 
   private scriptLoaded = false;
   private analyticsReady = false;

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -6,8 +6,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { PLAUSIBLE_DOMAIN, PLAUSIBLE_SRC } from '@lfx-one/shared/constants';
-import { PlausibleCall } from '@lfx-one/shared/interfaces';
+import { PlausibleCall, PlausiblePageviewContext } from '@lfx-one/shared/interfaces';
 import { filter } from 'rxjs';
+
+import { LensService } from './lens.service';
+import { ProjectContextService } from './project-context.service';
 
 /**
  * Plausible analytics service for privacy-friendly page and event tracking.
@@ -19,6 +22,14 @@ import { filter } from 'rxjs';
 export class PlausibleService {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly lensService = inject(LensService);
+
+  // Paths where context resolves asynchronously (public meeting page loads
+  // project data from the API after navigation). The auto-pageview is skipped
+  // for these and the owning component fires `trackPage()` once data settles,
+  // so we record one enriched event per visit instead of a context-free hit.
+  private static readonly deferredPageviewPattern = /^\/meetings\/\d+$/;
 
   private scriptLoaded = false;
   private analyticsReady = false;
@@ -117,7 +128,13 @@ export class PlausibleService {
       // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
         this.analyticsReady = true;
-        this.trackPage();
+        // Skip the initial pageview on deferred paths so a refresh on a
+        // public meeting URL doesn't leak a context-free hit before the
+        // component fires its enriched pageview.
+        if (PlausibleService.deferredPageviewPattern.test(window.location.pathname)) {
+          return;
+        }
+        this.trackPage(this.buildContextProps());
       };
 
       script.onerror = (error) => {
@@ -149,12 +166,49 @@ export class PlausibleService {
         if (typeof document === 'undefined') {
           return;
         }
+        const path = this.getSanitizedPath(event.urlAfterRedirects);
+        if (PlausibleService.deferredPageviewPattern.test(path)) {
+          return;
+        }
         this.trackPage({
-          path: this.getSanitizedPath(event.urlAfterRedirects),
+          path,
           url: this.getSanitizedUrl(),
           title: document.title,
+          ...this.buildContextProps(),
         });
       });
+  }
+
+  /**
+   * Build the foundation / project / lens custom-props for the current
+   * pageview from the active app state. Keys with empty values are omitted
+   * so Plausible doesn't store empty strings as a distinct dimension value.
+   * Returned as a Record so callers can spread into the broader pageview
+   * props payload that `trackPage` forwards to Plausible.
+   */
+  private buildContextProps(): Record<string, unknown> {
+    const context: PlausiblePageviewContext = {};
+    // Read foundation and project independently so the project lens emits
+    // both keys — letting the dashboard filter by either dimension.
+    const foundation = this.projectContextService.selectedFoundation();
+    if (foundation?.slug) {
+      context.foundation = foundation.slug;
+    }
+    if (foundation?.name) {
+      context.foundation_name = foundation.name;
+    }
+    const project = this.projectContextService.selectedProject();
+    if (project?.slug) {
+      context.project = project.slug;
+    }
+    if (project?.name) {
+      context.project_name = project.name;
+    }
+    const lens = this.lensService.activeLens();
+    if (lens) {
+      context.lens = lens;
+    }
+    return { ...context };
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -25,13 +25,7 @@ export class PlausibleService {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly lensService = inject(LensService);
 
-  // Paths where context resolves asynchronously (public meeting page loads
-  // project data from the API after navigation). The auto-pageview is skipped
-  // for these and the owning component fires `trackPage()` once data settles,
-  // so we record one enriched event per visit instead of a context-free hit.
-  // Matches both upcoming-meeting URLs (`/meetings/<id>`) and past-meeting
-  // occurrence URLs (`/meetings/<id>-<13-digit-timestamp>`); both forms route
-  // to MeetingJoinComponent — see isPastMeetingOccurrenceId in that file.
+  // Routes whose owning component fires `trackPage()` itself once async context resolves.
   private static readonly deferredPageviewPattern = /^\/meetings\/\d+(-\d{13})?$/;
 
   private scriptLoaded = false;
@@ -61,20 +55,41 @@ export class PlausibleService {
     });
   }
 
-  /**
-   * Track a page view
-   * @param properties Optional page properties
-   */
-  public trackPage(properties?: Record<string, unknown>): void {
+  // Auto-prepends sanitized path/url/title — callers only supply context.
+  public trackPage(context?: PlausiblePageviewContext): void {
     if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !window.plausible) {
       return;
     }
 
     try {
-      window.plausible('pageview', { u: this.getSanitizedUrl(), props: properties });
+      const url = this.getSanitizedUrl();
+      const props: Record<string, unknown> = {
+        path: this.getSanitizedPath(window.location.pathname),
+        url,
+        title: typeof document !== 'undefined' ? document.title : undefined,
+        ...(context as Record<string, unknown> | undefined),
+      };
+      window.plausible('pageview', { u: url, props });
     } catch (error) {
       console.error('Error tracking page with Plausible:', error);
     }
+  }
+
+  // Single owner of the pageview custom-prop schema — keep new dimensions here, not at callsites.
+  public static buildPageviewContext(input: {
+    foundationSlug?: string | null;
+    foundationName?: string | null;
+    projectSlug?: string | null;
+    projectName?: string | null;
+    lens?: string | null;
+  }): PlausiblePageviewContext {
+    const context: PlausiblePageviewContext = {};
+    if (input.foundationSlug) context.foundation = input.foundationSlug;
+    if (input.foundationName) context.foundation_name = input.foundationName;
+    if (input.projectSlug) context.project = input.projectSlug;
+    if (input.projectName) context.project_name = input.projectName;
+    if (input.lens) context.lens = input.lens;
+    return context;
   }
 
   /**
@@ -131,9 +146,6 @@ export class PlausibleService {
       // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
         this.analyticsReady = true;
-        // Skip the initial pageview on deferred paths so a refresh on a
-        // public meeting URL doesn't leak a context-free hit before the
-        // component fires its enriched pageview.
         if (PlausibleService.deferredPageviewPattern.test(window.location.pathname)) {
           return;
         }
@@ -173,45 +185,21 @@ export class PlausibleService {
         if (PlausibleService.deferredPageviewPattern.test(path)) {
           return;
         }
-        this.trackPage({
-          path,
-          url: this.getSanitizedUrl(),
-          title: document.title,
-          ...this.buildContextProps(),
-        });
+        this.trackPage(this.buildContextProps());
       });
   }
 
-  /**
-   * Build the foundation / project / lens custom-props for the current
-   * pageview from the active app state. Keys with empty values are omitted
-   * so Plausible doesn't store empty strings as a distinct dimension value.
-   * Returned as a Record so callers can spread into the broader pageview
-   * props payload that `trackPage` forwards to Plausible.
-   */
-  private buildContextProps(): Record<string, unknown> {
-    const context: PlausiblePageviewContext = {};
-    // Read foundation and project independently so the project lens emits
-    // both keys — letting the dashboard filter by either dimension.
+  // Foundation/project read independently (not via activeContext) so the project lens emits both.
+  private buildContextProps(): PlausiblePageviewContext {
     const foundation = this.projectContextService.selectedFoundation();
-    if (foundation?.slug) {
-      context.foundation = foundation.slug;
-    }
-    if (foundation?.name) {
-      context.foundation_name = foundation.name;
-    }
     const project = this.projectContextService.selectedProject();
-    if (project?.slug) {
-      context.project = project.slug;
-    }
-    if (project?.name) {
-      context.project_name = project.name;
-    }
-    const lens = this.lensService.activeLens();
-    if (lens) {
-      context.lens = lens;
-    }
-    return { ...context };
+    return PlausibleService.buildPageviewContext({
+      foundationSlug: foundation?.slug,
+      foundationName: foundation?.name,
+      projectSlug: project?.slug,
+      projectName: project?.name,
+      lens: this.lensService.activeLens(),
+    });
   }
 
   /**

--- a/packages/shared/src/interfaces/plausible.interface.ts
+++ b/packages/shared/src/interfaces/plausible.interface.ts
@@ -13,12 +13,7 @@ export interface PlausibleConfig {
   enabled: boolean;
 }
 
-/**
- * Custom-property context attached to Plausible pageviews so the dashboard
- * can be sliced by foundation / project / lens. Stays well under Plausible's
- * 30-keys-per-site limit. Keys are omitted when their value isn't known so
- * Plausible doesn't store empty strings as a distinct dimension value.
- */
+// Custom-prop schema attached to Plausible pageviews — keys omitted when unknown.
 export interface PlausiblePageviewContext {
   foundation?: string;
   foundation_name?: string;

--- a/packages/shared/src/interfaces/plausible.interface.ts
+++ b/packages/shared/src/interfaces/plausible.interface.ts
@@ -14,6 +14,20 @@ export interface PlausibleConfig {
 }
 
 /**
+ * Custom-property context attached to Plausible pageviews so the dashboard
+ * can be sliced by foundation / project / lens. Stays well under Plausible's
+ * 30-keys-per-site limit. Keys are omitted when their value isn't known so
+ * Plausible doesn't store empty strings as a distinct dimension value.
+ */
+export interface PlausiblePageviewContext {
+  foundation?: string;
+  foundation_name?: string;
+  project?: string;
+  project_name?: string;
+  lens?: string;
+}
+
+/**
  * One queued Plausible call captured by the upstream snippet's queue stub
  * before the real script loads. Each entry is the full argument tuple the
  * caller invoked `window.plausible(...)` with.


### PR DESCRIPTION
## Summary

- `PlausibleService` now reads `ProjectContextService` + `LensService` on every `NavigationEnd` and attaches `foundation` / `foundation_name` / `project` / `project_name` / `lens` custom-props to each pageview, so the Plausible dashboard becomes filterable/groupable by these dimensions.
- Public `/meetings/:numericId` routes load project context asynchronously — the auto NavigationEnd pageview is deferred for those paths and `MeetingJoinComponent` fires one enriched pageview once the meeting + project (and parent foundation when applicable) have resolved. A 2s timeout race guarantees the event still fires when the parent maps to `ROOT_PROJECT_SLUG` and is therefore returned as `null`.
- New shared interface `PlausiblePageviewContext` in `@lfx-one/shared/interfaces/plausible.interface.ts`.

No route, redirect, guard, or user-visible behavior changes. Total ≈ 142 lines across 3 files.

### Files changed

| File | Change |
|---|---|
| `packages/shared/src/interfaces/plausible.interface.ts` | Add `PlausiblePageviewContext` interface (5 optional string keys) |
| `apps/lfx-one/src/app/shared/services/plausible.service.ts` | Inject `ProjectContextService` + `LensService`; new `buildContextProps()`; merge into NavigationEnd + initial `script.onload` pageviews; skip auto-pageview for `/meetings/<digits>` paths |
| `apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts` | Inject `PlausibleService`; new `initializePublicMeetingPageviewTracking()` fires deferred enriched pageview after project resolves (browser-only, single-shot, with parent-fetch timeout race) |

## Why

The Plausible dashboard at `app.lfx.dev` shows entry pages like `/meetings/92079944361` with no signal of which foundation/project the visit belongs to. With this change the dashboard's existing Properties panel surfaces `foundation` / `project` / `lens` as filterable dimensions — operators can finally answer "how much traffic does the Kubernetes foundation see?" or slice top-pages by project. URLs are intentionally NOT normalized (e.g. `/meetings/:id`) — kept as-is so existing saved views and per-meeting drilldown still work.

5 custom-prop keys, well under Plausible's 30-keys-per-site limit. Historical pageviews predating the deploy will show up under `(none)` when grouping by these props.

## Test plan

- [ ] Local smoke: temporarily flip `environment.ts` → `plausible.enabled: true`, sign in, navigate `/foundation/meetings?project=<slug>` → confirm POST to `https://plausible.io/api/event` includes `props.foundation` / `props.foundation_name` / `props.project` / `props.project_name` / `props.lens` matching the active context
- [ ] Public meeting (incognito): open `/meetings/<real-numeric-id>` → confirm (a) NO Plausible POST on initial `NavigationEnd`, (b) exactly ONE POST after the `/public/api/meetings/:id` response settles, (c) that POST carries foundation/project props from the API response
- [ ] Anonymous on private meeting: confirm redacted `project: null` payload does NOT fire any Plausible POST
- [ ] Impersonation: trigger impersonation → confirm `setImpersonating(true)` short-circuit still suppresses the enriched pageview
- [ ] Post-deploy: Plausible dashboard → Properties panel surfaces `foundation`, `foundation_name`, `project`, `project_name`, `lens` as filterable dimensions

## Notes

- DCO sign-off attached. Local GPG/SSH signing config is incomplete on this machine (`gpg.ssh.allowedSignersFile` not set), so the commit may show as unverified on GitHub — happy to re-sign if needed.
- JIRA ticket not linked yet — please attach `LFXV2-<n>` after triage.