### PR TITLE
feat(voting): add ballot-casting drawer for plurality polls in my votes

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
@@ -1,0 +1,146 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full vote-cast-drawer"
+  data-testid="vote-cast-drawer">
+  @if (vote(); as voteData) {
+    <ng-template #header>
+      <div class="flex flex-col gap-3 w-full pr-4" data-testid="vote-cast-drawer-header">
+        <div class="flex items-center justify-between gap-2">
+          <h1 class="text-lg sm:text-xl font-semibold text-slate-900 flex-1 min-w-0 truncate" data-testid="vote-cast-drawer-title">
+            {{ voteData.name }}
+          </h1>
+          <button
+            type="button"
+            (click)="onClose()"
+            class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors flex-shrink-0"
+            data-testid="vote-cast-drawer-close"
+            aria-label="Close panel">
+            <i class="fa-light fa-xmark text-xl"></i>
+          </button>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+          @if (voteData.committee_name) {
+            <span class="bg-blue-100 text-blue-700 text-xs px-2.5 py-1 rounded font-medium">
+              {{ voteData.committee_name }}
+            </span>
+            <span class="text-slate-400">•</span>
+          }
+          <lfx-tag
+            [value]="voteData.status | pollStatusLabel"
+            [severity]="voteData.status | pollStatusSeverity"
+            data-testid="vote-cast-drawer-status"></lfx-tag>
+          <span class="text-slate-400">•</span>
+          <span>Due {{ voteData.end_time | date: 'MMM d, y' }}</span>
+        </div>
+      </div>
+    </ng-template>
+
+    <div class="flex flex-col gap-6" data-testid="vote-cast-drawer-content">
+      @if (loadingVote()) {
+        <div class="flex flex-col gap-4">
+          <p-skeleton width="60%" height="24px"></p-skeleton>
+          @for (i of [1, 2, 3]; track i) {
+            <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-3">
+              <p-skeleton width="80%" height="16px"></p-skeleton>
+              <p-skeleton width="40%" height="12px"></p-skeleton>
+              <p-skeleton width="40%" height="12px"></p-skeleton>
+            </div>
+          }
+        </div>
+      } @else if (!isGenericPoll()) {
+        <div class="flex flex-col items-center justify-center py-12 px-6 text-center" data-testid="vote-cast-drawer-unsupported">
+          <div class="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mb-6">
+            <i class="fa-light fa-hourglass-half text-2xl text-blue-600"></i>
+          </div>
+          <h2 class="text-xl font-semibold text-slate-900 mb-3">Coming soon</h2>
+          <p class="text-sm text-slate-600 max-w-md">Ballot casting for ranked-choice voting methods is on the way and will be available here shortly.</p>
+        </div>
+      } @else if (questions().length === 0) {
+        <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="vote-cast-drawer-no-questions">
+          <p class="text-sm text-gray-500">This vote has no questions to answer.</p>
+        </div>
+      } @else {
+        @if (voteData.description) {
+          <div class="text-sm text-slate-700 whitespace-pre-line" data-testid="vote-cast-drawer-description">
+            {{ voteData.description }}
+          </div>
+        }
+
+        <form [formGroup]="form" class="flex flex-col gap-6">
+          @for (question of questions(); track question.question_id) {
+            <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-3" [attr.data-testid]="'vote-cast-question-' + question.question_id">
+              <div class="flex flex-col gap-1">
+                <h3 class="text-sm font-semibold text-slate-900">{{ question.prompt }}</h3>
+                @if (isMultipleChoice(question)) {
+                  <p class="text-xs text-slate-500">Select all that apply.</p>
+                }
+              </div>
+
+              <div class="flex flex-col gap-2">
+                @if (isSingleChoice(question)) {
+                  @for (choice of question.choices; track choice.choice_id) {
+                    <lfx-radio-button
+                      [form]="form"
+                      [control]="question.question_id"
+                      [name]="question.question_id"
+                      [value]="choice.choice_id"
+                      [inputId]="'vote-cast-choice-' + choice.choice_id"
+                      [label]="choice.choice_text"
+                      [attr.data-testid]="'vote-cast-choice-' + choice.choice_id"></lfx-radio-button>
+                  }
+                } @else if (isMultipleChoice(question)) {
+                  @for (choice of question.choices; track choice.choice_id) {
+                    <div class="flex items-center gap-2" [attr.data-testid]="'vote-cast-choice-' + choice.choice_id">
+                      <p-checkbox
+                        [formControlName]="question.question_id"
+                        [value]="choice.choice_id"
+                        [binary]="false"
+                        [inputId]="'vote-cast-choice-' + choice.choice_id" />
+                      <label [for]="'vote-cast-choice-' + choice.choice_id" class="text-sm font-medium text-gray-700 cursor-pointer">
+                        {{ choice.choice_text }}
+                      </label>
+                    </div>
+                  }
+                }
+              </div>
+            </div>
+          }
+        </form>
+
+        @if (allowAbstain()) {
+          <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 flex flex-col gap-2">
+            <div class="flex items-center gap-2" data-testid="vote-cast-abstain-toggle">
+              <p-checkbox
+                [binary]="true"
+                [ngModel]="abstain()"
+                [ngModelOptions]="{ standalone: true }"
+                (ngModelChange)="onAbstainChange($event)"
+                inputId="vote-cast-abstain" />
+              <label for="vote-cast-abstain" class="text-sm font-medium text-gray-700 cursor-pointer">Abstain from this vote</label>
+            </div>
+            <p class="text-xs text-slate-500">An abstention is recorded as a non-vote and overrides any selections above.</p>
+          </div>
+        }
+
+        <div class="flex items-center justify-end gap-3 pt-2 border-t border-slate-200">
+          <lfx-button label="Cancel" severity="secondary" (onClick)="onClose()" [disabled]="submitting()" data-testid="vote-cast-cancel-button"></lfx-button>
+          <lfx-button
+            label="Submit Vote"
+            icon="fa-light fa-check"
+            severity="primary"
+            [disabled]="submitDisabled()"
+            [loading]="submitting()"
+            (onClick)="onSubmit()"
+            data-testid="vote-cast-submit-button"></lfx-button>
+        </div>
+      }
+    </div>
+  }
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
@@ -78,13 +78,13 @@
             <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-3" [attr.data-testid]="'vote-cast-question-' + question.question_id">
               <div class="flex flex-col gap-1">
                 <h3 class="text-sm font-semibold text-slate-900">{{ question.prompt }}</h3>
-                @if (isMultipleChoice(question)) {
+                @if (question.type === 'multiple_choice') {
                   <p class="text-xs text-slate-500">Select all that apply.</p>
                 }
               </div>
 
               <div class="flex flex-col gap-2">
-                @if (isSingleChoice(question)) {
+                @if (question.type === 'single_choice') {
                   @for (choice of question.choices; track choice.choice_id) {
                     <lfx-radio-button
                       [form]="form"
@@ -95,7 +95,7 @@
                       [label]="choice.choice_text"
                       [attr.data-testid]="'vote-cast-choice-' + choice.choice_id"></lfx-radio-button>
                   }
-                } @else if (isMultipleChoice(question)) {
+                } @else if (question.type === 'multiple_choice') {
                   @for (choice of question.choices; track choice.choice_id) {
                     <div class="flex items-center gap-2" [attr.data-testid]="'vote-cast-choice-' + choice.choice_id">
                       <p-checkbox
@@ -117,12 +117,7 @@
         @if (allowAbstain()) {
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 flex flex-col gap-2">
             <div class="flex items-center gap-2" data-testid="vote-cast-abstain-toggle">
-              <p-checkbox
-                [binary]="true"
-                [ngModel]="abstain()"
-                [ngModelOptions]="{ standalone: true }"
-                (ngModelChange)="onAbstainChange($event)"
-                inputId="vote-cast-abstain" />
+              <p-checkbox [binary]="true" [formControl]="abstainControl" inputId="vote-cast-abstain" />
               <label for="vote-cast-abstain" class="text-sm font-medium text-gray-700 cursor-pointer">Abstain from this vote</label>
             </div>
             <p class="text-xs text-slate-500">An abstention is recorded as a non-vote and overrides any selections above.</p>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -3,9 +3,9 @@
 
 import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, effect, inject, input, model, output, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, computed, DestroyRef, inject, input, model, output, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -18,7 +18,9 @@ import { MessageService } from 'primeng/api';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, finalize, of, shareReplay, startWith, Subject, switchMap, take, takeUntil, throwError } from 'rxjs';
+import { catchError, filter, finalize, of, shareReplay, startWith, Subject, switchMap, take, takeUntil, throwError } from 'rxjs';
+
+const INVITATION_NOT_FOUND = 'INVITATION_NOT_FOUND';
 
 @Component({
   selector: 'lfx-vote-cast-drawer',
@@ -26,7 +28,6 @@ import { catchError, finalize, of, shareReplay, startWith, Subject, switchMap, t
     DrawerModule,
     SkeletonModule,
     CheckboxModule,
-    FormsModule,
     ReactiveFormsModule,
     ButtonComponent,
     RadioButtonComponent,
@@ -42,6 +43,7 @@ export class VoteCastDrawerComponent {
   // === Services ===
   private readonly voteService = inject(VoteService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // === Inputs ===
   public readonly voteId = input<string | null>(null);
@@ -54,90 +56,60 @@ export class VoteCastDrawerComponent {
   public readonly voteSubmitted = output<string>();
 
   // === Forms ===
-  // Per-question form. Keys are question_id. Each value is:
-  //   - string | null for single_choice (selected choice_id)
-  //   - string[] | null for multiple_choice (array of selected choice_ids)
-  // Submit normalises both shapes into VoteAnswerInput.choice_ids.
   public readonly form = new FormGroup({});
+  public readonly abstainControl = new FormControl<boolean>(false, { nonNullable: true });
 
   // === Writable Signals ===
   protected readonly loadingVote = signal<boolean>(false);
   protected readonly submitting = signal<boolean>(false);
-  protected readonly abstain = signal<boolean>(false);
+  // Reactive dependency for submitDisabled — rebuildForm uses { emitEvent: false }, so statusChanges is silent.
+  private readonly formVersion = signal<number>(0);
 
   // === Shared Observables ===
   private readonly voteId$ = toObservable(this.voteId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
-  // Emits when the drawer is closed mid-submit. The submit chain pipes through
-  // takeUntil(cancelSubmit$) so the HTTP stream is cancelled cleanly and the
-  // success/error toast cannot fire after the user has already closed the drawer.
+  // Emits on drawer dismissal (close button OR ESC OR overlay click — all flip visible to false).
   private readonly cancelSubmit$ = new Subject<void>();
 
   // === Derived Signals (from API) ===
   protected readonly vote: Signal<Vote | null> = this.initVote();
-  // form.statusChanges is the canonical reactive surface for FormGroup validity.
-  // We pipe to startWith(form.status) so the signal has a synchronous initial value
-  // (status emissions only fire on changes, not on initial construction).
-  private readonly formStatus: Signal<string> = toSignal(this.form.statusChanges.pipe(startWith(this.form.status)), { initialValue: this.form.status });
+  protected readonly abstain: Signal<boolean> = toSignal(this.abstainControl.valueChanges, { initialValue: this.abstainControl.value });
 
   // === Computed Signals ===
   protected readonly isGenericPoll: Signal<boolean> = computed(() => this.vote()?.poll_type === PollType.GENERIC);
   protected readonly questions: Signal<PollQuestion[]> = computed(() => this.vote()?.poll_questions ?? []);
   protected readonly allowAbstain: Signal<boolean> = computed(() => !!this.vote()?.allow_abstain);
-  protected readonly submitDisabled: Signal<boolean> = computed(() => {
-    if (this.submitting()) return true;
-    if (this.abstain()) return false;
-    return this.formStatus() !== 'VALID';
-  });
+  protected readonly submitDisabled: Signal<boolean> = this.initSubmitDisabled();
 
   public constructor() {
-    // Rebuild the form whenever a new vote is loaded so controls match its questions.
-    effect(() => {
-      const questions = this.questions();
-      this.rebuildForm(questions);
+    // Rebuild the form when the loaded vote's questions change.
+    toObservable(this.questions)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((questions) => this.rebuildForm(questions));
+
+    // Abstain toggle disables answer controls without losing their values.
+    this.abstainControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((isAbstaining) => {
+      if (isAbstaining) this.form.disable({ emitEvent: false });
+      else this.form.enable({ emitEvent: false });
+      this.bumpFormVersion();
     });
 
-    // Reset transient state when the drawer closes so reopening starts fresh.
-    // Cancels any in-flight submit regardless of how the drawer was dismissed
-    // (close button, ESC, or overlay-click) so the success toast cannot fire
-    // after the user has already navigated away.
-    effect(() => {
-      if (!this.visible()) {
-        if (this.submitting()) {
-          this.cancelSubmit$.next();
-        }
-        this.abstain.set(false);
+    // Drawer dismissal (close button / ESC / overlay click) — cancel any in-flight submit and reset transient state.
+    toObservable(this.visible)
+      .pipe(
+        filter((v) => !v),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => {
+        if (this.submitting()) this.cancelSubmit$.next();
         this.submitting.set(false);
-      }
-    });
-
-    // Toggling abstain disables answer fields without losing their values.
-    effect(() => {
-      if (this.abstain()) {
-        this.form.disable({ emitEvent: false });
-      } else {
-        this.form.enable({ emitEvent: false });
-      }
-    });
+        // Reset abstain so reopening starts fresh — letting valueChanges fire keeps form.enable + abstain signal in sync.
+        if (this.abstainControl.value) this.abstainControl.setValue(false);
+      });
   }
 
   // === Protected Methods ===
   protected onClose(): void {
-    // Setting visible to false triggers the visibility effect, which handles
-    // in-flight submit cancellation and all other state resets for every
-    // close path (close button, ESC, overlay-click).
     this.visible.set(false);
-  }
-
-  protected onAbstainChange(checked: boolean): void {
-    this.abstain.set(checked);
-  }
-
-  protected isSingleChoice(question: PollQuestion): boolean {
-    return question.type === 'single_choice';
-  }
-
-  protected isMultipleChoice(question: PollQuestion): boolean {
-    return question.type === 'multiple_choice';
   }
 
   protected onSubmit(): void {
@@ -149,18 +121,13 @@ export class VoteCastDrawerComponent {
 
     this.submitting.set(true);
 
-    // The voting service pre-allocates one vote_response row per invitee when a vote
-    // is enabled; the cast endpoint requires that pre-allocated UID — a fresh client
-    // UUID returns 404. Chain the lookup into the submit via switchMap so the two
-    // sequential calls share one subscription and one error funnel.
+    // The voting service pre-allocates one vote_response row per invitee — POST /vote_responses MUST reuse that uid.
     this.voteService
       .getMyVoteResponse(vote.uid)
       .pipe(
         take(1),
         switchMap((myResponse) => {
-          if (!myResponse?.uid) {
-            return throwError(() => new Error('INVITATION_NOT_FOUND'));
-          }
+          if (!myResponse?.uid) return throwError(() => new Error(INVITATION_NOT_FOUND));
           const payload: CreateVoteResponseRequest = {
             vote_response_uid: myResponse.uid,
             vote_uid: vote.uid,
@@ -169,8 +136,6 @@ export class VoteCastDrawerComponent {
           };
           return this.voteService.createVoteResponse(payload);
         }),
-        // If the user closes the drawer mid-submit, drop the stream silently —
-        // no success/error toast fires, submitting is already reset by onClose.
         takeUntil(this.cancelSubmit$),
         finalize(() => this.submitting.set(false))
       )
@@ -185,8 +150,8 @@ export class VoteCastDrawerComponent {
           this.voteSubmitted.emit(vote.uid);
           this.visible.set(false);
         },
-        error: (err: Error | HttpErrorResponse) => {
-          const isInvitationMissing = err?.message === 'INVITATION_NOT_FOUND';
+        error: (err: unknown) => {
+          const isInvitationMissing = err instanceof Error && !(err instanceof HttpErrorResponse) && err.message === INVITATION_NOT_FOUND;
           this.messageService.add({
             severity: 'error',
             summary: isInvitationMissing ? 'Unable to find your invitation' : 'Unable to submit vote',
@@ -208,10 +173,8 @@ export class VoteCastDrawerComponent {
             this.loadingVote.set(false);
             return of(null);
           }
-
           this.loadingVote.set(true);
           const listVote = this.listVote();
-
           return this.voteService.getVote(id).pipe(
             catchError(() => of(listVote)),
             finalize(() => this.loadingVote.set(false)),
@@ -223,28 +186,37 @@ export class VoteCastDrawerComponent {
     );
   }
 
+  private initSubmitDisabled(): Signal<boolean> {
+    return computed(() => {
+      this.formVersion(); // re-evaluate when controls are added/removed/disabled via { emitEvent: false }
+      if (this.submitting()) return true;
+      if (this.abstain()) return false;
+      return !this.form.valid;
+    });
+  }
+
   // === Private Helpers ===
-  // Reconciles the form against the current vote's questions: drops controls for
-  // removed questions, adds controls for new ones, leaves stable controls alone.
+  // Reconciles the form against the current vote's questions; bumps formVersion since we suppress emitEvent.
   private rebuildForm(questions: PollQuestion[]): void {
     const desiredIds = new Set(questions.map((q) => q.question_id));
     for (const existingId of Object.keys(this.form.controls)) {
-      if (!desiredIds.has(existingId)) {
-        this.form.removeControl(existingId, { emitEvent: false });
-      }
+      if (!desiredIds.has(existingId)) this.form.removeControl(existingId, { emitEvent: false });
     }
     for (const question of questions) {
       if (this.form.contains(question.question_id)) continue;
       if (question.type === 'multiple_choice') {
-        this.form.addControl(question.question_id, new FormControl<string[]>([], Validators.required), { emitEvent: false });
+        this.form.addControl(question.question_id, new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] }), {
+          emitEvent: false,
+        });
       } else {
         this.form.addControl(question.question_id, new FormControl<string | null>(null, Validators.required), { emitEvent: false });
       }
     }
-    // All add/removeControl calls above suppress individual emissions to avoid
-    // per-control churn. Fire a single status update once all controls are
-    // reconciled so toSignal(statusChanges) reflects the correct validity state.
-    this.form.updateValueAndValidity({ emitEvent: true });
+    this.bumpFormVersion();
+  }
+
+  private bumpFormVersion(): void {
+    this.formVersion.update((v) => v + 1);
   }
 
   private buildAnswers(questions: PollQuestion[]): VoteAnswerInput[] {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -137,6 +137,7 @@ export class VoteCastDrawerComponent {
           return this.voteService.createVoteResponse(payload);
         }),
         takeUntil(this.cancelSubmit$),
+        takeUntilDestroyed(this.destroyRef),
         finalize(() => this.submitting.set(false))
       )
       .subscribe({

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -17,7 +17,7 @@ import { MessageService } from 'primeng/api';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, finalize, of, shareReplay, startWith, switchMap, take, throwError } from 'rxjs';
+import { catchError, finalize, of, shareReplay, startWith, Subject, switchMap, take, takeUntil, throwError } from 'rxjs';
 
 @Component({
   selector: 'lfx-vote-cast-drawer',
@@ -63,6 +63,10 @@ export class VoteCastDrawerComponent {
   protected readonly loadingVote = signal<boolean>(false);
   protected readonly submitting = signal<boolean>(false);
   protected readonly abstain = signal<boolean>(false);
+
+  // Emits when the drawer is closed. Used to cancel any in-flight submit so the
+  // success toast can't fire after the user "cancelled" (see PR #710 review).
+  private readonly cancelSubmit$ = new Subject<void>();
 
   // === Shared Observables ===
   private readonly voteId$ = toObservable(this.voteId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
@@ -111,6 +115,13 @@ export class VoteCastDrawerComponent {
 
   // === Protected Methods ===
   protected onClose(): void {
+    // Cancel any in-flight submit so its success/error toast doesn't fire after
+    // the user has already cancelled. The submit subscription pipes through
+    // takeUntil(cancelSubmit$) so emitting here completes the stream cleanly.
+    if (this.submitting()) {
+      this.cancelSubmit$.next();
+      this.submitting.set(false);
+    }
     this.visible.set(false);
   }
 
@@ -155,6 +166,9 @@ export class VoteCastDrawerComponent {
           };
           return this.voteService.createVoteResponse(payload);
         }),
+        // If the user closes the drawer mid-submit, drop the stream silently —
+        // no success/error toast fires, submitting is already reset by onClose.
+        takeUntil(this.cancelSubmit$),
         finalize(() => this.submitting.set(false))
       )
       .subscribe({

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -1,0 +1,261 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, effect, inject, input, model, output, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { PollType } from '@lfx-one/shared';
+import { CreateVoteResponseRequest, PollQuestion, Vote, VoteAnswerInput } from '@lfx-one/shared/interfaces';
+import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
+import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
+import { VoteService } from '@services/vote.service';
+import { MessageService } from 'primeng/api';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DrawerModule } from 'primeng/drawer';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, finalize, of, shareReplay, startWith, switchMap, take } from 'rxjs';
+
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'lfx-vote-cast-drawer',
+  imports: [
+    DrawerModule,
+    SkeletonModule,
+    CheckboxModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ButtonComponent,
+    RadioButtonComponent,
+    TagComponent,
+    PollStatusLabelPipe,
+    PollStatusSeverityPipe,
+    DatePipe,
+  ],
+  templateUrl: './vote-cast-drawer.component.html',
+  styleUrl: './vote-cast-drawer.component.scss',
+})
+export class VoteCastDrawerComponent {
+  // === Services ===
+  private readonly voteService = inject(VoteService);
+  private readonly messageService = inject(MessageService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // === Inputs ===
+  public readonly voteId = input<string | null>(null);
+  public readonly listVote = input<Vote | null>(null);
+
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Outputs ===
+  public readonly voteSubmitted = output<string>();
+
+  // === Forms ===
+  // Per-question form. Keys are question_id. Each value is:
+  //   - string | null for single_choice (selected choice_id)
+  //   - string[] | null for multiple_choice (array of selected choice_ids)
+  // Submit normalises both shapes into VoteAnswerInput.choice_ids.
+  public readonly form = new FormGroup({});
+
+  // === Writable Signals ===
+  protected readonly loadingVote = signal<boolean>(false);
+  protected readonly submitting = signal<boolean>(false);
+  protected readonly abstain = signal<boolean>(false);
+
+  // === Shared Observables ===
+  private readonly voteId$ = toObservable(this.voteId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+  // === Derived Signals (from API) ===
+  protected readonly vote: Signal<Vote | null> = this.initVote();
+  // form.statusChanges is the canonical reactive surface for FormGroup validity.
+  // We pipe to startWith(form.status) so the signal has a synchronous initial value
+  // (status emissions only fire on changes, not on initial construction).
+  private readonly formStatus: Signal<string> = toSignal(this.form.statusChanges.pipe(startWith(this.form.status)), { initialValue: this.form.status });
+
+  // === Computed Signals ===
+  protected readonly isGenericPoll: Signal<boolean> = computed(() => this.vote()?.poll_type === PollType.GENERIC);
+  protected readonly questions: Signal<PollQuestion[]> = computed(() => this.vote()?.poll_questions ?? []);
+  protected readonly allowAbstain: Signal<boolean> = computed(() => !!this.vote()?.allow_abstain);
+  protected readonly submitDisabled: Signal<boolean> = computed(() => {
+    if (this.submitting()) return true;
+    if (this.abstain()) return false;
+    return this.formStatus() !== 'VALID';
+  });
+
+  public constructor() {
+    // Rebuild the form whenever a new vote is loaded so controls match its questions.
+    effect(() => {
+      const questions = this.questions();
+      this.rebuildForm(questions);
+    });
+
+    // Reset transient state when the drawer closes so reopening starts fresh.
+    effect(() => {
+      if (!this.visible()) {
+        this.abstain.set(false);
+        this.submitting.set(false);
+      }
+    });
+
+    // Toggling abstain disables answer fields without losing their values.
+    effect(() => {
+      if (this.abstain()) {
+        this.form.disable({ emitEvent: false });
+      } else {
+        this.form.enable({ emitEvent: false });
+      }
+    });
+  }
+
+  // === Protected Methods ===
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  protected onAbstainChange(checked: boolean): void {
+    this.abstain.set(checked);
+  }
+
+  protected isSingleChoice(question: PollQuestion): boolean {
+    return question.type === 'single_choice';
+  }
+
+  protected isMultipleChoice(question: PollQuestion): boolean {
+    return question.type === 'multiple_choice';
+  }
+
+  protected onSubmit(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const vote = this.vote();
+    if (!vote || this.submitting()) return;
+
+    const isAbstain = this.abstain();
+    const userVoteContent = isAbstain ? undefined : this.buildAnswers(vote.poll_questions ?? []);
+
+    this.submitting.set(true);
+
+    // The voting service pre-allocates one vote_response row per invitee when a vote
+    // is enabled; the cast endpoint requires that pre-allocated UID. A fresh client
+    // UUID returns 404. Fetch the user's row first, then POST with its uid.
+    this.voteService
+      .getMyVoteResponse(vote.uid)
+      .pipe(take(1))
+      .subscribe({
+        next: (myResponse) => {
+          if (!myResponse?.uid) {
+            this.submitting.set(false);
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Unable to find your invitation',
+              detail: 'We could not find your vote invitation for this ballot. Please refresh and try again.',
+              life: 5000,
+            });
+            return;
+          }
+
+          const payload: CreateVoteResponseRequest = {
+            vote_response_uid: myResponse.uid,
+            vote_uid: vote.uid,
+            abstain: isAbstain,
+            user_vote_content: userVoteContent,
+          };
+
+          this.voteService
+            .createVoteResponse(payload)
+            .pipe(finalize(() => this.submitting.set(false)))
+            .subscribe({
+              next: () => {
+                this.messageService.add({
+                  severity: 'success',
+                  summary: 'Vote submitted',
+                  detail: `Your ${isAbstain ? 'abstention' : 'ballot'} has been recorded.`,
+                  life: 3000,
+                });
+                this.voteSubmitted.emit(vote.uid);
+                this.visible.set(false);
+              },
+              error: () => {
+                this.messageService.add({
+                  severity: 'error',
+                  summary: 'Unable to submit vote',
+                  detail: 'Something went wrong submitting your ballot. Please try again.',
+                  life: 5000,
+                });
+              },
+            });
+        },
+        error: () => {
+          this.submitting.set(false);
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Unable to submit vote',
+            detail: 'We could not look up your invitation. Please refresh and try again.',
+            life: 5000,
+          });
+        },
+      });
+  }
+
+  // === Private Initializers ===
+  private initVote(): Signal<Vote | null> {
+    return toSignal(
+      this.voteId$.pipe(
+        switchMap((id) => {
+          if (!id) {
+            this.loadingVote.set(false);
+            return of(null);
+          }
+
+          this.loadingVote.set(true);
+          const listVote = this.listVote();
+
+          return this.voteService.getVote(id).pipe(
+            catchError(() => of(listVote)),
+            finalize(() => this.loadingVote.set(false)),
+            startWith(listVote)
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  // === Private Helpers ===
+  // Reconciles the form against the current vote's questions: drops controls for
+  // removed questions, adds controls for new ones, leaves stable controls alone.
+  private rebuildForm(questions: PollQuestion[]): void {
+    const desiredIds = new Set(questions.map((q) => q.question_id));
+    for (const existingId of Object.keys(this.form.controls)) {
+      if (!desiredIds.has(existingId)) {
+        this.form.removeControl(existingId, { emitEvent: false });
+      }
+    }
+    for (const question of questions) {
+      if (this.form.contains(question.question_id)) continue;
+      if (question.type === 'multiple_choice') {
+        this.form.addControl(question.question_id, new FormControl<string[] | null>(null, Validators.required), { emitEvent: false });
+      } else {
+        this.form.addControl(question.question_id, new FormControl<string | null>(null, Validators.required), { emitEvent: false });
+      }
+    }
+  }
+
+  private buildAnswers(questions: PollQuestion[]): VoteAnswerInput[] {
+    return questions.map((q) => ({
+      question_id: q.question_id,
+      choice_ids: this.normaliseChoiceIds(this.form.get(q.question_id)?.value),
+    }));
+  }
+
+  private normaliseChoiceIds(raw: unknown): string[] {
+    if (Array.isArray(raw)) return raw as string[];
+    if (typeof raw === 'string' && raw.length > 0) return [raw];
+    return [];
+  }
+}

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, effect, inject, input, model, output, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -64,12 +65,12 @@ export class VoteCastDrawerComponent {
   protected readonly submitting = signal<boolean>(false);
   protected readonly abstain = signal<boolean>(false);
 
-  // Emits when the drawer is closed. Used to cancel any in-flight submit so the
-  // success toast can't fire after the user "cancelled" (see PR #710 review).
-  private readonly cancelSubmit$ = new Subject<void>();
-
   // === Shared Observables ===
   private readonly voteId$ = toObservable(this.voteId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+  // Emits when the drawer is closed mid-submit. The submit chain pipes through
+  // takeUntil(cancelSubmit$) so the HTTP stream is cancelled cleanly and the
+  // success/error toast cannot fire after the user has already closed the drawer.
+  private readonly cancelSubmit$ = new Subject<void>();
 
   // === Derived Signals (from API) ===
   protected readonly vote: Signal<Vote | null> = this.initVote();
@@ -96,8 +97,14 @@ export class VoteCastDrawerComponent {
     });
 
     // Reset transient state when the drawer closes so reopening starts fresh.
+    // Cancels any in-flight submit regardless of how the drawer was dismissed
+    // (close button, ESC, or overlay-click) so the success toast cannot fire
+    // after the user has already navigated away.
     effect(() => {
       if (!this.visible()) {
+        if (this.submitting()) {
+          this.cancelSubmit$.next();
+        }
         this.abstain.set(false);
         this.submitting.set(false);
       }
@@ -115,13 +122,9 @@ export class VoteCastDrawerComponent {
 
   // === Protected Methods ===
   protected onClose(): void {
-    // Cancel any in-flight submit so its success/error toast doesn't fire after
-    // the user has already cancelled. The submit subscription pipes through
-    // takeUntil(cancelSubmit$) so emitting here completes the stream cleanly.
-    if (this.submitting()) {
-      this.cancelSubmit$.next();
-      this.submitting.set(false);
-    }
+    // Setting visible to false triggers the visibility effect, which handles
+    // in-flight submit cancellation and all other state resets for every
+    // close path (close button, ESC, overlay-click).
     this.visible.set(false);
   }
 
@@ -182,7 +185,7 @@ export class VoteCastDrawerComponent {
           this.voteSubmitted.emit(vote.uid);
           this.visible.set(false);
         },
-        error: (err: Error) => {
+        error: (err: Error | HttpErrorResponse) => {
           const isInvitationMissing = err?.message === 'INVITATION_NOT_FOUND';
           this.messageService.add({
             severity: 'error',
@@ -233,11 +236,15 @@ export class VoteCastDrawerComponent {
     for (const question of questions) {
       if (this.form.contains(question.question_id)) continue;
       if (question.type === 'multiple_choice') {
-        this.form.addControl(question.question_id, new FormControl<string[] | null>(null, Validators.required), { emitEvent: false });
+        this.form.addControl(question.question_id, new FormControl<string[]>([], Validators.required), { emitEvent: false });
       } else {
         this.form.addControl(question.question_id, new FormControl<string | null>(null, Validators.required), { emitEvent: false });
       }
     }
+    // All add/removeControl calls above suppress individual emissions to avoid
+    // per-control churn. Fire a single status update once all controls are
+    // reconciled so toSignal(statusChanges) reflects the correct validity state.
+    this.form.updateValueAndValidity({ emitEvent: true });
   }
 
   private buildAnswers(questions: PollQuestion[]): VoteAnswerInput[] {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, effect, inject, input, model, output, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { Component, computed, effect, inject, input, model, output, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
@@ -17,9 +17,7 @@ import { MessageService } from 'primeng/api';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, finalize, of, shareReplay, startWith, switchMap, take } from 'rxjs';
-
-import { DatePipe } from '@angular/common';
+import { catchError, finalize, of, shareReplay, startWith, switchMap, take, throwError } from 'rxjs';
 
 @Component({
   selector: 'lfx-vote-cast-drawer',
@@ -43,7 +41,6 @@ export class VoteCastDrawerComponent {
   // === Services ===
   private readonly voteService = inject(VoteService);
   private readonly messageService = inject(MessageService);
-  private readonly platformId = inject(PLATFORM_ID);
 
   // === Inputs ===
   public readonly voteId = input<string | null>(null);
@@ -130,8 +127,6 @@ export class VoteCastDrawerComponent {
   }
 
   protected onSubmit(): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-
     const vote = this.vote();
     if (!vote || this.submitting()) return;
 
@@ -141,61 +136,46 @@ export class VoteCastDrawerComponent {
     this.submitting.set(true);
 
     // The voting service pre-allocates one vote_response row per invitee when a vote
-    // is enabled; the cast endpoint requires that pre-allocated UID. A fresh client
-    // UUID returns 404. Fetch the user's row first, then POST with its uid.
+    // is enabled; the cast endpoint requires that pre-allocated UID — a fresh client
+    // UUID returns 404. Chain the lookup into the submit via switchMap so the two
+    // sequential calls share one subscription and one error funnel.
     this.voteService
       .getMyVoteResponse(vote.uid)
-      .pipe(take(1))
-      .subscribe({
-        next: (myResponse) => {
+      .pipe(
+        take(1),
+        switchMap((myResponse) => {
           if (!myResponse?.uid) {
-            this.submitting.set(false);
-            this.messageService.add({
-              severity: 'error',
-              summary: 'Unable to find your invitation',
-              detail: 'We could not find your vote invitation for this ballot. Please refresh and try again.',
-              life: 5000,
-            });
-            return;
+            return throwError(() => new Error('INVITATION_NOT_FOUND'));
           }
-
           const payload: CreateVoteResponseRequest = {
             vote_response_uid: myResponse.uid,
             vote_uid: vote.uid,
             abstain: isAbstain,
             user_vote_content: userVoteContent,
           };
-
-          this.voteService
-            .createVoteResponse(payload)
-            .pipe(finalize(() => this.submitting.set(false)))
-            .subscribe({
-              next: () => {
-                this.messageService.add({
-                  severity: 'success',
-                  summary: 'Vote submitted',
-                  detail: `Your ${isAbstain ? 'abstention' : 'ballot'} has been recorded.`,
-                  life: 3000,
-                });
-                this.voteSubmitted.emit(vote.uid);
-                this.visible.set(false);
-              },
-              error: () => {
-                this.messageService.add({
-                  severity: 'error',
-                  summary: 'Unable to submit vote',
-                  detail: 'Something went wrong submitting your ballot. Please try again.',
-                  life: 5000,
-                });
-              },
-            });
+          return this.voteService.createVoteResponse(payload);
+        }),
+        finalize(() => this.submitting.set(false))
+      )
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Vote submitted',
+            detail: `Your ${isAbstain ? 'abstention' : 'ballot'} has been recorded.`,
+            life: 3000,
+          });
+          this.voteSubmitted.emit(vote.uid);
+          this.visible.set(false);
         },
-        error: () => {
-          this.submitting.set(false);
+        error: (err: Error) => {
+          const isInvitationMissing = err?.message === 'INVITATION_NOT_FOUND';
           this.messageService.add({
             severity: 'error',
-            summary: 'Unable to submit vote',
-            detail: 'We could not look up your invitation. Please refresh and try again.',
+            summary: isInvitationMissing ? 'Unable to find your invitation' : 'Unable to submit vote',
+            detail: isInvitationMissing
+              ? 'We could not find your vote invitation for this ballot. Please refresh and try again.'
+              : 'Something went wrong submitting your ballot. Please try again.',
             life: 5000,
           });
         },

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -191,28 +191,17 @@
                     }
                   } @else {
                     @if (vote.status === PollStatus.ACTIVE) {
-                      @if (vote.response_status === VoteResponseStatus.AWAITING_RESPONSE) {
-                        <lfx-button
-                          label="Vote"
-                          icon="fa-light fa-check-to-slot"
-                          severity="primary"
-                          size="small"
-                          styleClass="whitespace-nowrap"
-                          (onClick)="onViewVote(vote.uid)"
-                          [attr.data-testid]="'votes-cast-' + vote.uid">
-                        </lfx-button>
-                      } @else {
-                        <lfx-button
-                          label="Review"
-                          icon="fa-light fa-clipboard"
-                          severity="primary"
-                          [outlined]="true"
-                          size="small"
-                          styleClass="whitespace-nowrap"
-                          (onClick)="onViewVote(vote.uid)"
-                          [attr.data-testid]="'votes-cast-' + vote.uid">
-                        </lfx-button>
-                      }
+                      @let awaiting = vote.response_status === VoteResponseStatus.AWAITING_RESPONSE;
+                      <lfx-button
+                        [label]="awaiting ? 'Vote' : 'Review'"
+                        [icon]="awaiting ? 'fa-light fa-check-to-slot' : 'fa-light fa-clipboard'"
+                        severity="primary"
+                        [outlined]="!awaiting"
+                        size="small"
+                        styleClass="whitespace-nowrap"
+                        (onClick)="onViewVote(vote.uid)"
+                        [attr.data-testid]="'votes-cast-' + vote.uid">
+                      </lfx-button>
                     } @else if (vote.status === PollStatus.ENDED) {
                       <lfx-button
                         label="Results"

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -191,16 +191,28 @@
                     }
                   } @else {
                     @if (vote.status === PollStatus.ACTIVE) {
-                      <lfx-button
-                        label="Review"
-                        icon="fa-light fa-clipboard"
-                        severity="primary"
-                        [outlined]="true"
-                        size="small"
-                        styleClass="whitespace-nowrap"
-                        (onClick)="onViewVote(vote.uid)"
-                        [attr.data-testid]="'votes-cast-' + vote.uid">
-                      </lfx-button>
+                      @if (vote.response_status === VoteResponseStatus.AWAITING_RESPONSE) {
+                        <lfx-button
+                          label="Vote"
+                          icon="fa-light fa-check-to-slot"
+                          severity="primary"
+                          size="small"
+                          styleClass="whitespace-nowrap"
+                          (onClick)="onViewVote(vote.uid)"
+                          [attr.data-testid]="'votes-cast-' + vote.uid">
+                        </lfx-button>
+                      } @else {
+                        <lfx-button
+                          label="Review"
+                          icon="fa-light fa-clipboard"
+                          severity="primary"
+                          [outlined]="true"
+                          size="small"
+                          styleClass="whitespace-nowrap"
+                          (onClick)="onViewVote(vote.uid)"
+                          [attr.data-testid]="'votes-cast-' + vote.uid">
+                        </lfx-button>
+                      }
                     } @else if (vote.status === PollStatus.ENDED) {
                       <lfx-button
                         label="Results"

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -14,7 +14,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PollStatus, VOTE_LABEL } from '@lfx-one/shared';
+import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
 import { FilterPillOption, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
@@ -58,6 +58,7 @@ export class VotesTableComponent {
   // === Constants ===
   protected readonly voteLabel = VOTE_LABEL;
   protected readonly PollStatus = PollStatus;
+  protected readonly VoteResponseStatus = VoteResponseStatus;
   protected readonly statusTabOptions: FilterPillOption[] = [
     { id: 'all', label: 'All' },
     { id: PollStatus.ACTIVE, label: 'Active' },

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -65,3 +65,11 @@
   [voteId]="selectedVoteId()"
   [listVote]="selectedListVote()"
   data-testid="votes-results-drawer"></lfx-vote-results-drawer>
+
+<!-- Vote Cast Drawer — opens for active GENERIC votes the user has not yet responded to (Me lens). -->
+<lfx-vote-cast-drawer
+  [(visible)]="castDrawerVisible"
+  [voteId]="selectedVoteId()"
+  [listVote]="selectedListVote()"
+  (voteSubmitted)="onVoteSubmitted()"
+  data-testid="votes-dashboard-cast-drawer"></lfx-vote-cast-drawer>

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -109,10 +109,9 @@ export class VotesDashboardComponent {
     this.resultsDrawerVisible.set(true);
   }
 
-  // Refresh My Votes after a successful ballot submission so response_status flips to RESPONDED.
+  // Me-lens uses myVotes (refresh$); fetch$ feeds initVotes (non-Me) and would just cause extra churn.
   protected onVoteSubmitted(): void {
     this.refresh$.next();
-    this.fetch$.next();
   }
 
   protected refreshVotes(): void {

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -7,7 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { VOTE_LABEL } from '@lfx-one/shared';
+import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
 import { Committee, PaginatedResponse, ProjectContext, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
@@ -16,12 +16,13 @@ import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
 
+import { VoteCastDrawerComponent } from '../components/vote-cast-drawer/vote-cast-drawer.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
 import { VotesTableComponent } from '../components/votes-table/votes-table.component';
 
 @Component({
   selector: 'lfx-votes-dashboard',
-  imports: [LowerCasePipe, ButtonComponent, VotesTableComponent, VoteResultsDrawerComponent, RouterLink, EmptyStateComponent],
+  imports: [LowerCasePipe, ButtonComponent, VotesTableComponent, VoteResultsDrawerComponent, VoteCastDrawerComponent, RouterLink, EmptyStateComponent],
   templateUrl: './votes-dashboard.component.html',
   styleUrl: './votes-dashboard.component.scss',
 })
@@ -47,6 +48,7 @@ export class VotesDashboardComponent {
   protected readonly loading = signal<boolean>(true);
   protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly resultsDrawerVisible = signal<boolean>(false);
+  protected readonly castDrawerVisible = signal<boolean>(false);
   protected readonly selectedVoteId = signal<string | null>(null);
   protected readonly rowsPerPage = signal<number>(10);
   protected readonly currentFirst = signal<number>(0);
@@ -87,12 +89,30 @@ export class VotesDashboardComponent {
 
   protected onViewVote(voteId: string): void {
     this.selectedVoteId.set(voteId);
-    this.resultsDrawerVisible.set(true);
+
+    // Look up the picked vote synchronously — selectedListVote() hasn't re-derived yet.
+    const source = this.isMeLens() ? this.myVotes() : this.votes();
+    const picked = source.find((v) => v.uid === voteId) ?? null;
+
+    if (picked && this.shouldOpenCastDrawerFor(picked)) {
+      this.resultsDrawerVisible.set(false);
+      this.castDrawerVisible.set(true);
+    } else {
+      this.castDrawerVisible.set(false);
+      this.resultsDrawerVisible.set(true);
+    }
   }
 
   protected onViewResults(voteId: string): void {
     this.selectedVoteId.set(voteId);
+    this.castDrawerVisible.set(false);
     this.resultsDrawerVisible.set(true);
+  }
+
+  // Refresh My Votes after a successful ballot submission so response_status flips to RESPONDED.
+  protected onVoteSubmitted(): void {
+    this.refresh$.next();
+    this.fetch$.next();
   }
 
   protected refreshVotes(): void {
@@ -329,5 +349,16 @@ export class VotesDashboardComponent {
 
       return filtered;
     });
+  }
+
+  // Me lens routes all active-awaiting votes to the cast drawer (regardless of poll_type):
+  // - GENERIC renders the real ballot form
+  // - Advanced types (CONDORCET_IRV, INSTANT_RUNOFF_VOTE, MEEK_STV) render the "Coming soon"
+  //   placeholder inside the cast drawer
+  // Either way no PCC link is shown in Me lens. Project / Foundation / Organization lenses
+  // continue to open the read-only results drawer (existing behaviour) where the PCC link
+  // still lives for ops/admin workflows.
+  private shouldOpenCastDrawerFor(vote: Vote): boolean {
+    return this.isMeLens() && vote.status === PollStatus.ACTIVE && vote.response_status === VoteResponseStatus.AWAITING_RESPONSE;
   }
 }

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import {
   CreateVoteRequest,
@@ -13,7 +13,7 @@ import {
   Vote,
   VoteResultsResponse,
 } from '@lfx-one/shared/interfaces';
-import { catchError, map, Observable, of, take, tap } from 'rxjs';
+import { catchError, map, Observable, of, take, tap, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -135,11 +135,14 @@ export class VoteService {
 
   public getMyVoteResponse(voteUid: string): Observable<MyVoteResponse | null> {
     return this.http.get<MyVoteResponse | null>(`/api/votes/${voteUid}/my-response`).pipe(
-      catchError((err) => {
-        // Log the breadcrumb but degrade gracefully — callers (cast drawer) surface a user-facing
-        // toast and a `null` response triggers the "INVITATION_NOT_FOUND" path on submit.
+      catchError((err: HttpErrorResponse) => {
+        // 404 = the user genuinely has no invitation row for this vote — return null so
+        // callers can surface the "no invitation" UX. Any other error (500, network, etc.)
+        // is rethrown so the submit flow can show a generic "Unable to submit" toast
+        // instead of misreporting it as "Unable to find your invitation".
+        if (err?.status === 404) return of(null);
         console.error(`Failed to load my-response for vote ${voteUid}:`, err);
-        return of(null);
+        return throwError(() => err);
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -134,6 +134,13 @@ export class VoteService {
   }
 
   public getMyVoteResponse(voteUid: string): Observable<MyVoteResponse | null> {
-    return this.http.get<MyVoteResponse | null>(`/api/votes/${voteUid}/my-response`).pipe(catchError(() => of(null)));
+    return this.http.get<MyVoteResponse | null>(`/api/votes/${voteUid}/my-response`).pipe(
+      catchError((err) => {
+        // Log the breadcrumb but degrade gracefully — callers (cast drawer) surface a user-facing
+        // toast and a `null` response triggers the "INVITATION_NOT_FOUND" path on submit.
+        console.error(`Failed to load my-response for vote ${voteUid}:`, err);
+        return of(null);
+      })
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -3,7 +3,16 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { CreateVoteRequest, PaginatedResponse, QueryServiceCountResponse, UpdateVoteRequest, Vote, VoteResultsResponse } from '@lfx-one/shared/interfaces';
+import {
+  CreateVoteRequest,
+  CreateVoteResponseRequest,
+  MyVoteResponse,
+  PaginatedResponse,
+  QueryServiceCountResponse,
+  UpdateVoteRequest,
+  Vote,
+  VoteResultsResponse,
+} from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of, take, tap } from 'rxjs';
 
 @Injectable({
@@ -118,5 +127,13 @@ export class VoteService {
 
   public enableVote(voteUid: string): Observable<Vote> {
     return this.http.put<Vote>(`/api/votes/${voteUid}/enable`, {}).pipe(take(1));
+  }
+
+  public createVoteResponse(payload: CreateVoteResponseRequest): Observable<void> {
+    return this.http.post<void>('/api/votes/responses', payload).pipe(take(1));
+  }
+
+  public getMyVoteResponse(voteUid: string): Observable<MyVoteResponse | null> {
+    return this.http.get<MyVoteResponse | null>(`/api/votes/${voteUid}/my-response`).pipe(catchError(() => of(null)));
   }
 }

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -4,7 +4,7 @@
 import { CreateVoteRequest, CreateVoteResponseRequest, UpdateVoteRequest } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { ServiceValidationError } from '../errors';
+import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { validateRequestBody, validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { VoteService } from '../services/vote.service';
@@ -256,7 +256,22 @@ export class VoteController {
       }
 
       const response = await this.voteService.getMyVoteResponse(req, uid);
-      logger.success(req, 'get_my_vote_response', startTime, { vote_uid: uid, found: !!response });
+
+      if (!response) {
+        // Throw ResourceNotFoundError so apiErrorHandler emits a structured 404
+        // with request_id correlation — matches the surveys equivalent at
+        // SurveyController.getMyResponse. Clients distinguish "no invitation row"
+        // (404) from other failures (500/network) instead of seeing 200 + null.
+        return next(
+          new ResourceNotFoundError('Vote response', uid, {
+            operation: 'get_my_vote_response',
+            service: 'vote_controller',
+            path: `/votes/${uid}/my-response`,
+          })
+        );
+      }
+
+      logger.success(req, 'get_my_vote_response', startTime, { vote_uid: uid, found: true });
       res.json(response);
     } catch (error) {
       next(error);

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -236,11 +236,7 @@ export class VoteController {
     }
   }
 
-  /**
-   * GET /votes/:uid/my-response — current user's pre-allocated vote_response row.
-   * Used by the cast drawer to obtain the correct vote_response_uid before submitting
-   * (the voting service requires the existing invitation row's UID, not a fresh UUID).
-   */
+  /** GET /votes/:uid/my-response — pre-allocated vote_response row whose uid the cast drawer uses as vote_response_uid on submit. */
   public async getMyVoteResponse(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
     const startTime = logger.startOperation(req, 'get_my_vote_response', { vote_uid: uid });
@@ -258,10 +254,7 @@ export class VoteController {
       const response = await this.voteService.getMyVoteResponse(req, uid);
 
       if (!response) {
-        // Throw ResourceNotFoundError so apiErrorHandler emits a structured 404
-        // with request_id correlation — matches the surveys equivalent at
-        // SurveyController.getMyResponse. Clients distinguish "no invitation row"
-        // (404) from other failures (500/network) instead of seeing 200 + null.
+        // Mirrors SurveyController.getMyResponse — structured 404 lets clients distinguish "no invitation" from upstream failure.
         return next(
           new ResourceNotFoundError('Vote response', uid, {
             operation: 'get_my_vote_response',

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -237,6 +237,33 @@ export class VoteController {
   }
 
   /**
+   * GET /votes/:uid/my-response — current user's pre-allocated vote_response row.
+   * Used by the cast drawer to obtain the correct vote_response_uid before submitting
+   * (the voting service requires the existing invitation row's UID, not a fresh UUID).
+   */
+  public async getMyVoteResponse(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const startTime = logger.startOperation(req, 'get_my_vote_response', { vote_uid: uid });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'get_my_vote_response',
+          service: 'vote_controller',
+        })
+      ) {
+        return;
+      }
+
+      const response = await this.voteService.getMyVoteResponse(req, uid);
+      logger.success(req, 'get_my_vote_response', startTime, { vote_uid: uid, found: !!response });
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * POST /votes/responses
    */
   public async createVoteResponse(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/votes.route.ts
+++ b/apps/lfx-one/src/server/routes/votes.route.ts
@@ -23,6 +23,9 @@ router.get('/my-votes', (req, res, next) => voteController.getMyVotes(req, res, 
 // doesn't accidentally match 'responses' as a uid for any future POST /:uid/* route.
 router.post('/responses', (req, res, next) => voteController.createVoteResponse(req, res, next));
 
+// GET /votes/:uid/my-response - current user's pre-allocated vote_response (Me lens cast drawer)
+router.get('/:uid/my-response', (req, res, next) => voteController.getMyVoteResponse(req, res, next));
+
 // GET /votes/:uid/results - get vote results
 router.get('/:uid/results', (req, res, next) => voteController.getVoteResults(req, res, next));
 

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,11 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { VoteResponseStatus } from '@lfx-one/shared/enums';
 import {
   CreateVoteRequest,
   CreateVoteResponseRequest,
   IndexedVote,
   IndexedVoteResponse,
+  MyVoteResponse,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateVoteRequest,
@@ -330,14 +332,25 @@ export class VoteService {
       filtersOr.push(`username:${username}`);
     }
 
-    // Query vote_response records using filters_or (OR logic on data fields)
-    const responses = await fetchAllQueryResources<{ vote_uid: string }>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+    // Query vote_response records using filters_or (OR logic on data fields).
+    // `vote_status` distinguishes invited-only rows from submitted ballots — used below
+    // to stamp `response_status` on each Vote so the Me-lens UI can switch between the
+    // cast-ballot flow and the read-only results view.
+    const responses = await fetchAllQueryResources<{ vote_uid: string; vote_status?: string }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string; vote_status?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type: 'vote_response',
         filters_or: filtersOr,
         ...(pageToken && { page_token: pageToken }),
       })
     );
+
+    // Track which votes the user has already submitted a ballot for. `'submitted'` is the
+    // indexer's terminal state for a cast ballot; anything else (e.g. `'awaiting_response'`)
+    // is treated as still-invited.
+    const respondedVoteUids = new Set<string>();
+    for (const r of responses) {
+      if (r.vote_uid && r.vote_status === 'submitted') respondedVoteUids.add(r.vote_uid);
+    }
 
     // Extract unique vote UIDs
     const voteUids = [...new Set(responses.filter((r) => r.vote_uid).map((r) => r.vote_uid))];
@@ -349,13 +362,23 @@ export class VoteService {
     logger.debug(req, 'get_my_votes', 'Found user vote responses', {
       response_count: responses.length,
       unique_vote_count: voteUids.length,
+      responded_count: respondedVoteUids.size,
     });
 
-    // Fetch vote details in parallel via the voting microservice
+    // Fetch vote details in parallel via the voting microservice, then stamp
+    // `response_status` based on whether the user's vote_response row was 'submitted'.
+    // The UI consumes `response_status` on the Me lens to decide between the ballot-cast
+    // flow (AWAITING_RESPONSE) and the read-only results view (RESPONDED).
     const votes = await Promise.all(
-      voteUids.map(async (uid) => {
+      voteUids.map(async (uid): Promise<Vote | null> => {
         try {
-          return await this.microserviceProxy.proxyRequest<Vote>(req, 'LFX_V2_SERVICE', `/votes/${uid}`, 'GET');
+          const vote = await this.microserviceProxy.proxyRequest<Vote>(req, 'LFX_V2_SERVICE', `/votes/${uid}`, 'GET');
+          if (!vote) return vote;
+          const decorated: Vote = {
+            ...vote,
+            response_status: respondedVoteUids.has(uid) ? VoteResponseStatus.RESPONDED : VoteResponseStatus.AWAITING_RESPONSE,
+          };
+          return decorated;
         } catch (error) {
           logger.warning(req, 'get_my_votes', 'Failed to fetch vote details, skipping', {
             vote_uid: uid,
@@ -379,6 +402,39 @@ export class VoteService {
       });
 
     return this.projectService.enrichWithProjectData(req, sorted);
+  }
+
+  /**
+   * Fetches the current user's vote_response row for a single vote. The voting service
+   * pre-allocates these rows on invitation (one per invitee, addressable by `vote_response_uid`).
+   * Submitting a ballot via POST /vote_responses MUST reuse this UID — passing a fresh
+   * client-generated UUID returns 404 from the upstream service.
+   *
+   * Queries `type=vote_response` with filters_or on the user's email/username (same shape as
+   * getMyVotes), then matches `vote_uid` in-memory. Returns null when the user cannot be
+   * identified or no matching row exists.
+   */
+  public async getMyVoteResponse(req: Request, voteUid: string): Promise<MyVoteResponse | null> {
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = getEffectiveEmail(req);
+
+    if (!username && !email) return null;
+
+    const filtersOr: string[] = [];
+    if (email) filtersOr.push(`user_email:${email}`);
+    if (username) filtersOr.push(`username:${username}`);
+
+    const responses = await fetchAllQueryResources<MyVoteResponse>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MyVoteResponse>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'vote_response',
+        filters_or: filtersOr,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    const match = responses.find((r) => r?.vote_uid === voteUid && !!r?.uid);
+    return match ?? null;
   }
 
   // ============================================

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { VoteResponseStatus } from '@lfx-one/shared/enums';
+import { VoteResponseIndexerStatus, VoteResponseStatus } from '@lfx-one/shared/enums';
 import {
   CreateVoteRequest,
   CreateVoteResponseRequest,
@@ -286,7 +286,7 @@ export class VoteService {
             filters: [`vote_uid:${payload.vote_uid}`],
           }
         );
-        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === 'submitted');
+        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === VoteResponseIndexerStatus.SUBMITTED);
       },
       maxRetries: 5,
       retryDelayMs: 1000,
@@ -344,12 +344,12 @@ export class VoteService {
       })
     );
 
-    // Track which votes the user has already submitted a ballot for. `'submitted'` is the
-    // indexer's terminal state for a cast ballot; anything else (e.g. `'awaiting_response'`)
-    // is treated as still-invited.
+    // Track which votes the user has already submitted a ballot for.
+    // VoteResponseIndexerStatus.SUBMITTED is the indexer's terminal state for a cast ballot;
+    // anything else (e.g. VoteResponseIndexerStatus.AWAITING) is treated as still-invited.
     const respondedVoteUids = new Set<string>();
     for (const r of responses) {
-      if (r.vote_uid && r.vote_status === 'submitted') respondedVoteUids.add(r.vote_uid);
+      if (r.vote_uid && r.vote_status === VoteResponseIndexerStatus.SUBMITTED) respondedVoteUids.add(r.vote_uid);
     }
 
     // Extract unique vote UIDs

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -328,12 +328,18 @@ export class VoteService {
     if (email) filtersOr.push(`user_email:${email}`);
     if (username) filtersOr.push(`username:${username}`);
 
-    const responses = await fetchAllQueryResources<{ vote_uid: string; vote_status?: string }>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string; vote_status?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'vote_response',
-        filters_or: filtersOr,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    const responses = await fetchAllQueryResources<{ vote_uid: string; vote_status?: IndexedVoteResponseStatus }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string; vote_status?: IndexedVoteResponseStatus }>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        {
+          type: 'vote_response',
+          filters_or: filtersOr,
+          ...(pageToken && { page_token: pageToken }),
+        }
+      )
     );
 
     const respondedVoteUids = new Set<string>();

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { VoteResponseIndexerStatus, VoteResponseStatus } from '@lfx-one/shared/enums';
+import { IndexedVoteResponseStatus, VoteResponseStatus } from '@lfx-one/shared/enums';
 import {
   CreateVoteRequest,
   CreateVoteResponseRequest,
@@ -286,7 +286,7 @@ export class VoteService {
             filters: [`vote_uid:${payload.vote_uid}`],
           }
         );
-        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === VoteResponseIndexerStatus.SUBMITTED);
+        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === IndexedVoteResponseStatus.SUBMITTED);
       },
       maxRetries: 5,
       retryDelayMs: 1000,
@@ -323,19 +323,11 @@ export class VoteService {
       return [];
     }
 
-    // Build filters_or array — note: vote_response uses 'user_email' not 'email'
+    // vote_response uses 'user_email' not 'email'.
     const filtersOr: string[] = [];
-    if (email) {
-      filtersOr.push(`user_email:${email}`);
-    }
-    if (username) {
-      filtersOr.push(`username:${username}`);
-    }
+    if (email) filtersOr.push(`user_email:${email}`);
+    if (username) filtersOr.push(`username:${username}`);
 
-    // Query vote_response records using filters_or (OR logic on data fields).
-    // `vote_status` distinguishes invited-only rows from submitted ballots — used below
-    // to stamp `response_status` on each Vote so the Me-lens UI can switch between the
-    // cast-ballot flow and the read-only results view.
     const responses = await fetchAllQueryResources<{ vote_uid: string; vote_status?: string }>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string; vote_status?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type: 'vote_response',
@@ -344,12 +336,9 @@ export class VoteService {
       })
     );
 
-    // Track which votes the user has already submitted a ballot for.
-    // VoteResponseIndexerStatus.SUBMITTED is the indexer's terminal state for a cast ballot;
-    // anything else (e.g. VoteResponseIndexerStatus.AWAITING) is treated as still-invited.
     const respondedVoteUids = new Set<string>();
     for (const r of responses) {
-      if (r.vote_uid && r.vote_status === VoteResponseIndexerStatus.SUBMITTED) respondedVoteUids.add(r.vote_uid);
+      if (r.vote_uid && r.vote_status === IndexedVoteResponseStatus.SUBMITTED) respondedVoteUids.add(r.vote_uid);
     }
 
     // Extract unique vote UIDs
@@ -365,10 +354,7 @@ export class VoteService {
       responded_count: respondedVoteUids.size,
     });
 
-    // Fetch vote details in parallel via the voting microservice, then stamp
-    // `response_status` based on whether the user's vote_response row was 'submitted'.
-    // The UI consumes `response_status` on the Me lens to decide between the ballot-cast
-    // flow (AWAITING_RESPONSE) and the read-only results view (RESPONDED).
+    // Decorate each Vote with response_status so the Me-lens UI can branch cast vs view.
     const votes = await Promise.all(
       voteUids.map(async (uid): Promise<Vote | null> => {
         try {
@@ -404,16 +390,7 @@ export class VoteService {
     return this.projectService.enrichWithProjectData(req, sorted);
   }
 
-  /**
-   * Fetches the current user's vote_response row for a single vote. The voting service
-   * pre-allocates these rows on invitation (one per invitee, addressable by `vote_response_uid`).
-   * Submitting a ballot via POST /vote_responses MUST reuse this UID — passing a fresh
-   * client-generated UUID returns 404 from the upstream service.
-   *
-   * Queries `type=vote_response` with filters_or on the user's email/username (same shape as
-   * getMyVotes), then matches `vote_uid` in-memory. Returns null when the user cannot be
-   * identified or no matching row exists.
-   */
+  /** POST /vote_responses requires the pre-allocated invitation row's UID — a fresh UUID returns 404 upstream. */
   public async getMyVoteResponse(req: Request, voteUid: string): Promise<MyVoteResponse | null> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
@@ -425,15 +402,24 @@ export class VoteService {
     if (email) filtersOr.push(`user_email:${email}`);
     if (username) filtersOr.push(`username:${username}`);
 
+    // `filters` narrows on vote_uid at the index, avoiding a full-history scan per drawer open;
+    // `filters_or` then disjuncts the user-identity match. Both AND together.
     const responses = await fetchAllQueryResources<MyVoteResponse>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<MyVoteResponse>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type: 'vote_response',
+        filters: [`vote_uid:${voteUid}`],
         filters_or: filtersOr,
         ...(pageToken && { page_token: pageToken }),
       })
     );
 
-    const match = responses.find((r) => r?.vote_uid === voteUid && !!r?.uid);
+    // Defensive: `r.uid` should always be populated by the indexer, but fall back to `vote_id`
+    // (the v1 alias) if it isn't — logging the anomaly so we catch any indexer drift.
+    const match = responses.find((r) => r?.vote_uid === voteUid && (!!r?.uid || !!r?.vote_id));
+    if (match && !match.uid && match.vote_id) {
+      logger.warning(req, 'get_my_vote_response', 'vote_response row missing uid; falling back to vote_id', { vote_uid: voteUid, vote_id: match.vote_id });
+      return { ...match, uid: match.vote_id };
+    }
     return match ?? null;
   }
 

--- a/packages/shared/src/enums/poll.enum.ts
+++ b/packages/shared/src/enums/poll.enum.ts
@@ -39,3 +39,15 @@ export enum IndividualVoteStatus {
   AWAITING_RESPONSE = 'awaiting response',
   RESPONDED = 'responded',
 }
+
+/**
+ * Vote response status values as stored in the LFX query-service indexer.
+ * Used to distinguish invited-only rows from submitted ballots on vote_response resources.
+ * @description Indexer-side status for a vote_response record (different from VoteResponseStatus
+ *              which is the Me-lens decoration on Vote objects)
+ */
+export const VoteResponseIndexerStatus = {
+  AWAITING: 'awaiting_response',
+  SUBMITTED: 'submitted',
+} as const;
+

--- a/packages/shared/src/enums/poll.enum.ts
+++ b/packages/shared/src/enums/poll.enum.ts
@@ -31,23 +31,14 @@ export enum VoteResponseStatus {
   AWAITING_RESPONSE = 'awaiting_response',
 }
 
-/**
- * Individual vote status from query service
- * @description Status values as stored in lfx.index.individual_vote
- */
+/** Status values as stored in `lfx.index.individual_vote`. */
 export enum IndividualVoteStatus {
   AWAITING_RESPONSE = 'awaiting response',
   RESPONDED = 'responded',
 }
 
-/**
- * Vote response status values as stored in the LFX query-service indexer.
- * Used to distinguish invited-only rows from submitted ballots on vote_response resources.
- * @description Indexer-side status for a vote_response record (different from VoteResponseStatus
- *              which is the Me-lens decoration on Vote objects)
- */
-export const VoteResponseIndexerStatus = {
-  AWAITING: 'awaiting_response',
-  SUBMITTED: 'submitted',
-} as const;
-
+/** Raw `vote_status` values written by the v2 indexer to `vote_response` rows. */
+export enum IndexedVoteResponseStatus {
+  AWAITING_RESPONSE = 'awaiting_response',
+  SUBMITTED = 'submitted',
+}

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -215,44 +215,25 @@ export interface Vote {
   total_voting_request_invitations?: number;
   /** Number of responses received */
   num_response_received?: number;
-  /**
-   * The current user's response state for this vote, set only by the Me-lens
-   * `getMyVotes` server decoration. RESPONDED means the user has submitted a ballot
-   * (the indexed vote_response row has `vote_status === 'submitted'`); AWAITING_RESPONSE
-   * means invited but not yet voted. Absent on raw upstream Vote responses (e.g. GET /votes/:uid).
-   */
+  /** Server-decorated by getMyVotes (Me-lens only) — RESPONDED iff the indexed vote_response row has IndexedVoteResponseStatus.SUBMITTED. Absent on raw upstream Vote responses. */
   response_status?: VoteResponseStatus;
 }
 
-/**
- * Vote resource shape as returned by the query service indexer.
- * Uses `vote_uid` (v2 primary key) — NOT `uid`.
- * Normalize to canonical `Vote` shape before passing to downstream consumers.
- */
+/** Vote shape as returned by the query service indexer; uses `vote_uid` (v2 PK) not `uid`. Normalize before passing downstream. */
 export interface IndexedVote extends Omit<Vote, 'uid'> {
   vote_uid: string;
   uid?: string;
 }
 
-/**
- * Current user's vote_response row for a single vote, as returned by
- * GET /api/votes/:uid/my-response. Mirrors MySurveyResponse — the UID here is
- * the *invitation row* that was pre-allocated when the vote was enabled;
- * casting a ballot via POST /vote_responses MUST reuse this UID, otherwise the
- * voting service returns 404 because no such response exists.
- */
+/** Current user's vote_response row, returned by GET /api/votes/:uid/my-response. `uid` is the pre-allocated invitation row — POST /vote_responses must reuse it (a fresh UUID returns 404 upstream). */
 export interface MyVoteResponse {
-  /** vote_response_uid — pre-allocated by the voting service on invitation. */
   uid: string;
-  /** Parent poll identifier. */
   vote_uid: string;
-  /** Indexer status: `'awaiting_response'` until the user submits, then `'submitted'`. */
+  /** v1 alias for the response row id; identical value to `uid` when indexer populates it. */
+  vote_id?: string;
   vote_status?: string;
-  /** Whether the user has been removed from this poll's eligible list. */
   voter_removed?: boolean;
-  /** The voter's identifier in the index (whichever filter matched). */
   user_email?: string;
-  /** The voter's friendly username in the index. */
   username?: string;
 }
 

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { IndividualVoteStatus, PollStatus, PollType, VoteResponseStatus } from '../enums/poll.enum';
+import { IndexedVoteResponseStatus, IndividualVoteStatus, PollStatus, PollType, VoteResponseStatus } from '../enums/poll.enum';
 import { CommitteeReference } from './committee.interface';
 
 /**
@@ -231,7 +231,7 @@ export interface MyVoteResponse {
   vote_uid: string;
   /** v1 alias for the response row id; identical value to `uid` when indexer populates it. */
   vote_id?: string;
-  vote_status?: string;
+  vote_status?: IndexedVoteResponseStatus;
   voter_removed?: boolean;
   user_email?: string;
   username?: string;

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -215,6 +215,13 @@ export interface Vote {
   total_voting_request_invitations?: number;
   /** Number of responses received */
   num_response_received?: number;
+  /**
+   * The current user's response state for this vote, set only by the Me-lens
+   * `getMyVotes` server decoration. RESPONDED means the user has submitted a ballot
+   * (the indexed vote_response row has `vote_status === 'submitted'`); AWAITING_RESPONSE
+   * means invited but not yet voted. Absent on raw upstream Vote responses (e.g. GET /votes/:uid).
+   */
+  response_status?: VoteResponseStatus;
 }
 
 /**
@@ -225,6 +232,28 @@ export interface Vote {
 export interface IndexedVote extends Omit<Vote, 'uid'> {
   vote_uid: string;
   uid?: string;
+}
+
+/**
+ * Current user's vote_response row for a single vote, as returned by
+ * GET /api/votes/:uid/my-response. Mirrors MySurveyResponse — the UID here is
+ * the *invitation row* that was pre-allocated when the vote was enabled;
+ * casting a ballot via POST /vote_responses MUST reuse this UID, otherwise the
+ * voting service returns 404 because no such response exists.
+ */
+export interface MyVoteResponse {
+  /** vote_response_uid — pre-allocated by the voting service on invitation. */
+  uid: string;
+  /** Parent poll identifier. */
+  vote_uid: string;
+  /** Indexer status: `'awaiting_response'` until the user submits, then `'submitted'`. */
+  vote_status?: string;
+  /** Whether the user has been removed from this poll's eligible list. */
+  voter_removed?: boolean;
+  /** The voter's identifier in the index (whichever filter matched). */
+  user_email?: string;
+  /** The voter's friendly username in the index. */
+  username?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds in-app ballot casting for **plurality (`poll_type === GENERIC`)** polls on the **My Votes (Me lens)** flow. Ranked-choice methods (`condorcet_irv`, `instant_runoff_vote`, `meek_stv`) currently render a "Coming soon" placeholder — ranked-choice cast UI ships in [LFXV2-1839](https://linuxfoundation.atlassian.net/browse/LFXV2-1839) as PR 2.

JIRA: [LFXV2-1840](https://linuxfoundation.atlassian.net/browse/LFXV2-1840)

## What's new

- **`vote-cast-drawer`** — new component renders:
  - single-choice questions as radio buttons (via `lfx-radio-button` wrapper)
  - multi-choice questions as PrimeNG checkboxes with array-binding (`lfx-checkbox` wrapper only supports binary mode, so the raw `p-checkbox` is used here per the same pattern as other complex forms)
  - an Abstain toggle when `vote.allow_abstain === true`
  - a "Coming soon" placeholder for non-`GENERIC` poll types — **no PCC link inside the Me lens cast flow**
- **`getMyVotes` decorates each Vote with `response_status`** (`AWAITING_RESPONSE` / `RESPONDED`) — server-side enrichment that the Me lens uses to decide cast-vs-view
- **New endpoint** `GET /api/votes/:uid/my-response` — returns the user's pre-allocated `vote_response` row. Required because the voting service expects the existing invitation row's `vote_response_uid` on submit (a fresh client UUID returns 404 from upstream)
- **Cast-or-view branching in `votes-dashboard`** — Me-lens, active, awaiting-response rows open the cast drawer; everything else continues to open the existing read-only results drawer (current behaviour preserved)
- **`votes-table` action label** flips from "Review" to "Vote" for active-awaiting rows in Me lens (`response_status` is only set in Me lens, so the flag does double-duty as a lens marker)

## Reviewer callouts

1. **New shared type field**: `Vote.response_status?: VoteResponseStatus` in `packages/shared/src/interfaces/poll.interface.ts`. Optional on purpose — only `getMyVotes` (Me lens) decorates it; raw upstream `Vote` responses don't carry it.
2. **New shared type**: `MyVoteResponse` mirrors `MySurveyResponse`; backing the new `/my-response` endpoint.
3. **No PCC redirect in Me lens** — by design. Project/Foundation/Organization lenses still open the existing `vote-results-drawer` which retains the PCC link for ops/admin paths.
4. **Submit chain uses `switchMap`** (`vote-cast-drawer.component.ts:onSubmit`) — getMyVoteResponse → createVoteResponse with one error funnel and a sentinel error message (`INVITATION_NOT_FOUND`) to differentiate the two failure modes.

## Known limitation (separate ticket)

`lfx-v2-voting-service`'s `POST /vote_responses` still **proxies to v1 Salesforce ITX**. Any vote that originated in v2 (`POST /votes` without a Salesforce sync) returns 404 on submit because v1 has no record of it. Real prod votes (synced from v1) work end-to-end. Pure v2-only test votes do not. Tracked in [LFXV2-1842](https://linuxfoundation.atlassian.net/browse/LFXV2-1842).

## Follow-up PRs (tracked separately)

- **[LFXV2-1839](https://linuxfoundation.atlassian.net/browse/LFXV2-1839)** — Ranked-choice cast UI (Condorcet IRV / IRV / Meek STV) + ranked-choice results rendering. Blocked by this PR landing.
- **[LFXV2-1841](https://linuxfoundation.atlassian.net/browse/LFXV2-1841)** — My Vote Response drawer (surveys-parity read-only view of submitted ballot). Backend (`getMyVoteResponse`) already ships in this PR.
- **[LFXV2-1842](https://linuxfoundation.atlassian.net/browse/LFXV2-1842)** — Backend: v2-native ballot submission in `lfx-v2-voting-service`.

## Test plan

- [ ] Me lens, GENERIC + single_choice + `allow_abstain=true` → drawer renders radios (Approve/Reject) + Abstain toggle. Submit succeeds for v1-synced votes; fails gracefully with toast for v2-only votes.
- [ ] Me lens, GENERIC + single_choice + `allow_abstain=false` → radios only, no abstain section.
- [ ] Me lens, GENERIC + multiple_choice + `allow_abstain=true` → "Select all that apply" hint + checkboxes + Abstain toggle.
- [ ] Me lens, GENERIC + multiple_choice + `allow_abstain=false` → checkboxes only, no abstain.
- [ ] Me lens, GENERIC + multi-question (single + multi) → both question types render correctly in one ballot.
- [ ] Me lens, CONDORCET_IRV (or any non-GENERIC) → "Coming soon" placeholder, no PCC link visible.
- [ ] After a successful submit, the row's `response_status` flips to `RESPONDED` on refresh; the action button flips from "Vote" to "Review" and clicking opens the aggregate results drawer.
- [ ] Project lens (non-Me) on the same votes → action button is "Review" (not "Vote") and clicking opens the existing read-only results drawer. No regressions.
- [ ] Abstain toggle disables question controls and re-enables them on toggle-off.
- [ ] Submit button is disabled while no choice is selected (for non-abstain submits) and during the in-flight submit.
- [ ] Error toasts surface for INVITATION_NOT_FOUND (404 lookup) and upstream submit failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1839]: https://linuxfoundation.atlassian.net/browse/LFXV2-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1840]: https://linuxfoundation.atlassian.net/browse/LFXV2-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1842]: https://linuxfoundation.atlassian.net/browse/LFXV2-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ