### PR TITLE
feat(voting): add ranked-choice cast UI and ranked results rendering

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
@@ -54,14 +54,6 @@
             </div>
           }
         </div>
-      } @else if (!isGenericPoll()) {
-        <div class="flex flex-col items-center justify-center py-12 px-6 text-center" data-testid="vote-cast-drawer-unsupported">
-          <div class="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mb-6">
-            <i class="fa-light fa-hourglass-half text-2xl text-blue-600"></i>
-          </div>
-          <h2 class="text-xl font-semibold text-slate-900 mb-3">Coming soon</h2>
-          <p class="text-sm text-slate-600 max-w-md">Ballot casting for ranked-choice voting methods is on the way and will be available here shortly.</p>
-        </div>
       } @else if (questions().length === 0) {
         <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="vote-cast-drawer-no-questions">
           <p class="text-sm text-gray-500">This vote has no questions to answer.</p>
@@ -78,13 +70,48 @@
             <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-3" [attr.data-testid]="'vote-cast-question-' + question.question_id">
               <div class="flex flex-col gap-1">
                 <h3 class="text-sm font-semibold text-slate-900">{{ question.prompt }}</h3>
-                @if (question.type === 'multiple_choice') {
+                @if (isRankedPoll()) {
+                  <p class="text-xs text-slate-500">Drag to reorder, or use the arrow buttons. Top of the list is your first choice.</p>
+                } @else if (question.type === 'multiple_choice') {
                   <p class="text-xs text-slate-500">Select all that apply.</p>
                 }
               </div>
 
               <div class="flex flex-col gap-2">
-                @if (question.type === 'single_choice') {
+                @if (isRankedPoll()) {
+                  <div cdkDropList (cdkDropListDropped)="onRankedDrop(question.question_id, $event)" class="flex flex-col gap-2">
+                    @for (choice of rankedOrderByQuestion().get(question.question_id) ?? question.choices; track choice.choice_id; let i = $index) {
+                      <div
+                        cdkDrag
+                        class="flex items-center gap-3 p-3 bg-white border border-slate-200 rounded-lg cursor-move hover:bg-slate-50"
+                        [attr.data-testid]="'vote-cast-rank-' + choice.choice_id">
+                        <i cdkDragHandle class="fa-light fa-grip-vertical text-slate-400" aria-hidden="true"></i>
+                        <span class="flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-700 text-sm font-semibold flex-shrink-0">
+                          {{ i + 1 }}
+                        </span>
+                        <span class="flex-1 text-sm text-slate-800">{{ choice.choice_text }}</span>
+                        <button
+                          type="button"
+                          (click)="moveRank(question.question_id, i, i - 1)"
+                          [disabled]="i === 0"
+                          class="p-1 text-slate-500 hover:text-slate-700 disabled:opacity-30"
+                          [attr.data-testid]="'vote-cast-rank-up-' + choice.choice_id"
+                          aria-label="Move up">
+                          <i class="fa-light fa-arrow-up" aria-hidden="true"></i>
+                        </button>
+                        <button
+                          type="button"
+                          (click)="moveRank(question.question_id, i, i + 1)"
+                          [disabled]="i === question.choices.length - 1"
+                          class="p-1 text-slate-500 hover:text-slate-700 disabled:opacity-30"
+                          [attr.data-testid]="'vote-cast-rank-down-' + choice.choice_id"
+                          aria-label="Move down">
+                          <i class="fa-light fa-arrow-down" aria-hidden="true"></i>
+                        </button>
+                      </div>
+                    }
+                  </div>
+                } @else if (question.type === 'single_choice') {
                   @for (choice of question.choices; track choice.choice_id) {
                     <lfx-radio-button
                       [form]="form"

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.html
@@ -79,11 +79,19 @@
 
               <div class="flex flex-col gap-2">
                 @if (isRankedPoll()) {
-                  <div cdkDropList (cdkDropListDropped)="onRankedDrop(question.question_id, $event)" class="flex flex-col gap-2">
+                  <div
+                    cdkDropList
+                    [cdkDropListDisabled]="abstain()"
+                    (cdkDropListDropped)="onRankedDrop(question.question_id, $event)"
+                    class="flex flex-col gap-2"
+                    [class.opacity-60]="abstain()">
                     @for (choice of rankedOrderByQuestion().get(question.question_id) ?? question.choices; track choice.choice_id; let i = $index) {
                       <div
                         cdkDrag
-                        class="flex items-center gap-3 p-3 bg-white border border-slate-200 rounded-lg cursor-move hover:bg-slate-50"
+                        [cdkDragDisabled]="abstain()"
+                        class="flex items-center gap-3 p-3 bg-white border border-slate-200 rounded-lg hover:bg-slate-50"
+                        [class.cursor-move]="!abstain()"
+                        [class.cursor-not-allowed]="abstain()"
                         [attr.data-testid]="'vote-cast-rank-' + choice.choice_id">
                         <i cdkDragHandle class="fa-light fa-grip-vertical text-slate-400" aria-hidden="true"></i>
                         <span class="flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-700 text-sm font-semibold flex-shrink-0">
@@ -93,19 +101,19 @@
                         <button
                           type="button"
                           (click)="moveRank(question.question_id, i, i - 1)"
-                          [disabled]="i === 0"
+                          [disabled]="i === 0 || abstain()"
                           class="p-1 text-slate-500 hover:text-slate-700 disabled:opacity-30"
                           [attr.data-testid]="'vote-cast-rank-up-' + choice.choice_id"
-                          aria-label="Move up">
+                          [attr.aria-label]="'Move ' + choice.choice_text + ' up'">
                           <i class="fa-light fa-arrow-up" aria-hidden="true"></i>
                         </button>
                         <button
                           type="button"
                           (click)="moveRank(question.question_id, i, i + 1)"
-                          [disabled]="i === question.choices.length - 1"
+                          [disabled]="i === question.choices.length - 1 || abstain()"
                           class="p-1 text-slate-500 hover:text-slate-700 disabled:opacity-30"
                           [attr.data-testid]="'vote-cast-rank-down-' + choice.choice_id"
-                          aria-label="Move down">
+                          [attr.aria-label]="'Move ' + choice.choice_text + ' down'">
                           <i class="fa-light fa-arrow-down" aria-hidden="true"></i>
                         </button>
                       </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -77,7 +77,12 @@ export class VoteCastDrawerComponent {
   protected readonly abstain: Signal<boolean> = toSignal(this.abstainControl.valueChanges, { initialValue: this.abstainControl.value });
 
   // === Computed Signals ===
-  protected readonly isGenericPoll: Signal<boolean> = computed(() => this.vote()?.poll_type === PollType.GENERIC);
+  // Missing poll_type defaults to GENERIC (parity with vote-results-drawer.initIsGenericPoll) so the plurality branch renders when upstream omits the field.
+  protected readonly isGenericPoll: Signal<boolean> = computed(() => {
+    const v = this.vote();
+    if (!v) return false;
+    return (v.poll_type ?? PollType.GENERIC) === PollType.GENERIC;
+  });
   protected readonly isRankedPoll: Signal<boolean> = this.initIsRankedPoll();
   protected readonly questions: Signal<PollQuestion[]> = computed(() => this.vote()?.poll_questions ?? []);
   protected readonly allowAbstain: Signal<boolean> = computed(() => !!this.vote()?.allow_abstain);

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -117,7 +117,7 @@ export class VoteCastDrawerComponent {
     this.visible.set(false);
   }
 
-  /** Reorder via CDK drag-and-drop — setValue fires statusChanges so submitDisabled re-evaluates. */
+  /** Reorder via CDK drag-and-drop — bumpFormVersion() drives submitDisabled re-evaluation since rebuildForm/setValue here suppress statusChanges. */
   protected onRankedDrop(questionId: string, event: CdkDragDrop<string[]>): void {
     const control = this.form.get(questionId);
     if (!control) return;

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -66,6 +66,8 @@ export class VoteCastDrawerComponent {
   protected readonly submitting = signal<boolean>(false);
   // Reactive dependency for submitDisabled — rebuildForm uses { emitEvent: false }, so statusChanges is silent.
   private readonly formVersion = signal<number>(0);
+  // Tracks the poll_type the form was last built for; if it changes (e.g., list vote omitted poll_type and detail fetch supplied a ranked one), rebuildForm wipes controls so they get the right shape.
+  private lastBuiltPollType: PollType | null = null;
 
   // === Shared Observables ===
   private readonly voteId$ = toObservable(this.voteId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
@@ -260,7 +262,15 @@ export class VoteCastDrawerComponent {
   // === Private Helpers ===
   /** Reconciles the form against the current vote's questions; ranked polls seed declared order so the form is valid on load. */
   private rebuildForm(questions: PollQuestion[]): void {
+    const currentPollType = this.vote()?.poll_type ?? PollType.GENERIC;
     const pollIsRanked = this.isRankedPoll();
+    // If poll_type flipped between builds (e.g., list vote omitted it → detail fetch supplied a ranked one), wipe all controls so they get re-added with the correct shape.
+    if (this.lastBuiltPollType !== null && this.lastBuiltPollType !== currentPollType) {
+      for (const existingId of Object.keys(this.form.controls)) {
+        this.form.removeControl(existingId, { emitEvent: false });
+      }
+    }
+    this.lastBuiltPollType = currentPollType;
     const desiredIds = new Set(questions.map((q) => q.question_id));
     for (const existingId of Object.keys(this.form.controls)) {
       if (!desiredIds.has(existingId)) this.form.removeControl(existingId, { emitEvent: false });

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, inject, input, model, output, signal, Signal } from '@angular/core';
@@ -10,7 +11,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PollType } from '@lfx-one/shared';
-import { CreateVoteResponseRequest, PollQuestion, Vote, VoteAnswerInput } from '@lfx-one/shared/interfaces';
+import { CreateVoteResponseRequest, PollQuestion, UserChoice, Vote, VoteAnswerInput } from '@lfx-one/shared/interfaces';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { VoteService } from '@services/vote.service';
@@ -28,6 +29,7 @@ const INVITATION_NOT_FOUND = 'INVITATION_NOT_FOUND';
     DrawerModule,
     SkeletonModule,
     CheckboxModule,
+    DragDropModule,
     ReactiveFormsModule,
     ButtonComponent,
     RadioButtonComponent,
@@ -76,9 +78,12 @@ export class VoteCastDrawerComponent {
 
   // === Computed Signals ===
   protected readonly isGenericPoll: Signal<boolean> = computed(() => this.vote()?.poll_type === PollType.GENERIC);
+  protected readonly isRankedPoll: Signal<boolean> = this.initIsRankedPoll();
   protected readonly questions: Signal<PollQuestion[]> = computed(() => this.vote()?.poll_questions ?? []);
   protected readonly allowAbstain: Signal<boolean> = computed(() => !!this.vote()?.allow_abstain);
   protected readonly submitDisabled: Signal<boolean> = this.initSubmitDisabled();
+  // Map<question_id, ordered choices> — recomputed when questions or formVersion changes; replaces a per-render method call in @for.
+  protected readonly rankedOrderByQuestion: Signal<Map<string, UserChoice[]>> = this.initRankedOrderByQuestion();
 
   public constructor() {
     // Rebuild the form when the loaded vote's questions change.
@@ -110,6 +115,27 @@ export class VoteCastDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
+  }
+
+  /** Reorder via CDK drag-and-drop — setValue fires statusChanges so submitDisabled re-evaluates. */
+  protected onRankedDrop(questionId: string, event: CdkDragDrop<string[]>): void {
+    const control = this.form.get(questionId);
+    if (!control) return;
+    const current = [...((control.value as string[] | null) ?? [])];
+    moveItemInArray(current, event.previousIndex, event.currentIndex);
+    control.setValue(current);
+    this.bumpFormVersion();
+  }
+
+  /** Keyboard / arrow-button reorder fallback for the drag list. */
+  protected moveRank(questionId: string, fromIndex: number, toIndex: number): void {
+    const control = this.form.get(questionId);
+    if (!control) return;
+    const current = [...((control.value as string[] | null) ?? [])];
+    if (toIndex < 0 || toIndex >= current.length) return;
+    moveItemInArray(current, fromIndex, toIndex);
+    control.setValue(current);
+    this.bumpFormVersion();
   }
 
   protected onSubmit(): void {
@@ -187,6 +213,13 @@ export class VoteCastDrawerComponent {
     );
   }
 
+  private initIsRankedPoll(): Signal<boolean> {
+    return computed(() => {
+      const t = this.vote()?.poll_type;
+      return !!t && t !== PollType.GENERIC;
+    });
+  }
+
   private initSubmitDisabled(): Signal<boolean> {
     return computed(() => {
       this.formVersion(); // re-evaluate when controls are added/removed/disabled via { emitEvent: false }
@@ -196,16 +229,43 @@ export class VoteCastDrawerComponent {
     });
   }
 
+  private initRankedOrderByQuestion(): Signal<Map<string, UserChoice[]>> {
+    return computed(() => {
+      this.formVersion(); // re-evaluate when ranked-order setValue calls bumpFormVersion
+      const result = new Map<string, UserChoice[]>();
+      if (!this.isRankedPoll()) return result;
+      for (const question of this.questions()) {
+        const order = this.form.get(question.question_id)?.value as string[] | null | undefined;
+        if (!order?.length) {
+          result.set(question.question_id, question.choices);
+          continue;
+        }
+        const byId = new Map(question.choices.map((c) => [c.choice_id, c]));
+        result.set(
+          question.question_id,
+          order.map((id) => byId.get(id)).filter((c): c is UserChoice => !!c)
+        );
+      }
+      return result;
+    });
+  }
+
   // === Private Helpers ===
-  // Reconciles the form against the current vote's questions; bumps formVersion since we suppress emitEvent.
+  /** Reconciles the form against the current vote's questions; ranked polls seed declared order so the form is valid on load. */
   private rebuildForm(questions: PollQuestion[]): void {
+    const pollIsRanked = this.isRankedPoll();
     const desiredIds = new Set(questions.map((q) => q.question_id));
     for (const existingId of Object.keys(this.form.controls)) {
       if (!desiredIds.has(existingId)) this.form.removeControl(existingId, { emitEvent: false });
     }
     for (const question of questions) {
       if (this.form.contains(question.question_id)) continue;
-      if (question.type === 'multiple_choice') {
+      if (pollIsRanked) {
+        const seeded = question.choices.map((c) => c.choice_id);
+        this.form.addControl(question.question_id, new FormControl<string[]>(seeded, { nonNullable: true, validators: [Validators.required] }), {
+          emitEvent: false,
+        });
+      } else if (question.type === 'multiple_choice') {
         this.form.addControl(question.question_id, new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] }), {
           emitEvent: false,
         });
@@ -221,10 +281,21 @@ export class VoteCastDrawerComponent {
   }
 
   private buildAnswers(questions: PollQuestion[]): VoteAnswerInput[] {
-    return questions.map((q) => ({
-      question_id: q.question_id,
-      choice_ids: this.normaliseChoiceIds(this.form.get(q.question_id)?.value),
-    }));
+    const pollIsRanked = this.isRankedPoll();
+    return questions.map((q) => {
+      const raw = this.form.get(q.question_id)?.value as string | string[] | null | undefined;
+      if (pollIsRanked) {
+        const order = Array.isArray(raw) ? raw : [];
+        return {
+          question_id: q.question_id,
+          ranked_choices: order.map((choiceId, idx) => ({ choice_id: choiceId, choice_rank: idx + 1 })),
+        };
+      }
+      return {
+        question_id: q.question_id,
+        choice_ids: this.normaliseChoiceIds(raw),
+      };
+    });
   }
 
   private normaliseChoiceIds(raw: unknown): string[] {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-cast-drawer/vote-cast-drawer.component.ts
@@ -240,7 +240,9 @@ export class VoteCastDrawerComponent {
       const result = new Map<string, UserChoice[]>();
       if (!this.isRankedPoll()) return result;
       for (const question of this.questions()) {
-        const order = this.form.get(question.question_id)?.value as string[] | null | undefined;
+        // Defensive Array.isArray — if a stale non-array control value lingers (e.g. mid-session vote reshape), fall back to declared order.
+        const raw = this.form.get(question.question_id)?.value;
+        const order = Array.isArray(raw) ? (raw as string[]) : null;
         if (!order?.length) {
           result.set(question.question_id, question.choices);
           continue;

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -153,7 +153,7 @@
           @if (commentResults().length > 0) {
             <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
               <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
-              @for (commentResult of commentResults(); track commentResult.prompt) {
+              @for (commentResult of commentResults(); track $index) {
                 <div class="flex flex-col gap-2">
                   <h3 class="text-sm font-medium text-slate-700">{{ commentResult.prompt }}</h3>
                   @for (comment of commentResult.comments; track $index) {
@@ -249,7 +249,7 @@
           @if (commentResults().length > 0) {
             <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
               <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
-              @for (commentResult of commentResults(); track commentResult.prompt) {
+              @for (commentResult of commentResults(); track $index) {
                 <div class="flex flex-col gap-2">
                   <h3 class="text-sm font-medium text-slate-700">{{ commentResult.prompt }}</h3>
                   @for (comment of commentResult.comments; track $index) {
@@ -367,7 +367,7 @@
         @if (commentResults().length > 0) {
           <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
             <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
-            @for (commentResult of commentResults(); track commentResult.prompt) {
+            @for (commentResult of commentResults(); track $index) {
               <div class="flex flex-col gap-2">
                 <h3 class="text-sm font-medium text-slate-700">{{ commentResult.prompt }}</h3>
                 @for (comment of commentResult.comments; track $index) {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -79,32 +79,95 @@
           </div>
         </div>
       } @else if (!isGenericPoll()) {
-        <!-- Non-Generic Poll - Redirect to PCC -->
-        <div class="flex flex-col items-center justify-center py-12 px-6 text-center" data-testid="vote-results-pcc-redirect">
-          <div class="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mb-6">
-            <i class="fa-light fa-arrow-up-right-from-square text-2xl text-blue-600"></i>
+        <!-- Ranked-choice results (replaces the old PCC redirect) -->
+        <div class="flex flex-col gap-6" data-testid="vote-results-ranked">
+          <!-- Voting method + algorithm banner -->
+          <div class="rounded-lg bg-slate-50 border border-slate-200 p-4 flex items-start gap-3" data-testid="vote-results-ranked-method">
+            <i class="fa-light fa-list-ol text-2xl text-blue-600 flex-shrink-0 mt-0.5"></i>
+            <div class="flex flex-col gap-1">
+              <h3 class="text-sm font-semibold text-slate-900">{{ votingMethodText() }}</h3>
+              <p class="text-xs text-slate-600">
+                Ranked-choice voting: voters ranked the choices in order of preference. The algorithm tallies first-preference votes and reallocates from
+                eliminated choices until a winner emerges.
+              </p>
+            </div>
           </div>
 
-          <h2 class="text-xl font-semibold text-slate-900 mb-3">Advanced Voting Method</h2>
+          <!-- Participation summary -->
+          <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 flex flex-col gap-3" data-testid="vote-results-ranked-participation">
+            <div class="flex items-center justify-between text-sm text-slate-600">
+              <div class="text-center flex-1">
+                <p class="text-xs text-slate-500">Total Participants</p>
+                <p class="font-semibold text-slate-900 text-lg">{{ participationStats().eligibleVoters }}</p>
+              </div>
+              <div class="text-center flex-1">
+                <p class="text-xs text-slate-500">Total Responses</p>
+                <p class="font-semibold text-slate-900 text-lg">{{ participationStats().totalResponses }}</p>
+              </div>
+              <div class="text-center flex-1">
+                <p class="text-xs text-slate-500">Response Rate</p>
+                <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
+              </div>
+            </div>
+            <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
+              <div class="h-full bg-blue-500 transition-all" [style.width.%]="participationStats().participationRate"></div>
+            </div>
+          </div>
 
-          <p class="text-sm text-slate-600 mb-6 max-w-md">
-            This vote uses <span class="font-medium">{{ votingMethodText() }}</span
-            >, an advanced voting method. Results for this vote type are available in the Project Control Center.
-          </p>
+          <!-- Per-question rank distribution -->
+          @if (rankedQuestions().length > 0) {
+            @for (q of rankedQuestions(); track q.questionId) {
+              <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-4" [attr.data-testid]="'vote-results-ranked-question-' + q.questionId">
+                <h4 class="text-sm font-semibold text-slate-900">{{ q.prompt }}</h4>
 
-          <a [href]="pccVotingUrl()" target="_blank" rel="noopener noreferrer" class="inline-block">
-            <lfx-button
-              label="View in Project Control Center"
-              icon="fa-light fa-arrow-up-right-from-square"
-              severity="primary"
-              data-testid="vote-results-pcc-link"></lfx-button>
-          </a>
+                <div class="flex flex-col gap-3">
+                  @for (row of q.choiceDistributions; track row.choiceId) {
+                    <div class="flex flex-col gap-2" [attr.data-testid]="'vote-results-ranked-choice-' + row.choiceId">
+                      <div class="flex items-center justify-between gap-2">
+                        <span class="text-sm font-medium text-slate-800">{{ row.choiceText }}</span>
+                        <span class="text-xs text-slate-500">{{ row.totalRanked }} {{ row.totalRanked === 1 ? 'voter' : 'voters' }}</span>
+                      </div>
 
-          <!-- Vote Details Section for non-generic polls -->
+                      @if (row.rankCounts.length > 0) {
+                        <div class="flex flex-col gap-1">
+                          @for (rc of row.rankCounts; track rc.rank) {
+                            <div class="flex items-center gap-2 text-xs">
+                              <span class="w-14 text-slate-600 flex-shrink-0">Rank {{ rc.rank }}</span>
+                              <div class="flex-1 bg-slate-100 rounded h-2 overflow-hidden">
+                                <div class="bg-blue-500 h-full rounded" [style.width.%]="rc.percentage"></div>
+                              </div>
+                              <span class="w-8 text-right text-slate-700 flex-shrink-0">{{ rc.count }}</span>
+                            </div>
+                          }
+                        </div>
+                      } @else {
+                        <p class="text-xs text-slate-500 italic">No rankings recorded yet.</p>
+                      }
+                    </div>
+                  }
+                </div>
+
+                <!-- Round summary placeholder (IRV / Meek STV) -->
+                @if (q.hasRoundSummary) {
+                  <div
+                    class="rounded-md border border-slate-200 bg-slate-50 p-3 flex items-center gap-2"
+                    [attr.data-testid]="'vote-results-ranked-rounds-' + q.questionId">
+                    <i class="fa-light fa-arrows-rotate text-slate-500"></i>
+                    <p class="text-xs text-slate-600">Round-by-round details available from the voting service. Detailed round visualization is coming soon.</p>
+                  </div>
+                }
+              </div>
+            }
+          } @else {
+            <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="vote-results-ranked-empty">
+              <p class="text-sm text-gray-500">No ranked results recorded yet.</p>
+            </div>
+          }
+
+          <!-- Vote Details -->
           @if (voteData.description) {
-            <div class="w-full mt-8 pt-6 border-t border-slate-200 text-left" data-testid="vote-results-details">
-              <h3 class="text-base font-semibold text-slate-900 mb-2">Vote Details</h3>
-              <p class="text-sm text-slate-700 leading-relaxed"><span class="font-medium">Description:</span></p>
+            <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2" data-testid="vote-results-details">
+              <h4 class="text-sm font-semibold text-slate-900">Vote Details</h4>
               <div class="vote-description text-sm text-slate-700 leading-relaxed" [innerHTML]="voteData.description"></div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -164,6 +164,25 @@
             </div>
           }
 
+          <!-- Comments (parity with generic-live and final-results branches — ranked polls can
+               have comment prompts too; previously these were silently hidden in the PCC-redirect
+               branch). -->
+          @if (commentResults().length > 0) {
+            <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
+              <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
+              @for (commentResult of commentResults(); track commentResult.prompt) {
+                <div class="flex flex-col gap-2">
+                  <h3 class="text-sm font-medium text-slate-700">{{ commentResult.prompt }}</h3>
+                  @for (comment of commentResult.comments; track $index) {
+                    <div class="p-3 bg-slate-50 rounded-lg border border-slate-200">
+                      <p class="text-sm text-slate-700">{{ comment }}</p>
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          }
+
           <!-- Vote Details -->
           @if (voteData.description) {
             <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2" data-testid="vote-results-details">

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -70,7 +70,7 @@
       } @else if (!isGenericPoll()) {
         <div class="flex flex-col gap-6" data-testid="vote-results-ranked">
           <div class="rounded-lg bg-slate-50 border border-slate-200 p-4 flex items-start gap-3" data-testid="vote-results-ranked-method">
-            <i class="fa-light fa-list-ol text-2xl text-blue-600 flex-shrink-0 mt-0.5"></i>
+            <i class="fa-light fa-list-ol text-2xl text-blue-600 flex-shrink-0 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-slate-900">{{ votingMethodText() }}</h3>
               <p class="text-xs text-slate-600">{{ rankedMethodDescription() }}</p>
@@ -119,6 +119,7 @@
                                 <div class="bg-blue-500 h-full rounded" [style.width.%]="rc.percentage"></div>
                               </div>
                               <span class="w-8 text-right text-slate-700 flex-shrink-0">{{ rc.count }}</span>
+                              <span class="w-12 text-right text-slate-600 flex-shrink-0">{{ rc.percentage }}%</span>
                             </div>
                           }
                         </div>
@@ -137,7 +138,7 @@
                   <div
                     class="rounded-md border border-slate-200 bg-slate-50 p-3 flex items-center gap-2"
                     [attr.data-testid]="'vote-results-ranked-rounds-' + q.questionId">
-                    <i class="fa-light fa-arrows-rotate text-slate-500"></i>
+                    <i class="fa-light fa-arrows-rotate text-slate-500" aria-hidden="true"></i>
                     <p class="text-xs text-slate-600">Round-by-round details available from the voting service. Detailed round visualization is coming soon.</p>
                   </div>
                 }

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -73,10 +73,7 @@
             <i class="fa-light fa-list-ol text-2xl text-blue-600 flex-shrink-0 mt-0.5"></i>
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-slate-900">{{ votingMethodText() }}</h3>
-              <p class="text-xs text-slate-600">
-                Ranked-choice voting: voters ranked the choices in order of preference. The algorithm tallies first-preference votes and reallocates from
-                eliminated choices until a winner emerges.
-              </p>
+              <p class="text-xs text-slate-600">{{ rankedMethodDescription() }}</p>
             </div>
           </div>
 
@@ -129,6 +126,10 @@
                         <p class="text-xs text-slate-500 italic">No rankings recorded yet.</p>
                       }
                     </div>
+                  } @empty {
+                    <p class="text-sm text-gray-500 italic" [attr.data-testid]="'vote-results-ranked-question-empty-' + q.questionId">
+                      No ranked results recorded yet for this question.
+                    </p>
                   }
                 </div>
 

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -9,10 +9,8 @@
   styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full vote-results-drawer"
   data-testid="vote-results-drawer">
   @if (vote(); as voteData) {
-    <!-- Header Section -->
     <ng-template #header>
       <div class="flex flex-col gap-3 w-full pr-4" data-testid="vote-results-drawer-header">
-        <!-- Title Row with Close Button -->
         <div class="flex items-center justify-between gap-2">
           <h1 class="text-lg sm:text-xl font-semibold text-slate-900 flex-1 min-w-0 truncate" data-testid="vote-results-drawer-title">
             {{ voteData.name }}
@@ -26,38 +24,30 @@
           </button>
         </div>
 
-        <!-- Status and Meta Info -->
         <div class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
-          <!-- Committee Badge -->
           <span class="bg-blue-100 text-blue-700 text-xs px-2.5 py-1 rounded font-medium">
             {{ voteData.committee_name || 'Unknown' }}
           </span>
           <span class="text-slate-400">•</span>
-          <!-- Status -->
           <lfx-tag
             [value]="voteData.status | pollStatusLabel"
             [severity]="voteData.status | pollStatusSeverity"
             data-testid="vote-results-drawer-status"></lfx-tag>
           <span class="text-slate-400">•</span>
-          <!-- Close Date -->
           @if (isVoteClosed()) {
             <span>Closed {{ voteData.end_time | date: 'MMM d, y' }}</span>
           } @else {
             <span>Due {{ voteData.end_time | date: 'MMM d, y' }}</span>
           }
           <span class="text-slate-400">•</span>
-          <!-- Voting Method -->
           <span>{{ votingMethodText() }}</span>
         </div>
       </div>
     </ng-template>
 
-    <!-- Content Section -->
     <div class="flex flex-col gap-6" data-testid="vote-results-drawer-content">
       @if (isLoading()) {
-        <!-- Loading Skeleton -->
         <div class="flex flex-col gap-6">
-          <!-- Participation Stats Skeleton -->
           <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 flex flex-col gap-3">
             <div class="flex items-center justify-between">
               <p-skeleton width="80px" height="40px"></p-skeleton>
@@ -67,7 +57,6 @@
             <p-skeleton width="100%" height="8px"></p-skeleton>
           </div>
 
-          <!-- Questions Skeleton -->
           <div class="flex flex-col gap-4">
             <p-skeleton width="150px" height="24px"></p-skeleton>
             @for (i of [1, 2, 3]; track i) {
@@ -79,9 +68,7 @@
           </div>
         </div>
       } @else if (!isGenericPoll()) {
-        <!-- Ranked-choice results (replaces the old PCC redirect) -->
         <div class="flex flex-col gap-6" data-testid="vote-results-ranked">
-          <!-- Voting method + algorithm banner -->
           <div class="rounded-lg bg-slate-50 border border-slate-200 p-4 flex items-start gap-3" data-testid="vote-results-ranked-method">
             <i class="fa-light fa-list-ol text-2xl text-blue-600 flex-shrink-0 mt-0.5"></i>
             <div class="flex flex-col gap-1">
@@ -93,7 +80,6 @@
             </div>
           </div>
 
-          <!-- Participation summary -->
           <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 flex flex-col gap-3" data-testid="vote-results-ranked-participation">
             <div class="flex items-center justify-between text-sm text-slate-600">
               <div class="text-center flex-1">
@@ -114,7 +100,6 @@
             </div>
           </div>
 
-          <!-- Per-question rank distribution -->
           @if (rankedQuestions().length > 0) {
             @for (q of rankedQuestions(); track q.questionId) {
               <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-4" [attr.data-testid]="'vote-results-ranked-question-' + q.questionId">
@@ -147,7 +132,6 @@
                   }
                 </div>
 
-                <!-- Round summary placeholder (IRV / Meek STV) -->
                 @if (q.hasRoundSummary) {
                   <div
                     class="rounded-md border border-slate-200 bg-slate-50 p-3 flex items-center gap-2"
@@ -164,9 +148,6 @@
             </div>
           }
 
-          <!-- Comments (parity with generic-live and final-results branches — ranked polls can
-               have comment prompts too; previously these were silently hidden in the PCC-redirect
-               branch). -->
           @if (commentResults().length > 0) {
             <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
               <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
@@ -183,7 +164,6 @@
             </div>
           }
 
-          <!-- Vote Details -->
           @if (voteData.description) {
             <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2" data-testid="vote-results-details">
               <h4 class="text-sm font-semibold text-slate-900">Vote Details</h4>
@@ -192,9 +172,7 @@
           }
         </div>
       } @else if (!isVoteClosed()) {
-        <!-- Live/Active Vote - Simplified Layout -->
         <div class="flex flex-col gap-6">
-          <!-- Vote Details Section (at top for live votes) -->
           @if (voteData.description) {
             <div class="flex flex-col gap-4" data-testid="vote-results-details">
               <h2 class="text-lg font-semibold text-slate-900">Vote Details</h2>
@@ -203,18 +181,15 @@
             </div>
           }
 
-          <!-- Live Results -->
           <div class="flex flex-col gap-6" data-testid="vote-results-questions">
             <h2 class="text-lg font-semibold text-slate-900">Live Results</h2>
 
             @for (question of questionsWithResults(); track question.questionId; let idx = $index) {
               <div class="flex flex-col gap-4">
-                <!-- Question Header (only show for multi-question) -->
                 @if (questionsWithResults().length > 1) {
                   <h3 class="text-base font-semibold text-slate-900">Q{{ idx + 1 }}. {{ question.question }}</h3>
                 }
 
-                <!-- Options with horizontal bars -->
                 <div class="flex flex-col gap-3">
                   @for (option of question.options; track option.choiceId) {
                     <div class="flex flex-col gap-1.5" [attr.data-testid]="'vote-results-option-' + option.choiceId">
@@ -240,7 +215,6 @@
             }
           </div>
 
-          <!-- Participation Summary (at bottom for live votes) -->
           <div class="pt-4 border-t border-slate-200 flex flex-col gap-4">
             <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 flex flex-col gap-3" data-testid="vote-results-participation">
               <div class="flex items-center justify-between text-sm text-slate-600">
@@ -258,13 +232,11 @@
                 </div>
               </div>
 
-              <!-- Participation Progress Bar -->
               <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
                 <div class="h-full bg-blue-500 transition-all" [style.width.%]="participationStats().participationRate"></div>
               </div>
             </div>
 
-            <!-- Admin Governance Note -->
             <div class="p-3 bg-blue-50 border border-blue-200 rounded-lg">
               <p class="text-sm text-blue-800">
                 As the creator, you can monitor live results and close the vote when ready. Final results will be available after the vote closes.
@@ -272,7 +244,6 @@
             </div>
           </div>
 
-          <!-- Comments Section -->
           @if (commentResults().length > 0) {
             <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
               <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
@@ -290,12 +261,9 @@
           }
         </div>
       } @else {
-        <!-- Closed Vote - Final Results Layout -->
         <div class="flex flex-col gap-6">
-          <!-- Title -->
           <h2 class="text-xl font-semibold text-slate-900">Final Results</h2>
 
-          <!-- Participation Bar (at top for closed votes) -->
           <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 flex flex-col gap-3" data-testid="vote-results-participation">
             <div class="flex items-center justify-between text-sm text-slate-600">
               <div class="text-center flex-1">
@@ -312,17 +280,14 @@
               </div>
             </div>
 
-            <!-- Participation Progress Bar -->
             <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
               <div class="h-full bg-blue-500 transition-all" [style.width.%]="participationStats().participationRate"></div>
             </div>
           </div>
 
-          <!-- Question Results -->
           <div class="flex flex-col gap-6 mt-2" data-testid="vote-results-questions">
             @for (question of questionsWithResults(); track question.questionId; let idx = $index) {
               <div class="flex flex-col gap-4">
-                <!-- Question Header -->
                 <h3 class="text-base font-semibold text-slate-900">
                   @if (questionsWithResults().length > 1) {
                     Q{{ idx + 1 }}.
@@ -330,7 +295,6 @@
                   {{ question.question }}
                 </h3>
 
-                <!-- Options with Vote Results -->
                 <div class="flex flex-col gap-3">
                   @for (option of question.options; track option.choiceId) {
                     <div
@@ -382,7 +346,6 @@
                         </div>
                       </div>
 
-                      <!-- Progress Bar -->
                       <div class="w-full bg-white rounded-full h-2 overflow-hidden">
                         <div
                           class="h-full transition-all"
@@ -399,7 +362,6 @@
           </div>
         </div>
 
-        <!-- Comments Section -->
         @if (commentResults().length > 0) {
           <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-comments">
             <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
@@ -416,7 +378,6 @@
           </div>
         }
 
-        <!-- Vote Details Section (at bottom for closed votes) -->
         @if (voteData.description) {
           <div class="flex flex-col gap-4 pt-4 border-t border-slate-200" data-testid="vote-results-details">
             <h2 class="text-lg font-semibold text-slate-900">Vote Details</h2>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -112,7 +112,9 @@ export class VoteResultsDrawerComponent {
   private initIsGenericPoll(): Signal<boolean> {
     return computed(() => {
       const v = this.vote();
-      return v?.poll_type === PollType.GENERIC;
+      if (!v) return false;
+      // Missing poll_type defaults to GENERIC (matches initVotingMethodText) so the plurality branch renders.
+      return (v.poll_type ?? PollType.GENERIC) === PollType.GENERIC;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -6,31 +6,21 @@ import { Component, computed, inject, input, model, signal, Signal } from '@angu
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { TagComponent } from '@components/tag/tag.component';
 import { PollStatus, PollType } from '@lfx-one/shared';
-import { PollCommentResult, Vote, VoteParticipationStats, VoteResultsOption, VoteResultsQuestion, VoteResultsResponse } from '@lfx-one/shared/interfaces';
+import {
+  PollCommentResult,
+  RankedQuestionView,
+  Vote,
+  VoteParticipationStats,
+  VoteResultsOption,
+  VoteResultsQuestion,
+  VoteResultsResponse,
+} from '@lfx-one/shared/interfaces';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { VoteService } from '@services/vote.service';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, finalize, of, shareReplay, startWith, switchMap } from 'rxjs';
-
-/**
- * Local view model for ranked-choice question rendering. Derived from
- * `PollQuestionResult` by `initRankedQuestions`. Kept local because it's purely
- * a presentation-layer reshape; promote to `@lfx-one/shared/interfaces` if a
- * second consumer ever needs it.
- */
-interface RankedQuestionView {
-  questionId: string;
-  prompt: string;
-  choiceDistributions: {
-    choiceId: string;
-    choiceText: string;
-    totalRanked: number;
-    rankCounts: { rank: number; count: number; percentage: number }[];
-  }[];
-  hasRoundSummary: boolean;
-}
 
 @Component({
   selector: 'lfx-vote-results-drawer',
@@ -200,20 +190,14 @@ export class VoteResultsDrawerComponent {
     });
   }
 
-  // Derives the ranked-choice per-question view model from raw poll_results.
-  // For each question we build per-choice rank distributions (rank, count, percentage)
-  // and flag whether the upstream returned a round-by-round summary (IRV / Meek STV)
-  // so the template can show a placeholder banner — the round payload itself is
-  // currently untyped (`any`) so detailed visualization is deferred.
+  /** Derives the ranked-choice per-question view model — round-summary payload is untyped upstream so detailed visualization is deferred to a placeholder banner. */
   private initRankedQuestions(): Signal<RankedQuestionView[]> {
     return computed(() => {
       const results = this.voteResults();
       if (!results?.poll_results?.length) return [];
 
       return results.poll_results.map((pr) => {
-        // Choice text resolution: prefer the winner_info candidate list (it carries
-        // choice_text), fall back to the question's own choices. Defensive both ways
-        // in case upstream omits either.
+        // Choice text: prefer winner_info.poll_choices, fall back to question.choices.
         const choiceTextById = new Map((pr.ranked_choice_winner_info?.poll_choices ?? pr.question.choices ?? []).map((c) => [c.choice_id, c.choice_text]));
 
         const choiceDistributions = (pr.ranked_choice_votes ?? []).map((rcv) => {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -59,6 +59,7 @@ export class VoteResultsDrawerComponent {
   protected readonly rankedQuestions: Signal<RankedQuestionView[]> = this.initRankedQuestions();
   protected readonly commentResults: Signal<PollCommentResult[]> = this.initCommentResults();
   protected readonly votingMethodText: Signal<string> = this.initVotingMethodText();
+  protected readonly rankedMethodDescription: Signal<string> = this.initRankedMethodDescription();
 
   // === Protected Methods ===
   protected onClose(): void {
@@ -258,6 +259,22 @@ export class VoteResultsDrawerComponent {
 
       const pollType = v.poll_type ?? PollType.GENERIC;
       return methodLabels[pollType] || pollType;
+    });
+  }
+
+  private initRankedMethodDescription(): Signal<string> {
+    return computed(() => {
+      const pollType = this.vote()?.poll_type;
+      switch (pollType) {
+        case PollType.CONDORCET_IRV:
+          return 'Voters ranked the choices in order of preference. Condorcet IRV first looks for a candidate who would beat every other candidate in head-to-head pairwise comparisons; if no such Condorcet winner exists, it falls back to instant-runoff elimination.';
+        case PollType.INSTANT_RUNOFF_VOTE:
+          return 'Voters ranked the choices in order of preference. Instant-runoff voting tallies first-preference votes and eliminates the lowest-ranked choice each round, reallocating those ballots until a candidate has a majority.';
+        case PollType.MEEK_STV:
+          return 'Voters ranked the choices in order of preference. Meek STV is a multi-winner single-transferable-vote method that elects candidates as they meet a quota and proportionally redistributes surplus and eliminated ballots.';
+        default:
+          return 'Voters ranked the choices in order of preference. The configured ranked-choice algorithm determines the winner (or winners).';
+      }
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -4,9 +4,7 @@
 import { DatePipe } from '@angular/common';
 import { Component, computed, inject, input, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { environment } from '@environments/environment';
 import { PollStatus, PollType } from '@lfx-one/shared';
 import { PollCommentResult, Vote, VoteParticipationStats, VoteResultsOption, VoteResultsQuestion, VoteResultsResponse } from '@lfx-one/shared/interfaces';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
@@ -16,9 +14,27 @@ import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, finalize, of, shareReplay, startWith, switchMap } from 'rxjs';
 
+/**
+ * Local view model for ranked-choice question rendering. Derived from
+ * `PollQuestionResult` by `initRankedQuestions`. Kept local because it's purely
+ * a presentation-layer reshape; promote to `@lfx-one/shared/interfaces` if a
+ * second consumer ever needs it.
+ */
+interface RankedQuestionView {
+  questionId: string;
+  prompt: string;
+  choiceDistributions: {
+    choiceId: string;
+    choiceText: string;
+    totalRanked: number;
+    rankCounts: { rank: number; count: number; percentage: number }[];
+  }[];
+  hasRoundSummary: boolean;
+}
+
 @Component({
   selector: 'lfx-vote-results-drawer',
-  imports: [DrawerModule, TagComponent, ButtonComponent, DatePipe, PollStatusLabelPipe, PollStatusSeverityPipe, SkeletonModule],
+  imports: [DrawerModule, TagComponent, DatePipe, PollStatusLabelPipe, PollStatusSeverityPipe, SkeletonModule],
   templateUrl: './vote-results-drawer.component.html',
   styleUrl: './vote-results-drawer.component.scss',
 })
@@ -46,11 +62,11 @@ export class VoteResultsDrawerComponent {
 
   // === Computed Signals ===
   protected readonly isGenericPoll: Signal<boolean> = this.initIsGenericPoll();
-  protected readonly pccVotingUrl: Signal<string> = this.initPccVotingUrl();
   protected readonly isLoading: Signal<boolean> = computed(() => this.loadingVoteDetails() || this.loadingVoteResults());
   protected readonly participationStats: Signal<VoteParticipationStats> = this.initParticipationStats();
   protected readonly isVoteClosed: Signal<boolean> = this.initIsVoteClosed();
   protected readonly questionsWithResults: Signal<VoteResultsQuestion[]> = this.initQuestionsWithResults();
+  protected readonly rankedQuestions: Signal<RankedQuestionView[]> = this.initRankedQuestions();
   protected readonly commentResults: Signal<PollCommentResult[]> = this.initCommentResults();
   protected readonly votingMethodText: Signal<string> = this.initVotingMethodText();
 
@@ -107,18 +123,6 @@ export class VoteResultsDrawerComponent {
     return computed(() => {
       const v = this.vote();
       return v?.poll_type === PollType.GENERIC;
-    });
-  }
-
-  private initPccVotingUrl(): Signal<string> {
-    return computed(() => {
-      const v = this.vote();
-      if (!v) return '';
-
-      const pccBaseUrl = environment.urls.pcc;
-      // Remove trailing slash if present
-      const baseUrl = pccBaseUrl.endsWith('/') ? pccBaseUrl.slice(0, -1) : pccBaseUrl;
-      return `${baseUrl}/project/${v.project_uid}/collaboration/voting`;
     });
   }
 
@@ -191,6 +195,47 @@ export class VoteResultsDrawerComponent {
           question: pollResult.question.prompt,
           options: processedOptions,
           totalVotes,
+        };
+      });
+    });
+  }
+
+  // Derives the ranked-choice per-question view model from raw poll_results.
+  // For each question we build per-choice rank distributions (rank, count, percentage)
+  // and flag whether the upstream returned a round-by-round summary (IRV / Meek STV)
+  // so the template can show a placeholder banner — the round payload itself is
+  // currently untyped (`any`) so detailed visualization is deferred.
+  private initRankedQuestions(): Signal<RankedQuestionView[]> {
+    return computed(() => {
+      const results = this.voteResults();
+      if (!results?.poll_results?.length) return [];
+
+      return results.poll_results.map((pr) => {
+        // Choice text resolution: prefer the winner_info candidate list (it carries
+        // choice_text), fall back to the question's own choices. Defensive both ways
+        // in case upstream omits either.
+        const choiceTextById = new Map((pr.ranked_choice_winner_info?.poll_choices ?? pr.question.choices ?? []).map((c) => [c.choice_id, c.choice_text]));
+
+        const choiceDistributions = (pr.ranked_choice_votes ?? []).map((rcv) => {
+          const totalRanked = rcv.rank_counts.reduce((sum, rc) => sum + rc.count, 0);
+          const rankCounts = rcv.rank_counts.map((rc) => ({
+            rank: rc.rank,
+            count: rc.count,
+            percentage: totalRanked > 0 ? Math.round((rc.count / totalRanked) * 100) : 0,
+          }));
+          return {
+            choiceId: rcv.choice_id,
+            choiceText: choiceTextById.get(rcv.choice_id) ?? rcv.choice_id,
+            totalRanked,
+            rankCounts,
+          };
+        });
+
+        return {
+          questionId: pr.question.question_id,
+          prompt: pr.question.prompt,
+          choiceDistributions,
+          hasRoundSummary: !!pr.irv_round_summary || !!pr.meek_stv_round_summary,
         };
       });
     });

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -675,3 +675,26 @@ export interface UpdateVoteRequest {
   /** Winning threshold percentage required */
   winning_threshold_percentage?: number;
 }
+
+/** Per-rank distribution row for a ranked-choice question (drawer-side projection of RankedChoiceVoteResult.rank_counts). */
+export interface RankCountDistribution {
+  rank: number;
+  count: number;
+  percentage: number;
+}
+
+/** Per-choice rank distribution for a ranked-choice question (drawer-side projection of PollQuestionResult.ranked_choice_votes). */
+export interface RankedChoiceDistribution {
+  choiceId: string;
+  choiceText: string;
+  totalRanked: number;
+  rankCounts: RankCountDistribution[];
+}
+
+/** Drawer-side view model for a ranked-choice question — projection of PollQuestionResult assembled by VoteResultsDrawerComponent.initRankedQuestions. */
+export interface RankedQuestionView {
+  questionId: string;
+  prompt: string;
+  choiceDistributions: RankedChoiceDistribution[];
+  hasRoundSummary: boolean;
+}


### PR DESCRIPTION
## Summary

Builds on **[#710](https://github.com/linuxfoundation/lfx-self-serve/pull/710)** ([LFXV2-1840](https://linuxfoundation.atlassian.net/browse/LFXV2-1840)) which shipped the Plurality (GENERIC) cast flow. With this PR landed, the full **LFX One My Votes** flow supports every `PollType` end-to-end on the UI side — Plurality, Condorcet IRV, Instant Runoff Vote, and Meek STV.

JIRA: [LFXV2-1839](https://linuxfoundation.atlassian.net/browse/LFXV2-1839)

> **Stacked on #710.** PR base is `feat/LFXV2-1840-ballot-casting-plurality`. After #710 merges into `main`, GitHub will auto-retarget this PR to `main` (or I'll retarget manually).

## What's new

### Cast drawer — ranked-choice cast UI
- Replaces the **"Coming soon"** placeholder for non-`GENERIC` poll types with a real drag-to-rank cast UI using `@angular/cdk/drag-drop` (already a dep — no install needed).
- Each ranked choice renders as a draggable card with a grip handle, a 1-based rank badge, and **up/down arrow buttons** that double as a **keyboard-accessible reorder fallback** (`aria-label`s on both).
- The per-question `FormControl` for ranked questions holds the **ordered `choice_ids[]`** array. `rebuildForm` seeds controls with the question's declared choice order, so the form is valid on load — the no-touch default ranking is the declared order.
- `buildAnswers` branches on `poll_type`:
  - non-GENERIC → emits `ranked_choices: [{ choice_id, choice_rank }]` (1-based)
  - GENERIC → keeps existing `choice_ids` shape (no regression)

### Results drawer — ranked-choice results rendering
- Replaces the **"Advanced Voting Method → View in PCC"** redirect for non-GENERIC poll types with **real ranked-choice results rendering**.
- New per-question card shows **rank distribution per choice** (rank, count, percentage bar) plus a **participation summary** that matches the GENERIC paths (eligible voters / responses / response rate + progress bar).
- **Round-by-round details (IRV / Meek STV)** currently render a "coming soon" banner — upstream `irv_round_summary` / `meek_stv_round_summary` are typed `any`, so structured rendering is deferred to a follow-up.
- **Dropped imports/state:** removed `ButtonComponent` and `environment` imports + `pccVotingUrl` signal / `initPccVotingUrl` initializer. **No PCC link anywhere in the drawer now.**
- Added a local `RankedQuestionView` view-model type (JSDoc invites promotion to `@lfx-one/shared/interfaces` if a second consumer ever needs it).

## Reviewer callouts

1. **`@angular/cdk/drag-drop` first use in the repo** — `DragDropModule` + `CdkDragDrop` + `moveItemInArray`. `@angular/cdk@20.2.14` was already declared in `apps/lfx-one/package.json` so this PR doesn't change deps.
2. **Default ranking = declared order.** If a user opens a ranked ballot and submits without dragging, the recorded ballot reflects the declared choice order. This matches most ranked-choice UIs as the no-touch default; verify with PM if you want partial-rank semantics instead.
3. **`vote-results-drawer` PCC redirect is gone** — both for ops/admin lenses and the Me lens. If anyone still relies on a "View in PCC" escape hatch from the results drawer, flag now.
4. **No backend changes required** — the cast payload shape (`VoteAnswerInput.ranked_choices`) and the results endpoint already expose everything we render.

## Known limitation (separate ticket)

Same SFDC submit blocker as [#710](https://github.com/linuxfoundation/lfx-self-serve/pull/710): `lfx-v2-voting-service POST /vote_responses` still proxies to v1 Salesforce ITX, so v2-only votes return 404. Real prod votes that originated in v1 (or were cross-synced) work end-to-end. Tracked in [LFXV2-1842](https://linuxfoundation.atlassian.net/browse/LFXV2-1842).

## Follow-up PRs (tracked separately)

- **[LFXV2-1841](https://linuxfoundation.atlassian.net/browse/LFXV2-1841)** — My Vote Response drawer (surveys-parity read-only view of submitted ballot).
- **[LFXV2-1842](https://linuxfoundation.atlassian.net/browse/LFXV2-1842)** — Backend: v2-native ballot submission in `lfx-v2-voting-service`.

## Test plan

- [ ] Open a ranked-choice vote (CONDORCET_IRV / INSTANT_RUNOFF_VOTE / MEEK_STV) from Me lens → cast drawer renders draggable list (not "Coming soon" placeholder).
- [ ] Drag a choice to a new position → its rank badge updates; submit button stays enabled (form valid).
- [ ] Use the up/down arrow buttons to reorder → keyboard reorder works; top/bottom buttons correctly disable.
- [ ] Submit a ranked ballot on a real (v1-synced) prod vote → succeeds end-to-end with toast confirmation.
- [ ] Submit a ranked ballot on a v2-only test vote → falls through to the SFDC 404 path; "Unable to submit vote" toast appears. (Same behavior as #710's Plurality path.)
- [ ] Toggle "Abstain from this vote" on a ranked poll with `allow_abstain=true` → drag list disables; submit goes through with `abstain: true`.
- [ ] Open a ranked vote from **Project / Foundation / Organization lens** OR from Me lens after responding → results drawer opens with the new ranked-choice rendering (per-choice rank bars + participation summary + round-summary placeholder when present). **No PCC link visible.**
- [ ] GENERIC (Plurality) votes still work exactly as in #710 — no regression in the existing radio/checkbox/abstain flows or in the GENERIC results display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1840]: https://linuxfoundation.atlassian.net/browse/LFXV2-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1839]: https://linuxfoundation.atlassian.net/browse/LFXV2-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1842]: https://linuxfoundation.atlassian.net/browse/LFXV2-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ