### PR TITLE
feat(dashboards): add marketing attribution section and tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -1,0 +1,88 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="attribution-section">
+  <!-- Header -->
+  <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-base font-semibold text-gray-900">Marketing attribution</h3>
+      <p class="text-xs text-gray-500">Revenue by channel · {{ foundationName() || 'All foundations' }}</p>
+    </div>
+    <div class="flex items-center gap-3">
+      <lfx-select
+        [form]="modelForm"
+        control="model"
+        [options]="modelOptions"
+        optionLabel="label"
+        optionValue="value"
+        placeholder="Select model"
+        ariaLabel="Select attribution model"
+        styleClass="w-[150px]"
+        data-testid="attribution-model-select" />
+      <lfx-button
+        label="Open detail"
+        icon="fa-light fa-arrow-up-right-from-square"
+        severity="secondary"
+        [outlined]="true"
+        [disabled]="true"
+        ariaLabel="Open attribution detail (coming soon)"
+        data-testid="attribution-open-detail-btn" />
+    </div>
+  </div>
+
+  <!-- Alert banner -->
+  <div class="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2" data-testid="attribution-alert">
+    <i class="fa-light fa-triangle-exclamation mt-0.5 text-sm text-amber-600" aria-hidden="true"></i>
+    <p class="text-xs text-amber-800">Attribution data is directional. Models assign credit differently — compare models to validate insights.</p>
+  </div>
+
+  <!-- Table -->
+  @if (loading()) {
+    <div class="flex flex-col gap-3" data-testid="attribution-skeleton">
+      @for (i of [1, 2, 3, 4, 5]; track i) {
+        <div class="flex items-center gap-4">
+          <div class="h-4 w-28 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-4 flex-1 animate-pulse rounded bg-gray-100"></div>
+          <div class="h-4 w-20 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    </div>
+  } @else if (hasData()) {
+    <div class="flex flex-col gap-0" data-testid="attribution-table">
+      <!-- Table header -->
+      <div class="flex items-center gap-4 border-b border-gray-200 pb-2">
+        <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">CHANNEL</span>
+        <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">REVENUE SHARE</span>
+        <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">REVENUE</span>
+        <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">SESSIONS</span>
+      </div>
+
+      <!-- Rows -->
+      @for (row of channelRows(); track row.channel) {
+        <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" [attr.data-testid]="'attribution-row-' + row.channel">
+          <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.channel }}</span>
+          <div class="flex flex-1 items-center gap-2">
+            <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+              <div class="h-full rounded-full bg-blue-500" [style.width.%]="row.sharePercent"></div>
+            </div>
+            <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sharePercent | number: '1.0-0' }}%</span>
+          </div>
+          <span class="w-24 text-right text-xs font-medium text-gray-900">{{ row.revenueFormatted }}</span>
+          <span class="w-20 text-right text-xs text-gray-500">{{ row.sessionsFormatted }}</span>
+        </div>
+      }
+
+      <!-- Footer total -->
+      <div class="flex items-center gap-4 pt-2">
+        <span class="w-36 text-xs font-semibold text-gray-900">Total</span>
+        <div class="flex-1"></div>
+        <span class="w-24 text-right text-xs font-semibold text-gray-900">{{ totalRevenue() }}</span>
+        <span class="w-20"></span>
+      </div>
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="attribution-empty">
+      <p class="text-sm text-gray-500">No attribution data available.</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -48,27 +48,33 @@
       }
     </div>
   } @else if (hasData()) {
-    <div class="flex flex-col gap-0" data-testid="attribution-table">
+    <div class="flex flex-col gap-0" data-testid="attribution-table" role="table" aria-label="Marketing attribution by channel">
       <!-- Table header -->
-      <div class="flex items-center gap-4 border-b border-gray-200 pb-2">
-        <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">CHANNEL</span>
-        <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">REVENUE SHARE</span>
-        <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">REVENUE</span>
-        <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">SESSIONS</span>
+      <div class="flex items-center gap-4 border-b border-gray-200 pb-2" role="row">
+        <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CHANNEL</span>
+        <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE SHARE</span>
+        <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
+        <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSIONS</span>
       </div>
 
       <!-- Rows -->
       @for (row of channelRows(); track row.channel) {
-        <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" [attr.data-testid]="'attribution-row-' + row.channel">
-          <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.channel }}</span>
-          <div class="flex flex-1 items-center gap-2">
+        <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" [attr.data-testid]="'attribution-row-' + row.channel" role="row">
+          <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.channel }}</span>
+          <div class="flex flex-1 items-center gap-2" role="cell">
             <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
-              <div class="h-full rounded-full bg-blue-500" [style.width.%]="row.sharePercent"></div>
+              <div
+                class="h-full rounded-full bg-blue-500"
+                role="progressbar"
+                [attr.aria-valuenow]="row.sharePercent"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                [style.width.%]="row.sharePercent"></div>
             </div>
             <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sharePercent | number: '1.0-0' }}%</span>
           </div>
-          <span class="w-24 text-right text-xs font-medium text-gray-900">{{ row.revenueFormatted }}</span>
-          <span class="w-20 text-right text-xs text-gray-500">{{ row.sessionsFormatted }}</span>
+          <span class="w-24 text-right text-xs font-medium text-gray-900" role="cell">{{ row.revenueFormatted }}</span>
+          <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.sessionsFormatted }}</span>
         </div>
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -69,6 +69,7 @@
                 [attr.aria-valuenow]="row.sharePercent"
                 aria-valuemin="0"
                 aria-valuemax="100"
+                [attr.aria-label]="row.channel + ' revenue share'"
                 [style.width.%]="row.sharePercent"></div>
             </div>
             <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sharePercent | number: '1.0-0' }}%</span>
@@ -79,11 +80,11 @@
       }
 
       <!-- Footer total -->
-      <div class="flex items-center gap-4 pt-2">
-        <span class="w-36 text-xs font-semibold text-gray-900">Total</span>
-        <div class="flex-1"></div>
-        <span class="w-24 text-right text-xs font-semibold text-gray-900">{{ totalRevenue() }}</span>
-        <span class="w-20"></span>
+      <div class="flex items-center gap-4 pt-2" role="row">
+        <span class="w-36 text-xs font-semibold text-gray-900" role="cell">Total</span>
+        <div class="flex-1" role="cell"></div>
+        <span class="w-24 text-right text-xs font-semibold text-gray-900" role="cell">{{ totalRevenue() }}</span>
+        <span class="w-20" role="cell"></span>
       </div>
     </div>
   } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -1,0 +1,130 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectComponent } from '@components/select/select.component';
+import { ATTRIBUTION_MODEL_OPTIONS } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, startWith, switchMap, tap } from 'rxjs';
+
+import type {
+  AttributionChannelRow,
+  AttributionModel,
+  AttributionModelOption,
+  MarketingAttributionChannel,
+  MarketingAttributionResponse,
+} from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-attribution-section',
+  imports: [DecimalPipe, ReactiveFormsModule, SelectComponent, ButtonComponent],
+  templateUrl: './attribution-section.component.html',
+  styleUrl: './attribution-section.component.scss',
+})
+export class AttributionSectionComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly fb = inject(FormBuilder);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === Forms ===
+  protected readonly modelForm = this.fb.nonNullable.group({
+    model: ['linear' as AttributionModel],
+  });
+
+  protected readonly modelOptions: AttributionModelOption[] = ATTRIBUTION_MODEL_OPTIONS;
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly attributionData: Signal<MarketingAttributionResponse | null> = this.initAttributionData();
+  protected readonly selectedModel: Signal<AttributionModel> = this.initSelectedModel();
+  protected readonly channelRows: Signal<AttributionChannelRow[]> = this.initChannelRows();
+  protected readonly totalRevenue: Signal<string> = this.initTotalRevenue();
+  protected readonly hasData = computed(() => this.channelRows().length > 0);
+
+  // === Private Initializers ===
+  private initAttributionData(): Signal<MarketingAttributionResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getMarketingAttribution(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initSelectedModel(): Signal<AttributionModel> {
+    return toSignal(this.modelForm.controls.model.valueChanges.pipe(startWith('linear' as AttributionModel)), {
+      initialValue: 'linear' as AttributionModel,
+    });
+  }
+
+  private initChannelRows(): Signal<AttributionChannelRow[]> {
+    return computed(() => {
+      const data = this.attributionData();
+      const model = this.selectedModel();
+      if (!data?.channels?.length) return [];
+
+      const revenueKey = this.getRevenueKey(model);
+      const total = data.channels.reduce((sum, ch) => sum + (ch[revenueKey] as number), 0);
+
+      return data.channels
+        .map((ch): AttributionChannelRow => {
+          const revenue = ch[revenueKey] as number;
+          return {
+            channel: ch.channel,
+            revenue,
+            revenueFormatted: formatCurrency(revenue),
+            sharePercent: total > 0 ? (revenue / total) * 100 : 0,
+            sessions: ch.sessions,
+            sessionsFormatted: formatNumber(ch.sessions),
+            raw: ch,
+          };
+        })
+        .sort((a, b) => b.revenue - a.revenue);
+    });
+  }
+
+  private initTotalRevenue(): Signal<string> {
+    return computed(() => {
+      const rows = this.channelRows();
+      const total = rows.reduce((sum, r) => sum + r.revenue, 0);
+      return formatCurrency(total);
+    });
+  }
+
+  // === Private Helpers ===
+  private getRevenueKey(model: AttributionModel): keyof MarketingAttributionChannel {
+    const map: Record<AttributionModel, keyof MarketingAttributionChannel> = {
+      linear: 'linearRevenue',
+      firstTouch: 'firstTouchRevenue',
+      lastTouch: 'lastTouchRevenue',
+      timeDecay: 'timeDecayRevenue',
+    };
+    return map[model];
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -36,6 +36,14 @@ export class AttributionSectionComponent {
 
   protected readonly modelOptions: AttributionModelOption[] = ATTRIBUTION_MODEL_OPTIONS;
 
+  // === Static ===
+  private static readonly revenueKeyByModel: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
+    linear: 'linearRevenue',
+    firstTouch: 'firstTouchRevenue',
+    lastTouch: 'lastTouchRevenue',
+    timeDecay: 'timeDecayRevenue',
+  };
+
   // === WritableSignals ===
   protected readonly loading = signal(false);
 
@@ -109,14 +117,7 @@ export class AttributionSectionComponent {
   }
 
   // === Private Helpers ===
-  private static readonly REVENUE_KEY_BY_MODEL: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
-    linear: 'linearRevenue',
-    firstTouch: 'firstTouchRevenue',
-    lastTouch: 'lastTouchRevenue',
-    timeDecay: 'timeDecayRevenue',
-  };
-
   private getRevenueKey(model: AttributionModel): 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue' {
-    return AttributionSectionComponent.REVENUE_KEY_BY_MODEL[model];
+    return AttributionSectionComponent.revenueKeyByModel[model];
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -10,15 +10,9 @@ import { SelectComponent } from '@components/select/select.component';
 import { ATTRIBUTION_MODEL_OPTIONS } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, startWith, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, startWith, switchMap } from 'rxjs';
 
-import type {
-  AttributionChannelRow,
-  AttributionModel,
-  AttributionModelOption,
-  MarketingAttributionChannel,
-  MarketingAttributionResponse,
-} from '@lfx-one/shared/interfaces';
+import type { AttributionChannelRow, AttributionModel, AttributionModelOption, MarketingAttributionResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-attribution-section',
@@ -65,11 +59,8 @@ export class AttributionSectionComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getMarketingAttribution(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            catchError(() => of(null)),
+            finalize(() => this.loading.set(false))
           );
         })
       ),
@@ -90,11 +81,11 @@ export class AttributionSectionComponent {
       if (!data?.channels?.length) return [];
 
       const revenueKey = this.getRevenueKey(model);
-      const total = data.channels.reduce((sum, ch) => sum + (ch[revenueKey] as number), 0);
+      const total = data.channels.reduce((sum, ch) => sum + ch[revenueKey], 0);
 
       return data.channels
         .map((ch): AttributionChannelRow => {
-          const revenue = ch[revenueKey] as number;
+          const revenue = ch[revenueKey];
           return {
             channel: ch.channel,
             revenue,
@@ -118,13 +109,14 @@ export class AttributionSectionComponent {
   }
 
   // === Private Helpers ===
-  private getRevenueKey(model: AttributionModel): keyof MarketingAttributionChannel {
-    const map: Record<AttributionModel, keyof MarketingAttributionChannel> = {
-      linear: 'linearRevenue',
-      firstTouch: 'firstTouchRevenue',
-      lastTouch: 'lastTouchRevenue',
-      timeDecay: 'timeDecayRevenue',
-    };
-    return map[model];
+  private static readonly REVENUE_KEY_BY_MODEL: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
+    linear: 'linearRevenue',
+    firstTouch: 'firstTouchRevenue',
+    lastTouch: 'lastTouchRevenue',
+    timeDecay: 'timeDecayRevenue',
+  };
+
+  private getRevenueKey(model: AttributionModel): 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue' {
+    return AttributionSectionComponent.REVENUE_KEY_BY_MODEL[model];
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -32,6 +32,10 @@
     } @else {
       @for (kpi of performanceSummaryKpis(); track kpi.id) {
         <lfx-sparkline-kpi-card [kpi]="kpi" />
+      } @empty {
+        <div class="col-span-full text-center py-8 text-sm text-gray-500" data-testid="overview-tab-kpi-empty">
+          No performance data available for this period.
+        </div>
       }
     }
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -36,3 +36,5 @@
     }
   </div>
 </div>
+
+<lfx-attribution-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-attribution-section" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -10,11 +10,12 @@ import { catchError, forkJoin, of, switchMap, tap } from 'rxjs';
 
 import type { AttributionData, BrandReachResponse, EmailCtrResponse, PerformanceSummaryKpi, RevenueImpactResponse } from '@lfx-one/shared/interfaces';
 
+import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [ButtonComponent, SparklineKpiCardComponent],
+  imports: [ButtonComponent, SparklineKpiCardComponent, AttributionSectionComponent],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -6,9 +6,9 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, forkJoin, of, switchMap, tap } from 'rxjs';
+import { finalize, forkJoin, of, switchMap } from 'rxjs';
 
-import type { AttributionData, BrandReachResponse, EmailCtrResponse, PerformanceSummaryKpi, RevenueImpactResponse } from '@lfx-one/shared/interfaces';
+import type { AttributionData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
@@ -49,10 +49,10 @@ export class OverviewTabComponent {
           }
           this.loading.set(true);
           return forkJoin({
-            revenueImpact: this.analyticsService.getRevenueImpact(slug).pipe(catchError(() => of(null as RevenueImpactResponse | null))),
-            brandReach: this.analyticsService.getBrandReach(slug).pipe(catchError(() => of(null as BrandReachResponse | null))),
-            emailCtr: this.analyticsService.getEmailCtr(slug).pipe(catchError(() => of(null as EmailCtrResponse | null))),
-          }).pipe(tap(() => this.loading.set(false)));
+            revenueImpact: this.analyticsService.getRevenueImpact(slug),
+            brandReach: this.analyticsService.getBrandReach(slug),
+            emailCtr: this.analyticsService.getEmailCtr(slug),
+          }).pipe(finalize(() => this.loading.set(false)));
         })
       ),
       { initialValue: { revenueImpact: null, brandReach: null, emailCtr: null } }
@@ -80,7 +80,6 @@ export class OverviewTabComponent {
             yoyChange: this.formatChangePct(yoyPct, 'YoY'),
             yoyTrend: this.trendDirection(yoyPct),
             yoyTrendClass: this.trendColorClass(yoyPct),
-            comparisonLine: '',
           },
           {
             id: 'roas',
@@ -94,7 +93,6 @@ export class OverviewTabComponent {
             yoyChange: null,
             yoyTrend: 'neutral',
             yoyTrendClass: 'text-gray-500',
-            comparisonLine: '',
           }
         );
       }
@@ -114,7 +112,6 @@ export class OverviewTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         });
       }
 
@@ -133,7 +130,6 @@ export class OverviewTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
           badge: momPct < 0 ? 'Needs review' : undefined,
         });
       }
@@ -166,7 +162,7 @@ export class OverviewTabComponent {
 
       const name = this.foundationName();
       const foundation = name ? name : 'all LF projects';
-      return `vs ${momLabel} (MoM) and ${yoyLabel} (YoY) · Linear attribution · ${foundation}`;
+      return `Compared to ${momLabel} and ${yoyLabel} · Linear attribution · ${foundation}`;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -4,9 +4,9 @@
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
-import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { finalize, forkJoin, of, switchMap } from 'rxjs';
+import { catchError, finalize, forkJoin, of, switchMap } from 'rxjs';
 
 import type { OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
@@ -31,7 +31,7 @@ export class OverviewTabComponent {
   protected readonly loading = signal(false);
 
   // === Computed Signals ===
-  protected readonly attributionData: Signal<OverviewKpiData> = this.initOverviewKpiData();
+  protected readonly overviewKpiData: Signal<OverviewKpiData> = this.initOverviewKpiData();
   protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
   protected readonly summaryTitle: Signal<string> = this.initSummaryTitle();
   protected readonly summarySubtitle: Signal<string> = this.initSummarySubtitle();
@@ -49,9 +49,9 @@ export class OverviewTabComponent {
           }
           this.loading.set(true);
           return forkJoin({
-            revenueImpact: this.analyticsService.getRevenueImpact(slug),
-            brandReach: this.analyticsService.getBrandReach(slug),
-            emailCtr: this.analyticsService.getEmailCtr(slug),
+            revenueImpact: this.analyticsService.getRevenueImpact(slug).pipe(catchError(() => of(null))),
+            brandReach: this.analyticsService.getBrandReach(slug).pipe(catchError(() => of(null))),
+            emailCtr: this.analyticsService.getEmailCtr(slug).pipe(catchError(() => of(null))),
           }).pipe(finalize(() => this.loading.set(false)));
         })
       ),
@@ -61,7 +61,7 @@ export class OverviewTabComponent {
 
   private initPerformanceSummaryKpis(): Signal<PerformanceSummaryKpi[]> {
     return computed(() => {
-      const data = this.attributionData();
+      const data = this.overviewKpiData();
       const cards: PerformanceSummaryKpi[] = [];
 
       if (data.revenueImpact) {
@@ -77,16 +77,16 @@ export class OverviewTabComponent {
             momChange: null,
             momTrend: 'neutral',
             momTrendClass: 'text-gray-500',
-            yoyChange: this.formatChangePct(yoyPct, 'YoY'),
-            yoyTrend: this.trendDirection(yoyPct),
-            yoyTrendClass: this.trendColorClass(yoyPct),
+            yoyChange: formatChangePct(yoyPct, 'YoY'),
+            yoyTrend: trendDirection(yoyPct),
+            yoyTrendClass: trendColorClass(yoyPct),
           },
           {
             id: 'roas',
             label: 'Return on Ad Spend',
             icon: 'fa-light fa-chart-line-up',
             iconClass: 'bg-blue-100 text-blue-600',
-            value: `${ri.paidMedia.roas.toFixed(2)}x`,
+            value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
             momChange: null,
             momTrend: 'neutral',
             momTrendClass: 'text-gray-500',
@@ -106,9 +106,9 @@ export class OverviewTabComponent {
           icon: 'fa-light fa-globe',
           iconClass: 'bg-violet-100 text-violet-600',
           value: formatNumber(br.totalMonthlySessions),
-          momChange: this.formatChangePct(momPct, 'MoM'),
-          momTrend: this.trendDirection(momPct),
-          momTrendClass: this.trendColorClass(momPct),
+          momChange: formatChangePct(momPct, 'MoM'),
+          momTrend: trendDirection(momPct),
+          momTrendClass: trendColorClass(momPct),
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
@@ -119,18 +119,18 @@ export class OverviewTabComponent {
         const ec = data.emailCtr;
         const momPct = ec.changePercentage;
         cards.push({
-          id: 'email-open-rate',
-          label: 'Email Open Rate',
+          id: 'email-ctr',
+          label: 'Email CTR',
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${ec.currentCtr.toFixed(2)}%`,
-          momChange: this.formatChangePct(momPct, 'MoM'),
-          momTrend: this.trendDirection(momPct),
-          momTrendClass: this.trendColorClass(momPct),
+          momChange: formatChangePct(momPct, 'MoM'),
+          momTrend: trendDirection(momPct),
+          momTrendClass: trendColorClass(momPct),
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          badge: momPct < 0 ? 'Needs review' : undefined,
+          badge: momPct != null && momPct < 0 ? 'Needs review' : undefined,
         });
       }
 
@@ -164,26 +164,5 @@ export class OverviewTabComponent {
       const foundation = name ? name : 'all LF projects';
       return `Compared to ${momLabel} and ${yoyLabel} · Linear attribution · ${foundation}`;
     });
-  }
-
-  // === Private Helpers ===
-  private trendDirection(pct: number | null | undefined): 'up' | 'down' | 'neutral' {
-    if (pct == null || Number.isNaN(pct)) return 'neutral';
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number | null | undefined): string {
-    if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number | null | undefined, suffix: string): string | null {
-    if (pct == null || Number.isNaN(pct)) return null;
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -8,7 +8,7 @@ import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { finalize, forkJoin, of, switchMap } from 'rxjs';
 
-import type { AttributionData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
+import type { OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
@@ -31,13 +31,13 @@ export class OverviewTabComponent {
   protected readonly loading = signal(false);
 
   // === Computed Signals ===
-  protected readonly attributionData: Signal<AttributionData> = this.initAttributionData();
+  protected readonly attributionData: Signal<OverviewKpiData> = this.initOverviewKpiData();
   protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
   protected readonly summaryTitle: Signal<string> = this.initSummaryTitle();
   protected readonly summarySubtitle: Signal<string> = this.initSummarySubtitle();
 
   // === Private Initializers ===
-  private initAttributionData(): Signal<AttributionData> {
+  private initOverviewKpiData(): Signal<OverviewKpiData> {
     const slug$ = toObservable(this.foundationSlug);
 
     return toSignal(

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -171,19 +171,22 @@ export class OverviewTabComponent {
   }
 
   // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+  private trendDirection(pct: number | null | undefined): 'up' | 'down' | 'neutral' {
+    if (pct == null || Number.isNaN(pct)) return 'neutral';
     if (pct > 0) return 'up';
     if (pct < 0) return 'down';
     return 'neutral';
   }
 
-  private trendColorClass(pct: number): string {
+  private trendColorClass(pct: number | null | undefined): string {
+    if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
     if (pct > 0) return 'text-green-600';
     if (pct < 0) return 'text-red-600';
     return 'text-gray-500';
   }
 
-  private formatChangePct(pct: number, suffix: string): string {
+  private formatChangePct(pct: number | null | undefined, suffix: string): string | null {
+    if (pct == null || Number.isNaN(pct)) return null;
     const sign = pct > 0 ? '+' : '';
     return `${sign}${pct.toFixed(1)}% ${suffix}`;
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
@@ -1,14 +1,14 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-2 border-l border-gray-200 pl-4" [attr.data-testid]="'overview-tab-kpi-' + kpi().id">
+<div class="flex flex-col gap-2 border-l border-gray-200 pl-4" [attr.data-testid]="'kpi-card-' + kpi().id">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-1.5">
       <i [class]="kpi().icon + ' text-xs text-gray-400'" aria-hidden="true"></i>
       <span class="text-xs font-medium text-gray-500">{{ kpi().label }}</span>
     </div>
     @if (kpi().badge) {
-      <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-600" [attr.data-testid]="'overview-tab-badge-' + kpi().id">
+      <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-600" [attr.data-testid]="'kpi-card-badge-' + kpi().id">
         {{ kpi().badge }}
       </span>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
@@ -4,7 +4,9 @@
 <div class="flex flex-col gap-2 border-l border-gray-200 pl-4" [attr.data-testid]="'kpi-card-' + kpi().id">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-1.5">
-      <i [class]="kpi().icon + ' text-xs text-gray-400'" aria-hidden="true"></i>
+      <span class="inline-flex h-6 w-6 items-center justify-center rounded-md" [ngClass]="kpi().iconClass">
+        <i [class]="kpi().icon + ' text-xs'" aria-hidden="true"></i>
+      </span>
       <span class="text-xs font-medium text-gray-500">{{ kpi().label }}</span>
     </div>
     @if (kpi().badge) {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -78,6 +78,8 @@
           [selectedMonth]="selectedMonth()"
           [foundationName]="foundationName()"
           data-testid="marketing-impact-overview-tab" />
+      } @else if (selectedTab() === 'attribution') {
+        <lfx-attribution-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-attribution-tab" />
       } @else {
         <div
           class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -20,11 +20,12 @@ import type {
   MarketingImpactTabOption,
 } from '@lfx-one/shared/interfaces';
 
+import { AttributionSectionComponent } from './components/attribution-section/attribution-section.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
 
 @Component({
   selector: 'lfx-marketing-impact',
-  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent, FilterPillsComponent, OverviewTabComponent],
+  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent, FilterPillsComponent, OverviewTabComponent, AttributionSectionComponent],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',
 })

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { FilterPillOption } from '../interfaces/dashboard-metric.interface';
+import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
 import type { AttributionModelOption, MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
 
 /** Focus program filter options for the Marketing Impact FOCUS bar. */

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { FilterPillOption } from '../interfaces/dashboard-metric.interface';
-import type { MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
+import type { AttributionModelOption, MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
 
 /** Focus program filter options for the Marketing Impact FOCUS bar. */
 export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
@@ -22,4 +22,12 @@ export const MARKETING_IMPACT_TABS: MarketingImpactTabOption[] = [
   { id: 'web-activity', label: 'Web Activity' },
   { id: 'social-accounts', label: 'Social Accounts' },
   { id: 'social-listening', label: 'Social Listening' },
+];
+
+/** Attribution model options for the model selector dropdown. */
+export const ATTRIBUTION_MODEL_OPTIONS: AttributionModelOption[] = [
+  { label: 'Linear', value: 'linear' },
+  { label: 'First Touch', value: 'firstTouch' },
+  { label: 'Last Touch', value: 'lastTouch' },
+  { label: 'Time Decay', value: 'timeDecay' },
 ];

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -23,8 +23,8 @@ export type MarketingImpactFocusProgram = 'all' | 'events' | 'newsletters' | 'su
 /** Tab identifiers for the Marketing Impact section tabs. */
 export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';
 
-/** Aggregated attribution data fetched for the Marketing Impact overview. */
-export interface AttributionData {
+/** Aggregated KPI source data fetched for the Marketing Impact overview tab. */
+export interface OverviewKpiData {
   revenueImpact: RevenueImpactResponse | null;
   brandReach: BrandReachResponse | null;
   emailCtr: EmailCtrResponse | null;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { BrandReachResponse, EmailCtrResponse, RevenueImpactResponse } from './analytics-data.interface';
+import type { BrandReachResponse, EmailCtrResponse, MarketingAttributionChannel, RevenueImpactResponse } from './analytics-data.interface';
 
 /** Month option for the Marketing Impact page month picker. */
 export interface MarketingImpactMonthOption {
@@ -46,4 +46,24 @@ export interface PerformanceSummaryKpi {
   comparisonLine: string;
   /** Optional badge text (e.g., "Needs review") shown when metric requires attention. */
   badge?: string;
+}
+
+/** Attribution model identifier for the model selector dropdown. */
+export type AttributionModel = 'linear' | 'firstTouch' | 'lastTouch' | 'timeDecay';
+
+/** Option shape for the attribution model dropdown. */
+export interface AttributionModelOption {
+  label: string;
+  value: AttributionModel;
+}
+
+/** View-model row for the attribution channel table. */
+export interface AttributionChannelRow {
+  channel: string;
+  revenue: number;
+  revenueFormatted: string;
+  sharePercent: number;
+  sessions: number;
+  sessionsFormatted: string;
+  raw: MarketingAttributionChannel;
 }

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -43,7 +43,7 @@ export interface PerformanceSummaryKpi {
   yoyChange: string | null;
   yoyTrend: 'up' | 'down' | 'neutral';
   yoyTrendClass: string;
-  comparisonLine: string;
+  comparisonLine?: string;
   /** Optional badge text (e.g., "Needs review") shown when metric requires attention. */
   badge?: string;
 }

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -27,3 +27,30 @@ export function getDefaultMarketingImpactMonth(): string {
   const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
   return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
 }
+
+// === Trend Helpers ===
+
+export type TrendDirection = 'up' | 'down' | 'neutral';
+
+/** Determines trend direction from a percentage change value. */
+export function trendDirection(pct: number | null | undefined): TrendDirection {
+  if (pct == null || Number.isNaN(pct)) return 'neutral';
+  if (pct > 0) return 'up';
+  if (pct < 0) return 'down';
+  return 'neutral';
+}
+
+/** Returns a Tailwind color class based on trend direction. */
+export function trendColorClass(pct: number | null | undefined): string {
+  if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
+  if (pct > 0) return 'text-green-600';
+  if (pct < 0) return 'text-red-600';
+  return 'text-gray-500';
+}
+
+/** Formats a percentage change with sign and suffix (e.g., "+5.2% MoM"). */
+export function formatChangePct(pct: number | null | undefined, suffix: string): string | null {
+  if (pct == null || Number.isNaN(pct)) return null;
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct.toFixed(1)}% ${suffix}`;
+}


### PR DESCRIPTION
## Summary
- Adds attribution section component with model selector (Linear/First Touch/Last Touch/Time Decay)
- Channel revenue table with horizontal share bars
- Wires attribution as both a section in Overview tab and standalone Attribution tab

**Depends on:** #705

## Test plan
- [ ] Select TLF, verify Attribution tab shows channel table
- [ ] Switch attribution models in dropdown
- [ ] Verify Overview tab still shows attribution section below KPI cards

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)