### PR TITLE
feat(dashboards): add performance marketing tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -48,7 +48,7 @@
       }
     </div>
   } @else if (hasData()) {
-    <div class="flex flex-col gap-0" data-testid="attribution-table" role="table" aria-label="Marketing attribution by channel">
+    <div class="flex flex-col gap-0" role="table" aria-label="Marketing attribution by channel" data-testid="attribution-table">
       <!-- Table header -->
       <div class="flex items-center gap-4 border-b border-gray-200 pb-2" role="row">
         <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CHANNEL</span>
@@ -59,7 +59,7 @@
 
       <!-- Rows -->
       @for (row of channelRows(); track row.channel) {
-        <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" [attr.data-testid]="'attribution-row-' + row.channel" role="row">
+        <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'attribution-row-' + row.channel">
           <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.channel }}</span>
           <div class="flex flex-1 items-center gap-2" role="cell">
             <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
@@ -69,7 +69,7 @@
                 [attr.aria-valuenow]="row.sharePercent"
                 aria-valuemin="0"
                 aria-valuemax="100"
-                [attr.aria-label]="row.channel + ' revenue share'"
+                [attr.aria-label]="row.channel + ' revenue share: ' + (row.sharePercent | number: '1.0-0') + '%'"
                 [style.width.%]="row.sharePercent"></div>
             </div>
             <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sharePercent | number: '1.0-0' }}%</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -21,13 +21,6 @@ import type { AttributionChannelRow, AttributionModel, AttributionModelOption, M
   styleUrl: './attribution-section.component.scss',
 })
 export class AttributionSectionComponent {
-  private static readonly revenueKeyMap: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
-    linear: 'linearRevenue',
-    firstTouch: 'firstTouchRevenue',
-    lastTouch: 'lastTouchRevenue',
-    timeDecay: 'timeDecayRevenue',
-  };
-
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly fb = inject(FormBuilder);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -21,6 +21,13 @@ import type { AttributionChannelRow, AttributionModel, AttributionModelOption, M
   styleUrl: './attribution-section.component.scss',
 })
 export class AttributionSectionComponent {
+  private static readonly revenueKeyMap: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
+    linear: 'linearRevenue',
+    firstTouch: 'firstTouchRevenue',
+    lastTouch: 'lastTouchRevenue',
+    timeDecay: 'timeDecayRevenue',
+  };
+
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly fb = inject(FormBuilder);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -96,11 +96,11 @@ export class AttributionSectionComponent {
       if (!data?.channels?.length) return [];
 
       const revenueKey = this.getRevenueKey(model);
-      const total = data.channels.reduce((sum, ch) => sum + ch[revenueKey], 0);
+      const total = data.channels.reduce((sum, ch) => sum + (ch[revenueKey] ?? 0), 0);
 
       return data.channels
         .map((ch): AttributionChannelRow => {
-          const revenue = ch[revenueKey];
+          const revenue = ch[revenueKey] ?? 0;
           return {
             channel: ch.channel,
             revenue,

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -65,9 +65,11 @@
               <span class="w-16 text-right text-xs font-medium text-gray-900">{{ row.roas }}</span>
               <span class="w-24 text-right text-xs text-gray-500">{{ row.impressions }}</span>
               <div class="flex flex-1 justify-end">
-                <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
-                  {{ row.performance }}
-                </span>
+                @if (row.performanceClass) {
+                  <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
+                    {{ row.performance }}
+                  </span>
+                }
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -43,28 +43,28 @@
       <h4 class="text-sm font-semibold text-gray-900">Campaign performance by project</h4>
 
       @if (hasProjects()) {
-        <div class="flex flex-col gap-0" data-testid="performance-marketing-table">
+        <div class="flex flex-col gap-0" role="table" data-testid="performance-marketing-table">
           <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400">PROJECT</span>
-            <span class="w-20 text-[11px] font-semibold tracking-wide text-gray-400">STAGE</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SPEND</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">REVENUE</span>
-            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400">ROAS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">IMPRESSIONS</span>
-            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">PERF.</span>
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
+            <span class="w-20 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">STAGE</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
+            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PERF.</span>
           </div>
 
           <!-- Rows -->
           @for (row of projectRows(); track row.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'performance-marketing-row-' + row.name">
-              <span class="w-40 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
-              <span class="w-20 truncate text-[11px] text-gray-500">{{ row.funnelStage }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.spend }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.revenue }}</span>
-              <span class="w-16 text-right text-xs font-medium text-gray-900">{{ row.roas }}</span>
-              <span class="w-24 text-right text-xs text-gray-500">{{ row.impressions }}</span>
-              <div class="flex flex-1 justify-end">
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'performance-marketing-row-' + row.name">
+              <span class="w-40 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
+              <span class="w-20 truncate text-[11px] text-gray-500" role="cell">{{ row.funnelStage }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.revenue }}</span>
+              <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
+              <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.impressions }}</span>
+              <div class="flex flex-1 justify-end" role="cell">
                 @if (row.performanceClass) {
                   <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
                     {{ row.performance }}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -1,0 +1,82 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="performance-marketing-tab">
+  <!-- Header + funnel filter -->
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+      <div class="flex flex-col gap-0.5">
+        <h3 class="text-base font-semibold text-gray-900">Performance marketing</h3>
+        <p class="text-xs text-gray-500">Paid campaign metrics · {{ foundationName() || 'All foundations' }}</p>
+      </div>
+    </div>
+    <div class="flex items-center gap-3">
+      <span class="text-xs font-semibold tracking-wide text-gray-500">FUNNEL</span>
+      <lfx-filter-pills
+        [options]="funnelOptions"
+        [selectedFilter]="selectedFunnel()"
+        (filterChange)="onFunnelChange($event)"
+        data-testid="performance-marketing-funnel-pills" />
+    </div>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="performance-marketing-kpi-grid">
+    @if (loading()) {
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="performance-marketing-kpi-skeleton">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    } @else {
+      @for (kpi of kpiCards(); track kpi.id) {
+        <lfx-sparkline-kpi-card [kpi]="kpi" />
+      }
+    }
+  </div>
+
+  <!-- Project breakdown table -->
+  @if (!loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="performance-marketing-projects">
+      <h4 class="text-sm font-semibold text-gray-900">Campaign performance by project</h4>
+
+      @if (hasProjects()) {
+        <div class="flex flex-col gap-0" data-testid="performance-marketing-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400">PROJECT</span>
+            <span class="w-20 text-[11px] font-semibold tracking-wide text-gray-400">STAGE</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SPEND</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">REVENUE</span>
+            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400">ROAS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">IMPRESSIONS</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">PERF.</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of projectRows(); track row.name) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'performance-marketing-row-' + row.name">
+              <span class="w-40 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
+              <span class="w-20 truncate text-[11px] text-gray-500">{{ row.funnelStage }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.spend }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.revenue }}</span>
+              <span class="w-16 text-right text-xs font-medium text-gray-900">{{ row.roas }}</span>
+              <span class="w-24 text-right text-xs text-gray-500">{{ row.impressions }}</span>
+              <div class="flex flex-1 justify-end">
+                <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
+                  {{ row.performance }}
+                </span>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="performance-marketing-empty">
+          <p class="text-sm text-gray-500">No project data available for the selected filter.</p>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -65,11 +65,9 @@
               <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
               <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.impressions }}</span>
               <div class="flex flex-1 justify-end" role="cell">
-                @if (row.performanceClass) {
-                  <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
-                    {{ row.performance }}
-                  </span>
-                }
+                <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
+                  {{ row.performance }}
+                </span>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -43,7 +43,7 @@
       <h4 class="text-sm font-semibold text-gray-900">Campaign performance by project</h4>
 
       @if (hasProjects()) {
-        <div class="flex flex-col gap-0" role="table" data-testid="performance-marketing-table">
+        <div class="flex flex-col gap-0" role="table" aria-label="Campaign performance by project" data-testid="performance-marketing-table">
           <!-- Table header -->
           <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
             <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -1,0 +1,208 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import type { FilterPillOption, FunnelStage, PaidProjectRow, PerformanceSummaryKpi, SocialReachResponse } from '@lfx-one/shared/interfaces';
+
+import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+
+@Component({
+  selector: 'lfx-performance-marketing-tab',
+  imports: [FilterPillsComponent, SparklineKpiCardComponent],
+  templateUrl: './performance-marketing-tab.component.html',
+  styleUrl: './performance-marketing-tab.component.scss',
+})
+export class PerformanceMarketingTabComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === Constants ===
+  protected readonly funnelOptions: FilterPillOption[] = FUNNEL_STAGE_OPTIONS;
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+  protected readonly selectedFunnel = signal<FunnelStage>('all');
+
+  // === Computed Signals ===
+  protected readonly socialReachData: Signal<SocialReachResponse | null> = this.initSocialReachData();
+  protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
+  protected readonly projectRows: Signal<PaidProjectRow[]> = this.initProjectRows();
+  protected readonly hasProjects = computed(() => this.projectRows().length > 0);
+
+  // === Protected Methods ===
+  protected onFunnelChange(funnelId: string): void {
+    if (this.funnelOptions.some((o) => o.id === funnelId)) {
+      this.selectedFunnel.set(funnelId as FunnelStage);
+    }
+  }
+
+  // === Private Initializers ===
+  private initSocialReachData(): Signal<SocialReachResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getSocialReach(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKpiCards(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.socialReachData();
+      if (!data) return [];
+
+      const changePct = data.changePercentage;
+      const cards: PerformanceSummaryKpi[] = [
+        {
+          id: 'total-impressions',
+          label: 'Total Impressions',
+          icon: 'fa-light fa-eye',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: formatNumber(data.totalReach),
+          momChange: this.formatChangePct(changePct, 'MoM'),
+          momTrend: this.trendDirection(changePct),
+          momTrendClass: this.trendColorClass(changePct),
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'total-spend',
+          label: 'Total Spend',
+          icon: 'fa-light fa-wallet',
+          iconClass: 'bg-amber-100 text-amber-600',
+          value: formatCurrency(data.totalSpend),
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'total-revenue',
+          label: 'Total Revenue',
+          icon: 'fa-light fa-dollar-sign',
+          iconClass: 'bg-green-100 text-green-600',
+          value: formatCurrency(data.totalRevenue),
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'roas',
+          label: 'ROAS',
+          icon: 'fa-light fa-chart-line-up',
+          iconClass: 'bg-violet-100 text-violet-600',
+          value: `${data.roas.toFixed(2)}x`,
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+      ];
+
+      return cards;
+    });
+  }
+
+  private initProjectRows(): Signal<PaidProjectRow[]> {
+    return computed(() => {
+      const data = this.socialReachData();
+      const funnel = this.selectedFunnel();
+      if (!data?.projectBreakdown?.length) return [];
+
+      return data.projectBreakdown
+        .filter((p) => {
+          if (funnel === 'all') return true;
+          const stage = p.funnelStage?.toLowerCase() ?? '';
+          if (funnel === 'tofu') return stage.startsWith('tofu') || stage === 'unknown';
+          if (funnel === 'mofu') return stage === 'mofu';
+          if (funnel === 'bofu') return stage === 'bofu';
+          return true;
+        })
+        .map(
+          (p): PaidProjectRow => ({
+            name: p.projectName,
+            funnelStage: p.funnelStage,
+            spend: formatCurrency(p.spend),
+            revenue: formatCurrency(p.revenue),
+            roas: `${p.roas.toFixed(2)}x`,
+            impressions: formatNumber(p.impressions),
+            performance: p.performance,
+            performanceClass: this.getPerformanceClass(p.performance),
+          })
+        )
+        .sort((a, b) => {
+          const order: Record<string, number> = { EXCELLENT: 0, GOOD: 1, POOR: 2, 'NO REVENUE': 3 };
+          return (order[a.performance] ?? 4) - (order[b.performance] ?? 4);
+        });
+    });
+  }
+
+  // === Private Helpers ===
+  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+    if (pct > 0) return 'up';
+    if (pct < 0) return 'down';
+    return 'neutral';
+  }
+
+  private trendColorClass(pct: number): string {
+    if (pct > 0) return 'text-green-600';
+    if (pct < 0) return 'text-red-600';
+    return 'text-gray-500';
+  }
+
+  private formatChangePct(pct: number, suffix: string): string {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  }
+
+  private getPerformanceClass(perf: string): string {
+    switch (perf) {
+      case 'EXCELLENT':
+        return 'bg-green-50 text-green-700';
+      case 'GOOD':
+        return 'bg-blue-50 text-blue-700';
+      case 'POOR':
+        return 'bg-red-50 text-red-700';
+      default:
+        return 'bg-gray-50 text-gray-500';
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -199,10 +199,8 @@ export class PerformanceMarketingTabComponent {
         return 'bg-green-50 text-green-700';
       case 'GOOD':
         return 'bg-blue-50 text-blue-700';
-      case 'POOR':
-        return 'bg-red-50 text-red-700';
       default:
-        return 'bg-gray-50 text-gray-500';
+        return '';
     }
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -97,7 +97,9 @@ export class PerformanceMarketingTabComponent {
       const data = this.socialReachData();
       if (!data) return [];
 
-      const changePct = data.changePercentage;
+      const roasMomPct = data.changePercentage;
+      const impressionsMomPct = this.computeMomPct(data.monthlyData);
+
       const cards: PerformanceSummaryKpi[] = [
         {
           id: 'total-impressions',
@@ -105,9 +107,9 @@ export class PerformanceMarketingTabComponent {
           icon: 'fa-light fa-eye',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(data.totalReach),
-          momChange: formatChangePct(changePct, 'MoM'),
-          momTrend: trendDirection(changePct),
-          momTrendClass: trendColorClass(changePct),
+          momChange: formatChangePct(impressionsMomPct, 'MoM'),
+          momTrend: trendDirection(impressionsMomPct),
+          momTrendClass: trendColorClass(impressionsMomPct),
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
@@ -144,9 +146,9 @@ export class PerformanceMarketingTabComponent {
           icon: 'fa-light fa-chart-line-up',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${(data.roas ?? 0).toFixed(2)}x`,
-          momChange: null,
-          momTrend: 'neutral',
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(roasMomPct, 'MoM'),
+          momTrend: trendDirection(roasMomPct),
+          momTrendClass: trendColorClass(roasMomPct),
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
@@ -205,5 +207,13 @@ export class PerformanceMarketingTabComponent {
 
   private getPerformanceClass(perf: PaidProjectPerformance): string {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
+  }
+
+  private computeMomPct(arr: number[] | undefined): number | null {
+    if (!arr || arr.length < 2) return null;
+    const current = arr.at(-1) ?? 0;
+    const previous = arr.at(-2) ?? 0;
+    if (previous === 0) return null;
+    return ((current - previous) / previous) * 100;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -41,6 +41,8 @@ export class PerformanceMarketingTabComponent {
     'NO REVENUE': 3,
   };
 
+  private static readonly VALID_PERFORMANCE = new Set<PaidProjectPerformance>(['EXCELLENT', 'GOOD', 'POOR', 'NO REVENUE']);
+
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
 
@@ -179,8 +181,8 @@ export class PerformanceMarketingTabComponent {
             revenue: formatCurrency(p.revenue),
             roas: `${(p.roas ?? 0).toFixed(2)}x`,
             impressions: formatNumber(p.impressions),
-            performance: p.performance as PaidProjectPerformance,
-            performanceClass: this.getPerformanceClass(p.performance as PaidProjectPerformance),
+            performance: this.normalizePerformance(p.performance),
+            performanceClass: this.getPerformanceClass(this.normalizePerformance(p.performance)),
           })
         )
         .sort((a, b) => {
@@ -193,6 +195,14 @@ export class PerformanceMarketingTabComponent {
   }
 
   // === Private Helpers ===
+  private normalizePerformance(value: string | null | undefined): PaidProjectPerformance {
+    const upper = (value ?? '').toUpperCase().trim();
+    if (PerformanceMarketingTabComponent.VALID_PERFORMANCE.has(upper as PaidProjectPerformance)) {
+      return upper as PaidProjectPerformance;
+    }
+    return 'NO REVENUE';
+  }
+
   private getPerformanceClass(perf: PaidProjectPerformance): string {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -41,7 +41,7 @@ export class PerformanceMarketingTabComponent {
     'NO REVENUE': 3,
   };
 
-  private static readonly VALID_PERFORMANCE = new Set<PaidProjectPerformance>(['EXCELLENT', 'GOOD', 'POOR', 'NO REVENUE']);
+  private static readonly validPerformance = new Set<PaidProjectPerformance>(['EXCELLENT', 'GOOD', 'POOR', 'NO REVENUE']);
 
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
@@ -197,7 +197,7 @@ export class PerformanceMarketingTabComponent {
   // === Private Helpers ===
   private normalizePerformance(value: string | null | undefined): PaidProjectPerformance {
     const upper = (value ?? '').toUpperCase().trim();
-    if (PerformanceMarketingTabComponent.VALID_PERFORMANCE.has(upper as PaidProjectPerformance)) {
+    if (PerformanceMarketingTabComponent.validPerformance.has(upper as PaidProjectPerformance)) {
       return upper as PaidProjectPerformance;
     }
     return 'NO REVENUE';

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -7,9 +7,16 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
-import type { FilterPillOption, FunnelStage, PaidProjectRow, PerformanceSummaryKpi, SocialReachResponse } from '@lfx-one/shared/interfaces';
+import type {
+  FilterPillOption,
+  FunnelStage,
+  PaidProjectPerformance,
+  PaidProjectRow,
+  PerformanceSummaryKpi,
+  SocialReachResponse,
+} from '@lfx-one/shared/interfaces';
 
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
@@ -20,6 +27,20 @@ import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-c
   styleUrl: './performance-marketing-tab.component.scss',
 })
 export class PerformanceMarketingTabComponent {
+  private static readonly performanceClassMap: Record<PaidProjectPerformance, string> = {
+    EXCELLENT: 'bg-green-50 text-green-700',
+    GOOD: 'bg-blue-50 text-blue-700',
+    POOR: 'bg-amber-100 text-amber-700',
+    'NO REVENUE': 'bg-gray-100 text-gray-600',
+  };
+
+  private static readonly performanceOrderMap: Record<PaidProjectPerformance, number> = {
+    EXCELLENT: 0,
+    GOOD: 1,
+    POOR: 2,
+    'NO REVENUE': 3,
+  };
+
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
 
@@ -60,11 +81,8 @@ export class PerformanceMarketingTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getSocialReach(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            catchError(() => of(null)),
+            finalize(() => this.loading.set(false))
           );
         })
       ),
@@ -91,7 +109,6 @@ export class PerformanceMarketingTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
         {
           id: 'total-spend',
@@ -105,7 +122,6 @@ export class PerformanceMarketingTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
         {
           id: 'total-revenue',
@@ -119,7 +135,6 @@ export class PerformanceMarketingTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
         {
           id: 'roas',
@@ -133,7 +148,6 @@ export class PerformanceMarketingTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
       ];
 
@@ -151,7 +165,8 @@ export class PerformanceMarketingTabComponent {
         .filter((p) => {
           if (funnel === 'all') return true;
           const stage = p.funnelStage?.toLowerCase() ?? '';
-          if (funnel === 'tofu') return stage.startsWith('tofu') || stage === 'unknown';
+          if (stage === 'unknown') return false;
+          if (funnel === 'tofu') return stage.startsWith('tofu');
           if (funnel === 'mofu') return stage === 'mofu';
           if (funnel === 'bofu') return stage === 'bofu';
           return true;
@@ -164,43 +179,41 @@ export class PerformanceMarketingTabComponent {
             revenue: formatCurrency(p.revenue),
             roas: `${p.roas.toFixed(2)}x`,
             impressions: formatNumber(p.impressions),
-            performance: p.performance,
-            performanceClass: this.getPerformanceClass(p.performance),
+            performance: p.performance as PaidProjectPerformance,
+            performanceClass: this.getPerformanceClass(p.performance as PaidProjectPerformance),
           })
         )
         .sort((a, b) => {
-          const order: Record<string, number> = { EXCELLENT: 0, GOOD: 1, POOR: 2, 'NO REVENUE': 3 };
-          return (order[a.performance] ?? 4) - (order[b.performance] ?? 4);
+          return (
+            (PerformanceMarketingTabComponent.performanceOrderMap[a.performance] ?? 4) -
+            (PerformanceMarketingTabComponent.performanceOrderMap[b.performance] ?? 4)
+          );
         });
     });
   }
 
   // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+  private trendDirection(pct: number | null | undefined): 'up' | 'down' | 'neutral' {
+    if (pct == null || Number.isNaN(pct)) return 'neutral';
     if (pct > 0) return 'up';
     if (pct < 0) return 'down';
     return 'neutral';
   }
 
-  private trendColorClass(pct: number): string {
+  private trendColorClass(pct: number | null | undefined): string {
+    if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
     if (pct > 0) return 'text-green-600';
     if (pct < 0) return 'text-red-600';
     return 'text-gray-500';
   }
 
-  private formatChangePct(pct: number, suffix: string): string {
+  private formatChangePct(pct: number | null | undefined, suffix: string): string | null {
+    if (pct == null || Number.isNaN(pct)) return null;
     const sign = pct > 0 ? '+' : '';
     return `${sign}${pct.toFixed(1)}% ${suffix}`;
   }
 
-  private getPerformanceClass(perf: string): string {
-    switch (perf) {
-      case 'EXCELLENT':
-        return 'bg-green-50 text-green-700';
-      case 'GOOD':
-        return 'bg-blue-50 text-blue-700';
-      default:
-        return '';
-    }
+  private getPerformanceClass(perf: PaidProjectPerformance): string {
+    return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
-import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, finalize, of, switchMap } from 'rxjs';
 
@@ -103,9 +103,9 @@ export class PerformanceMarketingTabComponent {
           icon: 'fa-light fa-eye',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(data.totalReach),
-          momChange: this.formatChangePct(changePct, 'MoM'),
-          momTrend: this.trendDirection(changePct),
-          momTrendClass: this.trendColorClass(changePct),
+          momChange: formatChangePct(changePct, 'MoM'),
+          momTrend: trendDirection(changePct),
+          momTrendClass: trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
@@ -141,7 +141,7 @@ export class PerformanceMarketingTabComponent {
           label: 'ROAS',
           icon: 'fa-light fa-chart-line-up',
           iconClass: 'bg-violet-100 text-violet-600',
-          value: `${data.roas.toFixed(2)}x`,
+          value: `${(data.roas ?? 0).toFixed(2)}x`,
           momChange: null,
           momTrend: 'neutral',
           momTrendClass: 'text-gray-500',
@@ -177,7 +177,7 @@ export class PerformanceMarketingTabComponent {
             funnelStage: p.funnelStage,
             spend: formatCurrency(p.spend),
             revenue: formatCurrency(p.revenue),
-            roas: `${p.roas.toFixed(2)}x`,
+            roas: `${(p.roas ?? 0).toFixed(2)}x`,
             impressions: formatNumber(p.impressions),
             performance: p.performance as PaidProjectPerformance,
             performanceClass: this.getPerformanceClass(p.performance as PaidProjectPerformance),
@@ -193,26 +193,6 @@ export class PerformanceMarketingTabComponent {
   }
 
   // === Private Helpers ===
-  private trendDirection(pct: number | null | undefined): 'up' | 'down' | 'neutral' {
-    if (pct == null || Number.isNaN(pct)) return 'neutral';
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number | null | undefined): string {
-    if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number | null | undefined, suffix: string): string | null {
-    if (pct == null || Number.isNaN(pct)) return null;
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
-  }
-
   private getPerformanceClass(perf: PaidProjectPerformance): string {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -80,6 +80,11 @@
           data-testid="marketing-impact-overview-tab" />
       } @else if (selectedTab() === 'attribution') {
         <lfx-attribution-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-attribution-tab" />
+      } @else if (selectedTab() === 'performance-marketing') {
+        <lfx-performance-marketing-tab
+          [foundationSlug]="foundationSlug()"
+          [foundationName]="foundationName()"
+          data-testid="marketing-impact-performance-marketing-tab" />
       } @else {
         <div
           class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -22,10 +22,19 @@ import type {
 
 import { AttributionSectionComponent } from './components/attribution-section/attribution-section.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
+import { PerformanceMarketingTabComponent } from './components/performance-marketing-tab/performance-marketing-tab.component';
 
 @Component({
   selector: 'lfx-marketing-impact',
-  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent, FilterPillsComponent, OverviewTabComponent, AttributionSectionComponent],
+  imports: [
+    ReactiveFormsModule,
+    SelectComponent,
+    ButtonComponent,
+    FilterPillsComponent,
+    OverviewTabComponent,
+    AttributionSectionComponent,
+    PerformanceMarketingTabComponent,
+  ],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',
 })

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -31,3 +31,11 @@ export const ATTRIBUTION_MODEL_OPTIONS: AttributionModelOption[] = [
   { label: 'Last Touch', value: 'lastTouch' },
   { label: 'Time Decay', value: 'timeDecay' },
 ];
+
+/** Funnel stage filter options for the Performance Marketing tab. */
+export const FUNNEL_STAGE_OPTIONS: FilterPillOption[] = [
+  { id: 'all', label: 'All stages' },
+  { id: 'tofu', label: 'Top of funnel' },
+  { id: 'mofu', label: 'Middle of funnel' },
+  { id: 'bofu', label: 'Bottom of funnel' },
+];

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -71,6 +71,9 @@ export interface AttributionChannelRow {
 /** Funnel stage identifier for the performance marketing filter. */
 export type FunnelStage = 'all' | 'tofu' | 'mofu' | 'bofu';
 
+/** Performance rating for paid project campaigns. */
+export type PaidProjectPerformance = 'EXCELLENT' | 'GOOD' | 'POOR' | 'NO REVENUE';
+
 /** View-model row for the performance marketing project table. */
 export interface PaidProjectRow {
   name: string;
@@ -79,6 +82,6 @@ export interface PaidProjectRow {
   revenue: string;
   roas: string;
   impressions: string;
-  performance: string;
+  performance: PaidProjectPerformance;
   performanceClass: string;
 }

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -67,3 +67,18 @@ export interface AttributionChannelRow {
   sessionsFormatted: string;
   raw: MarketingAttributionChannel;
 }
+
+/** Funnel stage identifier for the performance marketing filter. */
+export type FunnelStage = 'all' | 'tofu' | 'mofu' | 'bofu';
+
+/** View-model row for the performance marketing project table. */
+export interface PaidProjectRow {
+  name: string;
+  funnelStage: string;
+  spend: string;
+  revenue: string;
+  roas: string;
+  impressions: string;
+  performance: string;
+  performanceClass: string;
+}


### PR DESCRIPTION
## Summary
- Adds Performance Marketing tab with KPI cards (Impressions, Spend, Revenue, ROAS)
- Funnel stage filter pills (All/TOFU/MOFU/BOFU)
- Project breakdown table with performance badges (only EXCELLENT/GOOD shown)
- Uses `getSocialReach` API

**Depends on:** #718

## Test plan
- [ ] Select TLF, click Performance Marketing tab — KPI cards and table render
- [ ] Toggle funnel filter pills — table filters correctly
- [ ] Verify POOR/NO REVENUE rows show no badge (not hidden, just no colored label)

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)