### PR TITLE
feat(dashboards): add email marketing tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -55,8 +55,8 @@
           <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
         </div>
 
-        @for (row of emailTypeRows(); track row.emailType) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + row.emailType">
+        @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + idx">
             <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.emailType }}</span>
             <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.campaignCount }}</span>
             <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
@@ -103,8 +103,8 @@
           <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
         </div>
 
-        @for (row of topCampaigns(); track row.type + '|' + row.name) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + row.name">
+        @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + idx">
             <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
             <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
             <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -26,74 +26,98 @@
   </div>
 
   <!-- Email type breakdown table -->
-  @if (!loading()) {
-    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-type-breakdown">
-      <h4 class="text-sm font-semibold text-gray-900">Performance by email type</h4>
+  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-type-breakdown">
+    <h4 class="text-sm font-semibold text-gray-900">Performance by email type</h4>
 
-      @if (hasEmailTypes()) {
-        <div class="flex flex-col gap-0" data-testid="email-type-table">
-          <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">TYPE</span>
-            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">CAMPAIGNS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SENDS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPENS</span>
-            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPEN RATE</span>
-            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">CTR</span>
-          </div>
-
-          <!-- Rows -->
-          @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + idx">
-              <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.emailType }}</span>
-              <span class="w-20 text-right text-xs text-gray-500">{{ row.campaignCount }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.sends }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.opens }}</span>
-              <span class="w-20 text-right text-xs text-gray-500">{{ row.openRate }}</span>
-              <span class="flex-1 text-right text-xs font-medium text-gray-900">{{ row.ctr }}</span>
-            </div>
+    @if (loading()) {
+      <div class="flex flex-col gap-0" data-testid="email-type-skeleton">
+        <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+          @for (i of [1, 2, 3, 4, 5, 6]; track i) {
+            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
           }
         </div>
-      } @else {
-        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-type-empty">
-          <p class="text-sm text-gray-500">No email type data available.</p>
-        </div>
-      }
-    </div>
-
-    <!-- Top campaigns table -->
-    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
-      <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
-
-      @if (hasTopCampaigns()) {
-        <div class="flex flex-col gap-0" data-testid="email-campaigns-table">
-          <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">CAMPAIGN</span>
-            <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400">TYPE</span>
-            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">SENDS</span>
-            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPENS</span>
-            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPEN RATE</span>
-            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400">CTR</span>
+        @for (i of [1, 2, 3]; track i) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5">
+            @for (j of [1, 2, 3, 4, 5, 6]; track j) {
+              <div class="h-3 w-20 animate-pulse rounded bg-gray-100"></div>
+            }
           </div>
+        }
+      </div>
+    } @else if (hasEmailTypes()) {
+      <div class="flex flex-col gap-0" role="table" aria-label="Performance by email type" data-testid="email-type-table">
+        <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+          <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
+          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGNS</span>
+          <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
+          <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
+          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
+          <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
+        </div>
 
-          <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + idx">
-              <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
-              <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>
-              <span class="w-20 text-right text-xs text-gray-900">{{ row.sends }}</span>
-              <span class="w-20 text-right text-xs text-gray-900">{{ row.opens }}</span>
-              <span class="w-20 text-right text-xs text-gray-500">{{ row.openRate }}</span>
-              <span class="w-16 text-right text-xs font-medium text-gray-900">{{ row.ctr }}</span>
-            </div>
+        @for (row of emailTypeRows(); track row.emailType) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + row.emailType">
+            <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.emailType }}</span>
+            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.campaignCount }}</span>
+            <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
+            <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
+            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
+            <span class="flex-1 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
+          </div>
+        }
+      </div>
+    } @else {
+      <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-type-empty">
+        <p class="text-sm text-gray-500">No email type data available.</p>
+      </div>
+    }
+  </div>
+
+  <!-- Top campaigns table -->
+  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
+    <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
+
+    @if (loading()) {
+      <div class="flex flex-col gap-0" data-testid="email-campaigns-skeleton">
+        <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+          @for (i of [1, 2, 3, 4, 5, 6]; track i) {
+            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
           }
         </div>
-      } @else {
-        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
-          <p class="text-sm text-gray-500">No campaign data available.</p>
+        @for (i of [1, 2, 3]; track i) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5">
+            @for (j of [1, 2, 3, 4, 5, 6]; track j) {
+              <div class="h-3 w-20 animate-pulse rounded bg-gray-100"></div>
+            }
+          </div>
+        }
+      </div>
+    } @else if (hasTopCampaigns()) {
+      <div class="flex flex-col gap-0" role="table" aria-label="Top campaigns by sends" data-testid="email-campaigns-table">
+        <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+          <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGN</span>
+          <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
+          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
+          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
+          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
+          <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
         </div>
-      }
-    </div>
-  }
+
+        @for (row of topCampaigns(); track row.type + '|' + row.name) {
+          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + row.name">
+            <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
+            <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
+            <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
+            <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
+            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
+            <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
+          </div>
+        }
+      </div>
+    } @else {
+      <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
+        <p class="text-sm text-gray-500">No campaign data available.</p>
+      </div>
+    }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -43,8 +43,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + idx">
+          @for (row of emailTypeRows(); track row.emailType) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + row.emailType">
               <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.emailType }}</span>
               <span class="w-20 text-right text-xs text-gray-500">{{ row.campaignCount }}</span>
               <span class="w-24 text-right text-xs text-gray-900">{{ row.sends }}</span>
@@ -78,8 +78,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + idx">
+          @for (row of topCampaigns(); track row.name) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
               <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>
               <span class="w-20 text-right text-xs text-gray-900">{{ row.sends }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -78,7 +78,7 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.name) {
+          @for (row of topCampaigns(); track row.type + '|' + row.name) {
             <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
               <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -43,8 +43,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of emailTypeRows(); track row.emailType) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + row.emailType">
+          @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + idx">
               <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.emailType }}</span>
               <span class="w-20 text-right text-xs text-gray-500">{{ row.campaignCount }}</span>
               <span class="w-24 text-right text-xs text-gray-900">{{ row.sends }}</span>
@@ -78,8 +78,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
+          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + idx">
               <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>
               <span class="w-20 text-right text-xs text-gray-900">{{ row.sends }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -3,9 +3,9 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, finalize, of, switchMap } from 'rxjs';
+import { catchError, of, switchMap, tap } from 'rxjs';
 
 import type { EmailCtrResponse, EmailTypeRow, PerformanceSummaryKpi, TopCampaignRow } from '@lfx-one/shared/interfaces';
 
@@ -49,8 +49,11 @@ export class EmailTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getEmailCtr(slug).pipe(
-            finalize(() => this.loading.set(false)),
-            catchError(() => of(null))
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
           );
         })
       ),
@@ -65,21 +68,8 @@ export class EmailTabComponent {
 
       const totalSends = data.monthlySends?.reduce((s, v) => s + v, 0) ?? 0;
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
+      const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
       const changePct = data.changePercentage;
-
-      const sendsMom = this.computeMomPct(data.monthlySends);
-      const opensMom = this.computeMomPct(data.monthlyOpens);
-
-      const sends = data.monthlySends ?? [];
-      const opens = data.monthlyOpens ?? [];
-      const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
-      const prevSends = sends.length > 1 ? sends[sends.length - 2] : undefined;
-      const lastOpens = sends.length > 0 ? (opens[opens.length - 1] ?? 0) : 0;
-      const prevOpens = sends.length > 1 ? (opens[opens.length - 2] ?? 0) : 0;
-
-      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
-      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
-      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
         {
@@ -88,9 +78,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-paper-plane',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(totalSends),
-          momChange: formatChangePct(sendsMom, 'MoM'),
-          momTrend: trendDirection(sendsMom),
-          momTrendClass: trendColorClass(sendsMom),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -102,9 +92,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-green-100 text-green-600',
           value: formatNumber(totalOpens),
-          momChange: formatChangePct(opensMom, 'MoM'),
-          momTrend: trendDirection(opensMom),
-          momTrendClass: trendColorClass(opensMom),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -115,10 +105,10 @@ export class EmailTabComponent {
           label: 'Open Rate',
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${currentOpenRate.toFixed(1)}%`,
-          momChange: formatChangePct(openRateMom, 'MoM'),
-          momTrend: trendDirection(openRateMom),
-          momTrendClass: trendColorClass(openRateMom),
+          value: `${openRate.toFixed(1)}%`,
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -130,9 +120,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${data.currentCtr.toFixed(2)}%`,
-          momChange: formatChangePct(changePct, 'vs avg'),
-          momTrend: trendDirection(changePct),
-          momTrendClass: trendColorClass(changePct),
+          momChange: this.formatChangePct(changePct, 'MoM'),
+          momTrend: this.trendDirection(changePct),
+          momTrendClass: this.trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -183,11 +173,20 @@ export class EmailTabComponent {
   }
 
   // === Private Helpers ===
-  private computeMomPct(arr: number[] | undefined): number | null {
-    if (!arr || arr.length < 2) return null;
-    const current = arr.at(-1) ?? 0;
-    const previous = arr.at(-2) ?? 0;
-    if (previous === 0) return null;
-    return ((current - previous) / previous) * 100;
+  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+    if (pct > 0) return 'up';
+    if (pct < 0) return 'down';
+    return 'neutral';
+  }
+
+  private trendColorClass(pct: number): string {
+    if (pct > 0) return 'text-green-600';
+    if (pct < 0) return 'text-red-600';
+    return 'text-gray-500';
+  }
+
+  private formatChangePct(pct: number, suffix: string): string {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}% ${suffix}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -78,8 +78,8 @@ export class EmailTabComponent {
       const lastOpens = minLen > 0 ? (opens[minLen - 1] ?? 0) : 0;
       const prevOpens = minLen > 1 ? (opens[minLen - 2] ?? 0) : 0;
 
-      const currentOpenRate = lastSends && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
-      const prevOpenRate = prevSends && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
+      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
+      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
       const openRateMom = this.computeMomPctFromValues(currentOpenRate, prevOpenRate);
 
       return [

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -72,14 +72,15 @@ export class EmailTabComponent {
 
       const sends = data.monthlySends ?? [];
       const opens = data.monthlyOpens ?? [];
-      const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
-      const prevSends = sends.length > 1 ? sends[sends.length - 2] : undefined;
-      const lastOpens = sends.length > 0 ? (opens[opens.length - 1] ?? 0) : 0;
-      const prevOpens = sends.length > 1 ? (opens[opens.length - 2] ?? 0) : 0;
+      const minLen = Math.min(sends.length, opens.length);
+      const lastSends = minLen > 0 ? sends[minLen - 1] : undefined;
+      const prevSends = minLen > 1 ? sends[minLen - 2] : undefined;
+      const lastOpens = minLen > 0 ? (opens[minLen - 1] ?? 0) : 0;
+      const prevOpens = minLen > 1 ? (opens[minLen - 2] ?? 0) : 0;
 
-      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
-      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
-      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
+      const currentOpenRate = lastSends && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
+      const prevOpenRate = prevSends && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
+      const openRateMom = this.computeMomPctFromValues(currentOpenRate, prevOpenRate);
 
       return [
         {
@@ -185,8 +186,10 @@ export class EmailTabComponent {
   // === Private Helpers ===
   private computeMomPct(arr: number[] | undefined): number | null {
     if (!arr || arr.length < 2) return null;
-    const current = arr.at(-1) ?? 0;
-    const previous = arr.at(-2) ?? 0;
+    return this.computeMomPctFromValues(arr.at(-1) ?? 0, arr.at(-2) ?? 0);
+  }
+
+  private computeMomPctFromValues(current: number, previous: number): number | null {
     if (previous === 0) return null;
     return ((current - previous) / previous) * 100;
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -3,9 +3,9 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type { EmailCtrResponse, EmailTypeRow, PerformanceSummaryKpi, TopCampaignRow } from '@lfx-one/shared/interfaces';
 
@@ -49,11 +49,8 @@ export class EmailTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getEmailCtr(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            finalize(() => this.loading.set(false)),
+            catchError(() => of(null))
           );
         })
       ),
@@ -71,6 +68,13 @@ export class EmailTabComponent {
       const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
       const changePct = data.changePercentage;
 
+      const sendsMom = this.computeMomPct(data.monthlySends);
+      const opensMom = this.computeMomPct(data.monthlyOpens);
+
+      const currentOpenRate = data.monthlySends?.at(-1) ? ((data.monthlyOpens?.at(-1) ?? 0) / data.monthlySends.at(-1)!) * 100 : 0;
+      const prevOpenRate = data.monthlySends?.at(-2) ? ((data.monthlyOpens?.at(-2) ?? 0) / data.monthlySends.at(-2)!) * 100 : 0;
+      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
+
       return [
         {
           id: 'total-sends',
@@ -78,9 +82,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-paper-plane',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(totalSends),
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(sendsMom, 'MoM'),
+          momTrend: trendDirection(sendsMom),
+          momTrendClass: trendColorClass(sendsMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -92,9 +96,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-green-100 text-green-600',
           value: formatNumber(totalOpens),
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(opensMom, 'MoM'),
+          momTrend: trendDirection(opensMom),
+          momTrendClass: trendColorClass(opensMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -106,9 +110,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${openRate.toFixed(1)}%`,
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(openRateMom, 'MoM'),
+          momTrend: trendDirection(openRateMom),
+          momTrendClass: trendColorClass(openRateMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -120,9 +124,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${data.currentCtr.toFixed(2)}%`,
-          momChange: this.formatChangePct(changePct, 'MoM'),
-          momTrend: this.trendDirection(changePct),
-          momTrendClass: this.trendColorClass(changePct),
+          momChange: formatChangePct(changePct, 'MoM'),
+          momTrend: trendDirection(changePct),
+          momTrendClass: trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -173,20 +177,11 @@ export class EmailTabComponent {
   }
 
   // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number): string {
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number, suffix: string): string {
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  private computeMomPct(arr: number[] | undefined): number | null {
+    if (!arr || arr.length < 2) return null;
+    const current = arr.at(-1) ?? 0;
+    const previous = arr.at(-2) ?? 0;
+    if (previous === 0) return null;
+    return ((current - previous) / previous) * 100;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -65,14 +65,20 @@ export class EmailTabComponent {
 
       const totalSends = data.monthlySends?.reduce((s, v) => s + v, 0) ?? 0;
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
-      const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
       const changePct = data.changePercentage;
 
       const sendsMom = this.computeMomPct(data.monthlySends);
       const opensMom = this.computeMomPct(data.monthlyOpens);
 
-      const currentOpenRate = data.monthlySends?.at(-1) ? ((data.monthlyOpens?.at(-1) ?? 0) / data.monthlySends.at(-1)!) * 100 : 0;
-      const prevOpenRate = data.monthlySends?.at(-2) ? ((data.monthlyOpens?.at(-2) ?? 0) / data.monthlySends.at(-2)!) * 100 : 0;
+      const sends = data.monthlySends ?? [];
+      const opens = data.monthlyOpens ?? [];
+      const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
+      const prevSends = sends.length > 1 ? sends[sends.length - 2] : undefined;
+      const lastOpens = sends.length > 0 ? (opens[opens.length - 1] ?? 0) : 0;
+      const prevOpens = sends.length > 1 ? (opens[opens.length - 2] ?? 0) : 0;
+
+      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
+      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
       const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
@@ -109,7 +115,7 @@ export class EmailTabComponent {
           label: 'Open Rate',
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${openRate.toFixed(1)}%`,
+          value: `${currentOpenRate.toFixed(1)}%`,
           momChange: formatChangePct(openRateMom, 'MoM'),
           momTrend: trendDirection(openRateMom),
           momTrendClass: trendColorClass(openRateMom),
@@ -124,7 +130,7 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${data.currentCtr.toFixed(2)}%`,
-          momChange: formatChangePct(changePct, 'MoM'),
+          momChange: formatChangePct(changePct, 'vs avg'),
           momTrend: trendDirection(changePct),
           momTrendClass: trendColorClass(changePct),
           yoyChange: null,


### PR DESCRIPTION
## Summary
- Adds Email tab with KPI cards (Total Sends, Opens, Open Rate, CTR)
- Email type breakdown table (campaigns by type with open rate and CTR)
- Top 5 campaigns table sorted by sends
- Uses `getEmailCtr` API

**Depends on:** #719

## Test plan
- [ ] Select TLF, click Email tab — KPI cards render
- [ ] Verify email type breakdown table shows rows
- [ ] Verify top campaigns table shows up to 5 campaigns

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)