### PR TITLE
feat(dashboards): add web activity tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -21,6 +21,13 @@ import type { AttributionChannelRow, AttributionModel, AttributionModelOption, M
   styleUrl: './attribution-section.component.scss',
 })
 export class AttributionSectionComponent {
+  private static readonly revenueKeyByModel: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
+    linear: 'linearRevenue',
+    firstTouch: 'firstTouchRevenue',
+    lastTouch: 'lastTouchRevenue',
+    timeDecay: 'timeDecayRevenue',
+  };
+
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly fb = inject(FormBuilder);
@@ -35,14 +42,6 @@ export class AttributionSectionComponent {
   });
 
   protected readonly modelOptions: AttributionModelOption[] = ATTRIBUTION_MODEL_OPTIONS;
-
-  // === Static ===
-  private static readonly revenueKeyByModel: Record<AttributionModel, 'linearRevenue' | 'firstTouchRevenue' | 'lastTouchRevenue' | 'timeDecayRevenue'> = {
-    linear: 'linearRevenue',
-    firstTouch: 'firstTouchRevenue',
-    lastTouch: 'lastTouchRevenue',
-    timeDecay: 'timeDecayRevenue',
-  };
 
   // === WritableSignals ===
   protected readonly loading = signal(false);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -1,0 +1,99 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="email-tab">
+  <!-- Header -->
+  <div class="flex flex-col gap-1">
+    <h3 class="text-base font-semibold text-gray-900">Email marketing</h3>
+    <p class="text-xs text-gray-500">Email engagement metrics · {{ foundationName() || 'All foundations' }}</p>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="email-kpi-grid">
+    @if (loading()) {
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="email-kpi-skeleton">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    } @else {
+      @for (kpi of kpiCards(); track kpi.id) {
+        <lfx-sparkline-kpi-card [kpi]="kpi" />
+      }
+    }
+  </div>
+
+  <!-- Email type breakdown table -->
+  @if (!loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-type-breakdown">
+      <h4 class="text-sm font-semibold text-gray-900">Performance by email type</h4>
+
+      @if (hasEmailTypes()) {
+        <div class="flex flex-col gap-0" data-testid="email-type-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">TYPE</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">CAMPAIGNS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SENDS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPENS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPEN RATE</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">CTR</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of emailTypeRows(); track row.emailType) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + row.emailType">
+              <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.emailType }}</span>
+              <span class="w-20 text-right text-xs text-gray-500">{{ row.campaignCount }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.sends }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.opens }}</span>
+              <span class="w-20 text-right text-xs text-gray-500">{{ row.openRate }}</span>
+              <span class="flex-1 text-right text-xs font-medium text-gray-900">{{ row.ctr }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-type-empty">
+          <p class="text-sm text-gray-500">No email type data available.</p>
+        </div>
+      }
+    </div>
+
+    <!-- Top campaigns table -->
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
+      <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
+
+      @if (hasTopCampaigns()) {
+        <div class="flex flex-col gap-0" data-testid="email-campaigns-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">CAMPAIGN</span>
+            <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400">TYPE</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">SENDS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPENS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400">OPEN RATE</span>
+            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400">CTR</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of topCampaigns(); track row.name) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
+              <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
+              <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>
+              <span class="w-20 text-right text-xs text-gray-900">{{ row.sends }}</span>
+              <span class="w-20 text-right text-xs text-gray-900">{{ row.opens }}</span>
+              <span class="w-20 text-right text-xs text-gray-500">{{ row.openRate }}</span>
+              <span class="w-16 text-right text-xs font-medium text-gray-900">{{ row.ctr }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
+          <p class="text-sm text-gray-500">No campaign data available.</p>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -78,7 +78,7 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.name) {
+          @for (row of topCampaigns(); track row.type + '|' + row.name) {
             <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
               <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -43,8 +43,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of emailTypeRows(); track row.emailType) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + row.emailType">
+          @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-type-row-' + idx">
               <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.emailType }}</span>
               <span class="w-20 text-right text-xs text-gray-500">{{ row.campaignCount }}</span>
               <span class="w-24 text-right text-xs text-gray-900">{{ row.sends }}</span>
@@ -78,8 +78,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + row.name">
+          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'email-campaign-row-' + idx">
               <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500">{{ row.type }}</span>
               <span class="w-20 text-right text-xs text-gray-900">{{ row.sends }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -3,9 +3,9 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type { EmailCtrResponse, EmailTypeRow, PerformanceSummaryKpi, TopCampaignRow } from '@lfx-one/shared/interfaces';
 
@@ -49,11 +49,8 @@ export class EmailTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getEmailCtr(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            finalize(() => this.loading.set(false)),
+            catchError(() => of(null))
           );
         })
       ),
@@ -71,6 +68,13 @@ export class EmailTabComponent {
       const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
       const changePct = data.changePercentage;
 
+      const sendsMom = this.computeMomPct(data.monthlySends);
+      const opensMom = this.computeMomPct(data.monthlyOpens);
+
+      const currentOpenRate = data.monthlySends?.at(-1) ? ((data.monthlyOpens?.at(-1) ?? 0) / data.monthlySends.at(-1)!) * 100 : 0;
+      const prevOpenRate = data.monthlySends?.at(-2) ? ((data.monthlyOpens?.at(-2) ?? 0) / data.monthlySends.at(-2)!) * 100 : 0;
+      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
+
       return [
         {
           id: 'total-sends',
@@ -78,9 +82,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-paper-plane',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(totalSends),
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(sendsMom, 'MoM'),
+          momTrend: trendDirection(sendsMom),
+          momTrendClass: trendColorClass(sendsMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -92,9 +96,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-green-100 text-green-600',
           value: formatNumber(totalOpens),
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(opensMom, 'MoM'),
+          momTrend: trendDirection(opensMom),
+          momTrendClass: trendColorClass(opensMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -106,9 +110,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${openRate.toFixed(1)}%`,
-          momChange: null,
-          momTrend: 'neutral' as const,
-          momTrendClass: 'text-gray-500',
+          momChange: formatChangePct(openRateMom, 'MoM'),
+          momTrend: trendDirection(openRateMom),
+          momTrendClass: trendColorClass(openRateMom),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -120,9 +124,9 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${data.currentCtr.toFixed(2)}%`,
-          momChange: this.formatChangePct(changePct, 'MoM'),
-          momTrend: this.trendDirection(changePct),
-          momTrendClass: this.trendColorClass(changePct),
+          momChange: formatChangePct(changePct, 'MoM'),
+          momTrend: trendDirection(changePct),
+          momTrendClass: trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -173,20 +177,11 @@ export class EmailTabComponent {
   }
 
   // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number): string {
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number, suffix: string): string {
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  private computeMomPct(arr: number[] | undefined): number | null {
+    if (!arr || arr.length < 2) return null;
+    const current = arr.at(-1) ?? 0;
+    const previous = arr.at(-2) ?? 0;
+    if (previous === 0) return null;
+    return ((current - previous) / previous) * 100;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -1,0 +1,192 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import type { EmailCtrResponse, EmailTypeRow, PerformanceSummaryKpi, TopCampaignRow } from '@lfx-one/shared/interfaces';
+
+import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+
+@Component({
+  selector: 'lfx-email-tab',
+  imports: [SparklineKpiCardComponent],
+  templateUrl: './email-tab.component.html',
+  styleUrl: './email-tab.component.scss',
+})
+export class EmailTabComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly emailData: Signal<EmailCtrResponse | null> = this.initEmailData();
+  protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
+  protected readonly emailTypeRows: Signal<EmailTypeRow[]> = this.initEmailTypeRows();
+  protected readonly hasEmailTypes = computed(() => this.emailTypeRows().length > 0);
+  protected readonly topCampaigns: Signal<TopCampaignRow[]> = this.initTopCampaigns();
+  protected readonly hasTopCampaigns = computed(() => this.topCampaigns().length > 0);
+
+  // === Private Initializers ===
+  private initEmailData(): Signal<EmailCtrResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getEmailCtr(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKpiCards(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.emailData();
+      if (!data) return [];
+
+      const totalSends = data.monthlySends?.reduce((s, v) => s + v, 0) ?? 0;
+      const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
+      const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
+      const changePct = data.changePercentage;
+
+      return [
+        {
+          id: 'total-sends',
+          label: 'Total Sends',
+          icon: 'fa-light fa-paper-plane',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: formatNumber(totalSends),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'total-opens',
+          label: 'Total Opens',
+          icon: 'fa-light fa-envelope-open',
+          iconClass: 'bg-green-100 text-green-600',
+          value: formatNumber(totalOpens),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'open-rate',
+          label: 'Open Rate',
+          icon: 'fa-light fa-chart-simple',
+          iconClass: 'bg-amber-100 text-amber-600',
+          value: `${openRate.toFixed(1)}%`,
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'ctr',
+          label: 'Click-Through Rate',
+          icon: 'fa-light fa-arrow-pointer',
+          iconClass: 'bg-violet-100 text-violet-600',
+          value: `${data.currentCtr.toFixed(2)}%`,
+          momChange: this.formatChangePct(changePct, 'MoM'),
+          momTrend: this.trendDirection(changePct),
+          momTrendClass: this.trendColorClass(changePct),
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+      ];
+    });
+  }
+
+  private initEmailTypeRows(): Signal<EmailTypeRow[]> {
+    return computed(() => {
+      const data = this.emailData();
+      if (!data?.emailTypeBreakdown?.length) return [];
+
+      return data.emailTypeBreakdown.map(
+        (et): EmailTypeRow => ({
+          emailType: et.emailType,
+          campaignCount: et.campaignCount,
+          sends: formatNumber(et.totalSends),
+          opens: formatNumber(et.totalOpens),
+          openRate: `${et.openRate.toFixed(1)}%`,
+          ctr: `${et.ctr.toFixed(2)}%`,
+        })
+      );
+    });
+  }
+
+  private initTopCampaigns(): Signal<TopCampaignRow[]> {
+    return computed(() => {
+      const data = this.emailData();
+      if (!data?.emailTypeBreakdown?.length) return [];
+
+      const allCampaigns = data.emailTypeBreakdown.flatMap((et) => et.campaigns ?? []);
+      return allCampaigns
+        .sort((a, b) => b.sends - a.sends)
+        .slice(0, 5)
+        .map(
+          (c): TopCampaignRow => ({
+            name: c.campaignName,
+            type: c.emailType,
+            sends: formatNumber(c.sends),
+            opens: formatNumber(c.opens),
+            openRate: `${c.openRate.toFixed(1)}%`,
+            ctr: `${c.ctr.toFixed(2)}%`,
+          })
+        );
+    });
+  }
+
+  // === Private Helpers ===
+  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+    if (pct > 0) return 'up';
+    if (pct < 0) return 'down';
+    return 'neutral';
+  }
+
+  private trendColorClass(pct: number): string {
+    if (pct > 0) return 'text-green-600';
+    if (pct < 0) return 'text-red-600';
+    return 'text-gray-500';
+  }
+
+  private formatChangePct(pct: number, suffix: string): string {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -65,14 +65,20 @@ export class EmailTabComponent {
 
       const totalSends = data.monthlySends?.reduce((s, v) => s + v, 0) ?? 0;
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
-      const openRate = totalSends > 0 ? (totalOpens / totalSends) * 100 : 0;
       const changePct = data.changePercentage;
 
       const sendsMom = this.computeMomPct(data.monthlySends);
       const opensMom = this.computeMomPct(data.monthlyOpens);
 
-      const currentOpenRate = data.monthlySends?.at(-1) ? ((data.monthlyOpens?.at(-1) ?? 0) / data.monthlySends.at(-1)!) * 100 : 0;
-      const prevOpenRate = data.monthlySends?.at(-2) ? ((data.monthlyOpens?.at(-2) ?? 0) / data.monthlySends.at(-2)!) * 100 : 0;
+      const sends = data.monthlySends ?? [];
+      const opens = data.monthlyOpens ?? [];
+      const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
+      const prevSends = sends.length > 1 ? sends[sends.length - 2] : undefined;
+      const lastOpens = sends.length > 0 ? (opens[opens.length - 1] ?? 0) : 0;
+      const prevOpens = sends.length > 1 ? (opens[opens.length - 2] ?? 0) : 0;
+
+      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
+      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
       const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
@@ -109,7 +115,7 @@ export class EmailTabComponent {
           label: 'Open Rate',
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${openRate.toFixed(1)}%`,
+          value: `${currentOpenRate.toFixed(1)}%`,
           momChange: formatChangePct(openRateMom, 'MoM'),
           momTrend: trendDirection(openRateMom),
           momTrendClass: trendColorClass(openRateMom),
@@ -124,7 +130,7 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${data.currentCtr.toFixed(2)}%`,
-          momChange: formatChangePct(changePct, 'MoM'),
+          momChange: formatChangePct(changePct, 'vs avg'),
           momTrend: trendDirection(changePct),
           momTrendClass: trendColorClass(changePct),
           yoyChange: null,

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -11,7 +11,7 @@
   <!-- KPI Cards -->
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="web-activity-kpi-grid">
     @if (loading()) {
-      @for (i of [1, 2, 3]; track i) {
+      @for (i of [1, 2, 3]; track $index) {
         <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="web-activity-kpi-skeleton">
           <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
           <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
@@ -28,7 +28,7 @@
   <!-- Domain breakdown table -->
   @if (!loading()) {
     <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="web-activity-domains">
-      <h4 class="text-sm font-semibold text-gray-900">Web activity by project</h4>
+      <h4 class="text-sm font-semibold text-gray-900">Web activity by domain</h4>
 
       @if (hasDomains()) {
         <div class="flex flex-col gap-0" data-testid="web-activity-table">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -1,0 +1,67 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="web-activity-tab">
+  <!-- Header -->
+  <div class="flex flex-col gap-1">
+    <h3 class="text-base font-semibold text-gray-900">Web activity</h3>
+    <p class="text-xs text-gray-500">Website engagement metrics · {{ foundationName() || 'All foundations' }}</p>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="web-activity-kpi-grid">
+    @if (loading()) {
+      @for (i of [1, 2, 3]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="web-activity-kpi-skeleton">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    } @else {
+      @for (kpi of kpiCards(); track kpi.id) {
+        <lfx-sparkline-kpi-card [kpi]="kpi" />
+      }
+    }
+  </div>
+
+  <!-- Domain breakdown table -->
+  @if (!loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="web-activity-domains">
+      <h4 class="text-sm font-semibold text-gray-900">Web activity by project</h4>
+
+      @if (hasDomains()) {
+        <div class="flex flex-col gap-0" data-testid="web-activity-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="w-44 text-[11px] font-semibold tracking-wide text-gray-400">DOMAIN</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SESSIONS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">PAGE VIEWS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">PAGES/SESSION</span>
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">SESSION SHARE</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of domainRows(); track row.domain) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'web-activity-row-' + row.domain">
+              <span class="w-44 truncate text-xs font-medium text-gray-700">{{ row.domain }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.sessions }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.pageViews }}</span>
+              <span class="w-24 text-right text-xs text-gray-500">{{ row.pagesPerSession }}</span>
+              <div class="flex flex-1 items-center gap-2">
+                <div class="h-2 flex-1 rounded-full bg-gray-100">
+                  <div class="h-2 rounded-full bg-blue-500" [style.width.%]="row.sessionShare"></div>
+                </div>
+                <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sessionShareFormatted }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="web-activity-empty">
+          <p class="text-sm text-gray-500">No web activity data available.</p>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.scss
@@ -1,2 +1,0 @@
-// Copyright The Linux Foundation and each contributor to LFX.
-// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -1,0 +1,140 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import type { PerformanceSummaryKpi, WebActivitiesSummaryResponse, WebActivityDomainRow } from '@lfx-one/shared/interfaces';
+
+import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+
+@Component({
+  selector: 'lfx-web-activity-tab',
+  imports: [SparklineKpiCardComponent],
+  templateUrl: './web-activity-tab.component.html',
+  styleUrl: './web-activity-tab.component.scss',
+})
+export class WebActivityTabComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly webData: Signal<WebActivitiesSummaryResponse | null> = this.initWebData();
+  protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
+  protected readonly domainRows: Signal<WebActivityDomainRow[]> = this.initDomainRows();
+  protected readonly hasDomains = computed(() => this.domainRows().length > 0);
+
+  // === Private Initializers ===
+  private initWebData(): Signal<WebActivitiesSummaryResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getWebActivitiesSummary(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKpiCards(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.webData();
+      if (!data) return [];
+
+      const totalSessions = data.totalSessions;
+      const totalPageViews = data.totalPageViews;
+      const pagesPerSession = totalSessions > 0 ? totalPageViews / totalSessions : 0;
+
+      return [
+        {
+          id: 'total-sessions',
+          label: 'Total Sessions',
+          icon: 'fa-light fa-browser',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: formatNumber(totalSessions),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'total-page-views',
+          label: 'Total Page Views',
+          icon: 'fa-light fa-file-lines',
+          iconClass: 'bg-green-100 text-green-600',
+          value: formatNumber(totalPageViews),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'pages-per-session',
+          label: 'Pages / Session',
+          icon: 'fa-light fa-layer-group',
+          iconClass: 'bg-amber-100 text-amber-600',
+          value: pagesPerSession.toFixed(1),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+      ];
+    });
+  }
+
+  private initDomainRows(): Signal<WebActivityDomainRow[]> {
+    return computed(() => {
+      const data = this.webData();
+      if (!data?.domainGroups?.length) return [];
+
+      const totalSessions = data.totalSessions || 1;
+
+      return data.domainGroups
+        .sort((a, b) => b.totalSessions - a.totalSessions)
+        .map((d): WebActivityDomainRow => {
+          const share = (d.totalSessions / totalSessions) * 100;
+          return {
+            domain: d.domainGroup,
+            sessions: formatNumber(d.totalSessions),
+            pageViews: formatNumber(d.totalPageViews),
+            pagesPerSession: d.totalSessions > 0 ? (d.totalPageViews / d.totalSessions).toFixed(1) : '0.0',
+            sessionShare: share,
+            sessionShareFormatted: `${Math.round(share)}%`,
+          };
+        });
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { finalize, of, switchMap } from 'rxjs';
 
 import type { PerformanceSummaryKpi, WebActivitiesSummaryResponse, WebActivityDomainRow } from '@lfx-one/shared/interfaces';
 
@@ -15,7 +15,7 @@ import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-c
   selector: 'lfx-web-activity-tab',
   imports: [SparklineKpiCardComponent],
   templateUrl: './web-activity-tab.component.html',
-  styleUrl: './web-activity-tab.component.scss',
+  styles: [],
 })
 export class WebActivityTabComponent {
   // === Services ===
@@ -46,13 +46,7 @@ export class WebActivityTabComponent {
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getWebActivitiesSummary(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
-          );
+          return this.analyticsService.getWebActivitiesSummary(slug).pipe(finalize(() => this.loading.set(false)));
         })
       ),
       { initialValue: null }
@@ -81,13 +75,12 @@ export class WebActivityTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
         {
           id: 'total-page-views',
           label: 'Total Page Views',
           icon: 'fa-light fa-file-lines',
-          iconClass: 'bg-green-100 text-green-600',
+          iconClass: 'bg-emerald-100 text-emerald-600',
           value: formatNumber(totalPageViews),
           momChange: null,
           momTrend: 'neutral' as const,
@@ -95,7 +88,6 @@ export class WebActivityTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
         {
           id: 'pages-per-session',
@@ -109,7 +101,6 @@ export class WebActivityTabComponent {
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
-          comparisonLine: '',
         },
       ];
     });
@@ -120,12 +111,12 @@ export class WebActivityTabComponent {
       const data = this.webData();
       if (!data?.domainGroups?.length) return [];
 
-      const totalSessions = data.totalSessions || 1;
+      const totalSessions = data.totalSessions ?? 0;
 
-      return data.domainGroups
+      return [...data.domainGroups]
         .sort((a, b) => b.totalSessions - a.totalSessions)
         .map((d): WebActivityDomainRow => {
-          const share = (d.totalSessions / totalSessions) * 100;
+          const share = totalSessions > 0 ? (d.totalSessions / totalSessions) * 100 : 0;
           return {
             domain: d.domainGroup,
             sessions: formatNumber(d.totalSessions),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -85,6 +85,8 @@
           [foundationSlug]="foundationSlug()"
           [foundationName]="foundationName()"
           data-testid="marketing-impact-performance-marketing-tab" />
+      } @else if (selectedTab() === 'email') {
+        <lfx-email-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-email-tab" />
       } @else {
         <div
           class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -87,6 +87,8 @@
           data-testid="marketing-impact-performance-marketing-tab" />
       } @else if (selectedTab() === 'email') {
         <lfx-email-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-email-tab" />
+      } @else if (selectedTab() === 'web-activity') {
+        <lfx-web-activity-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-web-activity-tab" />
       } @else {
         <div
           class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -24,6 +24,7 @@ import { AttributionSectionComponent } from './components/attribution-section/at
 import { EmailTabComponent } from './components/email-tab/email-tab.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
 import { PerformanceMarketingTabComponent } from './components/performance-marketing-tab/performance-marketing-tab.component';
+import { WebActivityTabComponent } from './components/web-activity-tab/web-activity-tab.component';
 
 @Component({
   selector: 'lfx-marketing-impact',
@@ -36,6 +37,7 @@ import { PerformanceMarketingTabComponent } from './components/performance-marke
     AttributionSectionComponent,
     PerformanceMarketingTabComponent,
     EmailTabComponent,
+    WebActivityTabComponent,
   ],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -21,6 +21,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from './components/attribution-section/attribution-section.component';
+import { EmailTabComponent } from './components/email-tab/email-tab.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
 import { PerformanceMarketingTabComponent } from './components/performance-marketing-tab/performance-marketing-tab.component';
 
@@ -34,6 +35,7 @@ import { PerformanceMarketingTabComponent } from './components/performance-marke
     OverviewTabComponent,
     AttributionSectionComponent,
     PerformanceMarketingTabComponent,
+    EmailTabComponent,
   ],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -85,3 +85,23 @@ export interface PaidProjectRow {
   performance: PaidProjectPerformance;
   performanceClass: string;
 }
+
+/** View-model row for the email type breakdown table. */
+export interface EmailTypeRow {
+  emailType: string;
+  campaignCount: number;
+  sends: string;
+  opens: string;
+  openRate: string;
+  ctr: string;
+}
+
+/** View-model row for the top campaigns table. */
+export interface TopCampaignRow {
+  name: string;
+  type: string;
+  sends: string;
+  opens: string;
+  openRate: string;
+  ctr: string;
+}

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -105,3 +105,13 @@ export interface TopCampaignRow {
   openRate: string;
   ctr: string;
 }
+
+/** View-model row for the web activity domain table. */
+export interface WebActivityDomainRow {
+  domain: string;
+  sessions: string;
+  pageViews: string;
+  pagesPerSession: string;
+  sessionShare: number;
+  sessionShareFormatted: string;
+}


### PR DESCRIPTION
## Summary
- Adds Web Activity tab with KPI cards (Sessions, Page Views, Pages/Session)
- Domain breakdown table with session share progress bars
- Uses `getWebActivitiesSummary` API

**Depends on:** #720

## Test plan
- [ ] Select TLF, click Web Activity tab — KPI cards render
- [ ] Verify domain table shows rows with share bars
- [ ] Verify empty state when no data

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)