### PR TITLE
feat(dashboards): add social accounts and social listening tabs

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
@@ -1,0 +1,62 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="social-accounts-tab">
+  <!-- Header -->
+  <div class="flex flex-col gap-1">
+    <h3 class="text-base font-semibold text-gray-900">Social accounts</h3>
+    <p class="text-xs text-gray-500">Social media performance · {{ foundationName() || 'All foundations' }}</p>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="social-accounts-kpi-grid">
+    @if (loading()) {
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="social-accounts-kpi-skeleton">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    } @else {
+      @for (kpi of kpiCards(); track kpi.id) {
+        <lfx-sparkline-kpi-card [kpi]="kpi" />
+      }
+    }
+  </div>
+
+  <!-- Platform breakdown table -->
+  @if (!loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-accounts-platforms">
+      <h4 class="text-sm font-semibold text-gray-900">Social accounts performance</h4>
+
+      @if (hasPlatforms()) {
+        <div class="flex flex-col gap-0" data-testid="social-accounts-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">PLATFORM</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">FOLLOWERS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">IMPRESSIONS</span>
+            <span class="w-28 text-right text-[11px] font-semibold tracking-wide text-gray-400">ENGAGEMENT</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">POSTS (30D)</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of platformRows(); track row.platform) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'social-account-row-' + row.platform">
+              <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.platform }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.followers }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ row.impressions }}</span>
+              <span class="w-28 text-right text-xs text-gray-500">{{ row.engagementRate }}</span>
+              <span class="flex-1 text-right text-xs text-gray-500">{{ row.posts }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="social-accounts-empty">
+          <p class="text-sm text-gray-500">No social account data available.</p>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type { PerformanceSummaryKpi, SocialAccountRow, SocialMediaResponse } from '@lfx-one/shared/interfaces';
 
@@ -47,11 +47,8 @@ export class SocialAccountsTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getSocialMedia(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            finalize(() => this.loading.set(false)),
+            catchError(() => of(null))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -1,0 +1,169 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import type { PerformanceSummaryKpi, SocialAccountRow, SocialMediaResponse } from '@lfx-one/shared/interfaces';
+
+import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+
+@Component({
+  selector: 'lfx-social-accounts-tab',
+  imports: [SparklineKpiCardComponent],
+  templateUrl: './social-accounts-tab.component.html',
+  styleUrl: './social-accounts-tab.component.scss',
+})
+export class SocialAccountsTabComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly socialData: Signal<SocialMediaResponse | null> = this.initSocialData();
+  protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
+  protected readonly platformRows: Signal<SocialAccountRow[]> = this.initPlatformRows();
+  protected readonly hasPlatforms = computed(() => this.platformRows().length > 0);
+
+  // === Private Initializers ===
+  private initSocialData(): Signal<SocialMediaResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getSocialMedia(slug).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKpiCards(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.socialData();
+      if (!data) return [];
+
+      const totalImpressions = data.platforms.reduce((sum, p) => sum + p.impressions, 0);
+      const totalPosts = data.platforms.reduce((sum, p) => sum + p.postsLast30Days, 0);
+      const avgEngagement = data.platforms.length > 0 ? data.platforms.reduce((sum, p) => sum + p.engagementRate, 0) / data.platforms.length : 0;
+      const changePct = data.changePercentage;
+
+      return [
+        {
+          id: 'total-followers',
+          label: 'Total Followers',
+          icon: 'fa-light fa-users',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: formatNumber(data.totalFollowers),
+          momChange: this.formatChangePct(changePct, 'MoM'),
+          momTrend: this.trendDirection(changePct),
+          momTrendClass: this.trendColorClass(changePct),
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'total-impressions',
+          label: 'Impressions',
+          icon: 'fa-light fa-eye',
+          iconClass: 'bg-green-100 text-green-600',
+          value: formatNumber(totalImpressions),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'engagement-rate',
+          label: 'Engagement Rate',
+          icon: 'fa-light fa-heart',
+          iconClass: 'bg-amber-100 text-amber-600',
+          value: `${avgEngagement.toFixed(2)}%`,
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'posts-published',
+          label: 'Posts Published',
+          icon: 'fa-light fa-pen-to-square',
+          iconClass: 'bg-violet-100 text-violet-600',
+          value: formatNumber(totalPosts),
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+      ];
+    });
+  }
+
+  private initPlatformRows(): Signal<SocialAccountRow[]> {
+    return computed(() => {
+      const data = this.socialData();
+      if (!data?.platforms?.length) return [];
+
+      return data.platforms
+        .sort((a, b) => b.followers - a.followers)
+        .map(
+          (p): SocialAccountRow => ({
+            platform: p.platform,
+            followers: formatNumber(p.followers),
+            impressions: formatNumber(p.impressions),
+            engagementRate: `${p.engagementRate.toFixed(2)}%`,
+            posts: formatNumber(p.postsLast30Days),
+          })
+        );
+    });
+  }
+
+  // === Private Helpers ===
+  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+    if (pct > 0) return 'up';
+    if (pct < 0) return 'down';
+    return 'neutral';
+  }
+
+  private trendColorClass(pct: number): string {
+    if (pct > 0) return 'text-green-600';
+    if (pct < 0) return 'text-red-600';
+    return 'text-gray-500';
+  }
+
+  private formatChangePct(pct: number, suffix: string): string {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, of, switchMap, tap } from 'rxjs';
 
@@ -76,9 +76,9 @@ export class SocialAccountsTabComponent {
           icon: 'fa-light fa-users',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(data.totalFollowers),
-          momChange: this.formatChangePct(changePct, 'MoM'),
-          momTrend: this.trendDirection(changePct),
-          momTrendClass: this.trendColorClass(changePct),
+          momChange: formatChangePct(changePct, 'MoM'),
+          momTrend: trendDirection(changePct),
+          momTrendClass: trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -135,7 +135,7 @@ export class SocialAccountsTabComponent {
       const data = this.socialData();
       if (!data?.platforms?.length) return [];
 
-      return data.platforms
+      return [...data.platforms]
         .sort((a, b) => b.followers - a.followers)
         .map(
           (p): SocialAccountRow => ({
@@ -147,23 +147,5 @@ export class SocialAccountsTabComponent {
           })
         );
     });
-  }
-
-  // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number): string {
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number, suffix: string): string {
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -79,9 +79,9 @@
       }
     </div>
 
-    <!-- Recent mentions -->
+    <!-- Top mentions -->
     <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-listening-mentions">
-      <h4 class="text-sm font-semibold text-gray-900">Recent mentions</h4>
+      <h4 class="text-sm font-semibold text-gray-900">Top mentions</h4>
 
       @if (hasTopMentions()) {
         <div class="flex flex-col gap-3" data-testid="social-listening-mentions-list">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -1,0 +1,114 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="social-listening-tab">
+  <!-- Header -->
+  <div class="flex flex-col gap-1">
+    <h3 class="text-base font-semibold text-gray-900">Social listening</h3>
+    <p class="text-xs text-gray-500">Brand mentions &amp; sentiment · {{ foundationName() || 'All foundations' }}</p>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="social-listening-kpi-grid">
+    @if (loading()) {
+      @for (i of [1, 2, 3]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="social-listening-kpi-skeleton">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    } @else {
+      @for (kpi of kpiCards(); track kpi.id) {
+        <lfx-sparkline-kpi-card [kpi]="kpi" />
+      }
+    }
+  </div>
+
+  @if (!loading()) {
+    <!-- Sentiment breakdown bar -->
+    @if (sentimentBar(); as bar) {
+      <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-listening-sentiment-bar">
+        <h4 class="text-sm font-semibold text-gray-900">Sentiment breakdown</h4>
+        <div class="flex h-3 w-full overflow-hidden rounded-full">
+          <div class="bg-green-500" [style.width.%]="bar.positive"></div>
+          <div class="bg-gray-300" [style.width.%]="bar.neutral"></div>
+          <div class="bg-red-500" [style.width.%]="bar.negative"></div>
+        </div>
+        <div class="flex items-center gap-4 text-xs text-gray-500">
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-2 w-2 rounded-full bg-green-500"></span>
+            Positive {{ bar.positiveLabel }}
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-2 w-2 rounded-full bg-gray-300"></span>
+            Neutral {{ bar.neutralLabel }}
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-2 w-2 rounded-full bg-red-500"></span>
+            Negative {{ bar.negativeLabel }}
+          </span>
+        </div>
+      </div>
+    }
+
+    <!-- Top projects by mentions -->
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-listening-projects">
+      <h4 class="text-sm font-semibold text-gray-900">Mentions by project</h4>
+
+      @if (hasTopProjects()) {
+        <div class="flex flex-col gap-0" data-testid="social-listening-projects-table">
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">PROJECT</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">MENTIONS</span>
+          </div>
+
+          @for (project of topProjects(); track project.name) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'social-listening-project-' + project.name">
+              <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ project.name }}</span>
+              <span class="w-24 text-right text-xs text-gray-900">{{ project.mentions }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div
+          class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8"
+          data-testid="social-listening-projects-empty">
+          <p class="text-sm text-gray-500">No project mention data available.</p>
+        </div>
+      }
+    </div>
+
+    <!-- Recent mentions -->
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-listening-mentions">
+      <h4 class="text-sm font-semibold text-gray-900">Recent mentions</h4>
+
+      @if (hasTopMentions()) {
+        <div class="flex flex-col gap-3" data-testid="social-listening-mentions-list">
+          @for (mention of topMentions(); track mention.url) {
+            <div class="flex flex-col gap-1 rounded-lg border border-gray-100 p-3" [attr.data-testid]="'social-listening-mention-' + mention.author">
+              <div class="flex items-center gap-2">
+                <span class="text-xs font-medium text-gray-700">{{ mention.author }}</span>
+                <span class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">{{ mention.sourcePlatform }}</span>
+                @if (mention.sentiment === 'positive') {
+                  <span class="rounded bg-green-50 px-1.5 py-0.5 text-[10px] font-medium text-green-700">positive</span>
+                } @else if (mention.sentiment === 'negative') {
+                  <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-700">negative</span>
+                } @else {
+                  <span class="rounded bg-gray-50 px-1.5 py-0.5 text-[10px] font-medium text-gray-600">neutral</span>
+                }
+              </div>
+              <p class="line-clamp-2 text-xs text-gray-600">{{ mention.title || mention.body }}</p>
+            </div>
+          }
+        </div>
+      } @else {
+        <div
+          class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8"
+          data-testid="social-listening-mentions-empty">
+          <p class="text-sm text-gray-500">No mention data available.</p>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -85,7 +85,7 @@
 
       @if (hasTopMentions()) {
         <div class="flex flex-col gap-3" data-testid="social-listening-mentions-list">
-          @for (mention of topMentions(); track mention.url) {
+          @for (mention of topMentions(); track $index) {
             <div class="flex flex-col gap-1 rounded-lg border border-gray-100 p-3" [attr.data-testid]="'social-listening-mention-' + mention.author">
               <div class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-700">{{ mention.author }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -1,0 +1,176 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import type { BrandHealthMention, BrandHealthResponse, BrandHealthTopProject, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
+
+import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+
+@Component({
+  selector: 'lfx-social-listening-tab',
+  imports: [SparklineKpiCardComponent],
+  templateUrl: './social-listening-tab.component.html',
+  styleUrl: './social-listening-tab.component.scss',
+})
+export class SocialListeningTabComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly brandData: Signal<BrandHealthResponse | null> = this.initBrandData();
+  protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
+  protected readonly sentimentBar: Signal<SentimentBar | null> = this.initSentimentBar();
+  protected readonly topProjects: Signal<BrandHealthTopProject[]> = this.initTopProjects();
+  protected readonly hasTopProjects = computed(() => this.topProjects().length > 0);
+  protected readonly topMentions: Signal<BrandHealthMention[]> = this.initTopMentions();
+  protected readonly hasTopMentions = computed(() => this.topMentions().length > 0);
+
+  // === Private Initializers ===
+  private initBrandData(): Signal<BrandHealthResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getBrandHealth(slug, true).pipe(
+            tap(() => this.loading.set(false)),
+            catchError(() => {
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKpiCards(): Signal<PerformanceSummaryKpi[]> {
+    return computed(() => {
+      const data = this.brandData();
+      if (!data) return [];
+
+      const changePct = data.mentionMomChangePct;
+
+      return [
+        {
+          id: 'total-mentions',
+          label: 'Total Mentions',
+          icon: 'fa-light fa-at',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: formatNumber(data.totalMentions),
+          momChange: this.formatChangePct(changePct, 'MoM'),
+          momTrend: this.trendDirection(changePct),
+          momTrendClass: this.trendColorClass(changePct),
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'positive-sentiment',
+          label: 'Positive Sentiment',
+          icon: 'fa-light fa-face-smile',
+          iconClass: 'bg-green-100 text-green-600',
+          value: `${data.sentiment.positive.toFixed(0)}%`,
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+        {
+          id: 'negative-sentiment',
+          label: 'Negative Sentiment',
+          icon: 'fa-light fa-face-frown',
+          iconClass: 'bg-red-100 text-red-600',
+          value: `${data.sentiment.negative.toFixed(0)}%`,
+          momChange: null,
+          momTrend: 'neutral' as const,
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral' as const,
+          yoyTrendClass: 'text-gray-500',
+          comparisonLine: '',
+        },
+      ];
+    });
+  }
+
+  private initSentimentBar(): Signal<SentimentBar | null> {
+    return computed(() => {
+      const data = this.brandData();
+      if (!data) return null;
+      return {
+        positive: data.sentiment.positive,
+        neutral: data.sentiment.neutral,
+        negative: data.sentiment.negative,
+        positiveLabel: `${Math.round(data.sentiment.positive)}%`,
+        neutralLabel: `${Math.round(data.sentiment.neutral)}%`,
+        negativeLabel: `${Math.round(data.sentiment.negative)}%`,
+      };
+    });
+  }
+
+  private initTopProjects(): Signal<BrandHealthTopProject[]> {
+    return computed(() => {
+      const data = this.brandData();
+      if (!data?.topProjects?.length) return [];
+      return data.topProjects.slice(0, 5);
+    });
+  }
+
+  private initTopMentions(): Signal<BrandHealthMention[]> {
+    return computed(() => {
+      const data = this.brandData();
+      if (!data) return [];
+      return [...(data.topPositiveMentions ?? []), ...(data.topNegativeMentions ?? [])].slice(0, 5);
+    });
+  }
+
+  // === Private Helpers ===
+  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
+    if (pct > 0) return 'up';
+    if (pct < 0) return 'down';
+    return 'neutral';
+  }
+
+  private trendColorClass(pct: number): string {
+    if (pct > 0) return 'text-green-600';
+    if (pct < 0) return 'text-red-600';
+    return 'text-gray-500';
+  }
+
+  private formatChangePct(pct: number, suffix: string): string {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}% ${suffix}`;
+  }
+}
+
+interface SentimentBar {
+  positive: number;
+  neutral: number;
+  negative: number;
+  positiveLabel: string;
+  neutralLabel: string;
+  negativeLabel: string;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -3,11 +3,11 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, of, switchMap, tap } from 'rxjs';
 
-import type { BrandHealthMention, BrandHealthResponse, BrandHealthTopProject, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
+import type { BrandHealthMention, BrandHealthResponse, BrandHealthTopProject, PerformanceSummaryKpi, SentimentBar } from '@lfx-one/shared/interfaces';
 
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
@@ -76,9 +76,9 @@ export class SocialListeningTabComponent {
           icon: 'fa-light fa-at',
           iconClass: 'bg-blue-100 text-blue-600',
           value: formatNumber(data.totalMentions),
-          momChange: this.formatChangePct(changePct, 'MoM'),
-          momTrend: this.trendDirection(changePct),
-          momTrendClass: this.trendColorClass(changePct),
+          momChange: formatChangePct(changePct, 'MoM'),
+          momTrend: trendDirection(changePct),
+          momTrendClass: trendColorClass(changePct),
           yoyChange: null,
           yoyTrend: 'neutral' as const,
           yoyTrendClass: 'text-gray-500',
@@ -146,31 +146,4 @@ export class SocialListeningTabComponent {
       return [...(data.topPositiveMentions ?? []), ...(data.topNegativeMentions ?? [])].slice(0, 5);
     });
   }
-
-  // === Private Helpers ===
-  private trendDirection(pct: number): 'up' | 'down' | 'neutral' {
-    if (pct > 0) return 'up';
-    if (pct < 0) return 'down';
-    return 'neutral';
-  }
-
-  private trendColorClass(pct: number): string {
-    if (pct > 0) return 'text-green-600';
-    if (pct < 0) return 'text-red-600';
-    return 'text-gray-500';
-  }
-
-  private formatChangePct(pct: number, suffix: string): string {
-    const sign = pct > 0 ? '+' : '';
-    return `${sign}${pct.toFixed(1)}% ${suffix}`;
-  }
-}
-
-interface SentimentBar {
-  positive: number;
-  neutral: number;
-  negative: number;
-  positiveLabel: string;
-  neutralLabel: string;
-  negativeLabel: string;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -140,7 +140,15 @@ export class SocialListeningTabComponent {
     return computed(() => {
       const data = this.brandData();
       if (!data) return [];
-      return [...(data.topPositiveMentions ?? []), ...(data.topNegativeMentions ?? [])].slice(0, 5);
+      const positive = data.topPositiveMentions ?? [];
+      const negative = data.topNegativeMentions ?? [];
+      const interleaved: BrandHealthMention[] = [];
+      const maxLen = Math.max(positive.length, negative.length);
+      for (let i = 0; i < maxLen && interleaved.length < 5; i++) {
+        if (i < positive.length) interleaved.push(positive[i]);
+        if (i < negative.length && interleaved.length < 5) interleaved.push(negative[i]);
+      }
+      return interleaved;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type { BrandHealthMention, BrandHealthResponse, BrandHealthTopProject, PerformanceSummaryKpi, SentimentBar } from '@lfx-one/shared/interfaces';
 
@@ -50,11 +50,8 @@ export class SocialListeningTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getBrandHealth(slug, true).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            finalize(() => this.loading.set(false)),
+            catchError(() => of(null))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { finalize, of, switchMap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type { PerformanceSummaryKpi, WebActivitiesSummaryResponse, WebActivityDomainRow } from '@lfx-one/shared/interfaces';
 
@@ -46,7 +46,10 @@ export class WebActivityTabComponent {
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getWebActivitiesSummary(slug).pipe(finalize(() => this.loading.set(false)));
+          return this.analyticsService.getWebActivitiesSummary(slug).pipe(
+            catchError(() => of(null)),
+            finalize(() => this.loading.set(false))
+          );
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -93,6 +93,15 @@
         <lfx-social-accounts-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-social-accounts-tab" />
       } @else if (selectedTab() === 'social-listening') {
         <lfx-social-listening-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-social-listening-tab" />
+      } @else {
+        <div
+          class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"
+          data-testid="marketing-impact-tab-placeholder">
+          <div class="flex flex-col items-center gap-2 text-center">
+            <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
+            <p class="text-sm text-gray-500">This section is coming soon.</p>
+          </div>
+        </div>
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -91,15 +91,8 @@
         <lfx-web-activity-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-web-activity-tab" />
       } @else if (selectedTab() === 'social-accounts') {
         <lfx-social-accounts-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-social-accounts-tab" />
-      } @else {
-        <div
-          class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"
-          data-testid="marketing-impact-tab-placeholder">
-          <div class="flex flex-col items-center gap-2 text-center">
-            <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
-            <p class="text-sm text-gray-500">{{ selectedTabLabel() }} data coming soon.</p>
-          </div>
-        </div>
+      } @else if (selectedTab() === 'social-listening') {
+        <lfx-social-listening-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-social-listening-tab" />
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -89,6 +89,8 @@
         <lfx-email-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-email-tab" />
       } @else if (selectedTab() === 'web-activity') {
         <lfx-web-activity-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-web-activity-tab" />
+      } @else if (selectedTab() === 'social-accounts') {
+        <lfx-social-accounts-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="marketing-impact-social-accounts-tab" />
       } @else {
         <div
           class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-16"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -25,6 +25,7 @@ import { EmailTabComponent } from './components/email-tab/email-tab.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
 import { PerformanceMarketingTabComponent } from './components/performance-marketing-tab/performance-marketing-tab.component';
 import { SocialAccountsTabComponent } from './components/social-accounts-tab/social-accounts-tab.component';
+import { SocialListeningTabComponent } from './components/social-listening-tab/social-listening-tab.component';
 import { WebActivityTabComponent } from './components/web-activity-tab/web-activity-tab.component';
 
 @Component({
@@ -40,6 +41,7 @@ import { WebActivityTabComponent } from './components/web-activity-tab/web-activ
     EmailTabComponent,
     WebActivityTabComponent,
     SocialAccountsTabComponent,
+    SocialListeningTabComponent,
   ],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -69,7 +69,6 @@ export class MarketingImpactComponent {
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
   protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
   protected readonly foundationSlug = computed(() => this.projectContextService.selectedFoundation()?.slug);
-  protected readonly selectedTabLabel = computed(() => this.tabs.find((t) => t.id === this.selectedTab())?.label ?? '');
   protected readonly selectedMonth: Signal<string> = this.initSelectedMonth();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
 

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -24,6 +24,7 @@ import { AttributionSectionComponent } from './components/attribution-section/at
 import { EmailTabComponent } from './components/email-tab/email-tab.component';
 import { OverviewTabComponent } from './components/overview-tab/overview-tab.component';
 import { PerformanceMarketingTabComponent } from './components/performance-marketing-tab/performance-marketing-tab.component';
+import { SocialAccountsTabComponent } from './components/social-accounts-tab/social-accounts-tab.component';
 import { WebActivityTabComponent } from './components/web-activity-tab/web-activity-tab.component';
 
 @Component({
@@ -38,6 +39,7 @@ import { WebActivityTabComponent } from './components/web-activity-tab/web-activ
     PerformanceMarketingTabComponent,
     EmailTabComponent,
     WebActivityTabComponent,
+    SocialAccountsTabComponent,
   ],
   templateUrl: './marketing-impact.component.html',
   styleUrl: './marketing-impact.component.scss',

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -115,6 +115,16 @@ export interface SocialAccountRow {
   posts: string;
 }
 
+/** Segment data for the sentiment breakdown horizontal bar chart. */
+export interface SentimentBar {
+  positive: number;
+  neutral: number;
+  negative: number;
+  positiveLabel: string;
+  neutralLabel: string;
+  negativeLabel: string;
+}
+
 /** View-model row for the web activity domain table. */
 export interface WebActivityDomainRow {
   domain: string;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -106,6 +106,15 @@ export interface TopCampaignRow {
   ctr: string;
 }
 
+/** View-model row for the social accounts platform table. */
+export interface SocialAccountRow {
+  platform: string;
+  followers: string;
+  impressions: string;
+  engagementRate: string;
+  posts: string;
+}
+
 /** View-model row for the web activity domain table. */
 export interface WebActivityDomainRow {
   domain: string;


### PR DESCRIPTION
## Summary
- Adds Social Accounts tab: KPI cards (Followers, Impressions, Engagement Rate, Posts) + platform table
- Adds Social Listening tab: KPI cards (Mentions, Sentiment) + sentiment bar + projects table + mentions feed
- Removes "coming soon" placeholder — all 7 tabs now render real data
- Uses `getSocialMedia` and `getBrandHealth` APIs

**Depends on:** #721

## Test plan
- [ ] Select TLF, click Social Accounts tab — KPI cards and platform table render
- [ ] Click Social Listening tab — sentiment bar, projects, and mentions render
- [ ] Verify no more "coming soon" placeholder for any tab

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/claude-code)