### PR TITLE
feat(dashboards): show all sections on overview tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -43,8 +43,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of emailTypeRows(); track row.emailType) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + row.emailType">
+          @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + idx">
               <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.emailType }}</span>
               <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.campaignCount }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
@@ -78,8 +78,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + row.name">
+          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + idx">
               <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
               <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -20,104 +20,80 @@
       }
     } @else {
       @for (kpi of kpiCards(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="email" />
       }
     }
   </div>
 
   <!-- Email type breakdown table -->
-  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-type-breakdown">
-    <h4 class="text-sm font-semibold text-gray-900">Performance by email type</h4>
+  @if (!loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-type-breakdown">
+      <h4 class="text-sm font-semibold text-gray-900">Performance by email type</h4>
 
-    @if (loading()) {
-      <div class="flex flex-col gap-0" data-testid="email-type-skeleton">
-        <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-          @for (i of [1, 2, 3, 4, 5, 6]; track i) {
-            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
+      @if (hasEmailTypes()) {
+        <div class="flex flex-col gap-0" role="table" aria-label="Performance by email type" data-testid="email-type-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGNS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
+          </div>
+
+          <!-- Rows -->
+          @for (row of emailTypeRows(); track row.emailType) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + row.emailType">
+              <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.emailType }}</span>
+              <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.campaignCount }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
+              <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
+              <span class="flex-1 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
+            </div>
           }
         </div>
-        @for (i of [1, 2, 3]; track i) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5">
-            @for (j of [1, 2, 3, 4, 5, 6]; track j) {
-              <div class="h-3 w-20 animate-pulse rounded bg-gray-100"></div>
-            }
-          </div>
-        }
-      </div>
-    } @else if (hasEmailTypes()) {
-      <div class="flex flex-col gap-0" role="table" aria-label="Performance by email type" data-testid="email-type-table">
-        <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
-          <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
-          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGNS</span>
-          <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
-          <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
-          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
-          <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-type-empty">
+          <p class="text-sm text-gray-500">No email type data available.</p>
         </div>
+      }
+    </div>
 
-        @for (row of emailTypeRows(); track row.emailType; let idx = $index) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-type-row-' + idx">
-            <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.emailType }}</span>
-            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.campaignCount }}</span>
-            <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
-            <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
-            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
-            <span class="flex-1 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
+    <!-- Top campaigns table -->
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
+      <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
+
+      @if (hasTopCampaigns()) {
+        <div class="flex flex-col gap-0" role="table" aria-label="Top campaigns by sends" data-testid="email-campaigns-table">
+          <!-- Table header -->
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGN</span>
+            <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
+            <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
+            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
           </div>
-        }
-      </div>
-    } @else {
-      <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-type-empty">
-        <p class="text-sm text-gray-500">No email type data available.</p>
-      </div>
-    }
-  </div>
 
-  <!-- Top campaigns table -->
-  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
-    <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
-
-    @if (loading()) {
-      <div class="flex flex-col gap-0" data-testid="email-campaigns-skeleton">
-        <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-          @for (i of [1, 2, 3, 4, 5, 6]; track i) {
-            <div class="h-3 w-20 animate-pulse rounded bg-gray-200"></div>
+          <!-- Rows -->
+          @for (row of topCampaigns(); track row.type + '|' + row.name) {
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + row.name">
+              <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
+              <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
+              <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
+              <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
+              <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
+              <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
+            </div>
           }
         </div>
-        @for (i of [1, 2, 3]; track i) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5">
-            @for (j of [1, 2, 3, 4, 5, 6]; track j) {
-              <div class="h-3 w-20 animate-pulse rounded bg-gray-100"></div>
-            }
-          </div>
-        }
-      </div>
-    } @else if (hasTopCampaigns()) {
-      <div class="flex flex-col gap-0" role="table" aria-label="Top campaigns by sends" data-testid="email-campaigns-table">
-        <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
-          <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGN</span>
-          <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
-          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
-          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
-          <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
-          <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
+          <p class="text-sm text-gray-500">No campaign data available.</p>
         </div>
-
-        @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
-          <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + idx">
-            <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
-            <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
-            <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
-            <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
-            <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
-            <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.ctr }}</span>
-          </div>
-        }
-      </div>
-    } @else {
-      <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
-        <p class="text-sm text-gray-500">No campaign data available.</p>
-      </div>
-    }
-  </div>
+      }
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -130,7 +130,7 @@ export class EmailTabComponent {
           label: 'Click-Through Rate',
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
-          value: `${data.currentCtr.toFixed(2)}%`,
+          value: `${(data.currentCtr ?? 0).toFixed(2)}%`,
           momChange: formatChangePct(changePct, 'vs avg'),
           momTrend: trendDirection(changePct),
           momTrendClass: trendColorClass(changePct),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -31,7 +31,7 @@
       }
     } @else {
       @for (kpi of performanceSummaryKpis(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="overview" />
       } @empty {
         <div class="col-span-full text-center py-8 text-sm text-gray-500" data-testid="overview-tab-kpi-empty">
           No performance data available for this period.

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -42,13 +42,3 @@
 </div>
 
 <lfx-attribution-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-attribution-section" />
-
-<lfx-performance-marketing-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-performance-marketing" />
-
-<lfx-email-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-email" />
-
-<lfx-web-activity-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-web-activity" />
-
-<lfx-social-accounts-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-social-accounts" />
-
-<lfx-social-listening-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-social-listening" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -42,3 +42,13 @@
 </div>
 
 <lfx-attribution-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-attribution-section" />
+
+<lfx-performance-marketing-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-performance-marketing" />
+
+<lfx-email-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-email" />
+
+<lfx-web-activity-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-web-activity" />
+
+<lfx-social-accounts-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-social-accounts" />
+
+<lfx-social-listening-tab [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-social-listening" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -11,25 +11,11 @@ import { catchError, finalize, forkJoin, of, switchMap } from 'rxjs';
 import type { OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
-import { EmailTabComponent } from '../email-tab/email-tab.component';
-import { PerformanceMarketingTabComponent } from '../performance-marketing-tab/performance-marketing-tab.component';
-import { SocialAccountsTabComponent } from '../social-accounts-tab/social-accounts-tab.component';
-import { SocialListeningTabComponent } from '../social-listening-tab/social-listening-tab.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
-import { WebActivityTabComponent } from '../web-activity-tab/web-activity-tab.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [
-    ButtonComponent,
-    SparklineKpiCardComponent,
-    AttributionSectionComponent,
-    PerformanceMarketingTabComponent,
-    EmailTabComponent,
-    WebActivityTabComponent,
-    SocialAccountsTabComponent,
-    SocialListeningTabComponent,
-  ],
+  imports: [ButtonComponent, SparklineKpiCardComponent, AttributionSectionComponent],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -11,11 +11,25 @@ import { catchError, finalize, forkJoin, of, switchMap } from 'rxjs';
 import type { OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
+import { EmailTabComponent } from '../email-tab/email-tab.component';
+import { PerformanceMarketingTabComponent } from '../performance-marketing-tab/performance-marketing-tab.component';
+import { SocialAccountsTabComponent } from '../social-accounts-tab/social-accounts-tab.component';
+import { SocialListeningTabComponent } from '../social-listening-tab/social-listening-tab.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
+import { WebActivityTabComponent } from '../web-activity-tab/web-activity-tab.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [ButtonComponent, SparklineKpiCardComponent, AttributionSectionComponent],
+  imports: [
+    ButtonComponent,
+    SparklineKpiCardComponent,
+    AttributionSectionComponent,
+    PerformanceMarketingTabComponent,
+    EmailTabComponent,
+    WebActivityTabComponent,
+    SocialAccountsTabComponent,
+    SocialListeningTabComponent,
+  ],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -137,7 +137,7 @@ export class OverviewTabComponent {
           label: 'Email CTR',
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${ec.currentCtr.toFixed(2)}%`,
+          value: `${(ec.currentCtr ?? 0).toFixed(2)}%`,
           momChange: formatChangePct(momPct, 'vs avg'),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -138,7 +138,7 @@ export class OverviewTabComponent {
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${ec.currentCtr.toFixed(2)}%`,
-          momChange: formatChangePct(momPct, 'MoM'),
+          momChange: formatChangePct(momPct, 'vs avg'),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),
           yoyChange: null,

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -56,7 +56,7 @@
           </div>
 
           <!-- Rows -->
-          @for (row of projectRows(); track row.name) {
+          @for (row of projectRows(); track row.funnelStage + '|' + row.name) {
             <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'performance-marketing-row-' + row.name">
               <span class="w-40 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
               <span class="w-20 truncate text-[11px] text-gray-500" role="cell">{{ row.funnelStage }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -32,7 +32,7 @@
       }
     } @else {
       @for (kpi of kpiCards(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="perf-marketing" />
       }
     }
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -7,7 +7,7 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
 import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, finalize, of, switchMap } from 'rxjs';
 
 import type {
   FilterPillOption,
@@ -87,11 +87,8 @@ export class PerformanceMarketingTabComponent {
           }
           this.loading.set(true);
           return this.analyticsService.getSocialReach(slug).pipe(
-            tap(() => this.loading.set(false)),
-            catchError(() => {
-              this.loading.set(false);
-              return of(null);
-            })
+            catchError(() => of(null)),
+            finalize(() => this.loading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -105,7 +105,8 @@ export class PerformanceMarketingTabComponent {
       if (!data) return [];
 
       const roasMomPct = data.changePercentage;
-      const impressionsMomPct = computeMomPct(data.monthlyData);
+      const completedMonths = data.monthlyData?.slice(0, -1);
+      const impressionsMomPct = computeMomPct(completedMonths);
 
       const cards: PerformanceSummaryKpi[] = [
         {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -176,11 +176,11 @@ export class PerformanceMarketingTabComponent {
         .filter((p) => {
           if (funnel === 'all') return true;
           const stage = p.funnelStage?.toLowerCase() ?? '';
-          if (stage === 'unknown') return false;
+          if (!stage || stage === 'unknown') return false;
           if (funnel === 'tofu') return stage.startsWith('tofu');
           if (funnel === 'mofu') return stage === 'mofu';
           if (funnel === 'bofu') return stage === 'bofu';
-          return true;
+          return false;
         })
         .map(
           (p): PaidProjectRow => ({

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
-import { formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, of, switchMap, tap } from 'rxjs';
 
@@ -105,7 +105,7 @@ export class PerformanceMarketingTabComponent {
       if (!data) return [];
 
       const roasMomPct = data.changePercentage;
-      const impressionsMomPct = this.computeMomPct(data.monthlyData);
+      const impressionsMomPct = computeMomPct(data.monthlyData);
 
       const cards: PerformanceSummaryKpi[] = [
         {
@@ -286,13 +286,5 @@ export class PerformanceMarketingTabComponent {
     if (roas >= 1) return 'GOOD';
     if (roas > 0) return 'AVERAGE';
     return 'EMERGING';
-  }
-
-  private computeMomPct(arr: number[] | undefined): number | null {
-    if (!arr || arr.length < 2) return null;
-    const current = arr.at(-1) ?? 0;
-    const previous = arr.at(-2) ?? 0;
-    if (previous === 0) return null;
-    return ((current - previous) / previous) * 100;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
@@ -20,7 +20,7 @@
       }
     } @else {
       @for (kpi of kpiCards(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="social-accounts" />
       }
     }
   </div>
@@ -31,24 +31,24 @@
       <h4 class="text-sm font-semibold text-gray-900">Social accounts performance</h4>
 
       @if (hasPlatforms()) {
-        <div class="flex flex-col gap-0" data-testid="social-accounts-table">
+        <div class="flex flex-col gap-0" role="table" aria-label="Social accounts performance" data-testid="social-accounts-table">
           <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400">PLATFORM</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">FOLLOWERS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">IMPRESSIONS</span>
-            <span class="w-28 text-right text-[11px] font-semibold tracking-wide text-gray-400">ENGAGEMENT</span>
-            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400">POSTS (30D)</span>
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PLATFORM</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">FOLLOWERS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+            <span class="w-28 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ENGAGEMENT</span>
+            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">POSTS (30D)</span>
           </div>
 
           <!-- Rows -->
           @for (row of platformRows(); track row.platform) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'social-account-row-' + row.platform">
-              <span class="w-36 truncate text-xs font-medium text-gray-700">{{ row.platform }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.followers }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.impressions }}</span>
-              <span class="w-28 text-right text-xs text-gray-500">{{ row.engagementRate }}</span>
-              <span class="flex-1 text-right text-xs text-gray-500">{{ row.posts }}</span>
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'social-account-row-' + row.platform">
+              <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.platform }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.followers }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.impressions }}</span>
+              <span class="w-28 text-right text-xs text-gray-500" role="cell">{{ row.engagementRate }}</span>
+              <span class="flex-1 text-right text-xs text-gray-500" role="cell">{{ row.posts }}</span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -63,7 +63,7 @@ export class SocialAccountsTabComponent {
 
       const totalImpressions = data.platforms.reduce((sum, p) => sum + p.impressions, 0);
       const totalPosts = data.platforms.reduce((sum, p) => sum + p.postsLast30Days, 0);
-      const avgEngagement = data.platforms.length > 0 ? data.platforms.reduce((sum, p) => sum + p.engagementRate, 0) / data.platforms.length : 0;
+      const avgEngagement = totalImpressions > 0 ? data.platforms.reduce((sum, p) => sum + p.engagementRate * p.impressions, 0) / totalImpressions : 0;
       const changePct = data.changePercentage;
 
       return [

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -20,7 +20,7 @@
       }
     } @else {
       @for (kpi of kpiCards(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="social-listening" />
       }
     }
   </div>
@@ -57,16 +57,16 @@
       <h4 class="text-sm font-semibold text-gray-900">Mentions by project</h4>
 
       @if (hasTopProjects()) {
-        <div class="flex flex-col gap-0" data-testid="social-listening-projects-table">
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">PROJECT</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">MENTIONS</span>
+        <div class="flex flex-col gap-0" role="table" aria-label="Mentions by project" data-testid="social-listening-projects-table">
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">MENTIONS</span>
           </div>
 
           @for (project of topProjects(); track project.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'social-listening-project-' + project.name">
-              <span class="flex-1 truncate text-xs font-medium text-gray-700">{{ project.name }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ project.mentions }}</span>
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'social-listening-project-' + project.name">
+              <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ project.name }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ project.mentions }}</span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-2 border-l border-gray-200 pl-4" [attr.data-testid]="'kpi-card-' + kpi().id">
+<div class="flex flex-col gap-2 border-l border-gray-200 pl-4" [attr.data-testid]="testId()">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-1.5">
       <span class="inline-flex h-6 w-6 items-center justify-center rounded-md" [ngClass]="kpi().iconClass">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.html
@@ -10,7 +10,7 @@
       <span class="text-xs font-medium text-gray-500">{{ kpi().label }}</span>
     </div>
     @if (kpi().badge) {
-      <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-600" [attr.data-testid]="'kpi-card-badge-' + kpi().id">
+      <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-600" [attr.data-testid]="testId() + '-badge'">
         {{ kpi().badge }}
       </span>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/sparkline-kpi-card/sparkline-kpi-card.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 import type { PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
@@ -14,4 +14,9 @@ import type { PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 })
 export class SparklineKpiCardComponent {
   public readonly kpi = input.required<PerformanceSummaryKpi>();
+  public readonly section = input<string>('');
+  protected readonly testId = computed(() => {
+    const prefix = this.section();
+    return prefix ? `${prefix}-kpi-card-${this.kpi().id}` : `kpi-card-${this.kpi().id}`;
+  });
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -20,7 +20,7 @@
       }
     } @else {
       @for (kpi of kpiCards(); track kpi.id) {
-        <lfx-sparkline-kpi-card [kpi]="kpi" />
+        <lfx-sparkline-kpi-card [kpi]="kpi" section="web-activity" />
       }
     }
   </div>
@@ -31,24 +31,24 @@
       <h4 class="text-sm font-semibold text-gray-900">Web activity by domain</h4>
 
       @if (hasDomains()) {
-        <div class="flex flex-col gap-0" data-testid="web-activity-table">
+        <div class="flex flex-col gap-0" role="table" aria-label="Web activity by domain" data-testid="web-activity-table">
           <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2">
-            <span class="w-44 text-[11px] font-semibold tracking-wide text-gray-400">DOMAIN</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">SESSIONS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">PAGE VIEWS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400">PAGES/SESSION</span>
-            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400">SESSION SHARE</span>
+          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="w-44 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">DOMAIN</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSIONS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PAGE VIEWS</span>
+            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PAGES/SESSION</span>
+            <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSION SHARE</span>
           </div>
 
           <!-- Rows -->
           @for (row of domainRows(); track row.domain) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" [attr.data-testid]="'web-activity-row-' + row.domain">
-              <span class="w-44 truncate text-xs font-medium text-gray-700">{{ row.domain }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.sessions }}</span>
-              <span class="w-24 text-right text-xs text-gray-900">{{ row.pageViews }}</span>
-              <span class="w-24 text-right text-xs text-gray-500">{{ row.pagesPerSession }}</span>
-              <div class="flex flex-1 items-center gap-2">
+            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'web-activity-row-' + row.domain">
+              <span class="w-44 truncate text-xs font-medium text-gray-700" role="cell">{{ row.domain }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sessions }}</span>
+              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.pageViews }}</span>
+              <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.pagesPerSession }}</span>
+              <div class="flex flex-1 items-center gap-2" role="cell">
                 <div class="h-2 flex-1 rounded-full bg-gray-100">
                   <div class="h-2 rounded-full bg-blue-500" [style.width.%]="row.sessionShare"></div>
                 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -83,7 +83,7 @@ export class WebActivityTabComponent {
           id: 'total-page-views',
           label: 'Total Page Views',
           icon: 'fa-light fa-file-lines',
-          iconClass: 'bg-emerald-100 text-emerald-600',
+          iconClass: 'bg-green-100 text-green-600',
           value: formatNumber(totalPageViews),
           momChange: null,
           momTrend: 'neutral' as const,

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -35,22 +35,23 @@ export type TrendDirection = 'up' | 'down' | 'neutral';
 /** Determines trend direction from a percentage change value. */
 export function trendDirection(pct: number | null | undefined): TrendDirection {
   if (pct == null || !Number.isFinite(pct)) return 'neutral';
+  if (Math.abs(pct) < 0.05) return 'neutral';
   if (pct > 0) return 'up';
-  if (pct < 0) return 'down';
-  return 'neutral';
+  return 'down';
 }
 
 /** Returns a Tailwind color class based on trend direction. */
 export function trendColorClass(pct: number | null | undefined): string {
   if (pct == null || !Number.isFinite(pct)) return 'text-gray-500';
+  if (Math.abs(pct) < 0.05) return 'text-gray-500';
   if (pct > 0) return 'text-green-600';
-  if (pct < 0) return 'text-red-600';
-  return 'text-gray-500';
+  return 'text-red-600';
 }
 
 /** Formats a percentage change with sign and suffix (e.g., "+5.2% MoM"). */
 export function formatChangePct(pct: number | null | undefined, suffix: string): string | null {
   if (pct == null || !Number.isFinite(pct)) return null;
+  if (Math.abs(pct) < 0.05) return `0.0% ${suffix}`;
   const sign = pct > 0 ? '+' : '';
   return `${sign}${pct.toFixed(1)}% ${suffix}`;
 }

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -55,3 +55,12 @@ export function formatChangePct(pct: number | null | undefined, suffix: string):
   const sign = pct > 0 ? '+' : '';
   return `${sign}${pct.toFixed(1)}% ${suffix}`;
 }
+
+/** Returns MoM percent change from the last two values of a monthly series. */
+export function computeMomPct(arr: number[] | undefined): number | null {
+  if (!arr || arr.length < 2) return null;
+  const current = arr.at(-1) ?? 0;
+  const previous = arr.at(-2) ?? 0;
+  if (previous === 0) return null;
+  return ((current - previous) / previous) * 100;
+}

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -34,7 +34,7 @@ export type TrendDirection = 'up' | 'down' | 'neutral';
 
 /** Determines trend direction from a percentage change value. */
 export function trendDirection(pct: number | null | undefined): TrendDirection {
-  if (pct == null || Number.isNaN(pct)) return 'neutral';
+  if (pct == null || !Number.isFinite(pct)) return 'neutral';
   if (pct > 0) return 'up';
   if (pct < 0) return 'down';
   return 'neutral';
@@ -42,7 +42,7 @@ export function trendDirection(pct: number | null | undefined): TrendDirection {
 
 /** Returns a Tailwind color class based on trend direction. */
 export function trendColorClass(pct: number | null | undefined): string {
-  if (pct == null || Number.isNaN(pct)) return 'text-gray-500';
+  if (pct == null || !Number.isFinite(pct)) return 'text-gray-500';
   if (pct > 0) return 'text-green-600';
   if (pct < 0) return 'text-red-600';
   return 'text-gray-500';
@@ -50,7 +50,7 @@ export function trendColorClass(pct: number | null | undefined): string {
 
 /** Formats a percentage change with sign and suffix (e.g., "+5.2% MoM"). */
 export function formatChangePct(pct: number | null | undefined, suffix: string): string | null {
-  if (pct == null || Number.isNaN(pct)) return null;
+  if (pct == null || !Number.isFinite(pct)) return null;
   const sign = pct > 0 ? '+' : '';
   return `${sign}${pct.toFixed(1)}% ${suffix}`;
 }


### PR DESCRIPTION
## Summary
- Embed all marketing impact sections into the **Overview tab** so it serves as the full dashboard summary
- Order: KPI cards → Attribution → Performance Marketing → Email → Web Activity → Social Accounts → Social Listening
- Individual tabs still show the focused detail view when selected
- Each embedded section fetches its own data independently (same `foundationSlug` input)

## Test plan
- [ ] Navigate to `/foundation/marketing-impact?project=tlf` → Overview tab
- [ ] Verify all sections appear stacked: KPI cards, attribution, performance marketing, email, web activity, social accounts, social listening
- [ ] Click individual tabs (Attribution, Performance Marketing, etc.) and verify they show the focused view
- [ ] Switch back to Overview and verify all sections are still visible
- [ ] Verify loading states work independently per section

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/code)