### PR TITLE
fix(meetings): stamp recurrence end date 100 years out instead of 2999

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { RECURRENCE_NO_END_SENTINEL_DATE } from '@lfx-one/shared/constants';
 import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   ApiResponse,
@@ -33,7 +32,7 @@ import {
   UpdateMeetingRequest,
   UpdatePastMeetingSummaryRequest,
 } from '@lfx-one/shared/interfaces';
-import { mapITXResponseToMeetingRsvp, transformV1SummaryToV2 } from '@lfx-one/shared/utils';
+import { buildRecurrenceNeverEndDate, mapITXResponseToMeetingRsvp, transformV1SummaryToV2 } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
@@ -1323,9 +1322,9 @@ export class MeetingService {
    * Ensures a recurrence object always has an end condition.
    * Zoom's recurrence API (via the itx adapter) requires either end_date_time or
    * end_times; the Goa schema marks both optional but Zoom rejects payloads where
-   * neither is set. When neither is present, we stamp RECURRENCE_NO_END_SENTINEL_DATE
-   * so the upstream call succeeds. The client recognises this sentinel and renders
-   * the meeting as "never ends" rather than showing a specific end date.
+   * neither is set. When neither is present, we stamp a date ~100 years from now
+   * so the upstream call succeeds. The client recognises this as a "never ends"
+   * placeholder via `isRecurrenceNeverEndSentinel` and renders it accordingly.
    */
   private normalizeRecurrence(req: Request, recurrence: MeetingRecurrence): MeetingRecurrence {
     const hasValidEndDateTime = typeof recurrence.end_date_time === 'string' && recurrence.end_date_time.trim().length > 0;
@@ -1334,10 +1333,11 @@ export class MeetingService {
     if (hasValidEndDateTime || hasValidEndTimes) {
       return recurrence;
     }
-    logger.debug(req, 'normalize_recurrence', 'Stamping never-end sentinel — recurrence has no end condition', {
-      end_date_time: RECURRENCE_NO_END_SENTINEL_DATE,
+    const neverEndDate = buildRecurrenceNeverEndDate();
+    logger.debug(req, 'normalize_recurrence', 'Stamping never-end placeholder — recurrence has no end condition', {
+      end_date_time: neverEndDate,
       recurrence_type: recurrence.type,
     });
-    return { ...recurrence, end_date_time: RECURRENCE_NO_END_SENTINEL_DATE };
+    return { ...recurrence, end_date_time: neverEndDate };
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -360,16 +360,6 @@ export const MEETING_FORM_STEPS = {
 };
 
 /**
- * Sentinel date used when a recurrence has no explicit end condition.
- * Zoom's recurrence API requires either end_date_time or end_times; this value
- * satisfies that requirement without representing a real user-chosen end date.
- * Both the server write path (normalizeRecurrence) and the client read path
- * (meeting-manage form population) must agree on this constant so the UI can
- * distinguish "never ends" from a user-selected date.
- */
-export const RECURRENCE_NO_END_SENTINEL_DATE = '2999-12-31T23:59:59.000Z';
-
-/**
  * Recurrence type string mappings
  * @description Maps recurrence types to their string identifiers used in forms and API
  * @readonly

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -3,7 +3,7 @@
 
 import { HttpParams } from '@angular/common/http';
 
-import { RECURRENCE_DAYS_OF_WEEK, RECURRENCE_NO_END_SENTINEL_DATE, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
+import { RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
 import {
   CustomRecurrencePattern,
   Meeting,
@@ -16,16 +16,33 @@ import {
   V1SummaryDetail,
 } from '../interfaces';
 
+const RECURRENCE_NEVER_ENDS_YEARS_OFFSET = 100;
+const FIFTY_YEARS_MS = 50 * 365.25 * 24 * 60 * 60 * 1000;
+
 /**
- * Whether the recurrence end_date_time matches the "never ends" sentinel.
- * Compares via Date.getTime() so equivalent ISO variants (e.g. '...59Z' vs '...59.000Z')
- * are treated as equal.
+ * Produces an ISO string ~100 years from `now`, used as the "never ends"
+ * placeholder on outgoing recurrence payloads. Stays well below year 2286
+ * (where Unix-timestamp strings grow a digit and break lexicographic sorts
+ * in the upstream meeting-service — see LFXV2-1855).
+ */
+export function buildRecurrenceNeverEndDate(now: Date = new Date()): string {
+  const d = new Date(now);
+  d.setFullYear(d.getFullYear() + RECURRENCE_NEVER_ENDS_YEARS_OFFSET);
+  return d.toISOString();
+}
+
+/**
+ * Whether `endDateTime` is one of our "never ends" placeholders.
+ * Returns true for any date ≥ 50 years from now — covers both new records
+ * stamped by `buildRecurrenceNeverEndDate` (~100 years out) and legacy
+ * records persisted with `2999-12-31` before LFXV2-1855. Real user-selected
+ * end dates never reach this far out.
  */
 export function isRecurrenceNeverEndSentinel(endDateTime: string | null | undefined): boolean {
   if (!endDateTime) return false;
   const end = new Date(endDateTime).getTime();
-  const sentinel = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
-  return Number.isFinite(end) && Number.isFinite(sentinel) && end === sentinel;
+  if (!Number.isFinite(end)) return false;
+  return end - Date.now() >= FIFTY_YEARS_MS;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the hard-coded `'2999-12-31T23:59:59.000Z'` sentinel with `buildRecurrenceNeverEndDate()`, which produces a date ~100 years from now when Zoom's API requires an end condition but the user chose "never ends"
- Remove the orphaned `RECURRENCE_NO_END_SENTINEL_DATE` constant (no longer needed)
- Update `isRecurrenceNeverEndSentinel` to use a ≥50-year heuristic so both new records (~100 years out) and legacy `2999-12-31` records continue to render as "never ends" in the UI

## Ticket

[LFXV2-1855](https://linuxfoundation.atlassian.net/browse/LFXV2-1855)

## Background

LFXV2-1855 surfaced because the upstream meeting-service was sorting occurrence IDs (Unix timestamp strings) lexicographically. Unix timestamps cross from 10 to 11 digits at year ~2286, so `10…` (2286) sorted before `17…` (2026) and the first 50 results were all from year 2286 instead of upcoming dates.

The root cause sort bug is being fixed separately in lfx-v2-meeting-service. This PR addresses the contributing factor: using year 2999 as the "never ends" sentinel is the reason occurrences were generated all the way to 2286+. Switching to ~100 years from now keeps the value well below the 11-digit boundary for any reasonable system lifetime.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1855]: https://linuxfoundation.atlassian.net/browse/LFXV2-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ