### PR TITLE
fix(votes): correct IndexedVoteResponseStatus enum to use ITX vocabulary

### DIFF
--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -9,7 +9,7 @@ import {
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   TSHIRT_SIZES,
 } from '@lfx-one/shared/constants';
-import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
+import { IndexedVoteResponseStatus, NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
   ActiveWeeksStreakResponse,
   ActiveWeeksStreakRow,
@@ -1079,7 +1079,7 @@ export class UserService {
    * OpenSearch to exactly this user's rows. When `projectUid` is provided it is pushed
    * server-side to drop out-of-scope rows before pagination; when omitted, the unscoped Me-lens
    * call already gets exactly the user's vote_response rows across all their projects via
-   * `filter_grants=direct`. The remaining `vote_status !== 'submitted'` and `!voter_removed`
+   * `filter_grants=direct`. The remaining `vote_status === 'awaiting_response'` and `!voter_removed`
    * checks stay client-side. Caveat: the FGA tuple is only emitted when the invitee has a
    * non-empty `Username`, so users invited by email but without an Auth0 username won't appear
    * here. We accept this trade-off — meetings already work the same way and FGA is the source
@@ -1109,7 +1109,7 @@ export class UserService {
     const pendingVoteUids = Array.from(
       new Set(
         responses
-          .filter((r) => r.vote_status !== 'submitted' && !r.voter_removed)
+          .filter((r) => r.vote_status === IndexedVoteResponseStatus.AWAITING_RESPONSE && !r.voter_removed)
           .map((r) => r.vote_uid ?? r.vote_id ?? r.poll_id)
           .filter((uid): uid is string => !!uid)
       )

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1079,7 +1079,7 @@ export class UserService {
    * OpenSearch to exactly this user's rows. When `projectUid` is provided it is pushed
    * server-side to drop out-of-scope rows before pagination; when omitted, the unscoped Me-lens
    * call already gets exactly the user's vote_response rows across all their projects via
-   * `filter_grants=direct`. The remaining `vote_status === 'awaiting_response'` and `!voter_removed`
+   * `filter_grants=direct`. The remaining `vote_status === IndexedVoteResponseStatus.AWAITING_RESPONSE` and `!voter_removed`
    * checks stay client-side. Caveat: the FGA tuple is only emitted when the invitee has a
    * non-empty `Username`, so users invited by email but without an Auth0 username won't appear
    * here. We accept this trade-off — meetings already work the same way and FGA is the source

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -252,7 +252,7 @@ export class VoteService {
 
   /**
    * Submits a ballot via POST /vote_responses using the user's bearer token (no M2M),
-   * then polls until the query service indexes the response as 'submitted'.
+   * then polls until the query service indexes the response as 'responded'.
    */
   public async createVoteResponse(req: Request, payload: CreateVoteResponseRequest): Promise<void> {
     logger.debug(req, 'create_vote_response', 'Submitting vote response', {
@@ -286,7 +286,7 @@ export class VoteService {
             filters: [`vote_uid:${payload.vote_uid}`],
           }
         );
-        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === IndexedVoteResponseStatus.SUBMITTED);
+        return resources.some((r) => r.data.uid === payload.vote_response_uid && r.data.vote_status === IndexedVoteResponseStatus.RESPONDED);
       },
       maxRetries: 5,
       retryDelayMs: 1000,
@@ -344,7 +344,7 @@ export class VoteService {
 
     const respondedVoteUids = new Set<string>();
     for (const r of responses) {
-      if (r.vote_uid && r.vote_status === IndexedVoteResponseStatus.SUBMITTED) respondedVoteUids.add(r.vote_uid);
+      if (r.vote_uid && r.vote_status === IndexedVoteResponseStatus.RESPONDED) respondedVoteUids.add(r.vote_uid);
     }
 
     // Extract unique vote UIDs

--- a/packages/shared/src/enums/poll.enum.ts
+++ b/packages/shared/src/enums/poll.enum.ts
@@ -37,8 +37,11 @@ export enum IndividualVoteStatus {
   RESPONDED = 'responded',
 }
 
-/** Raw `vote_status` values written by the v2 indexer to `vote_response` rows. */
+/** Raw `vote_status` values written by the legacy ITX system into `vote_response` rows.
+ *  `lfx-v2-voting-service` forwards these unchanged. */
 export enum IndexedVoteResponseStatus {
   AWAITING_RESPONSE = 'awaiting_response',
-  SUBMITTED = 'submitted',
+  RESPONDED = 'responded',
+  ENDED = 'ended',
+  AWAITING_RESPONSE_BUT_POLL_ENDED = 'awaiting_response_but_poll_ended',
 }

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -215,7 +215,7 @@ export interface Vote {
   total_voting_request_invitations?: number;
   /** Number of responses received */
   num_response_received?: number;
-  /** Server-decorated by getMyVotes (Me-lens only) — RESPONDED iff the indexed vote_response row has IndexedVoteResponseStatus.SUBMITTED. Absent on raw upstream Vote responses. */
+  /** Server-decorated by getMyVotes (Me-lens only) — RESPONDED iff the indexed vote_response row has IndexedVoteResponseStatus.RESPONDED. Absent on raw upstream Vote responses. */
   response_status?: VoteResponseStatus;
 }
 
@@ -254,7 +254,7 @@ export interface IndexedVoteResponse {
   poll_id?: string;
   /** V2 project UID the response belongs to */
   project_uid?: string;
-  /** Upstream submission status (e.g. `'submitted'`, `'awaiting_response'`) */
+  /** Upstream submission status (e.g. `'responded'`, `'awaiting_response'`, `'ended'`, `'awaiting_response_but_poll_ended'`) */
   vote_status?: string;
   /** Whether the voter has been removed from the poll's eligible list */
   voter_removed?: boolean;


### PR DESCRIPTION
## Summary

- `IndexedVoteResponseStatus.SUBMITTED = 'submitted'` was modeled on an upstream OpenAPI `Example("submitted")` doc string that is never actually emitted by the indexer — the legacy ITX system uses `'responded'` for a submitted ballot
- My Votes (Me lens) always showed responded votes as `awaiting_response` ("Vote" button instead of "Review") because `getMyVotes` built an empty `respondedVoteUids` set and unconditionally overwrote the upstream `response_status`
- Home-page pending-votes action list included already-responded votes because the `vote_status !== 'submitted'` exclusion filter was a no-op

Fixes both by replacing `SUBMITTED = 'submitted'` with the full ITX 4-value vocabulary (`RESPONDED`, `ENDED`, `AWAITING_RESPONSE_BUT_POLL_ENDED`), updating all three comparison sites, and flipping the `fetchPendingVotes` filter to a positive `=== AWAITING_RESPONSE` predicate.

Closes LFXV2-1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)