### PR TITLE
fix(settings): update "on this page" highlight as user scrolls

### DIFF
--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser, NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { afterNextRender, Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -43,6 +43,7 @@ export class AccountSettingsComponent {
 
   // ── TOC active section ──
   public activeSection = signal('email-settings');
+  private scrollSpyObserver?: IntersectionObserver;
 
   // ══════════════════════════════════════════
   // EMAIL SETTINGS
@@ -141,6 +142,10 @@ export class AccountSettingsComponent {
       });
 
     this.loadDeveloperToken();
+
+    afterNextRender(() => {
+      this.setupScrollSpy();
+    });
   }
 
   // ══════════════════════════════════════════
@@ -467,5 +472,34 @@ export class AccountSettingsComponent {
       if (!newPassword || !confirmPassword || !confirmPassword.value) return null;
       return newPassword.value !== confirmPassword.value ? { passwordMismatch: true } : null;
     };
+  }
+
+  private setupScrollSpy(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const sectionIds = ['email-settings', 'password', 'developer-settings'];
+    const sections = sectionIds.map((id) => document.getElementById(id)).filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    const intersecting = new Set<string>();
+
+    this.scrollSpyObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) intersecting.add(entry.target.id);
+          else intersecting.delete(entry.target.id);
+        }
+        const activeId = sectionIds.find((id) => intersecting.has(id));
+        if (activeId) this.activeSection.set(activeId);
+      },
+      { rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+    );
+
+    sections.forEach((section) => this.scrollSpyObserver!.observe(section));
+
+    this.destroyRef.onDestroy(() => {
+      this.scrollSpyObserver?.disconnect();
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -477,18 +477,28 @@ export class AccountSettingsComponent {
   private setupScrollSpy(): void {
     if (!isPlatformBrowser(this.platformId)) return;
 
+    // Observe the section heading rows (sentinels) rather than the full section divs.
+    // A heading is short enough that at most one fits in the activation band, which
+    // avoids two sections being considered active during the transition.
     const sectionIds = ['email-settings', 'password', 'developer-settings'];
-    const sections = sectionIds.map((id) => document.getElementById(id)).filter((el): el is HTMLElement => el !== null);
+    const headingByElement = new Map<Element, string>();
+    for (const id of sectionIds) {
+      const heading = document.querySelector(`[data-testid="${id}-heading"]`);
+      if (heading) headingByElement.set(heading, id);
+    }
 
-    if (sections.length === 0) return;
+    if (headingByElement.size === 0) return;
 
     const intersecting = new Set<string>();
+    const lastSectionId = sectionIds[sectionIds.length - 1];
 
     this.scrollSpyObserver = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
-          if (entry.isIntersecting) intersecting.add(entry.target.id);
-          else intersecting.delete(entry.target.id);
+          const id = headingByElement.get(entry.target);
+          if (!id) continue;
+          if (entry.isIntersecting) intersecting.add(id);
+          else intersecting.delete(id);
         }
         const activeId = sectionIds.find((id) => intersecting.has(id));
         if (activeId) this.activeSection.set(activeId);
@@ -496,9 +506,21 @@ export class AccountSettingsComponent {
       { rootMargin: '-80px 0px -70% 0px', threshold: 0 }
     );
 
-    sections.forEach((section) => this.scrollSpyObserver!.observe(section));
+    headingByElement.forEach((_, heading) => this.scrollSpyObserver!.observe(heading));
+
+    // End-of-scroll override: the last section is short enough that its heading
+    // never enters the activation band, so the observer alone leaves the highlight
+    // on the previous section. Snap to the last section when reaching the bottom.
+    const isAtBottom = () =>
+      document.documentElement.scrollHeight > window.innerHeight && window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 4;
+    const onScroll = () => {
+      if (isAtBottom()) this.activeSection.set(lastSectionId);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
 
     this.destroyRef.onDestroy(() => {
+      window.removeEventListener('scroll', onScroll);
       this.scrollSpyObserver?.disconnect();
     });
   }


### PR DESCRIPTION
## Summary

- Track the active "On this page" TOC item using an `IntersectionObserver` on the three section anchors (`email-settings`, `password`, `developer-settings`) instead of relying on click-only state.
- Observer is set up via `afterNextRender` and disconnected through `destroyRef.onDestroy`. Guarded with `isPlatformBrowser` per `.claude/rules/ssr-safety.md`, so SSR is unaffected.
- Activation band `rootMargin: '-80px 0px -70% 0px'` puts the highlight on the section whose top crosses roughly the upper third of the viewport, below the sticky page header.
- Click-to-scroll behavior in `scrollToSection()` is unchanged — the click still sets `activeSection` immediately for instant feedback, and the observer takes over once the smooth scroll settles.

## Test plan

- [x] Navigate to `/settings/account`
- [x] Scroll slowly down: TOC highlight advances Email Settings → Password → Developer Settings
- [x] Scroll back up: highlight reverses correctly
- [x] Click each TOC item: page smooth-scrolls to that section and the highlight lands on it
- [x] \`yarn build\` passes (browser + SSR bundles)
- [x] \`yarn lint:check\` passes