### PR TITLE
fix(server): resolve stale chunk import failure after deploy

### DIFF
--- a/apps/lfx-one/src/app/app.config.ts
+++ b/apps/lfx-one/src/app/app.config.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
-import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationConfig, ErrorHandler, provideZonelessChangeDetection } from '@angular/core';
 import { provideClientHydration, withEventReplay, withHttpTransferCacheOptions, withIncrementalHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter, withInMemoryScrolling, withPreloading } from '@angular/router';
@@ -20,6 +20,7 @@ import { routes } from './app.routes';
 import { provideDataDogRum } from './shared/providers/datadog-rum.provider';
 import { provideFeatureFlags } from './shared/providers/feature-flag.provider';
 import { provideRuntimeConfig } from './shared/providers/runtime-config.provider';
+import { ChunkLoadErrorHandler } from './shared/utils/chunk-load-error.handler';
 import { CustomPreloadingStrategy } from './shared/strategies/custom-preloading.strategy';
 
 const customPreset = definePreset(Aura, {
@@ -35,6 +36,7 @@ const customPreset = definePreset(Aura, {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
+    { provide: ErrorHandler, useClass: ChunkLoadErrorHandler },
     provideRouter(routes, withPreloading(CustomPreloadingStrategy), withInMemoryScrolling({ scrollPositionRestoration: 'top' })),
     provideClientHydration(withEventReplay(), withIncrementalHydration(), withHttpTransferCacheOptions({ includeHeaders: ['Authorization'] })),
     provideHttpClient(withFetch(), withInterceptors([authenticationInterceptor, ssrBaseUrlInterceptor])),

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
@@ -15,6 +15,7 @@ export const MAILING_LIST_ROUTES: Routes = [
     path: 'create',
     loadComponent: () => import('./mailing-list-manage/mailing-list-manage.component').then((m) => m.MailingListManageComponent),
     canActivate: [authGuard],
+    data: { preload: true, preloadDelay: 2000 },
   },
   {
     path: ':id',

--- a/apps/lfx-one/src/app/shared/utils/chunk-load-error.handler.ts
+++ b/apps/lfx-one/src/app/shared/utils/chunk-load-error.handler.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { ErrorHandler, inject, Injectable, PLATFORM_ID } from '@angular/core';
+
+const RELOAD_FLAG = 'lfx-chunk-reload-attempted';
+
+const isChunkLoadError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('Importing a module script failed') || // Safari
+    message.includes('Failed to fetch dynamically imported module') || // Chrome / Edge
+    message.includes('error loading dynamically imported module') // Firefox
+  );
+};
+
+@Injectable()
+export class ChunkLoadErrorHandler implements ErrorHandler {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  handleError(error: unknown): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    if (!isChunkLoadError(error)) {
+      console.error(error);
+      return;
+    }
+
+    // Guard against reload loops — only attempt once per session.
+    if (sessionStorage.getItem(RELOAD_FLAG)) {
+      console.error('Chunk load error persists after reload — giving up.', error);
+      return;
+    }
+
+    sessionStorage.setItem(RELOAD_FLAG, '1');
+    window.location.reload();
+  }
+}

--- a/apps/lfx-one/src/app/shared/utils/chunk-load-error.handler.ts
+++ b/apps/lfx-one/src/app/shared/utils/chunk-load-error.handler.ts
@@ -4,7 +4,8 @@
 import { isPlatformBrowser } from '@angular/common';
 import { ErrorHandler, inject, Injectable, PLATFORM_ID } from '@angular/core';
 
-const RELOAD_FLAG = 'lfx-chunk-reload-attempted';
+const RELOAD_FLAG = 'lfx-chunk-reload-at';
+const RELOAD_LOOP_WINDOW_MS = 60_000;
 
 const isChunkLoadError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
@@ -19,23 +20,22 @@ const isChunkLoadError = (error: unknown): boolean => {
 export class ChunkLoadErrorHandler implements ErrorHandler {
   private readonly platformId = inject(PLATFORM_ID);
 
-  handleError(error: unknown): void {
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
-    }
-
-    if (!isChunkLoadError(error)) {
+  public handleError(error: unknown): void {
+    // SSR + non-chunk errors fall through to default ErrorHandler behavior so logs surface.
+    if (!isPlatformBrowser(this.platformId) || !isChunkLoadError(error)) {
       console.error(error);
       return;
     }
 
-    // Guard against reload loops — only attempt once per session.
-    if (sessionStorage.getItem(RELOAD_FLAG)) {
-      console.error('Chunk load error persists after reload — giving up.', error);
+    // Timestamp-based loop guard: bail only if we already reloaded within the window.
+    const lastReloadStr = sessionStorage.getItem(RELOAD_FLAG);
+    const lastReload = lastReloadStr ? Number(lastReloadStr) : 0;
+    if (lastReload && Date.now() - lastReload < RELOAD_LOOP_WINDOW_MS) {
+      console.error('Chunk load error within 60s of reload — likely a loop, giving up.', error);
       return;
     }
 
-    sessionStorage.setItem(RELOAD_FLAG, '1');
+    sessionStorage.setItem(RELOAD_FLAG, String(Date.now()));
     window.location.reload();
   }
 }

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -103,8 +103,23 @@ app.get('/readyz', (_req: Request, res: Response) => {
 app.get(
   '**',
   express.static(browserDistFolder, {
-    maxAge: '1y',
     index: false,
+    setHeaders: (res, filePath) => {
+      if (filePath.endsWith('index.html') || filePath.endsWith('index.csr.html')) {
+        // index.html must not be cached long-term — returning users need the latest
+        // chunk hashes after a deploy, otherwise dynamic imports fail with
+        // "TypeError: Importing a module script failed."
+        res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+        return;
+      }
+      if (/-[A-Z0-9]{8,}\.(js|css|woff2?|ttf|otf|png|jpg|jpeg|svg|ico|webp)$/i.test(filePath)) {
+        // Angular emits content-hashed filenames (outputHashing: "all") — safe to
+        // cache permanently; the hash changes whenever content changes.
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        return;
+      }
+      res.setHeader('Cache-Control', 'public, max-age=300');
+    },
   })
 );
 


### PR DESCRIPTION
## Summary

- Serve `index.html` with `no-cache, must-revalidate` so returning users always revalidate after a deploy — fixes the root cause of stale chunk hashes being requested
- Keep `public, max-age=31536000, immutable` for content-hashed JS/CSS/font/image assets (no regression to asset caching)
- Add `ChunkLoadErrorHandler` global Angular `ErrorHandler` that detects `TypeError: Importing a module script failed` (Safari), `Failed to fetch dynamically imported module` (Chrome/Edge), and Firefox equivalents — triggers a single `window.location.reload()` per session to recover users whose browsers already have the stale `index.html` cached
- Opt `/mailing-lists/create` into the custom preloader (`data: { preload: true, preloadDelay: 2000 }`) to reduce click-time exposure

## Root cause

`apps/lfx-one/src/server/server.ts` was serving `index.html` with `Cache-Control: public, max-age=31536000`. After a deploy, Angular's `outputHashing: "all"` regenerates all chunk filenames. Returning users' browsers served the year-old cached `index.html` referencing old chunk hashes → the dynamic `import()` on clicking **Create Mailing List** requested a file that no longer existed → the SSR fallback returned HTML instead of JS → `TypeError: Importing a module script failed.`

Safari fails reliably (no speculation-rules prefetcher); Chrome/Arc fail intermittently (Chromium's `speculationrules` in `index.html` sometimes refreshes chunks before the click).

## Test plan

- [ ] `curl -I https://<preview-url>/` → `Cache-Control: no-cache, must-revalidate`
- [ ] `curl -I https://<preview-url>/main-<hash>.js` → `Cache-Control: public, max-age=31536000, immutable`
- [ ] Click **Create Mailing List** on Project Dashboard in Safari — no `TypeError: Importing a module script failed`
- [ ] Repeat in Chrome and Arc
- [ ] Confirm repeat visits to already-cached pages still load hashed assets from disk cache (no regression)

## JIRA

[LFXV2-1920](https://linuxfoundation.atlassian.net/browse/LFXV2-1920)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1920]: https://linuxfoundation.atlassian.net/browse/LFXV2-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ