### PR TITLE
feat(dashboards): add org memberships page with mock data

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -63,9 +63,9 @@ export const routes: Routes = [
       },
       {
         path: 'org/memberships',
-        data: { lens: 'org', title: 'Memberships', description: 'Active memberships and tier history.', icon: 'fa-light fa-display' },
+        data: { lens: 'org' },
         loadComponent: () =>
-          import('./modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component').then((m) => m.OrgPlaceholderPageComponent),
+          import('./modules/dashboards/org/org-memberships/org-memberships.component').then((m) => m.OrgMembershipsComponent),
       },
       {
         path: 'org/projects',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -1,0 +1,353 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6">
+  <h1 class="text-2xl font-semibold text-gray-900">Membership — {{ companyName() }}</h1>
+
+  <div class="flex items-center gap-1 border-b border-gray-200">
+    @for (tab of tabs; track tab.id) {
+      <button
+        type="button"
+        class="flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        [class.border-blue-600]="activeTab() === tab.id"
+        [class.text-blue-600]="activeTab() === tab.id"
+        [class.border-transparent]="activeTab() !== tab.id"
+        [class.text-gray-500]="activeTab() !== tab.id"
+        [class.hover:text-gray-700]="activeTab() !== tab.id"
+        (click)="switchTab(tab.id)">
+        <i [class]="tab.icon"></i>
+        {{ tab.label }}
+      </button>
+    }
+  </div>
+
+  @if (activeTab() === 'active') {
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="active-memberships-summary">
+      <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+        <div class="flex items-center gap-3 p-4">
+          <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+            <i class="fa-light fa-briefcase text-xl"></i>
+          </div>
+          <div class="flex flex-col gap-0.5">
+            @if (pageState() === 'loading') {
+              <p class="text-xl font-medium text-gray-400">&mdash;</p>
+            } @else {
+              <p class="text-xl font-medium text-gray-900">{{ summary()?.activeMemberships ?? 0 }}</p>
+            }
+            <p class="text-sm font-normal text-gray-900">Active Memberships</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-3 p-4">
+          <div class="flex items-center justify-center w-11 h-11 rounded-full bg-amber-100 text-amber-600 flex-shrink-0">
+            <i class="fa-light fa-clock text-xl"></i>
+          </div>
+          <div class="flex flex-col gap-0.5">
+            @if (pageState() === 'loading') {
+              <p class="text-xl font-medium text-gray-400">&mdash;</p>
+            } @else {
+              <p class="text-xl font-medium text-gray-900">{{ summary()?.renewingWithin90Days ?? 0 }}</p>
+            }
+            <p class="text-sm font-normal text-gray-900">Renewing Within 90 Days</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-3 p-4">
+          <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+            <i class="fa-light fa-users text-xl"></i>
+          </div>
+          <div class="flex flex-col gap-0.5">
+            @if (pageState() === 'loading') {
+              <p class="text-xl font-medium text-gray-400">&mdash;</p>
+            } @else {
+              <p class="text-xl font-medium text-gray-900">{{ summary()?.governanceRoles ?? 0 }}</p>
+            }
+            <p class="text-sm font-normal text-gray-900">Governance Roles</p>
+          </div>
+        </div>
+      </div>
+    </lfx-card>
+
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+      <div class="px-5 pt-4 pb-3">
+        <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
+          <div class="flex-1">
+            <div class="relative">
+              <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+              <input
+                pInputText
+                type="text"
+                placeholder="Search memberships..."
+                class="w-full pl-9"
+                [ngModel]="searchTerm()"
+                (ngModelChange)="searchTerm.set($event)" />
+            </div>
+          </div>
+          <div class="w-full sm:w-48">
+            <p-select
+              [options]="tierOptions"
+              [ngModel]="selectedTier()"
+              (ngModelChange)="selectedTier.set($event)"
+              optionLabel="label"
+              optionValue="value"
+              styleClass="w-full" />
+          </div>
+          <div class="w-full sm:w-48">
+            <p-select
+              [options]="renewalOptions"
+              [ngModel]="selectedRenewal()"
+              (ngModelChange)="selectedRenewal.set($event)"
+              optionLabel="label"
+              optionValue="value"
+              styleClass="w-full" />
+          </div>
+        </div>
+      </div>
+
+      <div class="px-5 pb-5">
+        @if (pageState() === 'error') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-triangle-exclamation"
+            title="Failed to load memberships"
+            subtitle="Please try again."
+            ctaLabel="Retry"
+            ctaIcon="fa-light fa-arrow-rotate-left"
+            (ctaClick)="retry()">
+          </lfx-empty-state>
+        } @else if (pageState() === 'empty') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-folder-open"
+            title="No active memberships"
+            subtitle="This organization does not have any active memberships.">
+          </lfx-empty-state>
+        } @else {
+          <lfx-table
+            [value]="memberships()"
+            [loading]="pageState() === 'loading'"
+            sortField="foundationName"
+            [sortOrder]="1"
+            [skeletonColumns]="6">
+            <ng-template #header>
+              <tr>
+                <th>Name</th>
+                <th>Membership Tier</th>
+                <th>Member Since</th>
+                <th>Board Members</th>
+                <th>Committee Members</th>
+                <th>Org Projects</th>
+              </tr>
+            </ng-template>
+            <ng-template #body let-membership>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center text-sm font-semibold text-gray-600 flex-shrink-0">
+                      {{ membership.foundationInitials }}
+                    </div>
+                    <div class="flex flex-col">
+                      <span class="font-medium text-gray-900">{{ membership.foundationName }}</span>
+                      <span class="text-xs text-gray-500">{{ membership.projectCount }} projects · {{ membership.memberCount }} members</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="flex flex-col">
+                    <span class="text-sm text-gray-900">{{ membership.membershipTier }}</span>
+                    <span class="text-xs text-gray-500">{{ formatTierRange(membership) }}</span>
+                  </div>
+                </td>
+                <td class="text-sm text-gray-700">{{ formatDateShort(membership.memberSince) }}</td>
+                <td class="text-sm text-gray-700">{{ membership.boardMembers }}</td>
+                <td class="text-sm text-gray-700">{{ membership.committeeMembers }}</td>
+                <td>
+                  @if (membership.orgProjects > 0) {
+                    <span class="text-sm font-medium text-blue-600">{{ membership.orgProjects }}</span>
+                  } @else {
+                    <span class="text-sm text-gray-700">0</span>
+                  }
+                </td>
+              </tr>
+            </ng-template>
+          </lfx-table>
+        }
+      </div>
+    </lfx-card>
+  }
+
+  @if (activeTab() === 'expired') {
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+      <div class="px-5 pt-4 pb-3">
+        <div class="flex flex-col gap-1 mb-3">
+          <h2 class="text-xl font-semibold text-gray-900">Expired Memberships</h2>
+          <p class="text-sm text-gray-500">Projects your organization had active memberships for, but are currently expired</p>
+        </div>
+        <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
+          <div class="flex-1">
+            <div class="relative">
+              <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+              <input
+                pInputText
+                type="text"
+                placeholder="Search..."
+                class="w-full pl-9"
+                [ngModel]="expiredSearchTerm()"
+                (ngModelChange)="expiredSearchTerm.set($event)" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="px-5 pb-5">
+        @if (expiredState() === 'error') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-triangle-exclamation"
+            title="Failed to load expired memberships"
+            subtitle="Please try again.">
+          </lfx-empty-state>
+        } @else if (expiredState() === 'empty') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-clock-rotate-left"
+            title="No expired memberships"
+            subtitle="All your memberships are current!">
+          </lfx-empty-state>
+        } @else {
+          <lfx-table
+            [value]="expiredMemberships()"
+            [loading]="expiredState() === 'loading'"
+            sortField="foundationName"
+            [sortOrder]="1"
+            [skeletonColumns]="4">
+            <ng-template #header>
+              <tr>
+                <th>Name</th>
+                <th>Membership Tier</th>
+                <th>Expiration Date</th>
+                <th>Actions</th>
+              </tr>
+            </ng-template>
+            <ng-template #body let-membership>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
+                      [class]="membership.foundationColor">
+                      {{ membership.foundationInitials }}
+                    </div>
+                    <div class="flex flex-col">
+                      <span class="font-medium text-gray-900">{{ membership.foundationName }}</span>
+                      <span class="text-xs text-gray-500">Expired {{ formatDateFull(membership.expirationDate) }}</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="flex flex-col">
+                    <span class="text-sm text-gray-900">{{ membership.membershipTier }}</span>
+                    <span class="text-xs text-gray-500">{{ formatDateFull(membership.tierStartDate) }} – {{ formatDateFull(membership.tierEndDate) }}</span>
+                  </div>
+                </td>
+                <td class="text-sm text-gray-700">{{ formatDateFull(membership.expirationDate) }}</td>
+                <td>
+                  @if (membership.actionType === 'renew') {
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors"
+                      pTooltip="Coming soon"
+                      tooltipPosition="top">
+                      Renew
+                    </button>
+                  } @else {
+                    <button
+                      type="button"
+                      class="text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                      pTooltip="Coming soon"
+                      tooltipPosition="top">
+                      Contact Us
+                    </button>
+                  }
+                </td>
+              </tr>
+            </ng-template>
+          </lfx-table>
+        }
+      </div>
+    </lfx-card>
+  }
+
+  @if (activeTab() === 'discover') {
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+      <div class="px-5 pt-4 pb-3">
+        <h2 class="text-xl font-semibold text-gray-900">Discover Opportunities</h2>
+      </div>
+
+      <div class="px-5 pb-5">
+        @if (discoverState() === 'error') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-triangle-exclamation"
+            title="Failed to load discover opportunities"
+            subtitle="Please try again.">
+          </lfx-empty-state>
+        } @else if (discoverState() === 'empty') {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-magnifying-glass"
+            title="No new opportunities available right now"
+            subtitle="Check back later for new membership opportunities.">
+          </lfx-empty-state>
+        } @else {
+          <lfx-table
+            [value]="discoverOpportunities()"
+            [loading]="discoverState() === 'loading'"
+            sortField="foundationName"
+            [sortOrder]="1"
+            [skeletonColumns]="5">
+            <ng-template #header>
+              <tr>
+                <th>Foundation</th>
+                <th>Category</th>
+                <th>Contributors</th>
+                <th>Contributions</th>
+                <th>Actions</th>
+              </tr>
+            </ng-template>
+            <ng-template #body let-opportunity>
+              <tr>
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
+                      [class]="opportunity.foundationColor">
+                      {{ opportunity.foundationInitials }}
+                    </div>
+                    <div class="flex flex-col">
+                      <span class="font-medium text-gray-900">{{ opportunity.foundationName }}</span>
+                      <span class="text-xs text-gray-500">{{ opportunity.category }} · {{ opportunity.relevantProjects }} relevant projects</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="flex flex-col">
+                    <span class="text-sm text-gray-900">{{ opportunity.suggestedTier }}</span>
+                    <span class="text-xs text-gray-500">Suggested tier</span>
+                  </div>
+                </td>
+                <td class="text-sm text-gray-700">{{ opportunity.contributors }}</td>
+                <td class="text-sm text-gray-700">{{ opportunity.contributions }}</td>
+                <td>
+                  <button
+                    type="button"
+                    class="px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors"
+                    pTooltip="Coming soon"
+                    tooltipPosition="top">
+                    Join
+                  </button>
+                </td>
+              </tr>
+            </ng-template>
+          </lfx-table>
+        }
+      </div>
+    </lfx-card>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -1,0 +1,225 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, effect, inject, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { catchError, combineLatest, filter, of, switchMap, tap } from 'rxjs';
+import { TooltipModule } from 'primeng/tooltip';
+import { SelectModule } from 'primeng/select';
+import { InputTextModule } from 'primeng/inputtext';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensMembershipsService } from '@services/org-lens-memberships.service';
+import { CardComponent } from '@components/card/card.component';
+import { TableComponent } from '@components/table/table.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import type {
+  OrgActiveMembership,
+  OrgActiveMembershipsResponse,
+  OrgDiscoverOpportunitiesResponse,
+  OrgExpiredMembershipsResponse,
+} from '@lfx-one/shared/interfaces';
+
+type PageState = 'loading' | 'error' | 'ready' | 'empty';
+type MembershipTab = 'active' | 'expired' | 'discover';
+
+interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+@Component({
+  selector: 'lfx-org-memberships',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TableComponent,
+    TooltipModule,
+    SelectModule,
+    InputTextModule,
+    CardComponent,
+    EmptyStateComponent,
+  ],
+  templateUrl: './org-memberships.component.html',
+})
+export class OrgMembershipsComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly membershipsService = inject(OrgLensMembershipsService);
+
+  protected readonly activeTab = signal<MembershipTab>('active');
+  protected readonly retryTrigger = signal(0);
+
+  protected readonly tabs = [
+    { id: 'active' as const, label: 'Active', icon: 'fa-light fa-circle-check' },
+    { id: 'expired' as const, label: 'Expired', icon: 'fa-light fa-clock-rotate-left' },
+    { id: 'discover' as const, label: 'Discover', icon: 'fa-light fa-magnifying-glass' },
+  ];
+
+  protected readonly tierOptions: DropdownOption[] = [
+    { label: 'All Membership Levels', value: '' },
+    { label: 'Platinum', value: 'Platinum Member' },
+    { label: 'Gold', value: 'Gold Member' },
+    { label: 'Silver', value: 'Silver Member' },
+    { label: 'Premier', value: 'Premier Member' },
+    { label: 'General', value: 'General Member' },
+    { label: 'Contributor', value: 'Contributor Member' },
+    { label: 'Steering', value: 'Steering Member' },
+  ];
+
+  protected readonly renewalOptions: DropdownOption[] = [
+    { label: 'All Renewals', value: '' },
+    { label: 'Renewing in 90 Days', value: '90' },
+    { label: 'Renewing in 30 Days', value: '30' },
+  ];
+
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
+
+  protected readonly searchTerm = signal('');
+  protected readonly selectedTier = signal('');
+  protected readonly selectedRenewal = signal('');
+  protected readonly expiredSearchTerm = signal('');
+
+  private readonly selectedAccountId$ = toObservable(
+    computed(() => this.accountContext.selectedAccount()?.accountId)
+  );
+
+  private readonly fetchError = signal(false);
+  private readonly fetchLoading = signal(true);
+
+  private readonly searchTerm$ = toObservable(this.searchTerm);
+  private readonly selectedTier$ = toObservable(this.selectedTier);
+  private readonly selectedRenewal$ = toObservable(this.selectedRenewal);
+
+  private readonly activeResponse$ = combineLatest([
+    this.selectedAccountId$.pipe(filter((id): id is string => !!id)),
+    this.searchTerm$,
+    this.selectedTier$,
+    this.selectedRenewal$,
+  ]).pipe(
+    tap(() => {
+      this.fetchLoading.set(true);
+      this.fetchError.set(false);
+    }),
+    switchMap(([id, search, tier, renewal]) =>
+      this.membershipsService.getActiveMemberships(id, { search: search || undefined, tier: tier || undefined, renewal: renewal || undefined }).pipe(
+        catchError(() => {
+          this.fetchError.set(true);
+          this.fetchLoading.set(false);
+          return of(null);
+        })
+      )
+    ),
+    tap(() => this.fetchLoading.set(false))
+  );
+
+  protected readonly activeData = toSignal<OrgActiveMembershipsResponse | null>(this.activeResponse$, { initialValue: null });
+  protected readonly summary = computed(() => this.activeData()?.summary);
+  protected readonly memberships = computed(() => this.activeData()?.memberships ?? []);
+
+  protected readonly pageState = computed<PageState>(() => {
+    if (this.fetchLoading()) return 'loading';
+    if (this.fetchError()) return 'error';
+    const data = this.activeData();
+    if (!data || data.memberships.length === 0) return 'empty';
+    return 'ready';
+  });
+
+  private readonly expiredLoading = signal(false);
+  private readonly expiredError = signal(false);
+  private readonly expiredData = signal<OrgExpiredMembershipsResponse | null>(null);
+
+  protected readonly expiredMemberships = computed(() => {
+    const data = this.expiredData();
+    if (!data) return [];
+    const search = this.expiredSearchTerm().toLowerCase();
+    if (!search) return data.memberships;
+    return data.memberships.filter(m => m.foundationName.toLowerCase().includes(search));
+  });
+
+  protected readonly expiredState = computed<PageState>(() => {
+    if (this.expiredLoading()) return 'loading';
+    if (this.expiredError()) return 'error';
+    if (!this.expiredData() || this.expiredMemberships().length === 0) return 'empty';
+    return 'ready';
+  });
+
+  private readonly discoverLoading = signal(false);
+  private readonly discoverError = signal(false);
+  private readonly discoverData = signal<OrgDiscoverOpportunitiesResponse | null>(null);
+
+  protected readonly discoverOpportunities = computed(() => this.discoverData()?.opportunities ?? []);
+
+  protected readonly discoverState = computed<PageState>(() => {
+    if (this.discoverLoading()) return 'loading';
+    if (this.discoverError()) return 'error';
+    if (!this.discoverData() || this.discoverOpportunities().length === 0) return 'empty';
+    return 'ready';
+  });
+
+  public constructor() {
+    effect(() => {
+      const tab = this.activeTab();
+      const accountId = this.accountContext.selectedAccount()?.accountId;
+      if (!accountId) return;
+
+      if (tab === 'expired' && !this.expiredData()) {
+        this.fetchExpired(accountId);
+      }
+      if (tab === 'discover' && !this.discoverData()) {
+        this.fetchDiscover(accountId);
+      }
+    });
+  }
+
+  protected switchTab(tab: MembershipTab): void {
+    this.activeTab.set(tab);
+  }
+
+  protected retry(): void {
+    this.retryTrigger.update((v) => v + 1);
+  }
+
+  protected formatDateShort(dateString: string | null): string {
+    if (!dateString) return '—';
+    return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+  }
+
+  protected formatDateFull(dateString: string | null): string {
+    if (!dateString) return '—';
+    return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  protected formatTierRange(membership: OrgActiveMembership): string {
+    return `${this.formatDateShort(membership.tierStartDate)} – ${this.formatDateShort(membership.tierEndDate)}`;
+  }
+
+  private fetchExpired(accountId: string): void {
+    this.expiredLoading.set(true);
+    this.expiredError.set(false);
+    this.membershipsService.getExpiredMemberships(accountId).subscribe({
+      next: (data) => {
+        this.expiredData.set(data);
+        this.expiredLoading.set(false);
+      },
+      error: () => {
+        this.expiredError.set(true);
+        this.expiredLoading.set(false);
+      },
+    });
+  }
+
+  private fetchDiscover(accountId: string): void {
+    this.discoverLoading.set(true);
+    this.discoverError.set(false);
+    this.membershipsService.getDiscoverOpportunities(accountId).subscribe({
+      next: (data) => {
+        this.discoverData.set(data);
+        this.discoverLoading.set(false);
+      },
+      error: () => {
+        this.discoverError.set(true);
+        this.discoverLoading.set(false);
+      },
+    });
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/org-lens-memberships.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-memberships.service.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import type { OrgActiveMembershipsResponse, OrgDiscoverOpportunitiesResponse, OrgExpiredMembershipsResponse } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgLensMembershipsService {
+  private readonly http = inject(HttpClient);
+
+  public getActiveMemberships(accountId: string, filters?: { search?: string; tier?: string; renewal?: string }): Observable<OrgActiveMembershipsResponse> {
+    let params = new HttpParams();
+    if (filters?.search) params = params.set('search', filters.search);
+    if (filters?.tier) params = params.set('tier', filters.tier);
+    if (filters?.renewal) params = params.set('renewal', filters.renewal);
+    return this.http.get<OrgActiveMembershipsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/memberships/active`, { params });
+  }
+
+  public getExpiredMemberships(accountId: string, search?: string): Observable<OrgExpiredMembershipsResponse> {
+    let params = new HttpParams();
+    if (search) params = params.set('search', search);
+    return this.http.get<OrgExpiredMembershipsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/memberships/expired`, { params });
+  }
+
+  public getDiscoverOpportunities(accountId: string): Observable<OrgDiscoverOpportunitiesResponse> {
+    return this.http.get<OrgDiscoverOpportunitiesResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/memberships/discover`);
+  }
+}

--- a/apps/lfx-one/src/server/controllers/org-lens-memberships.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-memberships.controller.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { OrgLensMembershipsService } from '../services/org-lens-memberships.service';
+
+const ACCOUNT_ID_PATTERN = /^001[A-Za-z0-9]{12,15}$/;
+
+export class OrgLensMembershipsController {
+  private readonly service: OrgLensMembershipsService;
+
+  public constructor() {
+    this.service = new OrgLensMembershipsService();
+  }
+
+  public async getActiveMemberships(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_memberships_active', {
+      account_id: accountId,
+    });
+
+    try {
+      if (!accountId || typeof accountId !== 'string') {
+        throw ServiceValidationError.forField('accountId', 'accountId path parameter is required', {
+          operation: 'get_org_lens_memberships_active',
+        });
+      }
+
+      if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+        throw ServiceValidationError.forField('accountId', 'Invalid Salesforce accountId format', {
+          operation: 'get_org_lens_memberships_active',
+        });
+      }
+
+      const search = req.query['search'] as string | undefined;
+      const tier = req.query['tier'] as string | undefined;
+      const renewal = req.query['renewal'] as string | undefined;
+
+      const response = this.service.getActiveMemberships(accountId, search, tier, renewal);
+
+      logger.success(req, 'get_org_lens_memberships_active', startTime, {
+        account_id: accountId,
+        membership_count: response.memberships.length,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getExpiredMemberships(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_memberships_expired', {
+      account_id: accountId,
+    });
+
+    try {
+      if (!accountId || typeof accountId !== 'string') {
+        throw ServiceValidationError.forField('accountId', 'accountId path parameter is required', {
+          operation: 'get_org_lens_memberships_expired',
+        });
+      }
+
+      if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+        throw ServiceValidationError.forField('accountId', 'Invalid Salesforce accountId format', {
+          operation: 'get_org_lens_memberships_expired',
+        });
+      }
+
+      const search = req.query['search'] as string | undefined;
+
+      const response = this.service.getExpiredMemberships(accountId, search);
+
+      logger.success(req, 'get_org_lens_memberships_expired', startTime, {
+        account_id: accountId,
+        membership_count: response.memberships.length,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getDiscoverOpportunities(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_memberships_discover', {
+      account_id: accountId,
+    });
+
+    try {
+      if (!accountId || typeof accountId !== 'string') {
+        throw ServiceValidationError.forField('accountId', 'accountId path parameter is required', {
+          operation: 'get_org_lens_memberships_discover',
+        });
+      }
+
+      if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+        throw ServiceValidationError.forField('accountId', 'Invalid Salesforce accountId format', {
+          operation: 'get_org_lens_memberships_discover',
+        });
+      }
+
+      const response = this.service.getDiscoverOpportunities(accountId);
+
+      logger.success(req, 'get_org_lens_memberships_discover', startTime, {
+        account_id: accountId,
+        opportunity_count: response.opportunities.length,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -4,12 +4,23 @@
 import { Router } from 'express';
 
 import { OrgLensFoundationsController } from '../controllers/org-lens-foundations.controller';
+import { OrgLensMembershipsController } from '../controllers/org-lens-memberships.controller';
 
 const router = Router();
 
 const orgLensFoundationsController = new OrgLensFoundationsController();
+const orgLensMembershipsController = new OrgLensMembershipsController();
 
 // GET /api/orgs/:accountId/lens/foundations-and-projects
 router.get('/:accountId/lens/foundations-and-projects', (req, res, next) => orgLensFoundationsController.getFoundationsAndProjects(req, res, next));
+
+// GET /api/orgs/:accountId/lens/memberships/active
+router.get('/:accountId/lens/memberships/active', (req, res, next) => orgLensMembershipsController.getActiveMemberships(req, res, next));
+
+// GET /api/orgs/:accountId/lens/memberships/expired
+router.get('/:accountId/lens/memberships/expired', (req, res, next) => orgLensMembershipsController.getExpiredMemberships(req, res, next));
+
+// GET /api/orgs/:accountId/lens/memberships/discover
+router.get('/:accountId/lens/memberships/discover', (req, res, next) => orgLensMembershipsController.getDiscoverOpportunities(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
@@ -1,0 +1,112 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type {
+  OrgActiveMembership,
+  OrgActiveMembershipsResponse,
+  OrgDiscoverOpportunitiesResponse,
+  OrgDiscoverOpportunity,
+  OrgExpiredMembership,
+  OrgExpiredMembershipsResponse,
+} from '@lfx-one/shared/interfaces';
+
+const DEMO_ACCOUNT_ID_PREFIX = '001';
+
+const ACTIVE_MEMBERSHIPS: OrgActiveMembership[] = [
+  { foundationId: 'agl-001', foundationName: 'Automotive Grade Linux (AGL)', foundationLogo: null, foundationInitials: 'AG', projectCount: 43, memberCount: 338, membershipTier: 'Platinum Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: '2012-07-01', boardMembers: 0, committeeMembers: 0, orgProjects: 4 },
+  { foundationId: 'cncf-001', foundationName: 'Cloud Native Computing Foundation (CNCF)', foundationLogo: null, foundationInitials: 'CN', projectCount: 55, memberCount: 440, membershipTier: 'Silver Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: '2020-01-01', boardMembers: 0, committeeMembers: 0, orgProjects: 2 },
+  { foundationId: 'ebpf-001', foundationName: 'eBPF Foundation', foundationLogo: null, foundationInitials: 'eB', projectCount: 58, memberCount: 443, membershipTier: 'Silver Member', tierStartDate: '2026-01-01', tierEndDate: '2026-10-31', memberSince: '2022-01-01', boardMembers: 1, committeeMembers: 0, orgProjects: 5 },
+  { foundationId: 'openchain-001', foundationName: 'OpenChain Project', foundationLogo: null, foundationInitials: 'OC', projectCount: 54, memberCount: 179, membershipTier: 'Platinum Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: '2017-01-01', boardMembers: 0, committeeMembers: 20, orgProjects: 5 },
+  { foundationId: 'lf-001', foundationName: 'The Linux Foundation', foundationLogo: null, foundationInitials: 'LF', projectCount: 61, memberCount: 356, membershipTier: 'Gold Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: '2015-01-01', boardMembers: 1, committeeMembers: 2, orgProjects: 6 },
+  { foundationId: 'todo-001', foundationName: 'TODO Group', foundationLogo: null, foundationInitials: 'TODO', projectCount: 10, memberCount: 225, membershipTier: 'General Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: null, boardMembers: 0, committeeMembers: 0, orgProjects: 3 },
+  { foundationId: 'uec-001', foundationName: 'Ultra Ethernet Consortium Fund', foundationLogo: null, foundationInitials: 'UE', projectCount: 77, memberCount: 462, membershipTier: 'Contributor Member', tierStartDate: '2026-01-01', tierEndDate: '2026-12-31', memberSince: '2023-07-01', boardMembers: 0, committeeMembers: 0, orgProjects: 0 },
+];
+
+const EXPIRED_MEMBERSHIPS: OrgExpiredMembership[] = [
+  { foundationId: 'soda-001', foundationName: 'SODA Foundation', foundationInitials: 'SF', foundationColor: 'bg-blue-600', membershipTier: 'General Member', tierStartDate: '2022-03-01', tierEndDate: '2025-12-31', expirationDate: '2025-12-31', actionType: 'renew' },
+  { foundationId: 'lfph-001', foundationName: 'LF Public Health', foundationInitials: 'LP', foundationColor: 'bg-purple-600', membershipTier: 'Premier Member', tierStartDate: '2020-04-01', tierEndDate: '2023-12-31', expirationDate: '2023-12-31', actionType: 'contact' },
+  { foundationId: 'magma-001', foundationName: 'Magma Fund', foundationInitials: 'MF', foundationColor: 'bg-green-600', membershipTier: 'Silver Member', tierStartDate: '2021-01-01', tierEndDate: '2022-12-31', expirationDate: '2022-12-31', actionType: 'renew' },
+  { foundationId: 'edgex-001', foundationName: 'EdgeX Foundry', foundationInitials: 'EF', foundationColor: 'bg-teal-600', membershipTier: 'Silver Member', tierStartDate: '2018-01-01', tierEndDate: '2020-12-31', expirationDate: '2020-12-31', actionType: 'renew' },
+  { foundationId: 'iovisor-001', foundationName: 'IO Visor Project', foundationInitials: 'IV', foundationColor: 'bg-red-600', membershipTier: 'Silver Member', tierStartDate: '2016-01-01', tierEndDate: '2018-12-31', expirationDate: '2018-12-31', actionType: 'contact' },
+  { foundationId: 'onap-001', foundationName: 'ONAP', foundationInitials: 'O', foundationColor: 'bg-pink-600', membershipTier: 'Silver Member', tierStartDate: '2017-01-01', tierEndDate: '2019-12-31', expirationDate: '2019-12-31', actionType: 'contact' },
+];
+
+const DISCOVER_OPPORTUNITIES: OrgDiscoverOpportunity[] = [
+  { foundationId: 'lfenergy-001', foundationName: 'LF Energy', foundationInitials: 'LE', foundationColor: 'bg-red-700', category: 'EV Charging & Grid', suggestedTier: 'Strategic Membership', relevantProjects: 5, contributors: 8, contributions: 184 },
+  { foundationId: 'lfai-001', foundationName: 'LF AI & Data', foundationInitials: 'LA', foundationColor: 'bg-orange-600', category: 'Autonomous Driving', suggestedTier: 'General Membership', relevantProjects: 4, contributors: 12, contributions: 312 },
+  { foundationId: 'pytorch-001', foundationName: 'PyTorch Foundation', foundationInitials: 'PT', foundationColor: 'bg-orange-700', category: 'Machine Learning', suggestedTier: 'Gold Membership', relevantProjects: 2, contributors: 7, contributions: 142 },
+  { foundationId: 'openssf-001', foundationName: 'OpenSSF', foundationInitials: 'OS', foundationColor: 'bg-blue-800', category: 'Supply Chain Security', suggestedTier: 'Premier Membership', relevantProjects: 3, contributors: 4, contributions: 56 },
+  { foundationId: 'ccc-001', foundationName: 'Confidential Computing Consortium', foundationInitials: 'CC', foundationColor: 'bg-green-700', category: 'Secure Compute', suggestedTier: 'Premier Membership', relevantProjects: 2, contributors: 2, contributions: 28 },
+  { foundationId: 'lfedge-001', foundationName: 'LF Edge', foundationInitials: 'LE', foundationColor: 'bg-red-600', category: 'Edge Compute', suggestedTier: 'Premier Membership', relevantProjects: 4, contributors: 5, contributions: 96 },
+];
+
+export class OrgLensMembershipsService {
+  public getActiveMemberships(accountId: string, search?: string, tier?: string, renewal?: string): OrgActiveMembershipsResponse {
+    if (!this.isDemoAccount(accountId)) {
+      return { accountId, summary: { activeMemberships: 0, renewingWithin90Days: 0, governanceRoles: 0 }, memberships: [] };
+    }
+
+    let filtered = [...ACTIVE_MEMBERSHIPS];
+
+    if (search) {
+      const term = search.toLowerCase();
+      filtered = filtered.filter(m => m.foundationName.toLowerCase().includes(term));
+    }
+
+    if (tier) {
+      filtered = filtered.filter(m => m.membershipTier === tier);
+    }
+
+    if (renewal === '90' || renewal === '30') {
+      const now = new Date();
+      const days = Number(renewal);
+      const cutoff = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+      filtered = filtered.filter(m => new Date(m.tierEndDate) <= cutoff);
+    }
+
+    const renewingWithin90Days = filtered.filter(m => {
+      const now = new Date();
+      const cutoff90 = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+      return new Date(m.tierEndDate) <= cutoff90;
+    }).length;
+
+    const governanceRoles = filtered.reduce((sum, m) => sum + m.boardMembers + m.committeeMembers, 0);
+
+    return {
+      accountId,
+      summary: {
+        activeMemberships: filtered.length,
+        renewingWithin90Days,
+        governanceRoles,
+      },
+      memberships: filtered,
+    };
+  }
+
+  public getExpiredMemberships(accountId: string, search?: string): OrgExpiredMembershipsResponse {
+    if (!this.isDemoAccount(accountId)) {
+      return { accountId, memberships: [] };
+    }
+
+    let filtered = [...EXPIRED_MEMBERSHIPS];
+
+    if (search) {
+      const term = search.toLowerCase();
+      filtered = filtered.filter(m => m.foundationName.toLowerCase().includes(term));
+    }
+
+    return { accountId, memberships: filtered };
+  }
+
+  public getDiscoverOpportunities(accountId: string): OrgDiscoverOpportunitiesResponse {
+    if (!this.isDemoAccount(accountId)) {
+      return { accountId, opportunities: [] };
+    }
+
+    return { accountId, opportunities: [...DISCOVER_OPPORTUNITIES] };
+  }
+
+  private isDemoAccount(accountId: string): boolean {
+    return accountId.startsWith(DEMO_ACCOUNT_ID_PREFIX);
+  }
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -162,3 +162,6 @@ export * from './marketing-impact.interface';
 
 // Enrollment interfaces
 export * from './enrollment.interface';
+
+// Org Memberships interfaces
+export * from './org-memberships.interface';

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -1,0 +1,64 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface OrgMembershipsSummary {
+  activeMemberships: number;
+  renewingWithin90Days: number;
+  governanceRoles: number;
+}
+
+export interface OrgActiveMembership {
+  foundationId: string;
+  foundationName: string;
+  foundationLogo: string | null;
+  foundationInitials: string;
+  projectCount: number;
+  memberCount: number;
+  membershipTier: string;
+  tierStartDate: string;
+  tierEndDate: string;
+  memberSince: string | null;
+  boardMembers: number;
+  committeeMembers: number;
+  orgProjects: number;
+}
+
+export interface OrgActiveMembershipsResponse {
+  accountId: string;
+  summary: OrgMembershipsSummary;
+  memberships: OrgActiveMembership[];
+}
+
+export interface OrgExpiredMembership {
+  foundationId: string;
+  foundationName: string;
+  foundationInitials: string;
+  foundationColor: string;
+  membershipTier: string;
+  tierStartDate: string;
+  tierEndDate: string;
+  expirationDate: string;
+  actionType: 'renew' | 'contact';
+}
+
+export interface OrgExpiredMembershipsResponse {
+  accountId: string;
+  memberships: OrgExpiredMembership[];
+}
+
+export interface OrgDiscoverOpportunity {
+  foundationId: string;
+  foundationName: string;
+  foundationInitials: string;
+  foundationColor: string;
+  category: string;
+  suggestedTier: string;
+  relevantProjects: number;
+  contributors: number;
+  contributions: number;
+}
+
+export interface OrgDiscoverOpportunitiesResponse {
+  accountId: string;
+  opportunities: OrgDiscoverOpportunity[];
+}


### PR DESCRIPTION
## Summary

- Add `/org/memberships` page with three tabs (Active, Expired, Discover) and mock SSR endpoints
- Active tab: summary stat cards (Active Memberships, Renewing Within 90 Days, Governance Roles), search + tier/renewal filters, sortable memberships table with 7 mock rows
- Expired tab: search filter, table with 6 expired memberships, Renew/Contact Us buttons (non-functional mock)
- Discover tab: table with 6 foundation opportunities, Join buttons (non-functional mock)
- SSR: 3 Express endpoints at `/api/orgs/:accountId/lens/memberships/{active|expired|discover}` with server-side filtering
- Uses LFX wrapper components (`lfx-card`, `lfx-table`, `lfx-empty-state`) matching the committee-table pattern

## Test plan

- [ ] Navigate to `/org/memberships` and verify Active tab renders with stat cards and 7 membership rows
- [ ] Switch to Expired tab — verify 6 rows with Renew/Contact Us buttons
- [ ] Switch to Discover tab — verify 6 opportunity rows with Join buttons
- [ ] Test search filter on Active tab — type "eBPF" and verify 1 row shows
- [ ] Test tier dropdown — select "Platinum" and verify 2 rows
- [ ] Verify `yarn build` passes
- [ ] Verify SSR: view page source contains table content


Made with [Cursor](https://cursor.com)