### PR TITLE
fix(server): extend no-cache to all non-hashed JS and CSS (LFXV2-1920)

### DIFF
--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -105,17 +105,17 @@ app.get(
   express.static(browserDistFolder, {
     index: false,
     setHeaders: (res, filePath) => {
-      if (filePath.endsWith('index.html') || filePath.endsWith('index.csr.html')) {
-        // index.html must not be cached long-term — returning users need the latest
-        // chunk hashes after a deploy, otherwise dynamic imports fail with
-        // "TypeError: Importing a module script failed."
-        res.setHeader('Cache-Control', 'no-cache, must-revalidate');
-        return;
-      }
       if (/-[A-Z0-9]{8,}\.(js|css|woff2?|ttf|otf|png|jpg|jpeg|svg|ico|webp)$/i.test(filePath)) {
         // Angular emits content-hashed filenames (outputHashing: "all") — safe to
         // cache permanently; the hash changes whenever content changes.
         res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        return;
+      }
+      if (/\.(html|js|css)$/i.test(filePath)) {
+        // Non-hashed HTML, JS, and CSS (e.g. index.html, main.js in dev builds where
+        // outputHashing is not "all") must revalidate on every request — stale entry
+        // bundles reference old chunk hashes and cause "Importing a module script failed".
+        res.setHeader('Cache-Control', 'no-cache, must-revalidate');
         return;
       }
       res.setHeader('Cache-Control', 'public, max-age=300');


### PR DESCRIPTION
## Problem

After PR #735 was merged and deployed to dev, the same `TypeError: Importing a module script failed` reappeared on `app.dev.lfx.dev` in Safari.

Root cause: dev builds leave entry bundles (`main.js`, `polyfills.js`) **unhashed** — Angular's `outputHashing` defaults to partial in non-production configurations. PR #735 only added `no-cache, must-revalidate` for `index.html`; unhashed `main.js` fell through to the `max-age=300` fallback. A returning user with a stale `main.js` would request old chunk hashes that no longer exist → 404 → `TypeError: Importing a module script failed`.

## Fix

Reorder the `setHeaders` branches:
1. **Hashed assets first** (regex match on `filename-HASH.ext`) → `immutable, max-age=31536000` — safe because content hash changes with every deploy
2. **Any `.html`, `.js`, or `.css` file** → `no-cache, must-revalidate` — covers both `index.html` and unhashed entry bundles in dev
3. **Everything else** (images, fonts without hash) → `max-age=300`

This is a follow-up to #735. No new logic — just extending the `no-cache` rule to cover the dev build's unhashed JS.

## Verification

```bash
# After deploy, confirm headers:
curl -I https://app.dev.lfx.dev/            # → no-cache, must-revalidate
curl -I https://app.dev.lfx.dev/main.js     # → no-cache, must-revalidate
curl -I https://app.dev.lfx.dev/main-ABC123.js  # → immutable
```

Issue: LFXV2-1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)