### PR TITLE
feat(profile): add auto-renew toggle to individual enrollment

### DIFF
--- a/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
@@ -60,6 +60,15 @@ test.describe('Individual Enrollment — Structural Tests', () => {
     });
   });
 
+  test.describe('Confirm dialog testid hook', () => {
+    test('should have confirm dialog attached in DOM (not visible until triggered)', async ({ page }) => {
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-confirm-dialog')).toBeAttached();
+    });
+  });
+});
+
+test.describe('Individual Enrollment — Mocked State Tests', () => {
   test.describe('Empty / error states', () => {
     test('should show empty state when no enrollments exist', async ({ page }) => {
       await page.route('**/api/enrollments', async (route) => {
@@ -77,13 +86,6 @@ test.describe('Individual Enrollment — Structural Tests', () => {
       await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
       await expect(page).not.toHaveURL(/auth0\.com/);
       await expect(page.getByTestId('individual-enrollment-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    });
-  });
-
-  test.describe('Confirm dialog testid hook', () => {
-    test('should have confirm dialog attached in DOM (not visible until triggered)', async ({ page }) => {
-      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
-      await expect(page.getByTestId('individual-enrollment-confirm-dialog')).toBeAttached();
     });
   });
 });

--- a/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
@@ -1,0 +1,89 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { expect, test } from '@playwright/test';
+
+const ENROLLMENT_URL = '/profile/individual-enrollment';
+const DATA_LOAD_TIMEOUT = 15_000;
+
+test.setTimeout(60_000);
+
+test.describe('Individual Enrollment — Structural Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    // Wait for either the loading skeleton or an actual content region to appear
+    await expect(
+      page
+        .getByTestId('individual-enrollment-loading')
+        .or(page.getByTestId('individual-enrollment-card'))
+        .or(page.getByTestId('individual-enrollment-empty'))
+        .or(page.getByTestId('individual-enrollment-error'))
+    ).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test.describe('Page root', () => {
+    test('should have root container', async ({ page }) => {
+      await expect(page.getByTestId('individual-enrollment-page')).toBeAttached();
+    });
+  });
+
+  test.describe('Card structure (demo user path)', () => {
+    test('should render at least one enrollment card', async ({ page }) => {
+      const card = page.getByTestId('individual-enrollment-card').first();
+      await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    });
+
+    test('should show a status chip on the card', async ({ page }) => {
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-status').first()).toBeAttached();
+    });
+
+    test('should show enrollment details section', async ({ page }) => {
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-details').first()).toBeAttached();
+    });
+
+    test('should show enrollment CTA section', async ({ page }) => {
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-cta').first()).toBeAttached();
+    });
+  });
+
+  test.describe('Auto-renew row', () => {
+    test('should NOT show the toggle for non-Stripe memberships', async ({ page }) => {
+      // Demo user has ExtPaymentType: '836366' (not 'stripe') — toggle must not render
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).not.toBeAttached();
+    });
+  });
+
+  test.describe('Empty / error states', () => {
+    test('should show empty state when no enrollments exist', async ({ page }) => {
+      await page.route('**/api/enrollments', async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      });
+      await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+      await expect(page).not.toHaveURL(/auth0\.com/);
+      await expect(page.getByTestId('individual-enrollment-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    });
+
+    test('should show error state when API fails', async ({ page }) => {
+      await page.route('**/api/enrollments', async (route) => {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'Internal server error' }) });
+      });
+      await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+      await expect(page).not.toHaveURL(/auth0\.com/);
+      await expect(page.getByTestId('individual-enrollment-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    });
+  });
+
+  test.describe('Confirm dialog testid hook', () => {
+    test('should have confirm dialog attached in DOM (not visible until triggered)', async ({ page }) => {
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-confirm-dialog')).toBeAttached();
+    });
+  });
+});

--- a/apps/lfx-one/e2e/individual-enrollment.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment.spec.ts
@@ -1,0 +1,229 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { expect, Page, test } from '@playwright/test';
+
+const ENROLLMENT_URL = '/profile/individual-enrollment';
+const DATA_LOAD_TIMEOUT = 15_000;
+const MEMBERSHIP_ID = 'test-membership-stripe-001';
+
+test.setTimeout(60_000);
+
+/** Mock enrollment response with an active Stripe membership — auto-renew enabled. */
+const stripeActiveMembership = [
+  {
+    projectName: 'The Linux Foundation',
+    projectSlug: 'tlf',
+    ProductName: 'The Linux Foundation Individual Supporter',
+    projectDesc: 'Test project description.',
+    enrollButton: 'Enroll as an Individual Supporter',
+    price: 99,
+    projectLogo: 'https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/thelinuxfoundation-color.svg',
+    benefits: ['Weekly newsletter', 'Up to 10% discount on training courses'],
+    projectId: 'a0941000002wBz9AAE',
+    productSFID: 'a0I2M00000PQymQUAT',
+    productId: '01t2M000005wBb0QAE',
+    ctaPath: '?product=01t2M000005wBb0QAE&project=tlf',
+    activeButtonText: '',
+    activeButtonURL: '',
+    membership: {
+      Status: 'Active',
+      AutoRenew: true,
+      PurchaseDate: '2024-06-01',
+      EndDate: '2025-06-01',
+      Price: 99,
+      ID: MEMBERSHIP_ID,
+      ExtPaymentType: 'stripe',
+    },
+  },
+];
+
+/** Same membership but AutoRenew: false. */
+const stripeActiveMembershipAutoRenewOff = [{ ...stripeActiveMembership[0], membership: { ...stripeActiveMembership[0].membership, AutoRenew: false } }];
+
+async function setupStripeEnrollmentMock(page: Page, autoRenew = true): Promise<void> {
+  const body = autoRenew ? stripeActiveMembership : stripeActiveMembershipAutoRenewOff;
+  await page.route('**/api/enrollments', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function setupPatchMock(page: Page, status: 200 | 204 | 500 = 204): Promise<void> {
+  await page.route(`**/api/enrollments/${MEMBERSHIP_ID}/auto-renew`, async (route) => {
+    if (status === 500) {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'Upstream error' }) });
+    } else {
+      await route.fulfill({ status, body: '' });
+    }
+  });
+}
+
+async function gotoAndWaitForCard(page: Page): Promise<void> {
+  await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('individual-enrollment-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.describe('Individual Enrollment — Content Tests', () => {
+  test.describe('Page rendering', () => {
+    test('shows enrollment card with product name and status', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const card = page.getByTestId('individual-enrollment-card');
+      await expect(card).toContainText('The Linux Foundation Individual Supporter');
+      await expect(page.getByTestId('individual-enrollment-status')).toBeVisible();
+    });
+
+    test('shows enrollment dates and price', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const details = page.getByTestId('individual-enrollment-details');
+      await expect(details).toContainText('$99');
+      await expect(details).toContainText('Purchased');
+    });
+  });
+
+  test.describe('Auto-renew toggle visibility', () => {
+    test('shows toggle for active Stripe membership', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).toBeVisible();
+    });
+
+    test('toggle label reads "Auto Renew"', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggleWrapper = page.getByTestId('individual-enrollment-auto-renew-toggle');
+      await expect(toggleWrapper).toContainText('Auto Renew');
+    });
+
+    test('toggle label is associated with the input via for/id', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const label = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('label');
+      const forAttr = await label.getAttribute('for');
+      expect(forAttr).toMatch(/^auto-renew-/);
+
+      // The switch's underlying input should have the same id
+      const input = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      const idAttr = await input.getAttribute('id');
+      expect(idAttr).toBe(forAttr);
+    });
+  });
+
+  test.describe('Toggle confirm → accept', () => {
+    test('confirm dialog appears after toggling', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await setupPatchMock(page);
+      await gotoAndWaitForCard(page);
+
+      // Toggle is currently ON (AutoRenew: true) — click it to disable
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.p-confirmdialog')).toContainText('Update Membership');
+      await expect(page.locator('.p-confirmdialog')).toContainText('Disable auto renew');
+    });
+
+    test('accepting the dialog shows success toast', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await setupPatchMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+      // Click the Disable button (acceptLabel)
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+
+      // Toast should appear
+      await expect(page.locator('.p-toast')).toContainText('Auto renew disabled successfully', { timeout: 10_000 });
+    });
+
+    test('accepting the dialog dismisses it', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await setupPatchMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+
+      await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe('Toggle confirm → cancel (reject)', () => {
+    test('cancelling the dialog dismisses it without a toast', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Cancel/i }).click();
+
+      await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.p-toast')).not.toBeVisible();
+    });
+
+    test('cancelling reverts the toggle to its original value', async ({ page }) => {
+      await setupStripeEnrollmentMock(page, true); // AutoRenew: true
+      await gotoAndWaitForCard(page);
+
+      const input = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await expect(input).toBeChecked(); // starts checked
+
+      await input.click(); // uncheck (optimistic)
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Cancel/i }).click();
+      await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
+
+      // After cancel, toggle should be back to checked
+      await expect(input).toBeChecked();
+    });
+  });
+
+  test.describe('Toggle confirm → upstream error', () => {
+    test('shows error toast on PATCH failure', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await setupPatchMock(page, 500);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+
+      await expect(page.locator('.p-toast')).toContainText('Failed to update membership', { timeout: 10_000 });
+    });
+
+    test('reverts toggle to original value on PATCH failure', async ({ page }) => {
+      await setupStripeEnrollmentMock(page, true); // AutoRenew: true
+      await setupPatchMock(page, 500);
+      await gotoAndWaitForCard(page);
+
+      const input = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await expect(input).toBeChecked();
+
+      await input.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+
+      // After error, toggle should revert to original checked state
+      await expect(input).toBeChecked({ timeout: 10_000 });
+    });
+  });
+});

--- a/apps/lfx-one/e2e/individual-enrollment.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment.spec.ts
@@ -31,8 +31,8 @@ const stripeActiveMembership = [
     membership: {
       Status: 'Active',
       AutoRenew: true,
-      PurchaseDate: '2024-06-01',
-      EndDate: '2025-06-01',
+      PurchaseDate: '2025-06-01',
+      EndDate: '2027-06-01',
       Price: 99,
       ID: MEMBERSHIP_ID,
       ExtPaymentType: 'stripe',
@@ -143,7 +143,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
 
       // Click the Disable button (acceptLabel)
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Disable/i })
+        .click();
 
       // Toast should appear
       await expect(page.locator('.p-toast')).toContainText('Auto renew disabled successfully', { timeout: 10_000 });
@@ -157,7 +160,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
       const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
       await toggle.click();
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Disable/i })
+        .click();
 
       await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
     });
@@ -172,7 +178,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
       await toggle.click();
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
 
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Cancel/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Cancel/i })
+        .click();
 
       await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
       await expect(page.locator('.p-toast')).not.toBeVisible();
@@ -188,7 +197,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
       await input.click(); // uncheck (optimistic)
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
 
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Cancel/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Cancel/i })
+        .click();
       await expect(page.locator('.p-confirmdialog')).not.toBeVisible({ timeout: 5000 });
 
       // After cancel, toggle should be back to checked
@@ -205,7 +217,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
       const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
       await toggle.click();
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Disable/i })
+        .click();
 
       await expect(page.locator('.p-toast')).toContainText('Failed to update membership', { timeout: 10_000 });
     });
@@ -220,7 +235,10 @@ test.describe('Individual Enrollment — Content Tests', () => {
 
       await input.click();
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
-      await page.locator('.p-confirmdialog').getByRole('button', { name: /Disable/i }).click();
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Disable/i })
+        .click();
 
       // After error, toggle should revert to original checked state
       await expect(input).toBeChecked({ timeout: 10_000 });

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-4" data-testid="individual-enrollment-page">
-  @if (enrollments() === undefined) {
+  @if (displayedEnrollments() === undefined) {
     <!-- Loading skeletons -->
     <div class="flex flex-col gap-4" data-testid="individual-enrollment-loading">
       @for (i of [1]; track i) {
@@ -22,14 +22,14 @@
       title="Could not load enrollment products"
       [subtitle]="enrollmentError() || 'We could not load your enrollment products. Please retry.'"
       data-testid="individual-enrollment-error" />
-  } @else if (enrollments()!.length === 0) {
+  } @else if (displayedEnrollments()!.length === 0) {
     <lfx-empty-state
       icon="fa-light fa-id-card"
       title="No enrollment products available"
       subtitle="There are no individual enrollment products at this time."
       data-testid="individual-enrollment-empty" />
   } @else {
-    @for (item of enrollments()!; track item.productId) {
+    @for (item of displayedEnrollments()!; track item.productId) {
       <lfx-card data-testid="individual-enrollment-card">
         <div class="flex flex-col gap-4 p-6">
           <!-- Header row: logo + name + status chip -->
@@ -48,24 +48,43 @@
             </div>
           </div>
 
-          <!-- Price + auto-renew info -->
-          @if (item.price !== null && item.price !== undefined) {
+          <!-- Enrollment dates, price, and auto-renew -->
+          @if (item.membership) {
+            <div class="flex flex-wrap items-center gap-4 text-sm text-gray-600" data-testid="individual-enrollment-details">
+              @if (item.price !== null && item.price !== undefined) {
+                <span
+                  ><span class="font-medium">${{ item.price }}</span> / year</span
+                >
+              }
+              @if (item.membership.PurchaseDate) {
+                <span data-testid="individual-enrollment-purchase-date">
+                  Purchased: <span class="font-medium">{{ item.membership.PurchaseDate | date: 'mediumDate' : 'UTC' }}</span>
+                </span>
+              }
+              @if (item.membership.EndDate) {
+                <span>
+                  {{ item.displayStatus === 'Expired' ? 'Expired' : 'Renews' }}:
+                  <span class="font-medium">{{ item.membership.EndDate | date: 'mediumDate' : 'UTC' }}</span>
+                </span>
+              }
+              @if (item.membership.ExtPaymentType === 'stripe') {
+                @if (item.displayStatus !== 'Expired') {
+                  <span class="flex items-center gap-2" data-testid="individual-enrollment-auto-renew-toggle">
+                    <p-toggleSwitch [ngModel]="getAutoRenew(item)" (onChange)="onToggleAutoRenew(item, $event.checked)" [disabled]="isPending(item)" />
+                    <span class="font-medium">Auto Renew</span>
+                  </span>
+                } @else {
+                  <span>
+                    Auto Renew: <span class="font-medium">{{ item.membership.AutoRenew ? 'Enabled' : 'Disabled' }}</span>
+                  </span>
+                }
+              }
+            </div>
+          } @else if (item.price !== null && item.price !== undefined) {
             <div class="flex flex-wrap items-center gap-4 text-sm text-gray-600" data-testid="individual-enrollment-details">
               <span
                 ><span class="font-medium">${{ item.price }}</span> / year</span
               >
-              @if (item.membership) {
-                <span>
-                  Auto-renew:
-                  <span class="font-medium">{{ item.membership.AutoRenew ? 'On' : 'Off' }}</span>
-                </span>
-                @if (item.membership.EndDate) {
-                  <span>
-                    {{ item.displayStatus === 'Expired' ? 'Expired' : 'Renews' }}:
-                    <span class="font-medium">{{ item.membership.EndDate | date: 'mediumDate' : 'UTC' }}</span>
-                  </span>
-                }
-              }
             </div>
           }
 
@@ -101,3 +120,6 @@
     }
   }
 </div>
+
+<p-toast position="top-right" />
+<p-confirmDialog data-testid="individual-enrollment-confirm-dialog" />

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -70,8 +70,12 @@
               @if (item.membership.ExtPaymentType === 'stripe') {
                 @if (item.displayStatus !== 'Expired') {
                   <span class="flex items-center gap-2" data-testid="individual-enrollment-auto-renew-toggle">
-                    <p-toggleSwitch [ngModel]="item.membership!.AutoRenew" (onChange)="onToggleAutoRenew(item, $event.checked)" [disabled]="isPending(item)" />
-                    <span class="font-medium">Auto Renew</span>
+                    <p-toggleSwitch
+                      [inputId]="'auto-renew-' + item.membership!.ID"
+                      [ngModel]="item.membership!.AutoRenew"
+                      (onChange)="onToggleAutoRenew(item, $event.checked)"
+                      [disabled]="isPending(item)" />
+                    <label class="font-medium" [attr.for]="'auto-renew-' + item.membership!.ID">Auto Renew</label>
                   </span>
                 } @else {
                   <span>

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -70,7 +70,7 @@
               @if (item.membership.ExtPaymentType === 'stripe') {
                 @if (item.displayStatus !== 'Expired') {
                   <span class="flex items-center gap-2" data-testid="individual-enrollment-auto-renew-toggle">
-                    <p-toggleSwitch [ngModel]="getAutoRenew(item)" (onChange)="onToggleAutoRenew(item, $event.checked)" [disabled]="isPending(item)" />
+                    <p-toggleSwitch [ngModel]="item.membership!.AutoRenew" (onChange)="onToggleAutoRenew(item, $event.checked)" [disabled]="isPending(item)" />
                     <span class="font-medium">Auto Renew</span>
                   </span>
                 } @else {

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -83,7 +83,6 @@ export class ProfileIndividualEnrollmentComponent {
     if (!item.membership || this.isPending(item)) return;
 
     const membershipId = item.membership.ID;
-    const originalValue = item.membership.AutoRenew;
 
     // Optimistically apply new value so the toggle does not flicker back
     this.autoRenewOverrides.update((m) => {
@@ -104,12 +103,12 @@ export class ProfileIndividualEnrollmentComponent {
       rejectLabel: 'Cancel',
       acceptButtonStyleClass: 'p-button-primary p-button-sm',
       rejectButtonStyleClass: 'p-button-text p-button-sm',
-      accept: () => void this.performAutoRenewUpdate(membershipId, newValue, originalValue),
-      reject: () => this.revertAutoRenewOverride(membershipId, originalValue),
+      accept: () => void this.performAutoRenewUpdate(membershipId, newValue),
+      reject: () => this.clearAutoRenewOverride(membershipId),
     });
   }
 
-  private performAutoRenewUpdate(membershipId: string, newValue: boolean, originalValue: boolean): void {
+  private performAutoRenewUpdate(membershipId: string, newValue: boolean): void {
     this.pendingIds.update((s) => new Set([...s, membershipId]));
 
     this.enrollmentService
@@ -126,6 +125,8 @@ export class ProfileIndividualEnrollmentComponent {
       )
       .subscribe({
         next: () => {
+          this.syncAutoRenewValue(membershipId, newValue);
+          this.clearAutoRenewOverride(membershipId);
           this.messageService.add({
             severity: 'success',
             summary: 'Success',
@@ -138,15 +139,27 @@ export class ProfileIndividualEnrollmentComponent {
             summary: 'Error',
             detail: 'Failed to update membership, please try again',
           });
-          this.revertAutoRenewOverride(membershipId, originalValue);
+          this.clearAutoRenewOverride(membershipId);
         },
       });
   }
 
-  private revertAutoRenewOverride(membershipId: string, originalValue: boolean): void {
+  private syncAutoRenewValue(membershipId: string, autoRenew: boolean): void {
+    this.enrollments.update((list) => {
+      if (!list) return list;
+      return list.map((item) => {
+        if (item.membership?.ID === membershipId) {
+          return { ...item, membership: { ...item.membership, AutoRenew: autoRenew } };
+        }
+        return item;
+      });
+    });
+  }
+
+  private clearAutoRenewOverride(membershipId: string): void {
     this.autoRenewOverrides.update((m) => {
       const next = new Map(m);
-      next.set(membershipId, originalValue);
+      next.delete(membershipId);
       return next;
     });
   }

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -42,22 +42,7 @@ export class ProfileIndividualEnrollmentComponent {
   /** Local overrides for auto-renew values applied optimistically before PATCH completes. */
   private readonly autoRenewOverrides = signal<Map<string, boolean>>(new Map());
 
-  /** Computed enrollments with auto-renew overrides applied. */
-  protected readonly displayedEnrollments: Signal<DisplayEnrollment[] | null | undefined> = computed(() => {
-    const list = this.enrollments();
-    const overrides = this.autoRenewOverrides();
-    if (!list) return list;
-    return list.map((item) => {
-      const membershipId = item.membership?.ID;
-      if (membershipId && overrides.has(membershipId)) {
-        const autoRenew = overrides.get(membershipId)!;
-        const updatedMembership = { ...item.membership!, AutoRenew: autoRenew };
-        const displayStatus = deriveEnrollmentStatus({ ...item, membership: updatedMembership });
-        return { ...item, membership: updatedMembership, displayStatus, severity: enrollmentStatusSeverity(displayStatus) };
-      }
-      return item;
-    });
-  });
+  protected readonly displayedEnrollments: Signal<DisplayEnrollment[] | null | undefined> = this.initDisplayedEnrollments();
 
   public constructor() {
     this.enrollmentService
@@ -87,17 +72,6 @@ export class ProfileIndividualEnrollmentComponent {
           this.enrollmentError.set(null);
         }
       });
-  }
-
-  protected getAutoRenew(item: DisplayEnrollment): boolean {
-    const membershipId = item.membership?.ID;
-    if (membershipId) {
-      const overrides = this.autoRenewOverrides();
-      if (overrides.has(membershipId)) {
-        return overrides.get(membershipId)!;
-      }
-    }
-    return item.membership?.AutoRenew ?? false;
   }
 
   protected isPending(item: DisplayEnrollment): boolean {
@@ -174,6 +148,24 @@ export class ProfileIndividualEnrollmentComponent {
       const next = new Map(m);
       next.set(membershipId, originalValue);
       return next;
+    });
+  }
+
+  private initDisplayedEnrollments(): Signal<DisplayEnrollment[] | null | undefined> {
+    return computed(() => {
+      const list = this.enrollments();
+      const overrides = this.autoRenewOverrides();
+      if (!list) return list;
+      return list.map((item) => {
+        const membershipId = item.membership?.ID;
+        if (membershipId && overrides.has(membershipId)) {
+          const autoRenew = overrides.get(membershipId)!;
+          const updatedMembership = { ...item.membership!, AutoRenew: autoRenew };
+          const displayStatus = deriveEnrollmentStatus({ ...item, membership: updatedMembership });
+          return { ...item, membership: updatedMembership, displayStatus, severity: enrollmentStatusSeverity(displayStatus) };
+        }
+        return item;
+      });
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -149,7 +149,10 @@ export class ProfileIndividualEnrollmentComponent {
       if (!list) return list;
       return list.map((item) => {
         if (item.membership?.ID === membershipId) {
-          return { ...item, membership: { ...item.membership, AutoRenew: autoRenew } };
+          const updatedMembership = { ...item.membership, AutoRenew: autoRenew };
+          const updatedItem = { ...item, membership: updatedMembership };
+          const displayStatus = deriveEnrollmentStatus(updatedItem);
+          return { ...updatedItem, displayStatus, severity: enrollmentStatusSeverity(displayStatus) };
         }
         return item;
       });

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -4,10 +4,16 @@
 // Generated with [Claude Code](https://claude.ai/code)
 
 import { DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
 import { DisplayEnrollment, EnrollmentsState } from '@lfx-one/shared/interfaces';
 import { deriveEnrollmentStatus, enrollmentStatusSeverity } from '@lfx-one/shared/utils';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
+import { ToastModule } from 'primeng/toast';
+import { finalize, take } from 'rxjs';
 
 import { environment } from '@environments/environment';
 import { ButtonComponent } from '@components/button/button.component';
@@ -18,46 +24,156 @@ import { EnrollmentService } from '@services/enrollment.service';
 
 @Component({
   selector: 'lfx-profile-individual-enrollment',
-  imports: [ButtonComponent, CardComponent, DatePipe, EmptyStateComponent, TagComponent],
+  imports: [ButtonComponent, CardComponent, ConfirmDialogModule, DatePipe, EmptyStateComponent, FormsModule, TagComponent, ToggleSwitchModule, ToastModule],
   templateUrl: './profile-individual-enrollment.component.html',
   styleUrl: './profile-individual-enrollment.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ConfirmationService, MessageService],
 })
 export class ProfileIndividualEnrollmentComponent {
   private readonly enrollmentService = inject(EnrollmentService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly messageService = inject(MessageService);
 
-  private readonly _state: Signal<EnrollmentsState | undefined> = this.initState();
+  protected readonly enrollments = signal<DisplayEnrollment[] | null | undefined>(undefined);
+  protected readonly enrollmentError = signal<string | null>(null);
+  protected readonly pendingIds = signal<Set<string>>(new Set());
 
-  protected readonly enrollments: Signal<DisplayEnrollment[] | null | undefined> = this.initEnrollments();
-  protected readonly enrollmentError: Signal<string | null> = this.initEnrollmentError();
+  /** Local overrides for auto-renew values applied optimistically before PATCH completes. */
+  private readonly autoRenewOverrides = signal<Map<string, boolean>>(new Map());
 
-  private initState(): Signal<EnrollmentsState | undefined> {
-    return toSignal(this.enrollmentService.getEnrollments());
+  /** Computed enrollments with auto-renew overrides applied. */
+  protected readonly displayedEnrollments: Signal<DisplayEnrollment[] | null | undefined> = computed(() => {
+    const list = this.enrollments();
+    const overrides = this.autoRenewOverrides();
+    if (!list) return list;
+    return list.map((item) => {
+      const membershipId = item.membership?.ID;
+      if (membershipId && overrides.has(membershipId)) {
+        const autoRenew = overrides.get(membershipId)!;
+        const updatedMembership = { ...item.membership!, AutoRenew: autoRenew };
+        const displayStatus = deriveEnrollmentStatus({ ...item, membership: updatedMembership });
+        return { ...item, membership: updatedMembership, displayStatus, severity: enrollmentStatusSeverity(displayStatus) };
+      }
+      return item;
+    });
+  });
+
+  public constructor() {
+    this.enrollmentService
+      .getEnrollments()
+      .pipe(takeUntilDestroyed())
+      .subscribe((state: EnrollmentsState) => {
+        if (state.kind === 'loading') {
+          this.enrollments.set(undefined);
+          this.enrollmentError.set(null);
+        } else if (state.kind === 'error') {
+          this.enrollments.set(null);
+          this.enrollmentError.set(state.message);
+        } else {
+          const base = environment.urls.enrollment;
+          this.enrollments.set(
+            state.items.map((item): DisplayEnrollment => {
+              const displayStatus = deriveEnrollmentStatus(item);
+              return {
+                ...item,
+                displayStatus,
+                severity: enrollmentStatusSeverity(displayStatus),
+                enrollHref: `${base}${item.ctaPath}`,
+                renewHref: `${base}${item.ctaPath}&renew=true`,
+              };
+            })
+          );
+          this.enrollmentError.set(null);
+        }
+      });
   }
 
-  private initEnrollments(): Signal<DisplayEnrollment[] | null | undefined> {
-    return computed(() => {
-      const s = this._state();
-      if (!s || s.kind === 'loading') return undefined;
-      if (s.kind === 'error') return null;
-      const base = environment.urls.enrollment;
-      return s.items.map((item): DisplayEnrollment => {
-        const displayStatus = deriveEnrollmentStatus(item);
-        return {
-          ...item,
-          displayStatus,
-          severity: enrollmentStatusSeverity(displayStatus),
-          enrollHref: `${base}${item.ctaPath}`,
-          renewHref: `${base}${item.ctaPath}&renew=true`,
-        };
-      });
+  protected getAutoRenew(item: DisplayEnrollment): boolean {
+    const membershipId = item.membership?.ID;
+    if (membershipId) {
+      const overrides = this.autoRenewOverrides();
+      if (overrides.has(membershipId)) {
+        return overrides.get(membershipId)!;
+      }
+    }
+    return item.membership?.AutoRenew ?? false;
+  }
+
+  protected isPending(item: DisplayEnrollment): boolean {
+    return item.membership ? this.pendingIds().has(item.membership.ID) : false;
+  }
+
+  protected onToggleAutoRenew(item: DisplayEnrollment, newValue: boolean): void {
+    if (!item.membership || this.isPending(item)) return;
+
+    const membershipId = item.membership.ID;
+
+    // Optimistically apply new value so the toggle does not flicker back
+    this.autoRenewOverrides.update((m) => {
+      const next = new Map(m);
+      next.set(membershipId, newValue);
+      return next;
+    });
+
+    const endDate = item.membership.EndDate
+      ? new Date(item.membership.EndDate).toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' })
+      : '';
+    const message = newValue
+      ? `This will Enable auto renew for your membership, your next payment will be charged on ${endDate}.`
+      : `This will Disable auto renew for your membership, your current membership will expire on ${endDate}.`;
+
+    this.confirmationService.confirm({
+      header: 'Update Membership',
+      message,
+      acceptLabel: newValue ? 'Enable' : 'Disable',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-primary p-button-sm',
+      rejectButtonStyleClass: 'p-button-text p-button-sm',
+      accept: () => void this.performAutoRenewUpdate(membershipId, newValue),
+      reject: () => this.revertAutoRenewOverride(membershipId, !newValue),
     });
   }
 
-  private initEnrollmentError(): Signal<string | null> {
-    return computed(() => {
-      const s = this._state();
-      return s?.kind === 'error' ? s.message : null;
+  private performAutoRenewUpdate(membershipId: string, newValue: boolean): void {
+    this.pendingIds.update((s) => new Set([...s, membershipId]));
+
+    this.enrollmentService
+      .updateAutoRenew(membershipId, newValue)
+      .pipe(
+        take(1),
+        finalize(() =>
+          this.pendingIds.update((s) => {
+            const next = new Set(s);
+            next.delete(membershipId);
+            return next;
+          })
+        )
+      )
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Success',
+            detail: `Auto renew ${newValue ? 'enabled' : 'disabled'} successfully`,
+          });
+        },
+        error: () => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Failed to update membership, please try again',
+          });
+          this.revertAutoRenewOverride(membershipId, !newValue);
+        },
+      });
+  }
+
+  private revertAutoRenewOverride(membershipId: string, originalValue: boolean): void {
+    this.autoRenewOverrides.update((m) => {
+      const next = new Map(m);
+      next.set(membershipId, originalValue);
+      return next;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -28,12 +28,13 @@ import { EnrollmentService } from '@services/enrollment.service';
   templateUrl: './profile-individual-enrollment.component.html',
   styleUrl: './profile-individual-enrollment.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [ConfirmationService, MessageService],
+  providers: [ConfirmationService, MessageService, DatePipe],
 })
 export class ProfileIndividualEnrollmentComponent {
   private readonly enrollmentService = inject(EnrollmentService);
   private readonly confirmationService = inject(ConfirmationService);
   private readonly messageService = inject(MessageService);
+  private readonly datePipe = inject(DatePipe);
 
   protected readonly enrollments = signal<DisplayEnrollment[] | null | undefined>(undefined);
   protected readonly enrollmentError = signal<string | null>(null);
@@ -82,6 +83,7 @@ export class ProfileIndividualEnrollmentComponent {
     if (!item.membership || this.isPending(item)) return;
 
     const membershipId = item.membership.ID;
+    const originalValue = item.membership.AutoRenew;
 
     // Optimistically apply new value so the toggle does not flicker back
     this.autoRenewOverrides.update((m) => {
@@ -90,9 +92,7 @@ export class ProfileIndividualEnrollmentComponent {
       return next;
     });
 
-    const endDate = item.membership.EndDate
-      ? new Date(item.membership.EndDate).toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' })
-      : '';
+    const endDate = item.membership.EndDate ? (this.datePipe.transform(item.membership.EndDate, 'mediumDate', 'UTC') ?? '') : '';
     const message = newValue
       ? `This will Enable auto renew for your membership, your next payment will be charged on ${endDate}.`
       : `This will Disable auto renew for your membership, your current membership will expire on ${endDate}.`;
@@ -104,12 +104,12 @@ export class ProfileIndividualEnrollmentComponent {
       rejectLabel: 'Cancel',
       acceptButtonStyleClass: 'p-button-primary p-button-sm',
       rejectButtonStyleClass: 'p-button-text p-button-sm',
-      accept: () => void this.performAutoRenewUpdate(membershipId, newValue),
-      reject: () => this.revertAutoRenewOverride(membershipId, !newValue),
+      accept: () => void this.performAutoRenewUpdate(membershipId, newValue, originalValue),
+      reject: () => this.revertAutoRenewOverride(membershipId, originalValue),
     });
   }
 
-  private performAutoRenewUpdate(membershipId: string, newValue: boolean): void {
+  private performAutoRenewUpdate(membershipId: string, newValue: boolean, originalValue: boolean): void {
     this.pendingIds.update((s) => new Set([...s, membershipId]));
 
     this.enrollmentService
@@ -138,7 +138,7 @@ export class ProfileIndividualEnrollmentComponent {
             summary: 'Error',
             detail: 'Failed to update membership, please try again',
           });
-          this.revertAutoRenewOverride(membershipId, !newValue);
+          this.revertAutoRenewOverride(membershipId, originalValue);
         },
       });
   }

--- a/apps/lfx-one/src/app/shared/services/enrollment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/enrollment.service.ts
@@ -5,7 +5,7 @@
 
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { EnrollmentsState, IndividualEnrollment } from '@lfx-one/shared/interfaces';
+import { EnrollmentsState, IndividualEnrollment, UpdateAutoRenewRequest } from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of, startWith } from 'rxjs';
 
 @Injectable({
@@ -26,5 +26,10 @@ export class EnrollmentService {
           })
       )
     );
+  }
+
+  public updateAutoRenew(membershipId: string, autoRenew: boolean): Observable<void> {
+    const body: UpdateAutoRenewRequest = { autorenew: autoRenew };
+    return this.http.patch<void>(`/api/enrollments/${membershipId}/auto-renew`, body);
   }
 }

--- a/apps/lfx-one/src/server/controllers/enrollment.controller.ts
+++ b/apps/lfx-one/src/server/controllers/enrollment.controller.ts
@@ -39,7 +39,7 @@ export class EnrollmentController {
       return;
     }
 
-    const { autorenew } = req.body as { autorenew?: unknown };
+    const autorenew = (req.body as { autorenew?: unknown } | null | undefined)?.autorenew;
 
     if (typeof autorenew !== 'boolean') {
       next(

--- a/apps/lfx-one/src/server/controllers/enrollment.controller.ts
+++ b/apps/lfx-one/src/server/controllers/enrollment.controller.ts
@@ -45,7 +45,7 @@ export class EnrollmentController {
       next(
         ServiceValidationError.forField('autorenew', 'autorenew must be a boolean', {
           operation: 'update_individual_enrollment_auto_renew',
-          service: 'enrollment_service',
+          service: 'enrollment_controller',
           path: req.path,
         })
       );

--- a/apps/lfx-one/src/server/controllers/enrollment.controller.ts
+++ b/apps/lfx-one/src/server/controllers/enrollment.controller.ts
@@ -5,6 +5,8 @@
 
 import { NextFunction, Request, Response } from 'express';
 
+import { ServiceValidationError } from '../errors';
+import { validateRequiredParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { EnrollmentService } from '../services/enrollment.service';
 
@@ -20,6 +22,42 @@ export class EnrollmentController {
       logger.success(req, 'get_individual_enrollments', startTime, { result_count: enrollments.length });
 
       res.json(enrollments);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async updateAutoRenew(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const membershipId = req.params['id'];
+    const startTime = logger.startOperation(req, 'update_individual_enrollment_auto_renew', { membershipId });
+
+    if (
+      !validateRequiredParameter(membershipId, 'id', req, next, {
+        operation: 'update_individual_enrollment_auto_renew',
+      })
+    ) {
+      return;
+    }
+
+    const { autorenew } = req.body as { autorenew?: unknown };
+
+    if (typeof autorenew !== 'boolean') {
+      next(
+        ServiceValidationError.forField('autorenew', 'autorenew must be a boolean', {
+          operation: 'update_individual_enrollment_auto_renew',
+          service: 'enrollment_service',
+          path: req.path,
+        })
+      );
+      return;
+    }
+
+    try {
+      await this.enrollmentService.updateAutoRenew(req, membershipId, autorenew);
+
+      logger.success(req, 'update_individual_enrollment_auto_renew', startTime, { membershipId, autorenew });
+
+      res.status(204).end();
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -21,9 +21,11 @@ export interface GatewayFetchOptions {
 }
 
 /**
- * Fetches a URL via the API gateway using req.apiGatewayToken.
+ * Fetches a URL via the API gateway. Uses req.apiGatewayToken by default;
+ * pass options.bearerToken to override (e.g. for user-token-authenticated calls).
  * Handles timeout (504), network failure (502), non-OK upstream responses,
- * empty bodies, and invalid JSON — all surfaced as MicroserviceError.
+ * and invalid JSON — all surfaced as MicroserviceError.
+ * 204 responses return null without error; all other empty bodies are errors.
  */
 export async function gatewayFetch<T>(req: Request, url: string, options: GatewayFetchOptions): Promise<T> {
   const token = options.bearerToken ?? req.apiGatewayToken;
@@ -95,7 +97,7 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
   const rawBody = await upstream.text();
 
   if (!rawBody.trim()) {
-    if (upstream.status === 204 || options.method === 'PATCH' || options.method === 'DELETE') {
+    if (upstream.status === 204) {
       return null as T;
     }
 

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -14,7 +14,10 @@ export interface GatewayFetchOptions {
   service: string;
   errorMessage: string;
   errorCode: string;
-  method?: 'GET' | 'POST';
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  body?: unknown;
+  /** When provided, overrides req.apiGatewayToken as the Authorization token. */
+  bearerToken?: string;
 }
 
 /**
@@ -23,7 +26,9 @@ export interface GatewayFetchOptions {
  * empty bodies, and invalid JSON — all surfaced as MicroserviceError.
  */
 export async function gatewayFetch<T>(req: Request, url: string, options: GatewayFetchOptions): Promise<T> {
-  if (!req.apiGatewayToken) {
+  const token = options.bearerToken ?? req.apiGatewayToken;
+
+  if (!token) {
     throw new MicroserviceError(
       'API Gateway token not available — check API_GW_AUDIENCE env var, auth middleware config, and server logs for M2M token failures',
       503,
@@ -35,11 +40,16 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
     );
   }
 
+  const hasBody = options.body !== undefined;
   let upstream: Response;
   try {
     upstream = await fetch(url, {
       method: options.method ?? 'GET',
-      headers: { Authorization: `Bearer ${req.apiGatewayToken}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(hasBody ? { body: JSON.stringify(options.body) } : {}),
       signal: AbortSignal.timeout(API_GW_TIMEOUT_MS),
     });
   } catch (error: unknown) {
@@ -85,6 +95,10 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
   const rawBody = await upstream.text();
 
   if (!rawBody.trim()) {
+    if (upstream.status === 204 || options.method === 'PATCH' || options.method === 'DELETE') {
+      return null as T;
+    }
+
     logger.warning(req, options.operation, 'Upstream returned empty response body', {
       status: upstream.status,
       status_text: upstream.statusText,

--- a/apps/lfx-one/src/server/routes/enrollment.route.ts
+++ b/apps/lfx-one/src/server/routes/enrollment.route.ts
@@ -11,5 +11,6 @@ const router = Router();
 const enrollmentController = new EnrollmentController();
 
 router.get('/', (req, res, next) => enrollmentController.getEnrollments(req, res, next));
+router.patch('/:id/auto-renew', (req, res, next) => enrollmentController.updateAutoRenew(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/enrollment.service.ts
+++ b/apps/lfx-one/src/server/services/enrollment.service.ts
@@ -102,7 +102,7 @@ export class EnrollmentService {
     }
 
     const baseUrl = getApiGatewayBaseUrl('update_individual_enrollment_auto_renew', ENROLLMENT_SERVICE);
-    const url = `${baseUrl}/member-service/v2/memberships/${membershipId}`;
+    const url = `${baseUrl}/member-service/v2/memberships/${encodeURIComponent(membershipId)}`;
 
     const today = new Date().toISOString().slice(0, 10);
     const payload = {

--- a/apps/lfx-one/src/server/services/enrollment.service.ts
+++ b/apps/lfx-one/src/server/services/enrollment.service.ts
@@ -6,6 +6,7 @@
 import { TLF_INDIVIDUAL_SUPPORTER } from '@lfx-one/shared/constants';
 import { EnrollmentMembership, IndividualEnrollment, RawMembership } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
+import { MicroserviceError } from '../errors';
 
 import { getApiGatewayBaseUrl } from '../helpers/api-gateway.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
@@ -83,5 +84,43 @@ export class EnrollmentService {
         membership: membershipMap.get(TLF_INDIVIDUAL_SUPPORTER.productId) ?? null,
       },
     ];
+  }
+
+  public async updateAutoRenew(req: Request, membershipId: string, autoRenew: boolean): Promise<void> {
+    const username = await getUsernameFromAuth(req);
+
+    if (username && usernameMatches(username, DEMO_USER)) {
+      logger.debug(req, 'update_individual_enrollment_auto_renew', 'Skipping update for demo user');
+      return;
+    }
+
+    if (!req.bearerToken) {
+      throw new MicroserviceError('User bearer token not available', 401, 'BEARER_TOKEN_UNAVAILABLE', {
+        operation: 'update_individual_enrollment_auto_renew',
+        service: ENROLLMENT_SERVICE,
+      });
+    }
+
+    const baseUrl = getApiGatewayBaseUrl('update_individual_enrollment_auto_renew', ENROLLMENT_SERVICE);
+    const url = `${baseUrl}/member-service/v2/memberships/${membershipId}`;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const payload = {
+      AutoRenew: autoRenew,
+      NumberOfYearsRequired: autoRenew ? 1 : 0,
+      ...(autoRenew ? {} : { CancellationDate: today, CancellationReason: 'By User' }),
+    };
+
+    logger.debug(req, 'update_individual_enrollment_auto_renew', 'Updating membership auto-renew', { membershipId, autoRenew });
+
+    await gatewayFetch<null>(req, url, {
+      operation: 'update_individual_enrollment_auto_renew',
+      service: ENROLLMENT_SERVICE,
+      errorMessage: 'Membership auto-renew update failed',
+      errorCode: 'MEMBERSHIP_AUTO_RENEW_UPDATE_FAILED',
+      method: 'PATCH',
+      body: payload,
+      bearerToken: req.bearerToken,
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Adds an interactive **Auto-Renew** toggle to Profile → Individual Enrollment, matching the legacy myprofile UX 1:1
- Renders **Purchase Date**, **Expiry Date**, **Status**, and **Auto-Renew** on each enrollment card
- Toggle gating mirrors myprofile: shown only when membership exists, is not expired, and `ExtPaymentType === 'stripe'`; expired Stripe memberships show a read-only `Enabled/Disabled` label; non-Stripe payment types hide the Auto Renew row entirely (intentional — Auto Renew is only meaningful for Stripe-managed memberships)
- Confirmation dialog before each change with contextual message (next payment date when enabling, expiry date when disabling); optimistic UI with revert on cancel or upstream error; success / error toasts
- New backend route `PATCH /api/enrollments/:id/auto-renew` proxies to upstream `member-service/v2/memberships/:id` using the user's bearer token, with the same payload shape as myprofile (`AutoRenew`, `NumberOfYearsRequired`, plus `CancellationDate` / `CancellationReason` when disabling)
- Demo user (`johnlf2727`) short-circuits the PATCH for parity with the existing GET demo path; demo fixture uses a non-Stripe ExtPaymentType so no Auto Renew row is shown
- `gatewayFetch` helper extended to support `PATCH`/`DELETE` methods, JSON request bodies, bearer-token override, and graceful 204 (empty) responses

LFXV2-1664

## Test plan

- [x] Sign in as a Stripe-paid active member, toggle Auto Renew off → confirm dialog → confirm → success toast, toggle stays off, `PATCH /api/enrollments/<id>/auto-renew` returns 204
- [x] Cancel the confirm dialog → toggle reverts to original value, no network call
- [x] Force upstream PATCH failure → error toast, toggle reverts to original value
- [x] Toggle Auto Renew back on → confirm dialog shows "Enable" + next-payment date (no timezone shift)
- [x] Sign in as demo user `johnlf2727` → expired enrollment renders **no** Auto Renew row (non-Stripe fixture)
- [x] Verify Purchase Date is displayed alongside Expiry Date and Status chip
- [x] Verify card with no membership still shows the Enroll CTA and no auto-renew row