### PR TITLE
fix(profile): remove redundant active button from individual enrollment

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -115,8 +115,6 @@
               <lfx-button label="Renew My Enrollment" severity="primary" [href]="item.renewHref" target="_blank" rel="noopener noreferrer" />
             } @else if (item.displayStatus === 'Expired') {
               <lfx-button label="Repurchase" severity="primary" [href]="item.enrollHref" target="_blank" rel="noopener noreferrer" />
-            } @else {
-              <lfx-button [label]="item.activeButtonText || 'Active'" severity="secondary" [disabled]="true" />
             }
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Removes the disabled "Active" button at the bottom of each individual
  enrollment card. Active state is already communicated by the green
  status tag in the top-right of the card header.
- Enroll / Renew My Enrollment / Repurchase CTAs are unchanged for
  their respective states.

## Why this slipped in

The redundant button was added as a placeholder for the active-state
CTA slot while the auto-renew toggle (#740) was being designed. Once
the auto-renew toggle landed in the card header alongside the status
tag, the placeholder CTA became visually duplicative but was not
removed in that PR. This change cleans it up.

Fixes [LFXV2-1664](https://linuxfoundation.atlassian.net/browse/LFXV2-1664)

## Test plan

- [x] Active enrollment card shows only the green "Active" tag in the top-right; no button at the bottom.
- [x] Expiring Soon card still shows the "Renew My Enrollment" button.
- [x] Expired card still shows the "Repurchase" button.
- [x] Not-yet-enrolled card still shows the Enroll button.
- [x] Auto-renew toggle in the card header still functions as before.

[LFXV2-1664]: https://linuxfoundation.atlassian.net/browse/LFXV2-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ