### PR TITLE
feat(invite): add deep link support for non-LF users via signed JWT token

### DIFF
--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -61,6 +61,7 @@
     "html-to-image": "^1.11.13",
     "launchdarkly-js-client-sdk": "^3.9.0",
     "marked": "^17.0.4",
+    "jose": "^2.0.7",
     "nats": "^2.29.3",
     "ngx-cookie-service-ssr": "20.0.0",
     "pdfkit": "^0.15.0",

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -334,4 +334,16 @@ export const routes: Routes = [
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
   },
+  // Invite acceptance — auth-protected so authGuard redirects to login (preserving ?token=)
+  // and the component runs after the user creates / signs into their account.
+  {
+    path: 'invite',
+    canActivate: [authGuard],
+    loadComponent: () => import('./modules/invite/invite.component').then((m) => m.InviteComponent),
+  },
+  // Error page is outside the auth guard so expired/invalid links are visible without login.
+  {
+    path: 'invite/error',
+    loadComponent: () => import('./modules/invite/invite-error/invite-error.component').then((m) => m.InviteErrorComponent),
+  },
 ];

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -345,8 +345,7 @@ export const routes: Routes = [
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
   },
-  // Invite acceptance — auth-protected so authGuard redirects to login (preserving ?token=)
-  // and the component runs after the user creates / signs into their account.
+  // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {
     path: 'invite',
     canActivate: [authGuard],

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
@@ -25,13 +25,7 @@
             {{ description }}
           </p>
 
-          <lfx-button
-            routerLink="/"
-            icon="fa-light fa-house"
-            label="Go to Dashboard"
-            size="small"
-            data-testid="invite-error-home-button">
-          </lfx-button>
+          <lfx-button routerLink="/" icon="fa-light fa-house" label="Go to Dashboard" size="small" data-testid="invite-error-home-button"> </lfx-button>
         </div>
       </lfx-card>
     </div>

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+<lfx-header></lfx-header>
+
+<div class="bg-gray-50 min-h-screen">
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-4xl mx-auto">
+      <lfx-card data-testid="invite-error-card">
+        <div class="text-center py-12">
+          <div class="flex justify-center mb-6">
+            <div class="w-24 h-24 bg-red-50 rounded-full flex items-center justify-center">
+              @if (reason === 'expired') {
+                <i class="fa-light fa-clock-rotate-left text-4xl text-red-400"></i>
+              } @else if (reason === 'missing') {
+                <i class="fa-light fa-link-slash text-4xl text-red-400"></i>
+              } @else {
+                <i class="fa-light fa-triangle-exclamation text-4xl text-red-400"></i>
+              }
+            </div>
+          </div>
+
+          <h1 class="mb-3" data-testid="invite-error-title">{{ title }}</h1>
+
+          <p class="text-gray-600 mb-8 max-w-lg mx-auto" data-testid="invite-error-description">
+            {{ description }}
+          </p>
+
+          <lfx-button
+            routerLink="/"
+            icon="fa-light fa-house"
+            label="Go to Dashboard"
+            size="small"
+            data-testid="invite-error-home-button">
+          </lfx-button>
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { HeaderComponent } from '@components/header/header.component';
+
+@Component({
+  selector: 'lfx-invite-error',
+  imports: [RouterLink, HeaderComponent, CardComponent, ButtonComponent],
+  templateUrl: './invite-error.component.html',
+})
+export class InviteErrorComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly reason: string;
+  protected readonly title: string;
+  protected readonly description: string;
+
+  public constructor() {
+    this.reason = this.route.snapshot.queryParamMap.get('reason') ?? 'failed';
+    this.title = this.initTitle();
+    this.description = this.initDescription();
+  }
+
+  private initTitle(): string {
+    switch (this.reason) {
+      case 'expired':
+        return 'Invite Link Expired';
+      case 'missing':
+        return 'Invalid Invite Link';
+      default:
+        return 'Could Not Accept Invite';
+    }
+  }
+
+  private initDescription(): string {
+    switch (this.reason) {
+      case 'expired':
+        return 'This invitation link has expired. Please ask the sender to generate a new invite.';
+      case 'missing':
+        return 'This invitation link is not valid. Please check the URL and try again.';
+      default:
+        return 'Something went wrong while accepting your invitation. Please try again or contact support.';
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/invite/invite.component.html
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.html
@@ -1,0 +1,12 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+<lfx-header></lfx-header>
+
+<div class="bg-gray-50 min-h-screen flex items-center justify-center">
+  @if (isProcessing()) {
+    <div class="flex flex-col items-center gap-4 text-center">
+      <i class="fa-light fa-spinner-third fa-spin text-4xl text-blue-500"></i>
+      <p class="text-gray-600 text-sm">Accepting your invitation&hellip;</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -57,7 +57,10 @@ export class InviteComponent implements OnInit {
       const parts = token.split('.');
       if (parts.length !== 3) return true;
       // Base64url → base64 padding for atob
-      const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
+      const padded = parts[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
       const payload = JSON.parse(atob(padded)) as InviteTokenPayload;
       return Date.now() / 1000 > payload.exp;
     } catch {

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformServer } from '@angular/common';
+import { isPlatformBrowser } from '@angular/common';
 import { Component, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HeaderComponent } from '@components/header/header.component';
@@ -23,8 +23,7 @@ export class InviteComponent implements OnInit {
   protected readonly isProcessing = signal(true);
 
   public ngOnInit(): void {
-    // Skip on SSR — the auth guard and redirect logic run browser-side only.
-    if (isPlatformServer(this.platformId)) return;
+    if (!isPlatformBrowser(this.platformId)) return;
 
     const token = this.route.snapshot.queryParamMap.get('token');
 

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -48,7 +48,6 @@ export class InviteComponent implements OnInit {
         },
         error: (err) => {
           const code = err?.error?.code as string;
-<<<<<<< HEAD
           let reason: string;
           if (code === 'INVITE_EXPIRED') {
             reason = 'expired';

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -48,6 +48,7 @@ export class InviteComponent implements OnInit {
         },
         error: (err) => {
           const code = err?.error?.code as string;
+<<<<<<< HEAD
           let reason: string;
           if (code === 'INVITE_EXPIRED') {
             reason = 'expired';

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -48,7 +48,14 @@ export class InviteComponent implements OnInit {
         },
         error: (err) => {
           const code = err?.error?.code as string;
-          const reason = code === 'INVITE_EXPIRED' ? 'expired' : code === 'VALIDATION_ERROR' ? 'missing' : 'failed';
+          let reason: string;
+          if (code === 'INVITE_EXPIRED') {
+            reason = 'expired';
+          } else if (code === 'VALIDATION_ERROR') {
+            reason = 'missing';
+          } else {
+            reason = 'failed';
+          }
           this.redirectToError(reason);
         },
       });

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -70,7 +70,7 @@ export class InviteComponent implements OnInit {
         .replace(/_/g, '/')
         .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
       const payload = JSON.parse(atob(padded)) as InviteTokenPayload;
-      if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) return 'invalid';
+      if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return 'invalid';
       return Date.now() / 1000 >= payload.exp ? 'expired' : null;
     } catch {
       return 'invalid';

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformServer } from '@angular/common';
+import { Component, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { HeaderComponent } from '@components/header/header.component';
+import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
+import { InviteService } from '@services/invite.service';
+import { take } from 'rxjs';
+
+@Component({
+  selector: 'lfx-invite',
+  imports: [HeaderComponent],
+  templateUrl: './invite.component.html',
+})
+export class InviteComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly inviteService = inject(InviteService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  protected readonly isProcessing = signal(true);
+
+  public ngOnInit(): void {
+    // Skip on SSR — the auth guard and redirect logic run browser-side only.
+    if (isPlatformServer(this.platformId)) return;
+
+    const token = this.route.snapshot.queryParamMap.get('token');
+
+    if (!token) {
+      this.redirectToError('missing');
+      return;
+    }
+
+    if (this.isTokenExpired(token)) {
+      this.redirectToError('expired');
+      return;
+    }
+
+    this.inviteService
+      .acceptInvite(token)
+      .pipe(take(1))
+      .subscribe({
+        next: (res) => {
+          window.location.href = res.return_url;
+        },
+        error: (err) => {
+          const reason = (err?.error?.code as string) === 'INVITE_EXPIRED' ? 'expired' : 'failed';
+          this.redirectToError(reason);
+        },
+      });
+  }
+
+  private isTokenExpired(token: string): boolean {
+    try {
+      const parts = token.split('.');
+      if (parts.length !== 3) return true;
+      // Base64url → base64 padding for atob
+      const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
+      const payload = JSON.parse(atob(padded)) as InviteTokenPayload;
+      return Date.now() / 1000 > payload.exp;
+    } catch {
+      return true;
+    }
+  }
+
+  private redirectToError(reason: string): void {
+    this.isProcessing.set(false);
+    void this.router.navigate(['/invite/error'], { queryParams: { reason }, replaceUrl: true });
+  }
+}

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -71,7 +71,7 @@ export class InviteComponent implements OnInit {
         .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
       const payload = JSON.parse(atob(padded)) as InviteTokenPayload;
       if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) return 'invalid';
-      return Date.now() / 1000 > payload.exp ? 'expired' : null;
+      return Date.now() / 1000 >= payload.exp ? 'expired' : null;
     } catch {
       return 'invalid';
     }

--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -33,8 +33,9 @@ export class InviteComponent implements OnInit {
       return;
     }
 
-    if (this.isTokenExpired(token)) {
-      this.redirectToError('expired');
+    const tokenStatus = this.checkToken(token);
+    if (tokenStatus) {
+      this.redirectToError(tokenStatus === 'expired' ? 'expired' : 'missing');
       return;
     }
 
@@ -46,25 +47,27 @@ export class InviteComponent implements OnInit {
           window.location.href = res.return_url;
         },
         error: (err) => {
-          const reason = (err?.error?.code as string) === 'INVITE_EXPIRED' ? 'expired' : 'failed';
+          const code = err?.error?.code as string;
+          const reason = code === 'INVITE_EXPIRED' ? 'expired' : code === 'VALIDATION_ERROR' ? 'missing' : 'failed';
           this.redirectToError(reason);
         },
       });
   }
 
-  private isTokenExpired(token: string): boolean {
+  private checkToken(token: string): 'expired' | 'invalid' | null {
     try {
       const parts = token.split('.');
-      if (parts.length !== 3) return true;
+      if (parts.length !== 3) return 'invalid';
       // Base64url → base64 padding for atob
       const padded = parts[1]
         .replace(/-/g, '+')
         .replace(/_/g, '/')
         .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
       const payload = JSON.parse(atob(padded)) as InviteTokenPayload;
-      return Date.now() / 1000 > payload.exp;
+      if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) return 'invalid';
+      return Date.now() / 1000 > payload.exp ? 'expired' : null;
     } catch {
-      return true;
+      return 'invalid';
     }
   }
 

--- a/apps/lfx-one/src/app/shared/services/invite.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invite.service.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { AcceptInviteResponse } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InviteService {
+  private readonly http = inject(HttpClient);
+
+  public acceptInvite(token: string): Observable<AcceptInviteResponse> {
+    return this.http.post<AcceptInviteResponse>('/api/invite/accept', { token });
+  }
+}

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -136,10 +136,11 @@ export class InviteController {
     }
   }
 
-  // Verifies the JWT signature using HS256 and the INVITE_SERVICE_JWT_SECRET env var.
+  // Verifies the JWT signature using HS256. The secret is used as raw UTF-8 bytes,
+  // matching how the invite service signs tokens (Go's []byte(secret) conversion).
   // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
   private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
-    const key = JWK.asKey(Buffer.from(secret, 'base64'));
+    const key = JWK.asKey(Buffer.from(secret));
     const payload = JWT.verify<InviteTokenPayload>(token, key, { algorithms: ['HS256'] });
     if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) {
       throw new Error('Token is missing required exp claim');

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -61,6 +61,16 @@ export class InviteController {
         );
       }
 
+      if (!payload.invite_uid || typeof payload.invite_uid !== 'string') {
+        return next(
+          ServiceValidationError.forField('token', 'Invite token is missing required claims', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
+
       const safeReturnUrl = this.validateReturnUrl(payload.return_url);
       if (!safeReturnUrl) {
         return next(
@@ -94,8 +104,12 @@ export class InviteController {
 
       const responseText = codec.decode(response.data);
       if (!responseText || responseText.startsWith('error:')) {
+        logger.warning(req, 'accept_invite', 'NATS handler rejected the invite acceptance', {
+          invite_uid: payload.invite_uid,
+          nats_response: responseText || '(empty)',
+        });
         return next(
-          new AuthorizationError(`Invite acceptance was rejected by the backend: ${responseText || '(empty response)'}`, {
+          new AuthorizationError('Invite could not be accepted', {
             operation: 'accept_invite',
             service: 'invite_controller',
             path: req.path,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
@@ -101,28 +100,10 @@ export class InviteController {
       }
 
       const codec = this.natsService.getCodec();
-      const response = await this.natsService.request(
+      await this.natsService.publish(
         NatsSubjects.INVITE_ACCEPTED,
-        codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })),
-        {
-          timeout: NATS_CONFIG.REQUEST_TIMEOUT,
-        }
+        codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username }))
       );
-
-      const responseText = codec.decode(response.data);
-      if (!responseText || responseText.startsWith('error:')) {
-        logger.warning(req, 'accept_invite', 'NATS handler rejected the invite acceptance', {
-          invite_uid: payload.invite_uid,
-          nats_response: responseText || '(empty)',
-        });
-        return next(
-          new AuthorizationError('Invite could not be accepted', {
-            operation: 'accept_invite',
-            service: 'invite_controller',
-            path: req.path,
-          })
-        );
-      }
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -140,7 +140,7 @@ export class InviteController {
   // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
   private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
     const key = JWK.asKey(Buffer.from(secret, 'base64'));
-    const payload = JWT.verify(token, key, { algorithms: ['HS256'] }) as InviteTokenPayload;
+    const payload = JWT.verify<InviteTokenPayload>(token, key, { algorithms: ['HS256'] });
     if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) {
       throw new Error('Token is missing required exp claim');
     }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -21,7 +21,7 @@ export class InviteController {
   /**
    * POST /api/invite/accept
    * Verifies the invite JWT signature (HS256), publishes lfx.invite.accepted via NATS
-   * request-reply, and returns the return_url so the client can navigate to the intended resource.
+   * (fire-and-forget), and returns the return_url so the client can navigate to the intended resource.
    */
   public async acceptInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'accept_invite');

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -131,12 +131,12 @@ export class InviteController {
     }
   }
 
-  // Verifies the JWT signature using HS256 and the INVITE_JWT_SECRET env var.
+  // Verifies the JWT signature using HS256 and the JWT_SECRET env var.
   // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
   private verifyInviteToken(token: string): InviteTokenPayload {
-    const secret = process.env['INVITE_JWT_SECRET'];
+    const secret = process.env['JWT_SECRET'];
     if (!secret) {
-      throw new Error('INVITE_JWT_SECRET is not configured');
+      throw new Error('JWT_SECRET is not configured');
     }
     const key = JWK.asKey(Buffer.from(secret, 'base64'));
     return JWT.verify(token, key, { algorithms: ['HS256'] }) as InviteTokenPayload;

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -112,7 +112,7 @@ export class InviteController {
   private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
     const key = JWK.asKey(Buffer.from(secret));
     const payload = JWT.verify<InviteTokenPayload>(token, key, { algorithms: ['HS256'] });
-    if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) {
+    if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) {
       throw new Error('Token is missing required exp claim');
     }
     return payload;

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -126,7 +126,7 @@ export class InviteController {
     return payload;
   }
 
-  // Only LFX-owned domains are valid redirect destinations — prevents open-redirect.
+  // Only lfx.dev (apex) and *.lfx.dev (subdomains) are valid redirect destinations — prevents open-redirect.
   private validateReturnUrl(url: string): string | null {
     try {
       const parsed = new URL(url);

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -12,17 +12,11 @@ import { logger } from '../services/logger.service';
 import { NatsService } from '../services/nats.service';
 import { getEffectiveUsername } from '../utils/auth-helper';
 
-/**
- * Controller for handling invite acceptance for non-LF users arriving via a signed invite link.
- */
+/** Controller for non-LF user invite acceptance via signed JWT. */
 export class InviteController {
   private readonly natsService = new NatsService();
 
-  /**
-   * POST /api/invite/accept
-   * Verifies the invite JWT signature (HS256), publishes lfx.invite.accepted via NATS
-   * (fire-and-forget), and returns the return_url so the client can navigate to the intended resource.
-   */
+  /** POST /api/invite/accept — verify JWT (HS256), publish NATS fire-and-forget, return return_url. */
   public async acceptInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'accept_invite');
 
@@ -114,9 +108,7 @@ export class InviteController {
     }
   }
 
-  // Verifies the JWT signature using HS256. The secret is used as raw UTF-8 bytes,
-  // matching how the invite service signs tokens (Go's []byte(secret) conversion).
-  // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
+  // Secret used as raw UTF-8 bytes to match Go invite service []byte(secret) key derivation.
   private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
     const key = JWK.asKey(Buffer.from(secret));
     const payload = JWT.verify<InviteTokenPayload>(token, key, { algorithms: ['HS256'] });
@@ -130,7 +122,7 @@ export class InviteController {
   private validateReturnUrl(url: string): string | null {
     try {
       const parsed = new URL(url);
-      if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+      if (parsed.protocol !== 'https:') return null;
       if (!parsed.hostname.endsWith('.lfx.dev') && parsed.hostname !== 'lfx.dev') return null;
       return validateAndSanitizeUrl(url) ?? null;
     } catch {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -40,9 +40,14 @@ export class InviteController {
         );
       }
 
+      const jwtSecret = process.env['JWT_SECRET'];
+      if (!jwtSecret) {
+        return next(new Error('JWT_SECRET is not configured'));
+      }
+
       let payload: InviteTokenPayload;
       try {
-        payload = this.verifyInviteToken(token);
+        payload = this.verifyInviteToken(token, jwtSecret);
       } catch (err) {
         if (err instanceof JoseErrors.JWTExpired) {
           return next(
@@ -133,13 +138,13 @@ export class InviteController {
 
   // Verifies the JWT signature using HS256 and the JWT_SECRET env var.
   // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
-  private verifyInviteToken(token: string): InviteTokenPayload {
-    const secret = process.env['JWT_SECRET'];
-    if (!secret) {
-      throw new Error('JWT_SECRET is not configured');
-    }
+  private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
     const key = JWK.asKey(Buffer.from(secret, 'base64'));
-    return JWT.verify(token, key, { algorithms: ['HS256'] }) as InviteTokenPayload;
+    const payload = JWT.verify(token, key, { algorithms: ['HS256'] }) as InviteTokenPayload;
+    if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) {
+      throw new Error('Token is missing required exp claim');
+    }
+    return payload;
   }
 
   // Only LFX-owned domains are valid redirect destinations — prevents open-redirect.

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { AuthorizationError, ServiceValidationError } from '../errors';
+import { validateAndSanitizeUrl } from '../helpers/url-validation';
+import { logger } from '../services/logger.service';
+import { NatsService } from '../services/nats.service';
+import { getEffectiveUsername } from '../utils/auth-helper';
+
+/**
+ * Controller for handling invite acceptance for non-LF users arriving via a signed invite link.
+ */
+export class InviteController {
+  private readonly natsService = new NatsService();
+
+  /**
+   * POST /api/invite/accept
+   * Decodes the invite JWT, publishes lfx.invite.accepted via NATS request-reply, and
+   * returns the return_url so the client can navigate to the intended resource.
+   */
+  public async acceptInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'accept_invite');
+
+    try {
+      const { token } = req.body as { token?: unknown };
+
+      if (!token || typeof token !== 'string') {
+        return next(
+          ServiceValidationError.forField('token', 'Invite token is required', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const payload = this.decodeInviteToken(token);
+      if (!payload) {
+        return next(
+          ServiceValidationError.forField('token', 'Invite token is malformed', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      if (Date.now() / 1000 > payload.exp) {
+        return next(
+          new AuthorizationError('Invite link has expired', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+            code: 'INVITE_EXPIRED',
+          })
+        );
+      }
+
+      const safeReturnUrl = this.validateReturnUrl(payload.return_url);
+      if (!safeReturnUrl) {
+        return next(
+          ServiceValidationError.forField('return_url', 'Invite token contains an invalid return URL', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const username = getEffectiveUsername(req);
+      if (!username) {
+        return next(
+          new AuthorizationError('Could not determine username from session', {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const codec = this.natsService.getCodec();
+      await this.natsService.request('lfx.invite.accepted', codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
+
+      logger.success(req, 'accept_invite', startTime, {
+        invite_uid: payload.invite_uid,
+        username,
+        resource_uid: payload.resource_uid,
+      });
+
+      res.json({ return_url: safeReturnUrl });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private decodeInviteToken(token: string): InviteTokenPayload | null {
+    try {
+      const parts = token.split('.');
+      if (parts.length !== 3) return null;
+      return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as InviteTokenPayload;
+    } catch {
+      return null;
+    }
+  }
+
+  // Only LFX-owned domains are valid redirect destinations — prevents open-redirect if
+  // an unverified token ever carries a crafted return_url.
+  private validateReturnUrl(url: string): string | null {
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+      if (!parsed.hostname.endsWith('.lfx.dev') && parsed.hostname !== 'lfx.dev') return null;
+      return validateAndSanitizeUrl(url) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -40,9 +40,9 @@ export class InviteController {
         );
       }
 
-      const jwtSecret = process.env['JWT_SECRET'];
+      const jwtSecret = process.env['INVITE_SERVICE_JWT_SECRET'];
       if (!jwtSecret) {
-        return next(new Error('JWT_SECRET is not configured'));
+        return next(new Error('INVITE_SERVICE_JWT_SECRET is not configured'));
       }
 
       let payload: InviteTokenPayload;

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -136,7 +136,7 @@ export class InviteController {
     }
   }
 
-  // Verifies the JWT signature using HS256 and the JWT_SECRET env var.
+  // Verifies the JWT signature using HS256 and the INVITE_SERVICE_JWT_SECRET env var.
   // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
   private verifyInviteToken(token: string, secret: string): InviteTokenPayload {
     const key = JWK.asKey(Buffer.from(secret, 'base64'));

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { NatsSubjects } from '@lfx-one/shared/enums';
 import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
@@ -48,7 +50,7 @@ export class InviteController {
         );
       }
 
-      if (Date.now() / 1000 > payload.exp) {
+      if (typeof payload.exp !== 'number' || !isFinite(payload.exp) || Date.now() / 1000 > payload.exp) {
         return next(
           new AuthorizationError('Invite link has expired', {
             operation: 'accept_invite',
@@ -82,7 +84,24 @@ export class InviteController {
       }
 
       const codec = this.natsService.getCodec();
-      await this.natsService.request('lfx.invite.accepted', codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
+      const response = await this.natsService.request(
+        NatsSubjects.INVITE_ACCEPTED,
+        codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })),
+        {
+          timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+        }
+      );
+
+      const responseText = codec.decode(response.data);
+      if (!responseText || responseText.startsWith('error:')) {
+        return next(
+          new AuthorizationError(`Invite acceptance was rejected by the backend: ${responseText || '(empty response)'}`, {
+            operation: 'accept_invite',
+            service: 'invite_controller',
+            path: req.path,
+          })
+        );
+      }
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -5,6 +5,7 @@ import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
+import { errors as JoseErrors, JWK, JWT } from 'jose';
 
 import { AuthorizationError, ServiceValidationError } from '../errors';
 import { validateAndSanitizeUrl } from '../helpers/url-validation';
@@ -20,8 +21,8 @@ export class InviteController {
 
   /**
    * POST /api/invite/accept
-   * Decodes the invite JWT, publishes lfx.invite.accepted via NATS request-reply, and
-   * returns the return_url so the client can navigate to the intended resource.
+   * Verifies the invite JWT signature (HS256), publishes lfx.invite.accepted via NATS
+   * request-reply, and returns the return_url so the client can navigate to the intended resource.
    */
   public async acceptInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'accept_invite');
@@ -39,24 +40,25 @@ export class InviteController {
         );
       }
 
-      const payload = this.decodeInviteToken(token);
-      if (!payload) {
+      let payload: InviteTokenPayload;
+      try {
+        payload = this.verifyInviteToken(token);
+      } catch (err) {
+        if (err instanceof JoseErrors.JWTExpired) {
+          return next(
+            new AuthorizationError('Invite link has expired', {
+              operation: 'accept_invite',
+              service: 'invite_controller',
+              path: req.path,
+              code: 'INVITE_EXPIRED',
+            })
+          );
+        }
         return next(
-          ServiceValidationError.forField('token', 'Invite token is malformed', {
+          ServiceValidationError.forField('token', 'Invite token is invalid', {
             operation: 'accept_invite',
             service: 'invite_controller',
             path: req.path,
-          })
-        );
-      }
-
-      if (typeof payload.exp !== 'number' || !isFinite(payload.exp) || Date.now() / 1000 > payload.exp) {
-        return next(
-          new AuthorizationError('Invite link has expired', {
-            operation: 'accept_invite',
-            service: 'invite_controller',
-            path: req.path,
-            code: 'INVITE_EXPIRED',
           })
         );
       }
@@ -129,18 +131,18 @@ export class InviteController {
     }
   }
 
-  private decodeInviteToken(token: string): InviteTokenPayload | null {
-    try {
-      const parts = token.split('.');
-      if (parts.length !== 3) return null;
-      return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as InviteTokenPayload;
-    } catch {
-      return null;
+  // Verifies the JWT signature using HS256 and the INVITE_JWT_SECRET env var.
+  // Throws JoseErrors.JWTExpired for expired tokens and other JoseErrors for invalid/tampered ones.
+  private verifyInviteToken(token: string): InviteTokenPayload {
+    const secret = process.env['INVITE_JWT_SECRET'];
+    if (!secret) {
+      throw new Error('INVITE_JWT_SECRET is not configured');
     }
+    const key = JWK.asKey(Buffer.from(secret, 'base64'));
+    return JWT.verify(token, key, { algorithms: ['HS256'] }) as InviteTokenPayload;
   }
 
-  // Only LFX-owned domains are valid redirect destinations — prevents open-redirect if
-  // an unverified token ever carries a crafted return_url.
+  // Only LFX-owned domains are valid redirect destinations — prevents open-redirect.
   private validateReturnUrl(url: string): string | null {
     try {
       const parsed = new URL(url);

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -100,10 +100,7 @@ export class InviteController {
       }
 
       const codec = this.natsService.getCodec();
-      await this.natsService.publish(
-        NatsSubjects.INVITE_ACCEPTED,
-        codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username }))
-      );
+      await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -45,6 +45,9 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // Protected API routes - require authentication and token
   { pattern: '/api', type: 'api', auth: 'required', tokenRequired: true },
 
+  // Invite error page — public so unauthenticated users see the error instead of being redirected to login
+  { pattern: '/invite/error', type: 'ssr', auth: 'public' },
+
   // All other routes - Angular SSR routes requiring authentication
   { pattern: '/', type: 'ssr', auth: 'required' },
 ];

--- a/apps/lfx-one/src/server/routes/invite.route.ts
+++ b/apps/lfx-one/src/server/routes/invite.route.ts
@@ -8,7 +8,7 @@ import { InviteController } from '../controllers/invite.controller';
 const router = Router();
 const inviteController = new InviteController();
 
-// POST /invite/accept — accept an invite JWT and receive the return_url
+// POST /api/invite/accept — accept an invite JWT and receive the return_url
 router.post('/accept', (req, res, next) => inviteController.acceptInvite(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/invite.route.ts
+++ b/apps/lfx-one/src/server/routes/invite.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { InviteController } from '../controllers/invite.controller';
+
+const router = Router();
+const inviteController = new InviteController();
+
+// POST /invite/accept — accept an invite JWT and receive the return_url
+router.post('/accept', (req, res, next) => inviteController.acceptInvite(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -19,6 +19,7 @@ import { authMiddleware } from './middleware/auth.middleware';
 import { apiErrorHandler } from './middleware/error-handler.middleware';
 import { apiRateLimiter, authRateLimiter, publicApiRateLimiter } from './middleware/rate-limit.middleware';
 import analyticsRouter from './routes/analytics.route';
+import inviteRouter from './routes/invite.route';
 import badgesRouter from './routes/badges.route';
 import changelogRouter from './routes/changelog.route';
 import committeesRouter from './routes/committees.route';
@@ -219,6 +220,7 @@ app.use('/api/enrollments', enrollmentRouter);
 app.use('/api/transactions', transactionRouter);
 app.use('/api/changelog', changelogRouter);
 app.use('/api/newsletters', newslettersRouter);
+app.use('/api/invite', inviteRouter);
 
 app.use('/api/*', apiErrorHandler);
 

--- a/apps/lfx-one/src/server/services/nats.service.ts
+++ b/apps/lfx-one/src/server/services/nats.service.ts
@@ -94,6 +94,48 @@ export class NatsService {
   }
 
   /**
+   * Publish a fire-and-forget message to NATS (no reply expected)
+   * @param subject - The NATS subject to publish to
+   * @param data - The data to send
+   */
+  public async publish(subject: string, data: Uint8Array): Promise<void> {
+    const connection = await this.ensureConnection();
+
+    return tracer.startActiveSpan(
+      `NATS publish ${subject}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [ATTR_MESSAGING_SYSTEM]: 'nats',
+          [ATTR_MESSAGING_OPERATION_TYPE]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: subject,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'nats',
+          [ATTR_SERVER_ADDRESS]: this.natsHostname,
+          [ATTR_SERVER_PORT]: this.natsPort,
+        },
+      },
+      async (span) => {
+        logger.debug(undefined, 'nats_publish', 'Publishing NATS message', { subject });
+        try {
+          connection.publish(subject, data);
+          span.setStatus({ code: SpanStatusCode.OK });
+          span.setAttribute(ATTR_MESSAGING_MESSAGE_BODY_SIZE, data.length);
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          logger.error(undefined, 'nats_publish', Date.now(), error, { subject });
+          throw error;
+        } finally {
+          span.end();
+        }
+      }
+    );
+  }
+
+  /**
    * Check if NATS connection is active
    */
   public isConnected(): boolean {

--- a/apps/lfx-one/src/server/services/nats.service.ts
+++ b/apps/lfx-one/src/server/services/nats.service.ts
@@ -115,6 +115,7 @@ export class NatsService {
         },
       },
       async (span) => {
+        const startTime = Date.now();
         logger.debug(undefined, 'nats_publish', 'Publishing NATS message', { subject });
         try {
           connection.publish(subject, data);
@@ -126,7 +127,7 @@ export class NatsService {
             message: error instanceof Error ? error.message : String(error),
           });
           span.recordException(error instanceof Error ? error : new Error(String(error)));
-          logger.error(undefined, 'nats_publish', Date.now(), error, { subject });
+          logger.error(undefined, 'nats_publish', startTime, error, { subject });
           throw error;
         } finally {
           span.end();

--- a/apps/lfx-one/src/server/services/nats.service.ts
+++ b/apps/lfx-one/src/server/services/nats.service.ts
@@ -93,11 +93,7 @@ export class NatsService {
     );
   }
 
-  /**
-   * Publish a fire-and-forget message to NATS (no reply expected)
-   * @param subject - The NATS subject to publish to
-   * @param data - The data to send
-   */
+  /** Publish a fire-and-forget NATS message (no reply expected). */
   public async publish(subject: string, data: Uint8Array): Promise<void> {
     const connection = await this.ensureConnection();
 

--- a/apps/lfx-one/src/server/services/nats.service.ts
+++ b/apps/lfx-one/src/server/services/nats.service.ts
@@ -115,6 +115,7 @@ export class NatsService {
         logger.debug(undefined, 'nats_publish', 'Publishing NATS message', { subject });
         try {
           connection.publish(subject, data);
+          await connection.flush();
           span.setStatus({ code: SpanStatusCode.OK });
           span.setAttribute(ATTR_MESSAGING_MESSAGE_BODY_SIZE, data.length);
         } catch (error) {

--- a/apps/lfx-one/src/types/jose.d.ts
+++ b/apps/lfx-one/src/types/jose.d.ts
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 declare module 'jose' {
+  export interface JoseKey {
+    readonly [key: string]: unknown;
+  }
+
   export const errors: {
-    JWTExpired: new (...args: unknown[]) => Error;
+    JWTExpired: new (message?: string) => Error;
   };
 
   export const JWK: {
-    asKey: (key: Buffer) => unknown;
+    asKey: (key: Buffer) => JoseKey;
   };
 
   export const JWT: {
-    verify: (
+    verify: <TPayload extends Record<string, unknown> = Record<string, unknown>>(
       token: string,
-      key: unknown,
+      key: JoseKey,
       options?: { algorithms?: string[] }
-    ) => Record<string, unknown>;
+    ) => TPayload;
   };
 }

--- a/apps/lfx-one/src/types/jose.d.ts
+++ b/apps/lfx-one/src/types/jose.d.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+declare module 'jose' {
+  export const errors: {
+    JWTExpired: new (...args: unknown[]) => Error;
+  };
+
+  export const JWK: {
+    asKey: (key: Buffer) => unknown;
+  };
+
+  export const JWT: {
+    verify: (
+      token: string,
+      key: unknown,
+      options?: { algorithms?: string[] }
+    ) => Record<string, unknown>;
+  };
+}

--- a/apps/lfx-one/src/types/jose.d.ts
+++ b/apps/lfx-one/src/types/jose.d.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// jose v2 doesn't ship JWK/JWT namespaces or errors.JWTExpired in its types; shim fills the gap until we can migrate to jose v5+ (blocked on openid-client hoisting conflict with @modelcontextprotocol/sdk).
 declare module 'jose' {
   export type JoseKey = Readonly<Record<string, unknown>>;
 

--- a/apps/lfx-one/src/types/jose.d.ts
+++ b/apps/lfx-one/src/types/jose.d.ts
@@ -13,6 +13,6 @@ declare module 'jose' {
   };
 
   export const JWT: {
-    verify: <TPayload extends Record<string, unknown> = Record<string, unknown>>(token: string, key: JoseKey, options?: { algorithms?: string[] }) => TPayload;
+    verify: <TPayload = Record<string, unknown>>(token: string, key: JoseKey, options?: { algorithms?: string[] }) => TPayload;
   };
 }

--- a/apps/lfx-one/src/types/jose.d.ts
+++ b/apps/lfx-one/src/types/jose.d.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 declare module 'jose' {
-  export interface JoseKey {
-    readonly [key: string]: unknown;
-  }
+  export type JoseKey = Readonly<Record<string, unknown>>;
 
   export const errors: {
     JWTExpired: new (message?: string) => Error;
@@ -15,10 +13,6 @@ declare module 'jose' {
   };
 
   export const JWT: {
-    verify: <TPayload extends Record<string, unknown> = Record<string, unknown>>(
-      token: string,
-      key: JoseKey,
-      options?: { algorithms?: string[] }
-    ) => TPayload;
+    verify: <TPayload extends Record<string, unknown> = Record<string, unknown>>(token: string, key: JoseKey, options?: { algorithms?: string[] }) => TPayload;
   };
 }

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -284,7 +284,7 @@ environment:
     value:
 
   # Invite JWT signing secret (HS256) — used to verify signed invite tokens
-  JWT_SECRET:
+  INVITE_SERVICE_JWT_SECRET:
     value: "qtPxtMAVHkg58Odl2j35iGweRNYUXK3PwO6DiDvaIIc="
 
   # Snowflake Analytics Configuration

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -283,6 +283,10 @@ environment:
   AI_API_KEY:
     value:
 
+  # Invite JWT signing secret (HS256) — used to verify signed invite tokens
+  JWT_SECRET:
+    value: "qtPxtMAVHkg58Odl2j35iGweRNYUXK3PwO6DiDvaIIc="
+
   # Snowflake Analytics Configuration
   # Required for analytics endpoints: active-weeks-streak, pull-requests-merged, code-commits
   SNOWFLAKE_ACCOUNT:

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -283,7 +283,10 @@ environment:
   AI_API_KEY:
     value:
 
-  # Invite JWT signing secret (HS256) — used to verify signed invite tokens
+  # Invite JWT signing secret (HS256) — used to verify signed invite tokens.
+  # Must match the INVITE_JWT_SECRET configured in lfx-v2-invite-service.
+  # The value is used as raw UTF-8 bytes (not base64-decoded) to match how
+  # the Go invite service derives the HMAC key ([]byte(secret)).
   INVITE_SERVICE_JWT_SECRET:
     value: "qtPxtMAVHkg58Odl2j35iGweRNYUXK3PwO6DiDvaIIc="
 

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -24,4 +24,5 @@ export enum NatsSubjects {
   LOOKUP_V1_MAPPING = 'lfx.lookup_v1_mapping',
   PERSONAS_GET = 'lfx.personas-api.get',
   IMPERSONATION_TOKEN_EXCHANGE = 'lfx.auth-service.impersonation.token_exchange',
+  INVITE_ACCEPTED = 'lfx.invite.accepted',
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -168,3 +168,6 @@ export * from './org-memberships.interface';
 
 // Newsletter interfaces
 export * from './newsletter.interface';
+
+// Invite interfaces
+export * from './invite.interface';

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface InviteTokenPayload {
+  email: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  invite_uid: string;
+  resource_uid: string;
+  return_url: string;
+  role: string;
+}
+
+export interface AcceptInviteResponse {
+  return_url: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17175,21 +17175,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12586,6 +12586,7 @@ __metadata:
     express-rate-limit: "npm:^8.3.2"
     form-data: "npm:^4.0.4"
     html-to-image: "npm:^1.11.13"
+    jose: "npm:^2.0.7"
     launchdarkly-js-client-sdk: "npm:^3.9.0"
     marked: "npm:^17.0.4"
     nats: "npm:^2.29.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17175,21 +17175,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
+  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `/invite` route (auth-protected) and `/invite/error` page (public) for the non-LF user invite flow
- `InviteController` decodes the JWT payload, validates `exp` and `return_url` domain (`*.lfx.dev`), then publishes `lfx.invite.accepted` via NATS request-reply before returning `return_url`
- Token survives the Auth0 login redirect via `authGuard` `returnTo` param so new accounts land back on `/invite?token=` after signup

## Flow

1. Non-LF user opens `https://app.lfx.dev/invite?token=<jwt>` → unauthenticated → `authGuard` → `/login?returnTo=/invite?token=<jwt>`
2. User creates account on Auth0 → redirected back to `/invite?token=<jwt>`
3. `InviteComponent`: client-side `exp` check → `POST /api/invite/accept { token }`
4. Backend: decode payload → validate expiry + `return_url` domain → NATS request-reply `lfx.invite.accepted { invite_uid, username }` → return `{ return_url }`
5. Client: `window.location.href = return_url`
6. Any error → `/invite/error?reason=expired|missing|failed`

## Test plan

- [ ] Cold-load `/invite?token=<valid-unexpired>` while logged out → Auth0 login → redirected to `return_url` after signup
- [ ] Cold-load with expired token → `/invite/error?reason=expired`
- [ ] Cold-load with no token → `/invite/error?reason=missing`
- [ ] Cold-load with malformed token → `/invite/error?reason=missing`
- [ ] Backend NATS failure → `/invite/error?reason=failed`
- [ ] `return_url` with non-LFX domain → backend 400, client shows error page
- [ ] Already-authenticated user hits `/invite?token=<valid>` → skips login, goes straight to accept + redirect

## JIRA

[LFXV2-1945](https://linuxfoundation.atlassian.net/browse/LFXV2-1945)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1945]: https://linuxfoundation.atlassian.net/browse/LFXV2-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ