### PR TITLE
feat(org-lens): integrate memberships page with real Snowflake data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -2,9 +2,9 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6">
-  <h1 class="text-2xl font-semibold text-gray-900">Membership — {{ companyName() }}</h1>
+  <h1 class="text-2xl font-semibold text-gray-900" data-testid="memberships-page-title">Membership — {{ companyName() }}</h1>
 
-  <div class="flex items-center gap-1 border-b border-gray-200">
+  <div class="flex items-center gap-1 border-b border-gray-200" data-testid="memberships-tab-bar">
     @for (tab of tabs; track tab.id) {
       <button
         type="button"
@@ -14,6 +14,7 @@
         [class.border-transparent]="activeTab() !== tab.id"
         [class.text-gray-500]="activeTab() !== tab.id"
         [class.hover:text-gray-700]="activeTab() !== tab.id"
+        [attr.data-testid]="'memberships-tab-' + tab.id"
         (click)="switchTab(tab.id)">
         <i [class]="tab.icon"></i>
         {{ tab.label }}
@@ -24,7 +25,7 @@
   @if (activeTab() === 'active') {
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="active-memberships-summary">
       <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-        <div class="flex items-center gap-3 p-4">
+        <div class="flex items-center gap-3 p-4" data-testid="memberships-stat-active">
           <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
             <i class="fa-light fa-briefcase text-xl"></i>
           </div>
@@ -37,7 +38,7 @@
             <p class="text-sm font-normal text-gray-900">Active Memberships</p>
           </div>
         </div>
-        <div class="flex items-center gap-3 p-4">
+        <div class="flex items-center gap-3 p-4" data-testid="memberships-stat-renewing">
           <div class="flex items-center justify-center w-11 h-11 rounded-full bg-amber-100 text-amber-600 flex-shrink-0">
             <i class="fa-light fa-clock text-xl"></i>
           </div>
@@ -50,7 +51,7 @@
             <p class="text-sm font-normal text-gray-900">Renewing Within 90 Days</p>
           </div>
         </div>
-        <div class="flex items-center gap-3 p-4">
+        <div class="flex items-center gap-3 p-4" data-testid="memberships-stat-governance">
           <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
             <i class="fa-light fa-users text-xl"></i>
           </div>
@@ -77,20 +78,21 @@
                 type="text"
                 placeholder="Search memberships..."
                 class="w-full pl-9"
+                data-testid="memberships-search-input"
                 [ngModel]="searchTerm()"
                 (ngModelChange)="searchTerm.set($event)" />
             </div>
           </div>
-          <div class="w-full sm:w-48">
+          <div class="w-full sm:w-48" data-testid="memberships-tier-filter">
             <p-select
-              [options]="tierOptions"
+              [options]="tierOptions()"
               [ngModel]="selectedTier()"
               (ngModelChange)="selectedTier.set($event)"
               optionLabel="label"
               optionValue="value"
               styleClass="w-full" />
           </div>
-          <div class="w-full sm:w-48">
+          <div class="w-full sm:w-48" data-testid="memberships-renewal-filter">
             <p-select
               [options]="renewalOptions"
               [ngModel]="selectedRenewal()"
@@ -111,6 +113,7 @@
             subtitle="Please try again."
             ctaLabel="Retry"
             ctaIcon="fa-light fa-arrow-rotate-left"
+            data-testid="memberships-error-state"
             (ctaClick)="retry()">
           </lfx-empty-state>
         } @else if (pageState() === 'empty') {
@@ -118,10 +121,11 @@
             [withCard]="false"
             icon="fa-light fa-folder-open"
             title="No active memberships"
-            subtitle="This organization does not have any active memberships.">
+            subtitle="This organization does not have any active memberships."
+            data-testid="memberships-empty-state">
           </lfx-empty-state>
         } @else {
-          <lfx-table [value]="memberships()" [loading]="pageState() === 'loading'" sortField="foundationName" [sortOrder]="1" [skeletonColumns]="6">
+          <lfx-table [value]="memberships()" [loading]="pageState() === 'loading'" sortField="foundationName" [sortOrder]="1" [skeletonColumns]="6" data-testid="memberships-active-table">
             <ng-template #header>
               <tr>
                 <th>Name</th>
@@ -136,9 +140,13 @@
               <tr>
                 <td>
                   <div class="flex items-center gap-3">
-                    <div class="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center text-sm font-semibold text-gray-600 flex-shrink-0">
-                      {{ membership.foundationInitials }}
-                    </div>
+                    @if (membership.foundationLogo) {
+                      <img [src]="membership.foundationLogo" [alt]="membership.foundationName" class="w-10 h-10 rounded-lg object-contain flex-shrink-0" />
+                    } @else {
+                      <div class="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center text-sm font-semibold text-gray-600 flex-shrink-0">
+                        {{ getInitials(membership.foundationName) }}
+                      </div>
+                    }
                     <div class="flex flex-col">
                       <span class="font-medium text-gray-900">{{ membership.foundationName }}</span>
                       <span class="text-xs text-gray-500">{{ membership.projectCount }} projects · {{ membership.memberCount }} members</span>
@@ -171,7 +179,7 @@
 
   @if (activeTab() === 'expired') {
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-      <div class="px-5 pt-4 pb-3">
+      <div class="px-5 pt-4 pb-3" data-testid="expired-memberships-title">
         <div class="flex flex-col gap-1 mb-3">
           <h2 class="text-xl font-semibold text-gray-900">Expired Memberships</h2>
           <p class="text-sm text-gray-500">Projects your organization had active memberships for, but are currently expired</p>
@@ -200,7 +208,7 @@
           <lfx-empty-state [withCard]="false" icon="fa-light fa-clock-rotate-left" title="No expired memberships" subtitle="All your memberships are current!">
           </lfx-empty-state>
         } @else {
-          <lfx-table [value]="expiredMemberships()" [loading]="expiredState() === 'loading'" sortField="foundationName" [sortOrder]="1" [skeletonColumns]="4">
+          <lfx-table [value]="expiredMemberships()" [loading]="expiredState() === 'loading'" sortField="foundationName" [sortOrder]="1" [skeletonColumns]="4" data-testid="memberships-expired-table">
             <ng-template #header>
               <tr>
                 <th>Name</th>
@@ -213,11 +221,15 @@
               <tr>
                 <td>
                   <div class="flex items-center gap-3">
-                    <div
-                      class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
-                      [class]="membership.foundationColor">
-                      {{ membership.foundationInitials }}
-                    </div>
+                    @if (membership.foundationLogo) {
+                      <img [src]="membership.foundationLogo" [alt]="membership.foundationName" class="w-10 h-10 rounded-lg object-contain flex-shrink-0" />
+                    } @else {
+                      <div
+                        class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
+                        [class]="getLogoClasses(membership.foundationId)">
+                        {{ getInitials(membership.foundationName) }}
+                      </div>
+                    }
                     <div class="flex flex-col">
                       <span class="font-medium text-gray-900">{{ membership.foundationName }}</span>
                       <span class="text-xs text-gray-500">Expired {{ formatDateFull(membership.expirationDate) }}</span>
@@ -233,17 +245,17 @@
                 <td class="text-sm text-gray-700">{{ formatDateFull(membership.expirationDate) }}</td>
                 <td>
                   @if (membership.actionType === 'renew') {
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors"
-                      pTooltip="Coming soon"
-                      tooltipPosition="top">
+                    <a
+                      [href]="getRenewUrl(membership.foundationId)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="inline-block px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors">
                       Renew
-                    </button>
+                    </a>
                   } @else {
-                    <button type="button" class="text-sm text-gray-600 hover:text-gray-900 transition-colors" pTooltip="Coming soon" tooltipPosition="top">
+                    <a href="https://jira.linuxfoundation.org/servicedesk/customer/portal/4" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 hover:text-gray-900 transition-colors">
                       Contact Us
-                    </button>
+                    </a>
                   }
                 </td>
               </tr>
@@ -256,7 +268,7 @@
 
   @if (activeTab() === 'discover') {
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-      <div class="px-5 pt-4 pb-3">
+      <div class="px-5 pt-4 pb-3" data-testid="discover-opportunities-title">
         <h2 class="text-xl font-semibold text-gray-900">Discover Opportunities</h2>
       </div>
 
@@ -281,7 +293,8 @@
             [loading]="discoverState() === 'loading'"
             sortField="foundationName"
             [sortOrder]="1"
-            [skeletonColumns]="5">
+            [skeletonColumns]="5"
+            data-testid="memberships-discover-table">
             <ng-template #header>
               <tr>
                 <th>Foundation</th>
@@ -295,11 +308,15 @@
               <tr>
                 <td>
                   <div class="flex items-center gap-3">
-                    <div
-                      class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
-                      [class]="opportunity.foundationColor">
-                      {{ opportunity.foundationInitials }}
-                    </div>
+                    @if (opportunity.foundationLogo) {
+                      <img [src]="opportunity.foundationLogo" [alt]="opportunity.foundationName" class="w-10 h-10 rounded-lg object-contain flex-shrink-0" />
+                    } @else {
+                      <div
+                        class="w-10 h-10 rounded-lg flex items-center justify-center text-sm font-semibold text-white flex-shrink-0"
+                        [class]="getLogoClasses(opportunity.foundationId)">
+                        {{ getInitials(opportunity.foundationName) }}
+                      </div>
+                    }
                     <div class="flex flex-col">
                       <span class="font-medium text-gray-900">{{ opportunity.foundationName }}</span>
                       <span class="text-xs text-gray-500">{{ opportunity.category }} · {{ opportunity.relevantProjects }} relevant projects</span>
@@ -315,13 +332,13 @@
                 <td class="text-sm text-gray-700">{{ opportunity.contributors }}</td>
                 <td class="text-sm text-gray-700">{{ opportunity.contributions }}</td>
                 <td>
-                  <button
-                    type="button"
-                    class="px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors"
-                    pTooltip="Coming soon"
-                    tooltipPosition="top">
+                  <a
+                    [href]="getJoinUrl(opportunity.foundationId)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-block px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-600 rounded-lg hover:bg-blue-50 transition-colors">
                     Join
-                  </button>
+                  </a>
                 </td>
               </tr>
             </ng-template>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -19,6 +19,7 @@ import type {
   OrgDiscoverOpportunitiesResponse,
   OrgExpiredMembershipsResponse,
 } from '@lfx-one/shared/interfaces';
+import { foundationInitials, foundationLogoSquareClasses } from '../components/org-overview-foundations-and-projects/helpers/foundation-logo.helper';
 
 type PageState = 'loading' | 'error' | 'ready' | 'empty';
 type MembershipTab = 'active' | 'expired' | 'discover';
@@ -47,16 +48,14 @@ export class OrgMembershipsComponent {
     { id: 'discover' as const, label: 'Discover', icon: 'fa-light fa-magnifying-glass' },
   ];
 
-  protected readonly tierOptions: DropdownOption[] = [
-    { label: 'All Membership Levels', value: '' },
-    { label: 'Platinum', value: 'Platinum Member' },
-    { label: 'Gold', value: 'Gold Member' },
-    { label: 'Silver', value: 'Silver Member' },
-    { label: 'Premier', value: 'Premier Member' },
-    { label: 'General', value: 'General Member' },
-    { label: 'Contributor', value: 'Contributor Member' },
-    { label: 'Steering', value: 'Steering Member' },
-  ];
+  private readonly allTiers = signal<string[]>([]);
+
+  protected readonly tierOptions = computed<DropdownOption[]>(() => {
+    return [
+      { label: 'All Membership Levels', value: '' },
+      ...this.allTiers().map((t) => ({ label: t, value: t })),
+    ];
+  });
 
   protected readonly renewalOptions: DropdownOption[] = [
     { label: 'All Renewals', value: '' },
@@ -99,7 +98,13 @@ export class OrgMembershipsComponent {
         })
       )
     ),
-    tap(() => this.fetchLoading.set(false))
+    tap((response) => {
+      this.fetchLoading.set(false);
+      if (response && !this.selectedTier()) {
+        const tiers = [...new Set(response.memberships.map((m) => m.membershipTier))].sort();
+        this.allTiers.set(tiers);
+      }
+    })
   );
 
   protected readonly activeData = toSignal<OrgActiveMembershipsResponse | null>(this.activeResponse$, { initialValue: null });
@@ -181,6 +186,24 @@ export class OrgMembershipsComponent {
 
   protected formatTierRange(membership: OrgActiveMembership): string {
     return `${this.formatDateShort(membership.tierStartDate)} – ${this.formatDateShort(membership.tierEndDate)}`;
+  }
+
+  protected getInitials(name: string): string {
+    return foundationInitials(name);
+  }
+
+  protected getLogoClasses(foundationId: string): string {
+    return foundationLogoSquareClasses(foundationId);
+  }
+
+  protected getRenewUrl(foundationId: string): string {
+    const slug = this.accountContext.selectedAccount()?.accountSlug ?? '';
+    return `https://myorg.lfx.dev/${slug}/project/project-group-membership/${foundationId}`;
+  }
+
+  protected getJoinUrl(foundationId: string): string {
+    const slug = this.accountContext.selectedAccount()?.accountSlug ?? '';
+    return `https://myorg.lfx.dev/${slug}/project/${foundationId}/membership`;
   }
 
   private fetchExpired(accountId: string): void {

--- a/apps/lfx-one/src/server/controllers/org-lens-memberships.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-memberships.controller.ts
@@ -39,7 +39,7 @@ export class OrgLensMembershipsController {
       const tier = req.query['tier'] as string | undefined;
       const renewal = req.query['renewal'] as string | undefined;
 
-      const response = this.service.getActiveMemberships(accountId, search, tier, renewal);
+      const response = await this.service.getActiveMemberships(accountId, search, tier, renewal);
 
       logger.success(req, 'get_org_lens_memberships_active', startTime, {
         account_id: accountId,
@@ -74,7 +74,7 @@ export class OrgLensMembershipsController {
 
       const search = req.query['search'] as string | undefined;
 
-      const response = this.service.getExpiredMemberships(accountId, search);
+      const response = await this.service.getExpiredMemberships(accountId, search);
 
       logger.success(req, 'get_org_lens_memberships_expired', startTime, {
         account_id: accountId,
@@ -107,7 +107,7 @@ export class OrgLensMembershipsController {
         });
       }
 
-      const response = this.service.getDiscoverOpportunities(accountId);
+      const response = await this.service.getDiscoverOpportunities(accountId);
 
       logger.success(req, 'get_org_lens_memberships_discover', startTime, {
         account_id: accountId,

--- a/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
@@ -10,261 +10,99 @@ import type {
   OrgExpiredMembershipsResponse,
 } from '@lfx-one/shared/interfaces';
 
-const DEMO_ACCOUNT_ID_PREFIX = '001';
+import { SnowflakeService } from './snowflake.service';
 
-const ACTIVE_MEMBERSHIPS: OrgActiveMembership[] = [
-  {
-    foundationId: 'agl-001',
-    foundationName: 'Automotive Grade Linux (AGL)',
-    foundationLogo: null,
-    foundationInitials: 'AG',
-    projectCount: 43,
-    memberCount: 338,
-    membershipTier: 'Platinum Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: '2012-07-01',
-    boardMembers: 0,
-    committeeMembers: 0,
-    orgProjects: 4,
-  },
-  {
-    foundationId: 'cncf-001',
-    foundationName: 'Cloud Native Computing Foundation (CNCF)',
-    foundationLogo: null,
-    foundationInitials: 'CN',
-    projectCount: 55,
-    memberCount: 440,
-    membershipTier: 'Silver Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: '2020-01-01',
-    boardMembers: 0,
-    committeeMembers: 0,
-    orgProjects: 2,
-  },
-  {
-    foundationId: 'ebpf-001',
-    foundationName: 'eBPF Foundation',
-    foundationLogo: null,
-    foundationInitials: 'eB',
-    projectCount: 58,
-    memberCount: 443,
-    membershipTier: 'Silver Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-10-31',
-    memberSince: '2022-01-01',
-    boardMembers: 1,
-    committeeMembers: 0,
-    orgProjects: 5,
-  },
-  {
-    foundationId: 'openchain-001',
-    foundationName: 'OpenChain Project',
-    foundationLogo: null,
-    foundationInitials: 'OC',
-    projectCount: 54,
-    memberCount: 179,
-    membershipTier: 'Platinum Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: '2017-01-01',
-    boardMembers: 0,
-    committeeMembers: 20,
-    orgProjects: 5,
-  },
-  {
-    foundationId: 'lf-001',
-    foundationName: 'The Linux Foundation',
-    foundationLogo: null,
-    foundationInitials: 'LF',
-    projectCount: 61,
-    memberCount: 356,
-    membershipTier: 'Gold Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: '2015-01-01',
-    boardMembers: 1,
-    committeeMembers: 2,
-    orgProjects: 6,
-  },
-  {
-    foundationId: 'todo-001',
-    foundationName: 'TODO Group',
-    foundationLogo: null,
-    foundationInitials: 'TODO',
-    projectCount: 10,
-    memberCount: 225,
-    membershipTier: 'General Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: null,
-    boardMembers: 0,
-    committeeMembers: 0,
-    orgProjects: 3,
-  },
-  {
-    foundationId: 'uec-001',
-    foundationName: 'Ultra Ethernet Consortium Fund',
-    foundationLogo: null,
-    foundationInitials: 'UE',
-    projectCount: 77,
-    memberCount: 462,
-    membershipTier: 'Contributor Member',
-    tierStartDate: '2026-01-01',
-    tierEndDate: '2026-12-31',
-    memberSince: '2023-07-01',
-    boardMembers: 0,
-    committeeMembers: 0,
-    orgProjects: 0,
-  },
-];
+interface RawMembershipRow {
+  ACCOUNT_ID: string;
+  ACCOUNT_NAME: string;
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string | null;
+  FOUNDATION_LOGO_URL: string | null;
+  MEMBERSHIP_TIER_DISPLAY_NAME: string;
+  MEMBERSHIP_TIER_CLASS: string;
+  TIER_RANK: number;
+  TIER_START_DATE: string | null;
+  TIER_END_DATE: string | null;
+  FIRST_MEMBERSHIP_STARTED_AT: string | null;
+  BOARD_MEMBER_SEAT_COUNT: number;
+  COMMITTEE_MEMBER_SEAT_COUNT: number;
+  ORG_PROJECTS_COUNT: number;
+  PROJECT_COUNT: number;
+  MEMBER_COUNT: number;
+  IS_RENEWING_WITHIN_90_DAYS: boolean;
+}
 
-const EXPIRED_MEMBERSHIPS: OrgExpiredMembership[] = [
-  {
-    foundationId: 'soda-001',
-    foundationName: 'SODA Foundation',
-    foundationInitials: 'SF',
-    foundationColor: 'bg-blue-600',
-    membershipTier: 'General Member',
-    tierStartDate: '2022-03-01',
-    tierEndDate: '2025-12-31',
-    expirationDate: '2025-12-31',
-    actionType: 'renew',
-  },
-  {
-    foundationId: 'lfph-001',
-    foundationName: 'LF Public Health',
-    foundationInitials: 'LP',
-    foundationColor: 'bg-purple-600',
-    membershipTier: 'Premier Member',
-    tierStartDate: '2020-04-01',
-    tierEndDate: '2023-12-31',
-    expirationDate: '2023-12-31',
-    actionType: 'contact',
-  },
-  {
-    foundationId: 'magma-001',
-    foundationName: 'Magma Fund',
-    foundationInitials: 'MF',
-    foundationColor: 'bg-green-600',
-    membershipTier: 'Silver Member',
-    tierStartDate: '2021-01-01',
-    tierEndDate: '2022-12-31',
-    expirationDate: '2022-12-31',
-    actionType: 'renew',
-  },
-  {
-    foundationId: 'edgex-001',
-    foundationName: 'EdgeX Foundry',
-    foundationInitials: 'EF',
-    foundationColor: 'bg-teal-600',
-    membershipTier: 'Silver Member',
-    tierStartDate: '2018-01-01',
-    tierEndDate: '2020-12-31',
-    expirationDate: '2020-12-31',
-    actionType: 'renew',
-  },
-  {
-    foundationId: 'iovisor-001',
-    foundationName: 'IO Visor Project',
-    foundationInitials: 'IV',
-    foundationColor: 'bg-red-600',
-    membershipTier: 'Silver Member',
-    tierStartDate: '2016-01-01',
-    tierEndDate: '2018-12-31',
-    expirationDate: '2018-12-31',
-    actionType: 'contact',
-  },
-  {
-    foundationId: 'onap-001',
-    foundationName: 'ONAP',
-    foundationInitials: 'O',
-    foundationColor: 'bg-pink-600',
-    membershipTier: 'Silver Member',
-    tierStartDate: '2017-01-01',
-    tierEndDate: '2019-12-31',
-    expirationDate: '2019-12-31',
-    actionType: 'contact',
-  },
-];
+interface RawExpiredRow {
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_LOGO_URL: string | null;
+  MEMBERSHIP_TIER_DISPLAY_NAME: string;
+  TIER_START_DATE: string | null;
+  TIER_END_DATE: string | null;
+  EXPIRATION_DATE: string | null;
+  ACTION_TYPE: 'renew' | 'contact';
+}
 
-const DISCOVER_OPPORTUNITIES: OrgDiscoverOpportunity[] = [
-  {
-    foundationId: 'lfenergy-001',
-    foundationName: 'LF Energy',
-    foundationInitials: 'LE',
-    foundationColor: 'bg-red-700',
-    category: 'EV Charging & Grid',
-    suggestedTier: 'Strategic Membership',
-    relevantProjects: 5,
-    contributors: 8,
-    contributions: 184,
-  },
-  {
-    foundationId: 'lfai-001',
-    foundationName: 'LF AI & Data',
-    foundationInitials: 'LA',
-    foundationColor: 'bg-orange-600',
-    category: 'Autonomous Driving',
-    suggestedTier: 'General Membership',
-    relevantProjects: 4,
-    contributors: 12,
-    contributions: 312,
-  },
-  {
-    foundationId: 'pytorch-001',
-    foundationName: 'PyTorch Foundation',
-    foundationInitials: 'PT',
-    foundationColor: 'bg-orange-700',
-    category: 'Machine Learning',
-    suggestedTier: 'Gold Membership',
-    relevantProjects: 2,
-    contributors: 7,
-    contributions: 142,
-  },
-  {
-    foundationId: 'openssf-001',
-    foundationName: 'OpenSSF',
-    foundationInitials: 'OS',
-    foundationColor: 'bg-blue-800',
-    category: 'Supply Chain Security',
-    suggestedTier: 'Premier Membership',
-    relevantProjects: 3,
-    contributors: 4,
-    contributions: 56,
-  },
-  {
-    foundationId: 'ccc-001',
-    foundationName: 'Confidential Computing Consortium',
-    foundationInitials: 'CC',
-    foundationColor: 'bg-green-700',
-    category: 'Secure Compute',
-    suggestedTier: 'Premier Membership',
-    relevantProjects: 2,
-    contributors: 2,
-    contributions: 28,
-  },
-  {
-    foundationId: 'lfedge-001',
-    foundationName: 'LF Edge',
-    foundationInitials: 'LE',
-    foundationColor: 'bg-red-600',
-    category: 'Edge Compute',
-    suggestedTier: 'Premier Membership',
-    relevantProjects: 4,
-    contributors: 5,
-    contributions: 96,
-  },
-];
+interface RawDiscoverRow {
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_LOGO_URL: string | null;
+  PROJECT_TYPE: string | null;
+  SUGGESTED_TIER: string | null;
+  CONTRIBUTORS_COUNT: number;
+  CONTRIBUTION_COUNT: number;
+  RELEVANT_PROJECTS: number;
+}
 
 export class OrgLensMembershipsService {
-  public getActiveMemberships(accountId: string, search?: string, tier?: string, renewal?: string): OrgActiveMembershipsResponse {
-    if (!this.isDemoAccount(accountId)) {
+  private snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  public async getActiveMemberships(accountId: string, search?: string, tier?: string, renewal?: string): Promise<OrgActiveMembershipsResponse> {
+    const query = `
+      SELECT
+        ACCOUNT_ID,
+        ACCOUNT_NAME,
+        FOUNDATION_ID,
+        FOUNDATION_NAME,
+        FOUNDATION_SLUG,
+        FOUNDATION_LOGO_URL,
+        MEMBERSHIP_TIER_DISPLAY_NAME,
+        MEMBERSHIP_TIER_CLASS,
+        TIER_RANK,
+        TIER_START_DATE,
+        TIER_END_DATE,
+        FIRST_MEMBERSHIP_STARTED_AT,
+        BOARD_MEMBER_SEAT_COUNT,
+        COMMITTEE_MEMBER_SEAT_COUNT,
+        ORG_PROJECTS_COUNT,
+        PROJECT_COUNT,
+        MEMBER_COUNT,
+        IS_RENEWING_WITHIN_90_DAYS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_MEMBERSHIPS_SUMMARY
+      WHERE ACCOUNT_ID = ?
+      ORDER BY FOUNDATION_NAME ASC
+    `;
+
+    const result = await this.snowflakeService.execute<RawMembershipRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
       return { accountId, summary: { activeMemberships: 0, renewingWithin90Days: 0, governanceRoles: 0 }, memberships: [] };
     }
 
-    let filtered = [...ACTIVE_MEMBERSHIPS];
+    const allMemberships = result.rows.map((raw) => this.shapeRow(raw));
+
+    const summary = {
+      activeMemberships: allMemberships.length,
+      renewingWithin90Days: result.rows.filter((r) => r.IS_RENEWING_WITHIN_90_DAYS).length,
+      governanceRoles: result.rows.reduce((sum, r) => sum + r.BOARD_MEMBER_SEAT_COUNT + r.COMMITTEE_MEMBER_SEAT_COUNT, 0),
+    };
+
+    let filtered = allMemberships;
 
     if (search) {
       const term = search.toLowerCase();
@@ -279,52 +117,112 @@ export class OrgLensMembershipsService {
       const now = new Date();
       const days = Number(renewal);
       const cutoff = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
-      filtered = filtered.filter((m) => new Date(m.tierEndDate) <= cutoff);
+      filtered = filtered.filter((m) => {
+        if (!m.tierEndDate) return false;
+        return new Date(m.tierEndDate) <= cutoff;
+      });
     }
 
-    const renewingWithin90Days = filtered.filter((m) => {
-      const now = new Date();
-      const cutoff90 = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
-      return new Date(m.tierEndDate) <= cutoff90;
-    }).length;
-
-    const governanceRoles = filtered.reduce((sum, m) => sum + m.boardMembers + m.committeeMembers, 0);
-
-    return {
-      accountId,
-      summary: {
-        activeMemberships: filtered.length,
-        renewingWithin90Days,
-        governanceRoles,
-      },
-      memberships: filtered,
-    };
+    return { accountId, summary, memberships: filtered };
   }
 
-  public getExpiredMemberships(accountId: string, search?: string): OrgExpiredMembershipsResponse {
-    if (!this.isDemoAccount(accountId)) {
+  public async getExpiredMemberships(accountId: string, search?: string): Promise<OrgExpiredMembershipsResponse> {
+    const query = `
+      SELECT
+        FOUNDATION_ID,
+        FOUNDATION_NAME,
+        FOUNDATION_LOGO_URL,
+        MEMBERSHIP_TIER_DISPLAY_NAME,
+        TIER_START_DATE,
+        TIER_END_DATE,
+        EXPIRATION_DATE,
+        ACTION_TYPE
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_EXPIRED_MEMBERSHIPS
+      WHERE ACCOUNT_ID = ?
+      ORDER BY FOUNDATION_NAME ASC
+    `;
+
+    const result = await this.snowflakeService.execute<RawExpiredRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
       return { accountId, memberships: [] };
     }
 
-    let filtered = [...EXPIRED_MEMBERSHIPS];
+    let memberships: OrgExpiredMembership[] = result.rows.map((raw) => ({
+      foundationId: raw.FOUNDATION_ID,
+      foundationName: raw.FOUNDATION_NAME,
+      foundationLogo: raw.FOUNDATION_LOGO_URL,
+      membershipTier: raw.MEMBERSHIP_TIER_DISPLAY_NAME,
+      tierStartDate: this.formatDate(raw.TIER_START_DATE),
+      tierEndDate: this.formatDate(raw.TIER_END_DATE),
+      expirationDate: this.formatDate(raw.EXPIRATION_DATE),
+      actionType: raw.ACTION_TYPE,
+    }));
 
     if (search) {
       const term = search.toLowerCase();
-      filtered = filtered.filter((m) => m.foundationName.toLowerCase().includes(term));
+      memberships = memberships.filter((m) => m.foundationName.toLowerCase().includes(term));
     }
 
-    return { accountId, memberships: filtered };
+    return { accountId, memberships };
   }
 
-  public getDiscoverOpportunities(accountId: string): OrgDiscoverOpportunitiesResponse {
-    if (!this.isDemoAccount(accountId)) {
+  public async getDiscoverOpportunities(accountId: string): Promise<OrgDiscoverOpportunitiesResponse> {
+    const query = `
+      SELECT
+        FOUNDATION_ID,
+        FOUNDATION_NAME,
+        FOUNDATION_LOGO_URL,
+        PROJECT_TYPE,
+        SUGGESTED_TIER,
+        CONTRIBUTORS_COUNT,
+        CONTRIBUTION_COUNT,
+        RELEVANT_PROJECTS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_DISCOVER_MEMBERSHIPS
+      WHERE ACCOUNT_ID = ?
+      ORDER BY CONTRIBUTION_COUNT DESC
+    `;
+
+    const result = await this.snowflakeService.execute<RawDiscoverRow>(query, [accountId]);
+
+    if (result.rows.length === 0) {
       return { accountId, opportunities: [] };
     }
 
-    return { accountId, opportunities: [...DISCOVER_OPPORTUNITIES] };
+    const opportunities: OrgDiscoverOpportunity[] = result.rows.map((raw) => ({
+      foundationId: raw.FOUNDATION_ID,
+      foundationName: raw.FOUNDATION_NAME,
+      foundationLogo: raw.FOUNDATION_LOGO_URL,
+      category: raw.PROJECT_TYPE ?? '',
+      suggestedTier: raw.SUGGESTED_TIER ?? '',
+      relevantProjects: raw.RELEVANT_PROJECTS,
+      contributors: raw.CONTRIBUTORS_COUNT,
+      contributions: raw.CONTRIBUTION_COUNT,
+    }));
+
+    return { accountId, opportunities };
   }
 
-  private isDemoAccount(accountId: string): boolean {
-    return accountId.startsWith(DEMO_ACCOUNT_ID_PREFIX);
+  private shapeRow(raw: RawMembershipRow): OrgActiveMembership {
+    return {
+      foundationId: raw.FOUNDATION_ID,
+      foundationName: raw.FOUNDATION_NAME,
+      foundationLogo: raw.FOUNDATION_LOGO_URL,
+      projectCount: raw.PROJECT_COUNT,
+      memberCount: raw.MEMBER_COUNT,
+      membershipTier: raw.MEMBERSHIP_TIER_DISPLAY_NAME,
+      tierStartDate: this.formatDate(raw.TIER_START_DATE),
+      tierEndDate: this.formatDate(raw.TIER_END_DATE),
+      memberSince: raw.FIRST_MEMBERSHIP_STARTED_AT ? this.formatDate(raw.FIRST_MEMBERSHIP_STARTED_AT) : null,
+      boardMembers: raw.BOARD_MEMBER_SEAT_COUNT,
+      committeeMembers: raw.COMMITTEE_MEMBER_SEAT_COUNT,
+      orgProjects: raw.ORG_PROJECTS_COUNT,
+    };
+  }
+
+  private formatDate(dateValue: string | null): string {
+    if (!dateValue) return '';
+    const d = new Date(dateValue);
+    return d.toISOString().split('T')[0];
   }
 }

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -11,7 +11,6 @@ export interface OrgActiveMembership {
   foundationId: string;
   foundationName: string;
   foundationLogo: string | null;
-  foundationInitials: string;
   projectCount: number;
   memberCount: number;
   membershipTier: string;
@@ -32,8 +31,7 @@ export interface OrgActiveMembershipsResponse {
 export interface OrgExpiredMembership {
   foundationId: string;
   foundationName: string;
-  foundationInitials: string;
-  foundationColor: string;
+  foundationLogo: string | null;
   membershipTier: string;
   tierStartDate: string;
   tierEndDate: string;
@@ -49,8 +47,7 @@ export interface OrgExpiredMembershipsResponse {
 export interface OrgDiscoverOpportunity {
   foundationId: string;
   foundationName: string;
-  foundationInitials: string;
-  foundationColor: string;
+  foundationLogo: string | null;
   category: string;
   suggestedTier: string;
   relevantProjects: number;


### PR DESCRIPTION
## Summary

Replace hardcoded mock data across all three memberships tabs (Active, Expired, Discover) with Snowflake-backed queries via `SnowflakeService`.

**Changes:**
- **BFF service** (`org-lens-memberships.service.ts`): All 3 methods (`getActiveMemberships`, `getExpiredMemberships`, `getDiscoverOpportunities`) now async, querying Snowflake. Mock data constants removed. Summary computed from unfiltered rows; JS-side search/tier/renewal filtering.
- **Controller** (`org-lens-memberships.controller.ts`): Added `await` for all 3 now-async service methods.
- **Interfaces** (`org-memberships.interface.ts`): Removed `foundationInitials` from `OrgActiveMembership`. Removed `foundationInitials`/`foundationColor` from `OrgExpiredMembership` and `OrgDiscoverOpportunity`, added `foundationLogo: string | null`.
- **Component TS** (`org-memberships.component.ts`): Dynamic tier dropdown via `computed()` signal from fetched data. Added `getInitials()`, `getLogoClasses()`, `getRenewUrl()`, `getJoinUrl()` helpers. Fixed tier dropdown losing options when filter applied (stable `allTiers` signal).
- **Template** (`org-memberships.component.html`): All 3 tabs use logo/initials fallback pattern. Expired tab: Renew → `<a>` to myorg.lfx.dev, Contact Us → `<a>` to LF support. Discover tab: Join → `<a>` to membership page. Dynamic `tierOptions()` signal call.

**Depends on:** [lf-dbt PR #2431](https://github.com/linuxfoundation/lf-dbt/pull/2431) — dbt models must be deployed first.

**Note:** Snowflake queries temporarily use `ANALYTICS_DEV.LF_LUIS_PLATINUM_LFX_ONE.*` for local testing. Switch to `ANALYTICS.PLATINUM_LFX_ONE.*` before merging to production.

Resolves: [LFXV2-1859](https://linuxfoundation.atlassian.net/browse/LFXV2-1859)

## Test plan

- [ ] Navigate to `/org/memberships`, select an org with known memberships
- [ ] Active tab: verify summary cards show real counts, table shows real data, tier dropdown is dynamic, filtering changes table but not summary
- [ ] Expired tab: verify real expired memberships, Renew links to myorg.lfx.dev for active foundations, Contact Us links to LF support for deactivated
- [ ] Discover tab: verify non-member foundations with contributions, Join links to membership page
- [ ] Search filtering works on Active and Expired tabs
- [ ] Empty states render correctly for orgs with no data
- [ ] `yarn check-types`, `yarn lint:check`, `yarn build` all pass


Made with [Cursor](https://cursor.com)

[LFXV2-1859]: https://linuxfoundation.atlassian.net/browse/LFXV2-1859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ