### PR TITLE
feat(dashboards): add focus program filter to web activity tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -3,9 +3,10 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
-import { catchError, finalize, of, switchMap } from 'rxjs';
+import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
 import type { MarketingImpactFocusProgram, PerformanceSummaryKpi, WebActivitiesSummaryResponse, WebActivityDomainRow } from '@lfx-one/shared/interfaces';
 
@@ -38,16 +39,18 @@ export class WebActivityTabComponent {
   // === Private Initializers ===
   private initWebData(): Signal<WebActivitiesSummaryResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
+    const focus$ = toObservable(this.focusProgram);
 
     return toSignal(
-      slug$.pipe(
-        switchMap((slug) => {
+      combineLatest([slug$, focus$]).pipe(
+        switchMap(([slug, focus]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getWebActivitiesSummary(slug).pipe(
+          const classification = FOCUS_TO_CLASSIFICATION[focus];
+          return this.analyticsService.getWebActivitiesSummary(slug, classification).pipe(
             catchError(() => of(null)),
             finalize(() => this.loading.set(false))
           );

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -833,6 +833,7 @@ export class AnalyticsService {
   /**
    * Get web activities summary grouped by domain category
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
+   * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'Events', 'Corporate')
    * @returns Observable of web activities summary response
    */
   public getWebActivitiesSummary(foundationSlug: string, classification?: string): Observable<WebActivitiesSummaryResponse> {
@@ -854,6 +855,7 @@ export class AnalyticsService {
   /**
    * Get email click-through rate data
    * @param foundationSlug - Foundation slug to filter by
+   * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'Events', 'Corporate')
    * @returns Observable of email CTR response
    */
   public getEmailCtr(foundationSlug: string, classification?: string): Observable<EmailCtrResponse> {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -835,8 +835,10 @@ export class AnalyticsService {
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
    * @returns Observable of web activities summary response
    */
-  public getWebActivitiesSummary(foundationSlug: string): Observable<WebActivitiesSummaryResponse> {
-    return this.http.get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', { params: { foundationSlug } }).pipe(
+  public getWebActivitiesSummary(foundationSlug: string, classification?: string): Observable<WebActivitiesSummaryResponse> {
+    const params: Record<string, string> = { foundationSlug };
+    if (classification) params['classification'] = classification;
+    return this.http.get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', { params }).pipe(
       catchError(() => {
         return of({
           totalSessions: 0,

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -1938,7 +1938,8 @@ export class AnalyticsController {
         });
       }
 
-      const response = await this.projectService.getWebActivitiesSummary(foundationSlug);
+      const classification = getStringQueryParam(req, 'classification');
+      const response = await this.projectService.getWebActivitiesSummary(foundationSlug, classification);
 
       logger.success(req, 'get_web_activities_summary', startTime, {
         foundation_slug: foundationSlug,

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -1939,6 +1939,13 @@ export class AnalyticsController {
       }
 
       const classification = getStringQueryParam(req, 'classification');
+
+      if (classification && !VALID_CLASSIFICATIONS.has(classification)) {
+        throw ServiceValidationError.forField('classification', `Invalid classification value. Allowed: ${[...VALID_CLASSIFICATIONS].join(', ')}`, {
+          operation: 'get_web_activities_summary',
+        });
+      }
+
       const response = await this.projectService.getWebActivitiesSummary(foundationSlug, classification);
 
       logger.success(req, 'get_web_activities_summary', startTime, {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -1932,6 +1932,12 @@ export class AnalyticsController {
         });
       }
 
+      if (foundationSlug.length > NAME_MAX_LENGTH) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug exceeds maximum length', {
+          operation: 'get_web_activities_summary',
+        });
+      }
+
       if (!SLUG_PATTERN.test(foundationSlug)) {
         throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
           operation: 'get_web_activities_summary',

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1924,6 +1924,7 @@ export class ProjectService {
    * Get web activities summary grouped by domain category
    * Queries ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_SUMMARY and ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_PROJECT
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG (aggregates all projects under the foundation)
+   * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g. 'Events', 'Corporate')
    */
   public async getWebActivitiesSummary(foundationSlug: string, classification?: string): Promise<WebActivitiesSummaryResponse> {
     logger.debug(undefined, 'get_web_activities_summary', 'Fetching web activities summary from Snowflake', {
@@ -1999,6 +2000,7 @@ export class ProjectService {
    * Get email click-through rate data from Snowflake
    * Queries ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CTR_SUMMARY and ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CTR_BY_MONTH
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG
+   * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g. 'Events', 'Corporate')
    * @returns Email CTR response with monthly trend and change percentage
    */
   public async getEmailCtr(foundationSlug: string, classification?: string): Promise<EmailCtrResponse> {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1925,10 +1925,16 @@ export class ProjectService {
    * Queries ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_SUMMARY and ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_PROJECT
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG (aggregates all projects under the foundation)
    */
-  public async getWebActivitiesSummary(foundationSlug: string): Promise<WebActivitiesSummaryResponse> {
-    logger.debug(undefined, 'get_web_activities_summary', 'Fetching web activities summary from Snowflake', { foundation_slug: foundationSlug });
+  public async getWebActivitiesSummary(foundationSlug: string, classification?: string): Promise<WebActivitiesSummaryResponse> {
+    logger.debug(undefined, 'get_web_activities_summary', 'Fetching web activities summary from Snowflake', {
+      foundation_slug: foundationSlug,
+      classification,
+    });
 
     try {
+      const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
+      const classificationParams = classification ? [classification] : [];
+
       // Query 1: Total sessions & page views per domain classification
       const summaryQuery = `
         SELECT
@@ -1937,11 +1943,14 @@ export class ProjectService {
           SUM(TOTAL_PAGE_VIEWS_LAST_30_DAYS) AS TOTAL_PAGE_VIEWS
         FROM ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_SUMMARY
         WHERE FOUNDATION_SLUG = ?
+          ${classificationFilter}
         GROUP BY LF_SUB_DOMAIN_CLASSIFICATION
         ORDER BY TOTAL_SESSIONS DESC
       `;
 
       // Query 2: Weekly sessions for trend chart (last 6 months)
+      // WEB_ACTIVITIES_BY_PROJECT does not have LF_SUB_DOMAIN_CLASSIFICATION,
+      // so the trend chart always shows all-program totals.
       const dailyQuery = `
         SELECT
           DATE_TRUNC('WEEK', ACTIVITY_DATE) AS ACTIVITY_DATE,
@@ -1956,6 +1965,7 @@ export class ProjectService {
       const [summaryResult, dailyResult] = await Promise.all([
         this.snowflakeService.execute<{ LF_SUB_DOMAIN_CLASSIFICATION: string; TOTAL_SESSIONS: number; TOTAL_PAGE_VIEWS: number }>(summaryQuery, [
           foundationSlug,
+          ...classificationParams,
         ]),
         this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, [foundationSlug]),
       ]);


### PR DESCRIPTION
## Summary
- Wire the FOCUS bar program filter to the web activities summary endpoint via optional `classification` query param
- Backend filters `WEB_ACTIVITIES_SUMMARY` by `LF_SUB_DOMAIN_CLASSIFICATION` when a classification is provided
- `WEB_ACTIVITIES_BY_PROJECT` (daily trend) does not have that column, so the sparkline always shows all-program totals
- Frontend `web-activity-tab` uses `combineLatest` with `focusProgram` input, same pattern as email tab (#745)

Depends on #744, #745

LFXV2-1951

🤖 Generated with [Claude Code](https://claude.ai/code)