### PR TITLE
feat(crowdfunding): add initiatives, donations, and settings UI

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -211,6 +211,11 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },
       {
+        path: 'crowdfunding',
+        data: { lens: 'me' },
+        loadChildren: () => import('./modules/crowdfunding/crowdfunding.routes').then((m) => m.CROWDFUNDING_ROUTES),
+      },
+      {
         path: 'me/events',
         redirectTo: 'events',
         pathMatch: 'full',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -135,7 +135,20 @@ export class MainLayoutComponent {
         {
           label: 'Crowdfunding',
           icon: 'fa-light fa-circle-dollar',
-          url: environment.urls.crowdfunding,
+          isGroup: true,
+          expanded: true,
+          items: [
+            {
+              label: 'My Initiatives',
+              icon: 'fa-light fa-hand-holding-heart',
+              routerLink: '/crowdfunding/initiatives',
+            },
+            {
+              label: 'My Donations',
+              icon: 'fa-light fa-heart',
+              routerLink: '/crowdfunding/donations',
+            },
+          ],
         },
         {
           label: 'Badges',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -135,20 +135,22 @@ export class MainLayoutComponent {
         {
           label: 'Crowdfunding',
           icon: 'fa-light fa-circle-dollar',
-          isGroup: true,
-          expanded: true,
-          items: [
-            {
-              label: 'My Initiatives',
-              icon: 'fa-light fa-hand-holding-heart',
-              routerLink: '/crowdfunding/initiatives',
-            },
-            {
-              label: 'My Donations',
-              icon: 'fa-light fa-heart',
-              routerLink: '/crowdfunding/donations',
-            },
-          ],
+          url: environment.urls.crowdfunding,
+          // TODO: add group items back in when the crowdfunding app is ready
+          // isGroup: true,
+          // expanded: true,
+          // items: [
+          //   {
+          //     label: 'My Initiatives',
+          //     icon: 'fa-light fa-hand-holding-heart',
+          //     routerLink: '/crowdfunding/initiatives',
+          //   },
+          //   {
+          //     label: 'My Donations',
+          //     icon: 'fa-light fa-heart',
+          //     routerLink: '/crowdfunding/donations',
+          //   },
+          // ],
         },
         {
           label: 'Badges',

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.mock.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.mock.ts
@@ -1,0 +1,81 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { environment } from '@environments/environment';
+import { FundType } from '@lfx-one/shared/enums';
+import { CrowdfundingInitiative, CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+
+export const MOCK_INITIATIVES: CrowdfundingInitiative[] = [
+  {
+    id: 'otel',
+    name: 'OpenTelemetry Community Fund',
+    description: 'Growing the observability standard for cloud-native software',
+    icon: '📡',
+    fundType: FundType.GENERAL_FUND,
+    status: 'active',
+    raised: 68000,
+    goal: 175000,
+    sponsorsCount: 94,
+    publicUrl: environment.urls.crowdfunding,
+  },
+  {
+    id: 'zephyr',
+    name: 'Zephyr RTOS Security Hardening',
+    description: 'Securing the real-time OS powering billions of IoT devices',
+    icon: '⚡',
+    fundType: FundType.SECURITY_AUDIT,
+    status: 'active',
+    raised: 52000,
+    goal: 200000,
+    sponsorsCount: 41,
+    publicUrl: environment.urls.crowdfunding,
+  },
+  {
+    id: 'lkm',
+    name: 'Linux Kernel Mentorship Fund',
+    description: 'Supporting contributors entering the Linux kernel ecosystem',
+    icon: '🌱',
+    fundType: FundType.MENTORSHIP,
+    status: 'pending',
+    raised: 0,
+    goal: null,
+    sponsorsCount: 0,
+  },
+];
+
+export const MOCK_INITIATIVE_DETAIL: CrowdfundingInitiativeDetail = {
+  id: 'otel',
+  name: 'OpenTelemetry Community Fund',
+  description: 'Growing the observability standard for cloud-native software.',
+  icon: '📡',
+  fundType: FundType.GENERAL_FUND,
+  status: 'active',
+  raised: 68000,
+  goal: 175000,
+  sponsorsCount: 94,
+  publicUrl: environment.urls.crowdfunding,
+  about:
+    'Funds maintainer stipends, CI/CD infrastructure, community events, and documentation for the OpenTelemetry project — the emerging standard for distributed tracing and observability.',
+  balance: 23000,
+  monthlyDelta: 3200,
+  tags: ['Observability', 'Cloud Native', 'CNCF'],
+  alloc: [
+    { name: 'Maintainer Stipends', spent: 28000, total: 70000, pct: 40 },
+    { name: 'Infrastructure & CI', spent: 12000, total: 40000, pct: 30 },
+    { name: 'Community Events', spent: 5000, total: 35000, pct: 14 },
+    { name: 'Documentation', spent: 0, total: 30000, pct: 0 },
+  ],
+  donationsIn: [
+    { who: 'Google Cloud', org: true, amount: 15000, date: 'May 8, 2026' },
+    { who: 'Cisco', org: true, amount: 5000, date: 'May 1, 2026' },
+    { who: 'Microsoft', org: true, amount: 10000, date: 'Apr 2, 2026' },
+    { who: 'Sarah Chen', amount: 250, date: 'Apr 14, 2026' },
+    { who: 'Intel', org: true, amount: 8000, date: 'Mar 15, 2026' },
+    { who: 'Red Hat', org: true, amount: 4750, date: 'Feb 20, 2026' },
+  ],
+  donationsOut: [
+    { who: 'Maintainer Stipends — Q1', amount: 12000, date: 'Mar 31, 2026' },
+    { who: 'Infrastructure — DigitalOcean', amount: 4000, date: 'Apr 18, 2026' },
+    { who: 'KubeCon Community Meetup', amount: 5000, date: 'Mar 22, 2026' },
+  ],
+};

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.mock.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.mock.ts
@@ -3,7 +3,14 @@
 
 import { environment } from '@environments/environment';
 import { FundType } from '@lfx-one/shared/enums';
-import { CrowdfundingInitiative, CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+import {
+  CrowdfundingInitiative,
+  CrowdfundingInitiativeDetail,
+  DonationHistoryItem,
+  DonationStats,
+  PaymentMethod,
+  RecurringDonation,
+} from '@lfx-one/shared/interfaces';
 
 export const MOCK_INITIATIVES: CrowdfundingInitiative[] = [
   {
@@ -79,3 +86,148 @@ export const MOCK_INITIATIVE_DETAIL: CrowdfundingInitiativeDetail = {
     { who: 'KubeCon Community Meetup', amount: 5000, date: 'Mar 22, 2026' },
   ],
 };
+
+export const MOCK_DONATION_STATS: DonationStats = {
+  totalDonated: 1450,
+  initiativesSupported: 6,
+  activeRecurringAmount: 50,
+  activeRecurringCount: 1,
+};
+
+export const MOCK_RECURRING_DONATIONS: RecurringDonation[] = [
+  {
+    id: 'curl',
+    name: 'curl Maintenance Fund',
+    icon: '🌀',
+    status: 'active',
+    amount: 50,
+    billingDescription: 'Billed monthly on the 1st',
+    startDate: 'Jan 2025',
+    nextChargeDate: 'Jun 1, 2026',
+  },
+  {
+    id: 'rust-for-linux',
+    name: 'Rust for Linux',
+    icon: '🦀',
+    status: 'paused',
+    amount: 25,
+    billingDescription: 'Billed monthly on the 5th',
+    startDate: 'Dec 2025',
+    pausedSince: 'Feb 5, 2026',
+  },
+];
+
+export const MOCK_DONATION_HISTORY: DonationHistoryItem[] = [
+  {
+    id: 'd1',
+    initiativeName: 'Kubernetes Security Audit',
+    initiativeIcon: '🔐',
+    fundType: 'Security Audit',
+    fundTypeIcon: 'fa-shield-halved',
+    date: 'Apr 2, 2026',
+    kind: 'one-time',
+    amount: 500,
+  },
+  {
+    id: 'd2',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Apr 1, 2026',
+    kind: 'monthly',
+    amount: 50,
+  },
+  {
+    id: 'd3',
+    initiativeName: 'Linux Kernel Mentorship',
+    initiativeIcon: '🐧',
+    fundType: 'Mentorship',
+    fundTypeIcon: 'fa-user-group',
+    date: 'Mar 15, 2026',
+    kind: 'one-time',
+    amount: 250,
+  },
+  {
+    id: 'd4',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Mar 1, 2026',
+    kind: 'monthly',
+    amount: 50,
+  },
+  {
+    id: 'd5',
+    initiativeName: "Let's Encrypt Infrastructure",
+    initiativeIcon: '🔒',
+    fundType: 'Security Audit',
+    fundTypeIcon: 'fa-shield-halved',
+    date: 'Jan 20, 2026',
+    kind: 'one-time',
+    amount: 100,
+  },
+  {
+    id: 'd6',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Jan 1, 2026',
+    kind: 'monthly',
+    amount: 50,
+  },
+  {
+    id: 'd7',
+    initiativeName: 'Rust for Linux',
+    initiativeIcon: '🦀',
+    fundType: 'Project',
+    fundTypeIcon: 'fa-display',
+    date: 'Dec 5, 2025',
+    kind: 'one-time',
+    amount: 100,
+  },
+  {
+    id: 'd8',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Dec 1, 2025',
+    kind: 'monthly',
+    amount: 50,
+  },
+  {
+    id: 'd9',
+    initiativeName: 'Node.js Sustainability',
+    initiativeIcon: '⬡',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Nov 12, 2025',
+    kind: 'one-time',
+    amount: 200,
+  },
+  {
+    id: 'd10',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Nov 1, 2025',
+    kind: 'monthly',
+    amount: 50,
+  },
+  {
+    id: 'd11',
+    initiativeName: 'curl Maintenance Fund',
+    initiativeIcon: '🌀',
+    fundType: 'General Fund',
+    fundTypeIcon: 'fa-piggy-bank',
+    date: 'Oct 1, 2025',
+    kind: 'monthly',
+    amount: 50,
+  },
+];
+
+export const MOCK_PAYMENT_METHODS: PaymentMethod[] = [{ id: 'pm1', brand: 'VISA', last4: '4567', expiry: '04/26' }];

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Routes } from '@angular/router';
+import { authGuard } from '@shared/guards/auth.guard';
+
+export const CROWDFUNDING_ROUTES: Routes = [
+  {
+    path: 'initiatives',
+    loadComponent: () => import('./my-initiatives/my-initiatives.component').then((m) => m.MyInitiativesComponent),
+    canActivate: [authGuard],
+  },
+  {
+    path: 'donations',
+    loadComponent: () => import('./my-donations/my-donations.component').then((m) => m.MyDonationsComponent),
+    canActivate: [authGuard],
+  },
+];

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -11,6 +11,11 @@ export const CROWDFUNDING_ROUTES: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'initiatives/:id',
+    loadComponent: () => import('./initiative-detail/initiative-detail.component').then((m) => m.InitiativeDetailComponent),
+    canActivate: [authGuard],
+  },
+  {
     path: 'donations',
     loadComponent: () => import('./my-donations/my-donations.component').then((m) => m.MyDonationsComponent),
     canActivate: [authGuard],

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.html
@@ -1,0 +1,11 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card data-testid="announcements-card">
+  <div class="flex flex-col items-center py-10 gap-3">
+    <i class="fa-light fa-bullhorn text-5xl text-gray-300" aria-hidden="true"></i>
+    <h3 class="text-base font-semibold text-gray-700">No announcements yet</h3>
+    <p class="text-sm text-gray-500 mb-2">Keep sponsors engaged by sharing milestones and updates.</p>
+    <lfx-button label="New Announcement" icon="fa-light fa-plus" severity="primary" size="small" data-testid="new-announcement-btn" />
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { ButtonComponent } from '@components/button/button.component';
+
+@Component({
+  selector: 'lfx-initiative-announcements',
+  imports: [CardComponent, ButtonComponent],
+  templateUrl: './initiative-announcements.component.html',
+  styleUrl: './initiative-announcements.component.scss',
+})
+export class InitiativeAnnouncementsComponent {}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
@@ -46,8 +46,27 @@
           <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
         </a>
       }
-      <lfx-button label="Settings" icon="fa-light fa-gear" severity="secondary" size="small" data-testid="initiative-settings-btn" />
-      <lfx-button icon="fa-light fa-ellipsis" severity="secondary" size="small" data-testid="initiative-more-btn" />
+      <lfx-button
+        label="Settings"
+        icon="fa-light fa-gear"
+        severity="secondary"
+        size="small"
+        data-testid="initiative-settings-btn"
+        (click)="settingsClick.emit()" />
+      <lfx-button icon="fa-light fa-ellipsis" severity="secondary" size="small" data-testid="initiative-more-btn" (click)="onMoreClick($event)" />
+      <lfx-menu #moreMenu [model]="moreMenuItems" [popup]="true" appendTo="body" styleClass="w-72">
+        <ng-template #item let-item>
+          <button class="flex flex-col gap-0.5 w-full px-3 py-2.5 text-left hover:bg-gray-50 transition-colors" [class.hover:bg-red-50]="item.danger">
+            <div class="flex items-center gap-2 text-sm font-medium" [class.text-gray-800]="!item.danger" [class.text-red-600]="item.danger">
+              <i [class]="item.icon" aria-hidden="true"></i>
+              {{ item.label }}
+            </div>
+            @if (item.description) {
+              <div class="text-xs text-gray-400 leading-relaxed pl-5">{{ item.description }}</div>
+            }
+          </button>
+        </ng-template>
+      </lfx-menu>
     </div>
   </div>
 

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
@@ -1,0 +1,69 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="initiative-detail-header">
+  <!-- Header body -->
+  <div class="flex items-start gap-4 p-6" data-testid="initiative-header-body">
+    <!-- Avatar -->
+    <lfx-avatar [label]="initiative().name" shape="square" size="xlarge" [styleClass]="avatarStyleClass()" [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
+
+    <!-- Content: type label, title+status, desc, tags -->
+    <div class="flex flex-col gap-1.5 flex-1 min-w-0">
+      <span class="text-xs font-semibold flex items-center gap-1" [class]="fundTypeColorClass()">
+        <i [class]="fundTypeIcon()" aria-hidden="true"></i>
+        {{ fundTypeLabel() }}
+      </span>
+      <div class="flex items-center gap-2 flex-wrap">
+        <h1 class="text-xl font-bold text-gray-900">{{ initiative().name }}</h1>
+        @if (initiative().status === 'active') {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+        } @else if (initiative().status === 'pending') {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"> Pending </span>
+        } @else {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"> Closed </span>
+        }
+      </div>
+      <p class="text-sm text-gray-500">{{ initiative().description }}</p>
+      @if (initiative().tags.length) {
+        <div class="flex items-center gap-1.5 flex-wrap mt-1" data-testid="initiative-tags">
+          @for (tag of initiative().tags; track tag) {
+            <lfx-tag [value]="tag" severity="secondary" [rounded]="true" />
+          }
+        </div>
+      }
+    </div>
+
+    <!-- Actions -->
+    <div class="flex items-center gap-2 flex-shrink-0 ml-4" data-testid="initiative-header-actions">
+      @if (initiative().publicUrl) {
+        <a
+          [href]="initiative().publicUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+          data-testid="initiative-view-public-btn">
+          View Public Page
+          <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+        </a>
+      }
+      <lfx-button label="Settings" icon="fa-light fa-gear" severity="secondary" size="small" data-testid="initiative-settings-btn" />
+      <lfx-button icon="fa-light fa-ellipsis" severity="secondary" size="small" data-testid="initiative-more-btn" />
+    </div>
+  </div>
+
+  <!-- Tab bar -->
+  <div class="border-t border-gray-200 flex items-center px-2" data-testid="initiative-tab-bar">
+    @for (tab of tabOptions; track tab.id) {
+      <button
+        class="relative px-4 py-3 text-sm font-medium transition-colors"
+        [class]="activeTab() === tab.id ? 'text-blue-600' : 'text-gray-500 hover:text-gray-900'"
+        (click)="tabChange.emit(tab.id)"
+        [attr.data-testid]="'initiative-tab-' + tab.id">
+        {{ tab.label }}
+        @if (activeTab() === tab.id) {
+          <div class="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 rounded-full"></div>
+        }
+      </button>
+    }
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -1,0 +1,56 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { CardComponent } from '@components/card/card.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { ButtonComponent } from '@components/button/button.component';
+import {
+  CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_COLOR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_ICONS,
+  CROWDFUNDING_FUND_TYPE_LABELS,
+} from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+
+interface TabOption {
+  id: string;
+  label: string;
+}
+
+@Component({
+  selector: 'lfx-initiative-detail-header',
+  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent],
+  templateUrl: './initiative-detail-header.component.html',
+  styleUrl: './initiative-detail-header.component.scss',
+})
+export class InitiativeDetailHeaderComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly activeTab = input.required<string>();
+  public readonly tabChange = output<string>();
+
+  protected readonly tabOptions: TabOption[] = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'financials', label: 'Financials' },
+    { id: 'announcements', label: 'Announcements' },
+  ];
+
+  protected readonly fundTypeLabel = computed(() => CROWDFUNDING_FUND_TYPE_LABELS[this.initiative().fundType]);
+  protected readonly fundTypeIcon = computed(() => CROWDFUNDING_FUND_TYPE_ICONS[this.initiative().fundType]);
+  protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
+  protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
+
+  protected readonly progressPercent = computed(() => {
+    const { raised, goal } = this.initiative();
+    if (!goal || goal === 0) return 0;
+    return Math.min(100, Math.round((raised / goal) * 100));
+  });
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -1,11 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output } from '@angular/core';
+import { Component, computed, input, output, viewChild } from '@angular/core';
 import { AvatarComponent } from '@components/avatar/avatar.component';
-import { CardComponent } from '@components/card/card.component';
-import { TagComponent } from '@components/tag/tag.component';
 import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { TagComponent } from '@components/tag/tag.component';
 import {
   CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
   CROWDFUNDING_FUND_TYPE_COLOR_CLASSES,
@@ -13,15 +14,21 @@ import {
   CROWDFUNDING_FUND_TYPE_LABELS,
 } from '@lfx-one/shared/constants';
 import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+import { MenuItem } from 'primeng/api';
 
 interface TabOption {
   id: string;
   label: string;
 }
 
+interface InitiativeMenuItem extends MenuItem {
+  description?: string;
+  danger?: boolean;
+}
+
 @Component({
   selector: 'lfx-initiative-detail-header',
-  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent],
+  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent],
   templateUrl: './initiative-detail-header.component.html',
   styleUrl: './initiative-detail-header.component.scss',
 })
@@ -29,6 +36,9 @@ export class InitiativeDetailHeaderComponent {
   public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
   public readonly activeTab = input.required<string>();
   public readonly tabChange = output<string>();
+  public readonly settingsClick = output<void>();
+
+  private readonly moreMenu = viewChild<MenuComponent>('moreMenu');
 
   protected readonly tabOptions: TabOption[] = [
     { id: 'overview', label: 'Overview' },
@@ -36,21 +46,26 @@ export class InitiativeDetailHeaderComponent {
     { id: 'announcements', label: 'Announcements' },
   ];
 
+  protected readonly moreMenuItems: InitiativeMenuItem[] = [
+    {
+      label: 'Pause fundraising',
+      icon: 'fa-solid fa-pause',
+      description: 'Temporarily stop accepting new donations. Your initiative stays visible but the "Donate" button is hidden.',
+    },
+    {
+      label: 'Close initiative',
+      icon: 'fa-solid fa-circle-xmark',
+      description: 'Permanently close this initiative and stop all recurring donations. Remaining balance is handled per LF policy.',
+      danger: true,
+    },
+  ];
+
   protected readonly fundTypeLabel = computed(() => CROWDFUNDING_FUND_TYPE_LABELS[this.initiative().fundType]);
   protected readonly fundTypeIcon = computed(() => CROWDFUNDING_FUND_TYPE_ICONS[this.initiative().fundType]);
   protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
   protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
 
-  protected readonly progressPercent = computed(() => {
-    const { raised, goal } = this.initiative();
-    if (!goal || goal === 0) return 0;
-    return Math.min(100, Math.round((raised / goal) * 100));
-  });
-
-  protected formatCurrency(value: number): string {
-    if (value >= 1000) {
-      return `$${(value / 1000).toFixed(0)}K`;
-    }
-    return `$${value.toLocaleString()}`;
+  protected onMoreClick(event: Event): void {
+    this.moreMenu()?.toggle(event);
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.html
@@ -1,0 +1,54 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card data-testid="finance-summary-card">
+  <!-- Current balance -->
+  <div class="text-xs font-bold text-gray-500 uppercase tracking-wide mb-1.5">Current Balance</div>
+  <div class="text-3xl font-extrabold text-gray-900 tracking-tight mb-5">{{ formatCurrency(initiative().balance) }}</div>
+
+  <!-- Raised / goal row -->
+  <div class="flex items-center justify-between text-sm mb-1.5">
+    <span>
+      <span class="font-bold text-gray-900">{{ formatCurrency(initiative().raised) }} raised</span>
+      <span class="text-gray-500">of {{ formatCurrency(initiative().goal!) }} goal</span>
+    </span>
+    <span class="text-gray-500 text-xs">{{ progressPercent() }}% funded</span>
+  </div>
+
+  <!-- Progress bar -->
+  <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden mb-2">
+    <div
+      class="h-full bg-blue-600 rounded-full"
+      [style.width.%]="progressPercent()"
+      role="progressbar"
+      [attr.aria-valuenow]="progressPercent()"
+      aria-valuemin="0"
+      aria-valuemax="100"></div>
+  </div>
+  <p class="text-xs text-gray-500 mb-6">{{ initiative().sponsorsCount }} sponsors · ↑ +{{ formatCurrency(initiative().monthlyDelta) }} this month</p>
+
+  <!-- Funding allocation -->
+  <div class="text-sm font-bold text-gray-900 mb-4">Funding allocation</div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-7 gap-y-5" data-testid="allocation-grid">
+    @for (item of initiative().alloc; track item.name) {
+      <div class="flex items-center gap-3.5" data-testid="allocation-item">
+        <lfx-donut-chart [rings]="allocRings(item)" />
+        <div class="min-w-0">
+          <div class="flex items-center gap-2.5 mb-1.5">
+            <span class="text-sm font-bold text-gray-900 truncate">{{ item.name }}</span>
+            <span class="w-px h-3 bg-gray-300 shrink-0"></span>
+            <span class="text-sm text-gray-400 whitespace-nowrap">Goal: {{ formatCurrency(item.total) }}</span>
+          </div>
+          <div class="flex items-center gap-1.5 text-xs text-gray-500">
+            <span class="w-2 h-2 rounded-full bg-blue-600 shrink-0"></span>
+            Donated {{ formatCurrency(item.spent) }}
+          </div>
+          <div class="flex items-center gap-1.5 text-xs text-gray-500">
+            <span class="w-2 h-2 rounded-full bg-slate-800 shrink-0"></span>
+            Spent {{ formatCurrency(item.spent) }}
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.ts
@@ -1,0 +1,39 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { DonutChartComponent } from '@components/donut-chart/donut-chart.component';
+import { AllocationItem, CrowdfundingInitiativeDetail, DonutRing } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-finance-summary',
+  imports: [CardComponent, DonutChartComponent],
+  templateUrl: './initiative-finance-summary.component.html',
+  styleUrl: './initiative-finance-summary.component.scss',
+})
+export class InitiativeFinanceSummaryComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+
+  protected readonly progressPercent = computed(() => {
+    const { raised, goal } = this.initiative();
+    if (!goal || goal === 0) return 0;
+    return Math.min(100, Math.round((raised / goal) * 100));
+  });
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected allocRings(item: AllocationItem): DonutRing[] {
+    const donatedPct = Math.min(100, item.pct);
+    const spentPct = item.total > 0 ? Math.min(100, Math.round((item.spent / item.total) * 100)) : 0;
+    return [
+      { value: donatedPct, color: '#006BFF' },
+      { value: spentPct, color: '#1e293b' },
+    ];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.html
@@ -1,0 +1,110 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiative-financials">
+  <!-- Metrics bar -->
+  <div class="bg-white border border-gray-200 rounded-lg shadow-sm flex items-stretch overflow-hidden" data-testid="financials-metrics-bar">
+    <div class="flex-1 flex items-center gap-3 px-5 py-4">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-circle-down text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Total received</div>
+        <div class="text-lg font-bold text-gray-900">{{ formatCurrency(totalReceived()) }}</div>
+      </div>
+    </div>
+    <div class="flex-1 flex items-center gap-3 px-5 py-4 border-l border-gray-200">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-circle-up text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Total expenses</div>
+        <div class="text-lg font-bold text-gray-900">{{ formatCurrency(totalExpenses()) }}</div>
+      </div>
+    </div>
+    <div class="flex-1 flex items-center gap-3 px-5 py-4 border-l border-gray-200">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-scale-balanced text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Balance</div>
+        <div class="text-lg font-bold text-gray-900">{{ formatCurrency(balance()) }}</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Donations received -->
+  <div data-testid="donations-received-section">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-sm font-bold text-gray-900">Donations received</span>
+      <span class="text-xs text-gray-400">{{ initiative().donationsIn.length }} transactions</span>
+    </div>
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead>
+            <tr class="bg-gray-50 border-b border-gray-200">
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Date</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Sponsor</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Type</th>
+              <th class="text-right text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (donation of initiative().donationsIn; track donation.who + donation.date) {
+              <tr class="border-b border-gray-100 last:border-0" data-testid="donation-row">
+                <td class="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">{{ donation.date }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-2.5">
+                    <lfx-avatar [label]="donation.who" shape="square" size="normal" [styleClass]="donorAvatarClass(donation.who)" />
+                    <span class="text-sm font-medium text-gray-900">{{ donation.who }}</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  @if (donation.org) {
+                    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Company</span>
+                  } @else {
+                    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-violet-50 text-violet-700">Individual</span>
+                  }
+                </td>
+                <td class="px-4 py-3 text-right text-sm font-bold text-gray-900 whitespace-nowrap">
+                  {{ formatCurrency(donation.amount) }}
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Expense breakdown -->
+  <div data-testid="expenses-section">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-sm font-bold text-gray-900">Expense breakdown</span>
+      <span class="text-xs text-gray-400">{{ initiative().donationsOut.length }} transactions</span>
+    </div>
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead>
+            <tr class="bg-gray-50 border-b border-gray-200">
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Date</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Description</th>
+              <th class="text-right text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (expense of initiative().donationsOut; track expense.who + expense.date) {
+              <tr class="border-b border-gray-100 last:border-0" data-testid="expense-row">
+                <td class="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">{{ expense.date }}</td>
+                <td class="px-4 py-3 text-sm text-gray-700">{{ expense.who }}</td>
+                <td class="px-4 py-3 text-right text-sm font-bold text-red-600 whitespace-nowrap">−{{ formatCurrency(expense.amount) }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { CROWDFUNDING_DONOR_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-financials',
+  imports: [AvatarComponent],
+  templateUrl: './initiative-financials.component.html',
+  styleUrl: './initiative-financials.component.scss',
+})
+export class InitiativeFinancialsComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+
+  protected readonly totalReceived = computed(() => {
+    return this.initiative().donationsIn.reduce((sum, d) => sum + d.amount, 0);
+  });
+
+  protected readonly totalExpenses = computed(() => {
+    return this.initiative().donationsOut.reduce((sum, d) => sum + d.amount, 0);
+  });
+
+  protected readonly balance = computed(() => {
+    return this.totalReceived() - this.totalExpenses();
+  });
+
+  protected donorAvatarClass(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) & 0xffffff;
+    }
+    return CROWDFUNDING_DONOR_AVATAR_PALETTE[Math.abs(hash) % CROWDFUNDING_DONOR_AVATAR_PALETTE.length];
+  }
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.html
@@ -1,0 +1,46 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiative-overview-sidebar">
+  <!-- Matching banner (optional) -->
+  @if (initiative().matchLabel) {
+    <div class="rounded-lg p-5 text-white" style="background: linear-gradient(135deg, #4f46e5, #7c3aed)" data-testid="matching-banner">
+      <div class="text-sm font-bold mb-1">{{ initiative().matchLabel }}</div>
+      <div class="text-xs opacity-90 leading-relaxed mb-4">{{ initiative().matchDesc }}</div>
+      <div class="h-1 bg-white/30 rounded-full overflow-hidden">
+        <div class="h-full bg-white rounded-full" [style.width.%]="initiative().matchPct ?? 0"></div>
+      </div>
+      <div class="text-xs opacity-70 mt-1.5">{{ initiative().matchPct }}% matched</div>
+    </div>
+  }
+
+  <!-- Recent donations card -->
+  <lfx-card data-testid="recent-donations-card">
+    <div class="flex items-center justify-between mb-4">
+      <div class="text-sm font-bold text-gray-900">Recent donations</div>
+      <button
+        class="text-xs font-medium text-blue-600 hover:text-blue-700 transition-colors"
+        (click)="viewAllFinancials.emit()"
+        data-testid="view-all-financials-btn">
+        View all
+      </button>
+    </div>
+    <div class="flex flex-col" data-testid="activity-feed">
+      @for (donation of recentDonations(); track donation.who + donation.date) {
+        <div class="flex items-center gap-3 py-2.5 border-b border-gray-100 last:border-0" data-testid="activity-row">
+          <lfx-avatar [label]="donation.who" shape="square" size="normal" [styleClass]="donorAvatarClass(donation.who)" />
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-900 truncate">
+              {{ donation.who }}
+              @if (donation.org) {
+                <span class="ml-1 text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded font-medium">ORG</span>
+              }
+            </div>
+            <div class="text-xs text-gray-400">{{ donation.date }}</div>
+          </div>
+          <div class="text-sm font-bold text-gray-900 whitespace-nowrap">{{ formatCurrency(donation.amount) }}</div>
+        </div>
+      }
+    </div>
+  </lfx-card>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.ts
@@ -1,0 +1,38 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { CardComponent } from '@components/card/card.component';
+import { CROWDFUNDING_DONOR_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-overview-sidebar',
+  imports: [CardComponent, AvatarComponent],
+  templateUrl: './initiative-overview-sidebar.component.html',
+  styleUrl: './initiative-overview-sidebar.component.scss',
+})
+export class InitiativeOverviewSidebarComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly viewAllFinancials = output<void>();
+
+  protected readonly recentDonations = computed(() => {
+    return this.initiative().donationsIn.slice(0, 5);
+  });
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected donorAvatarClass(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) & 0xffffff;
+    }
+    return CROWDFUNDING_DONOR_AVATAR_PALETTE[Math.abs(hash) % CROWDFUNDING_DONOR_AVATAR_PALETTE.length];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="grid grid-cols-1 lg:grid-cols-[3fr_1fr] gap-5 items-start" data-testid="initiative-overview">
+  <!-- Left column -->
+  <div class="flex flex-col gap-5">
+    <!-- Finance summary card -->
+    <lfx-initiative-finance-summary [initiative]="initiative()" />
+
+    <!-- About card -->
+    <lfx-card data-testid="about-card">
+      <div class="text-sm font-bold text-gray-900 mb-4">About this Initiative</div>
+      <p class="text-sm text-gray-600 leading-relaxed mb-3">{{ initiative().about }}</p>
+      <p class="text-sm text-gray-600 leading-relaxed mb-3">
+        Contributions go directly toward sustaining long-term maintainership, funding critical infrastructure, and ensuring the project remains vendor-neutral
+        and community-driven. All expenditures are tracked transparently and reported quarterly to sponsors and the broader community.
+      </p>
+      <p class="text-sm text-gray-600 leading-relaxed">
+        Whether you're an individual developer or a large organization, your support helps ensure this project continues to evolve, stays secure, and remains
+        accessible to everyone — regardless of company size or resources.
+      </p>
+    </lfx-card>
+  </div>
+
+  <!-- Right column -->
+  <lfx-initiative-overview-sidebar [initiative]="initiative()" (viewAllFinancials)="viewAllFinancials.emit()" />
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.ts
@@ -1,0 +1,19 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+import { InitiativeFinanceSummaryComponent } from '../initiative-finance-summary/initiative-finance-summary.component';
+import { InitiativeOverviewSidebarComponent } from '../initiative-overview-sidebar/initiative-overview-sidebar.component';
+
+@Component({
+  selector: 'lfx-initiative-overview',
+  imports: [CardComponent, InitiativeFinanceSummaryComponent, InitiativeOverviewSidebarComponent],
+  templateUrl: './initiative-overview.component.html',
+  styleUrl: './initiative-overview.component.scss',
+})
+export class InitiativeOverviewComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly viewAllFinancials = output<void>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -89,8 +89,9 @@
               </span>
             }
             <input
+              pInputText
               type="text"
-              class="flex-1 min-w-[80px] border-none outline-none text-sm bg-transparent py-0.5"
+              class="flex-1 min-w-[80px] border-none outline-none text-sm bg-transparent py-0.5 p-0 shadow-none"
               placeholder="Add category…"
               [value]="newTagValue()"
               (input)="newTagValue.set($any($event.target).value)"
@@ -144,24 +145,21 @@
         <p class="text-sm text-gray-500">You will be automatically added as a beneficiary. Add others who can submit expenses below.</p>
 
         <div class="flex flex-col gap-3" data-testid="settings-beneficiaries-list">
-          @for (beneficiary of beneficiaries(); track $index) {
+          @for (group of beneficiaryGroups(); track $index) {
             <div class="flex items-center gap-2" [attr.data-testid]="'settings-beneficiary-row-' + $index">
-              <input
-                pInputText
-                type="text"
-                class="flex-1"
+              <lfx-input-text
+                [form]="group"
+                control="name"
                 placeholder="Full name"
-                [value]="beneficiary.name"
-                (input)="updateBeneficiary($index, 'name', $any($event.target).value)"
-                [attr.aria-label]="'Beneficiary ' + ($index + 1) + ' full name'" />
-              <input
-                pInputText
+                class="flex-1"
+                [dataTest]="'beneficiary-name-' + $index" />
+              <lfx-input-text
+                [form]="group"
+                control="email"
                 type="email"
-                class="flex-[2]"
                 placeholder="Email"
-                [value]="beneficiary.email"
-                (input)="updateBeneficiary($index, 'email', $any($event.target).value)"
-                [attr.aria-label]="'Beneficiary ' + ($index + 1) + ' email'" />
+                class="flex-[2]"
+                [dataTest]="'beneficiary-email-' + $index" />
               <button
                 type="button"
                 (click)="removeBeneficiary($index)"

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -147,19 +147,8 @@
         <div class="flex flex-col gap-3" data-testid="settings-beneficiaries-list">
           @for (group of beneficiaryGroups(); track $index) {
             <div class="flex items-center gap-2" [attr.data-testid]="'settings-beneficiary-row-' + $index">
-              <lfx-input-text
-                [form]="group"
-                control="name"
-                placeholder="Full name"
-                class="flex-1"
-                [dataTest]="'beneficiary-name-' + $index" />
-              <lfx-input-text
-                [form]="group"
-                control="email"
-                type="email"
-                placeholder="Email"
-                class="flex-[2]"
-                [dataTest]="'beneficiary-email-' + $index" />
+              <lfx-input-text [form]="group" control="name" placeholder="Full name" class="flex-1" [dataTest]="'beneficiary-name-' + $index" />
+              <lfx-input-text [form]="group" control="email" type="email" placeholder="Email" class="flex-[2]" [dataTest]="'beneficiary-email-' + $index" />
               <button
                 type="button"
                 (click)="removeBeneficiary($index)"

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -1,0 +1,209 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[600px] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="initiative-settings-drawer">
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full">
+      <div class="flex flex-col gap-0.5 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="initiative-settings-drawer-title">Initiative Settings</h2>
+        <p class="text-sm text-gray-500">{{ initiative().name }}</p>
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors flex-shrink-0"
+        aria-label="Close panel"
+        data-testid="initiative-settings-drawer-close">
+        <i class="fa-light fa-xmark text-xl pointer-events-none"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-6 pb-2 overflow-x-hidden" data-testid="initiative-settings-drawer-content">
+    <!-- Tab bar -->
+    <div class="flex items-center border-b border-gray-200 -mx-6 px-6 -mt-2" data-testid="initiative-settings-tabs">
+      @for (tab of settingsTabs; track tab.id) {
+        <button
+          class="relative px-4 py-2.5 text-sm font-medium transition-colors whitespace-nowrap"
+          [class]="activeSettingsTab() === tab.id ? 'text-blue-600' : 'text-gray-500 hover:text-gray-800'"
+          (click)="activeSettingsTab.set(tab.id)"
+          [attr.data-testid]="'settings-tab-' + tab.id">
+          {{ tab.label }}
+          @if (activeSettingsTab() === tab.id) {
+            <div class="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 rounded-full"></div>
+          }
+        </button>
+      }
+    </div>
+
+    <!-- Initiative details tab -->
+    @if (activeSettingsTab() === 'details') {
+      <div class="flex flex-col gap-5" data-testid="settings-details-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">General Fund Details</h3>
+
+        <!-- Name -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-name">
+          <div class="flex items-center justify-between">
+            <label for="settings-name" class="text-sm font-medium text-gray-700">
+              Initiative name <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <span class="text-xs text-gray-400">{{ nameLength() }}/100</span>
+          </div>
+          <lfx-input-text [form]="form" control="name" id="settings-name" placeholder="Enter initiative name" />
+        </div>
+
+        <!-- Elevator pitch -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-description">
+          <div class="flex items-center justify-between">
+            <label for="settings-description" class="text-sm font-medium text-gray-700">
+              Elevator Pitch <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <span class="text-xs text-gray-400">{{ descriptionLength() }}/500</span>
+          </div>
+          <lfx-textarea
+            [form]="form"
+            control="description"
+            id="settings-description"
+            [rows]="4"
+            [maxlength]="500"
+            placeholder="Describe your initiative in a few sentences…" />
+        </div>
+
+        <!-- Topic / Category tags -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-tags">
+          <label class="text-sm font-medium text-gray-700"> Topic / Category <span class="text-red-500" aria-hidden="true">*</span> </label>
+          <div
+            class="flex flex-wrap items-center gap-1.5 p-2 border border-gray-300 rounded-md min-h-[42px] bg-white focus-within:border-blue-500 transition-colors cursor-text">
+            @for (tag of tags(); track tag) {
+              <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-50 text-blue-700 px-2 py-1 rounded">
+                {{ tag }}
+                <button type="button" (click)="removeTag(tag)" class="hover:text-blue-900 ml-0.5" [attr.aria-label]="'Remove ' + tag + ' category'">
+                  <i class="fa-solid fa-xmark text-[10px]" aria-hidden="true"></i>
+                </button>
+              </span>
+            }
+            <input
+              type="text"
+              class="flex-1 min-w-[80px] border-none outline-none text-sm bg-transparent py-0.5"
+              placeholder="Add category…"
+              [value]="newTagValue()"
+              (input)="newTagValue.set($any($event.target).value)"
+              (keydown.enter)="$event.preventDefault(); addTag()"
+              aria-label="Add category tag" />
+          </div>
+          <p class="text-xs text-gray-400">Press Enter to add a category.</p>
+        </div>
+
+        <!-- Website URL -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-website">
+          <label for="settings-website" class="text-sm font-medium text-gray-700">Website URL</label>
+          <lfx-input-text [form]="form" control="websiteUrl" id="settings-website" type="url" placeholder="https://example.org" />
+        </div>
+      </div>
+    }
+
+    <!-- Branding tab -->
+    @else if (activeSettingsTab() === 'branding') {
+      <div class="flex flex-col gap-5" data-testid="settings-branding-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Branding</h3>
+
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-logo">
+          <label class="text-sm font-medium text-gray-700"> Initiative logo <span class="text-red-500" aria-hidden="true">*</span> </label>
+          <div class="flex items-center gap-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
+            <!-- Current logo preview -->
+            <div
+              class="w-16 h-16 rounded-lg border border-gray-200 bg-white flex items-center justify-center text-3xl flex-shrink-0"
+              data-testid="settings-logo-preview"
+              aria-label="Current initiative logo">
+              {{ initiative().icon }}
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <p class="text-sm font-medium text-gray-700">{{ initiative().name | lowercase }}-logo.png</p>
+              <p class="text-xs text-gray-500">PNG, JPG, or SVG. Recommended size: 256×256px.</p>
+              <div class="flex items-center gap-2 mt-1">
+                <lfx-button label="Remove" icon="fa-regular fa-trash-can" severity="secondary" size="small" data-testid="settings-logo-remove-btn" />
+                <lfx-button label="Choose different" icon="fa-solid fa-upload" severity="secondary" size="small" data-testid="settings-logo-upload-btn" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- Beneficiaries tab -->
+    @else if (activeSettingsTab() === 'beneficiaries') {
+      <div class="flex flex-col gap-5" data-testid="settings-beneficiaries-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Beneficiaries</h3>
+
+        <p class="text-sm text-gray-500">You will be automatically added as a beneficiary. Add others who can submit expenses below.</p>
+
+        <div class="flex flex-col gap-3" data-testid="settings-beneficiaries-list">
+          @for (beneficiary of beneficiaries(); track $index) {
+            <div class="flex items-center gap-2" [attr.data-testid]="'settings-beneficiary-row-' + $index">
+              <input
+                pInputText
+                type="text"
+                class="flex-1"
+                placeholder="Full name"
+                [value]="beneficiary.name"
+                (input)="updateBeneficiary($index, 'name', $any($event.target).value)"
+                [attr.aria-label]="'Beneficiary ' + ($index + 1) + ' full name'" />
+              <input
+                pInputText
+                type="email"
+                class="flex-[2]"
+                placeholder="Email"
+                [value]="beneficiary.email"
+                (input)="updateBeneficiary($index, 'email', $any($event.target).value)"
+                [attr.aria-label]="'Beneficiary ' + ($index + 1) + ' email'" />
+              <button
+                type="button"
+                (click)="removeBeneficiary($index)"
+                class="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                [attr.aria-label]="'Remove beneficiary ' + ($index + 1)">
+                <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
+              </button>
+            </div>
+          }
+        </div>
+
+        <lfx-button
+          label="Add beneficiary"
+          icon="fa-solid fa-plus"
+          severity="secondary"
+          size="small"
+          styleClass="self-start"
+          (click)="addBeneficiary()"
+          data-testid="settings-add-beneficiary-btn" />
+      </div>
+    }
+
+    <!-- Funding tab -->
+    @else if (activeSettingsTab() === 'funding') {
+      <div class="flex flex-col gap-5" data-testid="settings-funding-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Funding</h3>
+
+        <p class="text-sm text-gray-500">Provide your initial estimated general fund funding goal.</p>
+
+        <div class="flex flex-col gap-1.5 max-w-[240px]" data-testid="settings-field-goal">
+          <label for="settings-goal" class="text-sm font-medium text-gray-700">
+            Annual Funding Goal <span class="text-red-500" aria-hidden="true">*</span>
+          </label>
+          <lfx-input-text [form]="form" control="goal" id="settings-goal" type="number" placeholder="0" icon="fa-light fa-dollar-sign" />
+        </div>
+      </div>
+    }
+
+    <!-- Footer actions -->
+    <div class="flex justify-end gap-2 pt-4 border-t border-gray-200 mt-auto" data-testid="initiative-settings-footer">
+      <lfx-button label="Cancel" severity="secondary" (click)="onClose()" data-testid="initiative-settings-cancel-btn" />
+      <lfx-button label="Save changes" severity="primary" data-testid="initiative-settings-save-btn" />
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -1,0 +1,103 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { LowerCasePipe } from '@angular/common';
+import { Component, effect, model, input, signal, computed } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+import { InputTextModule } from 'primeng/inputtext';
+import { DrawerModule } from 'primeng/drawer';
+
+interface SettingsTab {
+  id: string;
+  label: string;
+}
+
+interface Beneficiary {
+  name: string;
+  email: string;
+}
+
+@Component({
+  selector: 'lfx-initiative-settings-drawer',
+  imports: [DrawerModule, InputTextComponent, TextareaComponent, ButtonComponent, ReactiveFormsModule, InputTextModule, LowerCasePipe],
+  templateUrl: './initiative-settings-drawer.component.html',
+  styleUrl: './initiative-settings-drawer.component.scss',
+})
+export class InitiativeSettingsDrawerComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly visible = model(false);
+
+  protected readonly activeSettingsTab = signal<string>('details');
+
+  protected readonly settingsTabs: SettingsTab[] = [
+    { id: 'details', label: 'Initiative details' },
+    { id: 'branding', label: 'Branding' },
+    { id: 'beneficiaries', label: 'Beneficiaries' },
+    { id: 'funding', label: 'Funding' },
+  ];
+
+  protected readonly form: FormGroup = new FormGroup({
+    name: new FormControl('', [Validators.required, Validators.maxLength(100)]),
+    description: new FormControl('', [Validators.maxLength(500)]),
+    websiteUrl: new FormControl(''),
+    goal: new FormControl<number | null>(null),
+  });
+
+  protected readonly tags = signal<string[]>([]);
+  protected readonly newTagValue = signal<string>('');
+  protected readonly beneficiaries = signal<Beneficiary[]>([]);
+
+  private readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.value });
+  protected readonly nameLength = computed(() => this.formValue().name?.length ?? 0);
+  protected readonly descriptionLength = computed(() => this.formValue().description?.length ?? 0);
+
+  constructor() {
+    effect(() => {
+      if (this.visible()) {
+        const init = this.initiative();
+        this.form.patchValue({
+          name: init.name,
+          description: init.description,
+          websiteUrl: init.publicUrl ?? '',
+          goal: init.goal,
+        });
+        this.tags.set([...init.tags]);
+        this.beneficiaries.set([]);
+        this.activeSettingsTab.set('details');
+      }
+    });
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  protected addTag(): void {
+    const tag = this.newTagValue().trim();
+    if (tag && !this.tags().includes(tag)) {
+      this.tags.update((tags) => [...tags, tag]);
+    }
+    this.newTagValue.set('');
+  }
+
+  protected removeTag(tag: string): void {
+    this.tags.update((tags) => tags.filter((t) => t !== tag));
+  }
+
+  protected addBeneficiary(): void {
+    this.beneficiaries.update((list) => [...list, { name: '', email: '' }]);
+  }
+
+  protected removeBeneficiary(index: number): void {
+    this.beneficiaries.update((list) => list.filter((_, i) => i !== index));
+  }
+
+  protected updateBeneficiary(index: number, field: 'name' | 'email', value: string): void {
+    this.beneficiaries.update((list) => list.map((b, i) => (i === index ? { ...b, [field]: value } : b)));
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -17,11 +17,6 @@ interface SettingsTab {
   label: string;
 }
 
-interface Beneficiary {
-  name: string;
-  email: string;
-}
-
 @Component({
   selector: 'lfx-initiative-settings-drawer',
   imports: [DrawerModule, InputTextComponent, TextareaComponent, ButtonComponent, ReactiveFormsModule, InputTextModule, LowerCasePipe],
@@ -50,13 +45,13 @@ export class InitiativeSettingsDrawerComponent {
 
   protected readonly tags = signal<string[]>([]);
   protected readonly newTagValue = signal<string>('');
-  protected readonly beneficiaries = signal<Beneficiary[]>([]);
+  protected readonly beneficiaryGroups = signal<FormGroup[]>([]);
 
   private readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.value });
   protected readonly nameLength = computed(() => this.formValue().name?.length ?? 0);
   protected readonly descriptionLength = computed(() => this.formValue().description?.length ?? 0);
 
-  constructor() {
+  public constructor() {
     effect(() => {
       if (this.visible()) {
         const init = this.initiative();
@@ -67,7 +62,7 @@ export class InitiativeSettingsDrawerComponent {
           goal: init.goal,
         });
         this.tags.set([...init.tags]);
-        this.beneficiaries.set([]);
+        this.beneficiaryGroups.set([]);
         this.activeSettingsTab.set('details');
       }
     });
@@ -90,14 +85,14 @@ export class InitiativeSettingsDrawerComponent {
   }
 
   protected addBeneficiary(): void {
-    this.beneficiaries.update((list) => [...list, { name: '', email: '' }]);
+    const group = new FormGroup({
+      name: new FormControl(''),
+      email: new FormControl('', Validators.email),
+    });
+    this.beneficiaryGroups.update((groups) => [...groups, group]);
   }
 
   protected removeBeneficiary(index: number): void {
-    this.beneficiaries.update((list) => list.filter((_, i) => i !== index));
-  }
-
-  protected updateBeneficiary(index: number, field: 'name' | 'email', value: string): void {
-    this.beneficiaries.update((list) => list.map((b, i) => (i === index ? { ...b, [field]: value } : b)));
+    this.beneficiaryGroups.update((groups) => groups.filter((_, i) => i !== index));
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6 p-8">
+<div class="flex flex-col gap-5 p-8" data-testid="initiative-detail">
   <lfx-button
     label="Back to My Initiatives"
     icon="fa-light fa-chevron-left"
@@ -12,15 +12,13 @@
     styleClass="self-start"
     data-testid="initiative-detail-back-btn" />
 
-  <div>
-    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">Initiative Detail</h1>
-    <p class="text-sm text-gray-500 mt-1">{{ initiativeId() }}</p>
-  </div>
+  <lfx-initiative-detail-header [initiative]="initiative()" [activeTab]="activeTab()" (tabChange)="activeTab.set($event)" />
 
-  <div class="flex items-center justify-center py-16 text-gray-400">
-    <div class="flex flex-col items-center gap-3">
-      <i class="fa-light fa-hand-holding-heart text-5xl" aria-hidden="true"></i>
-      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
-    </div>
-  </div>
+  @if (activeTab() === 'overview') {
+    <lfx-initiative-overview [initiative]="initiative()" (viewAllFinancials)="activeTab.set('financials')" />
+  } @else if (activeTab() === 'financials') {
+    <lfx-initiative-financials [initiative]="initiative()" />
+  } @else if (activeTab() === 'announcements') {
+    <lfx-initiative-announcements />
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
@@ -1,0 +1,26 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8">
+  <lfx-button
+    label="Back to My Initiatives"
+    icon="fa-light fa-chevron-left"
+    severity="secondary"
+    size="small"
+    [text]="true"
+    routerLink="/crowdfunding/initiatives"
+    styleClass="self-start"
+    data-testid="initiative-detail-back-btn" />
+
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">Initiative Detail</h1>
+    <p class="text-sm text-gray-500 mt-1">{{ initiativeId() }}</p>
+  </div>
+
+  <div class="flex items-center justify-center py-16 text-gray-400">
+    <div class="flex flex-col items-center gap-3">
+      <i class="fa-light fa-hand-holding-heart text-5xl" aria-hidden="true"></i>
+      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
@@ -12,7 +12,13 @@
     styleClass="self-start"
     data-testid="initiative-detail-back-btn" />
 
-  <lfx-initiative-detail-header [initiative]="initiative()" [activeTab]="activeTab()" (tabChange)="activeTab.set($event)" />
+  <lfx-initiative-detail-header
+    [initiative]="initiative()"
+    [activeTab]="activeTab()"
+    (tabChange)="activeTab.set($event)"
+    (settingsClick)="settingsDrawerVisible.set(true)" />
+
+  <lfx-initiative-settings-drawer [initiative]="initiative()" [(visible)]="settingsDrawerVisible" />
 
   @if (activeTab() === 'overview') {
     <lfx-initiative-overview [initiative]="initiative()" (viewAllFinancials)="activeTab.set('financials')" />

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -11,10 +11,18 @@ import { InitiativeDetailHeaderComponent } from './components/initiative-detail-
 import { InitiativeOverviewComponent } from './components/initiative-overview/initiative-overview.component';
 import { InitiativeFinancialsComponent } from './components/initiative-financials/initiative-financials.component';
 import { InitiativeAnnouncementsComponent } from './components/initiative-announcements/initiative-announcements.component';
+import { InitiativeSettingsDrawerComponent } from './components/initiative-settings-drawer/initiative-settings-drawer.component';
 
 @Component({
   selector: 'lfx-initiative-detail',
-  imports: [ButtonComponent, InitiativeDetailHeaderComponent, InitiativeOverviewComponent, InitiativeFinancialsComponent, InitiativeAnnouncementsComponent],
+  imports: [
+    ButtonComponent,
+    InitiativeDetailHeaderComponent,
+    InitiativeOverviewComponent,
+    InitiativeFinancialsComponent,
+    InitiativeAnnouncementsComponent,
+    InitiativeSettingsDrawerComponent,
+  ],
   templateUrl: './initiative-detail.component.html',
   styleUrl: './initiative-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,4 +36,5 @@ export class InitiativeDetailComponent {
     return MOCK_INITIATIVE_DETAIL;
   });
   protected readonly activeTab = signal<string>('overview');
+  protected readonly settingsDrawerVisible = signal(false);
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { map } from 'rxjs';
+
+@Component({
+  selector: 'lfx-initiative-detail',
+  imports: [ButtonComponent, TagComponent],
+  templateUrl: './initiative-detail.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InitiativeDetailComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly initiativeId = toSignal(this.route.paramMap.pipe(map((params) => params.get('id') ?? '')), { initialValue: '' });
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -1,21 +1,31 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ButtonComponent } from '@components/button/button.component';
-import { TagComponent } from '@components/tag/tag.component';
 import { map } from 'rxjs';
+import { ButtonComponent } from '@components/button/button.component';
+import { MOCK_INITIATIVE_DETAIL } from '../crowdfunding.mock';
+import { InitiativeDetailHeaderComponent } from './components/initiative-detail-header/initiative-detail-header.component';
+import { InitiativeOverviewComponent } from './components/initiative-overview/initiative-overview.component';
+import { InitiativeFinancialsComponent } from './components/initiative-financials/initiative-financials.component';
+import { InitiativeAnnouncementsComponent } from './components/initiative-announcements/initiative-announcements.component';
 
 @Component({
   selector: 'lfx-initiative-detail',
-  imports: [ButtonComponent, TagComponent],
+  imports: [ButtonComponent, InitiativeDetailHeaderComponent, InitiativeOverviewComponent, InitiativeFinancialsComponent, InitiativeAnnouncementsComponent],
   templateUrl: './initiative-detail.component.html',
+  styleUrl: './initiative-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InitiativeDetailComponent {
   private readonly route = inject(ActivatedRoute);
 
   protected readonly initiativeId = toSignal(this.route.paramMap.pipe(map((params) => params.get('id') ?? '')), { initialValue: '' });
+  protected readonly initiative = computed(() => {
+    // For now, always return mock data. In a real app, fetch from service based on initiativeId()
+    return MOCK_INITIATIVE_DETAIL;
+  });
+  protected readonly activeTab = signal<string>('overview');
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -1,0 +1,76 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<form [formGroup]="form" (ngSubmit)="onSubmit()" class="flex flex-col gap-5" data-testid="add-card-form">
+  <!-- Card number -->
+  <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
+    <label for="card-number" class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
+    <input
+      pInputText
+      id="card-number"
+      type="text"
+      inputmode="numeric"
+      autocomplete="cc-number"
+      placeholder="1234 5678 9123 4567"
+      maxlength="19"
+      formControlName="cardNumber"
+      (input)="onCardNumberInput($event)"
+      class="w-full"
+      [class.ng-invalid]="form.controls.cardNumber.invalid && form.controls.cardNumber.touched"
+      [class.ng-dirty]="form.controls.cardNumber.dirty"
+      data-testid="add-card-number-input" />
+    @if (form.controls.cardNumber.invalid && form.controls.cardNumber.touched) {
+      <p class="text-xs text-red-500">Enter a valid 16-digit card number.</p>
+    }
+  </div>
+
+  <!-- Expiry + CVC -->
+  <div class="grid grid-cols-2 gap-4">
+    <!-- Expiry -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-expiry">
+      <label for="card-expiry" class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-expiry"
+        type="text"
+        inputmode="numeric"
+        autocomplete="cc-exp"
+        placeholder="MM/YY"
+        maxlength="5"
+        formControlName="expiry"
+        (input)="onExpiryInput($event)"
+        [class.ng-invalid]="form.controls.expiry.invalid && form.controls.expiry.touched"
+        [class.ng-dirty]="form.controls.expiry.dirty"
+        data-testid="add-card-expiry-input" />
+      @if (form.controls.expiry.invalid && form.controls.expiry.touched) {
+        <p class="text-xs text-red-500">Enter a valid expiry (MM/YY).</p>
+      }
+    </div>
+
+    <!-- CVC -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-cvc">
+      <label for="card-cvc" class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-cvc"
+        type="password"
+        inputmode="numeric"
+        autocomplete="cc-csc"
+        placeholder="•••"
+        maxlength="4"
+        formControlName="cvc"
+        [class.ng-invalid]="form.controls.cvc.invalid && form.controls.cvc.touched"
+        [class.ng-dirty]="form.controls.cvc.dirty"
+        data-testid="add-card-cvc-input" />
+      @if (form.controls.cvc.invalid && form.controls.cvc.touched) {
+        <p class="text-xs text-red-500">Enter a valid CVC.</p>
+      }
+    </div>
+  </div>
+
+  <!-- Footer actions -->
+  <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
+    <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
+    <lfx-button label="Add card" severity="primary" type="submit" data-testid="add-card-submit-btn" />
+  </div>
+</form>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextModule } from 'primeng/inputtext';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+
+// TODO: Replace card number, expiry, and CVC fields with Stripe Elements once
+// the Stripe API integration is in place for secure card tokenization and storage.
+
+@Component({
+  selector: 'lfx-add-payment-card-dialog',
+  imports: [ReactiveFormsModule, InputTextModule, ButtonComponent],
+  templateUrl: './add-payment-card-dialog.component.html',
+  styleUrl: './add-payment-card-dialog.component.scss',
+})
+export class AddPaymentCardDialogComponent {
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly form = new FormGroup({
+    cardNumber: new FormControl('', [Validators.required, Validators.minLength(19)]),
+    expiry: new FormControl('', [Validators.required, Validators.pattern(/^\d{2}\/\d{2}$/)]),
+    cvc: new FormControl('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  protected onCardNumberInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 16);
+    const formatted = digits.match(/.{1,4}/g)?.join(' ') ?? '';
+    this.form.controls.cardNumber.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onExpiryInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 4);
+    const formatted = digits.length > 2 ? `${digits.slice(0, 2)}/${digits.slice(2)}` : digits;
+    this.form.controls.expiry.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.dialogRef.close({ added: true });
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
@@ -1,0 +1,71 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col" data-testid="donation-history-table">
+  <div class="overflow-x-auto rounded-lg border border-gray-200">
+    <table class="w-full text-sm" aria-label="Donation history">
+      <thead>
+        <tr class="border-b border-gray-200 bg-gray-50">
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Initiative</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Date</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Type</th>
+          <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Amount</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 bg-white">
+        @for (item of visibleItems(); track item.id) {
+          <tr class="hover:bg-gray-50 transition-colors" [attr.data-testid]="'donation-row-' + item.id">
+            <!-- Initiative -->
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-2.5">
+                <div class="flex items-center justify-center w-8 h-8 rounded-md bg-gray-50 text-base flex-shrink-0" aria-hidden="true">
+                  {{ item.initiativeIcon }}
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <span class="font-medium text-gray-900">{{ item.initiativeName }}</span>
+                  <span class="text-xs text-gray-400">
+                    <i [class]="'fa-solid ' + item.fundTypeIcon + ' text-[10px] mr-1'" aria-hidden="true"></i>
+                    {{ item.fundType }}
+                  </span>
+                </div>
+              </div>
+            </td>
+
+            <!-- Date -->
+            <td class="px-4 py-3 text-gray-500 whitespace-nowrap">{{ item.date }}</td>
+
+            <!-- Kind badge -->
+            <td class="px-4 py-3">
+              @if (item.kind === 'monthly') {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Monthly </span>
+              } @else {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-blue-50 text-blue-700"> One-time </span>
+              }
+            </td>
+
+            <!-- Amount -->
+            <td class="px-4 py-3 text-right font-semibold text-gray-900 whitespace-nowrap">${{ item.amount | number }}</td>
+
+            <!-- Invoice -->
+            <td class="px-4 py-3 text-right">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 border border-gray-200 rounded px-2 py-1 hover:bg-gray-50 hover:border-gray-300 transition-colors"
+                [attr.aria-label]="'Download invoice for ' + item.initiativeName + ' on ' + item.date">
+                <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
+                Invoice
+              </button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+
+  @if (hasMore()) {
+    <div class="flex justify-center pt-3" data-testid="donation-history-load-more">
+      <lfx-button label="Load more" severity="secondary" size="small" (click)="loadMore()" />
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, input, signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { DonationHistoryItem } from '@lfx-one/shared/interfaces';
+
+const PAGE_SIZE = 10;
+
+@Component({
+  selector: 'lfx-donation-history-table',
+  imports: [ButtonComponent, DecimalPipe],
+  templateUrl: './donation-history-table.component.html',
+  styleUrl: './donation-history-table.component.scss',
+})
+export class DonationHistoryTableComponent {
+  public readonly items = input.required<DonationHistoryItem[]>();
+
+  protected readonly visibleCount = signal(PAGE_SIZE);
+  protected readonly visibleItems = computed(() => this.items().slice(0, this.visibleCount()));
+  protected readonly hasMore = computed(() => this.visibleCount() < this.items().length);
+
+  protected loadMore(): void {
+    this.visibleCount.update((n) => n + PAGE_SIZE);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="donations-stats-bar">
+  <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-total">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-50 text-blue-600 flex-shrink-0">
+        <i class="fa-solid fa-hand-holding-heart text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().totalDonated | number }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Donated</p>
+        <p class="text-xs text-gray-400">All time</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-initiatives">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-teal-50 text-teal-600 flex-shrink-0">
+        <i class="fa-solid fa-seedling text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().initiativesSupported }}</p>
+        <p class="text-sm font-normal text-gray-900">Initiatives Supported</p>
+        <p class="text-xs text-gray-400">Across 4 fund types</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-recurring">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-50 text-emerald-600 flex-shrink-0">
+        <i class="fa-solid fa-arrows-rotate text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().activeRecurringAmount }}<span class="text-sm font-normal text-gray-400">/mo</span></p>
+        <p class="text-sm font-normal text-gray-900">Active Recurring</p>
+        <p class="text-xs text-gray-400">{{ stats().activeRecurringCount }} active subscription</p>
+      </div>
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { DonationStats } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-donations-stats-bar',
+  imports: [CardComponent, DecimalPipe],
+  templateUrl: './donations-stats-bar.component.html',
+  styleUrl: './donations-stats-bar.component.scss',
+})
+export class DonationsStatsBarComponent {
+  public readonly stats = input.required<DonationStats>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3 p-4 bg-white border border-gray-200 rounded-lg" [attr.data-testid]="'payment-method-' + method().id">
+  <!-- Brand + actions -->
+  <div class="flex items-center justify-between">
+    <span class="inline-flex items-center px-2 py-0.5 text-xs font-bold tracking-widest border border-gray-300 rounded text-gray-700 bg-gray-50">
+      {{ method().brand }}
+    </span>
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        class="p-1.5 text-gray-400 hover:text-gray-600 transition-colors rounded"
+        [attr.aria-label]="revealed() ? 'Hide card details' : 'Show card details'"
+        (click)="toggleReveal()">
+        @if (revealed()) {
+          <i class="fa-solid fa-eye-slash text-sm" aria-hidden="true"></i>
+        } @else {
+          <i class="fa-solid fa-eye text-sm" aria-hidden="true"></i>
+        }
+      </button>
+      <button type="button" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors rounded" aria-label="Remove payment method" (click)="remove.emit()">
+        <i class="fa-solid fa-trash text-sm" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+
+  <!-- Card number + expiry -->
+  <div class="flex items-end justify-between gap-4 mt-auto">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-xs text-gray-400">Card number</p>
+      <p class="text-sm font-semibold text-gray-900 tabular-nums tracking-wider">•••• •••• •••• {{ method().last4 }}</p>
+    </div>
+    <div class="flex flex-col gap-0.5 text-right flex-shrink-0">
+      <p class="text-xs text-gray-400">Expiry</p>
+      <p class="text-sm font-semibold text-gray-900">{{ method().expiry }}</p>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
@@ -1,0 +1,22 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output, signal } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-payment-method-card',
+  imports: [],
+  templateUrl: './payment-method-card.component.html',
+  styleUrl: './payment-method-card.component.scss',
+})
+export class PaymentMethodCardComponent {
+  public readonly method = input.required<PaymentMethod>();
+  public readonly remove = output<void>();
+
+  protected readonly revealed = signal(false);
+
+  protected toggleReveal(): void {
+    this.revealed.update((v) => !v);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
@@ -1,0 +1,23 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="payment-methods">
+  <h2 class="text-sm font-bold text-gray-900" data-testid="payment-methods-heading">Payment Methods</h2>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="payment-methods-grid">
+    @for (method of methods(); track method.id) {
+      <lfx-payment-method-card [method]="method" (remove)="removeCard.emit(method)" />
+    }
+
+    <!-- Add card -->
+    <button
+      type="button"
+      class="flex flex-col items-center justify-center gap-2 p-4 bg-white border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:border-blue-300 hover:text-blue-500 transition-colors min-h-[112px]"
+      (click)="openAddCardDialog()"
+      data-testid="add-payment-method-btn"
+      aria-label="Add payment card">
+      <i class="fa-solid fa-plus text-xl" aria-hidden="true"></i>
+      <span class="text-sm font-medium">Add payment card</span>
+    </button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, input, output } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
+import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
+
+@Component({
+  selector: 'lfx-payment-methods',
+  imports: [PaymentMethodCardComponent],
+  providers: [DialogService],
+  templateUrl: './payment-methods.component.html',
+  styleUrl: './payment-methods.component.scss',
+})
+export class PaymentMethodsComponent {
+  private readonly dialogService = inject(DialogService);
+
+  public readonly methods = input.required<PaymentMethod[]>();
+  public readonly removeCard = output<PaymentMethod>();
+
+  private dialogRef: DynamicDialogRef | null = null;
+
+  protected openAddCardDialog(): void {
+    this.dialogRef = this.dialogService.open(AddPaymentCardDialogComponent, {
+      header: 'Add Payment Card',
+      width: '420px',
+      modal: true,
+      draggable: false,
+      resizable: false,
+      closeOnEscape: true,
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -1,0 +1,80 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="recurring-donations-list">
+  <!-- Section header -->
+  <div class="flex items-center justify-between" data-testid="recurring-donations-header">
+    <h2 class="text-sm font-bold text-gray-900">Recurring Donations</h2>
+    @if (cancelledCount() > 0) {
+      <button
+        type="button"
+        class="text-xs font-medium text-gray-400 underline underline-offset-2 hover:text-gray-600 transition-colors"
+        (click)="viewCancelled.emit()"
+        data-testid="view-cancelled-btn">
+        Cancelled recurring donations ({{ cancelledCount() }})
+      </button>
+    }
+  </div>
+
+  <!-- Cards -->
+  <div class="flex flex-col gap-2" data-testid="recurring-cards">
+    @for (entry of donationsWithMenuItems(); track entry.donation.id; let i = $index) {
+      <div
+        class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors cursor-pointer"
+        [attr.data-testid]="'recurring-card-' + entry.donation.id">
+        <!-- Icon -->
+        <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-gray-50 text-xl flex-shrink-0" aria-hidden="true">
+          {{ entry.donation.icon }}
+        </div>
+
+        <!-- Details -->
+        <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="text-sm font-semibold text-gray-900">{{ entry.donation.name }}</span>
+            @if (entry.donation.status === 'active') {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+            } @else {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500"> Paused </span>
+            }
+          </div>
+          <p class="text-xs text-gray-400">Started {{ entry.donation.startDate }} &middot; {{ entry.donation.billingDescription }}</p>
+        </div>
+
+        <!-- Amount + next charge -->
+        <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
+          <p class="text-sm font-semibold" [class]="entry.donation.status === 'active' ? 'text-gray-900' : 'text-gray-400'">
+            ${{ entry.donation.amount }}<span class="text-xs font-normal text-gray-400">/mo</span>
+          </p>
+          <p class="text-xs text-gray-400">
+            @if (entry.donation.status === 'active') {
+              Next charge: {{ entry.donation.nextChargeDate }}
+            } @else {
+              Paused since {{ entry.donation.pausedSince }}
+            }
+          </p>
+        </div>
+
+        <!-- Ellipsis menu -->
+        <div class="flex-shrink-0" (click)="$event.stopPropagation()">
+          <lfx-button
+            icon="fa-solid fa-ellipsis"
+            severity="secondary"
+            size="small"
+            [attr.aria-label]="'More options for ' + entry.donation.name"
+            (click)="onMenuToggle($event, i)" />
+          <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
+            <ng-template #item let-item>
+              <button
+                class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
+                [class.text-red-600]="item.styleClass === 'text-red-600'"
+                [class.text-gray-700]="item.styleClass !== 'text-red-600'">
+                <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
+                {{ item.label }}
+              </button>
+            </ng-template>
+          </lfx-menu>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, viewChildren } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MenuItem } from 'primeng/api';
+
+@Component({
+  selector: 'lfx-recurring-donations-list',
+  imports: [ButtonComponent, MenuComponent],
+  templateUrl: './recurring-donations-list.component.html',
+  styleUrl: './recurring-donations-list.component.scss',
+})
+export class RecurringDonationsListComponent {
+  public readonly donations = input.required<RecurringDonation[]>();
+  public readonly cancelledCount = input<number>(0);
+
+  public readonly viewCancelled = output<void>();
+  public readonly changeAmount = output<RecurringDonation>();
+  public readonly pauseDonation = output<RecurringDonation>();
+  public readonly resumeDonation = output<RecurringDonation>();
+  public readonly cancelDonation = output<RecurringDonation>();
+
+  private readonly menus = viewChildren<MenuComponent>(MenuComponent);
+
+  protected readonly donationsWithMenuItems = computed(() =>
+    this.donations().map((donation) => ({
+      donation,
+      menuItems: this.buildMenuItems(donation),
+    }))
+  );
+
+  protected onMenuToggle(event: Event, index: number): void {
+    this.menus()[index]?.toggle(event);
+  }
+
+  private buildMenuItems(donation: RecurringDonation): MenuItem[] {
+    if (donation.status === 'paused') {
+      return [
+        { label: 'Resume', icon: 'fa-solid fa-play', command: () => this.resumeDonation.emit(donation) },
+        { separator: true },
+        { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+      ];
+    }
+    return [
+      { label: 'Change amount', icon: 'fa-solid fa-pen-to-square', command: () => this.changeAmount.emit(donation) },
+      { label: 'Pause', icon: 'fa-solid fa-pause', command: () => this.pauseDonation.emit(donation) },
+      { separator: true },
+      { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+    ];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -1,0 +1,16 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Donations</h1>
+    <p class="text-sm text-gray-500 mt-1">Your giving history across LFX Crowdfunding initiatives</p>
+  </div>
+
+  <div class="flex items-center justify-center py-16 text-gray-400">
+    <div class="flex flex-col items-center gap-3">
+      <i class="fa-light fa-heart text-5xl"></i>
+      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -23,7 +23,14 @@
   <lfx-donations-stats-bar [stats]="stats()" />
 
   <!-- Recurring donations -->
-  <lfx-recurring-donations-list [donations]="recurringDonations()" [cancelledCount]="cancelledCount()" />
+  <lfx-recurring-donations-list
+    [donations]="recurringDonations()"
+    [cancelledCount]="cancelledCount()"
+    (viewCancelled)="onViewCancelled()"
+    (changeAmount)="onChangeAmount($event)"
+    (pauseDonation)="onPauseDonation($event)"
+    (resumeDonation)="onResumeDonation($event)"
+    (cancelDonation)="onCancelDonation($event)" />
 
   <!-- Donation history -->
   <div class="flex flex-col gap-3" data-testid="donation-history-section">
@@ -32,5 +39,5 @@
   </div>
 
   <!-- Payment methods -->
-  <lfx-payment-methods [methods]="paymentMethods()" />
+  <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" />
 </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -1,16 +1,36 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6 p-8">
-  <div>
-    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Donations</h1>
-    <p class="text-sm text-gray-500 mt-1">Your giving history across LFX Crowdfunding initiatives</p>
+<div class="flex flex-col gap-6 p-8" data-testid="my-donations">
+  <!-- Page header -->
+  <div class="flex items-start justify-between" data-testid="my-donations-header">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Donations</h1>
+      <p class="text-sm text-gray-500 mt-1">Your giving history across LFX Crowdfunding initiatives</p>
+    </div>
+    <a
+      [href]="crowdfundingUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+      data-testid="explore-initiatives-btn">
+      Explore Initiatives
+      <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+    </a>
   </div>
 
-  <div class="flex items-center justify-center py-16 text-gray-400">
-    <div class="flex flex-col items-center gap-3">
-      <i class="fa-light fa-heart text-5xl"></i>
-      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
-    </div>
+  <!-- Stats bar -->
+  <lfx-donations-stats-bar [stats]="stats()" />
+
+  <!-- Recurring donations -->
+  <lfx-recurring-donations-list [donations]="recurringDonations()" [cancelledCount]="cancelledCount()" />
+
+  <!-- Donation history -->
+  <div class="flex flex-col gap-3" data-testid="donation-history-section">
+    <h2 class="text-sm font-bold text-gray-900">Donation History</h2>
+    <lfx-donation-history-table [items]="donationHistory()" />
   </div>
+
+  <!-- Payment methods -->
+  <lfx-payment-methods [methods]="paymentMethods()" />
 </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -23,4 +23,33 @@ export class MyDonationsComponent {
   protected readonly donationHistory = signal<DonationHistoryItem[]>(MOCK_DONATION_HISTORY);
   protected readonly paymentMethods = signal<PaymentMethod[]>(MOCK_PAYMENT_METHODS);
   protected readonly cancelledCount = signal(4);
+
+  protected onViewCancelled(): void {
+    // TODO: navigate to cancelled donations view
+  }
+
+  protected onChangeAmount(donation: RecurringDonation): void {
+    // TODO: open change amount dialog for donation
+    void donation;
+  }
+
+  protected onPauseDonation(donation: RecurringDonation): void {
+    // TODO: call pause API for donation
+    void donation;
+  }
+
+  protected onResumeDonation(donation: RecurringDonation): void {
+    // TODO: call resume API for donation
+    void donation;
+  }
+
+  protected onCancelDonation(donation: RecurringDonation): void {
+    // TODO: call cancel API for donation
+    void donation;
+  }
+
+  protected onRemoveCard(card: PaymentMethod): void {
+    // TODO: call remove card API
+    void card;
+  }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TagComponent } from '@components/tag/tag.component';
+
+@Component({
+  selector: 'lfx-my-donations',
+  imports: [TagComponent],
+  templateUrl: './my-donations.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MyDonationsComponent {}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -1,13 +1,26 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TagComponent } from '@components/tag/tag.component';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { environment } from '@environments/environment';
+import { DonationHistoryItem, DonationStats, PaymentMethod, RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MOCK_DONATION_HISTORY, MOCK_DONATION_STATS, MOCK_PAYMENT_METHODS, MOCK_RECURRING_DONATIONS } from '../crowdfunding.mock';
+import { DonationsStatsBarComponent } from './components/donations-stats-bar/donations-stats-bar.component';
+import { DonationHistoryTableComponent } from './components/donation-history-table/donation-history-table.component';
+import { PaymentMethodsComponent } from './components/payment-methods/payment-methods.component';
+import { RecurringDonationsListComponent } from './components/recurring-donations-list/recurring-donations-list.component';
 
 @Component({
   selector: 'lfx-my-donations',
-  imports: [TagComponent],
+  imports: [DonationsStatsBarComponent, RecurringDonationsListComponent, DonationHistoryTableComponent, PaymentMethodsComponent],
   templateUrl: './my-donations.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MyDonationsComponent {}
+export class MyDonationsComponent {
+  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly stats = signal<DonationStats>(MOCK_DONATION_STATS);
+  protected readonly recurringDonations = signal<RecurringDonation[]>(MOCK_RECURRING_DONATIONS);
+  protected readonly donationHistory = signal<DonationHistoryItem[]>(MOCK_DONATION_HISTORY);
+  protected readonly paymentMethods = signal<PaymentMethod[]>(MOCK_PAYMENT_METHODS);
+  protected readonly cancelledCount = signal(4);
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -1,0 +1,81 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div
+  class="flex items-center gap-4 p-5"
+  [class.cursor-pointer]="isClickable()"
+  [class.hover:bg-gray-50]="isClickable()"
+  [class.opacity-80]="!isClickable()"
+  [attr.role]="isClickable() ? 'button' : null"
+  [attr.tabindex]="isClickable() ? 0 : null"
+  [attr.aria-label]="initiative().name"
+  [attr.data-testid]="'initiative-card-' + initiative().id"
+  (click)="onCardClick()"
+  (keydown.enter)="onCardClick()">
+
+  <!-- Avatar / Icon -->
+  <lfx-avatar
+    [label]="initiative().name"
+    shape="square"
+    size="large"
+    [styleClass]="avatarStyleClass()"
+    [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
+
+  <!-- Content -->
+  <div class="flex flex-col gap-1 min-w-0 flex-1">
+    <span class="text-xs font-semibold flex items-center gap-1" [class]="fundTypeColorClass()">
+      <i [class]="fundTypeIcon()" aria-hidden="true"></i>
+      {{ fundTypeLabel() }}
+    </span>
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="text-base font-bold text-gray-900">{{ initiative().name }}</span>
+      @if (initiative().status === 'active') {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700">Active</span>
+      } @else if (initiative().status === 'pending') {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Pending</span>
+      } @else {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Closed</span>
+      }
+    </div>
+    <p class="text-xs text-gray-500 truncate">{{ initiative().description }}</p>
+  </div>
+
+  <!-- Metrics -->
+  <div class="flex items-center gap-10 flex-shrink-0" data-testid="initiative-card-metrics">
+    @if ((initiative().status === 'active' || initiative().status === 'closed') && initiative().goal) {
+      <div class="flex flex-col gap-1 min-w-44">
+        <div class="flex items-center justify-between text-xs">
+          <span class="font-bold text-gray-900">{{ formatCurrency(initiative().raised) }}</span>
+          <span class="text-gray-500">of {{ formatCurrency(initiative().goal!) }}</span>
+        </div>
+        <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden w-full">
+          <div
+            class="h-full bg-blue-600 rounded-full"
+            [style.width.%]="progressPercent()"
+            role="progressbar"
+            [attr.aria-valuenow]="progressPercent()"
+            aria-valuemin="0"
+            aria-valuemax="100"></div>
+        </div>
+        <p class="text-xs text-gray-500">{{ progressPercent() }}% funded · {{ initiative().sponsorsCount }} sponsors</p>
+      </div>
+      <div class="flex-shrink-0">
+        <a
+          [href]="initiative().publicUrl || '#'"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600 border border-gray-300 bg-white rounded px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+          (click)="$event.stopPropagation()"
+          data-testid="initiative-card-view-public">
+          View Public
+          <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+        </a>
+      </div>
+    } @else if (initiative().status === 'pending') {
+      <div class="flex items-center gap-2 text-xs text-gray-400 whitespace-nowrap">
+        <i class="fa-light fa-clock" aria-hidden="true"></i>
+        Under review by our team
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -12,14 +12,8 @@
   [attr.data-testid]="'initiative-card-' + initiative().id"
   (click)="onCardClick()"
   (keydown.enter)="onCardClick()">
-
   <!-- Avatar / Icon -->
-  <lfx-avatar
-    [label]="initiative().name"
-    shape="square"
-    size="large"
-    [styleClass]="avatarStyleClass()"
-    [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
+  <lfx-avatar [label]="initiative().name" shape="square" size="large" [styleClass]="avatarStyleClass()" [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
 
   <!-- Content -->
   <div class="flex flex-col gap-1 min-w-0 flex-1">

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import {
+  CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_COLOR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_ICONS,
+  CROWDFUNDING_FUND_TYPE_LABELS,
+} from '@lfx-one/shared/constants';
+import { CrowdfundingInitiative } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-card',
+  imports: [AvatarComponent],
+  templateUrl: './initiative-card.component.html',
+  styleUrl: './initiative-card.component.scss',
+})
+export class InitiativeCardComponent {
+  public readonly initiative = input.required<CrowdfundingInitiative>();
+  public readonly cardClick = output<string>();
+
+  protected readonly fundTypeLabel = computed(() => CROWDFUNDING_FUND_TYPE_LABELS[this.initiative().fundType]);
+  protected readonly fundTypeIcon = computed(() => CROWDFUNDING_FUND_TYPE_ICONS[this.initiative().fundType]);
+  protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
+  protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
+
+  protected readonly progressPercent = computed(() => {
+    const { raised, goal } = this.initiative();
+    if (!goal || goal === 0) return 0;
+    return Math.min(100, Math.round((raised / goal) * 100));
+  });
+
+  protected readonly isClickable = computed(() => this.initiative().status !== 'pending');
+
+  protected formatCurrency(value: number): string {
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected onCardClick(): void {
+    if (this.isClickable()) {
+      this.cardClick.emit(this.initiative().id);
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiatives-list">
+  <lfx-filter-pills [options]="filterOptions()" [selectedFilter]="activeFilter()" (filterChange)="setFilter($event)" data-testid="initiatives-filter-pills" />
+
+  @if (filteredInitiatives().length > 0) {
+    <div class="flex flex-col gap-4" data-testid="initiatives-cards">
+      @for (initiative of filteredInitiatives(); track initiative.id) {
+        <lfx-initiative-card [initiative]="initiative" (cardClick)="onCardClick($event)" />
+      }
+    </div>
+  } @else {
+    <div class="flex flex-col items-center gap-3 py-16 text-gray-400" data-testid="initiatives-empty-state">
+      <i class="fa-light fa-box-archive text-5xl" aria-hidden="true"></i>
+      <p class="text-sm font-medium text-gray-500">
+        @if (activeFilter() === 'closed') {
+          No closed initiatives
+        } @else if (activeFilter() === 'pending') {
+          No pending initiatives
+        } @else {
+          No active initiatives
+        }
+      </p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, signal } from '@angular/core';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { CrowdfundingInitiative, CrowdfundingInitiativeStatus, FilterPillOption } from '@lfx-one/shared/interfaces';
+import { InitiativeCardComponent } from '../initiative-card/initiative-card.component';
+
+@Component({
+  selector: 'lfx-initiatives-list',
+  imports: [FilterPillsComponent, InitiativeCardComponent],
+  templateUrl: './initiatives-list.component.html',
+  styleUrl: './initiatives-list.component.scss',
+})
+export class InitiativesListComponent {
+  public readonly initiatives = input.required<CrowdfundingInitiative[]>();
+  public readonly initiativeClick = output<string>();
+
+  protected readonly activeFilter = signal<CrowdfundingInitiativeStatus>('active');
+
+  protected readonly statusCounts = computed(() => {
+    const all = this.initiatives();
+    return {
+      active: all.filter((i) => i.status === 'active').length,
+      pending: all.filter((i) => i.status === 'pending').length,
+      closed: all.filter((i) => i.status === 'closed').length,
+    };
+  });
+
+  protected readonly filterOptions = computed<FilterPillOption[]>(() => {
+    const counts = this.statusCounts();
+    return [
+      { id: 'active', label: `Active (${counts.active})` },
+      { id: 'pending', label: `Pending (${counts.pending})` },
+      { id: 'closed', label: `Closed (${counts.closed})` },
+    ];
+  });
+
+  protected readonly filteredInitiatives = computed(() => this.initiatives().filter((i) => i.status === this.activeFilter()));
+
+  protected setFilter(status: string): void {
+    this.activeFilter.set(status as CrowdfundingInitiativeStatus);
+  }
+
+  protected onCardClick(id: string): void {
+    this.initiativeClick.emit(id);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="initiatives-stats-bar">
+  <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-active">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-rocket text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().activeCount }}</p>
+        <p class="text-sm font-normal text-gray-900">Active Initiatives</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-raised">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-dollar-sign text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ formatCurrency(stats().totalRaised) }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Raised</p>
+        @if (stats().monthlyGain > 0) {
+          <p class="text-xs font-semibold text-emerald-600">↑ +{{ formatCurrency(stats().monthlyGain) }} this month</p>
+        }
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-sponsors">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-users text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().totalSponsors }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Sponsors</p>
+      </div>
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiatives-stats-bar',
+  imports: [CardComponent],
+  templateUrl: './initiatives-stats-bar.component.html',
+  styleUrl: './initiatives-stats-bar.component.scss',
+})
+export class InitiativesStatsBarComponent {
+  public readonly stats = input.required<CrowdfundingInitiativesStats>();
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
@@ -1,16 +1,27 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6 p-8">
-  <div>
-    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Initiatives</h1>
-    <p class="text-sm text-gray-500 mt-1">Fundraising initiatives you manage on LFX Crowdfunding</p>
+<div class="flex flex-col gap-6 p-8" data-testid="my-initiatives">
+  <!-- Page header -->
+  <div class="flex items-start justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Initiatives</h1>
+      <p class="text-sm text-gray-500 mt-1">Fundraising initiatives you manage on LFX Crowdfunding</p>
+    </div>
+    <a
+      [href]="crowdfundingUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+      data-testid="new-initiative-button">
+      New Initiative
+      <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+    </a>
   </div>
 
-  <div class="flex items-center justify-center py-16 text-gray-400">
-    <div class="flex flex-col items-center gap-3">
-      <i class="fa-light fa-hand-holding-heart text-5xl"></i>
-      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
-    </div>
-  </div>
+  <!-- Stats bar -->
+  <lfx-initiatives-stats-bar [stats]="stats()" />
+
+  <!-- Initiatives list with filter pills -->
+  <lfx-initiatives-list [initiatives]="initiatives()" (initiativeClick)="onInitiativeClick($event)" />
 </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
@@ -1,0 +1,16 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Initiatives</h1>
+    <p class="text-sm text-gray-500 mt-1">Fundraising initiatives you manage on LFX Crowdfunding</p>
+  </div>
+
+  <div class="flex items-center justify-center py-16 text-gray-400">
+    <div class="flex flex-col items-center gap-3">
+      <i class="fa-light fa-hand-holding-heart text-5xl"></i>
+      <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -3,49 +3,11 @@
 
 import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { FundType } from '@lfx-one/shared/enums';
+import { environment } from '@environments/environment';
 import { CrowdfundingInitiative, CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
+import { MOCK_INITIATIVES } from '../crowdfunding.mock';
 import { InitiativesStatsBarComponent } from './components/initiatives-stats-bar/initiatives-stats-bar.component';
 import { InitiativesListComponent } from './components/initiatives-list/initiatives-list.component';
-import { environment } from '@environments/environment';
-
-const MOCK_INITIATIVES: CrowdfundingInitiative[] = [
-  {
-    id: 'otel',
-    name: 'OpenTelemetry Community Fund',
-    description: 'Growing the observability standard for cloud-native software',
-    icon: '📡',
-    fundType: FundType.GENERAL_FUND,
-    status: 'active',
-    raised: 68000,
-    goal: 175000,
-    sponsorsCount: 94,
-    publicUrl: environment.urls.crowdfunding,
-  },
-  {
-    id: 'zephyr',
-    name: 'Zephyr RTOS Security Hardening',
-    description: 'Securing the real-time OS powering billions of IoT devices',
-    icon: '⚡',
-    fundType: FundType.SECURITY_AUDIT,
-    status: 'active',
-    raised: 52000,
-    goal: 200000,
-    sponsorsCount: 41,
-    publicUrl: environment.urls.crowdfunding,
-  },
-  {
-    id: 'lkm',
-    name: 'Linux Kernel Mentorship Fund',
-    description: 'Supporting contributors entering the Linux kernel ecosystem',
-    icon: '🌱',
-    fundType: FundType.MENTORSHIP,
-    status: 'pending',
-    raised: 0,
-    goal: null,
-    sponsorsCount: 0,
-  },
-];
 
 @Component({
   selector: 'lfx-my-initiatives',

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TagComponent } from '@components/tag/tag.component';
+
+@Component({
+  selector: 'lfx-my-initiatives',
+  imports: [TagComponent],
+  templateUrl: './my-initiatives.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MyInitiativesComponent {}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -1,13 +1,74 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TagComponent } from '@components/tag/tag.component';
+import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { FundType } from '@lfx-one/shared/enums';
+import { CrowdfundingInitiative, CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
+import { InitiativesStatsBarComponent } from './components/initiatives-stats-bar/initiatives-stats-bar.component';
+import { InitiativesListComponent } from './components/initiatives-list/initiatives-list.component';
+import { environment } from '@environments/environment';
+
+const MOCK_INITIATIVES: CrowdfundingInitiative[] = [
+  {
+    id: 'otel',
+    name: 'OpenTelemetry Community Fund',
+    description: 'Growing the observability standard for cloud-native software',
+    icon: '📡',
+    fundType: FundType.GENERAL_FUND,
+    status: 'active',
+    raised: 68000,
+    goal: 175000,
+    sponsorsCount: 94,
+    publicUrl: environment.urls.crowdfunding,
+  },
+  {
+    id: 'zephyr',
+    name: 'Zephyr RTOS Security Hardening',
+    description: 'Securing the real-time OS powering billions of IoT devices',
+    icon: '⚡',
+    fundType: FundType.SECURITY_AUDIT,
+    status: 'active',
+    raised: 52000,
+    goal: 200000,
+    sponsorsCount: 41,
+    publicUrl: environment.urls.crowdfunding,
+  },
+  {
+    id: 'lkm',
+    name: 'Linux Kernel Mentorship Fund',
+    description: 'Supporting contributors entering the Linux kernel ecosystem',
+    icon: '🌱',
+    fundType: FundType.MENTORSHIP,
+    status: 'pending',
+    raised: 0,
+    goal: null,
+    sponsorsCount: 0,
+  },
+];
 
 @Component({
   selector: 'lfx-my-initiatives',
-  imports: [TagComponent],
+  imports: [InitiativesStatsBarComponent, InitiativesListComponent],
   templateUrl: './my-initiatives.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MyInitiativesComponent {}
+export class MyInitiativesComponent {
+  private readonly router = inject(Router);
+  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly initiatives = signal<CrowdfundingInitiative[]>(MOCK_INITIATIVES);
+
+  protected readonly stats: Signal<CrowdfundingInitiativesStats> = computed(() => {
+    const all = this.initiatives();
+    return {
+      activeCount: all.filter((i) => i.status === 'active').length,
+      totalRaised: all.reduce((sum, i) => sum + i.raised, 0),
+      monthlyGain: 8400,
+      totalSponsors: all.reduce((sum, i) => sum + i.sponsorsCount, 0),
+    };
+  });
+
+  protected onInitiativeClick(id: string): void {
+    void this.router.navigate(['/crowdfunding/initiatives', id]);
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.html
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="relative shrink-0" [style.width.px]="size()" [style.height.px]="size()" data-testid="donut-chart">
+  <svg [attr.width]="size()" [attr.height]="size()" [attr.viewBox]="'0 0 ' + size() + ' ' + size()" fill="none" xmlns="http://www.w3.org/2000/svg">
+    @for (ring of resolvedRings(); track $index) {
+      <!-- Track -->
+      <circle [attr.cx]="center()" [attr.cy]="center()" [attr.r]="ring.r" [attr.stroke]="trackColor()" [attr.stroke-width]="strokeWidth()" fill="none" />
+      <!-- Progress arc -->
+      <circle
+        [attr.cx]="center()"
+        [attr.cy]="center()"
+        [attr.r]="ring.r"
+        [attr.stroke]="ring.color"
+        [attr.stroke-width]="strokeWidth()"
+        stroke-linecap="round"
+        fill="none"
+        [attr.stroke-dasharray]="ring.dash + ' ' + ring.circumference"
+        [attr.transform]="'rotate(-90 ' + center() + ' ' + center() + ')'" />
+    }
+  </svg>
+
+  <!-- Center slot for optional label/icon -->
+  <div class="absolute inset-0 flex items-center justify-center">
+    <ng-content />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.scss
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.ts
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input } from '@angular/core';
+import { DonutRing, ResolvedDonutRing } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-donut-chart',
+  templateUrl: './donut-chart.component.html',
+  styleUrl: './donut-chart.component.scss',
+})
+export class DonutChartComponent {
+  /** Rings ordered from outermost to innermost, each with a value (0–100) and color. */
+  public readonly rings = input.required<DonutRing[]>();
+  /** Diameter of the chart in px. */
+  public readonly size = input<number>(74);
+  /** Ring stroke thickness in px. */
+  public readonly strokeWidth = input<number>(4);
+  /** Track (background ring) color. */
+  public readonly trackColor = input<string>('#E2E8F0');
+  /**
+   * Distance between consecutive ring radii in px.
+   * Accounts for stroke widths on both rings plus a visual gap.
+   */
+  public readonly ringSpacing = input<number>(10);
+
+  protected readonly center = computed(() => this.size() / 2);
+
+  protected readonly resolvedRings = computed<ResolvedDonutRing[]>(() => {
+    const sw = this.strokeWidth();
+    const c = this.center();
+    // Outer ring radius: leave enough room so the stroke doesn't clip the SVG edge.
+    // edgePad = sw + 1 ensures at least 1px clearance beyond the stroke.
+    const outerRadius = c - sw / 2 - (sw + 1);
+    const spacing = this.ringSpacing();
+
+    return this.rings().map((ring, i) => {
+      const r = outerRadius - i * spacing;
+      const circumference = 2 * Math.PI * r;
+      const clampedValue = Math.min(100, Math.max(0, ring.value));
+      const dash = circumference * (clampedValue / 100);
+      return { ...ring, r, circumference, dash };
+    });
+  });
+}

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -75,7 +75,9 @@
       @if (lensLoaded()) {
         <div class="flex flex-col gap-2 items-start px-4 w-full">
           @for (item of itemsWithTestIds(); track item.label) {
-            @if (item.isSection) {
+            @if (item.isGroup) {
+              <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: item }"></ng-container>
+            } @else if (item.isSection) {
               <div class="w-full mt-2" [attr.data-testid]="item.testId">
                 <div class="flex items-center gap-2 px-2 py-1.5">
                   <span class="text-xs font-medium text-gray-400 uppercase tracking-wide whitespace-nowrap">{{ item.label }}</span>
@@ -85,7 +87,11 @@
                 @if (item.items?.length) {
                   <div class="flex flex-col gap-1 mt-2">
                     @for (childItem of item.items; track childItem.label) {
-                      <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
+                      @if (childItem.isGroup) {
+                        <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: childItem }"></ng-container>
+                      } @else {
+                        <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
+                      }
                     }
                   </div>
                 }
@@ -156,6 +162,32 @@
     </div>
   </div>
 </aside>
+
+<ng-template #groupItem let-item>
+  <div class="w-full" [attr.data-testid]="item.testId">
+    <button
+      type="button"
+      (click)="toggleGroup(item.label)"
+      class="flex items-center gap-2 px-2 py-2 rounded-lg w-full text-left text-base text-gray-600 font-normal hover:bg-gray-50 transition-colors"
+      [attr.aria-expanded]="expandedGroupStates()[item.label]"
+      [attr.aria-label]="item.label">
+      <div class="nav-item-icon flex items-center justify-center shrink-0 w-6 h-6">
+        <i [ngClass]="item.icon"></i>
+      </div>
+      <span class="whitespace-nowrap flex-1">{{ item.label }}</span>
+      <i
+        class="fa-light fa-chevron-down text-gray-400 text-xs transition-transform duration-200"
+        [ngClass]="{ 'rotate-180': expandedGroupStates()[item.label] }"></i>
+    </button>
+    @if (expandedGroupStates()[item.label] && item.items?.length) {
+      <div class="flex flex-col gap-1 mt-1 pl-6">
+        @for (childItem of item.items; track childItem.label) {
+          <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
+        }
+      </div>
+    }
+  </div>
+</ng-template>
 
 <ng-template #menuItem let-item>
   @if (item.routerLink) {

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, input, model, Signal } from '@angular/core';
+import { Component, computed, inject, input, model, Signal, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -81,6 +81,40 @@ export class SidebarComponent {
       external: item.url ? this.isExternalUrl(item.url) : undefined,
     }))
   );
+
+  // Stores user-toggled group states alongside the items reference they were built against.
+  // When items changes (lens switch), itemsRef no longer matches, so expandedGroupStates
+  // falls back to each item's default — no effect() needed.
+  private readonly expandedGroupOverrides = signal<{ itemsRef: SidebarMenuItem[]; overrides: Record<string, boolean> }>({
+    itemsRef: [],
+    overrides: {},
+  });
+
+  protected readonly expandedGroupStates = computed(() => {
+    const items = this.items();
+    const { itemsRef, overrides } = this.expandedGroupOverrides();
+    const effectiveOverrides = itemsRef === items ? overrides : {};
+    const states: Record<string, boolean> = {};
+    const scanForGroups = (candidates: SidebarMenuItem[]) => {
+      for (const item of candidates) {
+        if (item.isGroup) {
+          states[item.label] = item.label in effectiveOverrides ? effectiveOverrides[item.label] : (item.expanded ?? true);
+        } else if (item.isSection && item.items?.length) {
+          scanForGroups(item.items);
+        }
+      }
+    };
+    scanForGroups(items);
+    return states;
+  });
+
+  protected toggleGroup(label: string): void {
+    const items = this.items();
+    const current = this.expandedGroupStates()[label] ?? true;
+    const prev = this.expandedGroupOverrides();
+    const baseOverrides = prev.itemsRef === items ? prev.overrides : {};
+    this.expandedGroupOverrides.set({ itemsRef: items, overrides: { ...baseOverrides, [label]: !current } });
+  }
 
   protected onItemSelected(item: LensItem): void {
     const context = lensItemToProjectContext(item);

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -30,3 +30,10 @@ export const CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES: Record<FundType, string> = {
   [FundType.MENTORSHIP]: 'rounded-xl bg-emerald-100 !text-emerald-700',
   [FundType.EVENT]: 'rounded-xl bg-blue-100 !text-blue-700',
 };
+
+export const CROWDFUNDING_DONOR_AVATAR_PALETTE: string[] = [
+  'bg-blue-100 !text-blue-700',
+  'bg-violet-100 !text-violet-700',
+  'bg-emerald-100 !text-emerald-700',
+  'bg-amber-100 !text-amber-700',
+];

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FundType } from '../enums/crowdfunding.enum';
+
+export const CROWDFUNDING_FUND_TYPE_LABELS: Record<FundType, string> = {
+  [FundType.GENERAL_FUND]: 'General Fund',
+  [FundType.SECURITY_AUDIT]: 'Security Audit',
+  [FundType.MENTORSHIP]: 'Mentorship',
+  [FundType.EVENT]: 'Event',
+};
+
+export const CROWDFUNDING_FUND_TYPE_ICONS: Record<FundType, string> = {
+  [FundType.GENERAL_FUND]: 'fa-light fa-piggy-bank',
+  [FundType.SECURITY_AUDIT]: 'fa-light fa-shield-halved',
+  [FundType.MENTORSHIP]: 'fa-light fa-user-group',
+  [FundType.EVENT]: 'fa-light fa-calendar',
+};
+
+export const CROWDFUNDING_FUND_TYPE_COLOR_CLASSES: Record<FundType, string> = {
+  [FundType.GENERAL_FUND]: 'text-violet-600',
+  [FundType.SECURITY_AUDIT]: 'text-amber-600',
+  [FundType.MENTORSHIP]: 'text-emerald-600',
+  [FundType.EVENT]: 'text-blue-600',
+};
+
+export const CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES: Record<FundType, string> = {
+  [FundType.GENERAL_FUND]: 'rounded-xl bg-violet-100 !text-violet-700',
+  [FundType.SECURITY_AUDIT]: 'rounded-xl bg-amber-100 !text-amber-700',
+  [FundType.MENTORSHIP]: 'rounded-xl bg-emerald-100 !text-emerald-700',
+  [FundType.EVENT]: 'rounded-xl bg-blue-100 !text-blue-700',
+};

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -53,3 +53,4 @@ export * from './regex.constants';
 export * from './foundation-projects.constants';
 export * from './marketing-impact.constants';
 export * from './individual-enrollment-catalog';
+export * from './crowdfunding.constants';

--- a/packages/shared/src/enums/crowdfunding.enum.ts
+++ b/packages/shared/src/enums/crowdfunding.enum.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export enum FundType {
+  GENERAL_FUND = 'general_fund',
+  SECURITY_AUDIT = 'security_audit',
+  MENTORSHIP = 'mentorship',
+  EVENT = 'event',
+}

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -13,3 +13,4 @@ export * from './survey.enum';
 export * from './event.enum';
 export * from './project-funding.enum';
 export * from './project-stage.enum';
+export * from './crowdfunding.enum';

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -415,7 +415,9 @@ export interface SidebarMenuItem {
   testId?: string;
   /** Whether this item is a collapsible section header */
   isSection?: boolean;
-  /** Default expanded state for sections (defaults to true) */
+  /** Whether this item is a collapsible nav group (icon + label + chevron, toggleable) */
+  isGroup?: boolean;
+  /** Default expanded state for sections and groups (defaults to true) */
   expanded?: boolean;
   /** Whether to render a divider line before this item */
   dividerBefore?: boolean;

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -51,3 +51,43 @@ export interface CrowdfundingInitiativeDetail extends CrowdfundingInitiative {
   matchDesc?: string;
   matchPct?: number;
 }
+
+export interface DonationStats {
+  totalDonated: number;
+  initiativesSupported: number;
+  activeRecurringAmount: number;
+  activeRecurringCount: number;
+}
+
+export type RecurringDonationStatus = 'active' | 'paused';
+export type DonationKind = 'one-time' | 'monthly';
+
+export interface RecurringDonation {
+  id: string;
+  name: string;
+  icon: string;
+  status: RecurringDonationStatus;
+  amount: number;
+  billingDescription: string;
+  startDate: string;
+  nextChargeDate?: string;
+  pausedSince?: string;
+}
+
+export interface DonationHistoryItem {
+  id: string;
+  initiativeName: string;
+  initiativeIcon: string;
+  fundType: string;
+  fundTypeIcon: string;
+  date: string;
+  kind: DonationKind;
+  amount: number;
+}
+
+export interface PaymentMethod {
+  id: string;
+  brand: string;
+  last4: string;
+  expiry: string;
+}

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -24,3 +24,30 @@ export interface CrowdfundingInitiativesStats {
   monthlyGain: number;
   totalSponsors: number;
 }
+
+export interface AllocationItem {
+  name: string;
+  spent: number;
+  total: number;
+  pct: number;
+}
+
+export interface DonationTransaction {
+  who: string;
+  org?: boolean;
+  amount: number;
+  date: string;
+}
+
+export interface CrowdfundingInitiativeDetail extends CrowdfundingInitiative {
+  about: string;
+  balance: number;
+  monthlyDelta: number;
+  tags: string[];
+  alloc: AllocationItem[];
+  donationsIn: DonationTransaction[];
+  donationsOut: DonationTransaction[];
+  matchLabel?: string;
+  matchDesc?: string;
+  matchPct?: number;
+}

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -1,0 +1,26 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FundType } from '../enums/crowdfunding.enum';
+
+export type CrowdfundingInitiativeStatus = 'active' | 'pending' | 'closed';
+
+export interface CrowdfundingInitiative {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  fundType: FundType;
+  status: CrowdfundingInitiativeStatus;
+  raised: number;
+  goal: number | null;
+  sponsorsCount: number;
+  publicUrl?: string;
+}
+
+export interface CrowdfundingInitiativesStats {
+  activeCount: number;
+  totalRaised: number;
+  monthlyGain: number;
+  totalSponsors: number;
+}

--- a/packages/shared/src/interfaces/donut-chart.interface.ts
+++ b/packages/shared/src/interfaces/donut-chart.interface.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface DonutRing {
+  /** 0–100 percentage value */
+  value: number;
+  /** Solid color string */
+  color: string;
+}
+
+export interface ResolvedDonutRing extends DonutRing {
+  r: number;
+  circumference: number;
+  dash: number;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -159,3 +159,6 @@ export * from './enrollment.interface';
 
 // Crowdfunding interfaces
 export * from './crowdfunding.interface';
+
+// Donut chart interfaces
+export * from './donut-chart.interface';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -156,3 +156,6 @@ export * from './marketing-impact.interface';
 
 // Enrollment interfaces
 export * from './enrollment.interface';
+
+// Crowdfunding interfaces
+export * from './crowdfunding.interface';


### PR DESCRIPTION
 ## Summary
  
  - Add the new **Crowdfunding** module under `apps/lfx-one/src/app/modules/crowdfunding/` with three top-level routes: `my-initiatives` (list + stats), `initiative-detail/:id` (overview, financials, finance
  summary, announcements, settings drawer), and `my-donations` (stats, recurring donations, donation history, payment methods).
  - Introduce reusable presentational pieces: `initiative-card`, `initiatives-stats-bar`, `donations-stats-bar`, `donation-history-table`, `recurring-donations-list`, `payment-methods` (with `payment-method-card` +
   `add-payment-card-dialog`), and a shared `donut-chart` component used by financial views.
  - Wire the module into the app shell — register `crowdfunding.routes.ts` in `app.routes.ts`, extend `main-layout` and the shared `sidebar` for the new navigation entry (currently reverted to a single
  "Crowdfunding" link per the latest commit).
  - Extend `@lfx-one/shared` with crowdfunding interfaces, enums, and constants (`crowdfunding.interface.ts`, `crowdfunding.enum.ts`, `crowdfunding.constants.ts`) plus a `donut-chart.interface.ts`, all exported
  through the package barrels.
  - Ship a `crowdfunding.mock.ts` dataset to drive the UI while backend endpoints are pending — no API calls or services are introduced yet; this PR is **UI-only**.

