### PR TITLE
feat(crowdfunding): add my initiatives list page with initiative card and stats bar

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -10,4 +10,14 @@ export const CROWDFUNDING_ROUTES: Routes = [
     loadComponent: () => import('./my-initiatives/my-initiatives.component').then((m) => m.MyInitiativesComponent),
     canActivate: [authGuard],
   },
+  {
+    path: 'initiatives/:id',
+    loadComponent: () => import('./initiative-detail/initiative-detail.component').then((m) => m.InitiativeDetailComponent),
+    canActivate: [authGuard],
+  },
+  {
+    path: 'donations',
+    loadComponent: () => import('./my-donations/my-donations.component').then((m) => m.MyDonationsComponent),
+    canActivate: [authGuard],
+  },
 ];

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -2,5 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { authGuard } from '@shared/guards/auth.guard';
 
-export const CROWDFUNDING_ROUTES: Routes = [];
+export const CROWDFUNDING_ROUTES: Routes = [
+  {
+    path: 'initiatives',
+    loadComponent: () => import('./my-initiatives/my-initiatives.component').then((m) => m.MyInitiativesComponent),
+    canActivate: [authGuard],
+  },
+];

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.html
@@ -1,0 +1,11 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card data-testid="announcements-card">
+  <div class="flex flex-col items-center py-10 gap-3">
+    <i class="fa-light fa-bullhorn text-5xl text-gray-300" aria-hidden="true"></i>
+    <h3 class="text-base font-semibold text-gray-700">No announcements yet</h3>
+    <p class="text-sm text-gray-500 mb-2">Keep sponsors engaged by sharing milestones and updates.</p>
+    <lfx-button label="New Announcement" icon="fa-light fa-plus" severity="primary" size="small" data-testid="new-announcement-btn" />
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-announcements/initiative-announcements.component.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { ButtonComponent } from '@components/button/button.component';
+
+@Component({
+  selector: 'lfx-initiative-announcements',
+  imports: [CardComponent, ButtonComponent],
+  templateUrl: './initiative-announcements.component.html',
+  styleUrl: './initiative-announcements.component.scss',
+})
+export class InitiativeAnnouncementsComponent {}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
@@ -1,0 +1,88 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="initiative-detail-header">
+  <!-- Header body -->
+  <div class="flex items-start gap-4 p-6" data-testid="initiative-header-body">
+    <!-- Avatar -->
+    <lfx-avatar [label]="initiative().name" shape="square" size="xlarge" [styleClass]="avatarStyleClass()" [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
+
+    <!-- Content: type label, title+status, desc, tags -->
+    <div class="flex flex-col gap-1.5 flex-1 min-w-0">
+      <span class="text-xs font-semibold flex items-center gap-1" [class]="fundTypeColorClass()">
+        <i [class]="fundTypeIcon()" aria-hidden="true"></i>
+        {{ fundTypeLabel() }}
+      </span>
+      <div class="flex items-center gap-2 flex-wrap">
+        <h1 class="text-xl font-bold text-gray-900">{{ initiative().name }}</h1>
+        @if (initiative().status === 'active') {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+        } @else if (initiative().status === 'pending') {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"> Pending </span>
+        } @else {
+          <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"> Closed </span>
+        }
+      </div>
+      <p class="text-sm text-gray-500">{{ initiative().description }}</p>
+      @if (initiative().tags.length) {
+        <div class="flex items-center gap-1.5 flex-wrap mt-1" data-testid="initiative-tags">
+          @for (tag of initiative().tags; track tag) {
+            <lfx-tag [value]="tag" severity="secondary" [rounded]="true" />
+          }
+        </div>
+      }
+    </div>
+
+    <!-- Actions -->
+    <div class="flex items-center gap-2 flex-shrink-0 ml-4" data-testid="initiative-header-actions">
+      @if (initiative().publicUrl) {
+        <a
+          [href]="initiative().publicUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+          data-testid="initiative-view-public-btn">
+          View Public Page
+          <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+        </a>
+      }
+      <lfx-button
+        label="Settings"
+        icon="fa-light fa-gear"
+        severity="secondary"
+        size="small"
+        data-testid="initiative-settings-btn"
+        (click)="settingsClick.emit()" />
+      <lfx-button icon="fa-light fa-ellipsis" severity="secondary" size="small" data-testid="initiative-more-btn" (click)="onMoreClick($event)" />
+      <lfx-menu #moreMenu [model]="moreMenuItems" [popup]="true" appendTo="body" styleClass="w-72">
+        <ng-template #item let-item>
+          <button class="flex flex-col gap-0.5 w-full px-3 py-2.5 text-left hover:bg-gray-50 transition-colors" [class.hover:bg-red-50]="item.danger">
+            <div class="flex items-center gap-2 text-sm font-medium" [class.text-gray-800]="!item.danger" [class.text-red-600]="item.danger">
+              <i [class]="item.icon" aria-hidden="true"></i>
+              {{ item.label }}
+            </div>
+            @if (item.description) {
+              <div class="text-xs text-gray-400 leading-relaxed pl-5">{{ item.description }}</div>
+            }
+          </button>
+        </ng-template>
+      </lfx-menu>
+    </div>
+  </div>
+
+  <!-- Tab bar -->
+  <div class="border-t border-gray-200 flex items-center px-2" data-testid="initiative-tab-bar">
+    @for (tab of tabOptions; track tab.value) {
+      <button
+        class="relative px-4 py-3 text-sm font-medium transition-colors"
+        [class]="activeTab() === tab.value ? 'text-blue-600' : 'text-gray-500 hover:text-gray-900'"
+        (click)="tabChange.emit(tab.value)"
+        [attr.data-testid]="'initiative-tab-' + tab.value">
+        {{ tab.label }}
+        @if (activeTab() === tab.value) {
+          <div class="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 rounded-full"></div>
+        }
+      </button>
+    }
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -1,0 +1,60 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, viewChild } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { TagComponent } from '@components/tag/tag.component';
+import {
+  CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_COLOR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_ICONS,
+  CROWDFUNDING_FUND_TYPE_LABELS,
+} from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail, InitiativeMenuItem, TabOption } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-detail-header',
+  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent],
+  templateUrl: './initiative-detail-header.component.html',
+  styleUrl: './initiative-detail-header.component.scss',
+})
+export class InitiativeDetailHeaderComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly activeTab = input.required<string>();
+  public readonly tabChange = output<string>();
+  public readonly settingsClick = output<void>();
+
+  private readonly moreMenu = viewChild<MenuComponent>('moreMenu');
+
+  protected readonly tabOptions: TabOption<string>[] = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'financials', label: 'Financials' },
+    { value: 'announcements', label: 'Announcements' },
+  ];
+
+  protected readonly moreMenuItems: InitiativeMenuItem[] = [
+    {
+      label: 'Pause fundraising',
+      icon: 'fa-solid fa-pause',
+      description: 'Temporarily stop accepting new donations. Your initiative stays visible but the "Donate" button is hidden.',
+    },
+    {
+      label: 'Close initiative',
+      icon: 'fa-solid fa-circle-xmark',
+      description: 'Permanently close this initiative and stop all recurring donations. Remaining balance is handled per LF policy.',
+      danger: true,
+    },
+  ];
+
+  protected readonly fundTypeLabel = computed(() => CROWDFUNDING_FUND_TYPE_LABELS[this.initiative().fundType]);
+  protected readonly fundTypeIcon = computed(() => CROWDFUNDING_FUND_TYPE_ICONS[this.initiative().fundType]);
+  protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
+  protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
+
+  protected onMoreClick(event: Event): void {
+    this.moreMenu()?.toggle(event);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.html
@@ -1,0 +1,56 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card data-testid="finance-summary-card">
+  <!-- Current balance -->
+  <div class="text-xs font-bold text-gray-500 uppercase tracking-wide mb-1.5">Current Balance</div>
+  <div class="text-3xl font-extrabold text-gray-900 tracking-tight mb-5">{{ formattedBalance() }}</div>
+
+  <!-- Raised / goal row -->
+  <div class="flex items-center justify-between text-sm mb-1.5">
+    <span>
+      <span class="font-bold text-gray-900">{{ formattedRaised() }} raised</span>
+      @if (formattedGoal()) {
+        <span class="text-gray-500">of {{ formattedGoal() }} goal</span>
+      }
+    </span>
+    <span class="text-gray-500 text-xs">{{ progressPercent() }}% funded</span>
+  </div>
+
+  <!-- Progress bar -->
+  <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden mb-2">
+    <div
+      class="h-full bg-blue-600 rounded-full"
+      [style.width.%]="progressPercent()"
+      role="progressbar"
+      [attr.aria-valuenow]="progressPercent()"
+      aria-valuemin="0"
+      aria-valuemax="100"></div>
+  </div>
+  <p class="text-xs text-gray-500 mb-6">{{ initiative().sponsorsCount }} sponsors · ↑ +{{ formattedMonthlyDelta() }} this month</p>
+
+  <!-- Funding allocation -->
+  <div class="text-sm font-bold text-gray-900 mb-4">Funding allocation</div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-7 gap-y-5" data-testid="allocation-grid">
+    @for (item of allocItemsWithMeta(); track item.name) {
+      <div class="flex items-center gap-3.5" data-testid="allocation-item">
+        <lfx-donut-chart [rings]="item.rings" />
+        <div class="min-w-0">
+          <div class="flex items-center gap-2.5 mb-1.5">
+            <span class="text-sm font-bold text-gray-900 truncate">{{ item.name }}</span>
+            <span class="w-px h-3 bg-gray-300 shrink-0"></span>
+            <span class="text-sm text-gray-400 whitespace-nowrap">Goal: {{ item.formattedTotal }}</span>
+          </div>
+          <div class="flex items-center gap-1.5 text-xs text-gray-500">
+            <span class="w-2 h-2 rounded-full bg-blue-600 shrink-0"></span>
+            Donated {{ item.formattedDonated }}
+          </div>
+          <div class="flex items-center gap-1.5 text-xs text-gray-500">
+            <span class="w-2 h-2 rounded-full bg-slate-800 shrink-0"></span>
+            Spent {{ item.formattedSpent }}
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-finance-summary/initiative-finance-summary.component.ts
@@ -1,0 +1,64 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { DonutChartComponent } from '@components/donut-chart/donut-chart.component';
+import { AllocItemWithMeta, CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-finance-summary',
+  imports: [CardComponent, DonutChartComponent],
+  templateUrl: './initiative-finance-summary.component.html',
+  styleUrl: './initiative-finance-summary.component.scss',
+})
+export class InitiativeFinanceSummaryComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+
+  protected readonly progressPercent = computed(() => {
+    const { raised, goal } = this.initiative();
+    if (!goal || goal === 0) return 0;
+    return Math.min(100, Math.round((raised / goal) * 100));
+  });
+
+  protected readonly formattedBalance = computed(() => this.formatCurrency(this.initiative().balance));
+  protected readonly formattedRaised = computed(() => this.formatCurrency(this.initiative().raised));
+  protected readonly formattedGoal = this.initFormattedGoal();
+  protected readonly formattedMonthlyDelta = computed(() => this.formatCurrency(this.initiative().monthlyDelta));
+  protected readonly allocItemsWithMeta = this.initAllocItemsWithMeta();
+
+  private initFormattedGoal(): Signal<string | null> {
+    return computed(() => {
+      const g = this.initiative().goal;
+      return g != null ? this.formatCurrency(g) : null;
+    });
+  }
+
+  private initAllocItemsWithMeta(): Signal<AllocItemWithMeta[]> {
+    return computed(() =>
+      this.initiative().alloc.map((item) => {
+        const donated = Math.round((item.pct / 100) * item.total);
+        const donatedPct = Math.min(100, item.pct);
+        const spentPct = item.total > 0 ? Math.min(100, Math.round((item.spent / item.total) * 100)) : 0;
+        return {
+          ...item,
+          donated,
+          formattedTotal: this.formatCurrency(item.total),
+          formattedDonated: this.formatCurrency(donated),
+          formattedSpent: this.formatCurrency(item.spent),
+          rings: [
+            { value: donatedPct, color: '#006BFF' },
+            { value: spentPct, color: '#1e293b' },
+          ],
+        };
+      })
+    );
+  }
+
+  private formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.html
@@ -1,0 +1,110 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiative-financials">
+  <!-- Metrics bar -->
+  <div class="bg-white border border-gray-200 rounded-lg shadow-sm flex items-stretch overflow-hidden" data-testid="financials-metrics-bar">
+    <div class="flex-1 flex items-center gap-3 px-5 py-4">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-circle-down text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Total received</div>
+        <div class="text-lg font-bold text-gray-900">{{ formattedTotalReceived() }}</div>
+      </div>
+    </div>
+    <div class="flex-1 flex items-center gap-3 px-5 py-4 border-l border-gray-200">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-circle-up text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Total expenses</div>
+        <div class="text-lg font-bold text-gray-900">{{ formattedTotalExpenses() }}</div>
+      </div>
+    </div>
+    <div class="flex-1 flex items-center gap-3 px-5 py-4 border-l border-gray-200">
+      <div class="w-11 h-11 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+        <i class="fa-light fa-scale-balanced text-gray-500" aria-hidden="true"></i>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500 mb-0.5">Balance</div>
+        <div class="text-lg font-bold text-gray-900">{{ formattedBalance() }}</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Donations received -->
+  <div data-testid="donations-received-section">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-sm font-bold text-gray-900">Donations received</span>
+      <span class="text-xs text-gray-400">{{ initiative().donationsIn.length }} transactions</span>
+    </div>
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead>
+            <tr class="bg-gray-50 border-b border-gray-200">
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Date</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Sponsor</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Type</th>
+              <th class="text-right text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (donation of donationsInWithMeta(); track donation.who + donation.date) {
+              <tr class="border-b border-gray-100 last:border-0" data-testid="donation-row">
+                <td class="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">{{ donation.date }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-2.5">
+                    <lfx-avatar [label]="donation.who" shape="square" size="normal" [styleClass]="donation.avatarClass" />
+                    <span class="text-sm font-medium text-gray-900">{{ donation.who }}</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  @if (donation.org) {
+                    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Company</span>
+                  } @else {
+                    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-violet-50 text-violet-700">Individual</span>
+                  }
+                </td>
+                <td class="px-4 py-3 text-right text-sm font-bold text-gray-900 whitespace-nowrap">
+                  {{ donation.formattedAmount }}
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Expense breakdown -->
+  <div data-testid="expenses-section">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-sm font-bold text-gray-900">Expense breakdown</span>
+      <span class="text-xs text-gray-400">{{ initiative().donationsOut.length }} transactions</span>
+    </div>
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead>
+            <tr class="bg-gray-50 border-b border-gray-200">
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Date</th>
+              <th class="text-left text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Description</th>
+              <th class="text-right text-xs font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (expense of donationsOutWithMeta(); track expense.who + expense.date) {
+              <tr class="border-b border-gray-100 last:border-0" data-testid="expense-row">
+                <td class="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">{{ expense.date }}</td>
+                <td class="px-4 py-3 text-sm text-gray-700">{{ expense.who }}</td>
+                <td class="px-4 py-3 text-right text-sm font-bold text-red-600 whitespace-nowrap">−{{ expense.formattedAmount }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-financials/initiative-financials.component.ts
@@ -1,0 +1,61 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { CROWDFUNDING_DONOR_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail, DonationTransaction } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-financials',
+  imports: [AvatarComponent],
+  templateUrl: './initiative-financials.component.html',
+  styleUrl: './initiative-financials.component.scss',
+})
+export class InitiativeFinancialsComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+
+  protected readonly totalReceived = computed(() => this.initiative().donationsIn.reduce((sum, d) => sum + d.amount, 0));
+  protected readonly totalExpenses = computed(() => this.initiative().donationsOut.reduce((sum, d) => sum + d.amount, 0));
+  protected readonly balance = computed(() => this.totalReceived() - this.totalExpenses());
+
+  protected readonly formattedTotalReceived = computed(() => this.formatCurrency(this.totalReceived()));
+  protected readonly formattedTotalExpenses = computed(() => this.formatCurrency(this.totalExpenses()));
+  protected readonly formattedBalance = computed(() => this.formatCurrency(this.balance()));
+  protected readonly donationsInWithMeta = this.initDonationsInWithMeta();
+  protected readonly donationsOutWithMeta = this.initDonationsOutWithMeta();
+
+  private initDonationsInWithMeta(): Signal<(DonationTransaction & { formattedAmount: string; avatarClass: string })[]> {
+    return computed(() =>
+      this.initiative().donationsIn.map((d) => ({
+        ...d,
+        formattedAmount: this.formatCurrency(d.amount),
+        avatarClass: this.donorAvatarClass(d.who),
+      }))
+    );
+  }
+
+  private initDonationsOutWithMeta(): Signal<(DonationTransaction & { formattedAmount: string })[]> {
+    return computed(() =>
+      this.initiative().donationsOut.map((d) => ({
+        ...d,
+        formattedAmount: this.formatCurrency(d.amount),
+      }))
+    );
+  }
+
+  private donorAvatarClass(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) & 0xffffff;
+    }
+    return CROWDFUNDING_DONOR_AVATAR_PALETTE[Math.abs(hash) % CROWDFUNDING_DONOR_AVATAR_PALETTE.length];
+  }
+
+  private formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.html
@@ -1,0 +1,46 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiative-overview-sidebar">
+  <!-- Matching banner (optional) -->
+  @if (initiative().matchLabel) {
+    <div class="rounded-lg p-5 text-white" style="background: linear-gradient(135deg, #4f46e5, #7c3aed)" data-testid="matching-banner">
+      <div class="text-sm font-bold mb-1">{{ initiative().matchLabel }}</div>
+      <div class="text-xs opacity-90 leading-relaxed mb-4">{{ initiative().matchDesc }}</div>
+      <div class="h-1 bg-white/30 rounded-full overflow-hidden">
+        <div class="h-full bg-white rounded-full" [style.width.%]="initiative().matchPct ?? 0"></div>
+      </div>
+      <div class="text-xs opacity-70 mt-1.5">{{ initiative().matchPct }}% matched</div>
+    </div>
+  }
+
+  <!-- Recent donations card -->
+  <lfx-card data-testid="recent-donations-card">
+    <div class="flex items-center justify-between mb-4">
+      <div class="text-sm font-bold text-gray-900">Recent donations</div>
+      <button
+        class="text-xs font-medium text-blue-600 hover:text-blue-700 transition-colors"
+        (click)="viewAllFinancials.emit()"
+        data-testid="view-all-financials-btn">
+        View all
+      </button>
+    </div>
+    <div class="flex flex-col" data-testid="activity-feed">
+      @for (donation of recentDonationsWithMeta(); track donation.who + donation.date) {
+        <div class="flex items-center gap-3 py-2.5 border-b border-gray-100 last:border-0" data-testid="activity-row">
+          <lfx-avatar [label]="donation.who" shape="square" size="normal" [styleClass]="donation.avatarClass" />
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-900 truncate">
+              {{ donation.who }}
+              @if (donation.org) {
+                <span class="ml-1 text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded font-medium">ORG</span>
+              }
+            </div>
+            <div class="text-xs text-gray-400">{{ donation.date }}</div>
+          </div>
+          <div class="text-sm font-bold text-gray-900 whitespace-nowrap">{{ donation.formattedAmount }}</div>
+        </div>
+      }
+    </div>
+  </lfx-card>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview-sidebar/initiative-overview-sidebar.component.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, Signal } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { CardComponent } from '@components/card/card.component';
+import { CROWDFUNDING_DONOR_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { CrowdfundingInitiativeDetail, DonationTransaction } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-overview-sidebar',
+  imports: [CardComponent, AvatarComponent],
+  templateUrl: './initiative-overview-sidebar.component.html',
+  styleUrl: './initiative-overview-sidebar.component.scss',
+})
+export class InitiativeOverviewSidebarComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly viewAllFinancials = output<void>();
+
+  protected readonly recentDonationsWithMeta = this.initRecentDonationsWithMeta();
+
+  private initRecentDonationsWithMeta(): Signal<(DonationTransaction & { formattedAmount: string; avatarClass: string })[]> {
+    return computed(() =>
+      this.initiative()
+        .donationsIn.slice(0, 5)
+        .map((d) => ({
+          ...d,
+          formattedAmount: this.formatCurrency(d.amount),
+          avatarClass: this.donorAvatarClass(d.who),
+        }))
+    );
+  }
+
+  private formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+
+  private donorAvatarClass(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) & 0xffffff;
+    }
+    return CROWDFUNDING_DONOR_AVATAR_PALETTE[Math.abs(hash) % CROWDFUNDING_DONOR_AVATAR_PALETTE.length];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="grid grid-cols-1 lg:grid-cols-[3fr_1fr] gap-5 items-start" data-testid="initiative-overview">
+  <!-- Left column -->
+  <div class="flex flex-col gap-5">
+    <!-- Finance summary card -->
+    <lfx-initiative-finance-summary [initiative]="initiative()" />
+
+    <!-- About card -->
+    <lfx-card data-testid="about-card">
+      <div class="text-sm font-bold text-gray-900 mb-4">About this Initiative</div>
+      <p class="text-sm text-gray-600 leading-relaxed mb-3">{{ initiative().about }}</p>
+      <p class="text-sm text-gray-600 leading-relaxed mb-3">
+        Contributions go directly toward sustaining long-term maintainership, funding critical infrastructure, and ensuring the project remains vendor-neutral
+        and community-driven. All expenditures are tracked transparently and reported quarterly to sponsors and the broader community.
+      </p>
+      <p class="text-sm text-gray-600 leading-relaxed">
+        Whether you're an individual developer or a large organization, your support helps ensure this project continues to evolve, stays secure, and remains
+        accessible to everyone — regardless of company size or resources.
+      </p>
+    </lfx-card>
+  </div>
+
+  <!-- Right column -->
+  <lfx-initiative-overview-sidebar [initiative]="initiative()" (viewAllFinancials)="viewAllFinancials.emit()" />
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-overview/initiative-overview.component.ts
@@ -1,0 +1,19 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { CrowdfundingInitiativeDetail } from '@lfx-one/shared/interfaces';
+import { InitiativeFinanceSummaryComponent } from '../initiative-finance-summary/initiative-finance-summary.component';
+import { InitiativeOverviewSidebarComponent } from '../initiative-overview-sidebar/initiative-overview-sidebar.component';
+
+@Component({
+  selector: 'lfx-initiative-overview',
+  imports: [CardComponent, InitiativeFinanceSummaryComponent, InitiativeOverviewSidebarComponent],
+  templateUrl: './initiative-overview.component.html',
+  styleUrl: './initiative-overview.component.scss',
+})
+export class InitiativeOverviewComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly viewAllFinancials = output<void>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -1,0 +1,196 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[600px] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="initiative-settings-drawer">
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full">
+      <div class="flex flex-col gap-0.5 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="initiative-settings-drawer-title">Initiative Settings</h2>
+        <p class="text-sm text-gray-500">{{ initiative().name }}</p>
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors flex-shrink-0"
+        aria-label="Close panel"
+        data-testid="initiative-settings-drawer-close">
+        <i class="fa-light fa-xmark text-xl pointer-events-none"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-6 pb-2 overflow-x-hidden" data-testid="initiative-settings-drawer-content">
+    <!-- Tab bar -->
+    <div class="flex items-center border-b border-gray-200 -mx-6 px-6 -mt-2" data-testid="initiative-settings-tabs">
+      @for (tab of settingsTabs; track tab.value) {
+        <button
+          class="relative px-4 py-2.5 text-sm font-medium transition-colors whitespace-nowrap"
+          [class]="activeSettingsTab() === tab.value ? 'text-blue-600' : 'text-gray-500 hover:text-gray-800'"
+          (click)="activeSettingsTab.set(tab.value)"
+          [attr.data-testid]="'settings-tab-' + tab.value">
+          {{ tab.label }}
+          @if (activeSettingsTab() === tab.value) {
+            <div class="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 rounded-full"></div>
+          }
+        </button>
+      }
+    </div>
+
+    <!-- Initiative details tab -->
+    @if (activeSettingsTab() === 'details') {
+      <div class="flex flex-col gap-5" data-testid="settings-details-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">General Fund Details</h3>
+
+        <!-- Name -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-name">
+          <div class="flex items-center justify-between">
+            <label for="settings-name" class="text-sm font-medium text-gray-700">
+              Initiative name <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <span class="text-xs text-gray-400">{{ nameLength() }}/100</span>
+          </div>
+          <lfx-input-text [form]="form" control="name" id="settings-name" placeholder="Enter initiative name" />
+        </div>
+
+        <!-- Elevator pitch -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-description">
+          <div class="flex items-center justify-between">
+            <label for="settings-description" class="text-sm font-medium text-gray-700">
+              Elevator Pitch <span class="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <span class="text-xs text-gray-400">{{ descriptionLength() }}/500</span>
+          </div>
+          <lfx-textarea
+            [form]="form"
+            control="description"
+            id="settings-description"
+            [rows]="4"
+            [maxlength]="500"
+            placeholder="Describe your initiative in a few sentences…" />
+        </div>
+
+        <!-- Topic / Category tags -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-tags">
+          <label class="text-sm font-medium text-gray-700"> Topic / Category <span class="text-red-500" aria-hidden="true">*</span> </label>
+          <div
+            class="flex flex-wrap items-center gap-1.5 p-2 border border-gray-300 rounded-md min-h-[42px] bg-white focus-within:border-blue-500 transition-colors cursor-text">
+            @for (tag of tags(); track tag) {
+              <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-50 text-blue-700 px-2 py-1 rounded">
+                {{ tag }}
+                <button type="button" (click)="removeTag(tag)" class="hover:text-blue-900 ml-0.5" [attr.aria-label]="'Remove ' + tag + ' category'">
+                  <i class="fa-solid fa-xmark text-[10px]" aria-hidden="true"></i>
+                </button>
+              </span>
+            }
+            <input
+              pInputText
+              type="text"
+              class="flex-1 min-w-[80px] border-none outline-none text-sm bg-transparent py-0.5 p-0 shadow-none"
+              placeholder="Add category…"
+              [value]="newTagValue()"
+              (input)="newTagValue.set($any($event.target).value)"
+              (keydown.enter)="$event.preventDefault(); addTag()"
+              aria-label="Add category tag" />
+          </div>
+          <p class="text-xs text-gray-400">Press Enter to add a category.</p>
+        </div>
+
+        <!-- Website URL -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-website">
+          <label for="settings-website" class="text-sm font-medium text-gray-700">Website URL</label>
+          <lfx-input-text [form]="form" control="websiteUrl" id="settings-website" type="url" placeholder="https://example.org" />
+        </div>
+      </div>
+    }
+
+    <!-- Branding tab -->
+    @else if (activeSettingsTab() === 'branding') {
+      <div class="flex flex-col gap-5" data-testid="settings-branding-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Branding</h3>
+
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-logo">
+          <label class="text-sm font-medium text-gray-700"> Initiative logo <span class="text-red-500" aria-hidden="true">*</span> </label>
+          <div class="flex items-center gap-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
+            <!-- Current logo preview -->
+            <div
+              class="w-16 h-16 rounded-lg border border-gray-200 bg-white flex items-center justify-center text-3xl flex-shrink-0"
+              data-testid="settings-logo-preview"
+              aria-label="Current initiative logo">
+              {{ initiative().icon }}
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <p class="text-sm font-medium text-gray-700">{{ initiative().name | lowercase }}-logo.png</p>
+              <p class="text-xs text-gray-500">PNG, JPG, or SVG. Recommended size: 256×256px.</p>
+              <div class="flex items-center gap-2 mt-1">
+                <lfx-button label="Remove" icon="fa-regular fa-trash-can" severity="secondary" size="small" data-testid="settings-logo-remove-btn" />
+                <lfx-button label="Choose different" icon="fa-solid fa-upload" severity="secondary" size="small" data-testid="settings-logo-upload-btn" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- Beneficiaries tab -->
+    @else if (activeSettingsTab() === 'beneficiaries') {
+      <div class="flex flex-col gap-5" data-testid="settings-beneficiaries-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Beneficiaries</h3>
+
+        <p class="text-sm text-gray-500">You will be automatically added as a beneficiary. Add others who can submit expenses below.</p>
+
+        <div class="flex flex-col gap-3" data-testid="settings-beneficiaries-list">
+          @for (group of beneficiaryGroups(); track $index) {
+            <div class="flex items-center gap-2" [attr.data-testid]="'settings-beneficiary-row-' + $index">
+              <lfx-input-text [form]="group" control="name" placeholder="Full name" class="flex-1" [dataTest]="'beneficiary-name-' + $index" />
+              <lfx-input-text [form]="group" control="email" type="email" placeholder="Email" class="flex-[2]" [dataTest]="'beneficiary-email-' + $index" />
+              <button
+                type="button"
+                (click)="removeBeneficiary($index)"
+                class="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                [attr.aria-label]="'Remove beneficiary ' + ($index + 1)">
+                <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
+              </button>
+            </div>
+          }
+        </div>
+
+        <lfx-button
+          label="Add beneficiary"
+          icon="fa-solid fa-plus"
+          severity="secondary"
+          size="small"
+          styleClass="self-start"
+          (click)="addBeneficiary()"
+          data-testid="settings-add-beneficiary-btn" />
+      </div>
+    }
+
+    <!-- Funding tab -->
+    @else if (activeSettingsTab() === 'funding') {
+      <div class="flex flex-col gap-5" data-testid="settings-funding-tab">
+        <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Funding</h3>
+
+        <p class="text-sm text-gray-500">Provide your initial estimated general fund funding goal.</p>
+
+        <div class="flex flex-col gap-1.5 max-w-[240px]" data-testid="settings-field-goal">
+          <label for="settings-goal" class="text-sm font-medium text-gray-700">
+            Annual Funding Goal <span class="text-red-500" aria-hidden="true">*</span>
+          </label>
+          <lfx-input-text [form]="form" control="goal" id="settings-goal" type="number" placeholder="0" icon="fa-light fa-dollar-sign" />
+        </div>
+      </div>
+    }
+
+    <!-- Footer actions -->
+    <div class="flex justify-end gap-2 pt-4 border-t border-gray-200 mt-auto" data-testid="initiative-settings-footer">
+      <lfx-button label="Cancel" severity="secondary" (click)="onClose()" data-testid="initiative-settings-cancel-btn" />
+      <lfx-button label="Save changes" severity="primary" data-testid="initiative-settings-save-btn" />
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -1,0 +1,94 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { LowerCasePipe } from '@angular/common';
+import { Component, model, input, signal, computed } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { CrowdfundingInitiativeDetail, TabOption } from '@lfx-one/shared/interfaces';
+import { filter } from 'rxjs';
+import { InputTextModule } from 'primeng/inputtext';
+import { DrawerModule } from 'primeng/drawer';
+
+@Component({
+  selector: 'lfx-initiative-settings-drawer',
+  imports: [DrawerModule, InputTextComponent, TextareaComponent, ButtonComponent, ReactiveFormsModule, InputTextModule, LowerCasePipe],
+  templateUrl: './initiative-settings-drawer.component.html',
+  styleUrl: './initiative-settings-drawer.component.scss',
+})
+export class InitiativeSettingsDrawerComponent {
+  public readonly initiative = input.required<CrowdfundingInitiativeDetail>();
+  public readonly visible = model(false);
+
+  protected readonly activeSettingsTab = signal<string>('details');
+
+  protected readonly settingsTabs: TabOption<string>[] = [
+    { value: 'details', label: 'Initiative details' },
+    { value: 'branding', label: 'Branding' },
+    { value: 'beneficiaries', label: 'Beneficiaries' },
+    { value: 'funding', label: 'Funding' },
+  ];
+
+  protected readonly form: FormGroup = new FormGroup({
+    name: new FormControl('', [Validators.required, Validators.maxLength(100)]),
+    description: new FormControl('', [Validators.required, Validators.maxLength(500)]),
+    websiteUrl: new FormControl(''),
+    goal: new FormControl<number | null>(null),
+  });
+
+  protected readonly tags = signal<string[]>([]);
+  protected readonly newTagValue = signal<string>('');
+  protected readonly beneficiaryGroups = signal<FormGroup[]>([]);
+
+  private readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.value });
+  protected readonly nameLength = computed(() => this.formValue().name?.length ?? 0);
+  protected readonly descriptionLength = computed(() => this.formValue().description?.length ?? 0);
+
+  public constructor() {
+    toObservable(this.visible)
+      .pipe(filter(Boolean), takeUntilDestroyed())
+      .subscribe(() => {
+        const init = this.initiative();
+        this.form.patchValue({
+          name: init.name,
+          description: init.description,
+          websiteUrl: init.publicUrl ?? '',
+          goal: init.goal,
+        });
+        this.tags.set([...init.tags]);
+        this.beneficiaryGroups.set([]);
+        this.activeSettingsTab.set('details');
+      });
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  protected addTag(): void {
+    const tag = this.newTagValue().trim();
+    if (tag && !this.tags().includes(tag)) {
+      this.tags.update((tags) => [...tags, tag]);
+    }
+    this.newTagValue.set('');
+  }
+
+  protected removeTag(tag: string): void {
+    this.tags.update((tags) => tags.filter((t) => t !== tag));
+  }
+
+  protected addBeneficiary(): void {
+    const group = new FormGroup({
+      name: new FormControl(''),
+      email: new FormControl('', Validators.email),
+    });
+    this.beneficiaryGroups.update((groups) => [...groups, group]);
+  }
+
+  protected removeBeneficiary(index: number): void {
+    this.beneficiaryGroups.update((groups) => groups.filter((_, i) => i !== index));
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
@@ -1,0 +1,30 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5 p-8" data-testid="initiative-detail">
+  <lfx-button
+    label="Back to My Initiatives"
+    icon="fa-light fa-chevron-left"
+    severity="secondary"
+    size="small"
+    [text]="true"
+    routerLink="/crowdfunding/initiatives"
+    styleClass="self-start"
+    data-testid="initiative-detail-back-btn" />
+
+  <lfx-initiative-detail-header
+    [initiative]="initiative()"
+    [activeTab]="activeTab()"
+    (tabChange)="activeTab.set($event)"
+    (settingsClick)="settingsDrawerVisible.set(true)" />
+
+  <lfx-initiative-settings-drawer [initiative]="initiative()" [(visible)]="settingsDrawerVisible" />
+
+  @if (activeTab() === 'overview') {
+    <lfx-initiative-overview [initiative]="initiative()" (viewAllFinancials)="activeTab.set('financials')" />
+  } @else if (activeTab() === 'financials') {
+    <lfx-initiative-financials [initiative]="initiative()" />
+  } @else if (activeTab() === 'announcements') {
+    <lfx-initiative-announcements />
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -1,0 +1,40 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+import { ButtonComponent } from '@components/button/button.component';
+import { MOCK_INITIATIVE_DETAIL } from '../crowdfunding.mock';
+import { InitiativeDetailHeaderComponent } from './components/initiative-detail-header/initiative-detail-header.component';
+import { InitiativeOverviewComponent } from './components/initiative-overview/initiative-overview.component';
+import { InitiativeFinancialsComponent } from './components/initiative-financials/initiative-financials.component';
+import { InitiativeAnnouncementsComponent } from './components/initiative-announcements/initiative-announcements.component';
+import { InitiativeSettingsDrawerComponent } from './components/initiative-settings-drawer/initiative-settings-drawer.component';
+
+@Component({
+  selector: 'lfx-initiative-detail',
+  imports: [
+    ButtonComponent,
+    InitiativeDetailHeaderComponent,
+    InitiativeOverviewComponent,
+    InitiativeFinancialsComponent,
+    InitiativeAnnouncementsComponent,
+    InitiativeSettingsDrawerComponent,
+  ],
+  templateUrl: './initiative-detail.component.html',
+  styleUrl: './initiative-detail.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InitiativeDetailComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly initiativeId = toSignal(this.route.paramMap.pipe(map((params) => params.get('id') ?? '')), { initialValue: '' });
+  protected readonly initiative = computed(() => {
+    // For now, always return mock data. In a real app, fetch from service based on initiativeId()
+    return MOCK_INITIATIVE_DETAIL;
+  });
+  protected readonly activeTab = signal<string>('overview');
+  protected readonly settingsDrawerVisible = signal(false);
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -1,0 +1,76 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<form [formGroup]="form" (ngSubmit)="onSubmit()" class="flex flex-col gap-5" data-testid="add-card-form">
+  <!-- Card number -->
+  <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
+    <label for="card-number" class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
+    <input
+      pInputText
+      id="card-number"
+      type="text"
+      inputmode="numeric"
+      autocomplete="cc-number"
+      placeholder="1234 5678 9123 4567"
+      maxlength="19"
+      formControlName="cardNumber"
+      (input)="onCardNumberInput($event)"
+      class="w-full"
+      [class.ng-invalid]="form.controls.cardNumber.invalid && form.controls.cardNumber.touched"
+      [class.ng-dirty]="form.controls.cardNumber.dirty"
+      data-testid="add-card-number-input" />
+    @if (form.controls.cardNumber.invalid && form.controls.cardNumber.touched) {
+      <p class="text-xs text-red-500">Enter a valid 16-digit card number.</p>
+    }
+  </div>
+
+  <!-- Expiry + CVC -->
+  <div class="grid grid-cols-2 gap-4">
+    <!-- Expiry -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-expiry">
+      <label for="card-expiry" class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-expiry"
+        type="text"
+        inputmode="numeric"
+        autocomplete="cc-exp"
+        placeholder="MM/YY"
+        maxlength="5"
+        formControlName="expiry"
+        (input)="onExpiryInput($event)"
+        [class.ng-invalid]="form.controls.expiry.invalid && form.controls.expiry.touched"
+        [class.ng-dirty]="form.controls.expiry.dirty"
+        data-testid="add-card-expiry-input" />
+      @if (form.controls.expiry.invalid && form.controls.expiry.touched) {
+        <p class="text-xs text-red-500">Enter a valid expiry (MM/YY).</p>
+      }
+    </div>
+
+    <!-- CVC -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-cvc">
+      <label for="card-cvc" class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-cvc"
+        type="password"
+        inputmode="numeric"
+        autocomplete="cc-csc"
+        placeholder="•••"
+        maxlength="4"
+        formControlName="cvc"
+        [class.ng-invalid]="form.controls.cvc.invalid && form.controls.cvc.touched"
+        [class.ng-dirty]="form.controls.cvc.dirty"
+        data-testid="add-card-cvc-input" />
+      @if (form.controls.cvc.invalid && form.controls.cvc.touched) {
+        <p class="text-xs text-red-500">Enter a valid CVC.</p>
+      }
+    </div>
+  </div>
+
+  <!-- Footer actions -->
+  <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
+    <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
+    <lfx-button label="Add card" severity="primary" type="submit" data-testid="add-card-submit-btn" />
+  </div>
+</form>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextModule } from 'primeng/inputtext';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+
+// TODO: Replace card number, expiry, and CVC fields with Stripe Elements once
+// the Stripe API integration is in place for secure card tokenization and storage.
+
+@Component({
+  selector: 'lfx-add-payment-card-dialog',
+  imports: [ReactiveFormsModule, InputTextModule, ButtonComponent],
+  templateUrl: './add-payment-card-dialog.component.html',
+  styleUrl: './add-payment-card-dialog.component.scss',
+})
+export class AddPaymentCardDialogComponent {
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly form = new FormGroup({
+    cardNumber: new FormControl('', [Validators.required, Validators.pattern(/^(\d{4} ){3}\d{4}$/)]),
+    expiry: new FormControl('', [Validators.required, Validators.pattern(/^(0[1-9]|1[0-2])\/\d{2}$/)]),
+    cvc: new FormControl('', [Validators.required, Validators.pattern(/^\d{3,4}$/)]),
+  });
+
+  protected onCardNumberInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 16);
+    const formatted = digits.match(/.{1,4}/g)?.join(' ') ?? '';
+    this.form.controls.cardNumber.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onExpiryInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 4);
+    const formatted = digits.length > 2 ? `${digits.slice(0, 2)}/${digits.slice(2)}` : digits;
+    this.form.controls.expiry.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.dialogRef.close({ added: true });
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
@@ -1,0 +1,74 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col" data-testid="donation-history-table">
+  <div class="overflow-x-auto rounded-lg border border-gray-200">
+    <table class="w-full text-sm" aria-label="Donation history">
+      <thead>
+        <tr class="border-b border-gray-200 bg-gray-50">
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Initiative</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Date</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Type</th>
+          <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Amount</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 bg-white">
+        @for (item of visibleItems(); track item.id) {
+          <tr class="hover:bg-gray-50 transition-colors" [attr.data-testid]="'donation-row-' + item.id">
+            <!-- Initiative -->
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-2.5">
+                <div class="flex items-center justify-center w-8 h-8 rounded-md bg-gray-50 text-base flex-shrink-0" aria-hidden="true">
+                  {{ item.initiativeIcon }}
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <span class="font-medium text-gray-900">{{ item.initiativeName }}</span>
+                  <span class="text-xs text-gray-400">
+                    <i [class]="'fa-solid ' + item.fundTypeIcon + ' text-[10px] mr-1'" aria-hidden="true"></i>
+                    {{ item.fundType }}
+                  </span>
+                </div>
+              </div>
+            </td>
+
+            <!-- Date -->
+            <td class="px-4 py-3 text-gray-500 whitespace-nowrap">{{ item.date }}</td>
+
+            <!-- Kind badge -->
+            <td class="px-4 py-3">
+              @if (item.kind === 'monthly') {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Monthly </span>
+              } @else {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-blue-50 text-blue-700"> One-time </span>
+              }
+            </td>
+
+            <!-- Amount -->
+            <td class="px-4 py-3 text-right font-semibold text-gray-900 whitespace-nowrap">${{ item.amount | number }}</td>
+
+            <!-- Invoice -->
+            <td class="px-4 py-3 text-right">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-400 border border-gray-200 rounded px-2 py-1 opacity-60 cursor-not-allowed"
+                [attr.aria-label]="'Download invoice for ' + item.initiativeName + ' on ' + item.date"
+                title="Invoice downloads coming soon"
+                disabled
+                aria-disabled="true">
+                <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
+                Invoice
+              </button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+
+  @if (hasMore()) {
+    <div class="flex justify-center pt-3" data-testid="donation-history-load-more">
+      <lfx-button label="Load more" severity="secondary" size="small" (click)="loadMore()" />
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, input, signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { DonationHistoryItem } from '@lfx-one/shared/interfaces';
+
+const PAGE_SIZE = 10;
+
+@Component({
+  selector: 'lfx-donation-history-table',
+  imports: [ButtonComponent, DecimalPipe],
+  templateUrl: './donation-history-table.component.html',
+  styleUrl: './donation-history-table.component.scss',
+})
+export class DonationHistoryTableComponent {
+  public readonly items = input.required<DonationHistoryItem[]>();
+
+  protected readonly visibleCount = signal(PAGE_SIZE);
+  protected readonly visibleItems = computed(() => this.items().slice(0, this.visibleCount()));
+  protected readonly hasMore = computed(() => this.visibleCount() < this.items().length);
+
+  protected loadMore(): void {
+    this.visibleCount.update((n) => n + PAGE_SIZE);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="donations-stats-bar">
+  <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-total">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-50 text-blue-600 flex-shrink-0">
+        <i class="fa-solid fa-hand-holding-heart text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().totalDonated | number }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Donated</p>
+        <p class="text-xs text-gray-400">All time</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-initiatives">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-teal-50 text-teal-600 flex-shrink-0">
+        <i class="fa-solid fa-seedling text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().initiativesSupported }}</p>
+        <p class="text-sm font-normal text-gray-900">Initiatives Supported</p>
+        <p class="text-xs text-gray-400">Across 4 fund types</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-recurring">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-50 text-emerald-600 flex-shrink-0">
+        <i class="fa-solid fa-arrows-rotate text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().activeRecurringAmount }}<span class="text-sm font-normal text-gray-400">/mo</span></p>
+        <p class="text-sm font-normal text-gray-900">Active Recurring</p>
+        <p class="text-xs text-gray-400">{{ stats().activeRecurringCount }} active subscription{{ stats().activeRecurringCount === 1 ? '' : 's' }}</p>
+      </div>
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { DonationStats } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-donations-stats-bar',
+  imports: [CardComponent, DecimalPipe],
+  templateUrl: './donations-stats-bar.component.html',
+  styleUrl: './donations-stats-bar.component.scss',
+})
+export class DonationsStatsBarComponent {
+  public readonly stats = input.required<DonationStats>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
@@ -1,0 +1,28 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3 p-4 bg-white border border-gray-200 rounded-lg" [attr.data-testid]="'payment-method-' + method().id">
+  <!-- Brand + actions -->
+  <div class="flex items-center justify-between">
+    <span class="inline-flex items-center px-2 py-0.5 text-xs font-bold tracking-widest border border-gray-300 rounded text-gray-700 bg-gray-50">
+      {{ method().brand }}
+    </span>
+    <div class="flex items-center gap-1">
+      <button type="button" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors rounded" aria-label="Remove payment method" (click)="remove.emit()">
+        <i class="fa-solid fa-trash text-sm" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+
+  <!-- Card number + expiry -->
+  <div class="flex items-end justify-between gap-4 mt-auto">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-xs text-gray-400">Card number</p>
+      <p class="text-sm font-semibold text-gray-900 tabular-nums tracking-wider">•••• •••• •••• {{ method().last4 }}</p>
+    </div>
+    <div class="flex flex-col gap-0.5 text-right flex-shrink-0">
+      <p class="text-xs text-gray-400">Expiry</p>
+      <p class="text-sm font-semibold text-gray-900">{{ method().expiry }}</p>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-payment-method-card',
+  imports: [],
+  templateUrl: './payment-method-card.component.html',
+  styleUrl: './payment-method-card.component.scss',
+})
+export class PaymentMethodCardComponent {
+  public readonly method = input.required<PaymentMethod>();
+  public readonly remove = output<void>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
@@ -1,0 +1,23 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="payment-methods">
+  <h2 class="text-sm font-bold text-gray-900" data-testid="payment-methods-heading">Payment Methods</h2>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="payment-methods-grid">
+    @for (method of methods(); track method.id) {
+      <lfx-payment-method-card [method]="method" (remove)="removeCard.emit(method)" />
+    }
+
+    <!-- Add card -->
+    <button
+      type="button"
+      class="flex flex-col items-center justify-center gap-2 p-4 bg-white border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:border-blue-300 hover:text-blue-500 transition-colors min-h-[112px]"
+      (click)="openAddCardDialog()"
+      data-testid="add-payment-method-btn"
+      aria-label="Add payment card">
+      <i class="fa-solid fa-plus text-xl" aria-hidden="true"></i>
+      <span class="text-sm font-medium">Add payment card</span>
+    </button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -1,0 +1,33 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, input, output } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+import { DialogService } from 'primeng/dynamicdialog';
+import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
+import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
+
+@Component({
+  selector: 'lfx-payment-methods',
+  imports: [PaymentMethodCardComponent],
+  providers: [DialogService],
+  templateUrl: './payment-methods.component.html',
+  styleUrl: './payment-methods.component.scss',
+})
+export class PaymentMethodsComponent {
+  private readonly dialogService = inject(DialogService);
+
+  public readonly methods = input.required<PaymentMethod[]>();
+  public readonly removeCard = output<PaymentMethod>();
+
+  protected openAddCardDialog(): void {
+    this.dialogService.open(AddPaymentCardDialogComponent, {
+      header: 'Add Payment Card',
+      width: '420px',
+      modal: true,
+      draggable: false,
+      resizable: false,
+      closeOnEscape: true,
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -1,0 +1,78 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="recurring-donations-list">
+  <!-- Section header -->
+  <div class="flex items-center justify-between" data-testid="recurring-donations-header">
+    <h2 class="text-sm font-bold text-gray-900">Recurring Donations</h2>
+    @if (cancelledCount() > 0) {
+      <button
+        type="button"
+        class="text-xs font-medium text-gray-400 underline underline-offset-2 hover:text-gray-600 transition-colors"
+        (click)="viewCancelled.emit()"
+        data-testid="view-cancelled-btn">
+        Cancelled recurring donations ({{ cancelledCount() }})
+      </button>
+    }
+  </div>
+
+  <!-- Cards -->
+  <div class="flex flex-col gap-2" data-testid="recurring-cards">
+    @for (entry of donationsWithMenuItems(); track entry.donation.id; let i = $index) {
+      <div class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg" [attr.data-testid]="'recurring-card-' + entry.donation.id">
+        <!-- Icon -->
+        <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-gray-50 text-xl flex-shrink-0" aria-hidden="true">
+          {{ entry.donation.icon }}
+        </div>
+
+        <!-- Details -->
+        <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="text-sm font-semibold text-gray-900">{{ entry.donation.name }}</span>
+            @if (entry.donation.status === 'active') {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+            } @else {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500"> Paused </span>
+            }
+          </div>
+          <p class="text-xs text-gray-400">Started {{ entry.donation.startDate }} &middot; {{ entry.donation.billingDescription }}</p>
+        </div>
+
+        <!-- Amount + next charge -->
+        <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
+          <p class="text-sm font-semibold" [class]="entry.donation.status === 'active' ? 'text-gray-900' : 'text-gray-400'">
+            ${{ entry.donation.amount }}<span class="text-xs font-normal text-gray-400">/mo</span>
+          </p>
+          <p class="text-xs text-gray-400">
+            @if (entry.donation.status === 'active') {
+              Next charge: {{ entry.donation.nextChargeDate }}
+            } @else {
+              Paused since {{ entry.donation.pausedSince }}
+            }
+          </p>
+        </div>
+
+        <!-- Ellipsis menu -->
+        <div class="flex-shrink-0" (click)="$event.stopPropagation()">
+          <lfx-button
+            icon="fa-solid fa-ellipsis"
+            severity="secondary"
+            size="small"
+            [attr.aria-label]="'More options for ' + entry.donation.name"
+            (click)="onMenuToggle($event, i)" />
+          <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
+            <ng-template #item let-item>
+              <div
+                class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
+                [class.text-red-600]="item.styleClass === 'text-red-600'"
+                [class.text-gray-700]="item.styleClass !== 'text-red-600'">
+                <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
+                {{ item.label }}
+              </div>
+            </ng-template>
+          </lfx-menu>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, Signal, viewChildren } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MenuItem } from 'primeng/api';
+
+@Component({
+  selector: 'lfx-recurring-donations-list',
+  imports: [ButtonComponent, MenuComponent],
+  templateUrl: './recurring-donations-list.component.html',
+  styleUrl: './recurring-donations-list.component.scss',
+})
+export class RecurringDonationsListComponent {
+  public readonly donations = input.required<RecurringDonation[]>();
+  public readonly cancelledCount = input<number>(0);
+
+  public readonly viewCancelled = output<void>();
+  public readonly changeAmount = output<RecurringDonation>();
+  public readonly pauseDonation = output<RecurringDonation>();
+  public readonly resumeDonation = output<RecurringDonation>();
+  public readonly cancelDonation = output<RecurringDonation>();
+
+  private readonly menus = viewChildren<MenuComponent>(MenuComponent);
+
+  protected readonly donationsWithMenuItems = this.initDonationsWithMenuItems();
+
+  protected onMenuToggle(event: Event, index: number): void {
+    this.menus()[index]?.toggle(event);
+  }
+
+  private initDonationsWithMenuItems(): Signal<{ donation: RecurringDonation; menuItems: MenuItem[] }[]> {
+    return computed(() =>
+      this.donations().map((donation) => ({
+        donation,
+        menuItems: this.buildMenuItems(donation),
+      }))
+    );
+  }
+
+  private buildMenuItems(donation: RecurringDonation): MenuItem[] {
+    if (donation.status === 'paused') {
+      return [
+        { label: 'Resume', icon: 'fa-solid fa-play', command: () => this.resumeDonation.emit(donation) },
+        { separator: true },
+        { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+      ];
+    }
+    return [
+      { label: 'Change amount', icon: 'fa-solid fa-pen-to-square', command: () => this.changeAmount.emit(donation) },
+      { label: 'Pause', icon: 'fa-solid fa-pause', command: () => this.pauseDonation.emit(donation) },
+      { separator: true },
+      { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+    ];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -1,0 +1,43 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8" data-testid="my-donations">
+  <!-- Page header -->
+  <div class="flex items-start justify-between" data-testid="my-donations-header">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Donations</h1>
+      <p class="text-sm text-gray-500 mt-1">Your giving history across LFX Crowdfunding initiatives</p>
+    </div>
+    <a
+      [href]="crowdfundingUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+      data-testid="explore-initiatives-btn">
+      Explore Initiatives
+      <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <!-- Stats bar -->
+  <lfx-donations-stats-bar [stats]="stats()" />
+
+  <!-- Recurring donations -->
+  <lfx-recurring-donations-list
+    [donations]="recurringDonations()"
+    [cancelledCount]="cancelledCount()"
+    (viewCancelled)="onViewCancelled()"
+    (changeAmount)="onChangeAmount($event)"
+    (pauseDonation)="onPauseDonation($event)"
+    (resumeDonation)="onResumeDonation($event)"
+    (cancelDonation)="onCancelDonation($event)" />
+
+  <!-- Donation history -->
+  <div class="flex flex-col gap-3" data-testid="donation-history-section">
+    <h2 class="text-sm font-bold text-gray-900">Donation History</h2>
+    <lfx-donation-history-table [items]="donationHistory()" />
+  </div>
+
+  <!-- Payment methods -->
+  <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" />
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { environment } from '@environments/environment';
+import { DonationHistoryItem, DonationStats, PaymentMethod, RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MOCK_DONATION_HISTORY, MOCK_DONATION_STATS, MOCK_PAYMENT_METHODS, MOCK_RECURRING_DONATIONS } from '../crowdfunding.mock';
+import { DonationsStatsBarComponent } from './components/donations-stats-bar/donations-stats-bar.component';
+import { DonationHistoryTableComponent } from './components/donation-history-table/donation-history-table.component';
+import { PaymentMethodsComponent } from './components/payment-methods/payment-methods.component';
+import { RecurringDonationsListComponent } from './components/recurring-donations-list/recurring-donations-list.component';
+
+@Component({
+  selector: 'lfx-my-donations',
+  imports: [DonationsStatsBarComponent, RecurringDonationsListComponent, DonationHistoryTableComponent, PaymentMethodsComponent],
+  templateUrl: './my-donations.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MyDonationsComponent {
+  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly stats = signal<DonationStats>(MOCK_DONATION_STATS);
+  protected readonly recurringDonations = signal<RecurringDonation[]>(MOCK_RECURRING_DONATIONS);
+  protected readonly donationHistory = signal<DonationHistoryItem[]>(MOCK_DONATION_HISTORY);
+  protected readonly paymentMethods = signal<PaymentMethod[]>(MOCK_PAYMENT_METHODS);
+  protected readonly cancelledCount = signal(4);
+
+  protected onViewCancelled(): void {
+    // TODO: navigate to cancelled donations view
+  }
+
+  protected onChangeAmount(donation: RecurringDonation): void {
+    // TODO: open change amount dialog for donation
+    void donation;
+  }
+
+  protected onPauseDonation(donation: RecurringDonation): void {
+    // TODO: call pause API for donation
+    void donation;
+  }
+
+  protected onResumeDonation(donation: RecurringDonation): void {
+    // TODO: call resume API for donation
+    void donation;
+  }
+
+  protected onCancelDonation(donation: RecurringDonation): void {
+    // TODO: call cancel API for donation
+    void donation;
+  }
+
+  protected onRemoveCard(card: PaymentMethod): void {
+    // TODO: call remove card API
+    void card;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -11,7 +11,8 @@
   [attr.aria-label]="initiative().name"
   [attr.data-testid]="'initiative-card-' + initiative().id"
   (click)="onCardClick()"
-  (keydown.enter)="onCardClick()">
+  (keydown.enter)="onCardClick()"
+  (keydown.space)="onCardClick(); $event.preventDefault()">
   <!-- Avatar / Icon -->
   <lfx-avatar [label]="initiative().name" shape="square" size="large" [styleClass]="avatarStyleClass()" [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
 
@@ -39,8 +40,8 @@
     @if ((initiative().status === 'active' || initiative().status === 'closed') && initiative().goal) {
       <div class="flex flex-col gap-1 min-w-44">
         <div class="flex items-center justify-between text-xs">
-          <span class="font-bold text-gray-900">{{ formatCurrency(initiative().raised) }}</span>
-          <span class="text-gray-500">of {{ formatCurrency(initiative().goal!) }}</span>
+          <span class="font-bold text-gray-900">{{ formattedRaised() }}</span>
+          <span class="text-gray-500">of {{ formattedGoal() }}</span>
         </div>
         <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden w-full">
           <div
@@ -60,6 +61,8 @@
           rel="noopener noreferrer"
           class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600 border border-gray-300 bg-white rounded px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
           (click)="$event.stopPropagation()"
+          (keydown.enter)="$event.stopPropagation()"
+          (keydown.space)="$event.stopPropagation()"
           data-testid="initiative-card-view-public">
           View Public
           <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -1,0 +1,75 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div
+  class="flex items-center gap-4 p-5"
+  [class.cursor-pointer]="isClickable()"
+  [class.hover:bg-gray-50]="isClickable()"
+  [class.opacity-80]="!isClickable()"
+  [attr.role]="isClickable() ? 'button' : null"
+  [attr.tabindex]="isClickable() ? 0 : null"
+  [attr.aria-label]="initiative().name"
+  [attr.data-testid]="'initiative-card-' + initiative().id"
+  (click)="onCardClick()"
+  (keydown.enter)="onCardClick()">
+  <!-- Avatar / Icon -->
+  <lfx-avatar [label]="initiative().name" shape="square" size="large" [styleClass]="avatarStyleClass()" [ariaLabel]="fundTypeLabel() + ' initiative icon'" />
+
+  <!-- Content -->
+  <div class="flex flex-col gap-1 min-w-0 flex-1">
+    <span class="text-xs font-semibold flex items-center gap-1" [class]="fundTypeColorClass()">
+      <i [class]="fundTypeIcon()" aria-hidden="true"></i>
+      {{ fundTypeLabel() }}
+    </span>
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="text-base font-bold text-gray-900">{{ initiative().name }}</span>
+      @if (initiative().status === 'active') {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700">Active</span>
+      } @else if (initiative().status === 'pending') {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Pending</span>
+      } @else {
+        <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Closed</span>
+      }
+    </div>
+    <p class="text-xs text-gray-500 truncate">{{ initiative().description }}</p>
+  </div>
+
+  <!-- Metrics -->
+  <div class="flex items-center gap-10 flex-shrink-0" data-testid="initiative-card-metrics">
+    @if ((initiative().status === 'active' || initiative().status === 'closed') && initiative().goal) {
+      <div class="flex flex-col gap-1 min-w-44">
+        <div class="flex items-center justify-between text-xs">
+          <span class="font-bold text-gray-900">{{ formatCurrency(initiative().raised) }}</span>
+          <span class="text-gray-500">of {{ formatCurrency(initiative().goal!) }}</span>
+        </div>
+        <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden w-full">
+          <div
+            class="h-full bg-blue-600 rounded-full"
+            [style.width.%]="progressPercent()"
+            role="progressbar"
+            [attr.aria-valuenow]="progressPercent()"
+            aria-valuemin="0"
+            aria-valuemax="100"></div>
+        </div>
+        <p class="text-xs text-gray-500">{{ progressPercent() }}% funded · {{ initiative().sponsorsCount }} sponsors</p>
+      </div>
+      <div class="flex-shrink-0">
+        <a
+          [href]="initiative().publicUrl || '#'"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600 border border-gray-300 bg-white rounded px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+          (click)="$event.stopPropagation()"
+          data-testid="initiative-card-view-public">
+          View Public
+          <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+        </a>
+      </div>
+    } @else if (initiative().status === 'pending') {
+      <div class="flex items-center gap-2 text-xs text-gray-400 whitespace-nowrap">
+        <i class="fa-light fa-clock" aria-hidden="true"></i>
+        Under review by our team
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output } from '@angular/core';
+import { Component, computed, input, output, Signal } from '@angular/core';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import {
   CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
@@ -26,21 +26,31 @@ export class InitiativeCardComponent {
   protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
   protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
 
-  protected readonly progressPercent = computed(() => {
-    const { raised, goal } = this.initiative();
-    if (!goal || goal === 0) return 0;
-    return Math.min(100, Math.round((raised / goal) * 100));
-  });
+  protected readonly progressPercent = this.initProgressPercent();
 
   protected readonly isClickable = computed(() => this.initiative().status !== 'pending');
 
-  protected formatCurrency(value: number): string {
-    return `$${value.toLocaleString()}`;
-  }
+  protected readonly formattedRaised = computed(() => this.formatCurrency(this.initiative().raised));
+  protected readonly formattedGoal = computed(() => {
+    const g = this.initiative().goal;
+    return g != null ? this.formatCurrency(g) : null;
+  });
 
   protected onCardClick(): void {
     if (this.isClickable()) {
       this.cardClick.emit(this.initiative().id);
     }
+  }
+
+  private formatCurrency(value: number): string {
+    return `$${value.toLocaleString()}`;
+  }
+
+  private initProgressPercent(): Signal<number> {
+    return computed(() => {
+      const { raised, goal } = this.initiative();
+      if (!goal || goal === 0) return 0;
+      return Math.min(100, Math.round((raised / goal) * 100));
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import {
+  CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_COLOR_CLASSES,
+  CROWDFUNDING_FUND_TYPE_ICONS,
+  CROWDFUNDING_FUND_TYPE_LABELS,
+} from '@lfx-one/shared/constants';
+import { CrowdfundingInitiative } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiative-card',
+  imports: [AvatarComponent],
+  templateUrl: './initiative-card.component.html',
+  styleUrl: './initiative-card.component.scss',
+})
+export class InitiativeCardComponent {
+  public readonly initiative = input.required<CrowdfundingInitiative>();
+  public readonly cardClick = output<string>();
+
+  protected readonly fundTypeLabel = computed(() => CROWDFUNDING_FUND_TYPE_LABELS[this.initiative().fundType]);
+  protected readonly fundTypeIcon = computed(() => CROWDFUNDING_FUND_TYPE_ICONS[this.initiative().fundType]);
+  protected readonly fundTypeColorClass = computed(() => CROWDFUNDING_FUND_TYPE_COLOR_CLASSES[this.initiative().fundType]);
+  protected readonly avatarStyleClass = computed(() => CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES[this.initiative().fundType]);
+
+  protected readonly progressPercent = computed(() => {
+    const { raised, goal } = this.initiative();
+    if (!goal || goal === 0) return 0;
+    return Math.min(100, Math.round((raised / goal) * 100));
+  });
+
+  protected readonly isClickable = computed(() => this.initiative().status !== 'pending');
+
+  protected formatCurrency(value: number): string {
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected onCardClick(): void {
+    if (this.isClickable()) {
+      this.cardClick.emit(this.initiative().id);
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
@@ -5,11 +5,13 @@
   <lfx-filter-pills [options]="filterOptions()" [selectedFilter]="activeFilter()" (filterChange)="setFilter($event)" data-testid="initiatives-filter-pills" />
 
   @if (filteredInitiatives().length > 0) {
-    <div class="flex flex-col gap-4" data-testid="initiatives-cards">
+    <lfx-card
+      styleClass="flex flex-col gap-4 [&_.p-card-body]:p-0 [&_.p-card-content]:p-0 overflow-hidden hover:!border-gray-200"
+      data-testid="initiatives-cards">
       @for (initiative of filteredInitiatives(); track initiative.id) {
         <lfx-initiative-card [initiative]="initiative" (cardClick)="onCardClick($event)" />
       }
-    </div>
+    </lfx-card>
   } @else {
     <div class="flex flex-col items-center gap-3 py-16 text-gray-400" data-testid="initiatives-empty-state">
       <i class="fa-light fa-box-archive text-5xl" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-5" data-testid="initiatives-list">
+  <lfx-filter-pills [options]="filterOptions()" [selectedFilter]="activeFilter()" (filterChange)="setFilter($event)" data-testid="initiatives-filter-pills" />
+
+  @if (filteredInitiatives().length > 0) {
+    <div class="flex flex-col gap-4" data-testid="initiatives-cards">
+      @for (initiative of filteredInitiatives(); track initiative.id) {
+        <lfx-initiative-card [initiative]="initiative" (cardClick)="onCardClick($event)" />
+      }
+    </div>
+  } @else {
+    <div class="flex flex-col items-center gap-3 py-16 text-gray-400" data-testid="initiatives-empty-state">
+      <i class="fa-light fa-box-archive text-5xl" aria-hidden="true"></i>
+      <p class="text-sm font-medium text-gray-500">
+        @if (activeFilter() === 'closed') {
+          No closed initiatives
+        } @else if (activeFilter() === 'pending') {
+          No pending initiatives
+        } @else {
+          No active initiatives
+        }
+      </p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output, signal } from '@angular/core';
+import { Component, computed, input, output, signal, Signal } from '@angular/core';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { CrowdfundingInitiative, CrowdfundingInitiativeStatus, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { InitiativeCardComponent } from '../initiative-card/initiative-card.component';
@@ -18,24 +18,8 @@ export class InitiativesListComponent {
 
   protected readonly activeFilter = signal<CrowdfundingInitiativeStatus>('active');
 
-  protected readonly statusCounts = computed(() => {
-    const all = this.initiatives();
-    return {
-      active: all.filter((i) => i.status === 'active').length,
-      pending: all.filter((i) => i.status === 'pending').length,
-      closed: all.filter((i) => i.status === 'closed').length,
-    };
-  });
-
-  protected readonly filterOptions = computed<FilterPillOption[]>(() => {
-    const counts = this.statusCounts();
-    return [
-      { id: 'active', label: `Active (${counts.active})` },
-      { id: 'pending', label: `Pending (${counts.pending})` },
-      { id: 'closed', label: `Closed (${counts.closed})` },
-    ];
-  });
-
+  protected readonly statusCounts = this.initStatusCounts();
+  protected readonly filterOptions = this.initFilterOptions();
   protected readonly filteredInitiatives = computed(() => this.initiatives().filter((i) => i.status === this.activeFilter()));
 
   protected setFilter(status: string): void {
@@ -44,5 +28,27 @@ export class InitiativesListComponent {
 
   protected onCardClick(id: string): void {
     this.initiativeClick.emit(id);
+  }
+
+  private initStatusCounts(): Signal<{ active: number; pending: number; closed: number }> {
+    return computed(() => {
+      const all = this.initiatives();
+      return {
+        active: all.filter((i) => i.status === 'active').length,
+        pending: all.filter((i) => i.status === 'pending').length,
+        closed: all.filter((i) => i.status === 'closed').length,
+      };
+    });
+  }
+
+  private initFilterOptions(): Signal<FilterPillOption[]> {
+    return computed(() => {
+      const counts = this.statusCounts();
+      return [
+        { id: 'active', label: `Active (${counts.active})` },
+        { id: 'pending', label: `Pending (${counts.pending})` },
+        { id: 'closed', label: `Closed (${counts.closed})` },
+      ];
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -5,10 +5,11 @@ import { Component, computed, input, output, signal, Signal } from '@angular/cor
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { CrowdfundingInitiative, CrowdfundingInitiativeStatus, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { InitiativeCardComponent } from '../initiative-card/initiative-card.component';
+import { CardComponent } from '@components/card/card.component';
 
 @Component({
   selector: 'lfx-initiatives-list',
-  imports: [FilterPillsComponent, InitiativeCardComponent],
+  imports: [CardComponent, FilterPillsComponent, InitiativeCardComponent],
   templateUrl: './initiatives-list.component.html',
   styleUrl: './initiatives-list.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, signal } from '@angular/core';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { CrowdfundingInitiative, CrowdfundingInitiativeStatus, FilterPillOption } from '@lfx-one/shared/interfaces';
+import { InitiativeCardComponent } from '../initiative-card/initiative-card.component';
+
+@Component({
+  selector: 'lfx-initiatives-list',
+  imports: [FilterPillsComponent, InitiativeCardComponent],
+  templateUrl: './initiatives-list.component.html',
+  styleUrl: './initiatives-list.component.scss',
+})
+export class InitiativesListComponent {
+  public readonly initiatives = input.required<CrowdfundingInitiative[]>();
+  public readonly initiativeClick = output<string>();
+
+  protected readonly activeFilter = signal<CrowdfundingInitiativeStatus>('active');
+
+  protected readonly statusCounts = computed(() => {
+    const all = this.initiatives();
+    return {
+      active: all.filter((i) => i.status === 'active').length,
+      pending: all.filter((i) => i.status === 'pending').length,
+      closed: all.filter((i) => i.status === 'closed').length,
+    };
+  });
+
+  protected readonly filterOptions = computed<FilterPillOption[]>(() => {
+    const counts = this.statusCounts();
+    return [
+      { id: 'active', label: `Active (${counts.active})` },
+      { id: 'pending', label: `Pending (${counts.pending})` },
+      { id: 'closed', label: `Closed (${counts.closed})` },
+    ];
+  });
+
+  protected readonly filteredInitiatives = computed(() => this.initiatives().filter((i) => i.status === this.activeFilter()));
+
+  protected setFilter(status: string): void {
+    this.activeFilter.set(status as CrowdfundingInitiativeStatus);
+  }
+
+  protected onCardClick(id: string): void {
+    this.initiativeClick.emit(id);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
@@ -18,10 +18,10 @@
         <i class="fa-light fa-dollar-sign text-xl" aria-hidden="true"></i>
       </div>
       <div class="flex flex-col gap-0.5">
-        <p class="text-xl font-semibold text-gray-900">{{ formatCurrency(stats().totalRaised) }}</p>
+        <p class="text-xl font-semibold text-gray-900">{{ formattedTotalRaised() }}</p>
         <p class="text-sm font-normal text-gray-900">Total Raised</p>
         @if (stats().monthlyGain > 0) {
-          <p class="text-xs font-semibold text-emerald-600">↑ +{{ formatCurrency(stats().monthlyGain) }} this month</p>
+          <p class="text-xs font-semibold text-emerald-600">↑ +{{ formattedMonthlyGain() }} this month</p>
         }
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="initiatives-stats-bar">
+  <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-active">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-rocket text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().activeCount }}</p>
+        <p class="text-sm font-normal text-gray-900">Active Initiatives</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-raised">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-dollar-sign text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ formatCurrency(stats().totalRaised) }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Raised</p>
+        @if (stats().monthlyGain > 0) {
+          <p class="text-xs font-semibold text-emerald-600">↑ +{{ formatCurrency(stats().monthlyGain) }} this month</p>
+        }
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="initiatives-stat-sponsors">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-500 flex-shrink-0">
+        <i class="fa-light fa-users text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().totalSponsors }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Sponsors</p>
+      </div>
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-initiatives-stats-bar',
+  imports: [CardComponent],
+  templateUrl: './initiatives-stats-bar.component.html',
+  styleUrl: './initiatives-stats-bar.component.scss',
+})
+export class InitiativesStatsBarComponent {
+  public readonly stats = input.required<CrowdfundingInitiativesStats>();
+
+  protected formatCurrency(value: number): string {
+    if (value >= 1000) {
+      return `$${(value / 1000).toFixed(0)}K`;
+    }
+    return `$${value.toLocaleString()}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-stats-bar/initiatives-stats-bar.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { CardComponent } from '@components/card/card.component';
 import { CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
 
@@ -14,7 +14,10 @@ import { CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
 export class InitiativesStatsBarComponent {
   public readonly stats = input.required<CrowdfundingInitiativesStats>();
 
-  protected formatCurrency(value: number): string {
+  protected readonly formattedTotalRaised = computed(() => this.formatCurrency(this.stats().totalRaised));
+  protected readonly formattedMonthlyGain = computed(() => this.formatCurrency(this.stats().monthlyGain));
+
+  private formatCurrency(value: number): string {
     if (value >= 1000) {
       return `$${(value / 1000).toFixed(0)}K`;
     }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8" data-testid="my-initiatives">
+  <!-- Page header -->
+  <div class="flex items-start justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Initiatives</h1>
+      <p class="text-sm text-gray-500 mt-1">Fundraising initiatives you manage on LFX Crowdfunding</p>
+    </div>
+    <a
+      [href]="crowdfundingUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+      data-testid="new-initiative-button">
+      New Initiative
+      <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <!-- Stats bar -->
+  <lfx-initiatives-stats-bar [stats]="stats()" />
+
+  <!-- Initiatives list with filter pills -->
+  <lfx-initiatives-list [initiatives]="initiatives()" (initiativeClick)="onInitiativeClick($event)" />
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -20,17 +20,21 @@ export class MyInitiativesComponent {
   protected readonly crowdfundingUrl = environment.urls.crowdfunding;
   protected readonly initiatives = signal<CrowdfundingInitiative[]>(MOCK_INITIATIVES);
 
-  protected readonly stats: Signal<CrowdfundingInitiativesStats> = computed(() => {
-    const all = this.initiatives();
-    return {
-      activeCount: all.filter((i) => i.status === 'active').length,
-      totalRaised: all.reduce((sum, i) => sum + i.raised, 0),
-      monthlyGain: 8400,
-      totalSponsors: all.reduce((sum, i) => sum + i.sponsorsCount, 0),
-    };
-  });
+  protected readonly stats: Signal<CrowdfundingInitiativesStats> = this.initStats();
 
   protected onInitiativeClick(id: string): void {
     void this.router.navigate(['/crowdfunding/initiatives', id]);
+  }
+
+  private initStats(): Signal<CrowdfundingInitiativesStats> {
+    return computed(() => {
+      const all = this.initiatives();
+      return {
+        activeCount: all.filter((i) => i.status === 'active').length,
+        totalRaised: all.reduce((sum, i) => sum + i.raised, 0),
+        monthlyGain: 8400,
+        totalSponsors: all.reduce((sum, i) => sum + i.sponsorsCount, 0),
+      };
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { environment } from '@environments/environment';
+import { CrowdfundingInitiative, CrowdfundingInitiativesStats } from '@lfx-one/shared/interfaces';
+import { MOCK_INITIATIVES } from '../crowdfunding.mock';
+import { InitiativesStatsBarComponent } from './components/initiatives-stats-bar/initiatives-stats-bar.component';
+import { InitiativesListComponent } from './components/initiatives-list/initiatives-list.component';
+
+@Component({
+  selector: 'lfx-my-initiatives',
+  imports: [InitiativesStatsBarComponent, InitiativesListComponent],
+  templateUrl: './my-initiatives.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MyInitiativesComponent {
+  private readonly router = inject(Router);
+  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly initiatives = signal<CrowdfundingInitiative[]>(MOCK_INITIATIVES);
+
+  protected readonly stats: Signal<CrowdfundingInitiativesStats> = computed(() => {
+    const all = this.initiatives();
+    return {
+      activeCount: all.filter((i) => i.status === 'active').length,
+      totalRaised: all.reduce((sum, i) => sum + i.raised, 0),
+      monthlyGain: 8400,
+      totalSponsors: all.reduce((sum, i) => sum + i.sponsorsCount, 0),
+    };
+  });
+
+  protected onInitiativeClick(id: string): void {
+    void this.router.navigate(['/crowdfunding/initiatives', id]);
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.html
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="relative shrink-0" [style.width.px]="size()" [style.height.px]="size()" data-testid="donut-chart">
+  <svg [attr.width]="size()" [attr.height]="size()" [attr.viewBox]="'0 0 ' + size() + ' ' + size()" fill="none" xmlns="http://www.w3.org/2000/svg">
+    @for (ring of resolvedRings(); track $index) {
+      <!-- Track -->
+      <circle [attr.cx]="center()" [attr.cy]="center()" [attr.r]="ring.r" [attr.stroke]="trackColor()" [attr.stroke-width]="strokeWidth()" fill="none" />
+      <!-- Progress arc -->
+      <circle
+        [attr.cx]="center()"
+        [attr.cy]="center()"
+        [attr.r]="ring.r"
+        [attr.stroke]="ring.color"
+        [attr.stroke-width]="strokeWidth()"
+        stroke-linecap="round"
+        fill="none"
+        [attr.stroke-dasharray]="ring.dash + ' ' + ring.circumference"
+        [attr.transform]="'rotate(-90 ' + center() + ' ' + center() + ')'" />
+    }
+  </svg>
+
+  <!-- Center slot for optional label/icon -->
+  <div class="absolute inset-0 flex items-center justify-center">
+    <ng-content />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.scss
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.ts
+++ b/apps/lfx-one/src/app/shared/components/donut-chart/donut-chart.component.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input } from '@angular/core';
+import { DonutRing, ResolvedDonutRing } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-donut-chart',
+  templateUrl: './donut-chart.component.html',
+  styleUrl: './donut-chart.component.scss',
+})
+export class DonutChartComponent {
+  /** Rings ordered from outermost to innermost, each with a value (0–100) and color. */
+  public readonly rings = input.required<DonutRing[]>();
+  /** Diameter of the chart in px. */
+  public readonly size = input<number>(74);
+  /** Ring stroke thickness in px. */
+  public readonly strokeWidth = input<number>(4);
+  /** Track (background ring) color. */
+  public readonly trackColor = input<string>('#E2E8F0');
+  /** Gap between ring radii in px — accounts for stroke widths on both rings plus a visual gap. */
+  public readonly ringSpacing = input<number>(10);
+
+  protected readonly center = computed(() => this.size() / 2);
+
+  protected readonly resolvedRings = computed<ResolvedDonutRing[]>(() => {
+    const sw = this.strokeWidth();
+    const c = this.center();
+    // sw + 1 ensures at least 1px clearance so the stroke doesn't clip the SVG edge.
+    const outerRadius = c - sw / 2 - (sw + 1);
+    const spacing = this.ringSpacing();
+
+    return this.rings().map((ring, i) => {
+      const r = Math.max(1, outerRadius - i * spacing);
+      const circumference = 2 * Math.PI * r;
+      const clampedValue = Math.min(100, Math.max(0, ring.value));
+      const dash = circumference * (clampedValue / 100);
+      return { ...ring, r, circumference, dash };
+    });
+  });
+}

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { FundType } from '../enums/crowdfunding.enum';
+import { DonutRing } from './donut-chart.interface';
 
 export type CrowdfundingInitiativeStatus = 'active' | 'pending' | 'closed';
 
@@ -30,6 +31,14 @@ export interface AllocationItem {
   spent: number;
   total: number;
   pct: number;
+}
+
+export interface AllocItemWithMeta extends AllocationItem {
+  donated: number;
+  formattedTotal: string;
+  formattedDonated: string;
+  formattedSpent: string;
+  rings: DonutRing[];
 }
 
 export interface DonationTransaction {
@@ -90,4 +99,12 @@ export interface PaymentMethod {
   brand: string;
   last4: string;
   expiry: string;
+}
+
+export interface InitiativeMenuItem {
+  label?: string;
+  icon?: string;
+  description?: string;
+  danger?: boolean;
+  command?: (event: unknown) => void;
 }


### PR DESCRIPTION
## Summary

- Add `my-initiatives` page (route: `/crowdfunding/initiatives`)
- Add `initiatives-list` component — renders a grid of initiative cards
- Add `initiative-card` component — displays initiative title, description, goal/raised amounts, and status badge
- Add `initiatives-stats-bar` component — aggregate totals bar at the top of the page
- Wire `/crowdfunding/initiatives` into `crowdfunding.routes.ts`

All data is sourced from `crowdfunding.mock.ts` (UI-only, no API calls).

## Part of stacked PR series
This is **PR 2 of 4** — depends on [PR 1 (Foundation)](https://github.com/linuxfoundation/lfx-self-serve/pull/749).
- PR 3: Initiative Detail + Settings Drawer → [`feat/crowdfunding-initiative-detail`](https://github.com/linuxfoundation/lfx-self-serve/compare/feat/crowdfunding-initiatives-list...feat/crowdfunding-initiative-detail)
- PR 4: My Donations → [`feat/crowdfunding-my-donations`](https://github.com/linuxfoundation/lfx-self-serve/compare/feat/crowdfunding-initiative-detail...feat/crowdfunding-my-donations)

> **Review tip:** set base branch to `feat/crowdfunding-foundation` to see only this PR's diff.

## Test plan
- [ ] Navigate to `/crowdfunding/initiatives` → stats bar and initiative cards render from mock data
- [ ] Cards display title, description, funding progress, and status badge correctly
- [ ] `yarn lint:check && yarn check-types && yarn build` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)