### PR TITLE
feat(crowdfunding): add my donations page with recurring donations, history, and payment methods

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -15,4 +15,9 @@ export const CROWDFUNDING_ROUTES: Routes = [
     loadComponent: () => import('./initiative-detail/initiative-detail.component').then((m) => m.InitiativeDetailComponent),
     canActivate: [authGuard],
   },
+  {
+    path: 'donations',
+    loadComponent: () => import('./my-donations/my-donations.component').then((m) => m.MyDonationsComponent),
+    canActivate: [authGuard],
+  },
 ];

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -1,0 +1,76 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<form [formGroup]="form" (ngSubmit)="onSubmit()" class="flex flex-col gap-5" data-testid="add-card-form">
+  <!-- Card number -->
+  <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
+    <label for="card-number" class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
+    <input
+      pInputText
+      id="card-number"
+      type="text"
+      inputmode="numeric"
+      autocomplete="cc-number"
+      placeholder="1234 5678 9123 4567"
+      maxlength="19"
+      formControlName="cardNumber"
+      (input)="onCardNumberInput($event)"
+      class="w-full"
+      [class.ng-invalid]="form.controls.cardNumber.invalid && form.controls.cardNumber.touched"
+      [class.ng-dirty]="form.controls.cardNumber.dirty"
+      data-testid="add-card-number-input" />
+    @if (form.controls.cardNumber.invalid && form.controls.cardNumber.touched) {
+      <p class="text-xs text-red-500">Enter a valid 16-digit card number.</p>
+    }
+  </div>
+
+  <!-- Expiry + CVC -->
+  <div class="grid grid-cols-2 gap-4">
+    <!-- Expiry -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-expiry">
+      <label for="card-expiry" class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-expiry"
+        type="text"
+        inputmode="numeric"
+        autocomplete="cc-exp"
+        placeholder="MM/YY"
+        maxlength="5"
+        formControlName="expiry"
+        (input)="onExpiryInput($event)"
+        [class.ng-invalid]="form.controls.expiry.invalid && form.controls.expiry.touched"
+        [class.ng-dirty]="form.controls.expiry.dirty"
+        data-testid="add-card-expiry-input" />
+      @if (form.controls.expiry.invalid && form.controls.expiry.touched) {
+        <p class="text-xs text-red-500">Enter a valid expiry (MM/YY).</p>
+      }
+    </div>
+
+    <!-- CVC -->
+    <div class="flex flex-col gap-1.5" data-testid="add-card-field-cvc">
+      <label for="card-cvc" class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <input
+        pInputText
+        id="card-cvc"
+        type="password"
+        inputmode="numeric"
+        autocomplete="cc-csc"
+        placeholder="•••"
+        maxlength="4"
+        formControlName="cvc"
+        [class.ng-invalid]="form.controls.cvc.invalid && form.controls.cvc.touched"
+        [class.ng-dirty]="form.controls.cvc.dirty"
+        data-testid="add-card-cvc-input" />
+      @if (form.controls.cvc.invalid && form.controls.cvc.touched) {
+        <p class="text-xs text-red-500">Enter a valid CVC.</p>
+      }
+    </div>
+  </div>
+
+  <!-- Footer actions -->
+  <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
+    <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
+    <lfx-button label="Add card" severity="primary" type="submit" data-testid="add-card-submit-btn" />
+  </div>
+</form>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -20,9 +20,9 @@ export class AddPaymentCardDialogComponent {
   private readonly dialogRef = inject(DynamicDialogRef);
 
   protected readonly form = new FormGroup({
-    cardNumber: new FormControl('', [Validators.required, Validators.minLength(19)]),
-    expiry: new FormControl('', [Validators.required, Validators.pattern(/^\d{2}\/\d{2}$/)]),
-    cvc: new FormControl('', [Validators.required, Validators.minLength(3)]),
+    cardNumber: new FormControl('', [Validators.required, Validators.pattern(/^(\d{4} ){3}\d{4}$/)]),
+    expiry: new FormControl('', [Validators.required, Validators.pattern(/^(0[1-9]|1[0-2])\/\d{2}$/)]),
+    cvc: new FormControl('', [Validators.required, Validators.pattern(/^\d{3,4}$/)]),
   });
 
   protected onCardNumberInput(event: Event): void {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextModule } from 'primeng/inputtext';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+
+// TODO: Replace card number, expiry, and CVC fields with Stripe Elements once
+// the Stripe API integration is in place for secure card tokenization and storage.
+
+@Component({
+  selector: 'lfx-add-payment-card-dialog',
+  imports: [ReactiveFormsModule, InputTextModule, ButtonComponent],
+  templateUrl: './add-payment-card-dialog.component.html',
+  styleUrl: './add-payment-card-dialog.component.scss',
+})
+export class AddPaymentCardDialogComponent {
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly form = new FormGroup({
+    cardNumber: new FormControl('', [Validators.required, Validators.minLength(19)]),
+    expiry: new FormControl('', [Validators.required, Validators.pattern(/^\d{2}\/\d{2}$/)]),
+    cvc: new FormControl('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  protected onCardNumberInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 16);
+    const formatted = digits.match(/.{1,4}/g)?.join(' ') ?? '';
+    this.form.controls.cardNumber.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onExpiryInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 4);
+    const formatted = digits.length > 2 ? `${digits.slice(0, 2)}/${digits.slice(2)}` : digits;
+    this.form.controls.expiry.setValue(formatted, { emitEvent: false });
+    input.value = formatted;
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.dialogRef.close({ added: true });
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
@@ -51,8 +51,11 @@
             <td class="px-4 py-3 text-right">
               <button
                 type="button"
-                class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 border border-gray-200 rounded px-2 py-1 hover:bg-gray-50 hover:border-gray-300 transition-colors"
-                [attr.aria-label]="'Download invoice for ' + item.initiativeName + ' on ' + item.date">
+                class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-400 border border-gray-200 rounded px-2 py-1 opacity-60 cursor-not-allowed"
+                [attr.aria-label]="'Download invoice for ' + item.initiativeName + ' on ' + item.date"
+                title="Invoice downloads coming soon"
+                disabled
+                aria-disabled="true">
                 <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
                 Invoice
               </button>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.html
@@ -1,0 +1,71 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col" data-testid="donation-history-table">
+  <div class="overflow-x-auto rounded-lg border border-gray-200">
+    <table class="w-full text-sm" aria-label="Donation history">
+      <thead>
+        <tr class="border-b border-gray-200 bg-gray-50">
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Initiative</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Date</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Type</th>
+          <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Amount</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 bg-white">
+        @for (item of visibleItems(); track item.id) {
+          <tr class="hover:bg-gray-50 transition-colors" [attr.data-testid]="'donation-row-' + item.id">
+            <!-- Initiative -->
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-2.5">
+                <div class="flex items-center justify-center w-8 h-8 rounded-md bg-gray-50 text-base flex-shrink-0" aria-hidden="true">
+                  {{ item.initiativeIcon }}
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <span class="font-medium text-gray-900">{{ item.initiativeName }}</span>
+                  <span class="text-xs text-gray-400">
+                    <i [class]="'fa-solid ' + item.fundTypeIcon + ' text-[10px] mr-1'" aria-hidden="true"></i>
+                    {{ item.fundType }}
+                  </span>
+                </div>
+              </div>
+            </td>
+
+            <!-- Date -->
+            <td class="px-4 py-3 text-gray-500 whitespace-nowrap">{{ item.date }}</td>
+
+            <!-- Kind badge -->
+            <td class="px-4 py-3">
+              @if (item.kind === 'monthly') {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Monthly </span>
+              } @else {
+                <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full bg-blue-50 text-blue-700"> One-time </span>
+              }
+            </td>
+
+            <!-- Amount -->
+            <td class="px-4 py-3 text-right font-semibold text-gray-900 whitespace-nowrap">${{ item.amount | number }}</td>
+
+            <!-- Invoice -->
+            <td class="px-4 py-3 text-right">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 border border-gray-200 rounded px-2 py-1 hover:bg-gray-50 hover:border-gray-300 transition-colors"
+                [attr.aria-label]="'Download invoice for ' + item.initiativeName + ' on ' + item.date">
+                <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
+                Invoice
+              </button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+
+  @if (hasMore()) {
+    <div class="flex justify-center pt-3" data-testid="donation-history-load-more">
+      <lfx-button label="Load more" severity="secondary" size="small" (click)="loadMore()" />
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donation-history-table/donation-history-table.component.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, input, signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { DonationHistoryItem } from '@lfx-one/shared/interfaces';
+
+const PAGE_SIZE = 10;
+
+@Component({
+  selector: 'lfx-donation-history-table',
+  imports: [ButtonComponent, DecimalPipe],
+  templateUrl: './donation-history-table.component.html',
+  styleUrl: './donation-history-table.component.scss',
+})
+export class DonationHistoryTableComponent {
+  public readonly items = input.required<DonationHistoryItem[]>();
+
+  protected readonly visibleCount = signal(PAGE_SIZE);
+  protected readonly visibleItems = computed(() => this.items().slice(0, this.visibleCount()));
+  protected readonly hasMore = computed(() => this.visibleCount() < this.items().length);
+
+  protected loadMore(): void {
+    this.visibleCount.update((n) => n + PAGE_SIZE);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="donations-stats-bar">
+  <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-total">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-50 text-blue-600 flex-shrink-0">
+        <i class="fa-solid fa-hand-holding-heart text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().totalDonated | number }}</p>
+        <p class="text-sm font-normal text-gray-900">Total Donated</p>
+        <p class="text-xs text-gray-400">All time</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-initiatives">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-teal-50 text-teal-600 flex-shrink-0">
+        <i class="fa-solid fa-seedling text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">{{ stats().initiativesSupported }}</p>
+        <p class="text-sm font-normal text-gray-900">Initiatives Supported</p>
+        <p class="text-xs text-gray-400">Across 4 fund types</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 p-4" data-testid="donations-stat-recurring">
+      <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-50 text-emerald-600 flex-shrink-0">
+        <i class="fa-solid fa-arrows-rotate text-xl" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-xl font-semibold text-gray-900">${{ stats().activeRecurringAmount }}<span class="text-sm font-normal text-gray-400">/mo</span></p>
+        <p class="text-sm font-normal text-gray-900">Active Recurring</p>
+        <p class="text-xs text-gray-400">{{ stats().activeRecurringCount }} active subscription</p>
+      </div>
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.html
@@ -32,7 +32,7 @@
       <div class="flex flex-col gap-0.5">
         <p class="text-xl font-semibold text-gray-900">${{ stats().activeRecurringAmount }}<span class="text-sm font-normal text-gray-400">/mo</span></p>
         <p class="text-sm font-normal text-gray-900">Active Recurring</p>
-        <p class="text-xs text-gray-400">{{ stats().activeRecurringCount }} active subscription</p>
+        <p class="text-xs text-gray-400">{{ stats().activeRecurringCount }} active subscription{{ stats().activeRecurringCount === 1 ? '' : 's' }}</p>
       </div>
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/donations-stats-bar/donations-stats-bar.component.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { DonationStats } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-donations-stats-bar',
+  imports: [CardComponent, DecimalPipe],
+  templateUrl: './donations-stats-bar.component.html',
+  styleUrl: './donations-stats-bar.component.scss',
+})
+export class DonationsStatsBarComponent {
+  public readonly stats = input.required<DonationStats>();
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
@@ -8,17 +8,6 @@
       {{ method().brand }}
     </span>
     <div class="flex items-center gap-1">
-      <button
-        type="button"
-        class="p-1.5 text-gray-400 hover:text-gray-600 transition-colors rounded"
-        [attr.aria-label]="revealed() ? 'Hide card details' : 'Show card details'"
-        (click)="toggleReveal()">
-        @if (revealed()) {
-          <i class="fa-solid fa-eye-slash text-sm" aria-hidden="true"></i>
-        } @else {
-          <i class="fa-solid fa-eye text-sm" aria-hidden="true"></i>
-        }
-      </button>
       <button type="button" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors rounded" aria-label="Remove payment method" (click)="remove.emit()">
         <i class="fa-solid fa-trash text-sm" aria-hidden="true"></i>
       </button>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.html
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3 p-4 bg-white border border-gray-200 rounded-lg" [attr.data-testid]="'payment-method-' + method().id">
+  <!-- Brand + actions -->
+  <div class="flex items-center justify-between">
+    <span class="inline-flex items-center px-2 py-0.5 text-xs font-bold tracking-widest border border-gray-300 rounded text-gray-700 bg-gray-50">
+      {{ method().brand }}
+    </span>
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        class="p-1.5 text-gray-400 hover:text-gray-600 transition-colors rounded"
+        [attr.aria-label]="revealed() ? 'Hide card details' : 'Show card details'"
+        (click)="toggleReveal()">
+        @if (revealed()) {
+          <i class="fa-solid fa-eye-slash text-sm" aria-hidden="true"></i>
+        } @else {
+          <i class="fa-solid fa-eye text-sm" aria-hidden="true"></i>
+        }
+      </button>
+      <button type="button" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors rounded" aria-label="Remove payment method" (click)="remove.emit()">
+        <i class="fa-solid fa-trash text-sm" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+
+  <!-- Card number + expiry -->
+  <div class="flex items-end justify-between gap-4 mt-auto">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-xs text-gray-400">Card number</p>
+      <p class="text-sm font-semibold text-gray-900 tabular-nums tracking-wider">•••• •••• •••• {{ method().last4 }}</p>
+    </div>
+    <div class="flex flex-col gap-0.5 text-right flex-shrink-0">
+      <p class="text-xs text-gray-400">Expiry</p>
+      <p class="text-sm font-semibold text-gray-900">{{ method().expiry }}</p>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input, output, signal } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { PaymentMethod } from '@lfx-one/shared/interfaces';
 
 @Component({
@@ -13,10 +13,4 @@ import { PaymentMethod } from '@lfx-one/shared/interfaces';
 export class PaymentMethodCardComponent {
   public readonly method = input.required<PaymentMethod>();
   public readonly remove = output<void>();
-
-  protected readonly revealed = signal(false);
-
-  protected toggleReveal(): void {
-    this.revealed.update((v) => !v);
-  }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-method-card/payment-method-card.component.ts
@@ -1,0 +1,22 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output, signal } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-payment-method-card',
+  imports: [],
+  templateUrl: './payment-method-card.component.html',
+  styleUrl: './payment-method-card.component.scss',
+})
+export class PaymentMethodCardComponent {
+  public readonly method = input.required<PaymentMethod>();
+  public readonly remove = output<void>();
+
+  protected readonly revealed = signal(false);
+
+  protected toggleReveal(): void {
+    this.revealed.update((v) => !v);
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.html
@@ -1,0 +1,23 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="payment-methods">
+  <h2 class="text-sm font-bold text-gray-900" data-testid="payment-methods-heading">Payment Methods</h2>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="payment-methods-grid">
+    @for (method of methods(); track method.id) {
+      <lfx-payment-method-card [method]="method" (remove)="removeCard.emit(method)" />
+    }
+
+    <!-- Add card -->
+    <button
+      type="button"
+      class="flex flex-col items-center justify-center gap-2 p-4 bg-white border-2 border-dashed border-gray-200 rounded-lg text-gray-400 hover:border-blue-300 hover:text-blue-500 transition-colors min-h-[112px]"
+      (click)="openAddCardDialog()"
+      data-testid="add-payment-method-btn"
+      aria-label="Add payment card">
+      <i class="fa-solid fa-plus text-xl" aria-hidden="true"></i>
+      <span class="text-sm font-medium">Add payment card</span>
+    </button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, inject, input, output } from '@angular/core';
 import { PaymentMethod } from '@lfx-one/shared/interfaces';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DialogService } from 'primeng/dynamicdialog';
 import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
 import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
 
@@ -20,10 +20,8 @@ export class PaymentMethodsComponent {
   public readonly methods = input.required<PaymentMethod[]>();
   public readonly removeCard = output<PaymentMethod>();
 
-  private dialogRef: DynamicDialogRef | null = null;
-
   protected openAddCardDialog(): void {
-    this.dialogRef = this.dialogService.open(AddPaymentCardDialogComponent, {
+    this.dialogService.open(AddPaymentCardDialogComponent, {
       header: 'Add Payment Card',
       width: '420px',
       modal: true,

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, input, output } from '@angular/core';
+import { PaymentMethod } from '@lfx-one/shared/interfaces';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
+import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
+
+@Component({
+  selector: 'lfx-payment-methods',
+  imports: [PaymentMethodCardComponent],
+  providers: [DialogService],
+  templateUrl: './payment-methods.component.html',
+  styleUrl: './payment-methods.component.scss',
+})
+export class PaymentMethodsComponent {
+  private readonly dialogService = inject(DialogService);
+
+  public readonly methods = input.required<PaymentMethod[]>();
+  public readonly removeCard = output<PaymentMethod>();
+
+  private dialogRef: DynamicDialogRef | null = null;
+
+  protected openAddCardDialog(): void {
+    this.dialogRef = this.dialogService.open(AddPaymentCardDialogComponent, {
+      header: 'Add Payment Card',
+      width: '420px',
+      modal: true,
+      draggable: false,
+      resizable: false,
+      closeOnEscape: true,
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -1,0 +1,80 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="recurring-donations-list">
+  <!-- Section header -->
+  <div class="flex items-center justify-between" data-testid="recurring-donations-header">
+    <h2 class="text-sm font-bold text-gray-900">Recurring Donations</h2>
+    @if (cancelledCount() > 0) {
+      <button
+        type="button"
+        class="text-xs font-medium text-gray-400 underline underline-offset-2 hover:text-gray-600 transition-colors"
+        (click)="viewCancelled.emit()"
+        data-testid="view-cancelled-btn">
+        Cancelled recurring donations ({{ cancelledCount() }})
+      </button>
+    }
+  </div>
+
+  <!-- Cards -->
+  <div class="flex flex-col gap-2" data-testid="recurring-cards">
+    @for (entry of donationsWithMenuItems(); track entry.donation.id; let i = $index) {
+      <div
+        class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors cursor-pointer"
+        [attr.data-testid]="'recurring-card-' + entry.donation.id">
+        <!-- Icon -->
+        <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-gray-50 text-xl flex-shrink-0" aria-hidden="true">
+          {{ entry.donation.icon }}
+        </div>
+
+        <!-- Details -->
+        <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="text-sm font-semibold text-gray-900">{{ entry.donation.name }}</span>
+            @if (entry.donation.status === 'active') {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+            } @else {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500"> Paused </span>
+            }
+          </div>
+          <p class="text-xs text-gray-400">Started {{ entry.donation.startDate }} &middot; {{ entry.donation.billingDescription }}</p>
+        </div>
+
+        <!-- Amount + next charge -->
+        <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
+          <p class="text-sm font-semibold" [class]="entry.donation.status === 'active' ? 'text-gray-900' : 'text-gray-400'">
+            ${{ entry.donation.amount }}<span class="text-xs font-normal text-gray-400">/mo</span>
+          </p>
+          <p class="text-xs text-gray-400">
+            @if (entry.donation.status === 'active') {
+              Next charge: {{ entry.donation.nextChargeDate }}
+            } @else {
+              Paused since {{ entry.donation.pausedSince }}
+            }
+          </p>
+        </div>
+
+        <!-- Ellipsis menu -->
+        <div class="flex-shrink-0" (click)="$event.stopPropagation()">
+          <lfx-button
+            icon="fa-solid fa-ellipsis"
+            severity="secondary"
+            size="small"
+            [attr.aria-label]="'More options for ' + entry.donation.name"
+            (click)="onMenuToggle($event, i)" />
+          <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
+            <ng-template #item let-item>
+              <button
+                class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
+                [class.text-red-600]="item.styleClass === 'text-red-600'"
+                [class.text-gray-700]="item.styleClass !== 'text-red-600'">
+                <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
+                {{ item.label }}
+              </button>
+            </ng-template>
+          </lfx-menu>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -19,9 +19,7 @@
   <!-- Cards -->
   <div class="flex flex-col gap-2" data-testid="recurring-cards">
     @for (entry of donationsWithMenuItems(); track entry.donation.id; let i = $index) {
-      <div
-        class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors cursor-pointer"
-        [attr.data-testid]="'recurring-card-' + entry.donation.id">
+      <div class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg" [attr.data-testid]="'recurring-card-' + entry.donation.id">
         <!-- Icon -->
         <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-gray-50 text-xl flex-shrink-0" aria-hidden="true">
           {{ entry.donation.icon }}
@@ -64,13 +62,13 @@
             (click)="onMenuToggle($event, i)" />
           <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
             <ng-template #item let-item>
-              <button
+              <div
                 class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
                 [class.text-red-600]="item.styleClass === 'text-red-600'"
                 [class.text-gray-700]="item.styleClass !== 'text-red-600'">
                 <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
                 {{ item.label }}
-              </button>
+              </div>
             </ng-template>
           </lfx-menu>
         </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, viewChildren } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MenuItem } from 'primeng/api';
+
+@Component({
+  selector: 'lfx-recurring-donations-list',
+  imports: [ButtonComponent, MenuComponent],
+  templateUrl: './recurring-donations-list.component.html',
+  styleUrl: './recurring-donations-list.component.scss',
+})
+export class RecurringDonationsListComponent {
+  public readonly donations = input.required<RecurringDonation[]>();
+  public readonly cancelledCount = input<number>(0);
+
+  public readonly viewCancelled = output<void>();
+  public readonly changeAmount = output<RecurringDonation>();
+  public readonly pauseDonation = output<RecurringDonation>();
+  public readonly resumeDonation = output<RecurringDonation>();
+  public readonly cancelDonation = output<RecurringDonation>();
+
+  private readonly menus = viewChildren<MenuComponent>(MenuComponent);
+
+  protected readonly donationsWithMenuItems = computed(() =>
+    this.donations().map((donation) => ({
+      donation,
+      menuItems: this.buildMenuItems(donation),
+    }))
+  );
+
+  protected onMenuToggle(event: Event, index: number): void {
+    this.menus()[index]?.toggle(event);
+  }
+
+  private buildMenuItems(donation: RecurringDonation): MenuItem[] {
+    if (donation.status === 'paused') {
+      return [
+        { label: 'Resume', icon: 'fa-solid fa-play', command: () => this.resumeDonation.emit(donation) },
+        { separator: true },
+        { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+      ];
+    }
+    return [
+      { label: 'Change amount', icon: 'fa-solid fa-pen-to-square', command: () => this.changeAmount.emit(donation) },
+      { label: 'Pause', icon: 'fa-solid fa-pause', command: () => this.pauseDonation.emit(donation) },
+      { separator: true },
+      { label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) },
+    ];
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output, viewChildren } from '@angular/core';
+import { Component, computed, input, output, Signal, viewChildren } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { RecurringDonation } from '@lfx-one/shared/interfaces';
@@ -25,15 +25,19 @@ export class RecurringDonationsListComponent {
 
   private readonly menus = viewChildren<MenuComponent>(MenuComponent);
 
-  protected readonly donationsWithMenuItems = computed(() =>
-    this.donations().map((donation) => ({
-      donation,
-      menuItems: this.buildMenuItems(donation),
-    }))
-  );
+  protected readonly donationsWithMenuItems = this.initDonationsWithMenuItems();
 
   protected onMenuToggle(event: Event, index: number): void {
     this.menus()[index]?.toggle(event);
+  }
+
+  private initDonationsWithMenuItems(): Signal<{ donation: RecurringDonation; menuItems: MenuItem[] }[]> {
+    return computed(() =>
+      this.donations().map((donation) => ({
+        donation,
+        menuItems: this.buildMenuItems(donation),
+      }))
+    );
   }
 
   private buildMenuItems(donation: RecurringDonation): MenuItem[] {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -1,0 +1,43 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 p-8" data-testid="my-donations">
+  <!-- Page header -->
+  <div class="flex items-start justify-between" data-testid="my-donations-header">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">My Donations</h1>
+      <p class="text-sm text-gray-500 mt-1">Your giving history across LFX Crowdfunding initiatives</p>
+    </div>
+    <a
+      [href]="crowdfundingUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 border border-gray-300 bg-white rounded-md px-3 py-1.5 hover:bg-gray-50 hover:border-gray-400 transition-colors whitespace-nowrap"
+      data-testid="explore-initiatives-btn">
+      Explore Initiatives
+      <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <!-- Stats bar -->
+  <lfx-donations-stats-bar [stats]="stats()" />
+
+  <!-- Recurring donations -->
+  <lfx-recurring-donations-list
+    [donations]="recurringDonations()"
+    [cancelledCount]="cancelledCount()"
+    (viewCancelled)="onViewCancelled()"
+    (changeAmount)="onChangeAmount($event)"
+    (pauseDonation)="onPauseDonation($event)"
+    (resumeDonation)="onResumeDonation($event)"
+    (cancelDonation)="onCancelDonation($event)" />
+
+  <!-- Donation history -->
+  <div class="flex flex-col gap-3" data-testid="donation-history-section">
+    <h2 class="text-sm font-bold text-gray-900">Donation History</h2>
+    <lfx-donation-history-table [items]="donationHistory()" />
+  </div>
+
+  <!-- Payment methods -->
+  <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" />
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { environment } from '@environments/environment';
+import { DonationHistoryItem, DonationStats, PaymentMethod, RecurringDonation } from '@lfx-one/shared/interfaces';
+import { MOCK_DONATION_HISTORY, MOCK_DONATION_STATS, MOCK_PAYMENT_METHODS, MOCK_RECURRING_DONATIONS } from '../crowdfunding.mock';
+import { DonationsStatsBarComponent } from './components/donations-stats-bar/donations-stats-bar.component';
+import { DonationHistoryTableComponent } from './components/donation-history-table/donation-history-table.component';
+import { PaymentMethodsComponent } from './components/payment-methods/payment-methods.component';
+import { RecurringDonationsListComponent } from './components/recurring-donations-list/recurring-donations-list.component';
+
+@Component({
+  selector: 'lfx-my-donations',
+  imports: [DonationsStatsBarComponent, RecurringDonationsListComponent, DonationHistoryTableComponent, PaymentMethodsComponent],
+  templateUrl: './my-donations.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MyDonationsComponent {
+  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly stats = signal<DonationStats>(MOCK_DONATION_STATS);
+  protected readonly recurringDonations = signal<RecurringDonation[]>(MOCK_RECURRING_DONATIONS);
+  protected readonly donationHistory = signal<DonationHistoryItem[]>(MOCK_DONATION_HISTORY);
+  protected readonly paymentMethods = signal<PaymentMethod[]>(MOCK_PAYMENT_METHODS);
+  protected readonly cancelledCount = signal(4);
+
+  protected onViewCancelled(): void {
+    // TODO: navigate to cancelled donations view
+  }
+
+  protected onChangeAmount(donation: RecurringDonation): void {
+    // TODO: open change amount dialog for donation
+    void donation;
+  }
+
+  protected onPauseDonation(donation: RecurringDonation): void {
+    // TODO: call pause API for donation
+    void donation;
+  }
+
+  protected onResumeDonation(donation: RecurringDonation): void {
+    // TODO: call resume API for donation
+    void donation;
+  }
+
+  protected onCancelDonation(donation: RecurringDonation): void {
+    // TODO: call cancel API for donation
+    void donation;
+  }
+
+  protected onRemoveCard(card: PaymentMethod): void {
+    // TODO: call remove card API
+    void card;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.html
@@ -5,11 +5,13 @@
   <lfx-filter-pills [options]="filterOptions()" [selectedFilter]="activeFilter()" (filterChange)="setFilter($event)" data-testid="initiatives-filter-pills" />
 
   @if (filteredInitiatives().length > 0) {
-    <div class="flex flex-col gap-4" data-testid="initiatives-cards">
+    <lfx-card
+      styleClass="flex flex-col gap-4 [&_.p-card-body]:p-0 [&_.p-card-content]:p-0 overflow-hidden hover:!border-gray-200"
+      data-testid="initiatives-cards">
       @for (initiative of filteredInitiatives(); track initiative.id) {
         <lfx-initiative-card [initiative]="initiative" (cardClick)="onCardClick($event)" />
       }
-    </div>
+    </lfx-card>
   } @else {
     <div class="flex flex-col items-center gap-3 py-16 text-gray-400" data-testid="initiatives-empty-state">
       <i class="fa-light fa-box-archive text-5xl" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -5,10 +5,11 @@ import { Component, computed, input, output, signal } from '@angular/core';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { CrowdfundingInitiative, CrowdfundingInitiativeStatus, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { InitiativeCardComponent } from '../initiative-card/initiative-card.component';
+import { CardComponent } from '@components/card/card.component';
 
 @Component({
   selector: 'lfx-initiatives-list',
-  imports: [FilterPillsComponent, InitiativeCardComponent],
+  imports: [CardComponent, FilterPillsComponent, InitiativeCardComponent],
   templateUrl: './initiatives-list.component.html',
   styleUrl: './initiatives-list.component.scss',
 })


### PR DESCRIPTION
## Summary

- Add `my-donations` page (route: `/crowdfunding/donations`)
- Add `donations-stats-bar` — aggregate totals (total donated, active recurring, initiatives supported)
- Add `recurring-donations-list` — lists active recurring donations with cancel/edit actions
- Add `donation-history-table` — paginated history of past donations
- Add `payment-methods` section with `payment-method-card` — displays saved cards with remove action
- Add `add-payment-card-dialog` — dialog for adding a new payment card with validation
- Wire `/crowdfunding/donations` into `crowdfunding.routes.ts`

All data is sourced from `crowdfunding.mock.ts` (UI-only, no API calls).

## Part of stacked PR series
This is **PR 4 of 4** — depends on [PR 3 (Initiative Detail)](https://github.com/linuxfoundation/lfx-self-serve/pull/751).

> **Review tip:** set base branch to `feat/crowdfunding-initiative-detail` to see only this PR's diff.

## Test plan
- [ ] Navigate to `/crowdfunding/donations` → stats bar, recurring donations, history table, and payment methods render from mock data
- [ ] Click **Add payment card** → dialog opens, validates fields, closes cleanly
- [ ] `yarn lint:check && yarn check-types && yarn build` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)