### PR TITLE
fix(profile): remove johnlf2727 demo user from individual enrollment

### DIFF
--- a/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
@@ -30,7 +30,7 @@ test.describe('Individual Enrollment — Structural Tests', () => {
     });
   });
 
-  test.describe('Card structure (demo user path)', () => {
+  test.describe('Card structure', () => {
     test('should render at least one enrollment card', async ({ page }) => {
       const card = page.getByTestId('individual-enrollment-card').first();
       await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });

--- a/apps/lfx-one/src/server/services/enrollment.service.ts
+++ b/apps/lfx-one/src/server/services/enrollment.service.ts
@@ -10,37 +10,13 @@ import { MicroserviceError } from '../errors';
 
 import { getApiGatewayBaseUrl } from '../helpers/api-gateway.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
-import { getUsernameFromAuth, usernameMatches } from '../utils/auth-helper';
 import { logger } from './logger.service';
 
-const DEMO_USER = 'johnlf2727';
 const ENROLLMENT_SERVICE = 'enrollment_service';
 const VALID_STATUSES = new Set<EnrollmentMembership['Status']>(['Active', 'Purchased', 'Expired']);
 
-const DEMO_ENROLLMENTS: IndividualEnrollment[] = [
-  {
-    ...TLF_INDIVIDUAL_SUPPORTER,
-    membership: {
-      Status: 'Expired',
-      AutoRenew: false,
-      PurchaseDate: '2020-06-09',
-      EndDate: '2021-06-09',
-      Price: 0,
-      ID: '02i2M00000QTirbQAD',
-      ExtPaymentType: '836366',
-    },
-  },
-];
-
 export class EnrollmentService {
   public async getIndividualEnrollments(req: Request): Promise<IndividualEnrollment[]> {
-    const username = await getUsernameFromAuth(req);
-
-    if (username && usernameMatches(username, DEMO_USER)) {
-      logger.debug(req, 'get_individual_enrollments', 'Returning demo data for test user');
-      return DEMO_ENROLLMENTS;
-    }
-
     const baseUrl = getApiGatewayBaseUrl('get_individual_enrollments', ENROLLMENT_SERVICE);
     const url = `${baseUrl}/member-service/v2/me/memberships?productID=${TLF_INDIVIDUAL_SUPPORTER.productId}&status=Purchased,Active,Expired&membershipType=Individual`;
 
@@ -87,13 +63,6 @@ export class EnrollmentService {
   }
 
   public async updateAutoRenew(req: Request, membershipId: string, autoRenew: boolean): Promise<void> {
-    const username = await getUsernameFromAuth(req);
-
-    if (username && usernameMatches(username, DEMO_USER)) {
-      logger.debug(req, 'update_individual_enrollment_auto_renew', 'Skipping update for demo user');
-      return;
-    }
-
     if (!req.bearerToken) {
       throw new MicroserviceError('User bearer token not available', 401, 'BEARER_TOKEN_UNAVAILABLE', {
         operation: 'update_individual_enrollment_auto_renew',

--- a/docs/migration/individual-memberships.md
+++ b/docs/migration/individual-memberships.md
@@ -242,7 +242,7 @@ fields from member-service that influence whether the "Manage AutoRenew" toggle 
 | `backend/src/modules/enrollment/enrollment.module.ts`     | NestJS module registration                                              |
 | `backend/src/modules/enrollment/enrollment.controller.ts` | Controller for all `/enrollment/*` endpoints                            |
 | `backend/src/modules/enrollment/enrollment.service.ts`    | Business logic: product catalog, alias management, member-service calls |
-| `backend/src/modules/enrollment/dummy-data.ts`            | Mock data for demo user `johnlf2727`                                    |
+| `backend/src/modules/enrollment/dummy-data.ts`            | Mock enrollment data (myprofile only)                                   |
 | `backend/src/services/member.service.ts`                  | HTTP client to LFX `member-service` v2                                  |
 | `backend/src/services/apigateway.service.ts`              | Builds LFX API Gateway base URL from `STAGE` env var                    |
 | `backend/src/services/snowflake.service.ts`               | Snowflake query client for transactions/certs/trainings                 |
@@ -533,7 +533,7 @@ component import — candidates for cleanup:
 | `frontend/src/views/Home.vue:35, 147–148`                                  | SupportedProjects mount                                                                |
 | `backend/src/modules/enrollment/enrollment.controller.ts`                  | All `/enrollment/*` endpoints                                                          |
 | `backend/src/modules/enrollment/enrollment.service.ts`                     | Business logic, product catalog                                                        |
-| `backend/src/modules/enrollment/dummy-data.ts`                             | Mock data for demo user                                                                |
+| `backend/src/modules/enrollment/dummy-data.ts`                             | Mock enrollment data (myprofile only)                                                  |
 | `backend/src/services/member.service.ts`                                   | member-service v2 client                                                               |
 | `backend/src/services/apigateway.service.ts`                               | LFX API Gateway URL builder                                                            |
 | `backend/src/services/snowflake.service.ts`                                | Snowflake query client                                                                 |

--- a/docs/migration/individual-memberships.md
+++ b/docs/migration/individual-memberships.md
@@ -449,14 +449,6 @@ All enrollment CTAs are wrapped with `v-if="!$user.inPreviewMode"` in
 `block-enrollments-list.vue:34, 92, 105`. LF staff who impersonate a user via
 `x-for-id` / `x-for-username` headers cannot trigger enrollment actions.
 
-### Demo user
-
-Username `johnlf2727` returns hardcoded mock data from `dummy-data.ts` for all enrollment
-endpoints in the legacy myprofile backend. Used for demos and onboarding.
-
-This short-circuit was **not carried into `lfx-self-serve`**. Use impersonation (Auth0 CTE) to
-demo against a real account in lower environments.
-
 ### Legacy / dead code
 
 The following files exist in myprofile but are not reachable from any current route or

--- a/docs/migration/individual-memberships.md
+++ b/docs/migration/individual-memberships.md
@@ -452,7 +452,10 @@ All enrollment CTAs are wrapped with `v-if="!$user.inPreviewMode"` in
 ### Demo user
 
 Username `johnlf2727` returns hardcoded mock data from `dummy-data.ts` for all enrollment
-endpoints. Used for demos and onboarding.
+endpoints in the legacy myprofile backend. Used for demos and onboarding.
+
+This short-circuit was **not carried into `lfx-self-serve`**. Use impersonation (Auth0 CTE) to
+demo against a real account in lower environments.
 
 ### Legacy / dead code
 


### PR DESCRIPTION
## Summary

- Removed the hardcoded `johnlf2727` demo-user short-circuit in `EnrollmentService`. It returned a stale Expired-2021 TLF Individual Supporter stub and was not gated by env or feature flag, so it shipped to production.
- Removed the matching short-circuit in `updateAutoRenew()` which was silently dropping the upstream PATCH for that username — if any real LF SSO user ever holds `johnlf2727`, their auto-renew toggles would vanish.
- Impersonation via Auth0 CTE is the correct way to demo enrollments against real data in lower environments, making the stub redundant.
- Clarified `docs/migration/individual-memberships.md` to note the demo path stays in legacy myprofile and was not carried into self-serve.

Fixes LFXV2-1664

## Test plan

- [ ] `yarn check-types` passes
- [ ] `yarn lint:check` passes
- [ ] `yarn build` passes (SSR bundle)
- [ ] Impersonate a real LF account with an Individual Supporter membership in a lower env → `/profile` → Individual Enrollments tab renders real member-service data
- [ ] Toggle auto-renew while impersonating → confirm the PATCH to `/member-service/v2/memberships/<id>` fires (server log `update_individual_enrollment_auto_renew`) and the upstream state changes
- [ ] If a `johnlf2727` account exists in a lower env, confirm it no longer sees the Expired-2021 stub and auto-renew writes succeed