### PR TITLE
test(profile): add e2e coverage for individual-enrollment states

### DIFF
--- a/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment-robust.spec.ts
@@ -8,6 +8,35 @@ import { expect, test } from '@playwright/test';
 const ENROLLMENT_URL = '/profile/individual-enrollment';
 const DATA_LOAD_TIMEOUT = 15_000;
 
+/** Minimal active enrollment fixture with a non-Stripe payment type — used for deterministic structural assertions. */
+const MOCK_NON_STRIPE = [
+  {
+    projectName: 'The Linux Foundation',
+    projectSlug: 'tlf',
+    ProductName: 'The Linux Foundation Individual Supporter',
+    projectDesc: 'Test project description.',
+    enrollButton: 'Enroll',
+    price: 99,
+    projectLogo: '',
+    benefits: ['Weekly newsletter'],
+    projectId: 'a0941000002wBz9AAE',
+    productSFID: 'a0I2M00000PQymQUAT',
+    productId: '01t2M000005wBb0QAE',
+    ctaPath: '?product=01t2M000005wBb0QAE&project=tlf',
+    activeButtonText: '',
+    activeButtonURL: '',
+    membership: {
+      Status: 'Active',
+      AutoRenew: false,
+      PurchaseDate: '2025-06-01',
+      EndDate: '2027-06-01',
+      Price: 99,
+      ID: 'non-stripe-robust-001',
+      ExtPaymentType: 'manual',
+    },
+  },
+];
+
 test.setTimeout(60_000);
 
 test.describe('Individual Enrollment — Structural Tests', () => {
@@ -52,14 +81,6 @@ test.describe('Individual Enrollment — Structural Tests', () => {
     });
   });
 
-  test.describe('Auto-renew row', () => {
-    test('should NOT show the toggle for non-Stripe memberships', async ({ page }) => {
-      // Demo user has ExtPaymentType: '836366' (not 'stripe') — toggle must not render
-      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
-      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).not.toBeAttached();
-    });
-  });
-
   test.describe('Confirm dialog testid hook', () => {
     test('should have confirm dialog attached in DOM (not visible until triggered)', async ({ page }) => {
       await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
@@ -87,5 +108,44 @@ test.describe('Individual Enrollment — Mocked State Tests', () => {
       await expect(page).not.toHaveURL(/auth0\.com/);
       await expect(page.getByTestId('individual-enrollment-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     });
+  });
+
+  test.describe('Auto-renew row', () => {
+    test('should NOT show the toggle for non-Stripe memberships', async ({ page }) => {
+      await page.route('**/api/enrollments', async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_NON_STRIPE) });
+      });
+      await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+      await expect(page).not.toHaveURL(/auth0\.com/);
+      await page.getByTestId('individual-enrollment-card').first().waitFor({ state: 'visible', timeout: DATA_LOAD_TIMEOUT });
+      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).not.toBeAttached();
+    });
+  });
+
+  test.describe('Loading skeleton', () => {
+    test('should show loading skeleton while API is pending', async ({ page }) => {
+      await page.route('**/api/enrollments', async (route) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 2000));
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_NON_STRIPE) });
+      });
+      await page.goto(ENROLLMENT_URL, { waitUntil: 'domcontentloaded' });
+      await expect(page).not.toHaveURL(/auth0\.com/);
+      await expect(page.getByTestId('individual-enrollment-loading')).toBeVisible({ timeout: 5000 });
+    });
+  });
+});
+
+test.describe('Individual Enrollment — Tab Navigation', () => {
+  test('should navigate to individual-enrollment via Profile tabs', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.route('**/api/enrollments', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_NON_STRIPE) });
+    });
+    await page.goto('/profile', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('profile-tabs-desktop')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await page.getByTestId('profile-tab-individual-enrollment').click();
+    await expect(page).toHaveURL(/\/profile\/individual-enrollment/);
+    await expect(page.getByTestId('individual-enrollment-page')).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
   });
 });

--- a/apps/lfx-one/e2e/individual-enrollment.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment.spec.ts
@@ -43,11 +43,15 @@ const stripeActiveMembership = [
 /** Same membership but AutoRenew: false. */
 const stripeActiveMembershipAutoRenewOff = [{ ...stripeActiveMembership[0], membership: { ...stripeActiveMembership[0].membership, AutoRenew: false } }];
 
-/** Builds an ISO date string N days from today — keeps date-sensitive fixtures from going stale. */
+/** Builds a local YYYY-MM-DD string N days from today — keeps date-sensitive fixtures from going stale.
+ *  Uses local getters to match parseLocalDateString, which builds dates as local midnight. */
 function daysFromNow(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() + n);
-  return d.toISOString().slice(0, 10);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
 }
 
 /** Expired Stripe membership — displayStatus: 'Expired'. */
@@ -290,6 +294,7 @@ test.describe('Individual Enrollment — Content Tests', () => {
       await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
       await expect(page.locator('.p-confirmdialog')).toContainText('Update Membership');
       await expect(page.locator('.p-confirmdialog')).toContainText('Enable auto renew');
+      await expect(page.locator('.p-confirmdialog').getByRole('button', { name: /^Enable$/i })).toBeVisible();
     });
 
     test('accepting Enable shows success toast', async ({ page }) => {

--- a/apps/lfx-one/e2e/individual-enrollment.spec.ts
+++ b/apps/lfx-one/e2e/individual-enrollment.spec.ts
@@ -43,8 +43,40 @@ const stripeActiveMembership = [
 /** Same membership but AutoRenew: false. */
 const stripeActiveMembershipAutoRenewOff = [{ ...stripeActiveMembership[0], membership: { ...stripeActiveMembership[0].membership, AutoRenew: false } }];
 
+/** Builds an ISO date string N days from today — keeps date-sensitive fixtures from going stale. */
+function daysFromNow(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Expired Stripe membership — displayStatus: 'Expired'. */
+const expiredMembership = [
+  {
+    ...stripeActiveMembership[0],
+    membership: { ...stripeActiveMembership[0].membership, Status: 'Expired' as const, AutoRenew: false, EndDate: '2024-01-01' },
+  },
+];
+
+/** Expiring-soon Stripe membership (EndDate ~14 days out) — displayStatus: 'Expiring Soon'. */
+const expiringSoonMembership = [
+  {
+    ...stripeActiveMembership[0],
+    membership: { ...stripeActiveMembership[0].membership, Status: 'Active' as const, AutoRenew: false, EndDate: daysFromNow(14) },
+  },
+];
+
+/** Not-enrolled item (membership: null) — displayStatus: 'Not Enrolled'. */
+const notEnrolledItem = [{ ...stripeActiveMembership[0], membership: null }];
+
 async function setupStripeEnrollmentMock(page: Page, autoRenew = true): Promise<void> {
   const body = autoRenew ? stripeActiveMembership : stripeActiveMembershipAutoRenewOff;
+  await page.route('**/api/enrollments', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function setupCustomEnrollmentMock(page: Page, body: unknown[]): Promise<void> {
   await page.route('**/api/enrollments', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
   });
@@ -242,6 +274,121 @@ test.describe('Individual Enrollment — Content Tests', () => {
 
       // After error, toggle should revert to original checked state
       await expect(input).toBeChecked({ timeout: 10_000 });
+    });
+  });
+
+  test.describe('Auto-renew enable path (false → true)', () => {
+    test('confirm dialog shows Enable button when toggling on', async ({ page }) => {
+      await setupStripeEnrollmentMock(page, false); // AutoRenew: false
+      await setupPatchMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await expect(toggle).not.toBeChecked();
+      await toggle.click();
+
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.p-confirmdialog')).toContainText('Update Membership');
+      await expect(page.locator('.p-confirmdialog')).toContainText('Enable auto renew');
+    });
+
+    test('accepting Enable shows success toast', async ({ page }) => {
+      await setupStripeEnrollmentMock(page, false);
+      await setupPatchMock(page);
+      await gotoAndWaitForCard(page);
+
+      const toggle = page.getByTestId('individual-enrollment-auto-renew-toggle').locator('input[type="checkbox"]');
+      await toggle.click();
+      await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+      await page
+        .locator('.p-confirmdialog')
+        .getByRole('button', { name: /Enable/i })
+        .click();
+
+      await expect(page.locator('.p-toast')).toContainText('Auto renew enabled successfully', { timeout: 10_000 });
+    });
+  });
+
+  test.describe('Active card — benefits + chip', () => {
+    test('shows all benefit strings in the benefits section', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      const benefits = page.getByTestId('individual-enrollment-benefits');
+      await expect(benefits).toBeVisible();
+      for (const benefit of stripeActiveMembership[0].benefits) {
+        await expect(benefits).toContainText(benefit);
+      }
+    });
+
+    test('status chip shows Active', async ({ page }) => {
+      await setupStripeEnrollmentMock(page);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-status')).toContainText('Active');
+    });
+  });
+
+  test.describe('Expired state', () => {
+    test('chip text shows Expired', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiredMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-status')).toContainText('Expired');
+    });
+
+    test('CTA shows Repurchase', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiredMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-cta')).toContainText('Repurchase');
+    });
+
+    test('auto-renew toggle is not rendered', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiredMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).not.toBeAttached();
+    });
+
+    test('shows read-only auto-renew text', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiredMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-details')).toContainText('Auto Renew: Disabled');
+    });
+  });
+
+  test.describe('Expiring Soon state', () => {
+    test('chip text shows Expiring Soon', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiringSoonMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-status')).toContainText('Expiring Soon');
+    });
+
+    test('CTA shows Renew My Enrollment', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, expiringSoonMembership);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-cta')).toContainText('Renew My Enrollment');
+    });
+  });
+
+  test.describe('Not Enrolled state', () => {
+    test('card renders with Enroll CTA', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, notEnrolledItem);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-cta')).toContainText('Enroll');
+    });
+
+    test('auto-renew toggle is not rendered', async ({ page }) => {
+      await setupCustomEnrollmentMock(page, notEnrolledItem);
+      await gotoAndWaitForCard(page);
+
+      await expect(page.getByTestId('individual-enrollment-auto-renew-toggle')).not.toBeAttached();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fills the Playwright e2e gaps for `/profile/individual-enrollment` identified in LFXV2-1907.
Three scope items were already covered by the existing specs (direct URL navigation, empty
state, active card with toggle flows). This PR adds the remaining gaps and tightens the
robust suite.

### Added (content spec)
- Active card: benefits list rendering + chip text assertion
- Expired state: chip text, "Repurchase" CTA, no toggle, read-only "Auto Renew: Disabled" text
- Expiring Soon state: chip text + "Renew My Enrollment" CTA (uses a dynamically computed `EndDate` so the fixture doesn't go stale)
- Not Enrolled state: card renders with "Enroll" CTA, no toggle
- Auto-renew enable path (false → true): confirm dialog shows "Enable", success toast

### Added (robust spec)
- Loading skeleton test via 2s delayed route intercept
- Tab navigation: clicks `profile-tab-individual-enrollment` from `/profile` and asserts URL + page testid

### Cleanup
- Converted the "non-Stripe toggle hidden" test from live-data-dependent to mocked (`ExtPaymentType: 'manual'`) — the test was previously coupled to the real test user's upstream membership data. Removed the stale comment.

Fixes LFXV2-1907

## Test plan

- [x] `yarn lint` clean
- [x] `yarn check-types` clean
- [x] `yarn build` clean
- [x] `yarn workspace lfx-one e2e --project=chromium apps/lfx-one/e2e/individual-enrollment.spec.ts` passes
- [x] `yarn workspace lfx-one e2e --project=chromium apps/lfx-one/e2e/individual-enrollment-robust.spec.ts` passes