### PR TITLE
fix(analytics): show distinct latest-day maintainers per project

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -451,7 +451,7 @@ export class FoundationHealthComponent {
     return {
       ...metric,
       loading: this.maintainersLoading(),
-      value: data.currentMaintainers.toString(),
+      value: data.currentMaintainers.toLocaleString(),
       subtitle: asOfLabel ? `As of ${asOfLabel}` : 'Distinct active maintainers',
       chartData: {
         labels: data.trendLabels,

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -28,6 +28,7 @@ import type {
   CompanyBusFactor,
   DashboardMetricCard,
   FoundationCompanyBusFactorResponse,
+  FoundationMaintainersResponse,
   FoundationValueConcentrationResponse,
   HealthEventsMonthlyResponse,
   UniqueContributorsDailyResponse,
@@ -443,12 +444,15 @@ export class FoundationHealthComponent {
 
   private transformMaintainers(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.maintainersData();
+    const asOfLabel = data.asOfDate
+      ? new Date(`${data.asOfDate}T00:00:00Z`).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })
+      : null;
 
     return {
       ...metric,
       loading: this.maintainersLoading(),
-      value: data.avgMaintainers.toString(),
-      subtitle: 'Average maintainers over the past year',
+      value: data.currentMaintainers.toString(),
+      subtitle: asOfLabel ? `As of ${asOfLabel}` : 'Distinct active maintainers',
       chartData: {
         labels: data.trendLabels,
         datasets: [
@@ -646,10 +650,11 @@ export class FoundationHealthComponent {
   }
 
   private initializeMaintainersData() {
-    const defaultValue = {
-      avgMaintainers: 0,
-      trendData: [] as number[],
-      trendLabels: [] as string[],
+    const defaultValue: FoundationMaintainersResponse = {
+      currentMaintainers: 0,
+      asOfDate: null,
+      trendData: [],
+      trendLabels: [],
     };
 
     return toSignal(

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -477,7 +477,7 @@ export class FoundationHealthComponent {
               title: (context) => context[0]?.label ?? '',
               label: (context) => {
                 const count = context.parsed.y ?? 0;
-                return `Active maintainers: ${count}`;
+                return `Active maintainers: ${count.toLocaleString()}`;
               },
             },
           },

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -118,7 +118,7 @@ export class MaintainersDrawerComponent {
   });
 
   // === Inputs ===
-  public readonly data = input<FoundationMaintainersResponse>({ avgMaintainers: 0, trendData: [], trendLabels: [] });
+  public readonly data = input<FoundationMaintainersResponse>({ currentMaintainers: 0, asOfDate: null, trendData: [], trendLabels: [] });
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);
@@ -134,8 +134,8 @@ export class MaintainersDrawerComponent {
     })
   );
 
-  protected readonly metricValue: Signal<string> = computed(() => this.data().avgMaintainers.toLocaleString());
-  protected readonly hasData: Signal<boolean> = computed(() => this.data().avgMaintainers > 0);
+  protected readonly metricValue: Signal<string> = computed(() => this.data().currentMaintainers.toLocaleString());
+  protected readonly hasData: Signal<boolean> = computed(() => this.data().currentMaintainers > 0);
 
   private readonly drawerData = this.initDrawerData();
   protected readonly monthlyTrendData: Signal<FoundationMaintainersMonthlyResponse> = computed(() => this.drawerData().monthly);

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -135,7 +135,7 @@ export class MaintainersDrawerComponent {
   );
 
   protected readonly metricValue: Signal<string> = computed(() => this.data().currentMaintainers.toLocaleString());
-  protected readonly hasData: Signal<boolean> = computed(() => this.data().currentMaintainers > 0);
+  protected readonly hasData: Signal<boolean> = computed(() => this.data().asOfDate !== null);
 
   private readonly drawerData = this.initDrawerData();
   protected readonly monthlyTrendData: Signal<FoundationMaintainersMonthlyResponse> = computed(() => this.drawerData().monthly);

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -412,11 +412,7 @@ export class AnalyticsService {
     );
   }
 
-  /**
-   * Get foundation maintainers data from Snowflake
-   * @param foundationSlug - Required foundation slug to filter by (e.g., 'tlf', 'cncf')
-   * @returns Observable of foundation maintainers response with average and daily trend data
-   */
+  /** Latest-day distinct-maintainer snapshot + daily trend for a foundation. */
   public getFoundationMaintainers(foundationSlug: string): Observable<FoundationMaintainersResponse> {
     return this.http.get<FoundationMaintainersResponse>('/api/analytics/foundation-maintainers', { params: { foundationSlug } }).pipe(
       catchError(() => {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -421,7 +421,8 @@ export class AnalyticsService {
     return this.http.get<FoundationMaintainersResponse>('/api/analytics/foundation-maintainers', { params: { foundationSlug } }).pipe(
       catchError(() => {
         return of({
-          avgMaintainers: 0,
+          currentMaintainers: 0,
+          asOfDate: null,
           trendData: [],
           trendLabels: [],
         });

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -877,7 +877,8 @@ export class AnalyticsController {
 
       logger.success(req, 'get_foundation_maintainers', startTime, {
         foundation_slug: foundationSlug,
-        avg_maintainers: response.avgMaintainers,
+        current_maintainers: response.currentMaintainers,
+        as_of_date: response.asOfDate,
         trend_data_points: response.trendData.length,
       });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1413,14 +1413,18 @@ export class ProjectService {
     // of toISOString() is the correct calendar key. String()-then-slice was
     // tried first but breaks in non-UTC server TZs (returns the local-formatted
     // weekday-month prefix, e.g. "Tue May 19", not "2026-05-20").
-    const asOfDate = latest ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
+    const asOfDate = latest?.METRIC_DATE ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
 
     // Extract daily data and labels. Format trend labels in UTC to match the
     // UTC-anchored asOfDate the card subtitle renders — otherwise non-UTC server
     // deployments would show "May 19" on the chart's rightmost tick while the
     // card subtitle reads "As of May 20".
-    const trendData = result.rows.map((row) => row.ACTIVE_MAINTAINERS);
+    // Coerce per-row nulls the same way the snapshot does, so a data-gap day
+    // never leaks `null` into the chart series or "Invalid Date" into the
+    // x-axis labels.
+    const trendData = result.rows.map((row) => row.ACTIVE_MAINTAINERS ?? 0);
     const trendLabels = result.rows.map((row) => {
+      if (!row.METRIC_DATE) return '';
       const date = new Date(row.METRIC_DATE);
       return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
     });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1403,26 +1403,28 @@ export class ProjectService {
 
     const result = await this.snowflakeService.execute<FoundationMaintainersDailyRow>(query, [foundationSlug]);
 
-    // The rows are ordered ASC by date, so the last row carries the latest snapshot.
-    // Shane's dbt fix (2026-05-20) made ACTIVE_MAINTAINERS distinct per foundation,
-    // so this snapshot now reconciles with FOUNDATION_TOTAL_PROJECTS_DETAIL.MAINTAINERS_CURRENT_COUNT.
-    const latest = result.rows.length > 0 ? result.rows[result.rows.length - 1] : null;
+    // Filter rows with a missing METRIC_DATE up-front so trendData and
+    // trendLabels stay index-aligned, and so the snapshot picks the latest
+    // *labeled* day — the chart and the card always agree on which day
+    // "current" refers to.
+    const trendRows = result.rows.filter((row) => row.METRIC_DATE);
+
+    // The rows are ordered ASC by date, so the last labeled row carries the
+    // latest snapshot. Shane's dbt fix (2026-05-20) made ACTIVE_MAINTAINERS
+    // distinct per foundation, so this snapshot now reconciles with
+    // FOUNDATION_TOTAL_PROJECTS_DETAIL.MAINTAINERS_CURRENT_COUNT.
+    const latest = trendRows.length > 0 ? trendRows[trendRows.length - 1] : null;
     const currentMaintainers = latest?.ACTIVE_MAINTAINERS ?? 0;
     // The Snowflake Node SDK returns DATE columns as a JS Date pinned to UTC
     // midnight for the calendar day Snowflake stored, so the UTC date portion
     // of toISOString() is the correct calendar key. String()-then-slice was
     // tried first but breaks in non-UTC server TZs (returns the local-formatted
     // weekday-month prefix, e.g. "Tue May 19", not "2026-05-20").
-    const asOfDate = latest?.METRIC_DATE ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
+    const asOfDate = latest ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
 
-    // Extract daily data and labels. Format trend labels in UTC to match the
-    // UTC-anchored asOfDate the card subtitle renders — otherwise non-UTC server
-    // deployments would show "May 19" on the chart's rightmost tick while the
-    // card subtitle reads "As of May 20".
-    // Filter rows with a missing METRIC_DATE up-front so trendData and
-    // trendLabels stay index-aligned (skip-and-coerce on opposite sides would
-    // plot an unlabeled point for a data-quality glitch row).
-    const trendRows = result.rows.filter((row) => row.METRIC_DATE);
+    // Format trend labels in UTC to match the UTC-anchored asOfDate the card
+    // subtitle renders — otherwise non-UTC server deployments would show
+    // "May 19" on the chart's rightmost tick while the card reads "As of May 20".
     const trendData = trendRows.map((row) => row.ACTIVE_MAINTAINERS ?? 0);
     const trendLabels = trendRows.map((row) => {
       const date = new Date(row.METRIC_DATE);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -35,7 +35,7 @@ import {
   FoundationHealthEventsMonthlyRow,
   FoundationHealthScoreDistributionResponse,
   FoundationHealthScoreDistributionRow,
-  FoundationMaintainersDailyRow,
+  FoundationMaintainersDailySnapshotRow,
   FoundationMaintainersDistributionResponse,
   FoundationMaintainersDistributionRow,
   FoundationMaintainersMonthlyResponse,
@@ -1395,7 +1395,7 @@ export class ProjectService {
       ORDER BY METRIC_DATE ASC
     `;
 
-    const result = await this.snowflakeService.execute<FoundationMaintainersDailyRow>(query, [foundationSlug]);
+    const result = await this.snowflakeService.execute<FoundationMaintainersDailySnapshotRow>(query, [foundationSlug]);
 
     // Filter null-METRIC_DATE rows up-front so trendData/trendLabels stay index-aligned and the snapshot picks the latest *labeled* day.
     const trendRows = result.rows.filter((row) => row.METRIC_DATE);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1419,12 +1419,12 @@ export class ProjectService {
     // UTC-anchored asOfDate the card subtitle renders — otherwise non-UTC server
     // deployments would show "May 19" on the chart's rightmost tick while the
     // card subtitle reads "As of May 20".
-    // Coerce per-row nulls the same way the snapshot does, so a data-gap day
-    // never leaks `null` into the chart series or "Invalid Date" into the
-    // x-axis labels.
-    const trendData = result.rows.map((row) => row.ACTIVE_MAINTAINERS ?? 0);
-    const trendLabels = result.rows.map((row) => {
-      if (!row.METRIC_DATE) return '';
+    // Filter rows with a missing METRIC_DATE up-front so trendData and
+    // trendLabels stay index-aligned (skip-and-coerce on opposite sides would
+    // plot an unlabeled point for a data-quality glitch row).
+    const trendRows = result.rows.filter((row) => row.METRIC_DATE);
+    const trendData = trendRows.map((row) => row.ACTIVE_MAINTAINERS ?? 0);
+    const trendLabels = trendRows.map((row) => {
       const date = new Date(row.METRIC_DATE);
       return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
     });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1395,8 +1395,7 @@ export class ProjectService {
     const query = `
       SELECT
         METRIC_DATE,
-        ACTIVE_MAINTAINERS,
-        AVG_MAINTAINERS_YEARLY
+        ACTIVE_MAINTAINERS
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY
       WHERE FOUNDATION_SLUG = ?
       ORDER BY METRIC_DATE ASC
@@ -1404,8 +1403,12 @@ export class ProjectService {
 
     const result = await this.snowflakeService.execute<FoundationMaintainersDailyRow>(query, [foundationSlug]);
 
-    // Get average maintainers from first row (same across all rows)
-    const avgMaintainers = result.rows.length > 0 ? Math.round(result.rows[0].AVG_MAINTAINERS_YEARLY) : 0;
+    // The rows are ordered ASC by date, so the last row carries the latest snapshot.
+    // Shane's dbt fix (2026-05-20) made ACTIVE_MAINTAINERS distinct per foundation,
+    // so this snapshot now reconciles with FOUNDATION_TOTAL_PROJECTS_DETAIL.MAINTAINERS_CURRENT_COUNT.
+    const latest = result.rows.length > 0 ? result.rows[result.rows.length - 1] : null;
+    const currentMaintainers = latest ? latest.ACTIVE_MAINTAINERS : 0;
+    const asOfDate = latest ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
 
     // Extract daily data and labels
     const trendData = result.rows.map((row) => row.ACTIVE_MAINTAINERS);
@@ -1415,7 +1418,8 @@ export class ProjectService {
     });
 
     return {
-      avgMaintainers,
+      currentMaintainers,
+      asOfDate,
       trendData,
       trendLabels,
     };
@@ -1612,7 +1616,7 @@ export class ProjectService {
         LIFECYCLE_STAGE,
         CONTRIBUTORS_90D_COUNT,
         COMMITS_90D_COUNT,
-        MAINTAINERS_YTD_COUNT,
+        MAINTAINERS_CURRENT_COUNT,
         STARS_YTD_COUNT,
         LAST_UPDATED_TS
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_TOTAL_PROJECTS_DETAIL
@@ -1639,7 +1643,7 @@ export class ProjectService {
           row.LIFECYCLE_STAGE && VALID_LIFECYCLE_STAGES.has(row.LIFECYCLE_STAGE as LifecycleStage) ? (row.LIFECYCLE_STAGE as LifecycleStage) : null,
         activeContributors: row.CONTRIBUTORS_90D_COUNT ?? 0,
         commitsLast90Days: row.COMMITS_90D_COUNT ?? 0,
-        maintainers: row.MAINTAINERS_YTD_COUNT ?? 0,
+        maintainers: row.MAINTAINERS_CURRENT_COUNT ?? 0,
         stars: row.STARS_YTD_COUNT ?? 0,
         lastUpdated: row.LAST_UPDATED_TS ? new Date(row.LAST_UPDATED_TS).toISOString().split('T')[0] : null,
       }));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1385,11 +1385,11 @@ export class ProjectService {
   }
 
   /**
-   * Get foundation maintainers data from Snowflake
-   * Queries FOUNDATION_MAINTAINERS_DAILY table
-   * Returns daily maintainer counts for detailed trend visualization
+   * Get foundation maintainers data from Snowflake.
+   * Queries FOUNDATION_MAINTAINERS_DAILY and returns the latest-day distinct-maintainer
+   * snapshot (currentMaintainers + asOfDate) alongside the full daily trend.
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
-   * @returns Foundation maintainers response with average and daily trend data
+   * @returns Foundation maintainers response with latest snapshot and daily trend
    */
   public async getFoundationMaintainers(foundationSlug: string): Promise<FoundationMaintainersResponse> {
     const query = `
@@ -1407,14 +1407,22 @@ export class ProjectService {
     // Shane's dbt fix (2026-05-20) made ACTIVE_MAINTAINERS distinct per foundation,
     // so this snapshot now reconciles with FOUNDATION_TOTAL_PROJECTS_DETAIL.MAINTAINERS_CURRENT_COUNT.
     const latest = result.rows.length > 0 ? result.rows[result.rows.length - 1] : null;
-    const currentMaintainers = latest ? latest.ACTIVE_MAINTAINERS : 0;
+    const currentMaintainers = latest?.ACTIVE_MAINTAINERS ?? 0;
+    // The Snowflake Node SDK returns DATE columns as a JS Date pinned to UTC
+    // midnight for the calendar day Snowflake stored, so the UTC date portion
+    // of toISOString() is the correct calendar key. String()-then-slice was
+    // tried first but breaks in non-UTC server TZs (returns the local-formatted
+    // weekday-month prefix, e.g. "Tue May 19", not "2026-05-20").
     const asOfDate = latest ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
 
-    // Extract daily data and labels
+    // Extract daily data and labels. Format trend labels in UTC to match the
+    // UTC-anchored asOfDate the card subtitle renders — otherwise non-UTC server
+    // deployments would show "May 19" on the chart's rightmost tick while the
+    // card subtitle reads "As of May 20".
     const trendData = result.rows.map((row) => row.ACTIVE_MAINTAINERS);
     const trendLabels = result.rows.map((row) => {
       const date = new Date(row.METRIC_DATE);
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
     });
 
     return {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1384,13 +1384,7 @@ export class ProjectService {
     };
   }
 
-  /**
-   * Get foundation maintainers data from Snowflake.
-   * Queries FOUNDATION_MAINTAINERS_DAILY and returns the latest-day distinct-maintainer
-   * snapshot (currentMaintainers + asOfDate) alongside the full daily trend.
-   * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
-   * @returns Foundation maintainers response with latest snapshot and daily trend
-   */
+  /** Latest-day distinct-maintainer snapshot + full daily trend for a foundation (LFXV2-1625). */
   public async getFoundationMaintainers(foundationSlug: string): Promise<FoundationMaintainersResponse> {
     const query = `
       SELECT
@@ -1403,28 +1397,15 @@ export class ProjectService {
 
     const result = await this.snowflakeService.execute<FoundationMaintainersDailyRow>(query, [foundationSlug]);
 
-    // Filter rows with a missing METRIC_DATE up-front so trendData and
-    // trendLabels stay index-aligned, and so the snapshot picks the latest
-    // *labeled* day — the chart and the card always agree on which day
-    // "current" refers to.
+    // Filter null-METRIC_DATE rows up-front so trendData/trendLabels stay index-aligned and the snapshot picks the latest *labeled* day.
     const trendRows = result.rows.filter((row) => row.METRIC_DATE);
 
-    // The rows are ordered ASC by date, so the last labeled row carries the
-    // latest snapshot. Shane's dbt fix (2026-05-20) made ACTIVE_MAINTAINERS
-    // distinct per foundation, so this snapshot now reconciles with
-    // FOUNDATION_TOTAL_PROJECTS_DETAIL.MAINTAINERS_CURRENT_COUNT.
     const latest = trendRows.length > 0 ? trendRows[trendRows.length - 1] : null;
     const currentMaintainers = latest?.ACTIVE_MAINTAINERS ?? 0;
-    // The Snowflake Node SDK returns DATE columns as a JS Date pinned to UTC
-    // midnight for the calendar day Snowflake stored, so the UTC date portion
-    // of toISOString() is the correct calendar key. String()-then-slice was
-    // tried first but breaks in non-UTC server TZs (returns the local-formatted
-    // weekday-month prefix, e.g. "Tue May 19", not "2026-05-20").
+    // Snowflake SDK returns DATE columns as a JS Date at UTC midnight; toISOString().split('T')[0] gives the calendar key (String().slice gave "Tue May 19" in PT).
     const asOfDate = latest ? new Date(latest.METRIC_DATE).toISOString().split('T')[0] : null;
 
-    // Format trend labels in UTC to match the UTC-anchored asOfDate the card
-    // subtitle renders — otherwise non-UTC server deployments would show
-    // "May 19" on the chart's rightmost tick while the card reads "As of May 20".
+    // Anchor trend labels to UTC so the chart's rightmost tick matches the asOfDate the card subtitle renders.
     const trendData = trendRows.map((row) => row.ACTIVE_MAINTAINERS ?? 0);
     const trendLabels = trendRows.map((row) => {
       const date = new Date(row.METRIC_DATE);

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -860,19 +860,23 @@ export interface FoundationValueConcentrationResponse {
  */
 export interface FoundationMaintainersDailyRow {
   /**
-   * Foundation ID
+   * Foundation ID. Optional — not selected by `getFoundationMaintainers`
+   * after the LFXV2-1625 query trim; kept on the interface for any future
+   * caller that wants to project it.
    */
-  FOUNDATION_ID: string;
+  FOUNDATION_ID?: string;
 
   /**
-   * Foundation name
+   * Foundation name. Optional for the same reason as FOUNDATION_ID.
    */
-  FOUNDATION_NAME: string;
+  FOUNDATION_NAME?: string;
 
   /**
-   * Foundation URL slug
+   * Foundation URL slug. Optional because `getFoundationMaintainers` no
+   * longer selects this column — the slug is supplied as a WHERE-clause
+   * bind param, not read back from the result rows (LFXV2-1625).
    */
-  FOUNDATION_SLUG: string;
+  FOUNDATION_SLUG?: string;
 
   /**
    * Metric date (daily granularity)

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -885,9 +885,11 @@ export interface FoundationMaintainersDailyRow {
   ACTIVE_MAINTAINERS: number;
 
   /**
-   * Average maintainers yearly (calculated aggregate)
+   * Average maintainers yearly (calculated aggregate). Optional because
+   * `getFoundationMaintainers` no longer selects this column after the
+   * card switched to the latest-day snapshot (LFXV2-1625).
    */
-  AVG_MAINTAINERS_YEARLY: number;
+  AVG_MAINTAINERS_YEARLY?: number;
 }
 
 /**
@@ -912,16 +914,23 @@ export interface WeeklyMaintainersRow {
 
 /**
  * API response for foundation maintainers query
- * Contains average maintainers and weekly trend data
+ * Contains the latest distinct-maintainer snapshot and the daily trend.
  */
 export interface FoundationMaintainersResponse {
   /**
-   * Average number of maintainers (from AVG_MAINTAINERS_YEARLY)
+   * Distinct active maintainers as of the latest snapshot date
+   * (last row of FOUNDATION_MAINTAINERS_DAILY for the foundation).
    */
-  avgMaintainers: number;
+  currentMaintainers: number;
 
   /**
-   * Daily or aggregated maintainer count data for trend visualization
+   * Snapshot date for `currentMaintainers` (ISO yyyy-mm-dd, or null when
+   * no rows are returned).
+   */
+  asOfDate: string | null;
+
+  /**
+   * Daily maintainer count data for trend visualization
    */
   trendData: number[];
 
@@ -2252,6 +2261,7 @@ export interface FoundationProjectsDetailRow {
   CONTRIBUTORS_12M_COUNT: number;
   MAINTAINERS_YTD_COUNT: number;
   MAINTAINERS_12M_COUNT: number;
+  MAINTAINERS_CURRENT_COUNT: number;
   STARS_YTD_COUNT: number;
   STARS_12M_COUNT: number;
   LAST_UPDATED_TS: Date | string | null;

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -854,19 +854,19 @@ export interface FoundationValueConcentrationResponse {
   allOtherPercentage: number;
 }
 
-/** Row from ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY. */
+/** Full schema of ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY. */
 export interface FoundationMaintainersDailyRow {
-  /** Optional — not projected by getFoundationMaintainers after LFXV2-1625. */
-  FOUNDATION_ID?: string;
-  /** Optional — not projected by getFoundationMaintainers after LFXV2-1625. */
-  FOUNDATION_NAME?: string;
-  /** Optional — supplied as WHERE bind param, not read back from rows. */
-  FOUNDATION_SLUG?: string;
-  METRIC_DATE: string;
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string;
+  /** Snowflake Node SDK returns DATE columns as JS Date; some paths parse strings. */
+  METRIC_DATE: Date | string;
   ACTIVE_MAINTAINERS: number;
-  /** Optional — card switched to latest-day snapshot (LFXV2-1625). */
-  AVG_MAINTAINERS_YEARLY?: number;
+  AVG_MAINTAINERS_YEARLY: number;
 }
+
+/** Projection used by getFoundationMaintainers (METRIC_DATE + ACTIVE_MAINTAINERS only) — LFXV2-1625. */
+export type FoundationMaintainersDailySnapshotRow = Pick<FoundationMaintainersDailyRow, 'METRIC_DATE' | 'ACTIVE_MAINTAINERS'>;
 
 /**
  * Weekly aggregated maintainers result from Snowflake query

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -855,8 +855,8 @@ export interface FoundationValueConcentrationResponse {
 }
 
 /**
- * Foundation maintainers daily row from Snowflake
- * Raw response from FOUNDATION_MAINTAINERS_YEARLY table (despite name, contains daily data)
+ * Foundation maintainers daily row from Snowflake.
+ * Raw response from ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY.
  */
 export interface FoundationMaintainersDailyRow {
   /**

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -854,45 +854,17 @@ export interface FoundationValueConcentrationResponse {
   allOtherPercentage: number;
 }
 
-/**
- * Foundation maintainers daily row from Snowflake.
- * Raw response from ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY.
- */
+/** Row from ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_MAINTAINERS_DAILY. */
 export interface FoundationMaintainersDailyRow {
-  /**
-   * Foundation ID. Optional — not selected by `getFoundationMaintainers`
-   * after the LFXV2-1625 query trim; kept on the interface for any future
-   * caller that wants to project it.
-   */
+  /** Optional — not projected by getFoundationMaintainers after LFXV2-1625. */
   FOUNDATION_ID?: string;
-
-  /**
-   * Foundation name. Optional for the same reason as FOUNDATION_ID.
-   */
+  /** Optional — not projected by getFoundationMaintainers after LFXV2-1625. */
   FOUNDATION_NAME?: string;
-
-  /**
-   * Foundation URL slug. Optional because `getFoundationMaintainers` no
-   * longer selects this column — the slug is supplied as a WHERE-clause
-   * bind param, not read back from the result rows (LFXV2-1625).
-   */
+  /** Optional — supplied as WHERE bind param, not read back from rows. */
   FOUNDATION_SLUG?: string;
-
-  /**
-   * Metric date (daily granularity)
-   */
   METRIC_DATE: string;
-
-  /**
-   * Number of active maintainers on this date
-   */
   ACTIVE_MAINTAINERS: number;
-
-  /**
-   * Average maintainers yearly (calculated aggregate). Optional because
-   * `getFoundationMaintainers` no longer selects this column after the
-   * card switched to the latest-day snapshot (LFXV2-1625).
-   */
+  /** Optional — card switched to latest-day snapshot (LFXV2-1625). */
   AVG_MAINTAINERS_YEARLY?: number;
 }
 
@@ -916,32 +888,15 @@ export interface WeeklyMaintainersRow {
   AVG_MAINTAINERS_YEARLY: number;
 }
 
-/**
- * API response for foundation maintainers query
- * Contains the latest distinct-maintainer snapshot and the daily trend.
- */
+/** Latest-day distinct-maintainer snapshot + daily trend for a foundation. */
 export interface FoundationMaintainersResponse {
-  /**
-   * Distinct active maintainers as of the latest snapshot date
-   * (last row of FOUNDATION_MAINTAINERS_DAILY for the foundation).
-   */
+  /** Distinct active maintainers as of asOfDate (latest row of FOUNDATION_MAINTAINERS_DAILY). */
   currentMaintainers: number;
-
-  /**
-   * Snapshot date for `currentMaintainers` (ISO yyyy-mm-dd, or null when
-   * no rows are returned).
-   */
+  /** ISO yyyy-mm-dd, or null when no rows returned. */
   asOfDate: string | null;
-
-  /**
-   * Daily maintainer count data for trend visualization
-   */
+  /** Daily maintainer count data for trend visualization. */
   trendData: number[];
-
-  /**
-   * Date labels for chart visualization
-   * Array of date strings matching trendData
-   */
+  /** Date labels matching trendData (UTC-anchored, formatted server-side). */
   trendLabels: string[];
 }
 


### PR DESCRIPTION
## Summary

- Foundation Maintainers KPI and per-project drill-down switched from trailing-year average / `MAINTAINERS_YTD_COUNT` to the distinct latest-day snapshot (`ACTIVE_MAINTAINERS` from `FOUNDATION_MAINTAINERS_DAILY` and `MAINTAINERS_CURRENT_COUNT` from `FOUNDATION_TOTAL_PROJECTS_DETAIL`). Resolves the AAIF complaint that MCP displayed 92 maintainers when project governance recognized ~85 — root cause was YTD totals double-counting maintainers whose roles had ended.
- Card subtitle now reads "As of `<date>`" using an ISO `asOfDate` returned alongside the snapshot so the displayed value has explicit provenance instead of "Average maintainers over the past year."
- All consumers renamed end-to-end (`avgMaintainers` → `currentMaintainers` + `asOfDate`): shared interface, server service, controller log payload, frontend service catchError, foundation-health component, maintainers-drawer component.

LFXV2-1625

## Validation against prod (`agentic-ai-foundation`)

Local server with a captured prod session cookie, post-Snowflake-fix:

| Metric                                  | Value         |
| --------------------------------------- | ------------- |
| Foundation card `currentMaintainers`    | 93            |
| `asOfDate`                              | 2026-05-20    |
| MCP per-project row                     | 85            |
| Goose per-project row                   | 12            |
| AGENTS.md / agentgateway                | 0 / 0         |

Matches the expected values Shane shared in [Slack](https://linuxfoundation.slack.com/archives/C0B4QB03QP6/p1779291679617999) after his upstream dbt fix.

## Upstream dependency

This PR ships in lockstep with Shane Kalepp's 2026-05-20 dbt changes:

- `FOUNDATION_MAINTAINERS_DAILY.ACTIVE_MAINTAINERS` now counts distinct maintainers per foundation.
- `FOUNDATION_TOTAL_PROJECTS_DETAIL` gains `MAINTAINERS_CURRENT_COUNT` (excludes maintainers with non-null `end_date`).

The frontend changes here only make sense once those dbt models are deployed to prod; numbers will not change in dev until dbt rolls forward there as well.

## Commit shape

Five commits — one intent commit + four `fix(review):` follow-ups. Iterative tightening from the pre-PR reviewer pair (null guards, UTC-anchored trend labels, formatting parity between card/drawer/tooltip, index-aligned trendData/trendLabels, snapshot derived from filtered rows). Squashing on merge is fine; left unsquashed because the per-commit story is useful for review.

## Known minor (deferred)

`FoundationProjectsDetailRow` still declares `MAINTAINERS_YTD_COUNT` and `MAINTAINERS_12M_COUNT` even though the trimmed per-project query no longer selects them. The full-branch sweep flagged this as "lower-stakes" — the row interface still maps to what dbt produces, not necessarily what every query reads. Left as-is unless review pushes back.

## Test plan

- [ ] AAIF foundation overview: Maintainers card shows **93** with subtitle "As of May 20, 2026"
- [ ] AAIF projects page: MCP **85**, Goose **12**, AGENTS.md **0**, agentgateway **0**
- [ ] Per-project sum (85+12) reconciles with the foundation KPI (93) modulo cross-project maintainer overlap
- [ ] Trend chart's rightmost x-axis tick reads "May 20, 2026" (UTC anchor)
- [ ] Maintainers drawer headline matches the card (93)
- [ ] Tooltip on the trend chart formats counts with thousands separators
- [ ] Other foundations (e.g. CNCF) render real values, not 0