### PR TITLE
fix(settings): remove username field from permissions user form (LFXV2-1967)

### DIFF
--- a/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.html
+++ b/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.html
@@ -45,19 +45,6 @@
         }
       </div>
 
-      <!-- Username -->
-      <div>
-        <label for="username" class="block text-sm font-medium text-gray-700 mb-1"> Username </label>
-        <lfx-input-text
-          size="small"
-          [form]="form()"
-          control="username"
-          id="username"
-          placeholder="Enter username (optional)"
-          styleClass="w-full"
-          data-testid="settings-user-form-username"></lfx-input-text>
-      </div>
-
       <!-- Avatar URL -->
       <div>
         <label for="avatar" class="block text-sm font-medium text-gray-700 mb-1"> Avatar URL </label>

--- a/apps/lfx-one/src/app/shared/services/permissions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/permissions.service.ts
@@ -21,12 +21,12 @@ export class PermissionsService {
     return this.http.post<void>(`/api/projects/${project}/permissions`, request);
   }
 
-  // Update user role in project
+  // Update user role in project — identifier may be a username or email address
   public updateUserRole(project: string, identifier: string, request: UpdateUserRoleRequest): Observable<void> {
     return this.http.put<void>(`/api/projects/${project}/permissions/${encodeURIComponent(identifier)}`, request);
   }
 
-  // Remove user from project (removes from both writers and auditors)
+  // Remove user from project — identifier may be a username or email address
   public removeUserFromProject(project: string, identifier: string): Observable<void> {
     return this.http.delete<void>(`/api/projects/${project}/permissions/${encodeURIComponent(identifier)}`);
   }


### PR DESCRIPTION
## Summary

- Remove the username input field from the Add User dialog (shown after user-not-found confirmation) and the Edit User dialog in the project permissions settings page
- The backend resolves user identity via email address — requiring users to enter a username was an unnecessary friction point and could cause confusion for manually-added users who don't have an LFX username
- Clarify comments on `updateUserRole` / `removeUserFromProject` in `PermissionsService` to reflect that the identifier accepts either a username or email address

## Related

Follow-up to #765 (fix(permissions): LFXV2-1967)

## Test plan

- [ ] Open Settings → Permissions on a project with write access
- [ ] Click "Add User" — enter an email that exists in the directory → confirm no username field is visible at any step
- [ ] Click "Add User" — enter an unknown email → confirm the user-not-found dialog appears → proceed to manual entry → confirm only Name and Avatar URL fields appear (no Username field)
- [ ] Click the ellipsis menu on an existing user → Edit → confirm only Role radio buttons are shown (no Username/Name/Email fields beyond what was already there)
- [ ] Verify "Add User" and "Update User" submit successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)