### PR TITLE
feat(org-lens): add development notice banner on /org/overview (LFXV2-1672)

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -78,6 +78,7 @@ export const routes: Routes = [
               title: 'Org Overview',
               description: 'A summary of your organization across the Linux Foundation.',
               icon: 'fa-light fa-grid-2',
+              showDevelopmentNotice: true,
             },
             loadComponent: loadOrgPlaceholderPage,
           },

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.html
@@ -2,6 +2,19 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <main class="flex flex-col gap-6 p-6" data-testid="org-placeholder-page">
+  @if (showDevelopmentNotice()) {
+    <lfx-message
+      severity="warn"
+      icon="fa-light fa-screwdriver-wrench"
+      styleClass="mb-0"
+      title="Page in development"
+      data-testid="org-overview-development-notice">
+      <ng-template #content>
+        <p class="text-sm">This view is actively being built. Mock data is currently used for the organization dropdown and some content blocks.</p>
+      </ng-template>
+    </lfx-message>
+  }
+
   <header class="flex flex-col gap-1">
     <h1 class="text-xl font-semibold text-gray-900">{{ title() }}</h1>
     <p class="text-sm text-gray-500">{{ description() }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.ts
@@ -5,11 +5,12 @@ import { Component, computed, inject, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Data } from '@angular/router';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { MessageComponent } from '@components/message/message.component';
 import { OrgPlaceholderRouteData } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-org-placeholder-page',
-  imports: [EmptyStateComponent],
+  imports: [EmptyStateComponent, MessageComponent],
   templateUrl: './org-placeholder-page.component.html',
 })
 export class OrgPlaceholderPageComponent {
@@ -20,4 +21,5 @@ export class OrgPlaceholderPageComponent {
   protected readonly title = computed(() => (this.routeData() as OrgPlaceholderRouteData).title ?? 'Coming Soon');
   protected readonly description = computed(() => (this.routeData() as OrgPlaceholderRouteData).description ?? 'This view is in development.');
   protected readonly icon = computed(() => (this.routeData() as OrgPlaceholderRouteData).icon ?? 'fa-light fa-screwdriver-wrench');
+  protected readonly showDevelopmentNotice = computed(() => Boolean((this.routeData() as OrgPlaceholderRouteData).showDevelopmentNotice));
 }

--- a/packages/shared/src/interfaces/org-lens.interface.ts
+++ b/packages/shared/src/interfaces/org-lens.interface.ts
@@ -115,4 +115,6 @@ export interface OrgPlaceholderRouteData {
   title?: string;
   description?: string;
   icon?: string;
+  /** When true, shows a development notice banner above the page header. */
+  showDevelopmentNotice?: boolean;
 }


### PR DESCRIPTION
## Demo

<img width="1288" height="356" alt="image" src="https://github.com/user-attachments/assets/7bf4371c-4f59-46f7-aaf3-1f731736afda" />


## Summary

Adds a "Page in development" warning banner above the Org Overview header so users know the page is still being built and that the organization dropdown plus some content blocks render mock data.

- New opt-in route-data field `showDevelopmentNotice?: boolean` on `OrgPlaceholderRouteData` — only `org/overview` opts in for now; other `/org/*` placeholders are unchanged.
- `OrgPlaceholderPageComponent` reads the flag via a `computed()` signal and renders the existing `<lfx-message severity="warn">` when true.
- `data-testid="org-overview-development-notice"` is on the message host (no wrapper div), matching the established pattern in `profile-developer.component.html`.

## JIRA

Closes [LFXV2-1672](https://linuxfoundation.atlassian.net/browse/LFXV2-1672)

## Files changed

- `packages/shared/src/interfaces/org-lens.interface.ts` — added optional `showDevelopmentNotice` field (backward-compatible)
- `apps/lfx-one/src/app/app.routes.ts` *(protected file)* — added `showDevelopmentNotice: true` to the `org/overview` route data only; no routing, guard, or load-component logic changed
- `apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.ts` — imported `MessageComponent`; added `showDevelopmentNotice` computed signal
- `apps/lfx-one/src/app/modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component.html` — conditional banner block

## Behind

`org-lens-enabled` LaunchDarkly flag (same gate as the rest of `/org/*`). No new flag introduced.

## Validation

- \`yarn format\` — clean
- \`yarn lint\` — no errors
- \`yarn build\` — succeeded
- CLAUDE.md self-correction audit — all 12 applicable checks pass (license headers, no hex literals, no \`space-y-*\`, no dead imports, no nested ternaries, signal pattern compliance, no \`effect()\`, no helper methods in \`@if\`)

## Test plan

- [x] Hard-refresh `http://localhost:4200/org/overview` — banner renders above the heading, `[data-testid="org-overview-development-notice"]` resolves in DOM
- [x] Navigate to `/org/memberships`, `/org/projects`, etc. — banner does NOT appear (those routes omit the flag)
- [x] Lens switcher still shows Org button; `/org/*` deep-links still gated by `orgLensEnabledGuard`
- [ ] Reviewer: confirm warn severity (amber) is the right tone vs. info (blue)

## E2E coverage

Deferred — no existing org-placeholder e2e spec to extend, and creating a dedicated spec for a one-line presentational addition is disproportional. To be added when the next feature touches `/org/*` placeholder content.

## Protected file note

`apps/lfx-one/src/app/app.routes.ts` is on the preflight protected-files list. The change here is a single route-data field addition (`showDevelopmentNotice: true`) on the existing `org/overview` route — no path, guard, load, or hierarchy changes. Flagging per skill convention.

Made with [Cursor](https://cursor.com)

[LFXV2-1672]: https://linuxfoundation.atlassian.net/browse/LFXV2-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ