### PR TITLE
feat(dashboards): sort social listening mentions by sentiment and add source links

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -105,7 +105,8 @@
               [attr.data-testid]="'social-listening-mention-' + $index"
               (click)="openMentionUrl(mention.url)"
               (keydown.enter)="openMentionUrl(mention.url)"
-              [attr.role]="mention.url ? 'link' : null"
+              (keydown.space)="$event.preventDefault(); openMentionUrl(mention.url)"
+              [attr.role]="mention.url ? 'button' : null"
               [attr.tabindex]="mention.url ? 0 : null">
               <div class="flex items-center gap-2">
                 @if (mention.authorProfileLink) {
@@ -113,10 +114,10 @@
                     [href]="mention.authorProfileLink"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="text-xs font-medium text-blue-600 hover:underline"
+                    class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:underline"
                     (click)="$event.stopPropagation()"
-                    >{{ mention.author }}</a
-                  >
+                    >{{ mention.author }}<i class="fa-light fa-arrow-up-right-from-square text-[9px]" aria-hidden="true"></i
+                  ></a>
                 } @else {
                   <span class="text-xs font-medium text-gray-700">{{ mention.author }}</span>
                 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -116,6 +116,8 @@
                     rel="noopener noreferrer"
                     class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:underline"
                     (click)="$event.stopPropagation()"
+                    (keydown.enter)="$event.stopPropagation()"
+                    (keydown.space)="$event.stopPropagation()"
                     >{{ mention.author }}<i class="fa-light fa-arrow-up-right-from-square text-[9px]" aria-hidden="true"></i
                   ></a>
                 } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.html
@@ -97,9 +97,29 @@
       @if (hasTopMentions()) {
         <div class="flex flex-col gap-3" data-testid="social-listening-mentions-list">
           @for (mention of topMentions(); track $index) {
-            <div class="flex flex-col gap-1 rounded-lg border border-gray-100 p-3" [attr.data-testid]="'social-listening-mention-' + mention.author">
+            <div
+              class="flex flex-col gap-1 rounded-lg border border-gray-100 p-3 transition-colors"
+              [class.cursor-pointer]="mention.url"
+              [class.hover:border-gray-300]="mention.url"
+              [class.hover:bg-gray-50]="mention.url"
+              [attr.data-testid]="'social-listening-mention-' + $index"
+              (click)="openMentionUrl(mention.url)"
+              (keydown.enter)="openMentionUrl(mention.url)"
+              [attr.role]="mention.url ? 'link' : null"
+              [attr.tabindex]="mention.url ? 0 : null">
               <div class="flex items-center gap-2">
-                <span class="text-xs font-medium text-gray-700">{{ mention.author }}</span>
+                @if (mention.authorProfileLink) {
+                  <a
+                    [href]="mention.authorProfileLink"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs font-medium text-blue-600 hover:underline"
+                    (click)="$event.stopPropagation()"
+                    >{{ mention.author }}</a
+                  >
+                } @else {
+                  <span class="text-xs font-medium text-gray-700">{{ mention.author }}</span>
+                }
                 <span class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">{{ mention.sourcePlatform }}</span>
                 @if (mention.sentiment === 'positive') {
                   <span class="rounded bg-green-50 px-1.5 py-0.5 text-[10px] font-medium text-green-700">positive</span>
@@ -107,6 +127,9 @@
                   <span class="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-medium text-red-700">negative</span>
                 } @else {
                   <span class="rounded bg-gray-50 px-1.5 py-0.5 text-[10px] font-medium text-gray-600">neutral</span>
+                }
+                @if (mention.url) {
+                  <i class="fa-light fa-arrow-up-right-from-square ml-auto text-[10px] text-gray-400" aria-hidden="true"></i>
                 }
               </div>
               <p class="line-clamp-2 text-xs text-gray-600">{{ mention.title || mention.body }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
@@ -27,6 +28,7 @@ import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-c
 export class SocialListeningTabComponent {
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly platformId = inject(PLATFORM_ID);
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
@@ -44,6 +46,13 @@ export class SocialListeningTabComponent {
   protected readonly hasTopProjects = computed(() => this.topProjects().length > 0);
   protected readonly topMentions: Signal<BrandHealthMention[]> = this.initTopMentions();
   protected readonly hasTopMentions = computed(() => this.topMentions().length > 0);
+
+  // === Protected Methods ===
+  protected openMentionUrl(url: string): void {
+    if (url && isPlatformBrowser(this.platformId)) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  }
 
   // === Private Initializers ===
   private initBrandData(): Signal<BrandHealthResponse | null> {
@@ -145,18 +154,12 @@ export class SocialListeningTabComponent {
   }
 
   private initTopMentions(): Signal<BrandHealthMention[]> {
+    const sentimentOrder: Record<string, number> = { negative: 0, neutral: 1, positive: 2 };
     return computed(() => {
       const data = this.brandData();
       if (!data) return [];
-      const positive = data.topPositiveMentions ?? [];
-      const negative = data.topNegativeMentions ?? [];
-      const interleaved: BrandHealthMention[] = [];
-      const maxLen = Math.max(positive.length, negative.length);
-      for (let i = 0; i < maxLen && interleaved.length < 5; i++) {
-        if (i < positive.length) interleaved.push(positive[i]);
-        if (i < negative.length && interleaved.length < 5) interleaved.push(negative[i]);
-      }
-      return interleaved;
+      const all = [...(data.topNegativeMentions ?? []), ...(data.topPositiveMentions ?? [])];
+      return all.sort((a, b) => (sentimentOrder[a.sentiment] ?? 1) - (sentimentOrder[b.sentiment] ?? 1)).slice(0, 10);
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -49,7 +49,7 @@ export class SocialListeningTabComponent {
 
   // === Protected Methods ===
   protected openMentionUrl(url: string): void {
-    if (url && isPlatformBrowser(this.platformId)) {
+    if (url && isPlatformBrowser(this.platformId) && /^https?:\/\//i.test(url)) {
       window.open(url, '_blank', 'noopener,noreferrer');
     }
   }


### PR DESCRIPTION
## Summary
- Sort social listening mentions by sentiment (negative first, neutral, positive last) and limit to top 10
- Add clickable mention cards that open the source URL in a new tab
- Add clickable author profile links with external link icons
- Add hover states and keyboard accessibility (Enter/Space) for mention cards

LFXV2-1971

🤖 Generated with [Claude Code](https://claude.ai/claude-code)