### PR TITLE
feat(dashboards): add expandable project rows to performance marketing

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -68,19 +68,23 @@
 
           <!-- Rows -->
           @for (row of projectRows(); track row.funnelStage + '|' + row.name) {
+            @let projectKey = row.funnelStage + '|' + row.name;
             <div
-              class="flex cursor-pointer items-center gap-3 border-b border-gray-100 py-2.5 transition-colors hover:bg-gray-50"
+              class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
+              [class.cursor-pointer]="row.campaigns.length > 0"
+              [class.hover:bg-gray-50]="row.campaigns.length > 0"
               role="row"
               [attr.data-testid]="'performance-marketing-row-' + row.name"
-              [attr.aria-expanded]="row.campaigns.length > 0 ? isProjectExpanded(row.funnelStage + '|' + row.name) : null"
-              (click)="row.campaigns.length > 0 && toggleProjectExpand(row.funnelStage + '|' + row.name)"
-              (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(row.funnelStage + '|' + row.name)"
+              [attr.aria-expanded]="row.campaigns.length > 0 ? isProjectExpanded(projectKey) : null"
+              (click)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
+              (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
+              (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
               <div class="flex w-40 items-center gap-1.5" role="cell">
                 @if (row.campaigns.length > 0) {
                   <i
                     class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform"
-                    [class.rotate-90]="isProjectExpanded(row.funnelStage + '|' + row.name)"
+                    [class.rotate-90]="isProjectExpanded(projectKey)"
                     aria-hidden="true"></i>
                 } @else {
                   <span class="w-[9px]"></span>
@@ -100,7 +104,7 @@
             </div>
 
             <!-- Expanded campaign rows -->
-            @if (isProjectExpanded(row.funnelStage + '|' + row.name)) {
+            @if (isProjectExpanded(projectKey)) {
               @for (campaign of row.campaigns; track campaign.campaignName) {
                 <div
                   class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -68,8 +68,25 @@
 
           <!-- Rows -->
           @for (row of projectRows(); track row.funnelStage + '|' + row.name) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'performance-marketing-row-' + row.name">
-              <span class="w-40 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
+            <div
+              class="flex cursor-pointer items-center gap-3 border-b border-gray-100 py-2.5 transition-colors hover:bg-gray-50"
+              role="row"
+              [attr.data-testid]="'performance-marketing-row-' + row.name"
+              [attr.aria-expanded]="row.campaigns.length > 0 ? isProjectExpanded(row.funnelStage + '|' + row.name) : null"
+              (click)="row.campaigns.length > 0 && toggleProjectExpand(row.funnelStage + '|' + row.name)"
+              (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(row.funnelStage + '|' + row.name)"
+              [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
+              <div class="flex w-40 items-center gap-1.5" role="cell">
+                @if (row.campaigns.length > 0) {
+                  <i
+                    class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform"
+                    [class.rotate-90]="isProjectExpanded(row.funnelStage + '|' + row.name)"
+                    aria-hidden="true"></i>
+                } @else {
+                  <span class="w-[9px]"></span>
+                }
+                <span class="truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
+              </div>
               <span class="w-20 truncate text-[11px] text-gray-500" role="cell">{{ row.funnelStage }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.revenue }}</span>
@@ -81,6 +98,24 @@
                 </span>
               </div>
             </div>
+
+            <!-- Expanded campaign rows -->
+            @if (isProjectExpanded(row.funnelStage + '|' + row.name)) {
+              @for (campaign of row.campaigns; track campaign.campaignName) {
+                <div
+                  class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
+                  role="row"
+                  [attr.data-testid]="'campaign-row-' + campaign.campaignName">
+                  <span class="w-[calc(10rem-1.5rem)] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
+                  <span class="w-20 truncate text-[11px] text-gray-400" role="cell">{{ campaign.funnelStage }}</span>
+                  <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
+                  <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
+                  <span class="w-16 text-right text-[11px] text-gray-500" role="cell">{{ campaign.roas }}</span>
+                  <span class="w-24 text-right text-[11px] text-gray-400" role="cell">{{ campaign.impressions }}</span>
+                  <div class="flex-1" role="cell"></div>
+                </div>
+              }
+            }
           }
         </div>
       } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -13,6 +13,8 @@ import type {
   FilterPillOption,
   FunnelStage,
   MarketingImpactFocusProgram,
+  PaidCampaignPerformance,
+  PaidCampaignRow,
   PaidProjectPerformance,
   PaidProjectRow,
   PerformanceSummaryKpi,
@@ -59,6 +61,7 @@ export class PerformanceMarketingTabComponent {
   // === WritableSignals ===
   protected readonly loading = signal(false);
   protected readonly selectedFunnel = signal<FunnelStage>('all');
+  protected readonly expandedProjects = signal<Set<string>>(new Set());
 
   // === Computed Signals ===
   protected readonly socialReachData: Signal<SocialReachResponse | null> = this.initSocialReachData();
@@ -74,6 +77,22 @@ export class PerformanceMarketingTabComponent {
     if (this.funnelOptions.some((o) => o.id === funnelId)) {
       this.selectedFunnel.set(funnelId as FunnelStage);
     }
+  }
+
+  protected toggleProjectExpand(projectKey: string): void {
+    this.expandedProjects.update((current) => {
+      const next = new Set(current);
+      if (next.has(projectKey)) {
+        next.delete(projectKey);
+      } else {
+        next.add(projectKey);
+      }
+      return next;
+    });
+  }
+
+  protected isProjectExpanded(projectKey: string): boolean {
+    return this.expandedProjects().has(projectKey);
   }
 
   // === Private Initializers ===
@@ -182,18 +201,20 @@ export class PerformanceMarketingTabComponent {
           if (funnel === 'bofu') return stage === 'bofu';
           return false;
         })
-        .map(
-          (p): PaidProjectRow => ({
+        .map((p): PaidProjectRow => {
+          const perf = this.normalizePerformance(p.performance);
+          return {
             name: p.projectName,
             funnelStage: p.funnelStage,
             spend: formatCurrency(p.spend),
             revenue: formatCurrency(p.revenue),
             roas: `${(p.roas ?? 0).toFixed(2)}x`,
             impressions: formatNumber(p.impressions),
-            performance: this.normalizePerformance(p.performance),
-            performanceClass: this.getPerformanceClass(this.normalizePerformance(p.performance)),
-          })
-        )
+            performance: perf,
+            performanceClass: this.getPerformanceClass(perf),
+            campaigns: this.mapCampaignRows(p.campaigns),
+          };
+        })
         .sort((a, b) => {
           return (
             (PerformanceMarketingTabComponent.performanceOrderMap[a.performance] ?? 4) -
@@ -279,6 +300,20 @@ export class PerformanceMarketingTabComponent {
 
   private getPerformanceClass(perf: PaidProjectPerformance): string {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
+  }
+
+  private mapCampaignRows(campaigns: PaidCampaignPerformance[] | undefined): PaidCampaignRow[] {
+    if (!campaigns?.length) return [];
+    return campaigns.map(
+      (c): PaidCampaignRow => ({
+        campaignName: c.campaignName,
+        funnelStage: c.funnelStage,
+        spend: formatCurrency(c.spend),
+        revenue: formatCurrency(c.revenue),
+        roas: `${(c.roas ?? 0).toFixed(2)}x`,
+        impressions: formatNumber(c.impressions),
+      })
+    );
   }
 
   private getRoasPerformance(roas: number): PaidProjectPerformance {

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -87,6 +87,17 @@ export interface PaidProjectRow {
   impressions: string;
   performance: PaidProjectPerformance;
   performanceClass: string;
+  campaigns: PaidCampaignRow[];
+}
+
+/** View-model row for a nested campaign under a project. */
+export interface PaidCampaignRow {
+  campaignName: string;
+  funnelStage: string;
+  spend: string;
+  revenue: string;
+  roas: string;
+  impressions: string;
 }
 
 /** View-model row for the email type breakdown table. */


### PR DESCRIPTION
## Summary
- Add expand/collapse functionality to project rows in the Performance Marketing tab
- Clicking a project row reveals its individual campaign details (name, funnel stage, spend, revenue, ROAS, impressions)
- Campaign rows are indented and styled with a subtle background to distinguish from parent rows
- Uses `signal<Set<string>>` pattern for tracking expanded state with chevron rotation animation

LFXV2-1970

🤖 Generated with [Claude Code](https://claude.ai/claude-code)