### PR TITLE
feat(dashboards): add expandable platform rows with campaign details

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -156,12 +156,15 @@
               <!-- Rows -->
               @for (row of platformRows(); track row.platform) {
                 <div
-                  class="flex cursor-pointer items-center gap-2 border-b border-gray-100 py-2.5 transition-colors hover:bg-gray-50"
+                  class="flex items-center gap-2 border-b border-gray-100 py-2.5 transition-colors"
+                  [class.cursor-pointer]="row.campaigns.length > 0"
+                  [class.hover:bg-gray-50]="row.campaigns.length > 0"
                   role="row"
                   [attr.data-testid]="'platform-row-' + row.platform"
                   [attr.aria-expanded]="row.campaigns.length > 0 ? isPlatformExpanded(row.platform) : null"
                   (click)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
                   (keydown.enter)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
+                  (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
                   [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
                   <div class="flex w-32 items-center gap-1.5" role="cell">
                     @if (row.campaigns.length > 0) {
@@ -192,11 +195,11 @@
 
                 <!-- Expanded platform campaign rows -->
                 @if (isPlatformExpanded(row.platform)) {
-                  @for (campaign of row.campaigns; track campaign.campaignName) {
+                  @for (campaign of row.campaigns; track $index) {
                     <div
                       class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                       role="row"
-                      [attr.data-testid]="'platform-campaign-row-' + campaign.campaignName">
+                      [attr.data-testid]="'platform-campaign-row-' + $index">
                       <span class="w-[calc(8rem-1.5rem)] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
                       <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
                       <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -155,8 +155,25 @@
 
               <!-- Rows -->
               @for (row of platformRows(); track row.platform) {
-                <div class="flex items-center gap-2 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'platform-row-' + row.platform">
-                  <span class="w-32 truncate text-xs font-medium text-gray-700" role="cell">{{ row.platform }}</span>
+                <div
+                  class="flex cursor-pointer items-center gap-2 border-b border-gray-100 py-2.5 transition-colors hover:bg-gray-50"
+                  role="row"
+                  [attr.data-testid]="'platform-row-' + row.platform"
+                  [attr.aria-expanded]="row.campaigns.length > 0 ? isPlatformExpanded(row.platform) : null"
+                  (click)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
+                  (keydown.enter)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
+                  [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
+                  <div class="flex w-32 items-center gap-1.5" role="cell">
+                    @if (row.campaigns.length > 0) {
+                      <i
+                        class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform"
+                        [class.rotate-90]="isPlatformExpanded(row.platform)"
+                        aria-hidden="true"></i>
+                    } @else {
+                      <span class="w-[9px]"></span>
+                    }
+                    <span class="truncate text-xs font-medium text-gray-700">{{ row.platform }}</span>
+                  </div>
                   <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
                   <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.revenue }}</span>
                   <span class="w-14 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
@@ -172,6 +189,28 @@
                     </span>
                   </div>
                 </div>
+
+                <!-- Expanded platform campaign rows -->
+                @if (isPlatformExpanded(row.platform)) {
+                  @for (campaign of row.campaigns; track campaign.campaignName) {
+                    <div
+                      class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
+                      role="row"
+                      [attr.data-testid]="'platform-campaign-row-' + campaign.campaignName">
+                      <span class="w-[calc(8rem-1.5rem)] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
+                      <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
+                      <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
+                      <span class="w-14 text-right text-[11px] text-gray-500" role="cell">{{ campaign.roas }}</span>
+                      <span class="w-16 text-right text-[11px] text-gray-400" role="cell">{{ campaign.clicks }}</span>
+                      <span class="w-24 text-right text-[11px] text-gray-400" role="cell">{{ campaign.impressions }}</span>
+                      <span class="w-14" role="cell"></span>
+                      <span class="w-16" role="cell"></span>
+                      <span class="w-20" role="cell"></span>
+                      <span class="w-24" role="cell"></span>
+                      <div class="flex-1" role="cell"></div>
+                    </div>
+                  }
+                }
               }
 
               <!-- Total row -->

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -69,23 +69,21 @@
           <!-- Rows -->
           @for (row of projectRows(); track row.funnelStage + '|' + row.name) {
             @let projectKey = row.funnelStage + '|' + row.name;
+            @let projectExpanded = expandedProjects().has(projectKey);
             <div
               class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
               [class.cursor-pointer]="row.campaigns.length > 0"
               [class.hover:bg-gray-50]="row.campaigns.length > 0"
               role="row"
               [attr.data-testid]="'performance-marketing-row-' + row.name"
-              [attr.aria-expanded]="row.campaigns.length > 0 ? isProjectExpanded(projectKey) : null"
+              [attr.aria-expanded]="row.campaigns.length > 0 ? projectExpanded : null"
               (click)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
               <div class="flex w-40 items-center gap-1.5" role="cell">
                 @if (row.campaigns.length > 0) {
-                  <i
-                    class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform"
-                    [class.rotate-90]="isProjectExpanded(projectKey)"
-                    aria-hidden="true"></i>
+                  <i class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform" [class.rotate-90]="projectExpanded" aria-hidden="true"></i>
                 } @else {
                   <span class="w-[9px]"></span>
                 }
@@ -104,13 +102,14 @@
             </div>
 
             <!-- Expanded campaign rows -->
-            @if (isProjectExpanded(projectKey)) {
+            @if (projectExpanded) {
               @for (campaign of row.campaigns; track campaign.campaignName) {
                 <div
                   class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                   role="row"
                   [attr.data-testid]="'campaign-row-' + campaign.campaignName">
-                  <span class="w-[calc(10rem-1.5rem)] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
+                  <!-- w-40 (parent) minus pl-6 (indent) = 8.5rem -->
+                  <span class="w-[8.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
                   <span class="w-20 truncate text-[11px] text-gray-400" role="cell">{{ campaign.funnelStage }}</span>
                   <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
                   <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
@@ -197,7 +196,7 @@
                     <div
                       class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                       role="row"
-                      [attr.data-testid]="'platform-campaign-row-' + $index">
+                      [attr.data-testid]="'platform-campaign-row-' + row.platform + '-' + $index">
                       <!-- w-32 (parent) minus pl-6 (indent) = 6.5rem -->
                       <span class="w-[6.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
                       <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -103,11 +103,11 @@
 
             <!-- Expanded campaign rows -->
             @if (projectExpanded) {
-              @for (campaign of row.campaigns; track campaign.campaignName) {
+              @for (campaign of row.campaigns; track $index) {
                 <div
                   class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                   role="row"
-                  [attr.data-testid]="'campaign-row-' + campaign.campaignName">
+                  [attr.data-testid]="'campaign-row-' + projectKey + '-' + $index">
                   <!-- w-40 (parent) minus pl-6 (indent) = 8.5rem -->
                   <span class="w-[8.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
                   <span class="w-20 truncate text-[11px] text-gray-400" role="cell">{{ campaign.funnelStage }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -155,23 +155,21 @@
 
               <!-- Rows -->
               @for (row of platformRows(); track row.platform) {
+                @let expanded = expandedPlatforms().has(row.platform);
                 <div
                   class="flex items-center gap-2 border-b border-gray-100 py-2.5 transition-colors"
                   [class.cursor-pointer]="row.campaigns.length > 0"
                   [class.hover:bg-gray-50]="row.campaigns.length > 0"
                   role="row"
                   [attr.data-testid]="'platform-row-' + row.platform"
-                  [attr.aria-expanded]="row.campaigns.length > 0 ? isPlatformExpanded(row.platform) : null"
+                  [attr.aria-expanded]="row.campaigns.length > 0 ? expanded : null"
                   (click)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
                   (keydown.enter)="row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
                   (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && togglePlatformExpand(row.platform)"
                   [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
                   <div class="flex w-32 items-center gap-1.5" role="cell">
                     @if (row.campaigns.length > 0) {
-                      <i
-                        class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform"
-                        [class.rotate-90]="isPlatformExpanded(row.platform)"
-                        aria-hidden="true"></i>
+                      <i class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform" [class.rotate-90]="expanded" aria-hidden="true"></i>
                     } @else {
                       <span class="w-[9px]"></span>
                     }
@@ -194,13 +192,14 @@
                 </div>
 
                 <!-- Expanded platform campaign rows -->
-                @if (isPlatformExpanded(row.platform)) {
+                @if (expanded) {
                   @for (campaign of row.campaigns; track $index) {
                     <div
                       class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                       role="row"
                       [attr.data-testid]="'platform-campaign-row-' + $index">
-                      <span class="w-[calc(8rem-1.5rem)] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
+                      <!-- w-32 (parent) minus pl-6 (indent) = 6.5rem -->
+                      <span class="w-[6.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
                       <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
                       <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
                       <span class="w-14 text-right text-[11px] text-gray-500" role="cell">{{ campaign.roas }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -112,6 +112,8 @@ export class PerformanceMarketingTabComponent {
     return toSignal(
       slug$.pipe(
         switchMap((slug) => {
+          this.expandedProjects.set(new Set());
+          this.expandedPlatforms.set(new Set());
           if (!slug) {
             this.loading.set(false);
             return of(null);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -18,6 +18,7 @@ import type {
   PaidProjectPerformance,
   PaidProjectRow,
   PerformanceSummaryKpi,
+  PlatformCampaignRow,
   PlatformPerformanceRow,
   SocialReachResponse,
 } from '@lfx-one/shared/interfaces';
@@ -62,6 +63,7 @@ export class PerformanceMarketingTabComponent {
   protected readonly loading = signal(false);
   protected readonly selectedFunnel = signal<FunnelStage>('all');
   protected readonly expandedProjects = signal<Set<string>>(new Set());
+  protected readonly expandedPlatforms = signal<Set<string>>(new Set());
 
   // === Computed Signals ===
   protected readonly socialReachData: Signal<SocialReachResponse | null> = this.initSocialReachData();
@@ -91,8 +93,16 @@ export class PerformanceMarketingTabComponent {
     });
   }
 
-  protected isProjectExpanded(projectKey: string): boolean {
-    return this.expandedProjects().has(projectKey);
+  protected togglePlatformExpand(platform: string): void {
+    this.expandedPlatforms.update((current) => {
+      const next = new Set(current);
+      if (next.has(platform)) {
+        next.delete(platform);
+      } else {
+        next.add(platform);
+      }
+      return next;
+    });
   }
 
   // === Private Initializers ===
@@ -244,6 +254,7 @@ export class PerformanceMarketingTabComponent {
           conversions: formatNumber(p.conversions),
           performance: perf,
           performanceClass: this.getPerformanceClass(perf),
+          campaigns: this.mapPlatformCampaignRows(p.campaigns),
         };
       });
     });
@@ -285,6 +296,7 @@ export class PerformanceMarketingTabComponent {
         conversions: formatNumber(totals.conversions),
         performance: totalPerf,
         performanceClass: this.getPerformanceClass(totalPerf),
+        campaigns: [],
       };
     });
   }
@@ -302,6 +314,7 @@ export class PerformanceMarketingTabComponent {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
   }
 
+<<<<<<< HEAD
   private mapCampaignRows(campaigns: PaidCampaignPerformance[] | undefined): PaidCampaignRow[] {
     if (!campaigns?.length) return [];
     return campaigns.map(
@@ -311,6 +324,17 @@ export class PerformanceMarketingTabComponent {
         spend: formatCurrency(c.spend),
         revenue: formatCurrency(c.revenue),
         roas: `${(c.roas ?? 0).toFixed(2)}x`,
+=======
+  private mapPlatformCampaignRows(campaigns: PaidCampaignPerformance[] | undefined): PlatformCampaignRow[] {
+    if (!campaigns?.length) return [];
+    return campaigns.map(
+      (c): PlatformCampaignRow => ({
+        campaignName: c.campaignName,
+        spend: formatCurrency(c.spend),
+        revenue: formatCurrency(c.revenue),
+        roas: `${(c.roas ?? 0).toFixed(2)}x`,
+        clicks: formatNumber(c.clicks),
+>>>>>>> 63c56631 (feat(dashboards): add expandable platform rows with campaign details)
         impressions: formatNumber(c.impressions),
       })
     );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -314,7 +314,6 @@ export class PerformanceMarketingTabComponent {
     return PerformanceMarketingTabComponent.performanceClassMap[perf] ?? 'bg-gray-50 text-gray-700';
   }
 
-<<<<<<< HEAD
   private mapCampaignRows(campaigns: PaidCampaignPerformance[] | undefined): PaidCampaignRow[] {
     if (!campaigns?.length) return [];
     return campaigns.map(
@@ -324,7 +323,11 @@ export class PerformanceMarketingTabComponent {
         spend: formatCurrency(c.spend),
         revenue: formatCurrency(c.revenue),
         roas: `${(c.roas ?? 0).toFixed(2)}x`,
-=======
+        impressions: formatNumber(c.impressions),
+      })
+    );
+  }
+
   private mapPlatformCampaignRows(campaigns: PaidCampaignPerformance[] | undefined): PlatformCampaignRow[] {
     if (!campaigns?.length) return [];
     return campaigns.map(
@@ -334,7 +337,6 @@ export class PerformanceMarketingTabComponent {
         revenue: formatCurrency(c.revenue),
         roas: `${(c.roas ?? 0).toFixed(2)}x`,
         clicks: formatNumber(c.clicks),
->>>>>>> 63c56631 (feat(dashboards): add expandable platform rows with campaign details)
         impressions: formatNumber(c.impressions),
       })
     );

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2537,6 +2537,8 @@ export class ProjectService {
         return 'EMERGING';
       };
 
+      const CAMPAIGN_TOP_N = 10;
+
       const formatFunnel = (stages: Set<string>): string => {
         const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
         for (const p of priority) {
@@ -2564,9 +2566,9 @@ export class ProjectService {
             impressions: data.impressions,
             clicks: data.clicks,
             performance: getPaidPerformance(projectRoas),
-            campaigns: data.campaigns
+            campaigns: [...data.campaigns]
               .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
-              .slice(0, 10)
+              .slice(0, CAMPAIGN_TOP_N)
               .map((c) => ({
                 campaignName: c.CAMPAIGN_NAME,
                 funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
@@ -2586,6 +2588,7 @@ export class ProjectService {
 
       const platformBreakdown = Array.from(platformMap.entries())
         .map(([channel, data]) => {
+          // Ratios recomputed from aggregated totals; averaging per-campaign values would be statistically incorrect.
           const platRoas = data.spend > 0 ? Math.round((data.revenue / data.spend) * 100) / 100 : 0;
           const platCtr = data.impressions > 0 ? Math.round((data.clicks / data.impressions) * 10000) / 100 : 0;
           const platCpc = data.clicks > 0 ? Math.round((data.spend / data.clicks) * 100) / 100 : 0;
@@ -2602,9 +2605,9 @@ export class ProjectService {
             convRate: platConvRate,
             conversions: data.conversions,
             performance: getPaidPerformance(platRoas),
-            campaigns: data.campaigns
+            campaigns: [...data.campaigns]
               .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
-              .slice(0, 10)
+              .slice(0, CAMPAIGN_TOP_N)
               .map((c) => ({
                 campaignName: c.CAMPAIGN_NAME,
                 funnelStage: 'Unknown',

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2323,12 +2323,12 @@ export class ProjectService {
       ORDER BY SPEND DESC
     `;
 
-      // Block 6: Platform-level performance breakdown (aggregated by CHANNEL)
+      // Block 6: Platform-level performance breakdown (by CHANNEL + CAMPAIGN_NAME)
       // All blocks use LAST_TOUCH_REVENUE as the default attribution model
       // Also used to derive channelGroups (impressions by channel) — eliminates a separate query
       const platformPerfQuery = `
       SELECT
-        CHANNEL,
+        CHANNEL, CAMPAIGN_NAME,
         SUM(SPEND) AS SPEND, SUM(LAST_TOUCH_REVENUE) AS REVENUE,
         ROUND(DIV0(SUM(LAST_TOUCH_REVENUE), SUM(SPEND)), 2) AS ROAS,
         SUM(CLICKS) AS CLICKS,
@@ -2340,8 +2340,8 @@ export class ProjectService {
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
       WHERE FOUNDATION_SLUG = ?
         AND CAMPAIGN_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
-      GROUP BY CHANNEL
-      ORDER BY SPEND DESC
+      GROUP BY CHANNEL, CAMPAIGN_NAME
+      ORDER BY CHANNEL, SPEND DESC
     `;
 
       const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, projectPerfResult, platformPerfResult] = await Promise.all([
@@ -2389,6 +2389,7 @@ export class ProjectService {
         this.snowflakeService
           .execute<{
             CHANNEL: string;
+            CAMPAIGN_NAME: string;
             SPEND: number;
             REVENUE: number;
             ROAS: number;
@@ -2407,6 +2408,7 @@ export class ProjectService {
             return {
               rows: [] as {
                 CHANNEL: string;
+                CAMPAIGN_NAME: string;
                 SPEND: number;
                 REVENUE: number;
                 ROAS: number;
@@ -2453,10 +2455,40 @@ export class ProjectService {
         return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
       });
 
-      const channelGroups = platformPerfResult.rows
-        .map((row) => ({
-          channel: row.CHANNEL,
-          totalImpressions: row.IMPRESSIONS,
+      // Aggregate platform rows by CHANNEL for channelGroups and platformBreakdown
+      const platformMap = new Map<
+        string,
+        {
+          spend: number;
+          revenue: number;
+          clicks: number;
+          impressions: number;
+          conversions: number;
+          campaigns: typeof platformPerfResult.rows;
+        }
+      >();
+      for (const row of platformPerfResult.rows) {
+        const existing = platformMap.get(row.CHANNEL) ?? {
+          spend: 0,
+          revenue: 0,
+          clicks: 0,
+          impressions: 0,
+          conversions: 0,
+          campaigns: [] as typeof platformPerfResult.rows,
+        };
+        existing.spend += row.SPEND ?? 0;
+        existing.revenue += row.REVENUE ?? 0;
+        existing.clicks += row.CLICKS ?? 0;
+        existing.impressions += row.IMPRESSIONS ?? 0;
+        existing.conversions += row.CONVERSIONS ?? 0;
+        existing.campaigns.push(row);
+        platformMap.set(row.CHANNEL, existing);
+      }
+
+      const channelGroups = Array.from(platformMap.entries())
+        .map(([channel, data]) => ({
+          channel,
+          totalImpressions: data.impressions,
         }))
         .sort((a, b) => b.totalImpressions - a.totalImpressions);
 
@@ -2552,19 +2584,43 @@ export class ProjectService {
         })
         .sort((a, b) => b.spend - a.spend);
 
-      const platformBreakdown = platformPerfResult.rows.map((row) => ({
-        platform: row.CHANNEL,
-        spend: Math.round((row.SPEND ?? 0) * 100) / 100,
-        revenue: Math.round((row.REVENUE ?? 0) * 100) / 100,
-        roas: row.ROAS ?? 0,
-        clicks: row.CLICKS ?? 0,
-        impressions: row.IMPRESSIONS ?? 0,
-        ctr: row.CTR ?? 0,
-        cpc: row.CPC ?? 0,
-        convRate: row.CONV_RATE ?? 0,
-        conversions: row.CONVERSIONS ?? 0,
-        performance: getPaidPerformance(row.ROAS ?? 0),
-      }));
+      const platformBreakdown = Array.from(platformMap.entries())
+        .map(([channel, data]) => {
+          const platRoas = data.spend > 0 ? Math.round((data.revenue / data.spend) * 100) / 100 : 0;
+          const platCtr = data.impressions > 0 ? Math.round((data.clicks / data.impressions) * 10000) / 100 : 0;
+          const platCpc = data.clicks > 0 ? Math.round((data.spend / data.clicks) * 100) / 100 : 0;
+          const platConvRate = data.clicks > 0 ? Math.round((data.conversions / data.clicks) * 10000) / 100 : 0;
+          return {
+            platform: channel,
+            spend: Math.round(data.spend * 100) / 100,
+            revenue: Math.round(data.revenue * 100) / 100,
+            roas: platRoas,
+            clicks: data.clicks,
+            impressions: data.impressions,
+            ctr: platCtr,
+            cpc: platCpc,
+            convRate: platConvRate,
+            conversions: data.conversions,
+            performance: getPaidPerformance(platRoas),
+            campaigns: data.campaigns
+              .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
+              .slice(0, 10)
+              .map((c) => ({
+                campaignName: c.CAMPAIGN_NAME,
+                funnelStage: 'Unknown',
+                spend: Math.round((c.SPEND ?? 0) * 100) / 100,
+                revenue: Math.round((c.REVENUE ?? 0) * 100) / 100,
+                roas: c.ROAS ?? 0,
+                conversions: c.CONVERSIONS ?? 0,
+                convRate: c.CONV_RATE ?? 0,
+                cpc: c.CPC ?? 0,
+                sessions: 0,
+                impressions: c.IMPRESSIONS ?? 0,
+                clicks: c.CLICKS ?? 0,
+              })),
+          };
+        })
+        .sort((a, b) => b.spend - a.spend);
 
       return {
         totalReach,

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2677,6 +2677,7 @@ export interface PaidPlatformBreakdown {
   convRate: number;
   conversions: number;
   performance: PaidProjectPerformance;
+  campaigns: PaidCampaignPerformance[];
 }
 
 /**

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -163,4 +163,15 @@ export interface PlatformPerformanceRow {
   conversions: string;
   performance: PaidProjectPerformance;
   performanceClass: string;
+  campaigns: PlatformCampaignRow[];
+}
+
+/** View-model row for a nested campaign under a platform. */
+export interface PlatformCampaignRow {
+  campaignName: string;
+  spend: string;
+  revenue: string;
+  roas: string;
+  clicks: string;
+  impressions: string;
 }

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -166,12 +166,17 @@ export interface PlatformPerformanceRow {
   campaigns: PlatformCampaignRow[];
 }
 
-/** View-model row for a nested campaign under a platform. */
+/** View-model row for a nested campaign under a platform. All numeric fields are pre-formatted strings. */
 export interface PlatformCampaignRow {
   campaignName: string;
+  /** Pre-formatted currency string, e.g. "$1,234.56" */
   spend: string;
+  /** Pre-formatted currency string, e.g. "$5,678.90" */
   revenue: string;
+  /** Pre-formatted ROAS multiplier string, e.g. "2.34x" */
   roas: string;
+  /** Pre-formatted number string, e.g. "1,234" */
   clicks: string;
+  /** Pre-formatted number string, e.g. "12,345" */
   impressions: string;
 }


### PR DESCRIPTION
## Summary
- Add expand/collapse functionality to platform rows in the Performance Marketing tab
- Update backend Snowflake query to include `CAMPAIGN_NAME` grouping in the platform breakdown
- Add `PlatformCampaignRow` interface and `campaigns` field to `PlatformPerformanceRow`
- Add `campaigns` field to `PaidPlatformBreakdown` API interface for nested campaign data
- Campaign detail rows show name, spend, revenue, ROAS, clicks, and impressions
- Same expand/collapse pattern as project rows (LFXV2-1970)

LFXV2-1972

🤖 Generated with [Claude Code](https://claude.ai/claude-code)