### PR TITLE
feat(weekly-brief): add shared interfaces for weekly brief domain

### DIFF
--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -168,3 +168,6 @@ export * from './org-memberships.interface';
 
 // Newsletter interfaces
 export * from './newsletter.interface';
+
+// Weekly Brief interfaces
+export * from './weekly-brief.interface';

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -3,9 +3,11 @@
 
 export type WeeklyBriefState = 'empty' | 'generating' | 'generated' | 'edited' | 'approved' | 'error';
 
+export type WeeklyBriefSourceType = 'meeting' | 'vote' | 'member' | 'mailing_list';
+
 export interface WeeklyBriefSourceRef {
   claim_id: string;
-  source_type: string; // 'meeting' | 'vote' | 'member' | 'mailing_list'
+  source_type: WeeklyBriefSourceType;
   source_uid: string;
   source_label?: string;
   source_url?: string;

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export type WeeklyBriefState = 'empty' | 'generating' | 'generated' | 'edited' | 'approved' | 'error';
+
+export interface WeeklyBriefSourceRef {
+  claim_id: string;
+  source_type: string;        // 'meeting' | 'vote' | 'member' | 'mailing_list'
+  source_uid: string;
+  source_label?: string;
+  source_url?: string;
+}
+
+export interface WeeklyBrief {
+  uid: string;
+  committee_uid: string;
+  window_start: string;       // ISO8601 UTC Sunday 00:00:00
+  window_end: string;         // ISO8601 UTC Saturday 23:59:59
+  state: WeeklyBriefState;
+  brief_text: string;
+  source_refs: WeeklyBriefSourceRef[];
+  prompt_version: string;
+  model: string;
+  regeneration_count: number;
+  private_source_present: boolean;
+  created_at: string;
+  updated_at: string;
+  revision: number;
+}
+
+export interface WeeklyBriefThrottle {
+  generates_used: number;
+  generates_limit: number;
+  regenerations_used: number;
+  regenerations_limit: number;
+  window_resets_at: string;
+}
+
+export interface WeeklyBriefCurrentResponse {
+  brief: WeeklyBrief | null;
+  throttle: WeeklyBriefThrottle;
+}
+
+export interface GenerateWeeklyBriefRequest {
+  reason?: string;
+  revision?: number;
+  force?: boolean;
+}
+
+export interface GenerateWeeklyBriefResponse {
+  brief: WeeklyBrief;
+  throttle: WeeklyBriefThrottle;
+}
+
+export interface SaveWeeklyBriefRequest {
+  brief_text: string;
+  revision: number;
+}

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -5,7 +5,7 @@ export type WeeklyBriefState = 'empty' | 'generating' | 'generated' | 'edited' |
 
 export interface WeeklyBriefSourceRef {
   claim_id: string;
-  source_type: string;        // 'meeting' | 'vote' | 'member' | 'mailing_list'
+  source_type: string; // 'meeting' | 'vote' | 'member' | 'mailing_list'
   source_uid: string;
   source_label?: string;
   source_url?: string;
@@ -14,8 +14,8 @@ export interface WeeklyBriefSourceRef {
 export interface WeeklyBrief {
   uid: string;
   committee_uid: string;
-  window_start: string;       // ISO8601 UTC Sunday 00:00:00
-  window_end: string;         // ISO8601 UTC Saturday 23:59:59
+  window_start: string; // ISO8601 UTC Sunday 00:00:00
+  window_end: string; // ISO8601 UTC Saturday 23:59:59
   state: WeeklyBriefState;
   brief_text: string;
   source_refs: WeeklyBriefSourceRef[];


### PR DESCRIPTION
**Tracking:** [LFXV2-1981](https://linuxfoundation.atlassian.net/browse/LFXV2-1981) (part of Epic [LFXV2-1976](https://linuxfoundation.atlassian.net/browse/LFXV2-1976))

---

## Summary

Adds the `@lfx-one/shared` TypeScript interfaces for the WG Weekly Brief feature. Pure type additions — no runtime code.

## What's new

- `packages/shared/src/interfaces/weekly-brief.interface.ts`:
  - `WeeklyBriefState` union (`empty | generating | generated | edited | approved | error`)
  - `WeeklyBriefSourceRef` — claim_id + source provenance for citations
  - `WeeklyBrief` — full draft entity matching the committee-service domain shape
  - `WeeklyBriefThrottle` — per-committee/per-week generate + regenerate counters
  - `WeeklyBriefCurrentResponse`, request/response shapes
- `packages/shared/src/interfaces/index.ts` exports

Shapes mirror the committee-service Goa types so the BFF can pass through without remapping.

## Stack

PR 1/4 on lfx-self-serve. Independent base = `main`. PRs #6-8 stack on top.

## Test plan

- [ ] `yarn lint` / `yarn build` green (verified)
- [ ] Types compile cleanly across the monorepo


[LFXV2-1981]: https://linuxfoundation.atlassian.net/browse/LFXV2-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1976]: https://linuxfoundation.atlassian.net/browse/LFXV2-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ