### PR TITLE
feat(weekly-brief): BFF route, controller, service with mock/live switch

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -96,7 +96,11 @@ CDP_AUDIENCE=https://lf-staging.crowd.dev/api/
 # OpenAI-compatible proxy for meeting agenda generation
 AI_PROXY_URL=https://litellm.tools.lfx.dev/chat/completions
 AI_API_KEY=your-litellm-ai-api-key
-WEEKLY_BRIEF_BACKEND=         # Set to 'live' to proxy to committee-service; unset = mock data
+
+# Set to 'live' to proxy to committee-service; unset (or any other value) = mock data.
+# Inline comments on the same line as a dotenv assignment are commonly parsed as
+# part of the value, which would break the strict === 'live' check in code.
+WEEKLY_BRIEF_BACKEND=
 
 # Thought Industries (TI) API Configuration
 # Used to enrich course logo URLs for training certifications and enrollments.

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -96,6 +96,7 @@ CDP_AUDIENCE=https://lf-staging.crowd.dev/api/
 # OpenAI-compatible proxy for meeting agenda generation
 AI_PROXY_URL=https://litellm.tools.lfx.dev/chat/completions
 AI_API_KEY=your-litellm-ai-api-key
+WEEKLY_BRIEF_BACKEND=         # Set to 'live' to proxy to committee-service; unset = mock data
 
 # Thought Industries (TI) API Configuration
 # Used to enrich course logo URLs for training certifications and enrollments.

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -1,0 +1,131 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { GenerateWeeklyBriefRequest, SaveWeeklyBriefRequest } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { validateUidParameter } from '../helpers/validation.helper';
+import { logger } from '../services/logger.service';
+import { WeeklyBriefService } from '../services/weekly-brief.service';
+
+/**
+ * Controller for the WG Weekly Brief endpoints.
+ *
+ * Upstream HTTP status codes (404 → empty-state via service, 429 throttle,
+ * 409 revision conflict) are propagated through `next(error)` to the shared
+ * apiErrorHandler, which renders the original `statusCode` from MicroserviceError.
+ */
+export class WeeklyBriefController {
+  private weeklyBriefService: WeeklyBriefService = new WeeklyBriefService();
+
+  /**
+   * GET /committees/:committeeId/weekly-briefs/current
+   */
+  public async getCurrentBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { committeeId } = req.params;
+    const startTime = logger.startOperation(req, 'get_weekly_brief_current', {
+      committee_id: committeeId,
+    });
+
+    try {
+      if (
+        !validateUidParameter(committeeId, req, next, {
+          operation: 'get_weekly_brief_current',
+          service: 'weekly_brief_controller',
+        })
+      ) {
+        return;
+      }
+
+      const result = await this.weeklyBriefService.getCurrentBrief(req, committeeId);
+
+      logger.success(req, 'get_weekly_brief_current', startTime, {
+        committee_id: committeeId,
+        has_brief: !!result.brief,
+        state: result.brief?.state,
+        revision: result.brief?.revision,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /committees/:committeeId/weekly-briefs/generate
+   */
+  public async generateBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { committeeId } = req.params;
+    const body: GenerateWeeklyBriefRequest = req.body || {};
+    const startTime = logger.startOperation(req, 'generate_weekly_brief', {
+      committee_id: committeeId,
+      revision: body.revision,
+      force: body.force,
+      has_reason: !!body.reason,
+    });
+
+    try {
+      if (
+        !validateUidParameter(committeeId, req, next, {
+          operation: 'generate_weekly_brief',
+          service: 'weekly_brief_controller',
+        })
+      ) {
+        return;
+      }
+
+      const result = await this.weeklyBriefService.generateBrief(req, committeeId, body);
+
+      logger.success(req, 'generate_weekly_brief', startTime, {
+        committee_id: committeeId,
+        brief_uid: result.brief.uid,
+        revision: result.brief.revision,
+        regeneration_count: result.brief.regeneration_count,
+        generates_used: result.throttle.generates_used,
+        regenerations_used: result.throttle.regenerations_used,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * PUT /committees/:committeeId/weekly-briefs/current
+   */
+  public async saveBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { committeeId } = req.params;
+    const body: SaveWeeklyBriefRequest = req.body;
+    const startTime = logger.startOperation(req, 'save_weekly_brief', {
+      committee_id: committeeId,
+      revision: body?.revision,
+      brief_text_length: body?.brief_text?.length,
+    });
+
+    try {
+      if (
+        !validateUidParameter(committeeId, req, next, {
+          operation: 'save_weekly_brief',
+          service: 'weekly_brief_controller',
+        })
+      ) {
+        return;
+      }
+
+      const result = await this.weeklyBriefService.saveBrief(req, committeeId, body);
+
+      logger.success(req, 'save_weekly_brief', startTime, {
+        committee_id: committeeId,
+        brief_uid: result.uid,
+        revision: result.revision,
+        state: result.state,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -4,9 +4,42 @@
 import { GenerateWeeklyBriefRequest, SaveWeeklyBriefRequest } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
+import { ServiceValidationError } from '../errors';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { WeeklyBriefService } from '../services/weekly-brief.service';
+
+/**
+ * Narrow `req.body` to a SaveWeeklyBriefRequest, returning a ServiceValidationError
+ * with a per-field reason when anything is missing or has the wrong type.
+ * Without this, e.g. a string `revision` of "1" would cause `revision + 1`
+ * to concatenate to "11" downstream.
+ */
+function validateSaveBriefBody(
+  body: unknown
+): { ok: true; value: SaveWeeklyBriefRequest } | { ok: false; fieldErrors: Record<string, string> } {
+  const fieldErrors: Record<string, string> = {};
+  if (!body || typeof body !== 'object') {
+    return { ok: false, fieldErrors: { body: 'Request body must be a JSON object' } };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b['brief_text'] !== 'string') {
+    fieldErrors['brief_text'] = 'brief_text is required and must be a string';
+  }
+  if (typeof b['revision'] !== 'number' || !Number.isFinite(b['revision'] as number)) {
+    fieldErrors['revision'] = 'revision is required and must be a finite number';
+  }
+  if (Object.keys(fieldErrors).length > 0) {
+    return { ok: false, fieldErrors };
+  }
+  return {
+    ok: true,
+    value: {
+      brief_text: b['brief_text'] as string,
+      revision: b['revision'] as number,
+    },
+  };
+}
 
 /**
  * Controller for the WG Weekly Brief endpoints.
@@ -97,11 +130,8 @@ export class WeeklyBriefController {
    */
   public async saveBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { committeeId } = req.params;
-    const body: SaveWeeklyBriefRequest = req.body;
     const startTime = logger.startOperation(req, 'save_weekly_brief', {
       committee_id: committeeId,
-      revision: body?.revision,
-      brief_text_length: body?.brief_text?.length,
     });
 
     try {
@@ -113,6 +143,18 @@ export class WeeklyBriefController {
       ) {
         return;
       }
+
+      const validation = validateSaveBriefBody(req.body);
+      if (!validation.ok) {
+        return next(
+          ServiceValidationError.fromFieldErrors(validation.fieldErrors, 'Invalid save-weekly-brief request body', {
+            operation: 'save_weekly_brief',
+            service: 'weekly_brief_controller',
+            path: req.path,
+          })
+        );
+      }
+      const body = validation.value;
 
       const result = await this.weeklyBriefService.saveBrief(req, committeeId, body);
 

--- a/apps/lfx-one/src/server/routes/weekly-brief.route.ts
+++ b/apps/lfx-one/src/server/routes/weekly-brief.route.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { WeeklyBriefController } from '../controllers/weekly-brief.controller';
+
+const router = Router();
+
+const weeklyBriefController = new WeeklyBriefController();
+
+// GET /committees/:committeeId/weekly-briefs/current - get the current WG weekly brief
+router.get('/:committeeId/weekly-briefs/current', (req, res, next) => weeklyBriefController.getCurrentBrief(req, res, next));
+
+// POST /committees/:committeeId/weekly-briefs/generate - generate (or regenerate) the current brief
+router.post('/:committeeId/weekly-briefs/generate', (req, res, next) => weeklyBriefController.generateBrief(req, res, next));
+
+// PUT /committees/:committeeId/weekly-briefs/current - save edits to the current brief
+router.put('/:committeeId/weekly-briefs/current', (req, res, next) => weeklyBriefController.saveBrief(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -47,6 +47,7 @@ import enrollmentRouter from './routes/enrollment.route';
 import transactionRouter from './routes/transaction.route';
 import userRouter from './routes/user.route';
 import votesRouter from './routes/votes.route';
+import weeklyBriefRouter from './routes/weekly-brief.route';
 import { reqSerializer, resSerializer, serverLogger } from './server-logger';
 import { logger } from './services/logger.service';
 import { clearImpersonationSession, decodeJwtPayload } from './utils/auth-helper';
@@ -195,6 +196,7 @@ app.use('/public/api/projects', publicProjectsRouter);
 
 app.use('/api/projects', projectsRouter);
 app.use('/api/committees', committeesRouter);
+app.use('/api/committees', weeklyBriefRouter);
 app.use('/api/mailing-lists', mailingListsRouter);
 app.use('/api/meetings', meetingsRouter);
 app.use('/api/organizations', organizationsRouter);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1,0 +1,183 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  GenerateWeeklyBriefRequest,
+  GenerateWeeklyBriefResponse,
+  SaveWeeklyBriefRequest,
+  WeeklyBrief,
+  WeeklyBriefCurrentResponse,
+  WeeklyBriefThrottle,
+} from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { MicroserviceProxyService } from './microservice-proxy.service';
+
+/**
+ * Returns the ISO timestamp for the upcoming Sunday at 00:00:00 UTC.
+ * Used as the rolling window-reset for the WG Weekly Brief throttle.
+ */
+function nextSundayIso(): string {
+  const now = new Date();
+  const day = now.getUTCDay(); // 0 = Sunday
+  const daysUntilSunday = day === 0 ? 7 : 7 - day;
+  const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysUntilSunday, 0, 0, 0, 0));
+  return next.toISOString();
+}
+
+/**
+ * Returns Sunday→Saturday ISO range for the current week (UTC).
+ */
+function currentWeekWindow(): { window_start: string; window_end: string } {
+  const now = new Date();
+  const day = now.getUTCDay(); // 0 = Sunday
+  const sunday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - day, 0, 0, 0, 0));
+  const saturday = new Date(sunday);
+  saturday.setUTCDate(sunday.getUTCDate() + 6);
+  saturday.setUTCHours(23, 59, 59, 999);
+  return {
+    window_start: sunday.toISOString(),
+    window_end: saturday.toISOString(),
+  };
+}
+
+function defaultThrottle(): WeeklyBriefThrottle {
+  return {
+    generates_used: 0,
+    generates_limit: 2,
+    regenerations_used: 0,
+    regenerations_limit: 3,
+    window_resets_at: nextSundayIso(),
+  };
+}
+
+function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {}): WeeklyBrief {
+  const nowIso = new Date().toISOString();
+  const { window_start, window_end } = currentWeekWindow();
+  return {
+    uid: 'wb_mock_00000000-0000-0000-0000-000000000001',
+    committee_uid: committeeId,
+    window_start,
+    window_end,
+    state: 'generated',
+    brief_text:
+      'This week the working group made steady progress across collaboration and delivery streams. ' +
+      'There were 2 meetings held, with active participation from 3 members covering roadmap alignment, ' +
+      'open issues, and upcoming release planning.\n\n' +
+      'Discussion focused on outstanding action items, contributor onboarding, and prioritization for the ' +
+      'next iteration. The group surfaced no blocking risks and is on track for the planned milestones.',
+    source_refs: [],
+    prompt_version: 'v1',
+    model: 'mock',
+    regeneration_count: 0,
+    private_source_present: false,
+    created_at: nowIso,
+    updated_at: nowIso,
+    revision: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * Service for the WG Weekly Brief feature.
+ *
+ * Switches between mock data (default) and live committee-service proxy based on
+ * `WEEKLY_BRIEF_BACKEND`. Mock mode lets the UI iterate without standing up the
+ * upstream brief endpoints; flipping to 'live' proxies straight through.
+ */
+export class WeeklyBriefService {
+  private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
+
+  private isLive(): boolean {
+    return process.env['WEEKLY_BRIEF_BACKEND'] === 'live';
+  }
+
+  /**
+   * GET /committees/:committeeId/weekly-briefs/current
+   *
+   * Upstream may 404 when no brief has been generated yet for the current window;
+   * we normalize that to `{ brief: null, throttle: defaultThrottle() }` so the UI
+   * can render the empty-state without treating it as an error.
+   */
+  public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
+    if (!this.isLive()) {
+      return {
+        brief: buildMockBrief(committeeId),
+        throttle: {
+          generates_used: 1,
+          generates_limit: 2,
+          regenerations_used: 0,
+          regenerations_limit: 3,
+          window_resets_at: nextSundayIso(),
+        },
+      };
+    }
+
+    try {
+      return await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${committeeId}/weekly-briefs/current`,
+        'GET'
+      );
+    } catch (error: any) {
+      if (error?.statusCode === 404 || error?.status === 404) {
+        return { brief: null, throttle: defaultThrottle() };
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * POST /committees/:committeeId/weekly-briefs/generate
+   *
+   * 429 (throttle exhausted) and 409 (revision conflict / concurrent generate) are
+   * propagated as-is so the controller / global error handler can surface them to
+   * the UI without losing the upstream status code.
+   */
+  public async generateBrief(req: Request, committeeId: string, body: GenerateWeeklyBriefRequest): Promise<GenerateWeeklyBriefResponse> {
+    if (!this.isLive()) {
+      const regenerationCount = body?.revision ? body.revision : 1;
+      return {
+        brief: buildMockBrief(committeeId, {
+          regeneration_count: regenerationCount,
+          revision: regenerationCount,
+        }),
+        throttle: {
+          generates_used: 2,
+          generates_limit: 2,
+          regenerations_used: regenerationCount > 1 ? regenerationCount - 1 : 0,
+          regenerations_limit: 3,
+          window_resets_at: nextSundayIso(),
+        },
+      };
+    }
+
+    return this.microserviceProxy.proxyRequest<GenerateWeeklyBriefResponse>(
+      req,
+      'LFX_V2_SERVICE',
+      `/committees/${committeeId}/weekly-briefs/generate`,
+      'POST',
+      undefined,
+      body
+    );
+  }
+
+  /**
+   * PUT /committees/:committeeId/weekly-briefs/current
+   *
+   * 409 (revision conflict) is propagated as-is so the UI can prompt the user to
+   * reload the latest server copy before retrying their edit.
+   */
+  public async saveBrief(req: Request, committeeId: string, body: SaveWeeklyBriefRequest): Promise<WeeklyBrief> {
+    if (!this.isLive()) {
+      return buildMockBrief(committeeId, {
+        state: 'edited',
+        brief_text: body.brief_text,
+        revision: body.revision + 1,
+      });
+    }
+
+    return this.microserviceProxy.proxyRequest<WeeklyBrief>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/weekly-briefs/current`, 'PUT', undefined, body);
+  }
+}

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -11,6 +11,8 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { MicroserviceError } from '../errors';
+
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /**
@@ -116,8 +118,10 @@ export class WeeklyBriefService {
         `/committees/${committeeId}/weekly-briefs/current`,
         'GET'
       );
-    } catch (error: any) {
-      if (error?.statusCode === 404 || error?.status === 404) {
+    } catch (error) {
+      // Narrow the 404 to the proxy error type — checking a loose `.status`
+      // property could mask other errors that happen to have that field.
+      if (error instanceof MicroserviceError && error.statusCode === 404) {
         return { brief: null, throttle: defaultThrottle() };
       }
       throw error;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -88,10 +88,6 @@ function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {
 export class WeeklyBriefService {
   private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
 
-  private isLive(): boolean {
-    return process.env['WEEKLY_BRIEF_BACKEND'] === 'live';
-  }
-
   /**
    * GET /committees/:committeeId/weekly-briefs/current
    *
@@ -179,5 +175,9 @@ export class WeeklyBriefService {
     }
 
     return this.microserviceProxy.proxyRequest<WeeklyBrief>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/weekly-briefs/current`, 'PUT', undefined, body);
+  }
+
+  private isLive(): boolean {
+    return process.env['WEEKLY_BRIEF_BACKEND'] === 'live';
   }
 }

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -3,9 +3,11 @@
 
 export type WeeklyBriefState = 'empty' | 'generating' | 'generated' | 'edited' | 'approved' | 'error';
 
+export type WeeklyBriefSourceType = 'meeting' | 'vote' | 'member' | 'mailing_list';
+
 export interface WeeklyBriefSourceRef {
   claim_id: string;
-  source_type: string; // 'meeting' | 'vote' | 'member' | 'mailing_list'
+  source_type: WeeklyBriefSourceType;
   source_uid: string;
   source_label?: string;
   source_url?: string;


### PR DESCRIPTION
**Tracking:** [LFXV2-1982](https://linuxfoundation.atlassian.net/browse/LFXV2-1982) (part of Epic [LFXV2-1976](https://linuxfoundation.atlassian.net/browse/LFXV2-1976))

---

## Summary

Express BFF for the WG Weekly Brief: route + controller + service. Switches between mock data (default for local UI iteration) and live committee-service proxy via `WEEKLY_BRIEF_BACKEND=live`.

## What's new

- `apps/lfx-one/src/server/routes/weekly-brief.route.ts` — 3 endpoints: GET current, POST generate, PUT save
- `apps/lfx-one/src/server/controllers/weekly-brief.controller.ts`
- `apps/lfx-one/src/server/services/weekly-brief.service.ts` — mock fixtures + proxy passthrough
- `apps/lfx-one/.env.example` — adds `WEEKLY_BRIEF_BACKEND`

## Notes

- 404 from upstream on "no draft yet" is normalized to `{ brief: null, throttle: defaultThrottle() }` — matches committee-service's 200/null contract.
- 429 / 409 propagated as-is so the global error handler surfaces upstream status codes intact.
- Touches `apps/lfx-one/src/server/server.ts` (protected file) — registers the new route only.

## Stack

PR 2/4 on lfx-self-serve. **Base = PR #775** (shared-interfaces).

## Test plan

- [ ] `yarn lint` / `yarn build` green (verified)
- [ ] Mock mode returns canned brief
- [ ] Live mode proxies through `MicroserviceProxyService`


[LFXV2-1982]: https://linuxfoundation.atlassian.net/browse/LFXV2-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1976]: https://linuxfoundation.atlassian.net/browse/LFXV2-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ