### PR TITLE
feat(weekly-brief): Angular frontend service

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -96,7 +96,11 @@ CDP_AUDIENCE=https://lf-staging.crowd.dev/api/
 # OpenAI-compatible proxy for meeting agenda generation
 AI_PROXY_URL=https://litellm.tools.lfx.dev/chat/completions
 AI_API_KEY=your-litellm-ai-api-key
-WEEKLY_BRIEF_BACKEND=         # Set to 'live' to proxy to committee-service; unset = mock data
+
+# Set to 'live' to proxy to committee-service; unset (or any other value) = mock data.
+# Inline comments on the same line as a dotenv assignment are commonly parsed as
+# part of the value, which would break the strict === 'live' check in code.
+WEEKLY_BRIEF_BACKEND=
 
 # Thought Industries (TI) API Configuration
 # Used to enrich course logo URLs for training certifications and enrollments.

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -1,0 +1,47 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import {
+  GenerateWeeklyBriefRequest,
+  GenerateWeeklyBriefResponse,
+  SaveWeeklyBriefRequest,
+  WeeklyBrief,
+  WeeklyBriefCurrentResponse,
+} from '@lfx-one/shared/interfaces';
+import { catchError, Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WeeklyBriefService {
+  private readonly http = inject(HttpClient);
+
+  public getWeeklyBrief(committeeId: string): Observable<WeeklyBriefCurrentResponse> {
+    return this.http.get<WeeklyBriefCurrentResponse>(`/api/committees/${committeeId}/weekly-briefs/current`).pipe(
+      catchError(() =>
+        of({
+          brief: null,
+          throttle: {
+            generates_used: 0,
+            generates_limit: 2,
+            regenerations_used: 0,
+            regenerations_limit: 3,
+            window_resets_at: '',
+          },
+        } as WeeklyBriefCurrentResponse)
+      )
+    );
+  }
+
+  public generateWeeklyBrief(committeeId: string, body: GenerateWeeklyBriefRequest = {}): Observable<GenerateWeeklyBriefResponse> {
+    return this.http.post<GenerateWeeklyBriefResponse>(`/api/committees/${committeeId}/weekly-briefs/generate`, body);
+    // No catchError — caller handles 429/error states
+  }
+
+  public saveWeeklyBrief(committeeId: string, body: SaveWeeklyBriefRequest): Observable<WeeklyBrief> {
+    return this.http.put<WeeklyBrief>(`/api/committees/${committeeId}/weekly-briefs/current`, body);
+    // No catchError — caller handles 409 conflicts
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -20,8 +20,11 @@ export class WeeklyBriefService {
 
   public getWeeklyBrief(committeeId: string): Observable<WeeklyBriefCurrentResponse> {
     return this.http.get<WeeklyBriefCurrentResponse>(`/api/committees/${committeeId}/weekly-briefs/current`).pipe(
-      catchError(() =>
-        of({
+      catchError((error: unknown) => {
+        // Log before falling back so failures are visible in DataDog RUM and dev console,
+        // rather than silently degrading to the empty state.
+        console.error('weekly-brief: getWeeklyBrief failed, returning empty state', { committeeId, error });
+        return of({
           brief: null,
           throttle: {
             generates_used: 0,
@@ -30,8 +33,8 @@ export class WeeklyBriefService {
             regenerations_limit: 3,
             window_resets_at: '',
           },
-        } as WeeklyBriefCurrentResponse)
-      )
+        } as WeeklyBriefCurrentResponse);
+      })
     );
   }
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -4,9 +4,42 @@
 import { GenerateWeeklyBriefRequest, SaveWeeklyBriefRequest } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
+import { ServiceValidationError } from '../errors';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { WeeklyBriefService } from '../services/weekly-brief.service';
+
+/**
+ * Narrow `req.body` to a SaveWeeklyBriefRequest, returning a ServiceValidationError
+ * with a per-field reason when anything is missing or has the wrong type.
+ * Without this, e.g. a string `revision` of "1" would cause `revision + 1`
+ * to concatenate to "11" downstream.
+ */
+function validateSaveBriefBody(
+  body: unknown
+): { ok: true; value: SaveWeeklyBriefRequest } | { ok: false; fieldErrors: Record<string, string> } {
+  const fieldErrors: Record<string, string> = {};
+  if (!body || typeof body !== 'object') {
+    return { ok: false, fieldErrors: { body: 'Request body must be a JSON object' } };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b['brief_text'] !== 'string') {
+    fieldErrors['brief_text'] = 'brief_text is required and must be a string';
+  }
+  if (typeof b['revision'] !== 'number' || !Number.isFinite(b['revision'] as number)) {
+    fieldErrors['revision'] = 'revision is required and must be a finite number';
+  }
+  if (Object.keys(fieldErrors).length > 0) {
+    return { ok: false, fieldErrors };
+  }
+  return {
+    ok: true,
+    value: {
+      brief_text: b['brief_text'] as string,
+      revision: b['revision'] as number,
+    },
+  };
+}
 
 /**
  * Controller for the WG Weekly Brief endpoints.
@@ -97,11 +130,8 @@ export class WeeklyBriefController {
    */
   public async saveBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { committeeId } = req.params;
-    const body: SaveWeeklyBriefRequest = req.body;
     const startTime = logger.startOperation(req, 'save_weekly_brief', {
       committee_id: committeeId,
-      revision: body?.revision,
-      brief_text_length: body?.brief_text?.length,
     });
 
     try {
@@ -113,6 +143,18 @@ export class WeeklyBriefController {
       ) {
         return;
       }
+
+      const validation = validateSaveBriefBody(req.body);
+      if (!validation.ok) {
+        return next(
+          ServiceValidationError.fromFieldErrors(validation.fieldErrors, 'Invalid save-weekly-brief request body', {
+            operation: 'save_weekly_brief',
+            service: 'weekly_brief_controller',
+            path: req.path,
+          })
+        );
+      }
+      const body = validation.value;
 
       const result = await this.weeklyBriefService.saveBrief(req, committeeId, body);
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -11,6 +11,8 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { MicroserviceError } from '../errors';
+
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /**
@@ -116,8 +118,10 @@ export class WeeklyBriefService {
         `/committees/${committeeId}/weekly-briefs/current`,
         'GET'
       );
-    } catch (error: any) {
-      if (error?.statusCode === 404 || error?.status === 404) {
+    } catch (error) {
+      // Narrow the 404 to the proxy error type — checking a loose `.status`
+      // property could mask other errors that happen to have that field.
+      if (error instanceof MicroserviceError && error.statusCode === 404) {
         return { brief: null, throttle: defaultThrottle() };
       }
       throw error;


### PR DESCRIPTION
**Tracking:** [LFXV2-1983](https://linuxfoundation.atlassian.net/browse/LFXV2-1983) (part of Epic [LFXV2-1976](https://linuxfoundation.atlassian.net/browse/LFXV2-1976))

---

## Summary

Angular `WeeklyBriefService` that consumes the BFF endpoints from PR #776. Three methods: `getWeeklyBrief`, `generateWeeklyBrief`, `saveWeeklyBrief`.

## Notes

- `getWeeklyBrief` has `catchError` that logs before falling back to an empty envelope (so failures show up in DataDog RUM / dev console, not silent degradation).
- `generateWeeklyBrief` and `saveWeeklyBrief` deliberately have no `catchError` — callers handle 429 (throttle) and 409 (revision conflict) explicitly to drive the UI states.

## Stack

PR 3/4 on lfx-self-serve. **Base = PR #776** (bff).

## Test plan

- [ ] `yarn lint` / `yarn build` green (verified)
- [ ] Service hot-reloads against mock BFF


[LFXV2-1983]: https://linuxfoundation.atlassian.net/browse/LFXV2-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1976]: https://linuxfoundation.atlassian.net/browse/LFXV2-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ