### PR TITLE
fix(ui): suppress lens flash on dashboard pages until persona loads

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else {
     <div class="flex flex-col gap-6">

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -2,171 +2,178 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  <div class="flex flex-col gap-6">
-    <!-- Page Header -->
-    <div class="mt-3">
-      <div class="flex justify-between items-center w-full gap-4">
-        <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + committeeLabel.plural : committeeLabel.plural }}</h1>
-        @if (!isMeLens() && canWrite()) {
-          <lfx-button
-            [label]="'Create ' + committeeLabel.singular"
-            icon="fa-light fa-users mr-1"
-            severity="info"
-            size="small"
-            (onClick)="openCreateDialog()"
-            data-testid="committee-new-cta">
-          </lfx-button>
-        }
-      </div>
-      <p class="mt-1 text-sm text-gray-500" data-testid="dashboard-hero-description">
-        @if (isMeLens()) {
-          @if (projectFilter() || foundationFilter()) {
-            {{ committeeLabel.plural }} you are a member of in the selected scope.
-          } @else {
-            {{ committeeLabel.plural }} you are a member of across all foundations and projects.
-            @if (showFoundationFilter() || showProjectFilter()) {
-              <span class="text-gray-400">Use the filters above to narrow the view.</span>
-            }
-          }
-        } @else {
-          Manage {{ committeeLabel.plural.toLowerCase() }} and governance for your project.
-        }
-      </p>
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
     </div>
-
-    <!-- Summary Stat Cards (Foundation/Project lens) -->
-    @if (!isMeLens()) {
-      <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="committeesLoading()" data-testid="committees-foundation-stats" />
-    }
-
-    <!-- Summary Stat Cards (Me lens only) -->
-    @if (isMeLens()) {
-      <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
-    }
-
-    @let totalForChips = isMeLens() ? myCommittees().length : committees().length;
-    @if (totalForChips > 0) {
-      <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Filter groups by behavioral class" data-testid="groups-behavioral-class-chips">
-        <button
-          type="button"
-          class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-          [class]="behavioralClassFilter() === null ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
-          [attr.aria-pressed]="behavioralClassFilter() === null"
-          (click)="selectBehavioralClass(null)"
-          data-testid="groups-chip-all">
-          All ({{ totalForChips }})
-        </button>
-        @for (key of behavioralClassKeys; track key) {
-          @if (behavioralClassCounts()[key] > 0) {
-            <button
-              type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-              [class]="
-                behavioralClassFilter() === key
-                  ? 'bg-blue-600 text-white'
-                  : behavioralClassConfig[key].bgColor + ' ' + behavioralClassConfig[key].color + ' hover:opacity-80'
-              "
-              [attr.aria-pressed]="behavioralClassFilter() === key"
-              (click)="selectBehavioralClass(key)"
-              [attr.data-testid]="'groups-chip-' + key">
-              <i [class]="behavioralClassConfig[key].icon" aria-hidden="true"></i>
-              {{ behavioralClassConfig[key].label }} ({{ behavioralClassCounts()[key] }})
-            </button>
+  } @else {
+    <div class="flex flex-col gap-6">
+      <!-- Page Header -->
+      <div class="mt-3">
+        <div class="flex justify-between items-center w-full gap-4">
+          <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + committeeLabel.plural : committeeLabel.plural }}</h1>
+          @if (!isMeLens() && canWrite()) {
+            <lfx-button
+              [label]="'Create ' + committeeLabel.singular"
+              icon="fa-light fa-users mr-1"
+              severity="info"
+              size="small"
+              (onClick)="openCreateDialog()"
+              data-testid="committee-new-cta">
+            </lfx-button>
           }
-        }
-      </div>
-    }
-
-    <!-- My Groups Table (Me lens) -->
-    @if (isMeLens()) {
-      @if (myCommitteesLoading()) {
-        <lfx-card styleClass="[&_.p-card-body]:!px-5">
-          <div class="flex flex-col gap-4 py-2">
-            @for (_ of [1, 2, 3, 4, 5]; track _) {
-              <div class="flex items-center gap-6">
-                <p-skeleton width="18%" height="0.875rem" />
-                <p-skeleton width="10%" height="0.875rem" />
-                <p-skeleton width="22%" height="0.875rem" />
-                <p-skeleton width="6%" height="0.875rem" />
-                <p-skeleton width="6%" height="0.875rem" />
-                <p-skeleton width="6%" height="0.875rem" />
-                <p-skeleton width="10%" height="0.875rem" />
-                <p-skeleton width="10%" height="0.875rem" />
-              </div>
+        </div>
+        <p class="mt-1 text-sm text-gray-500" data-testid="dashboard-hero-description">
+          @if (isMeLens()) {
+            @if (projectFilter() || foundationFilter()) {
+              {{ committeeLabel.plural }} you are a member of in the selected scope.
+            } @else {
+              {{ committeeLabel.plural }} you are a member of across all foundations and projects.
+              @if (showFoundationFilter() || showProjectFilter()) {
+                <span class="text-gray-400">Use the filters above to narrow the view.</span>
+              }
             }
-          </div>
-        </lfx-card>
-      } @else {
-        <lfx-committee-table
-          [committees]="filteredMyCommittees()"
-          [hasItems]="myCommittees().length > 0"
-          [myCommitteeUids]="myCommitteeUids()"
-          [searchForm]="searchForm"
-          [votingStatusOptions]="votingStatusOptions()"
-          [showFoundationFilter]="showFoundationFilter()"
-          [showProjectFilter]="showProjectFilter()"
-          [foundationOptions]="foundationOptions()"
-          [projectOptions]="projectOptions()"
-          (foundationFilterChange)="onFoundationFilterChange($event)"
-          (projectFilterChange)="onProjectFilterChange($event)"
-          (resetRequested)="selectBehavioralClass(null)"
-          (refresh)="refreshCommittees()"
-          (rowClick)="onCommitteeClick($event)"
-          data-testid="committees-me-table">
-        </lfx-committee-table>
-      }
-    }
-
-    @if (!isMeLens()) {
-      <!-- All Groups Section -->
-      @if (committeesLoading()) {
-        <lfx-card>
-          <div class="flex flex-col gap-4 p-4">
-            @for (_ of [1, 2, 3, 4, 5]; track _) {
-              <div class="flex items-center gap-6">
-                <p-skeleton width="25%" height="0.875rem" />
-                <p-skeleton width="20%" height="0.875rem" />
-                <p-skeleton width="15%" height="0.875rem" />
-                <p-skeleton width="10%" height="0.875rem" />
-              </div>
-            }
-          </div>
-        </lfx-card>
-      }
-
-      <!-- Content Area - Table or Cards -->
-      @if (!committeesLoading()) {
-        <div class="min-h-[400px]">
-          @if (committees().length === 0 && project()?.uid) {
-            <lfx-empty-state
-              icon="fa-light fa-users-rectangle"
-              [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
-              subtitle="This project has no groups set up yet."
-              data-testid="committees-project-empty-state">
-            </lfx-empty-state>
-          } @else if (project()?.uid) {
-            <lfx-committee-table
-              data-testid="committees-project-table"
-              [committees]="filteredCommittees()"
-              [hasItems]="committees().length > 0"
-              [canManageCommittee]="canWrite()"
-              [myCommitteeUids]="myCommitteeUids()"
-              [searchForm]="searchForm"
-              [votingStatusOptions]="votingStatusOptions()"
-              (resetRequested)="selectBehavioralClass(null)"
-              (refresh)="refreshCommittees()"
-              (rowClick)="onCommitteeClick($event)">
-            </lfx-committee-table>
           } @else {
-            <lfx-empty-state
-              icon="fa-light fa-folder-open"
-              title="Select a project"
-              [subtitle]="'Choose a project to view its ' + committeeLabel.plural.toLowerCase() + '.'"
-              data-testid="committees-no-project-empty-state">
-            </lfx-empty-state>
+            Manage {{ committeeLabel.plural.toLowerCase() }} and governance for your project.
+          }
+        </p>
+      </div>
+
+      <!-- Summary Stat Cards (Foundation/Project lens) -->
+      @if (!isMeLens()) {
+        <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="committeesLoading()" data-testid="committees-foundation-stats" />
+      }
+
+      <!-- Summary Stat Cards (Me lens only) -->
+      @if (isMeLens()) {
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
+      }
+
+      @let totalForChips = isMeLens() ? myCommittees().length : committees().length;
+      @if (totalForChips > 0) {
+        <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Filter groups by behavioral class" data-testid="groups-behavioral-class-chips">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+            [class]="behavioralClassFilter() === null ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
+            [attr.aria-pressed]="behavioralClassFilter() === null"
+            (click)="selectBehavioralClass(null)"
+            data-testid="groups-chip-all">
+            All ({{ totalForChips }})
+          </button>
+          @for (key of behavioralClassKeys; track key) {
+            @if (behavioralClassCounts()[key] > 0) {
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+                [class]="
+                  behavioralClassFilter() === key
+                    ? 'bg-blue-600 text-white'
+                    : behavioralClassConfig[key].bgColor + ' ' + behavioralClassConfig[key].color + ' hover:opacity-80'
+                "
+                [attr.aria-pressed]="behavioralClassFilter() === key"
+                (click)="selectBehavioralClass(key)"
+                [attr.data-testid]="'groups-chip-' + key">
+                <i [class]="behavioralClassConfig[key].icon" aria-hidden="true"></i>
+                {{ behavioralClassConfig[key].label }} ({{ behavioralClassCounts()[key] }})
+              </button>
+            }
           }
         </div>
       }
-    }
-  </div>
+
+      <!-- My Groups Table (Me lens) -->
+      @if (isMeLens()) {
+        @if (myCommitteesLoading()) {
+          <lfx-card styleClass="[&_.p-card-body]:!px-5">
+            <div class="flex flex-col gap-4 py-2">
+              @for (_ of [1, 2, 3, 4, 5]; track _) {
+                <div class="flex items-center gap-6">
+                  <p-skeleton width="18%" height="0.875rem" />
+                  <p-skeleton width="10%" height="0.875rem" />
+                  <p-skeleton width="22%" height="0.875rem" />
+                  <p-skeleton width="6%" height="0.875rem" />
+                  <p-skeleton width="6%" height="0.875rem" />
+                  <p-skeleton width="6%" height="0.875rem" />
+                  <p-skeleton width="10%" height="0.875rem" />
+                  <p-skeleton width="10%" height="0.875rem" />
+                </div>
+              }
+            </div>
+          </lfx-card>
+        } @else {
+          <lfx-committee-table
+            [committees]="filteredMyCommittees()"
+            [hasItems]="myCommittees().length > 0"
+            [myCommitteeUids]="myCommitteeUids()"
+            [searchForm]="searchForm"
+            [votingStatusOptions]="votingStatusOptions()"
+            [showFoundationFilter]="showFoundationFilter()"
+            [showProjectFilter]="showProjectFilter()"
+            [foundationOptions]="foundationOptions()"
+            [projectOptions]="projectOptions()"
+            (foundationFilterChange)="onFoundationFilterChange($event)"
+            (projectFilterChange)="onProjectFilterChange($event)"
+            (resetRequested)="selectBehavioralClass(null)"
+            (refresh)="refreshCommittees()"
+            (rowClick)="onCommitteeClick($event)"
+            data-testid="committees-me-table">
+          </lfx-committee-table>
+        }
+      }
+
+      @if (!isMeLens()) {
+        <!-- All Groups Section -->
+        @if (committeesLoading()) {
+          <lfx-card>
+            <div class="flex flex-col gap-4 p-4">
+              @for (_ of [1, 2, 3, 4, 5]; track _) {
+                <div class="flex items-center gap-6">
+                  <p-skeleton width="25%" height="0.875rem" />
+                  <p-skeleton width="20%" height="0.875rem" />
+                  <p-skeleton width="15%" height="0.875rem" />
+                  <p-skeleton width="10%" height="0.875rem" />
+                </div>
+              }
+            </div>
+          </lfx-card>
+        }
+
+        <!-- Content Area - Table or Cards -->
+        @if (!committeesLoading()) {
+          <div class="min-h-[400px]">
+            @if (committees().length === 0 && project()?.uid) {
+              <lfx-empty-state
+                icon="fa-light fa-users-rectangle"
+                [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
+                subtitle="This project has no groups set up yet."
+                data-testid="committees-project-empty-state">
+              </lfx-empty-state>
+            } @else if (project()?.uid) {
+              <lfx-committee-table
+                data-testid="committees-project-table"
+                [committees]="filteredCommittees()"
+                [hasItems]="committees().length > 0"
+                [canManageCommittee]="canWrite()"
+                [myCommitteeUids]="myCommitteeUids()"
+                [searchForm]="searchForm"
+                [votingStatusOptions]="votingStatusOptions()"
+                (resetRequested)="selectBehavioralClass(null)"
+                (refresh)="refreshCommittees()"
+                (rowClick)="onCommitteeClick($event)">
+              </lfx-committee-table>
+            } @else {
+              <lfx-empty-state
+                icon="fa-light fa-folder-open"
+                title="Select a project"
+                [subtitle]="'Choose a project to view its ' + committeeLabel.plural.toLowerCase() + '.'"
+                data-testid="committees-no-project-empty-state">
+              </lfx-empty-state>
+            }
+          </div>
+        }
+      }
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -70,6 +70,7 @@ export class CommitteeDashboardComponent {
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
   private readonly isFoundationContext: Signal<boolean> = this.projectContextService.isFoundationContext;
   protected readonly canWrite = this.projectContextService.canWrite;
+  protected readonly personaLoaded = this.personaService.personaLoaded;
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="documents-dashboard">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else {
     <div class="flex flex-col gap-6">

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -2,339 +2,346 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="documents-dashboard">
-  <div class="flex flex-col gap-6">
-    <!-- Page Header -->
-    <div class="flex items-start justify-between mt-3">
-      <div>
-        <h1 class="font-display font-light text-2xl" data-testid="documents-dashboard-title">{{ pageTitle() }}</h1>
-        <p class="mt-1 text-sm text-gray-500" data-testid="documents-dashboard-description">
-          {{ documentLabel.plural }}, links, and attachments across groups, meetings, and foundations.
-        </p>
-      </div>
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
     </div>
+  } @else {
+    <div class="flex flex-col gap-6">
+      <!-- Page Header -->
+      <div class="flex items-start justify-between mt-3">
+        <div>
+          <h1 class="font-display font-light text-2xl" data-testid="documents-dashboard-title">{{ pageTitle() }}</h1>
+          <p class="mt-1 text-sm text-gray-500" data-testid="documents-dashboard-description">
+            {{ documentLabel.plural }}, links, and attachments across groups, meetings, and foundations.
+          </p>
+        </div>
+      </div>
 
-    <!-- Filter Bar + Table -->
-    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="documents-table-card">
-      @if (useProjectSource()) {
-        <!-- ── PROJECT / FOUNDATION lens ───────────────────────────────────── -->
-        <div class="px-5 pt-4 flex flex-col gap-3">
-          <!-- Toolbar -->
-          @if (canUpload()) {
-            <div class="flex items-center justify-end gap-2" data-testid="documents-dashboard-toolbar">
-              <lfx-button
-                label="Upload File"
-                icon="fa-light fa-arrow-up-from-line"
-                size="small"
-                severity="secondary"
-                [outlined]="true"
-                (onClick)="openUploadFileDialog()"
-                data-testid="documents-dashboard-upload-file-button"></lfx-button>
-              <lfx-button
-                label="New Folder"
-                icon="fa-light fa-folder-plus"
-                size="small"
-                severity="secondary"
-                [outlined]="true"
-                (onClick)="openNewFolderDialog()"
-                data-testid="documents-dashboard-new-folder-button"></lfx-button>
-              <lfx-button
-                label="Add Link"
-                icon="fa-light fa-link"
-                severity="info"
-                size="small"
-                (onClick)="openAddLinkDialog()"
-                data-testid="documents-dashboard-add-link-button"></lfx-button>
-            </div>
-          }
-
-          <!-- Breadcrumb (only when drilled into a folder) -->
-          @if (currentFolder(); as folder) {
-            <nav class="flex items-center gap-2 pb-3 border-b border-gray-100 text-sm" data-testid="documents-dashboard-breadcrumb" aria-label="Breadcrumb">
-              <button
-                type="button"
-                class="text-blue-600 hover:text-blue-700 hover:underline font-medium bg-transparent border-none cursor-pointer p-0"
-                (click)="onBreadcrumbHome()"
-                data-testid="documents-dashboard-breadcrumb-home">
-                <i class="fa-light fa-folder-open text-amber-500 mr-1"></i>
-                Documents
-              </button>
-              <i class="fa-light fa-chevron-right text-gray-300 text-xs"></i>
-              <span class="text-gray-900 font-medium" data-testid="documents-dashboard-breadcrumb-current">{{ folder.name }}</span>
-            </nav>
-          }
-
-          <!-- Search + Source filter -->
-          <div class="pb-3 border-b border-gray-100">
-            <div class="flex flex-wrap items-center gap-2">
-              <div class="flex-1 min-w-48">
-                <lfx-input-text
-                  [form]="filterForm"
-                  control="search"
-                  placeholder="Search documents..."
-                  icon="fa-light fa-search"
-                  styleClass="w-full"
+      <!-- Filter Bar + Table -->
+      <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="documents-table-card">
+        @if (useProjectSource()) {
+          <!-- ── PROJECT / FOUNDATION lens ───────────────────────────────────── -->
+          <div class="px-5 pt-4 flex flex-col gap-3">
+            <!-- Toolbar -->
+            @if (canUpload()) {
+              <div class="flex items-center justify-end gap-2" data-testid="documents-dashboard-toolbar">
+                <lfx-button
+                  label="Upload File"
+                  icon="fa-light fa-arrow-up-from-line"
                   size="small"
-                  data-testid="documents-search-input">
-                </lfx-input-text>
+                  severity="secondary"
+                  [outlined]="true"
+                  (onClick)="openUploadFileDialog()"
+                  data-testid="documents-dashboard-upload-file-button"></lfx-button>
+                <lfx-button
+                  label="New Folder"
+                  icon="fa-light fa-folder-plus"
+                  size="small"
+                  severity="secondary"
+                  [outlined]="true"
+                  (onClick)="openNewFolderDialog()"
+                  data-testid="documents-dashboard-new-folder-button"></lfx-button>
+                <lfx-button
+                  label="Add Link"
+                  icon="fa-light fa-link"
+                  severity="info"
+                  size="small"
+                  (onClick)="openAddLinkDialog()"
+                  data-testid="documents-dashboard-add-link-button"></lfx-button>
               </div>
-              <div class="w-36 shrink-0 overflow-hidden">
-                <lfx-select
-                  [form]="filterForm"
-                  control="projectSource"
-                  size="small"
-                  [options]="projectSourceOptions"
-                  placeholder="All Sources"
-                  [showClear]="true"
-                  styleClass="w-full"
-                  data-testid="documents-dashboard-source-filter">
-                </lfx-select>
+            }
+
+            <!-- Breadcrumb (only when drilled into a folder) -->
+            @if (currentFolder(); as folder) {
+              <nav class="flex items-center gap-2 pb-3 border-b border-gray-100 text-sm" data-testid="documents-dashboard-breadcrumb" aria-label="Breadcrumb">
+                <button
+                  type="button"
+                  class="text-blue-600 hover:text-blue-700 hover:underline font-medium bg-transparent border-none cursor-pointer p-0"
+                  (click)="onBreadcrumbHome()"
+                  data-testid="documents-dashboard-breadcrumb-home">
+                  <i class="fa-light fa-folder-open text-amber-500 mr-1"></i>
+                  Documents
+                </button>
+                <i class="fa-light fa-chevron-right text-gray-300 text-xs"></i>
+                <span class="text-gray-900 font-medium" data-testid="documents-dashboard-breadcrumb-current">{{ folder.name }}</span>
+              </nav>
+            }
+
+            <!-- Search + Source filter -->
+            <div class="pb-3 border-b border-gray-100">
+              <div class="flex flex-wrap items-center gap-2">
+                <div class="flex-1 min-w-48">
+                  <lfx-input-text
+                    [form]="filterForm"
+                    control="search"
+                    placeholder="Search documents..."
+                    icon="fa-light fa-search"
+                    styleClass="w-full"
+                    size="small"
+                    data-testid="documents-search-input">
+                  </lfx-input-text>
+                </div>
+                <div class="w-36 shrink-0 overflow-hidden">
+                  <lfx-select
+                    [form]="filterForm"
+                    control="projectSource"
+                    size="small"
+                    [options]="projectSourceOptions"
+                    placeholder="All Sources"
+                    [showClear]="true"
+                    styleClass="w-full"
+                    data-testid="documents-dashboard-source-filter">
+                  </lfx-select>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <!-- Documents table (shared component — folders, downloads, links handled internally) -->
-        <div class="px-5 pb-5">
-          <lfx-documents-table
-            [documents]="filteredDocuments()"
-            [loading]="loading()"
-            [showFoundation]="false"
-            (folderOpen)="onFolderOpen($event)"
-            testIdPrefix="documents-dashboard"
-            [emptyMessage]="projectEmptyMessage()">
-          </lfx-documents-table>
-        </div>
-      } @else {
-        <!-- ── ME / ORG lens — legacy aggregator UI ───────────────────────── -->
-        <!-- Source Tabs -->
-        <lfx-card-tabs-bar
-          [options]="sourceTabOptions"
-          [selectedFilter]="sourceTab()"
-          (filterChange)="onSourceTabChange($event)"
-          data-testid="documents-source-tabs">
-        </lfx-card-tabs-bar>
+          <!-- Documents table (shared component — folders, downloads, links handled internally) -->
+          <div class="px-5 pb-5">
+            <lfx-documents-table
+              [documents]="filteredDocuments()"
+              [loading]="loading()"
+              [showFoundation]="false"
+              (folderOpen)="onFolderOpen($event)"
+              testIdPrefix="documents-dashboard"
+              [emptyMessage]="projectEmptyMessage()">
+            </lfx-documents-table>
+          </div>
+        } @else {
+          <!-- ── ME / ORG lens — legacy aggregator UI ───────────────────────── -->
+          <!-- Source Tabs -->
+          <lfx-card-tabs-bar
+            [options]="sourceTabOptions"
+            [selectedFilter]="sourceTab()"
+            (filterChange)="onSourceTabChange($event)"
+            data-testid="documents-source-tabs">
+          </lfx-card-tabs-bar>
 
-        <!-- Filters -->
-        @if (loading() || documents().length > 0) {
-          <div class="px-5 pt-4 pb-3">
-            <div class="flex flex-wrap items-center gap-2">
-              <!-- Search -->
-              <div class="flex-1 min-w-48">
-                <lfx-input-text
-                  [form]="filterForm"
-                  control="search"
-                  placeholder="Search documents..."
-                  icon="fa-light fa-search"
-                  styleClass="w-full"
-                  size="small"
-                  data-testid="documents-search-input-legacy">
-                </lfx-input-text>
-              </div>
+          <!-- Filters -->
+          @if (loading() || documents().length > 0) {
+            <div class="px-5 pt-4 pb-3">
+              <div class="flex flex-wrap items-center gap-2">
+                <!-- Search -->
+                <div class="flex-1 min-w-48">
+                  <lfx-input-text
+                    [form]="filterForm"
+                    control="search"
+                    placeholder="Search documents..."
+                    icon="fa-light fa-search"
+                    styleClass="w-full"
+                    size="small"
+                    data-testid="documents-search-input-legacy">
+                  </lfx-input-text>
+                </div>
 
-              <!-- Foundation filter -->
-              <div class="w-40 shrink-0 overflow-hidden">
-                <lfx-select
-                  [form]="filterForm"
-                  control="foundation"
-                  size="small"
-                  [options]="foundationOptions()"
-                  placeholder="All Foundations"
-                  [showClear]="true"
-                  [filter]="true"
-                  filterPlaceholder="Search foundations..."
-                  styleClass="w-full"
-                  data-testid="documents-foundation-filter">
-                </lfx-select>
-              </div>
+                <!-- Foundation filter -->
+                <div class="w-40 shrink-0 overflow-hidden">
+                  <lfx-select
+                    [form]="filterForm"
+                    control="foundation"
+                    size="small"
+                    [options]="foundationOptions()"
+                    placeholder="All Foundations"
+                    [showClear]="true"
+                    [filter]="true"
+                    filterPlaceholder="Search foundations..."
+                    styleClass="w-full"
+                    data-testid="documents-foundation-filter">
+                  </lfx-select>
+                </div>
 
-              <!-- Group filter -->
-              <div class="w-36 shrink-0 overflow-hidden">
-                <lfx-select
-                  [form]="filterForm"
-                  control="group"
-                  size="small"
-                  [options]="groupOptions()"
-                  placeholder="All Groups"
-                  [showClear]="true"
-                  [filter]="true"
-                  filterPlaceholder="Search groups..."
-                  styleClass="w-full"
-                  data-testid="documents-group-filter">
-                </lfx-select>
-              </div>
+                <!-- Group filter -->
+                <div class="w-36 shrink-0 overflow-hidden">
+                  <lfx-select
+                    [form]="filterForm"
+                    control="group"
+                    size="small"
+                    [options]="groupOptions()"
+                    placeholder="All Groups"
+                    [showClear]="true"
+                    [filter]="true"
+                    filterPlaceholder="Search groups..."
+                    styleClass="w-full"
+                    data-testid="documents-group-filter">
+                  </lfx-select>
+                </div>
 
-              <!-- Meeting filter -->
-              <div class="w-36 shrink-0 overflow-hidden">
-                <lfx-select
-                  [form]="filterForm"
-                  control="meeting"
-                  size="small"
-                  [options]="meetingOptions()"
-                  placeholder="All Meetings"
-                  [showClear]="true"
-                  [filter]="true"
-                  filterPlaceholder="Search meetings..."
-                  styleClass="w-full"
-                  data-testid="documents-meeting-filter">
-                </lfx-select>
-              </div>
+                <!-- Meeting filter -->
+                <div class="w-36 shrink-0 overflow-hidden">
+                  <lfx-select
+                    [form]="filterForm"
+                    control="meeting"
+                    size="small"
+                    [options]="meetingOptions()"
+                    placeholder="All Meetings"
+                    [showClear]="true"
+                    [filter]="true"
+                    filterPlaceholder="Search meetings..."
+                    styleClass="w-full"
+                    data-testid="documents-meeting-filter">
+                  </lfx-select>
+                </div>
 
-              <!-- Mailing list filter -->
-              <div class="w-40 shrink-0 overflow-hidden">
-                <lfx-select
-                  [form]="filterForm"
-                  control="mailingList"
-                  size="small"
-                  [options]="mailingListOptions()"
-                  placeholder="All Mailing Lists"
-                  [showClear]="true"
-                  [filter]="true"
-                  filterPlaceholder="Search mailing lists..."
-                  styleClass="w-full"
-                  data-testid="documents-mailing-list-filter">
-                </lfx-select>
+                <!-- Mailing list filter -->
+                <div class="w-40 shrink-0 overflow-hidden">
+                  <lfx-select
+                    [form]="filterForm"
+                    control="mailingList"
+                    size="small"
+                    [options]="mailingListOptions()"
+                    placeholder="All Mailing Lists"
+                    [showClear]="true"
+                    [filter]="true"
+                    filterPlaceholder="Search mailing lists..."
+                    styleClass="w-full"
+                    data-testid="documents-mailing-list-filter">
+                  </lfx-select>
+                </div>
               </div>
             </div>
+          }
+
+          <div class="px-5 pb-5">
+            <!-- Primary empty state: no documents at all -->
+            @if (!loading() && documents().length === 0) {
+              <lfx-empty-state
+                [withCard]="false"
+                icon="fa-light fa-file-lines"
+                title="No documents yet"
+                subtitle="Documents, links, and attachments from your groups and meetings will appear here."
+                data-testid="documents-empty-state">
+              </lfx-empty-state>
+              <!-- Filtered empty state: documents exist but no results match -->
+            } @else if (!loading() && filteredDocuments().length === 0) {
+              <lfx-empty-state
+                [withCard]="false"
+                icon="fa-light fa-eyes"
+                title="No results found"
+                subtitle="Try adjusting your filter criteria"
+                ctaLabel="Reset filters"
+                ctaIcon="fa-light fa-arrow-rotate-left"
+                (ctaClick)="resetFilters()"
+                data-testid="documents-filtered-empty-state">
+              </lfx-empty-state>
+            } @else {
+              <!-- Table -->
+              <lfx-table
+                [value]="filteredDocuments()"
+                [paginator]="filteredDocuments().length > 0"
+                [rows]="10"
+                [rowsPerPageOptions]="rppOptions()"
+                [loading]="loading()"
+                [showFirstLastIcon]="false"
+                [showCurrentPageReport]="true"
+                currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+                styleClass="[&_table]:table-fixed"
+                data-testid="documents-table">
+                <ng-template #header>
+                  <tr>
+                    <th class="w-[33%]">Name</th>
+                    <th class="w-[18%]">Foundation</th>
+                    <th class="w-[18%]">Group / Meeting</th>
+                    <th class="w-[10%]">Source</th>
+                    <th class="w-[13%] whitespace-nowrap">Date</th>
+                    <th class="w-auto"></th>
+                  </tr>
+                </ng-template>
+
+                <ng-template #body let-doc let-rowIndex="rowIndex">
+                  <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
+                    <!-- Name column -->
+                    <td>
+                      <div class="flex items-center gap-2 min-w-0">
+                        <div class="flex items-center justify-center w-10 h-10 rounded-full border border-gray-200 bg-white shrink-0 shadow">
+                          <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' text-gray-900 text-base'"></i>
+                        </div>
+                        <span
+                          #nameEl
+                          class="text-sm font-medium text-gray-900 truncate min-w-0"
+                          [pTooltip]="doc.name"
+                          tooltipPosition="top"
+                          [tooltipDisabled]="nameEl.scrollWidth <= nameEl.offsetWidth"
+                          [attr.data-testid]="'documents-name-' + doc.id"
+                          >{{ doc.name }}</span
+                        >
+                      </div>
+                    </td>
+
+                    <!-- Foundation column -->
+                    <td>
+                      <span class="text-sm text-gray-700">{{ doc.foundationName || '—' }}</span>
+                    </td>
+
+                    <!-- Group / Meeting column -->
+                    <td>
+                      <span class="text-sm text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
+                    </td>
+
+                    <!-- Source column -->
+                    <td>
+                      <lfx-tag
+                        [value]="doc.source | myDocumentSourceTag: 'label'"
+                        [severity]="doc.source | myDocumentSourceTag: 'severity'"
+                        [attr.data-testid]="'documents-source-tag-' + doc.id">
+                      </lfx-tag>
+                    </td>
+
+                    <!-- Date column -->
+                    <td class="whitespace-nowrap">
+                      <span class="text-sm text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
+                    </td>
+
+                    <!-- Actions column -->
+                    <td>
+                      <div class="flex items-center justify-end gap-1">
+                        @if (doc.source === 'file' && doc.attachmentUid) {
+                          <lfx-button
+                            label="Download"
+                            icon="fa-light fa-arrow-down-to-line"
+                            severity="secondary"
+                            size="small"
+                            [outlined]="true"
+                            styleClass="whitespace-nowrap"
+                            (onClick)="openDocument(doc)"
+                            [attr.data-testid]="'documents-download-' + doc.id">
+                          </lfx-button>
+                        } @else if (doc.url) {
+                          @if (doc.source === 'recording') {
+                            <lfx-button
+                              label="Recording"
+                              icon="fa-light fa-circle-play"
+                              severity="secondary"
+                              size="small"
+                              [outlined]="true"
+                              styleClass="whitespace-nowrap"
+                              (onClick)="openDocument(doc)"
+                              [attr.data-testid]="'documents-open-' + doc.id">
+                            </lfx-button>
+                          } @else {
+                            <lfx-button
+                              label="Open"
+                              icon="fa-light fa-arrow-up-right-from-square"
+                              severity="secondary"
+                              size="small"
+                              [outlined]="true"
+                              styleClass="whitespace-nowrap"
+                              (onClick)="openDocument(doc)"
+                              [attr.data-testid]="'documents-open-' + doc.id">
+                            </lfx-button>
+                          }
+                        }
+                      </div>
+                    </td>
+                  </tr>
+                </ng-template>
+              </lfx-table>
+            }
           </div>
         }
-
-        <div class="px-5 pb-5">
-          <!-- Primary empty state: no documents at all -->
-          @if (!loading() && documents().length === 0) {
-            <lfx-empty-state
-              [withCard]="false"
-              icon="fa-light fa-file-lines"
-              title="No documents yet"
-              subtitle="Documents, links, and attachments from your groups and meetings will appear here."
-              data-testid="documents-empty-state">
-            </lfx-empty-state>
-            <!-- Filtered empty state: documents exist but no results match -->
-          } @else if (!loading() && filteredDocuments().length === 0) {
-            <lfx-empty-state
-              [withCard]="false"
-              icon="fa-light fa-eyes"
-              title="No results found"
-              subtitle="Try adjusting your filter criteria"
-              ctaLabel="Reset filters"
-              ctaIcon="fa-light fa-arrow-rotate-left"
-              (ctaClick)="resetFilters()"
-              data-testid="documents-filtered-empty-state">
-            </lfx-empty-state>
-          } @else {
-            <!-- Table -->
-            <lfx-table
-              [value]="filteredDocuments()"
-              [paginator]="filteredDocuments().length > 0"
-              [rows]="10"
-              [rowsPerPageOptions]="rppOptions()"
-              [loading]="loading()"
-              [showFirstLastIcon]="false"
-              [showCurrentPageReport]="true"
-              currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-              styleClass="[&_table]:table-fixed"
-              data-testid="documents-table">
-              <ng-template #header>
-                <tr>
-                  <th class="w-[33%]">Name</th>
-                  <th class="w-[18%]">Foundation</th>
-                  <th class="w-[18%]">Group / Meeting</th>
-                  <th class="w-[10%]">Source</th>
-                  <th class="w-[13%] whitespace-nowrap">Date</th>
-                  <th class="w-auto"></th>
-                </tr>
-              </ng-template>
-
-              <ng-template #body let-doc let-rowIndex="rowIndex">
-                <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
-                  <!-- Name column -->
-                  <td>
-                    <div class="flex items-center gap-2 min-w-0">
-                      <div class="flex items-center justify-center w-10 h-10 rounded-full border border-gray-200 bg-white shrink-0 shadow">
-                        <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' text-gray-900 text-base'"></i>
-                      </div>
-                      <span
-                        #nameEl
-                        class="text-sm font-medium text-gray-900 truncate min-w-0"
-                        [pTooltip]="doc.name"
-                        tooltipPosition="top"
-                        [tooltipDisabled]="nameEl.scrollWidth <= nameEl.offsetWidth"
-                        [attr.data-testid]="'documents-name-' + doc.id"
-                        >{{ doc.name }}</span
-                      >
-                    </div>
-                  </td>
-
-                  <!-- Foundation column -->
-                  <td>
-                    <span class="text-sm text-gray-700">{{ doc.foundationName || '—' }}</span>
-                  </td>
-
-                  <!-- Group / Meeting column -->
-                  <td>
-                    <span class="text-sm text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
-                  </td>
-
-                  <!-- Source column -->
-                  <td>
-                    <lfx-tag
-                      [value]="doc.source | myDocumentSourceTag: 'label'"
-                      [severity]="doc.source | myDocumentSourceTag: 'severity'"
-                      [attr.data-testid]="'documents-source-tag-' + doc.id">
-                    </lfx-tag>
-                  </td>
-
-                  <!-- Date column -->
-                  <td class="whitespace-nowrap">
-                    <span class="text-sm text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
-                  </td>
-
-                  <!-- Actions column -->
-                  <td>
-                    <div class="flex items-center justify-end gap-1">
-                      @if (doc.source === 'file' && doc.attachmentUid) {
-                        <lfx-button
-                          label="Download"
-                          icon="fa-light fa-arrow-down-to-line"
-                          severity="secondary"
-                          size="small"
-                          [outlined]="true"
-                          styleClass="whitespace-nowrap"
-                          (onClick)="openDocument(doc)"
-                          [attr.data-testid]="'documents-download-' + doc.id">
-                        </lfx-button>
-                      } @else if (doc.url) {
-                        @if (doc.source === 'recording') {
-                          <lfx-button
-                            label="Recording"
-                            icon="fa-light fa-circle-play"
-                            severity="secondary"
-                            size="small"
-                            [outlined]="true"
-                            styleClass="whitespace-nowrap"
-                            (onClick)="openDocument(doc)"
-                            [attr.data-testid]="'documents-open-' + doc.id">
-                          </lfx-button>
-                        } @else {
-                          <lfx-button
-                            label="Open"
-                            icon="fa-light fa-arrow-up-right-from-square"
-                            severity="secondary"
-                            size="small"
-                            [outlined]="true"
-                            styleClass="whitespace-nowrap"
-                            (onClick)="openDocument(doc)"
-                            [attr.data-testid]="'documents-open-' + doc.id">
-                          </lfx-button>
-                        }
-                      }
-                    </div>
-                  </td>
-                </tr>
-              </ng-template>
-            </lfx-table>
-          }
-        </div>
-      }
-    </lfx-card>
-  </div>
+      </lfx-card>
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -17,12 +17,14 @@ import { DOCUMENT_LABEL, MEETING_GROUP_SOURCES } from '@lfx-one/shared/constants
 import { DocumentFormMode, FilterPillOption, MyDocumentItem, MyDocumentSource, ProjectContext, ProjectDocument } from '@lfx-one/shared/interfaces';
 import { DocumentService } from '@services/document.service';
 import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { combineLatest, catchError, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap, take } from 'rxjs';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-tag.pipe';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { DocumentFormComponent } from '@components/document-form/document-form.component';
@@ -42,6 +44,7 @@ import { DocumentFormComponent } from '@components/document-form/document-form.c
     DatePipe,
     MyDocumentSourceTagPipe,
     EmptyStateComponent,
+    SkeletonModule,
     TooltipModule,
   ],
   // NOTE: Do NOT provide MessageService here. It's already provided at root and a single
@@ -56,6 +59,7 @@ export class DocumentsDashboardComponent {
   private readonly documentService = inject(DocumentService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly lensService = inject(LensService);
+  private readonly personaService = inject(PersonaService);
   private readonly dialogService = inject(DialogService);
   private readonly projectService = inject(ProjectService);
 
@@ -97,6 +101,7 @@ export class DocumentsDashboardComponent {
   // === Computed Signals ===
   protected readonly project = this.projectContextService.activeContext;
   protected readonly activeLens = this.lensService.activeLens;
+  protected readonly personaLoaded = this.personaService.personaLoaded;
   // Toolbar gated only on project-scope so it can't render under the legacy aggregator (no-op clicks).
   protected readonly canUpload = computed(() => this.useProjectSource());
   /** True when the dashboard is project-scoped (Project / Foundation lens with active context). */

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -2,7 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  @if (!isMeLens() && (mailingListsLoading() || !servicesLoaded())) {
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
+    </div>
+  } @else if (!isMeLens() && (mailingListsLoading() || !servicesLoaded())) {
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center">
         <i class="fa-light fa-spinner-third fa-spin text-3xl text-blue-600 mb-4"></i>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else if (!isMeLens() && (mailingListsLoading() || !servicesLoaded())) {
     <div class="flex justify-center items-center min-h-96">

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -25,6 +25,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
+import { SkeletonModule } from 'primeng/skeleton';
 import { BehaviorSubject, catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -32,7 +33,7 @@ import { MailingListTableComponent } from '../components/mailing-list-table/mail
 
 @Component({
   selector: 'lfx-mailing-list-dashboard',
-  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule, EmptyStateComponent, StatCardGridComponent],
+  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule, EmptyStateComponent, StatCardGridComponent, SkeletonModule],
   templateUrl: './mailing-list-dashboard.component.html',
   styleUrl: './mailing-list-dashboard.component.scss',
 })
@@ -65,6 +66,7 @@ export class MailingListDashboardComponent {
 
   // Lens
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  protected readonly personaLoaded = this.personaService.personaLoaded;
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
   public myMailingListsLoading = signal<boolean>(true);

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -3,12 +3,12 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else {
-    <div class="mb-8">
+    <div class="mt-3 mb-8">
       <div class="mb-6">
         <div class="flex justify-between items-center w-full gap-4">
           <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -2,327 +2,334 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  <div class="mb-8">
-    <div class="mb-6">
-      <div class="flex justify-between items-center w-full gap-4">
-        <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
-        @if (activeLens() !== 'me' && canWrite()) {
-          <lfx-button
-            icon="fa-light fa-calendar"
-            severity="info"
-            [attr.data-testid]="'meeting-create-button'"
-            label="Create Meeting"
-            size="small"
-            [routerLink]="['/meetings', 'create']">
-          </lfx-button>
-        }
-      </div>
-      <p class="mt-1 text-sm text-gray-500">Coordinate decisions, align stakeholders, and maintain transparent governance in your project</p>
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
     </div>
-
-    @if (activeLens() === 'me') {
-      <div class="mb-6" data-testid="meetings-me-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            @if (timeFilter() === 'upcoming') {
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                  <i class="fa-light fa-calendar text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (meLensStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ upcomingCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Upcoming Meetings</p>
-                  @if (!meLensStatsLoading() && nextMeetingDate()) {
-                    <p class="text-xs text-gray-400">Next: {{ nextMeetingDate() }}</p>
-                  }
-                </div>
-              </div>
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
-                  <i class="fa-light fa-repeat text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (meLensStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ recurringCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Recurring Series</p>
-                  @if (!meLensStatsLoading() && recurringAcrossLabel()) {
-                    <p class="text-xs text-gray-400">{{ recurringAcrossLabel() }}</p>
-                  }
-                </div>
-              </div>
-            } @else {
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                  <i class="fa-light fa-clock-rotate-left text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (meLensStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ pastThisMonthCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Past This Month</p>
-                  @if (!meLensStatsLoading() && pastThisMonthCount() > 0) {
-                    <p class="text-xs text-gray-400">{{ attendanceRate() }}% attendance rate</p>
-                  }
-                </div>
-              </div>
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-red-100 text-red-600 flex-shrink-0">
-                  <i class="fa-light fa-video text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (meLensStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ recordingsAvailableCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Recordings Available</p>
-                  @if (!meLensStatsLoading()) {
-                    <p class="text-xs text-gray-400">From past 30 days</p>
-                  }
-                </div>
-              </div>
-            }
-          </div>
-        </lfx-card>
-      </div>
-    }
-
-    @if (activeLens() !== 'me') {
-      <div class="mb-6" data-testid="meetings-foundation-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            @if (timeFilter() === 'upcoming') {
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                  <i class="fa-light fa-calendar text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (fpStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ fpUpcomingCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Upcoming Meetings</p>
-                </div>
-              </div>
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
-                  <i class="fa-light fa-repeat text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (fpStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ fpRecurringCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Recurring Series</p>
-                </div>
-              </div>
-            } @else {
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                  <i class="fa-light fa-clock-rotate-left text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (fpStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ fpPastCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Past Meetings</p>
-                </div>
-              </div>
-              <div class="flex items-center gap-3 p-4">
-                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-red-100 text-red-600 flex-shrink-0">
-                  <i class="fa-light fa-video text-xl"></i>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  @if (fpStatsLoading()) {
-                    <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                  } @else {
-                    <p class="text-xl font-medium text-gray-900">{{ fpRecordingsAvailableCount() }}</p>
-                  }
-                  <p class="text-sm font-normal text-gray-900">Recordings Available</p>
-                  @if (!fpStatsLoading()) {
-                    <p class="text-xs text-gray-400">From past 30 days</p>
-                  }
-                </div>
-              </div>
-            }
-          </div>
-        </lfx-card>
-      </div>
-    }
-
-    <!-- Top Bar with Tabs, Search, and Meeting Type Filter -->
-    <div class="sticky top-0 md:top-6 z-10 bg-white rounded-lg border border-gray-200 p-4 -mx-0 mb-8">
-      @if (upcomingMeetings() || pastMeetings()) {
-        <lfx-meetings-top-bar
-          [meetingTypeOptions]="meetingTypeOptions()"
-          [foundationOptions]="foundationOptions()"
-          [projectOptions]="projectOptions()"
-          [showFoundationFilter]="showFoundationFilter()"
-          [showProjectFilter]="showProjectFilter()"
-          [timeFilter]="timeFilter()"
-          [pendingRsvpOnly]="pendingRsvpOnly()"
-          [showPendingRsvpFilter]="activeLens() === 'me' && timeFilter() === 'upcoming'"
-          (meetingTypeChange)="onMeetingTypeChange($event)"
-          (foundationFilterChange)="onFoundationFilterChange($event)"
-          (projectFilterChange)="onProjectFilterChange($event)"
-          [searchQuery]="searchQuery()"
-          (searchQueryChange)="searchQuery.set($event)"
-          (timeFilterChange)="onTimeFilterChange($event)"
-          (pendingRsvpOnlyChange)="pendingRsvpOnly.set($event)" />
-      }
-    </div>
-  </div>
-
-  <div class="flex items-center justify-end gap-2 mb-4" data-testid="meetings-view-actions">
-    <div role="group" aria-label="Meetings view" class="flex items-center gap-2" data-testid="meetings-view-toggle">
-      <lfx-button
-        label="List"
-        icon="fa-light fa-list-ul"
-        size="small"
-        [severity]="isListView() ? 'info' : 'secondary'"
-        [outlined]="!isListView()"
-        [ariaLabel]="'List view' + (isListView() ? ' (active)' : '')"
-        (onClick)="viewMode.set('list')"
-        data-testid="meetings-list-btn"></lfx-button>
-      @if (canShowCalendarView()) {
-        <lfx-button
-          label="Calendar"
-          icon="fa-light fa-calendar-days"
-          size="small"
-          [severity]="isCalendarView() ? 'info' : 'secondary'"
-          [outlined]="!isCalendarView()"
-          [ariaLabel]="'Calendar view' + (isCalendarView() ? ' (active)' : '')"
-          (onClick)="viewMode.set('calendar')"
-          data-testid="meetings-calendar-btn"></lfx-button>
-      }
-    </div>
-    @if (canShowCalendarView()) {
-      <lfx-button
-        label="Subscribe"
-        icon="fa-light fa-calendar-arrow-down"
-        severity="secondary"
-        [outlined]="true"
-        size="small"
-        ariaLabel="Subscribe to calendar"
-        (onClick)="onSubscribe()"
-        data-testid="meetings-subscribe-btn"></lfx-button>
-    }
-  </div>
-
-  <div class="min-h-[400px]">
-    @if (isCalendarView()) {
-      <div class="flex flex-col gap-4" data-testid="meetings-calendar-view">
-        <div class="flex items-center gap-4 flex-wrap px-1 text-sm text-gray-500">
-          <span class="flex items-center gap-1.5">
-            <span class="w-2.5 h-2.5 rounded-full bg-blue-500 inline-block"></span>
-            Meeting (default)
-          </span>
-          <span class="flex items-center gap-1.5">
-            <span class="w-2.5 h-2.5 rounded-full bg-gray-400 inline-block"></span>
-            Cancelled
-          </span>
+  } @else {
+    <div class="mb-8">
+      <div class="mb-6">
+        <div class="flex justify-between items-center w-full gap-4">
+          <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
+          @if (activeLens() !== 'me' && canWrite()) {
+            <lfx-button
+              icon="fa-light fa-calendar"
+              severity="info"
+              [attr.data-testid]="'meeting-create-button'"
+              label="Create Meeting"
+              size="small"
+              [routerLink]="['/meetings', 'create']">
+            </lfx-button>
+          }
         </div>
-        @if (calendarLoading()) {
-          <div class="flex items-center justify-center py-20">
-            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
-          </div>
-        } @else {
-          <lfx-fullcalendar [events]="calendarEvents()" (eventClick)="onCalendarEventClick($event)" data-testid="meetings-calendar"></lfx-fullcalendar>
-        }
-      </div>
-    } @else if ((timeFilter() === 'upcoming' && meetingsLoading()) || (timeFilter() === 'past' && pastMeetingsLoading())) {
-      <div class="flex flex-col gap-4">
-        @for (item of [0, 1, 2]; track item) {
-          <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse">
-            <div class="h-6 bg-gray-200 rounded mb-4 w-4/5"></div>
-            <div class="h-5 bg-gray-200 rounded mb-3"></div>
-            <div class="h-4 bg-gray-200 rounded mb-4 w-3/5"></div>
-            <div class="grid grid-cols-2 gap-4 mt-4">
-              <div class="h-24 bg-gray-200 rounded"></div>
-              <div class="h-24 bg-gray-200 rounded"></div>
-            </div>
-          </div>
-        }
-      </div>
-    } @else if (upcomingMeetings().length === 0 && timeFilter() === 'upcoming' && !isFiltered()) {
-      <lfx-empty-state
-        icon="fa-light fa-calendar"
-        [title]="activeLens() === 'me' ? 'No upcoming meetings' : 'No meetings yet'"
-        [subtitle]="activeLens() === 'me' ? 'Meetings from your committees and projects will appear here.' : 'Schedule a meeting to get started.'"
-        data-testid="meetings-empty-state">
-      </lfx-empty-state>
-    } @else if (pastMeetings().length === 0 && timeFilter() === 'past' && !isFiltered()) {
-      <lfx-empty-state
-        icon="fa-light fa-clock-rotate-left"
-        title="No past meetings"
-        [subtitle]="activeLens() === 'me' ? 'Your past meetings will appear here.' : 'Past meetings will appear here once they have occurred.'"
-        data-testid="meetings-empty-state-past">
-      </lfx-empty-state>
-    } @else if (filteredMeetings().length === 0 && (project()?.uid || activeLens() === 'me')) {
-      <lfx-empty-state
-        icon="fa-light fa-eyes"
-        title="No results found"
-        subtitle="Try adjusting your filter criteria"
-        ctaLabel="Reset filters"
-        ctaIcon="fa-light fa-arrow-rotate-left"
-        (ctaClick)="resetFilters()"
-        data-testid="meetings-empty-state-filtered">
-      </lfx-empty-state>
-    } @else if (filteredMeetings().length > 0) {
-      <div class="flex flex-col gap-4">
-        @for (meeting of filteredMeetings(); track meeting.id; let i = $index) {
-          <!-- Invisible sentinel at the midpoint triggers auto-load when scrolled into view -->
-          @if (i === autoLoadTriggerIndex() && hasMore()) {
-            @defer (on viewport) {
-              <div lfxOnRender (rendered)="loadMore()" class="h-0 w-full"></div>
-            } @placeholder {
-              <div class="h-0 w-full" data-testid="meetings-load-more-sentinel"></div>
-            }
-          }
-          @defer (on viewport) {
-            <lfx-meeting-card
-              [attr.id]="'meeting-' + meeting.id"
-              [meetingInput]="meeting"
-              (meetingUpdated)="refreshMeetings()"
-              (meetingDeleted)="refreshMeetings()"
-              [pastMeeting]="timeFilter() === 'past'"
-              [showBorder]="true"></lfx-meeting-card>
-          } @placeholder {
-            <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse min-h-[200px]"></div>
-          }
-        }
+        <p class="mt-1 text-sm text-gray-500">Coordinate decisions, align stakeholders, and maintain transparent governance in your project</p>
       </div>
 
-      @if (hasMore()) {
-        <div class="flex justify-center mt-6">
-          @if (loadingMore()) {
-            <div class="flex flex-col gap-4 w-full">
-              @for (item of [0, 1]; track item) {
-                <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse">
-                  <div class="h-6 bg-gray-200 rounded mb-4 w-4/5"></div>
-                  <div class="h-5 bg-gray-200 rounded mb-3"></div>
-                  <div class="h-4 bg-gray-200 rounded w-3/5"></div>
+      @if (activeLens() === 'me') {
+        <div class="mb-6" data-testid="meetings-me-stats">
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="grid w-full grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+              @if (timeFilter() === 'upcoming') {
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+                    <i class="fa-light fa-calendar text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (meLensStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ upcomingCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Upcoming Meetings</p>
+                    @if (!meLensStatsLoading() && nextMeetingDate()) {
+                      <p class="text-xs text-gray-400">Next: {{ nextMeetingDate() }}</p>
+                    }
+                  </div>
+                </div>
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
+                    <i class="fa-light fa-repeat text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (meLensStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ recurringCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Recurring Series</p>
+                    @if (!meLensStatsLoading() && recurringAcrossLabel()) {
+                      <p class="text-xs text-gray-400">{{ recurringAcrossLabel() }}</p>
+                    }
+                  </div>
+                </div>
+              } @else {
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+                    <i class="fa-light fa-clock-rotate-left text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (meLensStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ pastThisMonthCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Past This Month</p>
+                    @if (!meLensStatsLoading() && pastThisMonthCount() > 0) {
+                      <p class="text-xs text-gray-400">{{ attendanceRate() }}% attendance rate</p>
+                    }
+                  </div>
+                </div>
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-red-100 text-red-600 flex-shrink-0">
+                    <i class="fa-light fa-video text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (meLensStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ recordingsAvailableCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Recordings Available</p>
+                    @if (!meLensStatsLoading()) {
+                      <p class="text-xs text-gray-400">From past 30 days</p>
+                    }
+                  </div>
                 </div>
               }
             </div>
-          } @else {
-            <lfx-button label="Load More" severity="secondary" [attr.data-testid]="'meetings-load-more-button'" (onClick)="loadMore()" />
-          }
+          </lfx-card>
         </div>
       }
-    }
-  </div>
+
+      @if (activeLens() !== 'me') {
+        <div class="mb-6" data-testid="meetings-foundation-stats">
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="grid w-full grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+              @if (timeFilter() === 'upcoming') {
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+                    <i class="fa-light fa-calendar text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (fpStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ fpUpcomingCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Upcoming Meetings</p>
+                  </div>
+                </div>
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
+                    <i class="fa-light fa-repeat text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (fpStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ fpRecurringCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Recurring Series</p>
+                  </div>
+                </div>
+              } @else {
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+                    <i class="fa-light fa-clock-rotate-left text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (fpStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ fpPastCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Past Meetings</p>
+                  </div>
+                </div>
+                <div class="flex items-center gap-3 p-4">
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full bg-red-100 text-red-600 flex-shrink-0">
+                    <i class="fa-light fa-video text-xl"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5">
+                    @if (fpStatsLoading()) {
+                      <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                    } @else {
+                      <p class="text-xl font-medium text-gray-900">{{ fpRecordingsAvailableCount() }}</p>
+                    }
+                    <p class="text-sm font-normal text-gray-900">Recordings Available</p>
+                    @if (!fpStatsLoading()) {
+                      <p class="text-xs text-gray-400">From past 30 days</p>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          </lfx-card>
+        </div>
+      }
+
+      <!-- Top Bar with Tabs, Search, and Meeting Type Filter -->
+      <div class="sticky top-0 md:top-6 z-10 bg-white rounded-lg border border-gray-200 p-4 -mx-0 mb-8">
+        @if (upcomingMeetings() || pastMeetings()) {
+          <lfx-meetings-top-bar
+            [meetingTypeOptions]="meetingTypeOptions()"
+            [foundationOptions]="foundationOptions()"
+            [projectOptions]="projectOptions()"
+            [showFoundationFilter]="showFoundationFilter()"
+            [showProjectFilter]="showProjectFilter()"
+            [timeFilter]="timeFilter()"
+            [pendingRsvpOnly]="pendingRsvpOnly()"
+            [showPendingRsvpFilter]="activeLens() === 'me' && timeFilter() === 'upcoming'"
+            (meetingTypeChange)="onMeetingTypeChange($event)"
+            (foundationFilterChange)="onFoundationFilterChange($event)"
+            (projectFilterChange)="onProjectFilterChange($event)"
+            [searchQuery]="searchQuery()"
+            (searchQueryChange)="searchQuery.set($event)"
+            (timeFilterChange)="onTimeFilterChange($event)"
+            (pendingRsvpOnlyChange)="pendingRsvpOnly.set($event)" />
+        }
+      </div>
+    </div>
+
+    <div class="flex items-center justify-end gap-2 mb-4" data-testid="meetings-view-actions">
+      <div role="group" aria-label="Meetings view" class="flex items-center gap-2" data-testid="meetings-view-toggle">
+        <lfx-button
+          label="List"
+          icon="fa-light fa-list-ul"
+          size="small"
+          [severity]="isListView() ? 'info' : 'secondary'"
+          [outlined]="!isListView()"
+          [ariaLabel]="'List view' + (isListView() ? ' (active)' : '')"
+          (onClick)="viewMode.set('list')"
+          data-testid="meetings-list-btn"></lfx-button>
+        @if (canShowCalendarView()) {
+          <lfx-button
+            label="Calendar"
+            icon="fa-light fa-calendar-days"
+            size="small"
+            [severity]="isCalendarView() ? 'info' : 'secondary'"
+            [outlined]="!isCalendarView()"
+            [ariaLabel]="'Calendar view' + (isCalendarView() ? ' (active)' : '')"
+            (onClick)="viewMode.set('calendar')"
+            data-testid="meetings-calendar-btn"></lfx-button>
+        }
+      </div>
+      @if (canShowCalendarView()) {
+        <lfx-button
+          label="Subscribe"
+          icon="fa-light fa-calendar-arrow-down"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          ariaLabel="Subscribe to calendar"
+          (onClick)="onSubscribe()"
+          data-testid="meetings-subscribe-btn"></lfx-button>
+      }
+    </div>
+
+    <div class="min-h-[400px]">
+      @if (isCalendarView()) {
+        <div class="flex flex-col gap-4" data-testid="meetings-calendar-view">
+          <div class="flex items-center gap-4 flex-wrap px-1 text-sm text-gray-500">
+            <span class="flex items-center gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-blue-500 inline-block"></span>
+              Meeting (default)
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-gray-400 inline-block"></span>
+              Cancelled
+            </span>
+          </div>
+          @if (calendarLoading()) {
+            <div class="flex items-center justify-center py-20">
+              <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+            </div>
+          } @else {
+            <lfx-fullcalendar [events]="calendarEvents()" (eventClick)="onCalendarEventClick($event)" data-testid="meetings-calendar"></lfx-fullcalendar>
+          }
+        </div>
+      } @else if ((timeFilter() === 'upcoming' && meetingsLoading()) || (timeFilter() === 'past' && pastMeetingsLoading())) {
+        <div class="flex flex-col gap-4">
+          @for (item of [0, 1, 2]; track item) {
+            <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse">
+              <div class="h-6 bg-gray-200 rounded mb-4 w-4/5"></div>
+              <div class="h-5 bg-gray-200 rounded mb-3"></div>
+              <div class="h-4 bg-gray-200 rounded mb-4 w-3/5"></div>
+              <div class="grid grid-cols-2 gap-4 mt-4">
+                <div class="h-24 bg-gray-200 rounded"></div>
+                <div class="h-24 bg-gray-200 rounded"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else if (upcomingMeetings().length === 0 && timeFilter() === 'upcoming' && !isFiltered()) {
+        <lfx-empty-state
+          icon="fa-light fa-calendar"
+          [title]="activeLens() === 'me' ? 'No upcoming meetings' : 'No meetings yet'"
+          [subtitle]="activeLens() === 'me' ? 'Meetings from your committees and projects will appear here.' : 'Schedule a meeting to get started.'"
+          data-testid="meetings-empty-state">
+        </lfx-empty-state>
+      } @else if (pastMeetings().length === 0 && timeFilter() === 'past' && !isFiltered()) {
+        <lfx-empty-state
+          icon="fa-light fa-clock-rotate-left"
+          title="No past meetings"
+          [subtitle]="activeLens() === 'me' ? 'Your past meetings will appear here.' : 'Past meetings will appear here once they have occurred.'"
+          data-testid="meetings-empty-state-past">
+        </lfx-empty-state>
+      } @else if (filteredMeetings().length === 0 && (project()?.uid || activeLens() === 'me')) {
+        <lfx-empty-state
+          icon="fa-light fa-eyes"
+          title="No results found"
+          subtitle="Try adjusting your filter criteria"
+          ctaLabel="Reset filters"
+          ctaIcon="fa-light fa-arrow-rotate-left"
+          (ctaClick)="resetFilters()"
+          data-testid="meetings-empty-state-filtered">
+        </lfx-empty-state>
+      } @else if (filteredMeetings().length > 0) {
+        <div class="flex flex-col gap-4">
+          @for (meeting of filteredMeetings(); track meeting.id; let i = $index) {
+            <!-- Invisible sentinel at the midpoint triggers auto-load when scrolled into view -->
+            @if (i === autoLoadTriggerIndex() && hasMore()) {
+              @defer (on viewport) {
+                <div lfxOnRender (rendered)="loadMore()" class="h-0 w-full"></div>
+              } @placeholder {
+                <div class="h-0 w-full" data-testid="meetings-load-more-sentinel"></div>
+              }
+            }
+            @defer (on viewport) {
+              <lfx-meeting-card
+                [attr.id]="'meeting-' + meeting.id"
+                [meetingInput]="meeting"
+                (meetingUpdated)="refreshMeetings()"
+                (meetingDeleted)="refreshMeetings()"
+                [pastMeeting]="timeFilter() === 'past'"
+                [showBorder]="true"></lfx-meeting-card>
+            } @placeholder {
+              <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse min-h-[200px]"></div>
+            }
+          }
+        </div>
+
+        @if (hasMore()) {
+          <div class="flex justify-center mt-6">
+            @if (loadingMore()) {
+              <div class="flex flex-col gap-4 w-full">
+                @for (item of [0, 1]; track item) {
+                  <div class="bg-white border border-gray-200 rounded-lg p-6 animate-pulse">
+                    <div class="h-6 bg-gray-200 rounded mb-4 w-4/5"></div>
+                    <div class="h-5 bg-gray-200 rounded mb-3"></div>
+                    <div class="h-4 bg-gray-200 rounded w-3/5"></div>
+                  </div>
+                }
+              </div>
+            } @else {
+              <lfx-button label="Load More" severity="secondary" [attr.data-testid]="'meetings-load-more-button'" (onClick)="loadMore()" />
+            }
+          </div>
+        }
+      }
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -23,6 +23,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
 import { DialogService } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
 import {
   BehaviorSubject,
   catchError,
@@ -47,7 +48,16 @@ import { MeetingsTopBarComponent } from './components/meetings-top-bar/meetings-
 
 @Component({
   selector: 'lfx-meetings-dashboard',
-  imports: [MeetingCardComponent, MeetingsTopBarComponent, ButtonComponent, CardComponent, OnRenderDirective, EmptyStateComponent, FullCalendarComponent],
+  imports: [
+    MeetingCardComponent,
+    MeetingsTopBarComponent,
+    ButtonComponent,
+    CardComponent,
+    OnRenderDirective,
+    EmptyStateComponent,
+    FullCalendarComponent,
+    SkeletonModule,
+  ],
   providers: [DialogService],
   templateUrl: './meetings-dashboard.component.html',
   styleUrl: './meetings-dashboard.component.scss',
@@ -64,6 +74,7 @@ export class MeetingsDashboardComponent {
   private readonly dialogService = inject(DialogService);
 
   public readonly activeLens: Signal<Lens> = this.lensService.activeLens;
+  protected readonly personaLoaded = this.personaService.personaLoaded;
 
   public viewMode = signal<ViewMode>('list');
   public isListView = computed(() => this.viewMode() === 'list');

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -2,64 +2,71 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  <!-- Page Header -->
-  <div class="flex items-center justify-between mb-6">
-    <div>
-      <h1 class="font-display font-light text-2xl" data-testid="surveys-dashboard-title">{{ isMeLens() ? 'My ' + surveyLabelPlural : surveyLabelPlural }}</h1>
-      <p class="mt-1 text-sm text-gray-500" data-testid="surveys-dashboard-description">
-        {{
-          isMeLens()
-            ? surveyLabelPlural + ' you have been invited to across all foundations and projects.'
-            : 'Create and manage surveys to gather feedback from your community.'
-        }}
-      </p>
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
     </div>
-    @if (!isMeLens() && canWrite()) {
-      <lfx-button
-        [label]="'Create ' + surveyLabel"
-        size="small"
-        icon="fa-light fa-clipboard-list"
-        severity="primary"
-        [routerLink]="['/surveys', 'create']"
-        data-testid="surveys-create-button">
-      </lfx-button>
-    }
-  </div>
-
-  <!-- Loading State (non-Me lens only) -->
-  @if (!isMeLens() && loading()) {
-    <div class="flex justify-center items-center min-h-96">
-      <div class="text-center">
-        <i class="fa-light fa-spinner-third fa-spin text-3xl text-violet-600 mb-4"></i>
-        <p class="text-gray-600">Loading {{ surveyLabel | lowercase }} details...</p>
-      </div>
-    </div>
-  } @else if (!isMeLens() && surveys().length === 0) {
-    <lfx-empty-state
-      icon="fa-light fa-clipboard-list"
-      [title]="'No ' + (surveyLabelPlural | lowercase) + ' yet'"
-      [subtitle]="'Create a ' + (surveyLabel | lowercase) + ' to gather feedback from your project community.'"
-      [ctaLabel]="canWrite() ? 'Create ' + surveyLabel : undefined"
-      [ctaRoute]="canWrite() ? ['/surveys', 'create'] : undefined"
-      data-testid="surveys-empty-state-card">
-    </lfx-empty-state>
   } @else {
-    <lfx-surveys-table
-      [surveys]="isMeLens() ? filteredMySurveys() : surveys()"
-      [hasPMOAccess]="!isMeLens() && canWrite()"
-      [loading]="isMeLens() ? mySurveysLoading() : loading()"
-      [isMeLens]="isMeLens()"
-      [foundationOptions]="foundationOptions()"
-      [projectOptions]="projectOptions()"
-      [showFoundationFilter]="showFoundationFilter()"
-      [showProjectFilter]="showProjectFilter()"
-      (foundationFilterChange)="onFoundationFilterChange($event)"
-      (projectFilterChange)="onProjectFilterChange($event)"
-      (viewResults)="onViewResults($event)"
-      (rowClick)="onRowClick($event)"
-      (refresh)="refreshSurveys()"
-      data-testid="surveys-table-container">
-    </lfx-surveys-table>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="font-display font-light text-2xl" data-testid="surveys-dashboard-title">{{ isMeLens() ? 'My ' + surveyLabelPlural : surveyLabelPlural }}</h1>
+        <p class="mt-1 text-sm text-gray-500" data-testid="surveys-dashboard-description">
+          {{
+            isMeLens()
+              ? surveyLabelPlural + ' you have been invited to across all foundations and projects.'
+              : 'Create and manage surveys to gather feedback from your community.'
+          }}
+        </p>
+      </div>
+      @if (!isMeLens() && canWrite()) {
+        <lfx-button
+          [label]="'Create ' + surveyLabel"
+          size="small"
+          icon="fa-light fa-clipboard-list"
+          severity="primary"
+          [routerLink]="['/surveys', 'create']"
+          data-testid="surveys-create-button">
+        </lfx-button>
+      }
+    </div>
+
+    <!-- Loading State (non-Me lens only) -->
+    @if (!isMeLens() && loading()) {
+      <div class="flex justify-center items-center min-h-96">
+        <div class="text-center">
+          <i class="fa-light fa-spinner-third fa-spin text-3xl text-violet-600 mb-4"></i>
+          <p class="text-gray-600">Loading {{ surveyLabel | lowercase }} details...</p>
+        </div>
+      </div>
+    } @else if (!isMeLens() && surveys().length === 0) {
+      <lfx-empty-state
+        icon="fa-light fa-clipboard-list"
+        [title]="'No ' + (surveyLabelPlural | lowercase) + ' yet'"
+        [subtitle]="'Create a ' + (surveyLabel | lowercase) + ' to gather feedback from your project community.'"
+        [ctaLabel]="canWrite() ? 'Create ' + surveyLabel : undefined"
+        [ctaRoute]="canWrite() ? ['/surveys', 'create'] : undefined"
+        data-testid="surveys-empty-state-card">
+      </lfx-empty-state>
+    } @else {
+      <lfx-surveys-table
+        [surveys]="isMeLens() ? filteredMySurveys() : surveys()"
+        [hasPMOAccess]="!isMeLens() && canWrite()"
+        [loading]="isMeLens() ? mySurveysLoading() : loading()"
+        [isMeLens]="isMeLens()"
+        [foundationOptions]="foundationOptions()"
+        [projectOptions]="projectOptions()"
+        [showFoundationFilter]="showFoundationFilter()"
+        [showProjectFilter]="showProjectFilter()"
+        (foundationFilterChange)="onFoundationFilterChange($event)"
+        (projectFilterChange)="onProjectFilterChange($event)"
+        (viewResults)="onViewResults($event)"
+        (rowClick)="onRowClick($event)"
+        (refresh)="refreshSurveys()"
+        data-testid="surveys-table-container">
+      </lfx-surveys-table>
+    }
   }
 </div>
 

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else {
     <!-- Page Header -->

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -13,6 +13,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
+import { SkeletonModule } from 'primeng/skeleton';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MyResponseDrawerComponent } from '../components/my-response-drawer/my-response-drawer.component';
@@ -21,7 +22,16 @@ import { SurveysTableComponent } from '../components/surveys-table/surveys-table
 
 @Component({
   selector: 'lfx-surveys-dashboard',
-  imports: [LowerCasePipe, ButtonComponent, SurveysTableComponent, RouterLink, SurveyResultsDrawerComponent, MyResponseDrawerComponent, EmptyStateComponent],
+  imports: [
+    LowerCasePipe,
+    ButtonComponent,
+    SurveysTableComponent,
+    RouterLink,
+    SurveyResultsDrawerComponent,
+    MyResponseDrawerComponent,
+    EmptyStateComponent,
+    SkeletonModule,
+  ],
   templateUrl: './surveys-dashboard.component.html',
   styleUrl: './surveys-dashboard.component.scss',
 })
@@ -52,6 +62,7 @@ export class SurveysDashboardComponent {
 
   // === Lens ===
   protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  protected readonly personaLoaded = this.personaService.personaLoaded;
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -2,60 +2,67 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  <!-- Page Header -->
-  <div class="flex items-center justify-between mb-6">
-    <div>
-      <h1 class="font-display font-light text-2xl" data-testid="votes-dashboard-title">{{ isMeLens() ? 'My ' + voteLabelPlural : voteLabelPlural }}</h1>
-      <p class="mt-1 text-sm text-gray-500" data-testid="votes-dashboard-description">
-        {{ isMeLens() ? voteLabelPlural + ' you have been invited to across all foundations and projects.' : 'Make decisions with your project groups.' }}
-      </p>
+  @if (!personaLoaded()) {
+    <div class="mt-3 flex flex-col gap-4">
+      <p-skeleton width="12rem" height="2rem" />
+      <p-skeleton width="28rem" height="1rem" />
     </div>
-    @if (!isMeLens() && canWrite()) {
-      <lfx-button
-        [label]="'Create ' + voteLabel"
-        size="small"
-        icon="fa-light fa-check-to-slot"
-        severity="primary"
-        [routerLink]="['/votes', 'create']"
-        data-testid="votes-create-button">
-      </lfx-button>
-    }
-  </div>
-
-  <!-- Dashboard-level empty state: only when there are genuinely no votes (no active filter). -->
-  <!-- Keep the table mounted in every other case so its form subscription doesn't re-fire on remount. -->
-  @if (!isMeLens() && !loading() && votes().length === 0 && !hasActiveFilters()) {
-    <lfx-empty-state
-      icon="fa-light fa-check-to-slot"
-      [title]="'No ' + (voteLabelPlural | lowercase) + ' yet'"
-      [subtitle]="'Create a ' + (voteLabel | lowercase) + ' to gather decisions from project groups.'"
-      [ctaLabel]="canWrite() ? 'Create ' + voteLabel : undefined"
-      [ctaRoute]="canWrite() ? ['/votes', 'create'] : undefined"
-      data-testid="votes-empty-state-card">
-    </lfx-empty-state>
   } @else {
-    <lfx-votes-table
-      [votes]="isMeLens() ? filteredMyVotes() : votes()"
-      [hasPMOAccess]="!isMeLens() && canWrite()"
-      [loading]="isMeLens() ? myVotesLoading() : loading()"
-      [totalRecords]="isMeLens() ? filteredMyVotes().length : totalRecords()"
-      [rowsPerPage]="rowsPerPage()"
-      [first]="isMeLens() ? 0 : currentFirst()"
-      [lazy]="!isMeLens()"
-      [groupOptions]="groupOptions()"
-      [foundationOptions]="foundationOptions()"
-      [projectOptions]="projectOptions()"
-      [showFoundationFilter]="showFoundationFilter()"
-      [showProjectFilter]="showProjectFilter()"
-      (foundationFilterChange)="onFoundationFilterChange($event)"
-      (projectFilterChange)="onProjectFilterChange($event)"
-      (viewVote)="onViewVote($event)"
-      (viewResults)="onViewResults($event)"
-      (refresh)="refreshVotes()"
-      (pageChange)="onPageChange($event)"
-      (filtersChange)="onFiltersChange($event)"
-      data-testid="votes-table-container">
-    </lfx-votes-table>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="font-display font-light text-2xl" data-testid="votes-dashboard-title">{{ isMeLens() ? 'My ' + voteLabelPlural : voteLabelPlural }}</h1>
+        <p class="mt-1 text-sm text-gray-500" data-testid="votes-dashboard-description">
+          {{ isMeLens() ? voteLabelPlural + ' you have been invited to across all foundations and projects.' : 'Make decisions with your project groups.' }}
+        </p>
+      </div>
+      @if (!isMeLens() && canWrite()) {
+        <lfx-button
+          [label]="'Create ' + voteLabel"
+          size="small"
+          icon="fa-light fa-check-to-slot"
+          severity="primary"
+          [routerLink]="['/votes', 'create']"
+          data-testid="votes-create-button">
+        </lfx-button>
+      }
+    </div>
+
+    <!-- Dashboard-level empty state: only when there are genuinely no votes (no active filter). -->
+    <!-- Keep the table mounted in every other case so its form subscription doesn't re-fire on remount. -->
+    @if (!isMeLens() && !loading() && votes().length === 0 && !hasActiveFilters()) {
+      <lfx-empty-state
+        icon="fa-light fa-check-to-slot"
+        [title]="'No ' + (voteLabelPlural | lowercase) + ' yet'"
+        [subtitle]="'Create a ' + (voteLabel | lowercase) + ' to gather decisions from project groups.'"
+        [ctaLabel]="canWrite() ? 'Create ' + voteLabel : undefined"
+        [ctaRoute]="canWrite() ? ['/votes', 'create'] : undefined"
+        data-testid="votes-empty-state-card">
+      </lfx-empty-state>
+    } @else {
+      <lfx-votes-table
+        [votes]="isMeLens() ? filteredMyVotes() : votes()"
+        [hasPMOAccess]="!isMeLens() && canWrite()"
+        [loading]="isMeLens() ? myVotesLoading() : loading()"
+        [totalRecords]="isMeLens() ? filteredMyVotes().length : totalRecords()"
+        [rowsPerPage]="rowsPerPage()"
+        [first]="isMeLens() ? 0 : currentFirst()"
+        [lazy]="!isMeLens()"
+        [groupOptions]="groupOptions()"
+        [foundationOptions]="foundationOptions()"
+        [projectOptions]="projectOptions()"
+        [showFoundationFilter]="showFoundationFilter()"
+        [showProjectFilter]="showProjectFilter()"
+        (foundationFilterChange)="onFoundationFilterChange($event)"
+        (projectFilterChange)="onProjectFilterChange($event)"
+        (viewVote)="onViewVote($event)"
+        (viewResults)="onViewResults($event)"
+        (refresh)="refreshVotes()"
+        (pageChange)="onPageChange($event)"
+        (filtersChange)="onFiltersChange($event)"
+        data-testid="votes-table-container">
+      </lfx-votes-table>
+    }
   }
 </div>
 

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   @if (!personaLoaded()) {
-    <div class="mt-3 flex flex-col gap-4">
+    <div class="mt-3 flex flex-col gap-4" data-testid="dashboard-persona-loading">
       <p-skeleton width="12rem" height="2rem" />
-      <p-skeleton width="28rem" height="1rem" />
+      <p-skeleton width="min(28rem, 100%)" height="1rem" />
     </div>
   } @else {
     <!-- Page Header -->

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -14,8 +14,8 @@ import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
-import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
 import { SkeletonModule } from 'primeng/skeleton';
+import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
 
 import { VoteCastDrawerComponent } from '../components/vote-cast-drawer/vote-cast-drawer.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -15,6 +15,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
+import { SkeletonModule } from 'primeng/skeleton';
 
 import { VoteCastDrawerComponent } from '../components/vote-cast-drawer/vote-cast-drawer.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
@@ -22,7 +23,16 @@ import { VotesTableComponent } from '../components/votes-table/votes-table.compo
 
 @Component({
   selector: 'lfx-votes-dashboard',
-  imports: [LowerCasePipe, ButtonComponent, VotesTableComponent, VoteResultsDrawerComponent, VoteCastDrawerComponent, RouterLink, EmptyStateComponent],
+  imports: [
+    LowerCasePipe,
+    ButtonComponent,
+    VotesTableComponent,
+    VoteResultsDrawerComponent,
+    VoteCastDrawerComponent,
+    RouterLink,
+    EmptyStateComponent,
+    SkeletonModule,
+  ],
   templateUrl: './votes-dashboard.component.html',
   styleUrl: './votes-dashboard.component.scss',
 })
@@ -59,6 +69,7 @@ export class VotesDashboardComponent {
 
   // === Lens ===
   protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  protected readonly personaLoaded = this.personaService.personaLoaded;
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 


### PR DESCRIPTION
## Summary

- **Root cause**: `DEFAULT_LENS = 'me'` causes all lens-aware dashboard pages to briefly render Me-lens content (e.g. "My Votes", "My Surveys") before the persona API responds and sets the correct lens for the authenticated user.
- **Fix**: Added a `personaLoaded` skeleton guard (`@if (!personaLoaded()) { ... } @else { ... }`) to 6 dashboard pages — committees, meetings, mailing-lists, votes, surveys, and documents — matching the pattern already used by the votes and surveys dashboards introduced in LFXV2-1917.
- `personaLoaded` is a `WritableSignal<boolean>` on `PersonaService` set to `true` after the persona API responds (including on error), so the guard resolves quickly and has no impact on time-to-interactive.

## Pages fixed

| Page | Change |
|------|--------|
| `committee-dashboard` | Added `personaLoaded` guard + skeleton |
| `meetings-dashboard` | Added `SkeletonModule` import + `personaLoaded` guard + skeleton |
| `mailing-list-dashboard` | Added `SkeletonModule` import + `personaLoaded` as first guard (restructured existing `@if/@else if` chain) |
| `votes-dashboard` | Added `SkeletonModule` import + `personaLoaded` guard + skeleton (already had the pattern, applied it consistently) |
| `surveys-dashboard` | Added `SkeletonModule` import + `personaLoaded` guard + skeleton (already had the pattern, applied it consistently) |
| `documents-dashboard` | Added `PersonaService` injection + `SkeletonModule` import + `personaLoaded` guard + skeleton |

## Skeleton pattern (consistent across all pages)

```html
@if (!personaLoaded()) {
  <div class="mt-3 flex flex-col gap-4">
    <p-skeleton width="12rem" height="2rem" />
    <p-skeleton width="28rem" height="1rem" />
  </div>
} @else {
  <!-- existing page content -->
}
```

## Test plan

- [ ] Switch between Me lens and project/foundation/org lens — verify no flash of wrong lens title on any of the 6 pages
- [ ] Confirm skeleton appears briefly on page load before persona resolves
- [ ] Confirm drawers (votes, surveys) outside the container div are unaffected
- [ ] Verify mailing-list-dashboard loading/empty states still render correctly after the guard restructure

Fixes LFXV2-1538