### PR TITLE
refactor(profile): tighten gatewayFetch return type and drop DatePipe DI

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -3,7 +3,7 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { DatePipe } from '@angular/common';
+import { DatePipe, formatDate } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
@@ -28,13 +28,12 @@ import { EnrollmentService } from '@services/enrollment.service';
   templateUrl: './profile-individual-enrollment.component.html',
   styleUrl: './profile-individual-enrollment.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [ConfirmationService, MessageService, DatePipe],
+  providers: [ConfirmationService, MessageService],
 })
 export class ProfileIndividualEnrollmentComponent {
   private readonly enrollmentService = inject(EnrollmentService);
   private readonly confirmationService = inject(ConfirmationService);
   private readonly messageService = inject(MessageService);
-  private readonly datePipe = inject(DatePipe);
 
   protected readonly enrollments = signal<DisplayEnrollment[] | null | undefined>(undefined);
   protected readonly enrollmentError = signal<string | null>(null);
@@ -91,7 +90,7 @@ export class ProfileIndividualEnrollmentComponent {
       return next;
     });
 
-    const endDate = item.membership.EndDate ? (this.datePipe.transform(item.membership.EndDate, 'mediumDate', 'UTC') ?? '') : '';
+    const endDate = item.membership.EndDate ? formatDate(item.membership.EndDate, 'mediumDate', 'en-US', 'UTC') : '';
     const message = newValue
       ? `This will Enable auto renew for your membership, your next payment will be charged on ${endDate}.`
       : `This will Disable auto renew for your membership, your current membership will expire on ${endDate}.`;

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -25,9 +25,9 @@ export interface GatewayFetchOptions {
  * pass options.bearerToken to override (e.g. for user-token-authenticated calls).
  * Handles timeout (504), network failure (502), non-OK upstream responses,
  * and invalid JSON — all surfaced as MicroserviceError.
- * 204 responses return null without error; all other empty bodies are errors.
+ * 204 responses return null; all other empty bodies throw MicroserviceError.
  */
-export async function gatewayFetch<T>(req: Request, url: string, options: GatewayFetchOptions): Promise<T> {
+export async function gatewayFetch<T>(req: Request, url: string, options: GatewayFetchOptions): Promise<T | null> {
   const token = options.bearerToken ?? req.apiGatewayToken;
 
   if (!token) {
@@ -98,7 +98,7 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
 
   if (!rawBody.trim()) {
     if (upstream.status === 204) {
-      return null as T;
+      return null;
     }
 
     logger.warning(req, options.operation, 'Upstream returned empty response body', {


### PR DESCRIPTION
## Summary

- `gatewayFetch` return type changed from `Promise<T>` to `Promise<T | null>` — the
  function has always returned `null` on HTTP 204 responses, but the old signature
  silently lied to callers via `return null as T`. The JSDoc is updated to match.
- Removed `DatePipe` from `providers` and the injected `datePipe` field in
  `ProfileIndividualEnrollmentComponent`; the single dialog-message formatting call
  is replaced with the standalone `formatDate()` from `@angular/common`. `DatePipe`
  stays in the component's `imports` array (still required by the template's `| date`
  pipe).

Both changes address nit-level observations from the [PR #740](https://github.com/linuxfoundation/lfx-self-serve/pull/740) review that were non-blocking at merge time.

## Test plan

- [x] Profile → Individual Enrollment: toggle Auto Renew on a Stripe-paid active
      membership — confirm dialog shows the correct UTC-formatted renewal/expiry date
      (unchanged from before)
- [x] Cancel the confirm dialog — toggle reverts, no network call
- [x] Confirm the dialog — PATCH succeeds, success toast shown, toggle stays in new state
- [x] `yarn build` passes (Angular compiler validates `DatePipe` still resolves in template)
- [x] `yarn check-types` passes (all `gatewayFetch` callers type-check against `T | null`)