### PR TITLE
feat(newsletters): add view-content drawer to sent newsletter list

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -106,7 +106,7 @@
                           ariaLabel="View newsletter"
                           (onClick)="openPreview(newsletter, $event)"
                           [attr.data-testid]="'newsletter-view-' + newsletter.id"
-                          pTooltip="View newsletter"
+                          pTooltip="Open preview of this sent newsletter"
                           tooltipPosition="top">
                         </lfx-button>
                         <lfx-tag value="Sent" severity="success"></lfx-tag>
@@ -158,13 +158,18 @@
 <p-confirmDialog></p-confirmDialog>
 
 @if (selectedNewsletter(); as n) {
+  <!--
+    Sent previews intentionally do not pass edName / displayName / logoUrl: those values would be
+    sourced from the *current* viewer/context, not from what recipients actually saw at send time.
+    The preview component already falls back to neutral labels ("Executive Director" / "Foundation").
+    True fidelity needs a backend snapshot of sender + project at send time — tracked as follow-up.
+  -->
   <lfx-newsletter-preview-drawer
     [(visible)]="previewVisible"
     [subject]="n.subject"
     [bodyHtml]="n.bodyHtml"
-    [edName]="edName()"
-    [logoUrl]="logoUrl()"
-    [displayName]="displayName()"
+    [edName]="''"
+    [displayName]="''"
     [edReplyEmail]="n.edReplyEmail">
   </lfx-newsletter-preview-drawer>
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -103,6 +103,7 @@
                           severity="secondary"
                           size="small"
                           [text]="true"
+                          ariaLabel="View newsletter"
                           (onClick)="openPreview(newsletter, $event)"
                           [attr.data-testid]="'newsletter-view-' + newsletter.id"
                           pTooltip="View newsletter"

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -97,7 +97,19 @@
                       </span>
                     </td>
                     <td class="text-right">
-                      <lfx-tag value="Sent" severity="success"></lfx-tag>
+                      <div class="flex items-center justify-end gap-2">
+                        <lfx-button
+                          icon="fa-light fa-eye"
+                          severity="secondary"
+                          size="small"
+                          [text]="true"
+                          (onClick)="openPreview(newsletter, $event)"
+                          [attr.data-testid]="'newsletter-view-' + newsletter.id"
+                          pTooltip="View newsletter"
+                          tooltipPosition="top">
+                        </lfx-button>
+                        <lfx-tag value="Sent" severity="success"></lfx-tag>
+                      </div>
                     </td>
                   } @else {
                     <td>
@@ -143,3 +155,15 @@
 </div>
 
 <p-confirmDialog></p-confirmDialog>
+
+@if (selectedNewsletter(); as n) {
+  <lfx-newsletter-preview-drawer
+    [(visible)]="previewVisible"
+    [subject]="n.subject"
+    [bodyHtml]="n.bodyHtml"
+    [edName]="edName()"
+    [logoUrl]="logoUrl()"
+    [displayName]="displayName()"
+    [edReplyEmail]="n.edReplyEmail">
+  </lfx-newsletter-preview-drawer>
+}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -23,11 +23,12 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, finalize, map, of, switchMap, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -53,6 +54,7 @@ export class NewsletterListComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
   private readonly newsletterService = inject(NewsletterService);
+  private readonly projectService = inject(ProjectService);
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
   private readonly confirmationService = inject(ConfirmationService);
@@ -75,6 +77,7 @@ export class NewsletterListComponent {
   protected readonly deletingId = signal<string | null>(null);
   protected readonly previewVisible = signal<boolean>(false);
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
+  private readonly fetchedLogoUrl = signal<string | undefined>(undefined);
 
   // === Reactive context ===
   public readonly activeContext: Signal<ProjectContext | null> = this.projectContextService.activeContext;
@@ -83,7 +86,7 @@ export class NewsletterListComponent {
   public readonly contextType: Signal<NewsletterContextType> = computed(() => (this.isFoundationContext() ? 'foundation' : 'project'));
   public readonly hasContext: Signal<boolean> = computed(() => this.contextUid().length > 0);
   public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
-  public readonly logoUrl: Signal<string | undefined> = computed(() => this.activeContext()?.logoUrl ?? undefined);
+  public readonly logoUrl: Signal<string | undefined> = computed(() => this.activeContext()?.logoUrl || this.fetchedLogoUrl());
   public readonly edName: Signal<string> = computed(() => {
     const user = this.userService.user();
     return user?.name || user?.given_name || user?.nickname || 'Executive Director';
@@ -110,6 +113,7 @@ export class NewsletterListComponent {
 
   public constructor() {
     this.initLoadOnContextOrTab();
+    this.initContextLogo();
   }
 
   protected onStatusTabChange(tab: string): void {
@@ -208,6 +212,24 @@ export class NewsletterListComponent {
           this.nextPageToken.set(undefined);
         }
       });
+  }
+
+  private initContextLogo(): void {
+    toObservable(this.activeContext)
+      .pipe(
+        switchMap((ctx) => {
+          if (ctx?.logoUrl || !ctx?.slug) {
+            this.fetchedLogoUrl.set(undefined);
+            return of(undefined);
+          }
+          return this.projectService.getProject(ctx.slug, false).pipe(
+            map((project) => project?.logo_url || undefined),
+            catchError(() => of(undefined))
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((url) => this.fetchedLogoUrl.set(url));
   }
 
   private loadInitial(status: NewsletterStatus): void {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -23,10 +23,13 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
+
+import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
 @Component({
   selector: 'lfx-newsletter-list',
@@ -40,6 +43,7 @@ import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
     TagComponent,
     ConfirmDialogModule,
     TooltipModule,
+    NewsletterPreviewDrawerComponent,
   ],
   providers: [ConfirmationService],
   templateUrl: './newsletter-list.component.html',
@@ -49,6 +53,7 @@ export class NewsletterListComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
   private readonly newsletterService = inject(NewsletterService);
+  private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
   private readonly confirmationService = inject(ConfirmationService);
   private readonly router = inject(Router);
@@ -68,6 +73,8 @@ export class NewsletterListComponent {
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly nextPageToken = signal<string | undefined>(undefined);
   protected readonly deletingId = signal<string | null>(null);
+  protected readonly previewVisible = signal<boolean>(false);
+  protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
 
   // === Reactive context ===
   public readonly activeContext: Signal<ProjectContext | null> = this.projectContextService.activeContext;
@@ -75,6 +82,12 @@ export class NewsletterListComponent {
   public readonly contextUid: Signal<string> = this.projectContextService.activeContextUid;
   public readonly contextType: Signal<NewsletterContextType> = computed(() => (this.isFoundationContext() ? 'foundation' : 'project'));
   public readonly hasContext: Signal<boolean> = computed(() => this.contextUid().length > 0);
+  public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
+  public readonly logoUrl: Signal<string | undefined> = computed(() => this.activeContext()?.logoUrl ?? undefined);
+  public readonly edName: Signal<string> = computed(() => {
+    const user = this.userService.user();
+    return user?.name || user?.given_name || user?.nickname || 'Executive Director';
+  });
   protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore());
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
 
@@ -112,6 +125,12 @@ export class NewsletterListComponent {
   protected goToRow(item: NewsletterListItem): void {
     const target = this.statusTab() === 'sent' ? 'analytics' : 'edit';
     this.router.navigate(['..', item.id, target], { relativeTo: this.route });
+  }
+
+  protected openPreview(item: NewsletterListItem, event: Event): void {
+    event.stopPropagation();
+    this.selectedNewsletter.set(item);
+    this.previewVisible.set(true);
   }
 
   protected loadMore(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -23,12 +23,10 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { ProjectService } from '@services/project.service';
-import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, distinctUntilChanged, finalize, map, of, switchMap, take } from 'rxjs';
+import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -54,8 +52,6 @@ export class NewsletterListComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
   private readonly newsletterService = inject(NewsletterService);
-  private readonly projectService = inject(ProjectService);
-  private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
   private readonly confirmationService = inject(ConfirmationService);
   private readonly router = inject(Router);
@@ -77,7 +73,6 @@ export class NewsletterListComponent {
   protected readonly deletingId = signal<string | null>(null);
   protected readonly previewVisible = signal<boolean>(false);
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
-  private readonly fetchedLogoUrl = signal<string | undefined>(undefined);
 
   // === Reactive context ===
   public readonly activeContext: Signal<ProjectContext | null> = this.projectContextService.activeContext;
@@ -85,12 +80,6 @@ export class NewsletterListComponent {
   public readonly contextUid: Signal<string> = this.projectContextService.activeContextUid;
   public readonly contextType: Signal<NewsletterContextType> = computed(() => (this.isFoundationContext() ? 'foundation' : 'project'));
   public readonly hasContext: Signal<boolean> = computed(() => this.contextUid().length > 0);
-  public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
-  public readonly logoUrl: Signal<string | undefined> = computed(() => this.activeContext()?.logoUrl || this.fetchedLogoUrl());
-  public readonly edName: Signal<string> = computed(() => {
-    const user = this.userService.user();
-    return user?.name || user?.given_name || user?.nickname || 'Executive Director';
-  });
   protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore());
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
 
@@ -113,7 +102,6 @@ export class NewsletterListComponent {
 
   public constructor() {
     this.initLoadOnContextOrTab();
-    this.initContextLogo();
   }
 
   protected onStatusTabChange(tab: string): void {
@@ -205,6 +193,9 @@ export class NewsletterListComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(([uid, status]) => {
+        // Reset any open preview so stale newsletter content doesn't bleed across context/tab changes.
+        this.previewVisible.set(false);
+        this.selectedNewsletter.set(null);
         if (uid) {
           this.loadInitial(status as NewsletterStatus);
         } else {
@@ -212,24 +203,6 @@ export class NewsletterListComponent {
           this.nextPageToken.set(undefined);
         }
       });
-  }
-
-  private initContextLogo(): void {
-    toObservable(this.activeContext)
-      .pipe(
-        switchMap((ctx) => {
-          if (ctx?.logoUrl || !ctx?.slug) {
-            this.fetchedLogoUrl.set(undefined);
-            return of(undefined);
-          }
-          return this.projectService.getProject(ctx.slug, false).pipe(
-            map((project) => project?.logo_url || undefined),
-            catchError(() => of(undefined))
-          );
-        }),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe((url) => this.fetchedLogoUrl.set(url));
   }
 
   private loadInitial(status: NewsletterStatus): void {


### PR DESCRIPTION
## Summary

- Adds an eye-icon action on each row in the **Sent** tab of the Newsletters list. Clicking it opens the existing `NewsletterPreviewDrawerComponent` rendering the full envelope the recipients received — subject, ED name, logo, body HTML, reply-to.
- Row click behavior is unchanged: clicking the row still navigates to the analytics page. `event.stopPropagation()` keeps the eye action separate from the row click.
- Mirrors `initContextLogo` from `newsletter-manage` so the preview falls back to fetching the project logo when the active context lacks one — ensures the displayed logo matches what was actually sent.

No backend changes — the list endpoint already returns the full `Newsletter` shape (`bodyHtml`, `edReplyEmail`, `subject`, etc.) and the existing `NewsletterPreviewComponent` / `NewsletterPreviewDrawerComponent` are reused as-is.

## Test plan

- [ ] Navigate to a foundation or project that has sent newsletters
- [ ] In the **Sent** tab, every row shows the eye icon next to the "Sent" tag
- [ ] In the **Drafts** tab, the eye icon does NOT appear
- [ ] Click the eye icon on a sent row → drawer slides in from the right with subject, ED name, logo, body HTML, reply-to
- [ ] Verify the URL did NOT change (row click did not also fire)
- [ ] Close the drawer via header X and via footer Close — both work
- [ ] Open one row's preview, close it, open another row — content updates correctly per row
- [ ] Click a row (outside the eye icon) → still navigates to `/:id/analytics`
- [ ] For a project where `ProjectContext.logoUrl` is empty, verify the preview still shows the project logo (fetched via `projectService.getProject(slug, false)`)
- [ ] Screen reader announces "View newsletter" on the eye-icon button (aria-label)