### PR TITLE
feat(dashboards): add social listening sidebar entry for ed persona (LFXV2-1689)

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -283,14 +283,14 @@ export class MainLayoutComponent {
         },
       ];
 
-      const foundationUid = this.projectContextService.selectedFoundation()?.uid;
-      if (foundationUid) {
+      const foundationSfid = this.projectContextService.selectedFoundationSfid();
+      if (foundationSfid) {
         const pccBaseUrl = environment.urls.pcc;
         const baseUrl = pccBaseUrl.endsWith('/') ? pccBaseUrl.slice(0, -1) : pccBaseUrl;
         metricsItems.push({
           label: 'Social Listening',
           icon: 'fa-light fa-ear-listen',
-          url: `${baseUrl}/project/${foundationUid}/reports/social-listening`,
+          url: `${baseUrl}/project/${foundationSfid}/reports/social-listening`,
           target: '_blank',
           rel: 'noopener noreferrer',
           testId: 'sidebar-metrics-social-listening',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -268,6 +268,33 @@ export class MainLayoutComponent {
     );
 
     if (this.personaService.currentPersona() === 'executive-director') {
+      const metricsItems: SidebarMenuItem[] = [
+        {
+          label: 'Health Metrics',
+          icon: 'fa-light fa-chart-line-up',
+          routerLink: '/foundation/health-metrics',
+          testId: 'sidebar-metrics-health-metrics',
+        },
+        {
+          label: 'Marketing Impact',
+          icon: 'fa-light fa-bullhorn',
+          routerLink: '/foundation/marketing-impact',
+          testId: 'sidebar-metrics-marketing-impact',
+        },
+      ];
+
+      const foundationUid = this.projectContextService.selectedFoundation()?.uid;
+      if (foundationUid) {
+        metricsItems.push({
+          label: 'Social Listening',
+          icon: 'fa-light fa-ear-listen',
+          url: `${environment.urls.pcc}/project/${foundationUid}/reports/social-listening`,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          testId: 'sidebar-metrics-social-listening',
+        });
+      }
+
       items.push({
         label: 'Communications',
         isSection: true,
@@ -286,20 +313,7 @@ export class MainLayoutComponent {
         label: 'Metrics',
         isSection: true,
         expanded: true,
-        items: [
-          {
-            label: 'Health Metrics',
-            icon: 'fa-light fa-chart-line-up',
-            routerLink: '/foundation/health-metrics',
-            testId: 'sidebar-metrics-health-metrics',
-          },
-          {
-            label: 'Marketing Impact',
-            icon: 'fa-light fa-bullhorn',
-            routerLink: '/foundation/marketing-impact',
-            testId: 'sidebar-metrics-marketing-impact',
-          },
-        ],
+        items: metricsItems,
       });
     }
 

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -285,10 +285,12 @@ export class MainLayoutComponent {
 
       const foundationUid = this.projectContextService.selectedFoundation()?.uid;
       if (foundationUid) {
+        const pccBaseUrl = environment.urls.pcc;
+        const baseUrl = pccBaseUrl.endsWith('/') ? pccBaseUrl.slice(0, -1) : pccBaseUrl;
         metricsItems.push({
           label: 'Social Listening',
           icon: 'fa-light fa-ear-listen',
-          url: `${environment.urls.pcc}/project/${foundationUid}/reports/social-listening`,
+          url: `${baseUrl}/project/${foundationUid}/reports/social-listening`,
           target: '_blank',
           rel: 'noopener noreferrer',
           testId: 'sidebar-metrics-social-listening',

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -8,7 +8,7 @@ import { Router } from '@angular/router';
 import { isBoardScopedPersona, ProjectContext } from '@lfx-one/shared/interfaces';
 import { isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, map, of, startWith, switchMap } from 'rxjs';
 
 import { LensService } from './lens.service';
 import { PersonaService } from './persona.service';
@@ -155,7 +155,7 @@ export class ProjectContextService {
           if (!foundation?.uid) {
             return of(null);
           }
-          return this.projectService.getProjectSfid(foundation.uid);
+          return this.projectService.getProjectSfid(foundation.uid).pipe(startWith(null));
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -41,6 +41,9 @@ export class ProjectContextService {
   /** Writer permission for the current active context — drives CTA visibility across dashboards. */
   public readonly canWrite: Signal<boolean> = this.initCanWrite();
 
+  /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
+  public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();
+
   public constructor() {
     // Clean up legacy cookies from the previous cookie-hydrated design.
     this.cookieService.delete(this.foundationStorageKey, '/');
@@ -142,6 +145,20 @@ export class ProjectContextService {
         })
       ),
       { initialValue: false }
+    );
+  }
+
+  private initSelectedFoundationSfid(): Signal<string | null> {
+    return toSignal(
+      toObservable(this.selectedFoundation).pipe(
+        switchMap((foundation) => {
+          if (!foundation?.uid) {
+            return of(null);
+          }
+          return this.projectService.getProjectSfid(foundation.uid);
+        })
+      ),
+      { initialValue: null }
     );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument } from '@lfx-one/shared/interfaces';
-import { BehaviorSubject, catchError, Observable, of, shareReplay, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of, shareReplay, take, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -45,6 +45,13 @@ export class ProjectService {
       this.projectCache.set(cacheKey, project$);
     }
     return this.projectCache.get(cacheKey)!;
+  }
+
+  public getProjectSfid(uid: string): Observable<string | null> {
+    return this.http.get<{ sfid: string | null }>(`/api/projects/${uid}/sfid`).pipe(
+      map((res) => res.sfid ?? null),
+      catchError(() => of(null))
+    );
   }
 
   public searchProjects(query: string): Observable<Project[]> {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -48,9 +48,12 @@ export class ProjectService {
   }
 
   public getProjectSfid(uid: string): Observable<string | null> {
-    return this.http.get<{ sfid: string | null }>(`/api/projects/${uid}/sfid`).pipe(
+    return this.http.get<{ sfid: string | null }>(`/api/projects/${encodeURIComponent(uid)}/sfid`).pipe(
       map((res) => res.sfid ?? null),
-      catchError(() => of(null))
+      catchError((error) => {
+        console.error('Failed to fetch project sfid:', error);
+        return of(null);
+      })
     );
   }
 

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -138,6 +138,7 @@ export class ProjectController {
   /**
    * GET /projects/:uid/sfid — UUID → Salesforce 18-char ID translation via NATS.
    * Returns `{ sfid: string | null }`; null on lookup failure so callers can hide cleanly.
+   * Project access is enforced via getProjectById before the NATS mapping (FGA on upstream).
    */
   public async getProjectSfid(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -153,6 +154,7 @@ export class ProjectController {
         return;
       }
 
+      await this.projectService.getProjectById(req, uid, false);
       const sfid = await this.projectService.getProjectSfidByUid(req, uid);
 
       logger.success(req, 'get_project_sfid', startTime, {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -136,6 +136,28 @@ export class ProjectController {
   }
 
   /**
+   * GET /projects/:uid/sfid — UUID → Salesforce 18-char ID translation via NATS.
+   * Returns `{ sfid: string | null }`; null on lookup failure so callers can hide cleanly.
+   */
+  public async getProjectSfid(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const startTime = logger.startOperation(req, 'get_project_sfid', { project_uid: uid });
+
+    try {
+      const sfid = await this.projectService.getProjectSfidByUid(req, uid);
+
+      logger.success(req, 'get_project_sfid', startTime, {
+        project_uid: uid,
+        resolved: sfid != null,
+      });
+
+      res.json({ sfid });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /projects/:uid/permissions
    */
   public async getProjectPermissions(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -13,7 +13,7 @@ import { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import { ServiceValidationError } from '../errors';
 import { contentDispositionAttachment } from '../helpers/content-disposition.helper';
 import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
-import { getStringQueryParam } from '../helpers/validation.helper';
+import { getStringQueryParam, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { ProjectService } from '../services/project.service';
@@ -144,6 +144,15 @@ export class ProjectController {
     const startTime = logger.startOperation(req, 'get_project_sfid', { project_uid: uid });
 
     try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'get_project_sfid',
+          service: 'project_controller',
+        })
+      ) {
+        return;
+      }
+
       const sfid = await this.projectService.getProjectSfidByUid(req, uid);
 
       logger.success(req, 'get_project_sfid', startTime, {

--- a/apps/lfx-one/src/server/routes/projects.route.ts
+++ b/apps/lfx-one/src/server/routes/projects.route.ts
@@ -26,6 +26,8 @@ router.put('/:uid/permissions/:username', (req, res, next) => projectController.
 
 router.delete('/:uid/permissions/:username', (req, res, next) => projectController.removeUserFromProjectPermissions(req, res, next));
 
+router.get('/:uid/sfid', (req, res, next) => projectController.getProjectSfid(req, res, next));
+
 // ── Document routes (folders + links + file uploads) ─────────────────────
 router.get('/:uid/documents', (req, res, next) => projectController.getProjectDocuments(req, res, next));
 router.post('/:uid/documents', (req, res, next) => projectController.createProjectDocument(req, res, next));


### PR DESCRIPTION
# Summary

This pull request updates the sidebar menu for users with the `executive-director` persona in the `MainLayoutComponent`. The main change is the dynamic construction of the "Metrics" section, which now includes an additional "Social Listening" menu item when a foundation is selected, and refactors how the metrics items are defined.

Sidebar menu improvements for executive directors:

* Dynamically builds the `metricsItems` array to include "Health Metrics" and "Marketing Impact" links, and conditionally adds a "Social Listening" link (which opens in a new tab) if a foundation is selected. (`apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts`)
* Refactors the "Metrics" sidebar section to use the new `metricsItems` array, replacing the previous hardcoded items. (`apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts`)