### PR TITLE
fix(snowflake): add circuit breaker and reduce pool timeouts

### DIFF
--- a/apps/lfx-one/src/server/services/snowflake.service.ts
+++ b/apps/lfx-one/src/server/services/snowflake.service.ts
@@ -11,8 +11,8 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { ATTR_DB_RESPONSE_RETURNED_ROWS } from '@opentelemetry/semantic-conventions/incubating';
 import { SNOWFLAKE_CONFIG } from '@lfx-one/shared/constants';
-import { SnowflakeLockStrategy } from '@lfx-one/shared/enums';
-import { LockStats, SnowflakePoolStats, SnowflakeQueryOptions, SnowflakeQueryResult } from '@lfx-one/shared/interfaces';
+import { SnowflakeCircuitState, SnowflakeLockStrategy } from '@lfx-one/shared/enums';
+import { LockStats, SnowflakeCircuitStats, SnowflakePoolStats, SnowflakeQueryOptions, SnowflakeQueryResult } from '@lfx-one/shared/interfaces';
 import crypto from 'crypto';
 import snowflakeSdk from 'snowflake-sdk';
 
@@ -40,6 +40,11 @@ export class SnowflakeService {
   private pool: Pool<Connection> | null = null;
   private poolPromise: Promise<Pool<Connection>> | null = null;
   private lockManager: LockManager;
+
+  // === Circuit Breaker ===
+  private circuitState: SnowflakeCircuitState = SnowflakeCircuitState.CLOSED;
+  private consecutiveFailures = 0;
+  private lastFailureTime = 0;
 
   /**
    * Get the singleton instance of SnowflakeService
@@ -93,6 +98,9 @@ export class SnowflakeService {
     // Validate that query is read-only
     this.validateReadOnlyQuery(sqlText);
 
+    // Fail fast if the circuit is OPEN (Snowflake is known to be unreachable)
+    this.checkCircuit();
+
     // Generate query hash for deduplication
     const queryHash = this.lockManager.hashQuery(sqlText, binds);
 
@@ -119,39 +127,53 @@ export class SnowflakeService {
             query_hash: queryHash,
             sql_preview: sqlText.substring(0, 100).replace(/\s+/g, ' ').trim(),
             bind_count: binds?.length || 0,
+            circuit_state: this.circuitState,
           });
 
           const startTime = Date.now();
           const pool = await this.ensurePool();
+          const queryTimeoutMs = options?.timeout ?? SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT;
 
           try {
-            // Execute query with parameterized binds
-            const result: any = await new Promise((resolve, reject) => {
-              pool.use(async (connection: Connection) => {
-                connection.execute({
-                  sqlText,
-                  binds: binds as any[],
-                  fetchAsString: options?.fetchAsString,
-                  complete: (err: SnowflakeError | undefined, stmt: RowStatement, rows: any[] | undefined) => {
-                    if (err) {
-                      reject(err);
-                    } else {
-                      resolve({
-                        rows,
-                        metadata: stmt.getColumns(),
-                        statementHandle: stmt.getQueryId(),
-                      });
-                    }
-                  },
-                });
-              });
+            // Race the full pool.use() + query execution against a per-query timeout.
+            // This bounds event-loop exposure to a slow/unresponsive Snowflake regardless
+            // of the pool's own acquire timeout — whichever fires first wins.
+            const executePromise = new Promise<SnowflakeQueryResult<T>>((resolve, reject) => {
+              pool
+                .use(async (connection: Connection) => {
+                  connection.execute({
+                    sqlText,
+                    binds: binds as any[],
+                    fetchAsString: options?.fetchAsString,
+                    complete: (err: SnowflakeError | undefined, stmt: RowStatement, rows: any[] | undefined) => {
+                      if (err) {
+                        reject(err);
+                      } else {
+                        resolve({
+                          rows: rows ?? [],
+                          metadata: stmt.getColumns() ?? [],
+                          statementHandle: stmt.getQueryId(),
+                        });
+                      }
+                    },
+                  });
+                })
+                .catch(reject);
             });
+
+            const timeoutPromise = new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error(`Snowflake query timed out after ${queryTimeoutMs}ms`)), queryTimeoutMs)
+            );
+
+            const result = await Promise.race([executePromise, timeoutPromise]);
 
             const rowCount = Array.isArray(result?.rows) ? result.rows.length : 0;
             const poolStats = this.getPoolStats();
 
             span.setStatus({ code: SpanStatusCode.OK });
             span.setAttribute(ATTR_DB_RESPONSE_RETURNED_ROWS, rowCount);
+
+            this.recordSuccess();
 
             logger.debug(undefined, 'snowflake_query', 'Query completed', {
               query_hash: queryHash,
@@ -161,7 +183,7 @@ export class SnowflakeService {
               pool_idle: poolStats.idleConnections,
             });
 
-            return result as SnowflakeQueryResult<T>;
+            return result;
           } catch (error) {
             span.setStatus({
               code: SpanStatusCode.ERROR,
@@ -169,9 +191,13 @@ export class SnowflakeService {
             });
             span.recordException(error instanceof Error ? error : new Error(String(error)));
 
+            this.recordFailure();
+
             logger.error(undefined, 'snowflake_query', startTime, error instanceof Error ? error : new Error(String(error)), {
               query_hash: queryHash,
               sql_preview: sqlText.substring(0, 100).replace(/\s+/g, ' ').trim(),
+              circuit_state: this.circuitState,
+              consecutive_failures: this.consecutiveFailures,
             });
 
             // Wrap Snowflake SDK errors in MicroserviceError for proper error handling
@@ -232,6 +258,23 @@ export class SnowflakeService {
    */
   public getLockStats(): LockStats {
     return this.lockManager.getStats();
+  }
+
+  /**
+   * Get circuit breaker statistics for observability
+   */
+  public getCircuitStats(): SnowflakeCircuitStats {
+    const msUntilProbe =
+      this.circuitState === SnowflakeCircuitState.OPEN
+        ? Math.max(0, SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS - (Date.now() - this.lastFailureTime))
+        : 0;
+
+    return {
+      state: this.circuitState,
+      consecutiveFailures: this.consecutiveFailures,
+      lastFailureTime: this.lastFailureTime,
+      msUntilProbe,
+    };
   }
 
   /**
@@ -406,6 +449,81 @@ export class SnowflakeService {
         },
         originalError: error instanceof Error ? error : undefined,
       });
+    }
+  }
+
+  /**
+   * Throw immediately if the circuit is OPEN and the reset timeout hasn't elapsed.
+   * Transitions OPEN → HALF_OPEN once the timeout passes, allowing one probe query.
+   * @private
+   */
+  private checkCircuit(): void {
+    if (this.circuitState === SnowflakeCircuitState.OPEN) {
+      const elapsed = Date.now() - this.lastFailureTime;
+      if (elapsed < SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS) {
+        const secondsLeft = Math.ceil((SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS - elapsed) / 1000);
+        throw new MicroserviceError(
+          `Snowflake circuit breaker OPEN — retrying in ${secondsLeft}s`,
+          503,
+          'SNOWFLAKE_CIRCUIT_OPEN',
+          {
+            operation: 'circuit_breaker_check',
+            service: 'snowflake',
+            errorBody: {
+              state: this.circuitState,
+              consecutive_failures: this.consecutiveFailures,
+              seconds_until_probe: secondsLeft,
+            },
+          }
+        );
+      }
+      this.circuitState = SnowflakeCircuitState.HALF_OPEN;
+      logger.info(undefined, 'snowflake_circuit_breaker', 'Circuit transitioned to HALF_OPEN — probing connection', {
+        consecutive_failures: this.consecutiveFailures,
+      });
+    }
+  }
+
+  /**
+   * Record a successful query — close the circuit if it was HALF_OPEN.
+   * @private
+   */
+  private recordSuccess(): void {
+    if (this.circuitState !== SnowflakeCircuitState.CLOSED) {
+      logger.info(undefined, 'snowflake_circuit_breaker', 'Circuit closed — Snowflake connection recovered', {
+        consecutive_failures: this.consecutiveFailures,
+      });
+    }
+    this.consecutiveFailures = 0;
+    this.circuitState = SnowflakeCircuitState.CLOSED;
+  }
+
+  /**
+   * Record a failed query — open the circuit after reaching the failure threshold,
+   * or immediately if the circuit was already HALF_OPEN (probe failed).
+   * @private
+   */
+  private recordFailure(): void {
+    this.consecutiveFailures++;
+    this.lastFailureTime = Date.now();
+
+    const shouldOpen =
+      this.circuitState === SnowflakeCircuitState.HALF_OPEN ||
+      this.consecutiveFailures >= SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_FAILURE_THRESHOLD;
+
+    if (shouldOpen) {
+      this.circuitState = SnowflakeCircuitState.OPEN;
+      logger.error(
+        undefined,
+        'snowflake_circuit_breaker',
+        this.lastFailureTime,
+        new Error('Snowflake circuit breaker OPENED — failing fast until recovery probe succeeds'),
+        {
+          consecutive_failures: this.consecutiveFailures,
+          threshold: SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+          reset_timeout_ms: SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS,
+        }
+      );
     }
   }
 

--- a/apps/lfx-one/src/server/services/snowflake.service.ts
+++ b/apps/lfx-one/src/server/services/snowflake.service.ts
@@ -134,16 +134,25 @@ export class SnowflakeService {
           });
 
           const startTime = Date.now();
-          const pool = await this.ensurePool();
-          const queryTimeoutMs = options?.timeout ?? SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT;
 
           try {
+            // ensurePool is inside try so a pool-creation failure during a HALF_OPEN
+            // probe is caught by the catch below and calls recordFailure(), preventing
+            // probeInFlight from getting stuck.
+            const pool = await this.ensurePool();
+            const queryTimeoutMs = options?.timeout ?? SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT;
+
             // Race the full pool.use() + query execution against a per-query timeout.
             // This bounds event-loop exposure to a slow/unresponsive Snowflake regardless
             // of the pool's own acquire timeout — whichever fires first wins.
-            const executePromise = new Promise<SnowflakeQueryResult<T>>((resolve, reject) => {
-              pool
-                .use(async (connection: Connection) => {
+            //
+            // The pool.use callback returns a Promise that settles inside the Snowflake
+            // complete callback so generic-pool holds the connection until the statement
+            // finishes, keeping pool accounting (max, maxWaitingClients, acquireTimeout)
+            // accurate for in-flight queries.
+            const executePromise = pool.use(
+              (connection: Connection) =>
+                new Promise<SnowflakeQueryResult<T>>((resolve, reject) => {
                   connection.execute({
                     sqlText,
                     binds: binds as any[],
@@ -161,8 +170,7 @@ export class SnowflakeService {
                     },
                   });
                 })
-                .catch(reject);
-            });
+            );
 
             let timeoutHandle: ReturnType<typeof setTimeout>;
             const timeoutPromise = new Promise<never>((_, reject) => {

--- a/apps/lfx-one/src/server/services/snowflake.service.ts
+++ b/apps/lfx-one/src/server/services/snowflake.service.ts
@@ -45,6 +45,9 @@ export class SnowflakeService {
   private circuitState: SnowflakeCircuitState = SnowflakeCircuitState.CLOSED;
   private consecutiveFailures = 0;
   private lastFailureTime = 0;
+  // True while a HALF_OPEN probe is in-flight; subsequent requests fail fast
+  // rather than stampeding Snowflake with multiple concurrent probes.
+  private probeInFlight = false;
 
   /**
    * Get the singleton instance of SnowflakeService
@@ -161,11 +164,17 @@ export class SnowflakeService {
                 .catch(reject);
             });
 
-            const timeoutPromise = new Promise<never>((_, reject) =>
-              setTimeout(() => reject(new Error(`Snowflake query timed out after ${queryTimeoutMs}ms`)), queryTimeoutMs)
-            );
+            let timeoutHandle: ReturnType<typeof setTimeout>;
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              timeoutHandle = setTimeout(() => reject(new Error(`Snowflake query timed out after ${queryTimeoutMs}ms`)), queryTimeoutMs);
+            });
 
-            const result = await Promise.race([executePromise, timeoutPromise]);
+            let result: SnowflakeQueryResult<T>;
+            try {
+              result = await Promise.race([executePromise, timeoutPromise]);
+            } finally {
+              clearTimeout(timeoutHandle!);
+            }
 
             const rowCount = Array.isArray(result?.rows) ? result.rows.length : 0;
             const poolStats = this.getPoolStats();
@@ -477,6 +486,20 @@ export class SnowflakeService {
         consecutive_failures: this.consecutiveFailures,
       });
     }
+
+    // Allow only one concurrent probe in HALF_OPEN — reject additional callers until
+    // the in-flight probe settles so we don't stampede Snowflake during recovery.
+    if (this.circuitState === SnowflakeCircuitState.HALF_OPEN && this.probeInFlight) {
+      throw new MicroserviceError('Snowflake circuit breaker HALF_OPEN — probe already in flight', 503, 'SNOWFLAKE_CIRCUIT_OPEN', {
+        operation: 'circuit_breaker_check',
+        service: 'snowflake',
+        errorBody: { state: this.circuitState },
+      });
+    }
+
+    if (this.circuitState === SnowflakeCircuitState.HALF_OPEN) {
+      this.probeInFlight = true;
+    }
   }
 
   /**
@@ -490,6 +513,7 @@ export class SnowflakeService {
       });
     }
     this.consecutiveFailures = 0;
+    this.probeInFlight = false;
     this.circuitState = SnowflakeCircuitState.CLOSED;
   }
 
@@ -501,6 +525,7 @@ export class SnowflakeService {
   private recordFailure(): void {
     this.consecutiveFailures++;
     this.lastFailureTime = Date.now();
+    this.probeInFlight = false;
 
     const shouldOpen = this.circuitState === SnowflakeCircuitState.HALF_OPEN || this.consecutiveFailures >= SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_FAILURE_THRESHOLD;
 

--- a/apps/lfx-one/src/server/services/snowflake.service.ts
+++ b/apps/lfx-one/src/server/services/snowflake.service.ts
@@ -462,20 +462,15 @@ export class SnowflakeService {
       const elapsed = Date.now() - this.lastFailureTime;
       if (elapsed < SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS) {
         const secondsLeft = Math.ceil((SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_RESET_TIMEOUT_MS - elapsed) / 1000);
-        throw new MicroserviceError(
-          `Snowflake circuit breaker OPEN — retrying in ${secondsLeft}s`,
-          503,
-          'SNOWFLAKE_CIRCUIT_OPEN',
-          {
-            operation: 'circuit_breaker_check',
-            service: 'snowflake',
-            errorBody: {
-              state: this.circuitState,
-              consecutive_failures: this.consecutiveFailures,
-              seconds_until_probe: secondsLeft,
-            },
-          }
-        );
+        throw new MicroserviceError(`Snowflake circuit breaker OPEN — retrying in ${secondsLeft}s`, 503, 'SNOWFLAKE_CIRCUIT_OPEN', {
+          operation: 'circuit_breaker_check',
+          service: 'snowflake',
+          errorBody: {
+            state: this.circuitState,
+            consecutive_failures: this.consecutiveFailures,
+            seconds_until_probe: secondsLeft,
+          },
+        });
       }
       this.circuitState = SnowflakeCircuitState.HALF_OPEN;
       logger.info(undefined, 'snowflake_circuit_breaker', 'Circuit transitioned to HALF_OPEN — probing connection', {
@@ -507,9 +502,7 @@ export class SnowflakeService {
     this.consecutiveFailures++;
     this.lastFailureTime = Date.now();
 
-    const shouldOpen =
-      this.circuitState === SnowflakeCircuitState.HALF_OPEN ||
-      this.consecutiveFailures >= SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_FAILURE_THRESHOLD;
+    const shouldOpen = this.circuitState === SnowflakeCircuitState.HALF_OPEN || this.consecutiveFailures >= SNOWFLAKE_CONFIG.CIRCUIT_BREAKER_FAILURE_THRESHOLD;
 
     if (shouldOpen) {
       this.circuitState = SnowflakeCircuitState.OPEN;

--- a/packages/shared/src/constants/snowflake.constant.ts
+++ b/packages/shared/src/constants/snowflake.constant.ts
@@ -6,9 +6,12 @@
  */
 export const SNOWFLAKE_CONFIG = {
   /**
-   * Default query execution timeout in milliseconds
+   * Per-query execution timeout in milliseconds.
+   * Covers both pool acquisition wait and query execution time.
+   * Reduced from 60s to 15s so a single slow query fails fast instead of
+   * tying up the event loop and downstream callers.
    */
-  DEFAULT_QUERY_TIMEOUT: 60000, // 60 seconds
+  DEFAULT_QUERY_TIMEOUT: 15000, // 15 seconds
 
   /**
    * Connection timeout in milliseconds
@@ -16,9 +19,11 @@ export const SNOWFLAKE_CONFIG = {
   CONNECTION_TIMEOUT: 30000, // 30 seconds
 
   /**
-   * Minimum number of connections in the pool
+   * Minimum connections kept warm in the pool.
+   * Set to 0 so the pool only creates connections on demand — no eager
+   * warm-up attempts at server start when Snowflake may be unreachable.
    */
-  MIN_CONNECTIONS: 2,
+  MIN_CONNECTIONS: 0,
 
   /**
    * Maximum number of connections in the pool
@@ -26,14 +31,18 @@ export const SNOWFLAKE_CONFIG = {
   MAX_CONNECTIONS: 20,
 
   /**
-   * Maximum number of clients waiting when pool is exhausted
+   * Maximum requests queued when the pool is exhausted.
+   * Reduced from 50 to 10 so the server fails fast under sustained Snowflake
+   * outages instead of holding 50 requests for up to 30s each.
    */
-  MAX_WAITING_CLIENTS: 50,
+  MAX_WAITING_CLIENTS: 10,
 
   /**
-   * Timeout for acquiring a connection from the pool in milliseconds
+   * Timeout for acquiring a connection from the pool in milliseconds.
+   * Halved from 30s to 15s — pairs with DEFAULT_QUERY_TIMEOUT so the
+   * total worst-case per-request wait stays bounded at ~15s.
    */
-  CONNECTION_ACQUIRE_TIMEOUT: 30000, // 30 seconds
+  CONNECTION_ACQUIRE_TIMEOUT: 15000, // 15 seconds
 
   /**
    * Idle timeout for connections in milliseconds
@@ -59,6 +68,19 @@ export const SNOWFLAKE_CONFIG = {
    * Maximum number of retry attempts for transient failures
    */
   MAX_RETRIES: 3,
+
+  /**
+   * Number of consecutive failures before the circuit breaker opens.
+   * Once open, all Snowflake calls fail immediately (503) without attempting
+   * a connection, preventing event-loop saturation during outages.
+   */
+  CIRCUIT_BREAKER_FAILURE_THRESHOLD: 5,
+
+  /**
+   * How long the circuit stays OPEN before allowing a probe request (HALF_OPEN).
+   * If the probe succeeds the circuit closes; if it fails the timer resets.
+   */
+  CIRCUIT_BREAKER_RESET_TIMEOUT_MS: 60000, // 60 seconds
 } as const;
 
 /**

--- a/packages/shared/src/enums/snowflake.enum.ts
+++ b/packages/shared/src/enums/snowflake.enum.ts
@@ -2,6 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Circuit breaker states for Snowflake connection resilience
+ */
+export enum SnowflakeCircuitState {
+  /** Normal operation — all queries pass through to Snowflake */
+  CLOSED = 'CLOSED',
+  /** Snowflake is unreachable — queries fail immediately without attempting a connection */
+  OPEN = 'OPEN',
+  /** Cooldown elapsed — one probe query allowed to test if Snowflake recovered */
+  HALF_OPEN = 'HALF_OPEN',
+}
+
+/**
  * Lock strategy for query deduplication
  */
 export enum SnowflakeLockStrategy {

--- a/packages/shared/src/interfaces/snowflake.interface.ts
+++ b/packages/shared/src/interfaces/snowflake.interface.ts
@@ -80,6 +80,20 @@ export interface LockStats {
 }
 
 /**
+ * Circuit breaker statistics for observability
+ */
+export interface SnowflakeCircuitStats {
+  /** Current circuit state */
+  state: string;
+  /** Number of consecutive failures since last success */
+  consecutiveFailures: number;
+  /** Epoch ms of the last recorded failure (0 if none) */
+  lastFailureTime: number;
+  /** Milliseconds until the circuit allows a probe request (0 when CLOSED or HALF_OPEN) */
+  msUntilProbe: number;
+}
+
+/**
  * Internal lock entry structure for in-memory locking
  */
 export interface LockEntry {

--- a/packages/shared/src/interfaces/snowflake.interface.ts
+++ b/packages/shared/src/interfaces/snowflake.interface.ts
@@ -3,6 +3,8 @@
 
 import type { Column, DataType } from 'snowflake-sdk';
 
+import type { SnowflakeCircuitState } from '../enums/snowflake.enum';
+
 /**
  * Result of a Snowflake query execution
  * Uses SDK's Column type for metadata
@@ -84,7 +86,7 @@ export interface LockStats {
  */
 export interface SnowflakeCircuitStats {
   /** Current circuit state */
-  state: string;
+  state: SnowflakeCircuitState;
   /** Number of consecutive failures since last success */
   consecutiveFailures: number;
   /** Epoch ms of the last recorded failure (0 if none) */


### PR DESCRIPTION
## Summary

Fixes LFXV2-1397 — a slow or unreachable Snowflake connection was causing the entire app to degrade, including routes with no Snowflake dependency (committees, meetings, mailing lists) due to event-loop saturation from queued timeout callbacks.

### Root cause recap

- `MIN_CONNECTIONS: 2` caused the pool to eagerly warm up 2 connections on first use
- `MAX_WAITING_CLIENTS: 50` allowed 50 requests to queue, each blocking up to 30s
- No circuit breaker meant every request took the full 30–60s timeout path indefinitely
- No per-query timeout — queries could block the caller for the full pool acquire + connection timeout

### Changes

#### Circuit breaker (`snowflake.service.ts`)

Three-state FSM — `CLOSED → OPEN → HALF_OPEN → CLOSED`:

- After **5 consecutive failures** the circuit opens; all subsequent `execute()` calls throw 503 immediately without touching the connection pool
- After **60s** the circuit transitions to `HALF_OPEN` and allows one probe query
- On probe success → circuit closes; on probe failure → timer resets
- `getCircuitStats()` added for observability (state, failure count, ms until next probe)

#### Per-query timeout (`snowflake.service.ts`)

`execute()` now races `pool.use()` + the query callback against `DEFAULT_QUERY_TIMEOUT` (15s) via `Promise.race()`. Covers both pool acquisition wait and query execution time. Callers can override with `options.timeout`.

#### Pool config tightened (`snowflake.constant.ts`)

| Setting | Before | After | Reason |
|---------|--------|-------|--------|
| `DEFAULT_QUERY_TIMEOUT` | 60s | **15s** | Bound per-query exposure |
| `MIN_CONNECTIONS` | 2 | **0** | No eager warm-up at server start |
| `MAX_WAITING_CLIENTS` | 50 | **10** | Fail fast under sustained outage |
| `CONNECTION_ACQUIRE_TIMEOUT` | 30s | **15s** | Pairs with query timeout |

#### New shared types

- `SnowflakeCircuitState` enum (`packages/shared/src/enums/snowflake.enum.ts`)
- `SnowflakeCircuitStats` interface (`packages/shared/src/interfaces/snowflake.interface.ts`)

## Test plan

- [ ] Set `SNOWFLAKE_API_KEY` to an invalid value locally; hit any analytics endpoint — should fail within 15s with `SNOWFLAKE_QUERY_ERROR` (not hang 60s)
- [ ] After 5 failures, further calls should return 503 `SNOWFLAKE_CIRCUIT_OPEN` immediately
- [ ] Non-Snowflake endpoints (`/api/committees`, `/api/meetings`) remain responsive during Snowflake outage
- [ ] After 60s with circuit OPEN, next call triggers a probe; restore valid credentials → circuit closes and subsequent calls succeed
- [ ] Happy path: restore valid credentials and confirm analytics endpoints return data normally

---

🤖 Assisted by [Claude Code](https://claude.ai/code)