### PR TITLE
fix(nps-card): fall back to most-recent prior period when YTD has no data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/nps-card/nps-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/nps-card/nps-card.component.html
@@ -7,7 +7,14 @@
     <div class="flex flex-col">
       <h3 class="text-sm font-bold tracking-wide text-gray-900 uppercase">Net Promoter Score</h3>
       @if (hasData()) {
-        <span class="text-xs text-gray-500">Last Updated: {{ summaryData().lastUpdatedLabel }}</span>
+        <div class="flex items-center gap-2">
+          @if (summaryData().periodLabel) {
+            <span class="rounded bg-blue-50 px-1.5 py-0.5 text-xs font-medium text-blue-700" data-testid="nps-card-period-label">{{
+              summaryData().periodLabel
+            }}</span>
+          }
+          <span class="text-xs text-gray-500">Last Updated: {{ summaryData().lastUpdatedLabel }}</span>
+        </div>
       }
     </div>
     @if (hasData()) {

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/nps-card/nps-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/nps-card/nps-card.component.html
@@ -7,14 +7,16 @@
     <div class="flex flex-col">
       <h3 class="text-sm font-bold tracking-wide text-gray-900 uppercase">Net Promoter Score</h3>
       @if (hasData()) {
-        <div class="flex items-center gap-2">
-          @if (summaryData().periodLabel) {
+        @if (summaryData().periodLabel) {
+          <div class="flex items-center gap-2">
             <span class="rounded bg-blue-50 px-1.5 py-0.5 text-xs font-medium text-blue-700" data-testid="nps-card-period-label">{{
               summaryData().periodLabel
             }}</span>
-          }
+            <span class="text-xs text-gray-500">Last Updated: {{ summaryData().lastUpdatedLabel }}</span>
+          </div>
+        } @else {
           <span class="text-xs text-gray-500">Last Updated: {{ summaryData().lastUpdatedLabel }}</span>
-        </div>
+        }
       }
     </div>
     @if (hasData()) {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -71,6 +71,7 @@ import {
   MarketingAttributionResponse,
   MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
+import { HEALTH_METRICS_NPS_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
 import { catchError, Observable, of, shareReplay } from 'rxjs';
 
 /**
@@ -1002,22 +1003,7 @@ export class AnalyticsService {
     if (range && range !== 'YTD') {
       params['range'] = range;
     }
-    return this.http.get<NpsSummaryResponse>('/api/analytics/nps-summary', { params }).pipe(
-      catchError(() => {
-        return of({
-          projectId: '',
-          npsScore: 0,
-          promoters: 0,
-          passives: 0,
-          detractors: 0,
-          nonResponses: 0,
-          responses: 0,
-          lastUpdatedLabel: 'N/A',
-          effectiveRange: 'YTD' as const,
-          periodLabel: '',
-        });
-      })
-    );
+    return this.http.get<NpsSummaryResponse>('/api/analytics/nps-summary', { params }).pipe(catchError(() => of(HEALTH_METRICS_NPS_DEFAULT_SUMMARY)));
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1013,6 +1013,8 @@ export class AnalyticsService {
           nonResponses: 0,
           responses: 0,
           lastUpdatedLabel: 'N/A',
+          effectiveRange: 'YTD' as const,
+          periodLabel: '',
         });
       })
     );

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3751,7 +3751,11 @@ export class ProjectService {
 
     const resolvedRange = isHealthMetricsRange(row.EFFECTIVE_RANGE) ? row.EFFECTIVE_RANGE : null;
 
-    const periodLabel = resolvedRange ? (resolvedRange === 'YTD' ? `YTD ${getYearForRange(resolvedRange)}` : `FY ${getYearForRange(resolvedRange)}`) : '';
+    let periodLabel = '';
+    if (resolvedRange) {
+      const year = getYearForRange(resolvedRange);
+      periodLabel = resolvedRange === 'YTD' ? `YTD ${year}` : `FY ${year}`;
+    }
 
     const promoters = row.PROMOTERS ?? 0;
     const passives = row.PASSIVES ?? 0;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3690,7 +3690,7 @@ export class ProjectService {
     // all other columns use the identical WHEN ordering so no period mixing occurs.
     const buildCaseWhen = (colPrefix: string): string =>
       fallbackRanges
-        .map((r, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN sr.${colPrefix}${fallbackSuffixes[i]}`)
+        .map((_, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN sr.${colPrefix}${fallbackSuffixes[i]}`)
         .join('\n        ');
 
     const rangeCases = fallbackRanges.map((r, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN '${r}'`).join('\n        ');
@@ -3749,10 +3749,9 @@ export class ProjectService {
       }
     }
 
-    const resolvedRange: HealthMetricsRange = isHealthMetricsRange(row.EFFECTIVE_RANGE) ? row.EFFECTIVE_RANGE : requestedRange;
+    const resolvedRange = isHealthMetricsRange(row.EFFECTIVE_RANGE) ? row.EFFECTIVE_RANGE : null;
 
-    const year = getYearForRange(resolvedRange);
-    const periodLabel = resolvedRange === 'YTD' ? `YTD ${year}` : `FY ${year}`;
+    const periodLabel = resolvedRange ? (resolvedRange === 'YTD' ? `YTD ${getYearForRange(resolvedRange)}` : `FY ${getYearForRange(resolvedRange)}`) : '';
 
     const promoters = row.PROMOTERS ?? 0;
     const passives = row.PASSIVES ?? 0;
@@ -3768,7 +3767,7 @@ export class ProjectService {
       nonResponses,
       responses: promoters + passives + detractors + nonResponses,
       lastUpdatedLabel,
-      range: resolvedRange,
+      range: resolvedRange ?? requestedRange,
       periodLabel,
       changeNpsScore: row.CHANGE_NPS_SCORE ?? 0,
     };

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG, PENDING_ACTION_SEVERITY, PENDING_ACTION_SURVEYS_ROW_LIMIT, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import { getYearForRange, NATS_CONFIG, PENDING_ACTION_SEVERITY, PENDING_ACTION_SURVEYS_ROW_LIMIT, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
   BoardMeetingInviteeRow,
@@ -3662,18 +3662,29 @@ export class ProjectService {
   public async getNpsSummary(foundationSlug: string, range: string = 'YTD'): Promise<NpsSummaryResponse> {
     interface NpsSummaryRow {
       PROJECT_ID: string;
-      NPS_SCORE: number;
-      PROMOTERS: number;
-      PASSIVES: number;
-      DETRACTORS: number;
-      NON_RESPONSES: number;
+      NPS_SCORE: number | null;
+      PROMOTERS: number | null;
+      PASSIVES: number | null;
+      DETRACTORS: number | null;
+      NON_RESPONSES: number | null;
       LAST_UPDATED: string | null;
-      CHANGE_NPS_SCORE: number;
+      CHANGE_NPS_SCORE: number | null;
+      EFFECTIVE_RANGE: string | null;
     }
 
-    const VALID_RANGES = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
-    const effectiveRange = VALID_RANGES.includes(range) ? range : 'YTD';
-    const suffix = this.getRangeSuffix(effectiveRange);
+    const ORDERED_RANGES: HealthMetricsRange[] = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
+    const requestedRange: HealthMetricsRange = ORDERED_RANGES.includes(range as HealthMetricsRange) ? (range as HealthMetricsRange) : 'YTD';
+    const startIdx = ORDERED_RANGES.indexOf(requestedRange);
+    const fallbackRanges = ORDERED_RANGES.slice(startIdx);
+    const fallbackSuffixes = fallbackRanges.map((r) => this.getRangeSuffix(r));
+
+    const npsCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_nps_score${sfx}`).join(', ');
+    const promotersCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_promoters${sfx}`).join(', ');
+    const passivesCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_passives${sfx}`).join(', ');
+    const detractorsCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_detractors${sfx}`).join(', ');
+    const nonResponsesCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_non_responses${sfx}`).join(', ');
+    const changeCoalesce = fallbackSuffixes.map((sfx) => `sr.nps_score_most_recent_to_previous_change${sfx}`).join(', ');
+    const rangeCases = fallbackRanges.map((r, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN '${r}'`).join('\n        ');
 
     const query = `
       WITH slug_resolve AS (
@@ -3683,13 +3694,17 @@ export class ProjectService {
       )
       SELECT
         sr.project_id AS PROJECT_ID,
-        IFNULL(sr.most_recent_nps_score${suffix}, 0) AS NPS_SCORE,
-        IFNULL(sr.most_recent_count_promoters${suffix}, 0) AS PROMOTERS,
-        IFNULL(sr.most_recent_count_passives${suffix}, 0) AS PASSIVES,
-        IFNULL(sr.most_recent_count_detractors${suffix}, 0) AS DETRACTORS,
-        IFNULL(sr.most_recent_count_non_responses${suffix}, 0) AS NON_RESPONSES,
+        COALESCE(${npsCoalesce}) AS NPS_SCORE,
+        COALESCE(${promotersCoalesce}) AS PROMOTERS,
+        COALESCE(${passivesCoalesce}) AS PASSIVES,
+        COALESCE(${detractorsCoalesce}) AS DETRACTORS,
+        COALESCE(${nonResponsesCoalesce}) AS NON_RESPONSES,
         sr.last_updated AS LAST_UPDATED,
-        IFNULL(sr.nps_score_most_recent_to_previous_change${suffix}, 0) AS CHANGE_NPS_SCORE
+        COALESCE(${changeCoalesce}) AS CHANGE_NPS_SCORE,
+        CASE
+        ${rangeCases}
+        ELSE NULL
+        END AS EFFECTIVE_RANGE
       FROM ANALYTICS.PLATINUM.SURVEY_RESPONSES sr
       INNER JOIN slug_resolve s ON sr.project_id = s.project_id
       LIMIT 1
@@ -3707,6 +3722,8 @@ export class ProjectService {
         nonResponses: 0,
         responses: 0,
         lastUpdatedLabel: 'N/A',
+        effectiveRange: requestedRange,
+        periodLabel: '',
       };
     }
 
@@ -3723,16 +3740,29 @@ export class ProjectService {
       }
     }
 
+    const resolvedRange: HealthMetricsRange =
+      row.EFFECTIVE_RANGE && ORDERED_RANGES.includes(row.EFFECTIVE_RANGE as HealthMetricsRange) ? (row.EFFECTIVE_RANGE as HealthMetricsRange) : requestedRange;
+
+    const year = getYearForRange(resolvedRange);
+    const periodLabel = resolvedRange === 'YTD' ? `YTD ${year}` : `FY ${year}`;
+
+    const promoters = row.PROMOTERS ?? 0;
+    const passives = row.PASSIVES ?? 0;
+    const detractors = row.DETRACTORS ?? 0;
+    const nonResponses = row.NON_RESPONSES ?? 0;
+
     return {
       projectId: row.PROJECT_ID ?? '',
-      npsScore: row.NPS_SCORE,
-      promoters: row.PROMOTERS,
-      passives: row.PASSIVES,
-      detractors: row.DETRACTORS,
-      nonResponses: row.NON_RESPONSES,
-      responses: row.PROMOTERS + row.PASSIVES + row.DETRACTORS + row.NON_RESPONSES,
+      npsScore: row.NPS_SCORE ?? 0,
+      promoters,
+      passives,
+      detractors,
+      nonResponses,
+      responses: promoters + passives + detractors + nonResponses,
       lastUpdatedLabel,
-      changeNpsScore: row.CHANGE_NPS_SCORE,
+      effectiveRange: resolvedRange,
+      periodLabel,
+      changeNpsScore: row.CHANGE_NPS_SCORE ?? 0,
     };
   }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1,7 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { getYearForRange, NATS_CONFIG, PENDING_ACTION_SEVERITY, PENDING_ACTION_SURVEYS_ROW_LIMIT, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import {
+  getYearForRange,
+  HEALTH_METRICS_RANGES,
+  isHealthMetricsRange,
+  NATS_CONFIG,
+  PENDING_ACTION_SEVERITY,
+  PENDING_ACTION_SURVEYS_ROW_LIMIT,
+  ROOT_PROJECT_SLUG,
+} from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
   BoardMeetingInviteeRow,
@@ -3672,18 +3680,19 @@ export class ProjectService {
       EFFECTIVE_RANGE: string | null;
     }
 
-    const ORDERED_RANGES: HealthMetricsRange[] = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
-    const requestedRange: HealthMetricsRange = ORDERED_RANGES.includes(range as HealthMetricsRange) ? (range as HealthMetricsRange) : 'YTD';
-    const startIdx = ORDERED_RANGES.indexOf(requestedRange);
-    const fallbackRanges = ORDERED_RANGES.slice(startIdx);
+    const requestedRange: HealthMetricsRange = isHealthMetricsRange(range) ? range : 'YTD';
+    const startIdx = HEALTH_METRICS_RANGES.indexOf(requestedRange);
+    const fallbackRanges = HEALTH_METRICS_RANGES.slice(startIdx);
     const fallbackSuffixes = fallbackRanges.map((r) => this.getRangeSuffix(r));
 
-    const npsCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_nps_score${sfx}`).join(', ');
-    const promotersCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_promoters${sfx}`).join(', ');
-    const passivesCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_passives${sfx}`).join(', ');
-    const detractorsCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_detractors${sfx}`).join(', ');
-    const nonResponsesCoalesce = fallbackSuffixes.map((sfx) => `sr.most_recent_count_non_responses${sfx}`).join(', ');
-    const changeCoalesce = fallbackSuffixes.map((sfx) => `sr.nps_score_most_recent_to_previous_change${sfx}`).join(', ');
+    // Build CASE WHEN blocks so every column reads from the same period.
+    // The first suffix whose NPS score is non-null defines the effective range;
+    // all other columns use the identical WHEN ordering so no period mixing occurs.
+    const buildCaseWhen = (colPrefix: string): string =>
+      fallbackRanges
+        .map((r, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN sr.${colPrefix}${fallbackSuffixes[i]}`)
+        .join('\n        ');
+
     const rangeCases = fallbackRanges.map((r, i) => `WHEN sr.most_recent_nps_score${fallbackSuffixes[i]} IS NOT NULL THEN '${r}'`).join('\n        ');
 
     const query = `
@@ -3694,13 +3703,13 @@ export class ProjectService {
       )
       SELECT
         sr.project_id AS PROJECT_ID,
-        COALESCE(${npsCoalesce}) AS NPS_SCORE,
-        COALESCE(${promotersCoalesce}) AS PROMOTERS,
-        COALESCE(${passivesCoalesce}) AS PASSIVES,
-        COALESCE(${detractorsCoalesce}) AS DETRACTORS,
-        COALESCE(${nonResponsesCoalesce}) AS NON_RESPONSES,
+        CASE ${buildCaseWhen('most_recent_nps_score')} ELSE NULL END AS NPS_SCORE,
+        CASE ${buildCaseWhen('most_recent_count_promoters')} ELSE NULL END AS PROMOTERS,
+        CASE ${buildCaseWhen('most_recent_count_passives')} ELSE NULL END AS PASSIVES,
+        CASE ${buildCaseWhen('most_recent_count_detractors')} ELSE NULL END AS DETRACTORS,
+        CASE ${buildCaseWhen('most_recent_count_non_responses')} ELSE NULL END AS NON_RESPONSES,
         sr.last_updated AS LAST_UPDATED,
-        COALESCE(${changeCoalesce}) AS CHANGE_NPS_SCORE,
+        CASE ${buildCaseWhen('nps_score_most_recent_to_previous_change')} ELSE NULL END AS CHANGE_NPS_SCORE,
         CASE
         ${rangeCases}
         ELSE NULL
@@ -3722,7 +3731,7 @@ export class ProjectService {
         nonResponses: 0,
         responses: 0,
         lastUpdatedLabel: 'N/A',
-        effectiveRange: requestedRange,
+        range: requestedRange,
         periodLabel: '',
       };
     }
@@ -3740,8 +3749,7 @@ export class ProjectService {
       }
     }
 
-    const resolvedRange: HealthMetricsRange =
-      row.EFFECTIVE_RANGE && ORDERED_RANGES.includes(row.EFFECTIVE_RANGE as HealthMetricsRange) ? (row.EFFECTIVE_RANGE as HealthMetricsRange) : requestedRange;
+    const resolvedRange: HealthMetricsRange = isHealthMetricsRange(row.EFFECTIVE_RANGE) ? row.EFFECTIVE_RANGE : requestedRange;
 
     const year = getYearForRange(resolvedRange);
     const periodLabel = resolvedRange === 'YTD' ? `YTD ${year}` : `FY ${year}`;
@@ -3760,7 +3768,7 @@ export class ProjectService {
       nonResponses,
       responses: promoters + passives + detractors + nonResponses,
       lastUpdatedLabel,
-      effectiveRange: resolvedRange,
+      range: resolvedRange,
       periodLabel,
       changeNpsScore: row.CHANGE_NPS_SCORE ?? 0,
     };

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -687,7 +687,7 @@ export const HEALTH_METRICS_NPS_DEFAULT_SUMMARY: NpsSummaryResponse = {
   nonResponses: 0,
   responses: 0,
   lastUpdatedLabel: 'N/A',
-  effectiveRange: 'YTD',
+  range: 'YTD',
   periodLabel: '',
 };
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -687,6 +687,8 @@ export const HEALTH_METRICS_NPS_DEFAULT_SUMMARY: NpsSummaryResponse = {
   nonResponses: 0,
   responses: 0,
   lastUpdatedLabel: 'N/A',
+  effectiveRange: 'YTD',
+  periodLabel: '',
 };
 
 export const HEALTH_METRICS_OUTSTANDING_BALANCE_DEFAULT_SUMMARY: OutstandingBalanceSummaryResponse = {

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -445,6 +445,10 @@ export interface NpsSummaryResponse {
   responses: number;
   /** Human-readable reporting period for Last Updated (e.g. "Q4 2025" or "N/A") */
   lastUpdatedLabel: string;
+  /** The range that actually has data — may differ from the requested range when YTD is empty and the BFF fell back to a prior year */
+  effectiveRange: HealthMetricsRange;
+  /** Human-readable period label derived from effectiveRange (e.g. "YTD 2026" or "FY 2025") */
+  periodLabel: string;
   /** Optional period-over-period NPS change (omit from card UI in v1) */
   changeNpsScore?: number;
 }

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -447,7 +447,7 @@ export interface NpsSummaryResponse {
   lastUpdatedLabel: string;
   /** Range whose data was actually returned — may differ from the requested range when YTD is empty and the BFF fell back to a prior year */
   range: HealthMetricsRange;
-  /** Human-readable period label derived from effectiveRange (e.g. "YTD 2026" or "FY 2025") */
+  /** Human-readable period label derived from `range` (e.g. "YTD 2026" or "FY 2025"); empty string when no period has data */
   periodLabel: string;
   /** Optional period-over-period NPS change (omit from card UI in v1) */
   changeNpsScore?: number;

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -445,8 +445,8 @@ export interface NpsSummaryResponse {
   responses: number;
   /** Human-readable reporting period for Last Updated (e.g. "Q4 2025" or "N/A") */
   lastUpdatedLabel: string;
-  /** The range that actually has data — may differ from the requested range when YTD is empty and the BFF fell back to a prior year */
-  effectiveRange: HealthMetricsRange;
+  /** Range whose data was actually returned — may differ from the requested range when YTD is empty and the BFF fell back to a prior year */
+  range: HealthMetricsRange;
   /** Human-readable period label derived from effectiveRange (e.g. "YTD 2026" or "FY 2025") */
   periodLabel: string;
   /** Optional period-over-period NPS change (omit from card UI in v1) */


### PR DESCRIPTION
## Summary

- **Root cause**: `getNpsSummary()` previously defaulted period-scoped values in a way that could hide missing YTD data and, in earlier iterations, risk mixing values across periods.
- **Fix**: The query now resolves a single effective period using fallback ordering from the requested range, and all returned NPS metrics are selected from that same period via aligned `CASE WHEN` logic.
- **API behavior**: `periodLabel` is now only populated when a valid effective period exists; otherwise it returns an empty string.
- **UX**: The NPS card shows a blue period badge when `periodLabel` is present, and keeps a clean single-label header when it is not.

## Changes

| File | Change |
|------|--------|
| `packages/shared/src/interfaces/dashboard-metric.interface.ts` | `NpsSummaryResponse` now uses `range: HealthMetricsRange` and `periodLabel: string` (JSDoc updated to match `range`) |
| `packages/shared/src/constants/dashboard-metrics.constants.ts` | Updated `HEALTH_METRICS_NPS_DEFAULT_SUMMARY` to match the `range` field and defaults |
| `apps/lfx-one/src/server/services/project.service.ts` | Reworked `getNpsSummary()` fallback selection and aligned all period-scoped metric reads to one resolved period; `periodLabel` is empty when no valid effective range is found |
| `apps/lfx-one/src/app/shared/services/analytics.service.ts` | Uses `HEALTH_METRICS_NPS_DEFAULT_SUMMARY` in `catchError` fallback |
| `apps/lfx-one/src/app/modules/dashboards/health-metrics/nps-card/nps-card.component.html` | Period badge rendering is conditional; no extra flex wrapper when `periodLabel` is absent |

## Test plan

Scenarios covered for verification:
- Project with YTD data shows `YTD <year>` badge and correct NPS metrics
- Project with no YTD data falls back to most-recent prior year (for example `FY <year>`) with real values
- Project with no data renders empty state and no period badge
- Requesting `COMPLETED_YEAR` with no data falls back to `COMPLETED_YEAR_2` (not forward to YTD)
- `periodLabel` remains empty when no effective range exists