### PR TITLE
fix(votes): fix vote list pagination (LFXV2-1969)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -46,7 +46,7 @@
         [loading]="isMeLens() ? myVotesLoading() : loading()"
         [totalRecords]="isMeLens() ? filteredMyVotes().length : totalRecords()"
         [rowsPerPage]="rowsPerPage()"
-        [first]="isMeLens() ? 0 : currentFirst()"
+        [first]="currentFirst()"
         [lazy]="!isMeLens()"
         [groupOptions]="groupOptions()"
         [foundationOptions]="foundationOptions()"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -100,12 +100,14 @@ export class VotesDashboardComponent {
   });
 
   // Lens-change pagination reset is independent of the data-fetch pipelines so it fires for every lens emission, not just Me-lens loads.
+  // fetch$.next() forces initVotes() to re-run after the reset — field-init order means it would otherwise see stale currentFirst and stop at the page-token guard.
   public constructor() {
     toObservable(this.lensService.activeLens)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.pageTokens = [];
         this.currentFirst.set(0);
+        this.fetch$.next();
       });
   }
 

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { LowerCasePipe } from '@angular/common';
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -43,6 +43,7 @@ export class VotesDashboardComponent {
   private readonly lensService = inject(LensService);
   private readonly personaService = inject(PersonaService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // === Constants ===
   protected readonly voteLabel = VOTE_LABEL.singular;
@@ -98,6 +99,16 @@ export class VotesDashboardComponent {
     return !!(f.search?.trim() || f.status || f.group);
   });
 
+  // Lens-change pagination reset is independent of the data-fetch pipelines so it fires for every lens emission, not just Me-lens loads.
+  public constructor() {
+    toObservable(this.lensService.activeLens)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.pageTokens = [];
+        this.currentFirst.set(0);
+      });
+  }
+
   protected onViewVote(voteId: string): void {
     this.selectedVoteId.set(voteId);
 
@@ -147,11 +158,15 @@ export class VotesDashboardComponent {
   }
 
   protected onFoundationFilterChange(value: string | null): void {
+    this.pageTokens = [];
+    this.currentFirst.set(0);
     this.foundationFilter.set(value);
     this.projectFilter.set(null);
   }
 
   protected onProjectFilterChange(value: string | null): void {
+    this.pageTokens = [];
+    this.currentFirst.set(0);
     this.projectFilter.set(value);
   }
 

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -54,6 +54,10 @@ export class VoteService {
   ): Observable<PaginatedResponse<Vote>> {
     let params = new HttpParams().set('parent', `project:${projectUid}`);
 
+    if (pageSize) {
+      params = params.set('page_size', pageSize.toString());
+    }
+
     if (pageToken) {
       params = params.set('page_token', pageToken);
     }
@@ -92,7 +96,8 @@ export class VoteService {
 
   /** Fetches votes scoped to a committee via `tags=committee_uid:{uid}` query parameter. */
   public getVotesByCommittee(committeeUid: string, orderBy?: string): Observable<Vote[]> {
-    let params = new HttpParams().set('tags', `committee_uid:${committeeUid}`);
+    // page_size=100 keeps the drain-all UX after VoteService.getVotes switched to single-page; committees over 100 are out of scope (LFXV2-1969).
+    let params = new HttpParams().set('tags', `committee_uid:${committeeUid}`).set('page_size', '100');
 
     if (orderBy) {
       params = params.set('order', orderBy);

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -24,13 +24,14 @@ export class VoteController {
     });
 
     try {
-      const votes = await this.voteService.getVotes(req, req.query as Record<string, any>);
+      const { data: votes, page_token } = await this.voteService.getVotes(req, req.query as Record<string, any>);
 
       logger.success(req, 'get_votes', startTime, {
         vote_count: votes.length,
+        has_more_pages: !!page_token,
       });
 
-      res.json({ data: votes });
+      res.json({ data: votes, page_token });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -8,6 +8,7 @@ import {
   IndexedVote,
   IndexedVoteResponse,
   MyVoteResponse,
+  PaginatedResponse,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateVoteRequest,
@@ -39,34 +40,32 @@ export class VoteService {
   /**
    * Fetches all votes based on query parameters
    */
-  public async getVotes(req: Request, query: Record<string, any> = {}): Promise<Vote[]> {
+  public async getVotes(req: Request, query: Record<string, any> = {}): Promise<PaginatedResponse<Vote>> {
     logger.debug(req, 'get_votes', 'Starting vote fetch', {
       query_params: Object.keys(query),
     });
 
-    const queryFilters = { ...query };
-    delete queryFilters['page_token'];
-    delete queryFilters['page_size'];
-
     const params = {
-      ...queryFilters,
+      ...query,
       type: 'vote',
     };
 
-    const rawVotes = await fetchAllQueryResources<IndexedVote>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVote>>(
+      req,
+      'LFX_V2_SERVICE',
+      '/query/resources',
+      'GET',
+      params
     );
 
-    const votes = rawVotes.map((v) => this.normalizeIndexedVote(req, v));
+    const votes = resources.map((resource) => this.normalizeIndexedVote(req, resource.data));
 
     logger.debug(req, 'get_votes', 'Completed vote fetch', {
       final_count: votes.length,
+      has_more_pages: !!page_token,
     });
 
-    return votes;
+    return { data: votes, page_token };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -38,7 +38,7 @@ export class VoteService {
   }
 
   /**
-   * Fetches all votes based on query parameters
+   * Fetches a single page of votes using cursor-based pagination — callers paginate via the returned page_token.
    */
   public async getVotes(req: Request, query: Record<string, any> = {}): Promise<PaginatedResponse<Vote>> {
     logger.debug(req, 'get_votes', 'Starting vote fetch', {


### PR DESCRIPTION
# Summary

This pull request introduces several improvements to the votes dashboard, focusing on pagination consistency, page reset behaviors, and backend pagination support. The changes ensure that pagination resets correctly when filters or lenses change, and backend APIs now support and return pagination tokens and sizes. This enhances both frontend and backend handling of large vote datasets.

**Frontend: Pagination and Filter Improvements**
- The votes dashboard now resets pagination (clears `pageTokens` and sets `currentFirst` to 0) whenever the lens, foundation filter, or project filter changes, ensuring that users always see the first page of results after such changes. [[1]](diffhunk://#diff-e4d0bdbb50bc9d94717717f48c431dca8a43e53d0d5079270b9d29742698b1d1R102-R111) [[2]](diffhunk://#diff-e4d0bdbb50bc9d94717717f48c431dca8a43e53d0d5079270b9d29742698b1d1R161-R169)
- The `[first]` property in the table component is now always set to `currentFirst()`, simplifying the logic and ensuring correct page navigation.

**Frontend: Pagination Parameter Passing**
- The frontend vote service now includes `page_size` in requests when provided, enabling backend pagination. Committee vote requests are capped at 100 results for performance and UX reasons. [[1]](diffhunk://#diff-f9ebeaa7142eaa1ba86b5626618f406b456ab61364dd1dbb523596ba9ef4276eR57-R60) [[2]](diffhunk://#diff-f9ebeaa7142eaa1ba86b5626618f406b456ab61364dd1dbb523596ba9ef4276eL95-R100)

**Backend: Pagination Support**
- The backend vote controller and service now support and return paginated responses (`data` and `page_token`), aligning with frontend expectations and making it possible to handle large datasets efficiently. [[1]](diffhunk://#diff-5e2f7bdd4fc128c2e660bd384a9f63981e28c84e85ea7fdd76e6ff83ae00a374L27-R34) [[2]](diffhunk://#diff-18c155558dc67592a24e987f4cacba24250d9f76d07126b74ceee8cb6e4c7933R11) [[3]](diffhunk://#diff-18c155558dc67592a24e987f4cacba24250d9f76d07126b74ceee8cb6e4c7933L42-R68)