### PR TITLE
feat(crowdfunding): integrate Stripe Elements into add-payment-card-d…

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -157,3 +157,8 @@ CREDLY_API_TOKEN=your-credly-api-token
 CHANGELOG_API_URL=https://changelog.lfx.dev
 CHANGELOG_API_KEY=your-changelog-api-key
 CHANGELOG_PRODUCT_ID=your-changelog-product-uuid
+
+# Stripe publishable key
+# This value can be obtained from our AWS Systems Manager Parameter Store:
+# us-east-1 list_parameter_filters=Name:Contains:stripe
+STRIPE_PUBLISHABLE_KEY=pk_test

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -160,5 +160,5 @@ CHANGELOG_PRODUCT_ID=your-changelog-product-uuid
 
 # Stripe publishable key
 # This value can be obtained from our AWS Systems Manager Parameter Store:
-# us-east-1 list_parameter_filters=Name:Contains:stripe
+# aws ssm get-parameters-by-path --region us-east-1 --path / --recursive --query "Parameters[?contains(Name, 'stripe')].Name" --output text
 STRIPE_PUBLISHABLE_KEY=pk_test

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -1,76 +1,63 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<form [formGroup]="form" (ngSubmit)="onSubmit()" class="flex flex-col gap-5" data-testid="add-card-form">
+<div class="flex flex-col gap-5" data-testid="add-card-form">
   <!-- Card number -->
   <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
-    <label for="card-number" class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
-    <input
-      pInputText
-      id="card-number"
-      type="text"
-      inputmode="numeric"
-      autocomplete="cc-number"
-      placeholder="1234 5678 9123 4567"
-      maxlength="19"
-      formControlName="cardNumber"
-      (input)="onCardNumberInput($event)"
-      class="w-full"
-      [class.ng-invalid]="form.controls.cardNumber.invalid && form.controls.cardNumber.touched"
-      [class.ng-dirty]="form.controls.cardNumber.dirty"
-      data-testid="add-card-number-input" />
-    @if (form.controls.cardNumber.invalid && form.controls.cardNumber.touched) {
-      <p class="text-xs text-red-500">Enter a valid 16-digit card number.</p>
+    <label class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
+    <div
+      class="flex items-center border rounded-md shadow-xs transition-all"
+      [class.border-neutral-900]="cardNumberFocused()"
+      [class.border-red-500]="!cardNumberFocused() && cardNumberError()"
+      [class.border-gray-200]="!cardNumberFocused() && !cardNumberError()">
+      <div #cardNumberContainer class="w-full py-2 px-2" data-testid="add-card-number-input"></div>
+    </div>
+    @if (cardNumberError()) {
+      <p class="text-xs text-red-500" role="alert">{{ cardNumberError() }}</p>
     }
   </div>
 
   <!-- Expiry + CVC -->
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-3 gap-4">
     <!-- Expiry -->
-    <div class="flex flex-col gap-1.5" data-testid="add-card-field-expiry">
-      <label for="card-expiry" class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
-      <input
-        pInputText
-        id="card-expiry"
-        type="text"
-        inputmode="numeric"
-        autocomplete="cc-exp"
-        placeholder="MM/YY"
-        maxlength="5"
-        formControlName="expiry"
-        (input)="onExpiryInput($event)"
-        [class.ng-invalid]="form.controls.expiry.invalid && form.controls.expiry.touched"
-        [class.ng-dirty]="form.controls.expiry.dirty"
-        data-testid="add-card-expiry-input" />
-      @if (form.controls.expiry.invalid && form.controls.expiry.touched) {
-        <p class="text-xs text-red-500">Enter a valid expiry (MM/YY).</p>
+    <div class="col-span-2 flex flex-col gap-1.5" data-testid="add-card-field-expiry">
+      <label class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <div
+        class="flex items-center border rounded-md shadow-xs transition-all"
+        [class.border-neutral-900]="cardExpiryFocused()"
+        [class.border-red-500]="!cardExpiryFocused() && cardExpiryError()"
+        [class.border-gray-200]="!cardExpiryFocused() && !cardExpiryError()">
+        <div #cardExpiryContainer class="w-full py-2 px-2" data-testid="add-card-expiry-input"></div>
+      </div>
+      @if (cardExpiryError()) {
+        <p class="text-xs text-red-500" role="alert">{{ cardExpiryError() }}</p>
       }
     </div>
 
     <!-- CVC -->
     <div class="flex flex-col gap-1.5" data-testid="add-card-field-cvc">
-      <label for="card-cvc" class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
-      <input
-        pInputText
-        id="card-cvc"
-        type="password"
-        inputmode="numeric"
-        autocomplete="cc-csc"
-        placeholder="•••"
-        maxlength="4"
-        formControlName="cvc"
-        [class.ng-invalid]="form.controls.cvc.invalid && form.controls.cvc.touched"
-        [class.ng-dirty]="form.controls.cvc.dirty"
-        data-testid="add-card-cvc-input" />
-      @if (form.controls.cvc.invalid && form.controls.cvc.touched) {
-        <p class="text-xs text-red-500">Enter a valid CVC.</p>
+      <label class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <div
+        class="flex items-center border rounded-md shadow-xs transition-all"
+        [class.border-neutral-900]="cardCvcFocused()"
+        [class.border-red-500]="!cardCvcFocused() && cardCvcError()"
+        [class.border-gray-200]="!cardCvcFocused() && !cardCvcError()">
+        <div #cardCvcContainer class="w-full py-2 px-2" data-testid="add-card-cvc-input"></div>
+      </div>
+      @if (cardCvcError()) {
+        <p class="text-xs text-red-500" role="alert">{{ cardCvcError() }}</p>
       }
     </div>
   </div>
 
+  <!-- Stripe / general error -->
+  @if (stripeError()) {
+    <p class="text-xs text-red-500" role="alert" data-testid="add-card-stripe-error">{{ stripeError() }}</p>
+  }
+
   <!-- Footer actions -->
   <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
     <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
-    <lfx-button label="Add card" severity="primary" type="submit" data-testid="add-card-submit-btn" />
+    <lfx-button label="Add card" severity="primary" type="button" [loading]="submitting()" (click)="onSubmit()" data-testid="add-card-submit-btn" />
   </div>
-</form>
+</div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-5" data-testid="add-card-form">
+<form class="flex flex-col gap-5" (submit)="$event.preventDefault(); onSubmit()" novalidate data-testid="add-card-form">
   <!-- Card number -->
   <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
     <label class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
@@ -58,6 +58,6 @@
   <!-- Footer actions -->
   <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
     <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
-    <lfx-button label="Add card" severity="primary" type="button" [loading]="submitting()" (click)="onSubmit()" data-testid="add-card-submit-btn" />
+    <lfx-button label="Add card" severity="primary" type="submit" [loading]="submitting()" data-testid="add-card-submit-btn" />
   </div>
-</div>
+</form>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.html
@@ -4,13 +4,13 @@
 <form class="flex flex-col gap-5" (submit)="$event.preventDefault(); onSubmit()" novalidate data-testid="add-card-form">
   <!-- Card number -->
   <div class="flex flex-col gap-1.5" data-testid="add-card-field-number">
-    <label class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
+    <label id="card-number-label" class="text-sm font-medium text-gray-700"> Card number <span class="text-red-500" aria-hidden="true">*</span> </label>
     <div
       class="flex items-center border rounded-md shadow-xs transition-all"
       [class.border-neutral-900]="cardNumberFocused()"
       [class.border-red-500]="!cardNumberFocused() && cardNumberError()"
       [class.border-gray-200]="!cardNumberFocused() && !cardNumberError()">
-      <div #cardNumberContainer class="w-full py-2 px-2" data-testid="add-card-number-input"></div>
+      <div #cardNumberContainer class="w-full py-2 px-2" aria-labelledby="card-number-label" data-testid="add-card-number-input"></div>
     </div>
     @if (cardNumberError()) {
       <p class="text-xs text-red-500" role="alert">{{ cardNumberError() }}</p>
@@ -21,13 +21,13 @@
   <div class="grid grid-cols-3 gap-4">
     <!-- Expiry -->
     <div class="col-span-2 flex flex-col gap-1.5" data-testid="add-card-field-expiry">
-      <label class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <label id="card-expiry-label" class="text-sm font-medium text-gray-700"> Expiry <span class="text-red-500" aria-hidden="true">*</span> </label>
       <div
         class="flex items-center border rounded-md shadow-xs transition-all"
         [class.border-neutral-900]="cardExpiryFocused()"
         [class.border-red-500]="!cardExpiryFocused() && cardExpiryError()"
         [class.border-gray-200]="!cardExpiryFocused() && !cardExpiryError()">
-        <div #cardExpiryContainer class="w-full py-2 px-2" data-testid="add-card-expiry-input"></div>
+        <div #cardExpiryContainer class="w-full py-2 px-2" aria-labelledby="card-expiry-label" data-testid="add-card-expiry-input"></div>
       </div>
       @if (cardExpiryError()) {
         <p class="text-xs text-red-500" role="alert">{{ cardExpiryError() }}</p>
@@ -36,13 +36,13 @@
 
     <!-- CVC -->
     <div class="flex flex-col gap-1.5" data-testid="add-card-field-cvc">
-      <label class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
+      <label id="card-cvc-label" class="text-sm font-medium text-gray-700"> CVC <span class="text-red-500" aria-hidden="true">*</span> </label>
       <div
         class="flex items-center border rounded-md shadow-xs transition-all"
         [class.border-neutral-900]="cardCvcFocused()"
         [class.border-red-500]="!cardCvcFocused() && cardCvcError()"
         [class.border-gray-200]="!cardCvcFocused() && !cardCvcError()">
-        <div #cardCvcContainer class="w-full py-2 px-2" data-testid="add-card-cvc-input"></div>
+        <div #cardCvcContainer class="w-full py-2 px-2" aria-labelledby="card-cvc-label" data-testid="add-card-cvc-input"></div>
       </div>
       @if (cardCvcError()) {
         <p class="text-xs text-red-500" role="alert">{{ cardCvcError() }}</p>
@@ -58,6 +58,6 @@
   <!-- Footer actions -->
   <div class="flex justify-end gap-2 pt-2 border-t border-gray-100">
     <lfx-button label="Cancel" severity="secondary" type="button" (click)="onCancel()" data-testid="add-card-cancel-btn" />
-    <lfx-button label="Add card" severity="primary" type="submit" [loading]="submitting()" data-testid="add-card-submit-btn" />
+    <lfx-button label="Add card" severity="primary" type="submit" [loading]="submitting()" [disabled]="!formReady()" data-testid="add-card-submit-btn" />
   </div>
 </form>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -12,6 +12,7 @@ import { STRIPE_ELEMENT_STYLE } from '@lfx-one/shared/constants';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { CrowdfundingService } from '@services/crowdfunding.service';
 import { StripeService } from '@services/stripe.service';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 
 @Component({
   selector: 'lfx-add-payment-card-dialog',
@@ -29,6 +30,9 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
   protected readonly cardNumberContainer = viewChild<ElementRef<HTMLElement>>('cardNumberContainer');
   protected readonly cardExpiryContainer = viewChild<ElementRef<HTMLElement>>('cardExpiryContainer');
   protected readonly cardCvcContainer = viewChild<ElementRef<HTMLElement>>('cardCvcContainer');
+
+  // ─── Destroy guard (prevents mount() on detached DOM nodes) ─────────────
+  private destroyed = false;
 
   // ─── Stripe element instances (not signals — not reactive values) ─────────
   private cardNumberEl: StripeCardNumberElement | null = null;
@@ -62,6 +66,7 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
   }
 
   public ngOnDestroy(): void {
+    this.destroyed = true;
     this.destroyElements();
   }
 
@@ -96,6 +101,8 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
       const saved = await firstValueFrom(this.crowdfundingService.savePaymentMethod(paymentMethod.id));
 
       this.dialogRef.close({ added: true, paymentMethod: saved });
+    } catch (err) {
+      this.stripeError.set(extractErrorMessage(err, 'Failed to save payment method. Please try again.'));
     } finally {
       this.submitting.set(false);
     }
@@ -113,6 +120,8 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
 
   private async mountStripeElements(): Promise<void> {
     const stripe = await this.stripeService.getStripe();
+
+    if (this.destroyed) return;
 
     const numberEl = this.cardNumberContainer()?.nativeElement;
     const expiryEl = this.cardExpiryContainer()?.nativeElement;

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -3,7 +3,7 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { afterNextRender, Component, ElementRef, inject, OnDestroy, signal, viewChild } from '@angular/core';
+import { afterNextRender, Component, computed, ElementRef, inject, OnDestroy, signal, viewChild } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import type { StripeCardCvcElement, StripeCardExpiryElement, StripeCardNumberElement } from '@stripe/stripe-js';
 
@@ -57,6 +57,8 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
   // ─── Submission state ─────────────────────────────────────────────────────
   protected readonly stripeError = signal('');
   protected readonly submitting = signal(false);
+  protected readonly elementsReady = signal(false);
+  protected readonly formReady = computed(() => this.elementsReady() && this.cardNumberComplete() && this.cardExpiryComplete() && this.cardCvcComplete());
 
   public constructor() {
     // afterNextRender runs only in the browser, after the view is available — SSR safe.
@@ -128,7 +130,12 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
       const expiryEl = this.cardExpiryContainer()?.nativeElement;
       const cvcEl = this.cardCvcContainer()?.nativeElement;
 
-      if (!stripe || !numberEl || !expiryEl || !cvcEl) return;
+      if (!stripe || !numberEl || !expiryEl || !cvcEl) {
+        if (!stripe) {
+          this.stripeError.set('Payment fields are unavailable. Please refresh the page or try again later.');
+        }
+        return;
+      }
 
       const elements = stripe.elements();
 
@@ -160,12 +167,15 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
       });
       this.cardCvcEl.on('focus', () => this.cardCvcFocused.set(true));
       this.cardCvcEl.on('blur', () => this.cardCvcFocused.set(false));
+
+      this.elementsReady.set(true);
     } catch (err) {
       this.stripeError.set(extractErrorMessage(err, 'Failed to mount Stripe elements. Please try again.'));
     }
   }
 
   private destroyElements(): void {
+    this.elementsReady.set(false);
     this.cardNumberEl?.destroy();
     this.cardExpiryEl?.destroy();
     this.cardCvcEl?.destroy();

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -31,7 +31,7 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
   protected readonly cardExpiryContainer = viewChild<ElementRef<HTMLElement>>('cardExpiryContainer');
   protected readonly cardCvcContainer = viewChild<ElementRef<HTMLElement>>('cardCvcContainer');
 
-  // ─── Destroy guard (prevents mount() on detached DOM nodes) ─────────────
+  // Guards mountStripeElements from running on an already-destroyed view.
   private destroyed = false;
 
   // ─── Stripe element instances (not signals — not reactive values) ─────────
@@ -119,46 +119,50 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
   }
 
   private async mountStripeElements(): Promise<void> {
-    const stripe = await this.stripeService.getStripe();
+    try {
+      const stripe = await this.stripeService.getStripe();
 
-    if (this.destroyed) return;
+      if (this.destroyed) return;
 
-    const numberEl = this.cardNumberContainer()?.nativeElement;
-    const expiryEl = this.cardExpiryContainer()?.nativeElement;
-    const cvcEl = this.cardCvcContainer()?.nativeElement;
+      const numberEl = this.cardNumberContainer()?.nativeElement;
+      const expiryEl = this.cardExpiryContainer()?.nativeElement;
+      const cvcEl = this.cardCvcContainer()?.nativeElement;
 
-    if (!stripe || !numberEl || !expiryEl || !cvcEl) return;
+      if (!stripe || !numberEl || !expiryEl || !cvcEl) return;
 
-    const elements = stripe.elements();
+      const elements = stripe.elements();
 
-    this.cardNumberEl = elements.create('cardNumber', { style: STRIPE_ELEMENT_STYLE, placeholder: '1234 5678 9012 3456' });
-    this.cardExpiryEl = elements.create('cardExpiry', { style: STRIPE_ELEMENT_STYLE });
-    this.cardCvcEl = elements.create('cardCvc', { style: STRIPE_ELEMENT_STYLE });
+      this.cardNumberEl = elements.create('cardNumber', { style: STRIPE_ELEMENT_STYLE, placeholder: '1234 5678 9012 3456' });
+      this.cardExpiryEl = elements.create('cardExpiry', { style: STRIPE_ELEMENT_STYLE });
+      this.cardCvcEl = elements.create('cardCvc', { style: STRIPE_ELEMENT_STYLE });
 
-    this.cardNumberEl.mount(numberEl);
-    this.cardExpiryEl.mount(expiryEl);
-    this.cardCvcEl.mount(cvcEl);
+      this.cardNumberEl.mount(numberEl);
+      this.cardExpiryEl.mount(expiryEl);
+      this.cardCvcEl.mount(cvcEl);
 
-    this.cardNumberEl.on('change', (e) => {
-      this.cardNumberComplete.set(e.complete);
-      this.cardNumberError.set(e.error?.message ?? '');
-    });
-    this.cardNumberEl.on('focus', () => this.cardNumberFocused.set(true));
-    this.cardNumberEl.on('blur', () => this.cardNumberFocused.set(false));
+      this.cardNumberEl.on('change', (e) => {
+        this.cardNumberComplete.set(e.complete);
+        this.cardNumberError.set(e.error?.message ?? '');
+      });
+      this.cardNumberEl.on('focus', () => this.cardNumberFocused.set(true));
+      this.cardNumberEl.on('blur', () => this.cardNumberFocused.set(false));
 
-    this.cardExpiryEl.on('change', (e) => {
-      this.cardExpiryComplete.set(e.complete);
-      this.cardExpiryError.set(e.error?.message ?? '');
-    });
-    this.cardExpiryEl.on('focus', () => this.cardExpiryFocused.set(true));
-    this.cardExpiryEl.on('blur', () => this.cardExpiryFocused.set(false));
+      this.cardExpiryEl.on('change', (e) => {
+        this.cardExpiryComplete.set(e.complete);
+        this.cardExpiryError.set(e.error?.message ?? '');
+      });
+      this.cardExpiryEl.on('focus', () => this.cardExpiryFocused.set(true));
+      this.cardExpiryEl.on('blur', () => this.cardExpiryFocused.set(false));
 
-    this.cardCvcEl.on('change', (e) => {
-      this.cardCvcComplete.set(e.complete);
-      this.cardCvcError.set(e.error?.message ?? '');
-    });
-    this.cardCvcEl.on('focus', () => this.cardCvcFocused.set(true));
-    this.cardCvcEl.on('blur', () => this.cardCvcFocused.set(false));
+      this.cardCvcEl.on('change', (e) => {
+        this.cardCvcComplete.set(e.complete);
+        this.cardCvcError.set(e.error?.message ?? '');
+      });
+      this.cardCvcEl.on('focus', () => this.cardCvcFocused.set(true));
+      this.cardCvcEl.on('blur', () => this.cardCvcFocused.set(false));
+    } catch (err) {
+      this.stripeError.set(extractErrorMessage(err, 'Failed to mount Stripe elements. Please try again.'));
+    }
   }
 
   private destroyElements(): void {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -1,56 +1,163 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ButtonComponent } from '@components/button/button.component';
-import { InputTextModule } from 'primeng/inputtext';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+// Generated with [Claude Code](https://claude.ai/code)
 
-// Raw <input> elements are intentional here: the masking logic (onCardNumberInput/onExpiryInput)
-// requires (input) event binding and inputmode/maxlength attributes that lfx-input-text does not
-// expose. These will be replaced by Stripe Elements once the payment API integration lands.
+import { afterNextRender, Component, ElementRef, inject, OnDestroy, signal, viewChild } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import type { StripeCardCvcElement, StripeCardExpiryElement, StripeCardNumberElement } from '@stripe/stripe-js';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { STRIPE_ELEMENT_STYLE } from '@lfx-one/shared/constants';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { CrowdfundingService } from '@services/crowdfunding.service';
+import { StripeService } from '@services/stripe.service';
 
 @Component({
   selector: 'lfx-add-payment-card-dialog',
-  imports: [ReactiveFormsModule, InputTextModule, ButtonComponent],
+  imports: [ButtonComponent],
   templateUrl: './add-payment-card-dialog.component.html',
   styleUrl: './add-payment-card-dialog.component.scss',
 })
-export class AddPaymentCardDialogComponent {
+export class AddPaymentCardDialogComponent implements OnDestroy {
+  // ─── Private injections ──────────────────────────────────────────────────
   private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly stripeService = inject(StripeService);
+  private readonly crowdfundingService = inject(CrowdfundingService);
 
-  protected readonly form = new FormGroup({
-    cardNumber: new FormControl('', [Validators.required, Validators.pattern(/^(\d{4} ){3}\d{4}$/)]),
-    expiry: new FormControl('', [Validators.required, Validators.pattern(/^(0[1-9]|1[0-2])\/\d{2}$/)]),
-    cvc: new FormControl('', [Validators.required, Validators.pattern(/^\d{3,4}$/)]),
-  });
+  // ─── Template refs ───────────────────────────────────────────────────────
+  protected readonly cardNumberContainer = viewChild<ElementRef<HTMLElement>>('cardNumberContainer');
+  protected readonly cardExpiryContainer = viewChild<ElementRef<HTMLElement>>('cardExpiryContainer');
+  protected readonly cardCvcContainer = viewChild<ElementRef<HTMLElement>>('cardCvcContainer');
 
-  protected onCardNumberInput(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const digits = input.value.replace(/\D/g, '').slice(0, 16);
-    const formatted = digits.match(/.{1,4}/g)?.join(' ') ?? '';
-    this.form.controls.cardNumber.setValue(formatted, { emitEvent: false });
-    input.value = formatted;
+  // ─── Stripe element instances (not signals — not reactive values) ─────────
+  private cardNumberEl: StripeCardNumberElement | null = null;
+  private cardExpiryEl: StripeCardExpiryElement | null = null;
+  private cardCvcEl: StripeCardCvcElement | null = null;
+
+  // ─── Per-field focus state ────────────────────────────────────────────────
+  protected readonly cardNumberFocused = signal(false);
+  protected readonly cardExpiryFocused = signal(false);
+  protected readonly cardCvcFocused = signal(false);
+
+  // ─── Per-field error messages ─────────────────────────────────────────────
+  protected readonly cardNumberError = signal('');
+  protected readonly cardExpiryError = signal('');
+  protected readonly cardCvcError = signal('');
+
+  // ─── Per-field completion flags ───────────────────────────────────────────
+  private readonly cardNumberComplete = signal(false);
+  private readonly cardExpiryComplete = signal(false);
+  private readonly cardCvcComplete = signal(false);
+
+  // ─── Submission state ─────────────────────────────────────────────────────
+  protected readonly stripeError = signal('');
+  protected readonly submitting = signal(false);
+
+  public constructor() {
+    // afterNextRender runs only in the browser, after the view is available — SSR safe.
+    afterNextRender(() => {
+      void this.mountStripeElements();
+    });
   }
 
-  protected onExpiryInput(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const digits = input.value.replace(/\D/g, '').slice(0, 4);
-    const formatted = digits.length > 2 ? `${digits.slice(0, 2)}/${digits.slice(2)}` : digits;
-    this.form.controls.expiry.setValue(formatted, { emitEvent: false });
-    input.value = formatted;
+  public ngOnDestroy(): void {
+    this.destroyElements();
   }
 
-  protected onSubmit(): void {
-    if (this.form.invalid) {
-      this.form.markAllAsTouched();
+  // ─── Public methods ───────────────────────────────────────────────────────
+
+  protected async onSubmit(): Promise<void> {
+    if (!this.cardNumberEl || !this.allComplete()) {
       return;
     }
-    this.dialogRef.close({ added: true });
+
+    this.stripeError.set('');
+    this.submitting.set(true);
+
+    try {
+      const stripe = await this.stripeService.getStripe();
+
+      if (!stripe) {
+        this.stripeError.set('Stripe is not available. Please try again.');
+        return;
+      }
+
+      const { paymentMethod, error } = await stripe.createPaymentMethod({
+        type: 'card',
+        card: this.cardNumberEl,
+      });
+
+      if (error) {
+        this.stripeError.set(error.message ?? 'Failed to process card. Please try again.');
+        return;
+      }
+
+      const saved = await firstValueFrom(this.crowdfundingService.savePaymentMethod(paymentMethod.id));
+
+      this.dialogRef.close({ added: true, paymentMethod: saved });
+    } finally {
+      this.submitting.set(false);
+    }
   }
 
   protected onCancel(): void {
     this.dialogRef.close();
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private allComplete(): boolean {
+    return this.cardNumberComplete() && this.cardExpiryComplete() && this.cardCvcComplete();
+  }
+
+  private async mountStripeElements(): Promise<void> {
+    const stripe = await this.stripeService.getStripe();
+
+    const numberEl = this.cardNumberContainer()?.nativeElement;
+    const expiryEl = this.cardExpiryContainer()?.nativeElement;
+    const cvcEl = this.cardCvcContainer()?.nativeElement;
+
+    if (!stripe || !numberEl || !expiryEl || !cvcEl) return;
+
+    const elements = stripe.elements();
+
+    this.cardNumberEl = elements.create('cardNumber', { style: STRIPE_ELEMENT_STYLE, placeholder: '1234 5678 9012 3456' });
+    this.cardExpiryEl = elements.create('cardExpiry', { style: STRIPE_ELEMENT_STYLE });
+    this.cardCvcEl = elements.create('cardCvc', { style: STRIPE_ELEMENT_STYLE });
+
+    this.cardNumberEl.mount(numberEl);
+    this.cardExpiryEl.mount(expiryEl);
+    this.cardCvcEl.mount(cvcEl);
+
+    this.cardNumberEl.on('change', (e) => {
+      this.cardNumberComplete.set(e.complete);
+      this.cardNumberError.set(e.error?.message ?? '');
+    });
+    this.cardNumberEl.on('focus', () => this.cardNumberFocused.set(true));
+    this.cardNumberEl.on('blur', () => this.cardNumberFocused.set(false));
+
+    this.cardExpiryEl.on('change', (e) => {
+      this.cardExpiryComplete.set(e.complete);
+      this.cardExpiryError.set(e.error?.message ?? '');
+    });
+    this.cardExpiryEl.on('focus', () => this.cardExpiryFocused.set(true));
+    this.cardExpiryEl.on('blur', () => this.cardExpiryFocused.set(false));
+
+    this.cardCvcEl.on('change', (e) => {
+      this.cardCvcComplete.set(e.complete);
+      this.cardCvcError.set(e.error?.message ?? '');
+    });
+    this.cardCvcEl.on('focus', () => this.cardCvcFocused.set(true));
+    this.cardCvcEl.on('blur', () => this.cardCvcFocused.set(false));
+  }
+
+  private destroyElements(): void {
+    this.cardNumberEl?.destroy();
+    this.cardExpiryEl?.destroy();
+    this.cardCvcEl?.destroy();
+    this.cardNumberEl = null;
+    this.cardExpiryEl = null;
+    this.cardCvcEl = null;
   }
 }

--- a/apps/lfx-one/src/app/shared/providers/runtime-config.provider.ts
+++ b/apps/lfx-one/src/app/shared/providers/runtime-config.provider.ts
@@ -14,6 +14,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   dataDogRumApplicationId: '',
   allowedTracingUrls: [],
   intercomAppId: '',
+  stripePublishableKey: '',
 };
 
 /**

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -24,7 +24,7 @@ import {
   PaymentMethod,
   RecurringDonationsResponse,
 } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, of } from 'rxjs';
+import { catchError, Observable, of, take } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -61,6 +61,11 @@ export class CrowdfundingService {
 
   public getMyPaymentMethod(): Observable<PaymentMethod | null> {
     return this.http.get<PaymentMethod>('/api/crowdfunding/payment-method').pipe(catchError(() => of(null)));
+  }
+
+  // POST /api/crowdfunding/payment-method — mirrors the crowdfunding-app BFF payload: { paymentMethodId }.
+  public savePaymentMethod(paymentMethodId: string): Observable<PaymentMethod> {
+    return this.http.post<PaymentMethod>('/api/crowdfunding/payment-method', { paymentMethodId }).pipe(take(1));
   }
 
   public getMyDonationStats(): Observable<DonationStats> {

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -24,7 +24,7 @@ import {
   PaymentMethod,
   RecurringDonationsResponse,
 } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, of, take } from 'rxjs';
+import { catchError, Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -65,7 +65,7 @@ export class CrowdfundingService {
 
   // POST /api/crowdfunding/payment-method — mirrors the crowdfunding-app BFF payload: { paymentMethodId }.
   public savePaymentMethod(paymentMethodId: string): Observable<PaymentMethod> {
-    return this.http.post<PaymentMethod>('/api/crowdfunding/payment-method', { paymentMethodId }).pipe(take(1));
+    return this.http.post<PaymentMethod>('/api/crowdfunding/payment-method', { paymentMethodId });
   }
 
   public getMyDonationStats(): Observable<DonationStats> {

--- a/apps/lfx-one/src/app/shared/services/stripe.service.ts
+++ b/apps/lfx-one/src/app/shared/services/stripe.service.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { TransferState } from '@angular/core';
+import type { Stripe } from '@stripe/stripe-js';
+
+import { getRuntimeConfig } from '@app/shared/providers/runtime-config.provider';
+
+// SSR-safe Stripe.js loader — mirrors the Vue useStripe composable; dynamically imported to keep window off the SSR bundle.
+@Injectable({
+  providedIn: 'root',
+})
+export class StripeService {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly transferState = inject(TransferState);
+
+  private stripePromise: Promise<Stripe | null> | null = null;
+  private loadedKey = '';
+
+  // Returns the cached Stripe instance (null on server or when publishable key is absent).
+  public getStripe(): Promise<Stripe | null> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return Promise.resolve(null);
+    }
+
+    const { stripePublishableKey } = getRuntimeConfig(this.transferState);
+
+    if (!stripePublishableKey) {
+      return Promise.resolve(null);
+    }
+
+    if (!this.stripePromise || this.loadedKey !== stripePublishableKey) {
+      this.loadedKey = stripePublishableKey;
+      this.stripePromise = import('@stripe/stripe-js').then(({ loadStripe }) => loadStripe(stripePublishableKey));
+    }
+
+    return this.stripePromise;
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/stripe.service.ts
+++ b/apps/lfx-one/src/app/shared/services/stripe.service.ts
@@ -3,9 +3,8 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID, TransferState } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { TransferState } from '@angular/core';
 import type { Stripe } from '@stripe/stripe-js';
 
 import { getRuntimeConfig } from '@app/shared/providers/runtime-config.provider';

--- a/apps/lfx-one/src/app/shared/services/stripe.service.ts
+++ b/apps/lfx-one/src/app/shared/services/stripe.service.ts
@@ -35,7 +35,13 @@ export class StripeService {
 
     if (!this.stripePromise || this.loadedKey !== stripePublishableKey) {
       this.loadedKey = stripePublishableKey;
-      this.stripePromise = import('@stripe/stripe-js').then(({ loadStripe }) => loadStripe(stripePublishableKey));
+      this.stripePromise = import('@stripe/stripe-js')
+        .then(({ loadStripe }) => loadStripe(stripePublishableKey))
+        .catch((err) => {
+          this.stripePromise = null;
+          this.loadedKey = '';
+          return Promise.reject(err);
+        });
     }
 
     return this.stripePromise;

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -39,6 +39,37 @@ export class CrowdfundingController {
     }
   }
 
+  // POST /api/crowdfunding/payment-method
+  public async saveMyPaymentMethod(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'save_my_payment_method');
+
+    try {
+      const rawUsername = await getUsernameFromAuth(req);
+
+      if (!rawUsername) {
+        throw new AuthenticationError('User authentication required', {
+          operation: 'save_my_payment_method',
+        });
+      }
+
+      const { paymentMethodId } = req.body as { paymentMethodId?: string };
+
+      if (!paymentMethodId) {
+        res.status(400).json({ message: 'paymentMethodId is required' });
+        return;
+      }
+
+      const username = stripAuthPrefix(rawUsername);
+      const paymentMethod = await this.crowdfundingService.saveMyPaymentMethod(req, username, paymentMethodId);
+
+      logger.success(req, 'save_my_payment_method', startTime, { paymentMethodId });
+
+      res.json(paymentMethod);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   // GET /api/crowdfunding/payment-method
   public async getMyPaymentMethod(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_my_payment_method');
@@ -151,10 +182,7 @@ export class CrowdfundingController {
     }
   }
 
-  /**
-   * GET /api/crowdfunding/initiatives-stats
-   * Get aggregated initiatives stats for the authenticated user
-   */
+  // GET /api/crowdfunding/initiatives-stats
   public async getInitiativesStats(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_initiatives_stats');
 

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -5,7 +5,7 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import { AuthenticationError } from '../errors';
+import { AuthenticationError, ServiceValidationError } from '../errors';
 import { CrowdfundingService } from '../services/crowdfunding.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -52,12 +52,13 @@ export class CrowdfundingController {
         });
       }
 
-      const { paymentMethodId } = req.body as { paymentMethodId?: string };
-
-      if (!paymentMethodId) {
-        res.status(400).json({ message: 'paymentMethodId is required' });
-        return;
+      const rawId = (req.body as Record<string, unknown>)['paymentMethodId'];
+      if (typeof rawId !== 'string' || !rawId.trim()) {
+        throw ServiceValidationError.forField('paymentMethodId', 'paymentMethodId is required and must be a non-empty string', {
+          operation: 'save_my_payment_method',
+        });
       }
+      const paymentMethodId = rawId.trim();
 
       const username = stripAuthPrefix(rawUsername);
       const paymentMethod = await this.crowdfundingService.saveMyPaymentMethod(req, username, paymentMethodId);

--- a/apps/lfx-one/src/server/routes/crowdfunding.route.ts
+++ b/apps/lfx-one/src/server/routes/crowdfunding.route.ts
@@ -10,6 +10,7 @@ import { CrowdfundingController } from '../controllers/crowdfunding.controller';
 const router = Router();
 const crowdfundingController = new CrowdfundingController();
 
+router.post('/payment-method', (req, res, next) => crowdfundingController.saveMyPaymentMethod(req, res, next));
 router.get('/payment-method', (req, res, next) => crowdfundingController.getMyPaymentMethod(req, res, next));
 router.get('/donation-stats', (req, res, next) => crowdfundingController.getMyDonationStats(req, res, next));
 router.get('/recurring-donations', (req, res, next) => crowdfundingController.getMyRecurringDonations(req, res, next));

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -313,6 +313,7 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     dataDogRumApplicationId: process.env['DD_RUM_APPLICATION_ID'] || '',
     allowedTracingUrls: [process.env['LFX_V2_SERVICE'], process.env['PCC_BASE_URL']].filter(Boolean) as string[],
     intercomAppId: process.env['INTERCOM_APP_ID'] || '',
+    stripePublishableKey: process.env['STRIPE_PUBLISHABLE_KEY'] || '',
   };
 
   angularApp

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -88,6 +88,24 @@ export class CrowdfundingService {
     return MOCK_PAYMENT_METHOD;
   }
 
+  // Mock for POST /api/crowdfunding/payment-method — replace with upstream proxy once the payment-method service is live.
+  public async saveMyPaymentMethod(req: Request, username: string, paymentMethodId: string): Promise<PaymentMethod> {
+    logger.debug(req, 'save_my_payment_method', 'Saving payment method for user', { username, paymentMethodId });
+
+    // Mock: Visa test card — real impl will proxy to POST /v1/me/payment-method.
+    const saved: PaymentMethod = {
+      paymentMethodId,
+      brand: 'visa',
+      lastFour: '4242',
+      expiryMonth: 12,
+      expiryYear: 2028,
+    };
+
+    logger.debug(req, 'save_my_payment_method', 'Payment method saved', { paymentMethodId });
+
+    return saved;
+  }
+
   public async getMyDonationStats(req: Request, username: string): Promise<DonationStats> {
     logger.debug(req, 'get_my_donation_stats', 'Fetching donation stats for user', { username });
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     ]
   },
   "dependencies": {
+    "@stripe/stripe-js": "^9.7.0",
     "chart.js": "^4.5.1"
   }
 }

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -58,7 +58,7 @@ export const STRIPE_ELEMENT_STYLE = {
     lineHeight: '20px',
     '::placeholder': { color: '#94A3B8' },
   },
-  invalid: { color: '#0F172A' },
+  invalid: { color: '#EF4444' },
 };
 export const EMPTY_INITIATIVES_RESPONSE: InitiativesResponse = { data: [], total: 0, pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset: 0 };
 export const EMPTY_CROWDFUNDING_STATS: CrowdfundingInitiativesStats = { activeCount: 0, totalRaised: 0, monthlyGain: 0, totalSponsors: 0 };

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -48,6 +48,18 @@ export const CROWDFUNDING_DONOR_AVATAR_PALETTE: string[] = [
 ];
 
 export const DEFAULT_CROWDFUNDING_PAGE_SIZE = 10;
+
+// Stripe Elements style — hex values required (Stripe does not accept Tailwind classes).
+export const STRIPE_ELEMENT_STYLE = {
+  base: {
+    color: '#0F172A',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    fontSize: '14px',
+    lineHeight: '20px',
+    '::placeholder': { color: '#94A3B8' },
+  },
+  invalid: { color: '#0F172A' },
+};
 export const EMPTY_INITIATIVES_RESPONSE: InitiativesResponse = { data: [], total: 0, pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset: 0 };
 export const EMPTY_CROWDFUNDING_STATS: CrowdfundingInitiativesStats = { activeCount: 0, totalRaised: 0, monthlyGain: 0, totalSponsors: 0 };
 

--- a/packages/shared/src/interfaces/runtime-config.interface.ts
+++ b/packages/shared/src/interfaces/runtime-config.interface.ts
@@ -38,6 +38,10 @@ export interface RuntimeConfig {
    * `intercom_user_jwt`.
    */
   intercomAppId: string;
-  // Stripe publishable key for client-side Stripe Elements integration (safe to expose in browser).
+
+  /**
+   * Stripe publishable key for client-side Stripe Elements integration.
+   * Safe to expose in the browser — see https://stripe.com/docs/keys
+   */
   stripePublishableKey: string;
 }

--- a/packages/shared/src/interfaces/runtime-config.interface.ts
+++ b/packages/shared/src/interfaces/runtime-config.interface.ts
@@ -38,4 +38,6 @@ export interface RuntimeConfig {
    * `intercom_user_jwt`.
    */
   intercomAppId: string;
+  // Stripe publishable key for client-side Stripe Elements integration (safe to expose in browser).
+  stripePublishableKey: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6608,6 +6608,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stripe/stripe-js@npm:^9.7.0":
+  version: 9.7.0
+  resolution: "@stripe/stripe-js@npm:9.7.0"
+  checksum: 10c0/e93e70f3701f757dbd690fcc4f4de884bdc579ea3aef7db188be7bb2c5e2501b9e077c746dd30a3a19bb1151f4d161519b59b2b0ed356af43297060a7d5d2b47
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:^0.3.13":
   version: 0.3.17
   resolution: "@swc/helpers@npm:0.3.17"
@@ -12619,6 +12626,7 @@ __metadata:
     "@commitlint/cli": "npm:^20.1.0"
     "@commitlint/config-angular": "npm:^20.0.0"
     "@linuxfoundation/lfx-ui-core": "npm:^0.2.0"
+    "@stripe/stripe-js": "npm:^9.7.0"
     "@types/node": "npm:^24.2.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.39.1"
     "@typescript-eslint/parser": "npm:^8.39.1"


### PR DESCRIPTION
## Summary

  Replaces the raw masked `<input>` placeholders in the Add Payment Card dialog with real Stripe Elements, wired end-to-end through a mock BFF endpoint.

  ## Changes
  
  ### Shared (`packages/shared`)
  - **`runtime-config.interface.ts`** — Added `stripePublishableKey` to `RuntimeConfig`
  - **`crowdfunding.constants.ts`** — Added `STRIPE_ELEMENT_STYLE` constant (hex values intentional — Stripe Elements does not accept Tailwind/CSS classes)

  ### Backend (`apps/lfx-one/src/server`)
  - **`server.ts`** ⚠️  _protected_ — Threads `STRIPE_PUBLISHABLE_KEY` env var into `RuntimeConfig` via the SSR `TransferState` pipeline alongside existing LD/DataDog keys
  - **`crowdfunding.service.ts`** — Added `saveMyPaymentMethod` mock; mirrors the crowdfunding-app BFF contract (`POST /v1/me/payment-method` → `CardDetailsWire` → camelCase `PaymentMethod`). Returns a hardcoded
  Visa test card — **not production data**. Marked for replacement once the payment-method service is live.
  - **`crowdfunding.controller.ts`** — Added `POST /api/crowdfunding/payment-method` handler with `paymentMethodId` validation
  - **`crowdfunding.route.ts`** — Registered `POST /payment-method`

  ### Frontend (`apps/lfx-one/src/app`)
  - **`stripe.service.ts`** _(new)_ — SSR-safe `StripeService`; mirrors the Vue `useStripe` composable. Uses `isPlatformBrowser` + dynamic `import('@stripe/stripe-js')` so the SSR bundle never references `window`
  at module-evaluation time. Promise is cached and keyed on the publishable key.
  - **`runtime-config.provider.ts`** — Added `stripePublishableKey` to `DEFAULT_RUNTIME_CONFIG`
  - **`crowdfunding.service.ts`** — Added `savePaymentMethod(paymentMethodId)` — `POST /api/crowdfunding/payment-method`
  - **`add-payment-card-dialog`** — Full rewrite: Stripe Elements (`cardNumber`, `cardExpiry`, `cardCvc`) mounted via `afterNextRender`, destroyed in `ngOnDestroy`. Per-field focus/error/complete signals drive
  border styling and inline error messages. `onSubmit` calls `stripe.createPaymentMethod()` then `savePaymentMethod()` and closes the dialog with the saved `PaymentMethod`.

  ### Dependencies
  - **`package.json`** ⚠️  _protected_ — Added `@stripe/stripe-js ^9.7.0`

  ### Environment
  - **`.env.example`** — Documented `STRIPE_PUBLISHABLE_KEY` (obtain from AWS SSM Parameter Store)

  ## Flow

  Dialog opens
    → afterNextRender() → StripeService.getStripe() [dynamic import, browser-only]
    → stripe.elements() → mount cardNumber / cardExpiry / cardCvc

  User fills card → Stripe validates per-field, signals update borders + errors

  User clicks "Add card"
    → stripe.createPaymentMethod({ type: 'card', card: cardNumberEl })
    → POST /api/crowdfunding/payment-method { paymentMethodId }
    → dialogRef.close({ added: true, paymentMethod: SavedPaymentMethod })

  ## Notes

  - **Mock data**: The `POST /api/crowdfunding/payment-method` service returns `{ brand: 'visa', lastFour: '4242', expiryMonth: 12, expiryYear: 2028 }` regardless of the submitted `paymentMethodId`. This is a BFF
  placeholder — the real implementation will proxy to the upstream payment-method service.
  - **Hex values in `STRIPE_ELEMENT_STYLE`**: These are intentional. Stripe Elements renders inside an iframe and only accepts raw CSS property values, not Tailwind utility classes.
  - **`server.ts` change**: One line added to the existing `runtimeConfig` object — no structural changes to middleware or routing.
