### PR TITLE
feat(org-lens): always enable org items mock until real data is wired

### DIFF
--- a/apps/lfx-one/src/server/utils/mock-org-items.util.ts
+++ b/apps/lfx-one/src/server/utils/mock-org-items.util.ts
@@ -1,9 +1,5 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/** Dev-only fixture gate — enabled when MOCK_ORG_ITEMS is the literal `'true'` or `'1'` AND NODE_ENV !== 'production'. Fail-closed: other truthy-looking values are rejected. */
-export const isMockOrgItemsEnabled = (): boolean => {
-  if (process.env['NODE_ENV'] === 'production') return false;
-  const value = process.env['MOCK_ORG_ITEMS'];
-  return value === 'true' || value === '1';
-};
+/** Temporary: always return mock data until real data is available. */
+export const isMockOrgItemsEnabled = (): boolean => true;


### PR DESCRIPTION
## Summary

- Simplifies `isMockOrgItemsEnabled()` to unconditionally return `true`, removing the `MOCK_ORG_ITEMS` env-var gate
- Temporary change to unblock UI development while the real data source is not yet available
- All existing callers (`org-navigation.service`, `org-identity.controller`) continue to work through the same abstraction

## Test plan

- [ ] Verify org selector mock data is returned without setting `MOCK_ORG_ITEMS` env var
- [ ] Confirm no regression in org navigation and identity controller behaviour


Made with [Cursor](https://cursor.com)