### PR TITLE
feat(org-profile): add view + edit organization profile [LFXV2-1905]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,10 +296,6 @@ When the work is "done" — no more code commits planned:
 
 After `/compact`, re-invoke `/develop` or the relevant convention skill if continuing work that depends on it.
 
-## Recent Specs
-
-- **020-org-selector-integration** — Replaces the persona-seeded `lfx-org-selector` with a paginated, FGA-filtered list from the query-service (`GET /api/nav/org-items`), adds session-cached role-grants (`GET /api/orgs/me/role-grants`) for per-row writer/auditor badges, and reconciles the selected org against the member-service canonical record on selection (`GET /api/orgs/uid/:uid` polymorphic). Sidebar trigger visibility is gated on `flag && (roleGrants > 0 || personaSeeds > 0)`. Cookie schema unchanged (`lfx-selected-account` still stores legacy `accountId`).
-
 ## What NOT to do
 
 - ❌ Edit a file without re-reading it if 5+ turns have passed

--- a/apps/lfx-one/e2e/org-profile.spec.ts
+++ b/apps/lfx-one/e2e/org-profile.spec.ts
@@ -213,7 +213,7 @@ test.describe('Org Profile — authenticated smoke set (S1/S2/S3/S4)', () => {
   });
 
   test('S4: load error surfaces data-state="error" and retry re-fetches successfully', async ({ page }) => {
-    await stubOrgProfileContext(page, [MOCK_UID]);
+    await stubOrgProfileContext(page, { writers: [MOCK_UID] });
 
     let canonicalAttempts = 0;
     await page.route(`**/api/orgs/uid/${MOCK_UID}`, (route) => {

--- a/apps/lfx-one/e2e/org-profile.spec.ts
+++ b/apps/lfx-one/e2e/org-profile.spec.ts
@@ -207,8 +207,8 @@ test.describe('Org Profile — authenticated smoke set (S1/S2/S3/S4)', () => {
     await expect(editPage).toHaveAttribute('data-can-save', 'true');
 
     await page.getByTestId('org-profile-edit-save-button').click();
-    await expect(editPage).toHaveAttribute('data-saving', 'false');
     await expect(root).toHaveAttribute('data-mode', 'view');
+    await expect(editPage).toBeHidden();
     await expect(page.getByTestId('org-profile-description')).toContainText(updatedDescription);
   });
 

--- a/apps/lfx-one/e2e/org-profile.spec.ts
+++ b/apps/lfx-one/e2e/org-profile.spec.ts
@@ -1,0 +1,262 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Profile E2E — Spec 021-org-profile-edit smoke set.
+ *
+ * Coverage map:
+ * - S1: authenticated load — stubbed canonical + addresses; page reports data-state="loaded"
+ * - S2: writer gate — stubbed role-grants show/hide the edit button
+ * - S3: edit + save — stubbed PUT returns updated record; page returns to data-mode="view"
+ * - S4: load error + retry — first canonical GET fails; retry re-fetches and loads
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+const PROFILE_URL = '/org/profile';
+const DATA_LOAD_TIMEOUT = 30_000;
+
+const MOCK_UID = '4c46585f-878c-8285-b2e9-2dbfc38ddd9b';
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+
+const MOCK_CANONICAL = {
+  uid: MOCK_UID,
+  accountId: MOCK_ACCOUNT_ID,
+  name: 'Red Hat LLC',
+  description: 'Open source software company providing enterprise solutions.',
+  website: 'redhat.com',
+  primaryDomain: 'redhat.com',
+  logoUrl: null,
+  industry: 'Open Source Software',
+  sector: 'Information Technology',
+  numberOfEmployees: 19000,
+  crunchBaseUrl: 'https://crunchbase.com/organization/red-hat',
+  updatedAt: '2026-05-20T12:34:56Z',
+  parentUid: null,
+  isMember: true,
+};
+
+const MOCK_ADDRESSES = {
+  primaryAddress: {
+    line1: '100 East Davie Street',
+    city: 'Raleigh',
+    stateProvince: 'NC',
+    postalCode: '27601',
+    country: 'United States',
+  },
+  billingAddress: {
+    line1: '100 East Davie Street',
+    city: 'Raleigh',
+    stateProvince: 'NC',
+    postalCode: '27601',
+    country: 'United States',
+  },
+};
+
+test.setTimeout(120_000);
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+async function stubOrgProfileContext(page: Page, options: { writers: string[]; auditors?: string[] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [
+          {
+            accountId: MOCK_ACCOUNT_ID,
+            accountName: MOCK_CANONICAL.name,
+            accountSlug: 'red-hat-llc',
+            membershipTier: '',
+            uid: MOCK_UID,
+          },
+        ],
+        isRootWriter: false,
+      }),
+    })
+  );
+
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: options.writers,
+        auditors: options.auditors ?? [],
+        username: 'e2e-org-profile',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubCanonicalAndAddresses(page: Page, canonicalStatus: number = 200, canonicalBody: unknown = MOCK_CANONICAL): Promise<void> {
+  await page.route(`**/api/orgs/uid/${MOCK_UID}`, (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: canonicalStatus,
+      contentType: 'application/json',
+      body: canonicalStatus === 200 ? JSON.stringify(canonicalBody) : JSON.stringify({ error: 'Upstream failure' }),
+    });
+  });
+
+  await page.route(`**/api/orgs/uid/${MOCK_UID}/addresses`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_ADDRESSES),
+    })
+  );
+}
+
+async function gotoProfileWithStubs(page: Page, writers: string[]): Promise<void> {
+  await stubOrgProfileContext(page, { writers });
+  await stubCanonicalAndAddresses(page);
+
+  // Install stubs before reload so client-side persona + role-grant fetches are intercepted (mirrors org-selector S9).
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PROFILE_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+
+  if (!page.url().includes('/org/profile')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/profile redirected away');
+  }
+}
+
+test.describe('Org Profile — authenticated smoke set (S1/S2/S3/S4)', () => {
+  test('S1: stubbed canonical + addresses load the summary card with data-state="loaded"', async ({ page }) => {
+    await gotoProfileWithStubs(page, [MOCK_UID]);
+
+    const root = page.getByTestId('org-profile-page');
+    await expect(root).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(root).toHaveAttribute('data-state', 'loaded');
+    await expect(root).toHaveAttribute('data-mode', 'view');
+    await expect(page.getByTestId('org-profile-summary-card')).toBeVisible();
+    await expect(page.getByTestId('org-profile-name')).toHaveText(MOCK_CANONICAL.name);
+    await expect(page.getByTestId('org-profile-primary-address-card')).toBeVisible();
+  });
+
+  test('S2: writer gate hides the edit button when role-grants omit the selected uid', async ({ page }) => {
+    await gotoProfileWithStubs(page, []);
+
+    const root = page.getByTestId('org-profile-page');
+    await expect(root).toHaveAttribute('data-state', 'loaded', { timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-profile-edit-button')).not.toBeVisible();
+  });
+
+  test('S2b: writer gate shows the edit button when role-grants include the selected uid', async ({ page }) => {
+    await gotoProfileWithStubs(page, [MOCK_UID]);
+
+    const root = page.getByTestId('org-profile-page');
+    await expect(root).toHaveAttribute('data-state', 'loaded', { timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-profile-edit-button')).toBeVisible();
+  });
+
+  test('S3: edit + save returns to view mode after a stubbed PUT', async ({ page }) => {
+    await gotoProfileWithStubs(page, [MOCK_UID]);
+
+    const root = page.getByTestId('org-profile-page');
+    await expect(root).toHaveAttribute('data-state', 'loaded', { timeout: DATA_LOAD_TIMEOUT });
+
+    const updatedDescription = 'Updated by e2e save flow.';
+    await page.route(`**/api/orgs/uid/${MOCK_UID}`, (route) => {
+      if (route.request().method() === 'PUT') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ...MOCK_CANONICAL, description: updatedDescription }),
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.getByTestId('org-profile-edit-button').click();
+    await expect(root).toHaveAttribute('data-mode', 'edit');
+
+    const editPage = page.getByTestId('org-profile-edit-page');
+    await expect(editPage).toBeVisible();
+    await expect(editPage).toHaveAttribute('data-dirty', 'false');
+    await expect(editPage).toHaveAttribute('data-can-save', 'false');
+
+    await page.getByTestId('org-profile-edit-description-textarea').fill(updatedDescription);
+    await expect(editPage).toHaveAttribute('data-dirty', 'true');
+    await expect(editPage).toHaveAttribute('data-can-save', 'true');
+
+    await page.getByTestId('org-profile-edit-save-button').click();
+    await expect(editPage).toHaveAttribute('data-saving', 'false');
+    await expect(root).toHaveAttribute('data-mode', 'view');
+    await expect(page.getByTestId('org-profile-description')).toContainText(updatedDescription);
+  });
+
+  test('S4: load error surfaces data-state="error" and retry re-fetches successfully', async ({ page }) => {
+    await stubOrgProfileContext(page, [MOCK_UID]);
+
+    let canonicalAttempts = 0;
+    await page.route(`**/api/orgs/uid/${MOCK_UID}`, (route) => {
+      if (route.request().method() !== 'GET') {
+        return route.fallback();
+      }
+      canonicalAttempts += 1;
+      if (canonicalAttempts === 1) {
+        return route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'Upstream failure' }) });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CANONICAL),
+      });
+    });
+
+    await page.route(`**/api/orgs/uid/${MOCK_UID}/addresses`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_ADDRESSES),
+      })
+    );
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    await page.goto(PROFILE_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    if (!page.url().includes('/org/profile')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/profile redirected away');
+    }
+
+    const root = page.getByTestId('org-profile-page');
+    await expect(root).toHaveAttribute('data-state', 'error', { timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-profile-load-error')).toBeVisible();
+
+    await page.getByTestId('org-profile-retry-button').click();
+    await expect(root).toHaveAttribute('data-state', 'loaded', { timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-profile-summary-card')).toBeVisible();
+    expect(canonicalAttempts).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -12,6 +12,8 @@ import { projectQueryParamGuard } from './shared/guards/project-query-param.guar
 const loadOrgPlaceholderPage = () =>
   import('./modules/dashboards/org/components/org-placeholder-page/org-placeholder-page.component').then((m) => m.OrgPlaceholderPageComponent);
 
+const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
+
 export const routes: Routes = [
   {
     path: '',
@@ -156,7 +158,7 @@ export const routes: Routes = [
           {
             path: 'profile',
             data: { lens: 'org', title: 'Profile', description: 'Public-facing details about your organization.', icon: 'fa-light fa-file' },
-            loadComponent: loadOrgPlaceholderPage,
+            loadComponent: loadOrgProfilePage,
           },
         ],
       },

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -1,0 +1,177 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section
+  class="flex flex-col gap-6"
+  data-testid="org-profile-edit-page"
+  [attr.data-saving]="saving()"
+  [attr.data-dirty]="dirty()"
+  [attr.data-can-save]="canSave()">
+  <p-toast position="top-right" />
+
+  <!-- Breadcrumb (clicking Profile cancels back to the read-only view per US2 scenario 5). -->
+  <nav class="text-sm" data-testid="org-profile-edit-breadcrumb">
+    <button type="button" class="font-semibold text-blue-600 hover:underline" (click)="onCancel()">Profile</button>
+    <span class="mx-1 text-gray-500">/</span>
+    <span class="text-gray-700">Edit Profile</span>
+  </nav>
+
+  <div class="rounded-lg border border-gray-200 bg-white p-6">
+    <!-- Logo + Upload Logo button (disabled per FR-012). -->
+    <header class="flex items-center gap-4 border-b border-gray-100 pb-4">
+      <div
+        class="flex h-20 w-20 items-center justify-center rounded-md bg-blue-600 text-xl font-semibold text-white"
+        data-testid="org-profile-edit-logo-initials">
+        {{ (record().name | initials) || 'OR' }}
+      </div>
+      <div class="flex flex-col gap-1">
+        <p-button
+          label="Upload Logo"
+          severity="secondary"
+          [outlined]="true"
+          [disabled]="true"
+          pTooltip="Coming soon"
+          tooltipPosition="right"
+          data-testid="org-profile-edit-upload-logo-button" />
+        <p class="text-xs text-gray-500">Only SVG logos, not more than 1mb, will be accepted.</p>
+      </div>
+    </header>
+
+    <form [formGroup]="form" (ngSubmit)="onSave()" class="mt-6 flex flex-col gap-6" data-testid="org-profile-edit-form">
+      <!-- Two-column grid (FR-006). -->
+      <div class="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2">
+        <!-- Organization Name (read-only / locked, FR-011) -->
+        <div data-testid="org-profile-edit-field-name">
+          <div class="flex items-baseline justify-between">
+            <label class="text-sm font-semibold text-gray-900">Organization Name</label>
+            <span class="text-xs text-gray-500">
+              Need to edit?
+              <button type="button" class="text-blue-600 hover:underline" data-testid="org-profile-edit-name-support-link">Contact Support</button>
+            </span>
+          </div>
+          <input type="text" pInputText [value]="record().name" disabled class="mt-1 w-full bg-gray-50" data-testid="org-profile-edit-name-input" />
+        </div>
+
+        <!-- Website -->
+        <div data-testid="org-profile-edit-field-website">
+          <label class="text-sm font-semibold text-gray-900">Website</label>
+          <div class="mt-1 flex items-center overflow-hidden rounded-md border border-gray-300 focus-within:border-blue-500">
+            <div class="flex items-center justify-center border-r border-gray-300 bg-gray-50 px-3 py-2 text-gray-400">
+              <i class="fa-light fa-globe text-sm"></i>
+            </div>
+            <input
+              type="text"
+              pInputText
+              formControlName="website"
+              placeholder="example.com"
+              class="flex-1 border-0 focus:ring-0"
+              data-testid="org-profile-edit-website-input" />
+          </div>
+        </div>
+
+        <!-- Number of Employees -->
+        <div data-testid="org-profile-edit-field-employees">
+          <label class="text-sm font-semibold text-gray-900">Number of Employees</label>
+          <p-inputNumber
+            formControlName="numberOfEmployees"
+            [min]="0"
+            [useGrouping]="false"
+            inputStyleClass="w-full"
+            styleClass="mt-1 w-full block"
+            (onBlur)="onFieldBlur('numberOfEmployees')"
+            data-testid="org-profile-edit-employees-input" />
+          @if (employeesInvalid()) {
+            <p class="mt-1 text-xs text-red-600" data-testid="org-profile-edit-employees-error">Number of employees must be 0 or greater.</p>
+          }
+          <p class="mt-1 text-xs text-gray-500">Enter the number of employees within your organization.</p>
+        </div>
+
+        <!-- Crunchbase Profile -->
+        <div data-testid="org-profile-edit-field-crunchbase">
+          <label class="text-sm font-semibold text-gray-900">Crunchbase Profile</label>
+          <div class="mt-1 flex items-center overflow-hidden rounded-md border border-gray-300 focus-within:border-blue-500">
+            <div class="flex items-center justify-center border-r border-gray-300 bg-gray-50 px-3 py-2">
+              <span class="flex h-5 w-5 items-center justify-center rounded-sm bg-sky-600 text-[9px] font-extrabold text-white">cb</span>
+            </div>
+            <input
+              type="text"
+              pInputText
+              formControlName="crunchBaseUrl"
+              placeholder="https://crunchbase.com/organization/company"
+              class="flex-1 border-0 focus:ring-0"
+              (blur)="onFieldBlur('crunchBaseUrl')"
+              data-testid="org-profile-edit-crunchbase-input" />
+          </div>
+          @if (crunchbaseInvalid()) {
+            <p class="mt-1 text-xs text-red-600" data-testid="org-profile-edit-crunchbase-error">
+              Crunchbase URL must be a valid <code>https://</code> address.
+            </p>
+          }
+          <p class="mt-1 text-xs text-gray-500">Please use a secure HTTPS URL (for example https://crunchbase.com/organization/company).</p>
+        </div>
+
+        <!-- Industry -->
+        <div data-testid="org-profile-edit-field-industry">
+          <label class="text-sm font-semibold text-gray-900">Industry</label>
+          <p-select
+            formControlName="industry"
+            [options]="industryOptions"
+            placeholder="Select Industry"
+            appendTo="body"
+            styleClass="w-full"
+            data-testid="org-profile-edit-industry-select" />
+          <p class="mt-1 text-xs text-gray-500">Select the primary industry that your organization is servicing.</p>
+        </div>
+
+        <!-- Technology Sector -->
+        <div data-testid="org-profile-edit-field-sector">
+          <label class="text-sm font-semibold text-gray-900">Technology Sector</label>
+          <p-select
+            formControlName="sector"
+            [options]="sectorOptions"
+            placeholder="Select Sector"
+            appendTo="body"
+            styleClass="w-full"
+            data-testid="org-profile-edit-sector-select" />
+          <p class="mt-1 text-xs text-gray-500">Select the technology sector that your organization is most closely identified with.</p>
+        </div>
+      </div>
+
+      <!-- Full-width description -->
+      <div data-testid="org-profile-edit-field-description">
+        <label class="text-sm font-semibold text-gray-900">Organization Description</label>
+        <textarea
+          pTextarea
+          formControlName="description"
+          [maxlength]="descriptionMaxLength"
+          rows="4"
+          class="mt-1 w-full"
+          (blur)="onFieldBlur('description')"
+          data-testid="org-profile-edit-description-textarea"></textarea>
+        @if (descriptionInvalid()) {
+          <p class="mt-1 text-xs text-red-600" data-testid="org-profile-edit-description-error">
+            Description must be {{ descriptionMaxLength }} characters or fewer.
+          </p>
+        }
+      </div>
+
+      <!-- Action row -->
+      <div class="flex items-center justify-start gap-2 border-t border-gray-100 pt-4">
+        <p-button
+          label="Cancel"
+          severity="secondary"
+          [outlined]="true"
+          [disabled]="saving()"
+          data-testid="org-profile-edit-cancel-button"
+          (onClick)="onCancel()" />
+        <p-button
+          type="submit"
+          [label]="saving() ? 'Saving…' : 'Save Changes'"
+          severity="primary"
+          [disabled]="!canSave()"
+          [loading]="saving()"
+          data-testid="org-profile-edit-save-button" />
+      </div>
+    </form>
+  </div>
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -46,7 +46,9 @@
             <label class="text-sm font-semibold text-gray-900">Organization Name</label>
             <span class="text-xs text-gray-500">
               Need to edit?
-              <button type="button" lfxOpenIntercom class="text-blue-600 hover:underline" data-testid="org-profile-edit-name-support-link">Contact Support</button>
+              <button type="button" lfxOpenIntercom class="text-blue-600 hover:underline" data-testid="org-profile-edit-name-support-link">
+                Contact Support
+              </button>
             </span>
           </div>
           <input type="text" pInputText [value]="record().name" disabled class="mt-1 w-full bg-gray-50" data-testid="org-profile-edit-name-input" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -67,6 +67,7 @@
               formControlName="website"
               placeholder="example.com"
               class="flex-1 border-0 focus:ring-0"
+              (blur)="onFieldBlur('website')"
               data-testid="org-profile-edit-website-input" />
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -46,7 +46,7 @@
             <label class="text-sm font-semibold text-gray-900">Organization Name</label>
             <span class="text-xs text-gray-500">
               Need to edit?
-              <button type="button" class="text-blue-600 hover:underline" data-testid="org-profile-edit-name-support-link">Contact Support</button>
+              <button type="button" lfxOpenIntercom class="text-blue-600 hover:underline" data-testid="org-profile-edit-name-support-link">Contact Support</button>
             </span>
           </div>
           <input type="text" pInputText [value]="record().name" disabled class="mt-1 w-full bg-gray-50" data-testid="org-profile-edit-name-input" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -19,12 +19,24 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { InitialsPipe } from '@pipes/initials.pipe';
 import { OrgProfileService } from '@services/org-profile.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 
 /** Spec 021 — Org Profile edit form (US2): reactive form with dirty-check + validation gate (FR-007), partial-update PUT (FR-008), `AccountContextService` propagation (FR-009), differentiated 403/502 toasts (FR-010). */
 @Component({
   selector: 'lfx-org-profile-edit',
   standalone: true,
-  imports: [ReactiveFormsModule, ButtonModule, InputTextModule, InputNumberModule, SelectModule, TextareaModule, ToastModule, TooltipModule, InitialsPipe],
+  imports: [
+    ReactiveFormsModule,
+    ButtonModule,
+    InputTextModule,
+    InputNumberModule,
+    SelectModule,
+    TextareaModule,
+    ToastModule,
+    TooltipModule,
+    InitialsPipe,
+    OpenIntercomDirective,
+  ],
   providers: [MessageService],
   templateUrl: './org-profile-edit.component.html',
 })
@@ -93,12 +105,6 @@ export class OrgProfileEditComponent implements OnInit {
         next: (updated) => {
           this.saving.set(false);
           this.form.enable({ emitEvent: false });
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Profile updated',
-            detail: 'Your organization profile has been saved.',
-            life: 3000,
-          });
           this.saved.emit(updated);
         },
         error: (error: unknown) => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -41,6 +41,11 @@ import { OpenIntercomDirective } from '@shared/directives/open-intercom.directiv
   templateUrl: './org-profile-edit.component.html',
 })
 export class OrgProfileEditComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly orgProfileService = inject(OrgProfileService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+
   /** Emitted on successful save — parent applies the new record and exits edit mode. */
   @Output() public readonly saved = new EventEmitter<OrgCanonicalRecord>();
 
@@ -51,11 +56,6 @@ export class OrgProfileEditComponent implements OnInit {
   public readonly record = input.required<OrgCanonicalRecord>();
 
   protected form!: FormGroup;
-
-  private readonly fb = inject(FormBuilder);
-  private readonly orgProfileService = inject(OrgProfileService);
-  private readonly messageService = inject(MessageService);
-  private readonly destroyRef = inject(DestroyRef);
 
   protected industryOptions: string[] = INDUSTRY_OPTIONS;
   protected sectorOptions: string[] = SECTOR_OPTIONS;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -1,0 +1,209 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, DestroyRef, EventEmitter, inject, input, OnInit, Output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { INDUSTRY_OPTIONS, ORG_DESCRIPTION_MAX_LENGTH, SECTOR_OPTIONS } from '@lfx-one/shared/constants';
+import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
+import { httpsUrlValidator } from '@lfx-one/shared/validators';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { InputNumberModule } from 'primeng/inputnumber';
+import { InputTextModule } from 'primeng/inputtext';
+import { SelectModule } from 'primeng/select';
+import { TextareaModule } from 'primeng/textarea';
+import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { InitialsPipe } from '@pipes/initials.pipe';
+import { OrgProfileService } from '@services/org-profile.service';
+
+/** Spec 021 — Org Profile edit form (US2): reactive form with dirty-check + validation gate (FR-007), partial-update PUT (FR-008), `AccountContextService` propagation (FR-009), differentiated 403/502 toasts (FR-010). */
+@Component({
+  selector: 'lfx-org-profile-edit',
+  standalone: true,
+  imports: [ReactiveFormsModule, ButtonModule, InputTextModule, InputNumberModule, SelectModule, TextareaModule, ToastModule, TooltipModule, InitialsPipe],
+  providers: [MessageService],
+  templateUrl: './org-profile-edit.component.html',
+})
+export class OrgProfileEditComponent implements OnInit {
+  /** Emitted on successful save — parent applies the new record and exits edit mode. */
+  @Output() public readonly saved = new EventEmitter<OrgCanonicalRecord>();
+
+  /** Emitted on cancel — parent exits edit mode and discards changes. */
+  @Output() public readonly cancelled = new EventEmitter<void>();
+
+  /** Source record loaded on the read-only view; reused here to avoid re-fetching (research R4). */
+  public readonly record = input.required<OrgCanonicalRecord>();
+
+  protected form!: FormGroup;
+
+  private readonly fb = inject(FormBuilder);
+  private readonly orgProfileService = inject(OrgProfileService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly industryOptions = INDUSTRY_OPTIONS;
+  protected readonly sectorOptions = SECTOR_OPTIONS;
+  protected readonly descriptionMaxLength = ORG_DESCRIPTION_MAX_LENGTH;
+
+  protected readonly saving = signal(false);
+
+  /** Tracks whether any field differs from the original snapshot. Updated on each form value change. */
+  protected readonly dirty = signal(false);
+  protected readonly formValid = signal(true);
+
+  /** Per-field touched-and-invalid flags — keep `form.get(...)` out of the template (CLAUDE.md "No functions in HTML templates"). */
+  protected readonly descriptionInvalid = signal(false);
+  protected readonly employeesInvalid = signal(false);
+  protected readonly crunchbaseInvalid = signal(false);
+
+  /** Disabled until the user changes a field AND all validation passes (FR-007). */
+  protected readonly canSave = computed(() => this.dirty() && this.formValid() && !this.saving());
+
+  private original!: OrgProfileEditableFields;
+
+  public ngOnInit(): void {
+    this.initForm();
+  }
+
+  protected onCancel(): void {
+    if (this.saving()) return;
+    this.cancelled.emit();
+  }
+
+  protected onSave(): void {
+    if (!this.canSave()) return;
+
+    const current = this.form.value as OrgProfileEditableFields;
+    const payload = this.buildPartialPayload(current);
+    if (Object.keys(payload).length === 0) {
+      return;
+    }
+
+    this.saving.set(true);
+    this.form.disable({ emitEvent: false });
+
+    this.orgProfileService
+      .updateOrg(this.record().uid, payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.saving.set(false);
+          this.form.enable({ emitEvent: false });
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Profile updated',
+            detail: 'Your organization profile has been saved.',
+            life: 3000,
+          });
+          this.saved.emit(updated);
+        },
+        error: (error: unknown) => {
+          this.saving.set(false);
+          this.form.enable({ emitEvent: false });
+          this.dirty.set(this.computeDirty(this.form.value as OrgProfileEditableFields));
+          this.formValid.set(this.form.valid);
+          this.messageService.add(this.toastForError(error));
+        },
+      });
+  }
+
+  protected onFieldBlur(field: 'description' | 'numberOfEmployees' | 'crunchBaseUrl'): void {
+    this.form.get(field)?.markAsTouched();
+    this.refreshFieldFlags();
+  }
+
+  private initForm(): void {
+    this.original = this.snapshotFromRecord(this.record());
+    this.form = this.fb.group({
+      description: [this.original.description, [Validators.maxLength(this.descriptionMaxLength)]],
+      website: [this.original.website],
+      numberOfEmployees: [this.original.numberOfEmployees, [Validators.min(0)]],
+      crunchBaseUrl: [this.original.crunchBaseUrl, [httpsUrlValidator()]],
+      industry: [this.original.industry],
+      sector: [this.original.sector],
+    });
+
+    this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
+      this.dirty.set(this.computeDirty(value as OrgProfileEditableFields));
+      this.formValid.set(this.form.valid);
+    });
+
+    this.form.statusChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refreshFieldFlags());
+  }
+
+  /** FR-010 — differentiated error copy by upstream status. */
+  private toastForError(error: unknown): { severity: string; summary: string; detail: string; life: number } {
+    const status = error instanceof HttpErrorResponse ? error.status : 0;
+    if (status === 403) {
+      return {
+        severity: 'error',
+        summary: 'Permission denied',
+        detail: 'You no longer have permission to edit this organization.',
+        life: 5000,
+      };
+    }
+    if (status === 502 || status === 504 || status === 0) {
+      return {
+        severity: 'error',
+        summary: 'Save failed',
+        detail: 'Unable to save changes. Please try again.',
+        life: 5000,
+      };
+    }
+    return {
+      severity: 'error',
+      summary: 'Save failed',
+      detail: 'Something went wrong while saving. Please try again.',
+      life: 5000,
+    };
+  }
+
+  private refreshFieldFlags(): void {
+    this.descriptionInvalid.set(this.isFieldInvalid('description'));
+    this.employeesInvalid.set(this.isFieldInvalid('numberOfEmployees'));
+    this.crunchbaseInvalid.set(this.isFieldInvalid('crunchBaseUrl'));
+  }
+
+  private isFieldInvalid(field: string): boolean {
+    const control = this.form.get(field);
+    return !!control && control.invalid && control.touched;
+  }
+
+  private snapshotFromRecord(record: OrgCanonicalRecord): OrgProfileEditableFields {
+    return {
+      description: record.description ?? '',
+      website: record.website ?? '',
+      numberOfEmployees: record.numberOfEmployees ?? null,
+      crunchBaseUrl: record.crunchBaseUrl ?? '',
+      industry: record.industry ?? '',
+      sector: record.sector ?? '',
+    };
+  }
+
+  private computeDirty(current: OrgProfileEditableFields): boolean {
+    return (
+      current.description !== this.original.description ||
+      current.website !== this.original.website ||
+      current.numberOfEmployees !== this.original.numberOfEmployees ||
+      current.crunchBaseUrl !== this.original.crunchBaseUrl ||
+      current.industry !== this.original.industry ||
+      current.sector !== this.original.sector
+    );
+  }
+
+  /** Build partial-update payload by including only changed fields; null/empty values pass through so users can clear upstream values. */
+  private buildPartialPayload(current: OrgProfileEditableFields): OrgUpdateRequest {
+    const payload: OrgUpdateRequest = {};
+    if (current.description !== this.original.description) payload.description = current.description;
+    if (current.website !== this.original.website) payload.website = current.website;
+    if (current.numberOfEmployees !== this.original.numberOfEmployees) payload.numberOfEmployees = current.numberOfEmployees;
+    if (current.crunchBaseUrl !== this.original.crunchBaseUrl) payload.crunchBaseUrl = current.crunchBaseUrl;
+    if (current.industry !== this.original.industry) payload.industry = current.industry;
+    if (current.sector !== this.original.sector) payload.sector = current.sector;
+    return payload;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -57,8 +57,8 @@ export class OrgProfileEditComponent implements OnInit {
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
 
-  protected readonly industryOptions = INDUSTRY_OPTIONS;
-  protected readonly sectorOptions = SECTOR_OPTIONS;
+  protected industryOptions: string[] = INDUSTRY_OPTIONS;
+  protected sectorOptions: string[] = SECTOR_OPTIONS;
   protected readonly descriptionMaxLength = ORG_DESCRIPTION_MAX_LENGTH;
 
   protected readonly saving = signal(false);
@@ -124,6 +124,8 @@ export class OrgProfileEditComponent implements OnInit {
 
   private initForm(): void {
     this.original = this.snapshotFromRecord(this.record());
+    this.industryOptions = this.withCurrentSelectOption(INDUSTRY_OPTIONS, this.original.industry);
+    this.sectorOptions = this.withCurrentSelectOption(SECTOR_OPTIONS, this.original.sector);
     this.form = this.fb.group({
       description: [this.original.description, [Validators.maxLength(this.descriptionMaxLength)]],
       website: [this.original.website],
@@ -188,6 +190,21 @@ export class OrgProfileEditComponent implements OnInit {
       industry: record.industry ?? '',
       sector: record.sector ?? '',
     };
+  }
+
+  /** Spec edge case — keep unrecognized backend values visible by injecting them into the dropdown list. */
+  private withCurrentSelectOption(options: string[], currentValue: string): string[] {
+    const value = currentValue.trim();
+    if (!value || options.includes(value)) {
+      return options;
+    }
+
+    const otherIndex = options.indexOf('Other');
+    if (otherIndex >= 0) {
+      return [...options.slice(0, otherIndex), value, ...options.slice(otherIndex)];
+    }
+
+    return [...options, value];
   }
 
   private computeDirty(current: OrgProfileEditableFields): boolean {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -117,8 +117,15 @@ export class OrgProfileEditComponent implements OnInit {
       });
   }
 
-  protected onFieldBlur(field: 'description' | 'numberOfEmployees' | 'crunchBaseUrl'): void {
-    this.form.get(field)?.markAsTouched();
+  protected onFieldBlur(field: 'description' | 'numberOfEmployees' | 'crunchBaseUrl' | 'website'): void {
+    const control = this.form.get(field);
+    control?.markAsTouched();
+    if (field === 'website' || field === 'crunchBaseUrl') {
+      const trimmed = this.normalizeUrlField(String(control?.value ?? ''));
+      if (trimmed !== control?.value) {
+        control?.setValue(trimmed, { emitEvent: true });
+      }
+    }
     this.refreshFieldFlags();
   }
 
@@ -184,9 +191,9 @@ export class OrgProfileEditComponent implements OnInit {
   private snapshotFromRecord(record: OrgCanonicalRecord): OrgProfileEditableFields {
     return {
       description: record.description ?? '',
-      website: record.website ?? '',
+      website: this.normalizeUrlField(record.website ?? ''),
       numberOfEmployees: record.numberOfEmployees ?? null,
-      crunchBaseUrl: record.crunchBaseUrl ?? '',
+      crunchBaseUrl: this.normalizeUrlField(record.crunchBaseUrl ?? ''),
       industry: record.industry ?? '',
       sector: record.sector ?? '',
     };
@@ -208,25 +215,39 @@ export class OrgProfileEditComponent implements OnInit {
   }
 
   private computeDirty(current: OrgProfileEditableFields): boolean {
+    const normalized = this.normalizeEditableFields(current);
     return (
-      current.description !== this.original.description ||
-      current.website !== this.original.website ||
-      current.numberOfEmployees !== this.original.numberOfEmployees ||
-      current.crunchBaseUrl !== this.original.crunchBaseUrl ||
-      current.industry !== this.original.industry ||
-      current.sector !== this.original.sector
+      normalized.description !== this.original.description ||
+      normalized.website !== this.original.website ||
+      normalized.numberOfEmployees !== this.original.numberOfEmployees ||
+      normalized.crunchBaseUrl !== this.original.crunchBaseUrl ||
+      normalized.industry !== this.original.industry ||
+      normalized.sector !== this.original.sector
     );
   }
 
   /** Build partial-update payload by including only changed fields; null/empty values pass through so users can clear upstream values. */
   private buildPartialPayload(current: OrgProfileEditableFields): OrgUpdateRequest {
+    const normalized = this.normalizeEditableFields(current);
     const payload: OrgUpdateRequest = {};
-    if (current.description !== this.original.description) payload.description = current.description;
-    if (current.website !== this.original.website) payload.website = current.website;
-    if (current.numberOfEmployees !== this.original.numberOfEmployees) payload.numberOfEmployees = current.numberOfEmployees;
-    if (current.crunchBaseUrl !== this.original.crunchBaseUrl) payload.crunchBaseUrl = current.crunchBaseUrl;
-    if (current.industry !== this.original.industry) payload.industry = current.industry;
-    if (current.sector !== this.original.sector) payload.sector = current.sector;
+    if (normalized.description !== this.original.description) payload.description = normalized.description;
+    if (normalized.website !== this.original.website) payload.website = normalized.website;
+    if (normalized.numberOfEmployees !== this.original.numberOfEmployees) payload.numberOfEmployees = normalized.numberOfEmployees;
+    if (normalized.crunchBaseUrl !== this.original.crunchBaseUrl) payload.crunchBaseUrl = normalized.crunchBaseUrl;
+    if (normalized.industry !== this.original.industry) payload.industry = normalized.industry;
+    if (normalized.sector !== this.original.sector) payload.sector = normalized.sector;
     return payload;
+  }
+
+  private normalizeEditableFields(fields: OrgProfileEditableFields): OrgProfileEditableFields {
+    return {
+      ...fields,
+      website: this.normalizeUrlField(fields.website),
+      crunchBaseUrl: this.normalizeUrlField(fields.crunchBaseUrl),
+    };
+  }
+
+  private normalizeUrlField(value: string): string {
+    return value.trim();
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -41,16 +41,16 @@ import { OpenIntercomDirective } from '@shared/directives/open-intercom.directiv
   templateUrl: './org-profile-edit.component.html',
 })
 export class OrgProfileEditComponent implements OnInit {
-  private readonly fb = inject(FormBuilder);
-  private readonly orgProfileService = inject(OrgProfileService);
-  private readonly messageService = inject(MessageService);
-  private readonly destroyRef = inject(DestroyRef);
-
   /** Emitted on successful save — parent applies the new record and exits edit mode. */
   @Output() public readonly saved = new EventEmitter<OrgCanonicalRecord>();
 
   /** Emitted on cancel — parent exits edit mode and discards changes. */
   @Output() public readonly cancelled = new EventEmitter<void>();
+
+  private readonly fb = inject(FormBuilder);
+  private readonly orgProfileService = inject(OrgProfileService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /** Source record loaded on the read-only view; reused here to avoid re-fetching (research R4). */
   public readonly record = input.required<OrgCanonicalRecord>();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
@@ -2,6 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <main class="flex flex-col gap-6 p-6" data-testid="org-profile-page" [attr.data-state]="state()" [attr.data-mode]="editMode() ? 'edit' : 'view'">
+  <p-toast position="top-right" data-testid="org-profile-success-toast" />
   @if (state() === 'loading') {
     <!-- Skeleton loaders (FR-015) — mirror the loaded card layout so the page doesn't jump. -->
     <section class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-skeleton">
@@ -51,6 +52,7 @@
                   [href]="href"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Visit website"
                   class="text-gray-500 hover:text-blue-600"
                   pTooltip="Visit website"
                   data-testid="org-profile-website-icon-link">
@@ -62,6 +64,7 @@
                   [href]="href"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="View on Crunchbase"
                   class="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-sky-600 text-[9px] font-extrabold text-white hover:bg-sky-700"
                   pTooltip="View on Crunchbase"
                   data-testid="org-profile-crunchbase-icon-link">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
@@ -122,7 +122,7 @@
         }
       </div>
       <div class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-billing-address-card">
-        <h2 class="text-sm font-semibold text-gray-900">Billing Address 1</h2>
+        <h2 class="text-sm font-semibold text-gray-900">Billing Address</h2>
         @if (addresses()?.billingAddress; as addr) {
           <p class="mt-2 text-sm text-gray-700">{{ addr.line1 }}</p>
           <p class="text-sm text-gray-700">{{ addr.city }}, {{ addr.stateProvince }} {{ addr.postalCode }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.html
@@ -1,0 +1,133 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<main class="flex flex-col gap-6 p-6" data-testid="org-profile-page" [attr.data-state]="state()" [attr.data-mode]="editMode() ? 'edit' : 'view'">
+  @if (state() === 'loading') {
+    <!-- Skeleton loaders (FR-015) — mirror the loaded card layout so the page doesn't jump. -->
+    <section class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-skeleton">
+      <div class="flex items-start gap-6">
+        <p-skeleton width="6rem" height="6rem" styleClass="rounded-md" />
+        <div class="flex flex-1 flex-col gap-2">
+          <p-skeleton width="40%" height="1.5rem" />
+          <p-skeleton width="80%" height="1rem" />
+          <p-skeleton width="60%" height="1rem" />
+        </div>
+      </div>
+    </section>
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <p-skeleton width="100%" height="8rem" />
+      <p-skeleton width="100%" height="8rem" />
+    </div>
+  } @else if (state() === 'error') {
+    <!-- FR-020 — inline error card with retry. -->
+    <section class="flex flex-col items-center gap-3 rounded-lg border border-red-200 bg-red-50 p-8 text-center" data-testid="org-profile-load-error">
+      <i class="fa-light fa-triangle-exclamation text-2xl text-red-600"></i>
+      <h2 class="text-base font-semibold text-gray-900">Unable to load organization profile</h2>
+      <p class="text-sm text-gray-600">There was a problem reaching the organization service.</p>
+      <p-button label="Retry" icon="fa-light fa-rotate-right" severity="secondary" data-testid="org-profile-retry-button" (onClick)="retry()" />
+    </section>
+  } @else if (editMode() && record(); as r) {
+    <lfx-org-profile-edit [record]="r" (saved)="onProfileSaved($event)" (cancelled)="exitEditMode()" data-testid="org-profile-edit" />
+  } @else if (record(); as r) {
+    <!-- Profile summary card (matches LFX One V3 wireframe). -->
+    <section class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-summary-card">
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-4">
+          <!-- Logo or initials placeholder (FR-003). -->
+          @if (r.logoUrl) {
+            <img [src]="r.logoUrl" [alt]="r.name + ' logo'" class="h-24 w-24 rounded-md object-contain" data-testid="org-profile-logo-image" />
+          } @else {
+            <div
+              class="flex h-24 w-24 items-center justify-center rounded-md bg-blue-600 text-2xl font-semibold text-white"
+              data-testid="org-profile-logo-initials">
+              {{ (r.name | initials) || 'OR' }}
+            </div>
+          }
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <h1 class="text-xl font-semibold text-gray-900" data-testid="org-profile-name">{{ r.name }}</h1>
+              @if (websiteHref(); as href) {
+                <a
+                  [href]="href"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-gray-500 hover:text-blue-600"
+                  pTooltip="Visit website"
+                  data-testid="org-profile-website-icon-link">
+                  <i class="fa-light fa-globe"></i>
+                </a>
+              }
+              @if (crunchbaseHref(); as href) {
+                <a
+                  [href]="href"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-sky-600 text-[9px] font-extrabold text-white hover:bg-sky-700"
+                  pTooltip="View on Crunchbase"
+                  data-testid="org-profile-crunchbase-icon-link">
+                  cb
+                </a>
+              }
+            </div>
+            <p class="max-w-2xl text-sm text-gray-700" data-testid="org-profile-description">{{ r.description | displayValue }}</p>
+            <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-700">
+              <div data-testid="org-profile-meta-website">
+                <span class="font-semibold text-gray-900">Website:</span>
+                @if (websiteHref(); as href) {
+                  <a [href]="href" target="_blank" rel="noopener noreferrer" class="ml-1 text-blue-600 hover:underline">{{ r.website }}</a>
+                } @else {
+                  <span class="ml-1">—</span>
+                }
+              </div>
+              <div data-testid="org-profile-meta-employees">
+                <span class="font-semibold text-gray-900">Employees:</span>
+                <span class="ml-1">{{ r.numberOfEmployees | displayValue }}</span>
+              </div>
+              <div data-testid="org-profile-meta-industry">
+                <span class="font-semibold text-gray-900">Industry:</span>
+                <span class="ml-1">{{ r.industry | displayValue }}</span>
+              </div>
+              <div data-testid="org-profile-meta-sector">
+                <span class="font-semibold text-gray-900">Sector:</span>
+                <span class="ml-1">{{ r.sector | displayValue }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col items-end gap-2">
+          <span class="text-xs text-gray-500" data-testid="org-profile-last-updated">
+            <span class="font-semibold text-gray-700">Last Updated:</span>
+            {{ r.updatedAt ? (r.updatedAt | date: 'mediumDate') : '—' }}
+          </span>
+          @if (canEdit()) {
+            <p-button label="Edit Profile" severity="primary" [outlined]="true" data-testid="org-profile-edit-button" (onClick)="enterEditMode()" />
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Two address cards side by side (FR-004). Read-only in v1. -->
+    <section class="grid grid-cols-1 gap-4 md:grid-cols-2" data-testid="org-profile-addresses">
+      <div class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-primary-address-card">
+        <h2 class="text-sm font-semibold text-gray-900">Primary Address</h2>
+        @if (addresses()?.primaryAddress; as addr) {
+          <p class="mt-2 text-sm text-gray-700">{{ addr.line1 }}</p>
+          <p class="text-sm text-gray-700">{{ addr.city }}, {{ addr.stateProvince }} {{ addr.postalCode }}</p>
+          <p class="text-sm text-gray-700">{{ addr.country }}</p>
+        } @else {
+          <p class="mt-2 text-sm text-gray-500">—</p>
+        }
+      </div>
+      <div class="rounded-lg border border-gray-200 bg-white p-6" data-testid="org-profile-billing-address-card">
+        <h2 class="text-sm font-semibold text-gray-900">Billing Address 1</h2>
+        @if (addresses()?.billingAddress; as addr) {
+          <p class="mt-2 text-sm text-gray-700">{{ addr.line1 }}</p>
+          <p class="text-sm text-gray-700">{{ addr.city }}, {{ addr.stateProvince }} {{ addr.postalCode }}</p>
+          <p class="text-sm text-gray-700">{{ addr.country }}</p>
+        } @else {
+          <p class="mt-2 text-sm text-gray-500">—</p>
+        }
+      </div>
+    </section>
+  }
+</main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
@@ -5,8 +5,10 @@ import { DatePipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, Injector, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import type { OrgAddressesResponse, OrgCanonicalRecord } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { SkeletonModule } from 'primeng/skeleton';
+import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, distinctUntilChanged, filter, forkJoin, of, switchMap, tap } from 'rxjs';
 
@@ -22,13 +24,15 @@ import { OrgProfileEditComponent } from './org-profile-edit.component';
 @Component({
   selector: 'lfx-org-profile',
   standalone: true,
-  imports: [DatePipe, SkeletonModule, ButtonModule, TooltipModule, OrgProfileEditComponent, DisplayValuePipe, InitialsPipe],
+  imports: [DatePipe, SkeletonModule, ButtonModule, ToastModule, TooltipModule, OrgProfileEditComponent, DisplayValuePipe, InitialsPipe],
+  providers: [MessageService],
   templateUrl: './org-profile.component.html',
 })
 export class OrgProfileComponent {
   private readonly accountContext = inject(AccountContextService);
   private readonly orgProfileService = inject(OrgProfileService);
   private readonly orgRoleGrants = inject(OrgRoleGrantsService);
+  private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly injector = inject(Injector);
 
@@ -70,6 +74,12 @@ export class OrgProfileComponent {
     this.record.set(updated);
     this.accountContext.updateCanonicalRecord(updated);
     this.editMode.set(false);
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Profile updated',
+      detail: 'Your organization profile has been saved.',
+      life: 3000,
+    });
   }
 
   protected retry(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { Component, computed, DestroyRef, inject, Injector, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import type { OrgAddressesResponse, OrgCanonicalRecord } from '@lfx-one/shared/interfaces';
+import { ButtonModule } from 'primeng/button';
+import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
+import { catchError, combineLatest, distinctUntilChanged, filter, forkJoin, of, switchMap, tap } from 'rxjs';
+
+import { DisplayValuePipe } from '@pipes/display-value.pipe';
+import { InitialsPipe } from '@pipes/initials.pipe';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgProfileService } from '@services/org-profile.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
+
+import { OrgProfileEditComponent } from './org-profile-edit.component';
+
+/** Spec 021 — Org Profile read-only view (US1): summary card + address cards, writer-gated edit button (FR-005), org-selector reactive (US3, FR-019). */
+@Component({
+  selector: 'lfx-org-profile',
+  standalone: true,
+  imports: [DatePipe, SkeletonModule, ButtonModule, TooltipModule, OrgProfileEditComponent, DisplayValuePipe, InitialsPipe],
+  templateUrl: './org-profile.component.html',
+})
+export class OrgProfileComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly orgProfileService = inject(OrgProfileService);
+  private readonly orgRoleGrants = inject(OrgRoleGrantsService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly injector = inject(Injector);
+
+  /** US2 toggle — true when the user has clicked "Edit Profile". Reset on org change (US3) and after save/cancel. */
+  protected readonly editMode = signal(false);
+  protected readonly record = signal<OrgCanonicalRecord | null>(null);
+  protected readonly addresses = signal<OrgAddressesResponse | null>(null);
+  protected readonly state: Signal<'loading' | 'loaded' | 'error'>;
+
+  private readonly retryTrigger = signal(0);
+  private readonly loadState = signal<'loading' | 'loaded' | 'error'>('loading');
+
+  /** Writer detection (FR-005) — uses the existing role-grants signal seeded at bootstrap. */
+  protected readonly canEdit = computed(() => {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    return !!uid && this.orgRoleGrants.writerSet().has(uid);
+  });
+
+  /** Auto-prepend `https://` when the stored value lacks a protocol (FR-003). */
+  protected readonly websiteHref = computed(() => this.computeUrlHref(this.record()?.website ?? null));
+  protected readonly crunchbaseHref = computed(() => this.computeUrlHref(this.record()?.crunchBaseUrl ?? null));
+
+  public constructor() {
+    this.state = this.loadState.asReadonly();
+    this.initLoadPipeline();
+  }
+
+  protected enterEditMode(): void {
+    if (!this.canEdit() || !this.record()) return;
+    this.editMode.set(true);
+  }
+
+  protected exitEditMode(): void {
+    this.editMode.set(false);
+  }
+
+  /** Called by the edit component after a successful save (FR-009) — refresh the local record and pop back to read-only. */
+  protected onProfileSaved(updated: OrgCanonicalRecord): void {
+    this.record.set(updated);
+    this.accountContext.updateCanonicalRecord(updated);
+    this.editMode.set(false);
+  }
+
+  protected retry(): void {
+    this.retryTrigger.update((v) => v + 1);
+  }
+
+  private initLoadPipeline(): void {
+    const selectedUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid ?? null), { injector: this.injector });
+    const retryTrigger$ = toObservable(this.retryTrigger, { injector: this.injector });
+
+    combineLatest([
+      selectedUid$.pipe(
+        filter((uid): uid is string => !!uid),
+        distinctUntilChanged()
+      ),
+      retryTrigger$,
+    ])
+      .pipe(
+        tap(() => {
+          this.loadState.set('loading');
+          this.record.set(null);
+          this.addresses.set(null);
+          // Exiting edit mode whenever the underlying org changes preserves the "discard unsaved changes" guarantee (FR-019).
+          this.editMode.set(false);
+        }),
+        switchMap(([uid]) =>
+          forkJoin({
+            record: this.orgProfileService.getCanonicalRecord(uid),
+            addresses: this.orgProfileService.getAddresses(uid).pipe(catchError(() => of(null))),
+          }).pipe(
+            catchError(() => {
+              this.loadState.set('error');
+              return of(null);
+            })
+          )
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((result) => {
+        if (!result) return;
+        this.record.set(result.record);
+        this.addresses.set(result.addresses);
+        this.loadState.set('loaded');
+      });
+  }
+
+  private computeUrlHref(raw: string | null): string | null {
+    if (!raw) return null;
+    return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
@@ -87,16 +87,28 @@ export class OrgProfileComponent {
   }
 
   private initLoadPipeline(): void {
-    const selectedUid$ = toObservable(
-      computed(() => this.accountContext.selectedAccount()?.uid ?? null),
+    const selectedOrg$ = toObservable(
+      computed(() => {
+        const account = this.accountContext.selectedAccount();
+        if (!account) {
+          return null;
+        }
+        if (account.uid) {
+          return { kind: 'uid' as const, id: account.uid };
+        }
+        if (account.accountId) {
+          return { kind: 'sfid' as const, id: account.accountId };
+        }
+        return null;
+      }),
       { injector: this.injector }
     );
     const retryTrigger$ = toObservable(this.retryTrigger, { injector: this.injector });
 
     combineLatest([
-      selectedUid$.pipe(
-        filter((uid): uid is string => !!uid),
-        distinctUntilChanged()
+      selectedOrg$.pipe(
+        filter((org): org is { kind: 'uid'; id: string } | { kind: 'sfid'; id: string } => !!org),
+        distinctUntilChanged((a, b) => a.kind === b.kind && a.id === b.id)
       ),
       retryTrigger$,
     ])
@@ -108,17 +120,19 @@ export class OrgProfileComponent {
           // Exiting edit mode whenever the underlying org changes preserves the "discard unsaved changes" guarantee (FR-019).
           this.editMode.set(false);
         }),
-        switchMap(([uid]) =>
-          forkJoin({
-            record: this.orgProfileService.getCanonicalRecord(uid),
-            addresses: this.orgProfileService.getAddresses(uid).pipe(catchError(() => of(null))),
+        switchMap(([org]) => {
+          const record$ = org.kind === 'uid' ? this.orgProfileService.getCanonicalRecord(org.id) : this.orgProfileService.getCanonicalRecordByAccountId(org.id);
+
+          return forkJoin({
+            record: record$,
+            addresses: record$.pipe(switchMap((record) => this.orgProfileService.getAddresses(record.uid).pipe(catchError(() => of(null))))),
           }).pipe(
             catchError(() => {
               this.loadState.set('error');
               return of(null);
             })
-          )
-        ),
+          );
+        }),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((result) => {
@@ -131,6 +145,7 @@ export class OrgProfileComponent {
 
   private computeUrlHref(raw: string | null): string | null {
     if (!raw) return null;
-    return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    const trimmed = raw.trim();
+    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile.component.ts
@@ -77,7 +77,10 @@ export class OrgProfileComponent {
   }
 
   private initLoadPipeline(): void {
-    const selectedUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid ?? null), { injector: this.injector });
+    const selectedUid$ = toObservable(
+      computed(() => this.accountContext.selectedAccount()?.uid ?? null),
+      { injector: this.injector }
+    );
     const retryTrigger$ = toObservable(this.retryTrigger, { injector: this.injector });
 
     combineLatest([

--- a/apps/lfx-one/src/app/shared/pipes/display-value.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/display-value.pipe.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+/** Renders a field value with an em-dash placeholder for null/undefined/empty; numbers are locale-formatted. Used by Org Profile (spec 021) read-only meta rows. */
+@Pipe({
+  name: 'displayValue',
+  standalone: true,
+  pure: true,
+})
+export class DisplayValuePipe implements PipeTransform {
+  public transform(value: string | number | null | undefined, locale: string = 'en-US'): string {
+    if (value === null || value === undefined || value === '') return '—';
+    return typeof value === 'number' ? value.toLocaleString(locale) : value;
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/account-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/account-context.service.ts
@@ -90,7 +90,13 @@ export class AccountContextService {
 
   public setAccount(account: Account): void {
     const live = this.liveAccounts().get(account.accountId);
-    const next = live ?? account;
+    const next = live
+      ? {
+          ...live,
+          uid: account.uid ?? live.uid ?? null,
+          parentUid: account.parentUid ?? live.parentUid ?? null,
+        }
+      : account;
     this.selectedAccount.set(next);
     this.persistToStorage(next);
   }
@@ -190,7 +196,11 @@ export class AccountContextService {
         const current = this.selectedAccount();
         const liveCurrent = live.get(current.accountId);
         if (liveCurrent) {
-          this.selectedAccount.set(liveCurrent);
+          this.selectedAccount.set({
+            ...liveCurrent,
+            uid: current.uid ?? liveCurrent.uid ?? null,
+            parentUid: current.parentUid ?? liveCurrent.parentUid ?? null,
+          });
         } else if (!current.accountId) {
           const firstSeed = this.userOrganizations()[0];
           if (firstSeed) {

--- a/apps/lfx-one/src/app/shared/services/account-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/account-context.service.ts
@@ -142,6 +142,11 @@ export class AccountContextService {
     return promise;
   }
 
+  /** Spec 021 — Public propagation hook for the Org Profile edit flow after a successful PUT (FR-009); patches `selectedAccount` so sidebar + selector reflect the edit without waiting for the next natural fetch. */
+  public updateCanonicalRecord(canonical: OrgCanonicalRecord): void {
+    this.applyCanonicalRecord(canonical);
+  }
+
   private applyCanonicalRecord(canonical: OrgCanonicalRecord): void {
     const current = this.selectedAccount();
     // Only patch when the canonical record corresponds to the still-selected org —

--- a/apps/lfx-one/src/app/shared/services/org-profile.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-profile.service.ts
@@ -17,6 +17,10 @@ export class OrgProfileService {
     return this.http.get<OrgCanonicalRecord>(`/api/orgs/uid/${encodeURIComponent(uid)}`);
   }
 
+  public getCanonicalRecordByAccountId(accountId: string): Observable<OrgCanonicalRecord> {
+    return this.http.get<OrgCanonicalRecord>(`/api/orgs/sfid/${encodeURIComponent(accountId)}`);
+  }
+
   public getAddresses(uid: string): Observable<OrgAddressesResponse> {
     return this.http.get<OrgAddressesResponse>(`/api/orgs/uid/${encodeURIComponent(uid)}/addresses`);
   }

--- a/apps/lfx-one/src/app/shared/services/org-profile.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-profile.service.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import type { OrgAddressesResponse, OrgCanonicalRecord, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+/** Spec 021 — Client service wrapping the three Org Profile BFF endpoints: GET canonical record, GET addresses (mock in v1), PUT partial-update. */
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgProfileService {
+  private readonly http = inject(HttpClient);
+
+  public getCanonicalRecord(uid: string): Observable<OrgCanonicalRecord> {
+    return this.http.get<OrgCanonicalRecord>(`/api/orgs/uid/${encodeURIComponent(uid)}`);
+  }
+
+  public getAddresses(uid: string): Observable<OrgAddressesResponse> {
+    return this.http.get<OrgAddressesResponse>(`/api/orgs/uid/${encodeURIComponent(uid)}/addresses`);
+  }
+
+  public updateOrg(uid: string, payload: OrgUpdateRequest): Observable<OrgCanonicalRecord> {
+    return this.http.put<OrgCanonicalRecord>(`/api/orgs/uid/${encodeURIComponent(uid)}`, payload);
+  }
+}

--- a/apps/lfx-one/src/server/controllers/org-identity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-identity.controller.ts
@@ -186,7 +186,7 @@ export class OrgIdentityController {
         res.status(404).json({ error: 'Organization not found' });
         return;
       }
-      if (error instanceof MicroserviceError && error.statusCode >= 500) {
+      if (error instanceof MicroserviceError && (error.statusCode >= 500 || error.statusCode === 408)) {
         logger.warning(req, 'update_org_canonical_record', 'Upstream failure', { err: error, upstream_status: error.statusCode });
         res.status(502).json({ error: 'Unable to save changes. Please try again.' });
         return;

--- a/apps/lfx-one/src/server/controllers/org-identity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-identity.controller.ts
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 import { UUID_REGEX } from '@lfx-one/shared/constants';
-import { MemberServiceB2bOrgResponse, OrgCanonicalRecord, OrgItem, RoleGrantsResponse } from '@lfx-one/shared/interfaces';
+import {
+  MemberServiceB2bOrgResponse,
+  MemberServiceB2bOrgUpdateBody,
+  OrgAddressesResponse,
+  OrgCanonicalMockExtras,
+  OrgCanonicalRecord,
+  OrgItem,
+  OrgUpdateRequest,
+  RoleGrantsResponse,
+} from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { MicroserviceError } from '../errors/microservice.error';
 import { ServiceValidationError } from '../errors/service-validation.error';
+import orgAddressesMock from '../services/fixtures/org-addresses.mock.json';
 import orgSelectorMock from '../services/fixtures/org-selector.mock.json';
 import { logger } from '../services/logger.service';
 import { MicroserviceProxyService } from '../services/microservice-proxy.service';
@@ -135,6 +145,92 @@ export class OrgIdentityController {
     }
   }
 
+  /** Spec 021 — `PUT /api/orgs/uid/:uid`. Partial-update proxy to member-service `PUT /b2b_orgs/{uid}`. Returns the full updated canonical record so the client can refresh the read-only view without an extra GET (FR-016). */
+  public async updateOrg(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'update_org_canonical_record');
+
+    try {
+      const uid = req.params['uid'];
+      this.assertNonEmpty(uid, 'uid', 'update_org_canonical_record', req.path);
+      if (!UUID_REGEX.test(uid)) {
+        throw ServiceValidationError.forField('uid', 'Invalid organization identifier', {
+          operation: 'update_org_canonical_record',
+          service: 'org_identity_controller',
+          path: req.path,
+        });
+      }
+
+      const update = this.toMemberServiceUpdate(req.body as OrgUpdateRequest | undefined);
+
+      const raw = await this.microserviceProxy.proxyRequest<MemberServiceB2bOrgResponse>(
+        req,
+        'LFX_V2_SERVICE',
+        `/b2b_orgs/${encodeURIComponent(uid)}`,
+        'PUT',
+        undefined,
+        update
+      );
+
+      const response = this.toCanonicalRecord(raw);
+
+      logger.success(req, 'update_org_canonical_record', startTime, { uid, field_count: Object.keys(update).length });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.statusCode === 403) {
+        logger.warning(req, 'update_org_canonical_record', 'Upstream rejected with 403', { err: error });
+        res.status(403).json({ error: 'You no longer have permission to edit this organization.' });
+        return;
+      }
+      if (error instanceof MicroserviceError && error.statusCode === 404) {
+        res.status(404).json({ error: 'Organization not found' });
+        return;
+      }
+      if (error instanceof MicroserviceError && error.statusCode >= 500) {
+        logger.warning(req, 'update_org_canonical_record', 'Upstream failure', { err: error, upstream_status: error.statusCode });
+        res.status(502).json({ error: 'Unable to save changes. Please try again.' });
+        return;
+      }
+      next(error);
+    }
+  }
+
+  /** Spec 021 — `GET /api/orgs/uid/:uid/addresses`. Returns mock fixture when `isMockOrgItemsEnabled()`; otherwise 404 until member-service exposes upstream address fields (fail-closed, mirrors `getCanonicalRecord`). */
+  public async getOrgAddresses(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_addresses');
+
+    try {
+      const uid = req.params['uid'];
+      this.assertNonEmpty(uid, 'uid', 'get_org_addresses', req.path);
+      if (!UUID_REGEX.test(uid)) {
+        throw ServiceValidationError.forField('uid', 'Invalid organization identifier', {
+          operation: 'get_org_addresses',
+          service: 'org_identity_controller',
+          path: req.path,
+        });
+      }
+
+      if (!isMockOrgItemsEnabled()) {
+        // Fail-closed per rulebook (mock fixtures gated on flag && NODE_ENV !== 'production').
+        // Real upstream address fields land in a follow-up spec; until then, no fixture in prod.
+        res.status(404).json({ error: 'Addresses unavailable' });
+        logger.success(req, 'get_org_addresses', startTime, { uid, status_code: 404, mock: false });
+        return;
+      }
+
+      const response: OrgAddressesResponse = {
+        primaryAddress: orgAddressesMock.primaryAddress,
+        billingAddress: orgAddressesMock.billingAddress,
+      };
+
+      logger.success(req, 'get_org_addresses', startTime, { uid, mock: true });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   /** Parses `req.params` into `{ identifier, identifierKind }`; polymorphic `/:id` uses UUID_REGEX to dispatch (mirrors project.controller pattern). */
   private extractIdentifier(req: Request): { identifier: string; identifierKind: 'uid' | 'sfid' } {
     const { uid, accountId, id } = req.params;
@@ -178,8 +274,7 @@ export class OrgIdentityController {
     const items = orgSelectorMock.items as OrgItem[];
     const match = identifierKind === 'uid' ? items.find((item) => item.uid === identifier) : items.find((item) => item.accountId === identifier);
     if (!match) return null;
-    type MockCanonicalExtras = Partial<Pick<OrgCanonicalRecord, 'description' | 'website' | 'industry' | 'sector' | 'numberOfEmployees' | 'parentUid'>>;
-    const extrasMap = (orgSelectorMock.canonicalExtras ?? {}) as Record<string, MockCanonicalExtras>;
+    const extrasMap = (orgSelectorMock.canonicalExtras ?? {}) as Record<string, OrgCanonicalMockExtras>;
     const extras = extrasMap[match.uid] ?? {};
     return {
       uid: match.uid,
@@ -192,9 +287,26 @@ export class OrgIdentityController {
       industry: extras.industry ?? null,
       sector: extras.sector ?? null,
       numberOfEmployees: extras.numberOfEmployees ?? null,
+      crunchBaseUrl: extras.crunchBaseUrl ?? null,
+      updatedAt: extras.updatedAt ?? null,
       parentUid: extras.parentUid ?? null,
       isMember: match.isMember ?? false,
     };
+  }
+
+  /** Spec 021 — Whitelist + camelCase → snake_case transform for the PUT body; `name`/`logoUrl` stripped (FR-011/012); `undefined` omitted to preserve upstream "no change" semantics. */
+  private toMemberServiceUpdate(body: OrgUpdateRequest | undefined): MemberServiceB2bOrgUpdateBody {
+    const payload: MemberServiceB2bOrgUpdateBody = {};
+    if (!body || typeof body !== 'object') return payload;
+
+    if (body.description !== undefined) payload.description = body.description;
+    if (body.website !== undefined) payload.website = body.website;
+    if (body.industry !== undefined) payload.industry = body.industry;
+    if (body.sector !== undefined) payload.sector = body.sector;
+    if (body.crunchBaseUrl !== undefined) payload.crunch_base_url = body.crunchBaseUrl;
+    if (body.numberOfEmployees !== undefined) payload.number_of_employees = body.numberOfEmployees;
+
+    return payload;
   }
 
   /** Transforms member-service snake_case response to the BFF camelCase contract. */
@@ -210,6 +322,8 @@ export class OrgIdentityController {
       industry: raw.industry ?? null,
       sector: raw.sector ?? null,
       numberOfEmployees: raw.number_of_employees ?? null,
+      crunchBaseUrl: raw.crunch_base_url ?? null,
+      updatedAt: raw.updated_at ?? null,
       parentUid: raw.parent_uid ?? null,
       isMember: raw.is_member ?? false,
     };

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -30,6 +30,12 @@ router.get('/me/role-grants', (req, res, next) => orgIdentityController.getRoleG
 // GET /api/orgs/uid/:uid — canonical record by b2b_org.uid
 router.get('/uid/:uid', (req, res, next) => orgIdentityController.getCanonicalRecord(req, res, next));
 
+// Spec 021 — PUT /api/orgs/uid/:uid — partial-update of org profile fields (FR-008, FR-016)
+router.put('/uid/:uid', (req, res, next) => orgIdentityController.updateOrg(req, res, next));
+
+// Spec 021 — GET /api/orgs/uid/:uid/addresses — primary + billing addresses (mock in v1, FR-004)
+router.get('/uid/:uid/addresses', (req, res, next) => orgIdentityController.getOrgAddresses(req, res, next));
+
 // GET /api/orgs/sfid/:accountId — canonical record by legacy Salesforce account id
 router.get('/sfid/:accountId', (req, res, next) => orgIdentityController.getCanonicalRecord(req, res, next));
 

--- a/apps/lfx-one/src/server/services/fixtures/org-addresses.mock.json
+++ b/apps/lfx-one/src/server/services/fixtures/org-addresses.mock.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "TEMPORARY — Spec 021 mock address data. Same fixture is returned for every uid since member-service does not yet expose address fields. REPLACE before GA, or remove once GET /b2b_orgs/{uid} upstream includes shipping_address + billing_address. Gated by isMockOrgItemsEnabled() (NODE_ENV !== 'production' AND MOCK_ORG_ITEMS === 'true' or '1').",
+  "primaryAddress": {
+    "line1": "1 Toyota-Cho",
+    "city": "Toyota City",
+    "stateProvince": "Aichi",
+    "postalCode": "471-8571",
+    "country": "Japan"
+  },
+  "billingAddress": {
+    "line1": "1 Toyota-Cho",
+    "city": "Toyota City",
+    "stateProvince": "Aichi",
+    "postalCode": "471-8571",
+    "country": "Japan"
+  }
+}

--- a/apps/lfx-one/src/server/services/fixtures/org-selector.mock.json
+++ b/apps/lfx-one/src/server/services/fixtures/org-selector.mock.json
@@ -131,24 +131,30 @@
     "$comment": "Optional per-uid enrichment surfaced by the canonical-record endpoint (US4). When a uid is missing here the controller derives the camelCase record from the items[] entry only.",
     "4c46585f-878c-8285-b2e9-2dbfc38ddd9b": {
       "description": "Open source software company providing enterprise solutions including Red Hat Enterprise Linux, OpenShift, and Ansible.",
-      "website": "https://www.redhat.com",
-      "industry": "Information Technology",
-      "sector": "Software & Services",
-      "numberOfEmployees": 19000
+      "website": "redhat.com",
+      "industry": "Open Source Software",
+      "sector": "Information Technology",
+      "numberOfEmployees": 19000,
+      "crunchBaseUrl": "https://crunchbase.com/organization/red-hat",
+      "updatedAt": "2026-05-20T12:34:56Z"
     },
     "4c46585f-878c-8285-b2e9-2dbfc38dc8a7": {
       "description": "Multinational technology company offering hybrid cloud and AI solutions.",
-      "website": "https://www.ibm.com",
-      "industry": "Information Technology",
-      "sector": "Software & Services",
-      "numberOfEmployees": 282000
+      "website": "ibm.com",
+      "industry": "Computer Hardware & Software",
+      "sector": "Information Technology",
+      "numberOfEmployees": 282000,
+      "crunchBaseUrl": "https://crunchbase.com/organization/ibm",
+      "updatedAt": "2026-05-25T10:00:00Z"
     },
     "4c46585f-878c-8285-b2e9-2dbfc38dbefe": {
-      "description": "Japanese multinational automotive manufacturer.",
-      "website": "https://global.toyota",
+      "description": "Toyota Motor Corporation is a Japanese multinational automotive manufacturer headquartered in Toyota City, Aichi, Japan. It is one of the world's largest automobile manufacturers and a pioneer in hybrid electric vehicles.",
+      "website": "toyota.com",
       "industry": "Automotive",
-      "sector": "Consumer Discretionary",
-      "numberOfEmployees": 372000
+      "sector": "Manufacturing",
+      "numberOfEmployees": 370870,
+      "crunchBaseUrl": "https://crunchbase.com/organization/toyota",
+      "updatedAt": "2026-05-27T15:42:00Z"
     }
   }
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -54,6 +54,7 @@ export * from './org-lens.constants';
 export * from './org-memberships.constants';
 export * from './feature-flags.constants';
 export * from './org-selector.constants';
+export * from './org-profile.constants';
 export * from './foundation-projects.constants';
 export * from './marketing-impact.constants';
 export * from './org-people.constants';

--- a/packages/shared/src/constants/org-profile.constants.ts
+++ b/packages/shared/src/constants/org-profile.constants.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Spec 021 — Org Profile edit form dropdown options. Values match the LFX One V3 wireframe Industry and Technology Sector lists; "Other" is the fallback for unrecognized backend values.
+
+export const INDUSTRY_OPTIONS: string[] = [
+  'Internet Software & Services',
+  'Open Source Software',
+  'Automotive',
+  'Computer Hardware & Software',
+  'Social Media & Technology',
+  'Financial Services',
+  'Healthcare & Life Sciences',
+  'Telecommunications',
+  'Energy',
+  'Other',
+];
+
+export const SECTOR_OPTIONS: string[] = [
+  'Information Technology',
+  'Manufacturing',
+  'Financial Services',
+  'Healthcare',
+  'Energy',
+  'Government',
+  'Education',
+  'Other',
+];
+
+/** Max length for the Organization Description textarea (FR-007). */
+export const ORG_DESCRIPTION_MAX_LENGTH = 2000;

--- a/packages/shared/src/interfaces/org-selector.interface.ts
+++ b/packages/shared/src/interfaces/org-selector.interface.ts
@@ -87,9 +87,63 @@ export interface OrgCanonicalRecord {
   industry?: string | null;
   sector?: string | null;
   numberOfEmployees?: number | null;
+  /** Crunchbase profile URL (spec 021). */
+  crunchBaseUrl?: string | null;
+  /** Last-modified timestamp from upstream (ISO 8601 UTC); displayed as "Last Updated" on the profile page (spec 021). */
+  updatedAt?: string | null;
   /** b2b_org.uid of the parent; null for top-level orgs. */
   parentUid?: string | null;
   isMember: boolean;
+}
+
+/** Partial-update payload for `PUT /api/orgs/uid/:uid` (spec 021). Only changed fields are included. Excludes `name` (locked at UI) and `logoUrl` (deferred). */
+export interface OrgUpdateRequest {
+  description?: string;
+  website?: string;
+  industry?: string;
+  sector?: string;
+  crunchBaseUrl?: string;
+  numberOfEmployees?: number | null;
+}
+
+/** Snake_case body for member-service `PUT /b2b_orgs/{uid}` — mirrors upstream Goa `B2BOrgUpdateBody` (spec 021). */
+export interface MemberServiceB2bOrgUpdateBody {
+  description?: string;
+  website?: string;
+  industry?: string;
+  sector?: string;
+  crunch_base_url?: string;
+  number_of_employees?: number | null;
+}
+
+/** Editable form fields for the Org Profile edit view — drives dirty-check + validation (spec 021). */
+export interface OrgProfileEditableFields {
+  description: string;
+  website: string;
+  numberOfEmployees: number | null;
+  crunchBaseUrl: string;
+  industry: string;
+  sector: string;
+}
+
+/** Optional per-uid enrichment in org-selector.mock.json `canonicalExtras` (spec 020/021). */
+export type OrgCanonicalMockExtras = Partial<
+  Pick<OrgCanonicalRecord, 'description' | 'website' | 'industry' | 'sector' | 'numberOfEmployees' | 'crunchBaseUrl' | 'updatedAt' | 'parentUid'>
+>;
+
+/** Single physical address (spec 021). */
+export interface OrgAddress {
+  line1: string;
+  city: string;
+  stateProvince: string;
+  postalCode: string;
+  country: string;
+}
+
+/** Response shape for `GET /api/orgs/uid/:uid/addresses` (spec 021). Mock-backed in v1; future-ready for member-service integration. */
+export interface OrgAddressesResponse {
+  primaryAddress: OrgAddress | null;
+  billingAddress: OrgAddress | null;
 }
 
 /** Internal page result used by the client `OrgNavigationService` reactive pipeline. `reset=true` marks a fresh first page. */
@@ -148,6 +202,10 @@ export interface MemberServiceB2bOrgResponse {
   industry?: string | null;
   sector?: string | null;
   number_of_employees?: number | null;
+  /** Crunchbase URL on the upstream record (spec 021). */
+  crunch_base_url?: string | null;
+  /** Upstream last-modified timestamp (spec 021). */
+  updated_at?: string | null;
   parent_uid?: string | null;
   is_member?: boolean;
 }

--- a/packages/shared/src/validators/https-url.validator.ts
+++ b/packages/shared/src/validators/https-url.validator.ts
@@ -1,0 +1,19 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function httpsUrlValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (value === null || value === undefined || value === '') return null;
+    if (typeof value !== 'string') return { httpsUrl: true };
+
+    try {
+      const parsed = new URL(value.trim());
+      return parsed.protocol === 'https:' ? null : { httpsUrl: true };
+    } catch {
+      return { httpsUrl: true };
+    }
+  };
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 export * from './date.validators';
+export * from './https-url.validator';
 export * from './mailing-list.validators';
 export * from './meeting.validators';
 export * from './vote.validators';


### PR DESCRIPTION
## Summary

Implements `/org/profile` in the Org Lens with a read-only view (auditor + writer) and an edit form (writer only) per spec `specs/021-org-profile-edit`.

- **Read-only view (US1)** — summary card with logo/initials, name, website + Crunchbase external links, description, metadata row (Website, Employees, Industry, Sector), "Last Updated" date, plus two read-only address cards (Primary + Billing). Writer-gated "Edit Profile" button via the existing `OrgRoleGrantsService.writerSet` signal.
- **Edit form (US2)** — two-column reactive form matching the V3 wireframe (Organization Name locked with "Contact Support" link, Website, Employees, Crunchbase Profile with `cb` badge prefix, Industry, Sector dropdowns, full-width Description). Dirty-check + lightweight validation gates "Save Changes". PUT sends only changed fields; success toast + `AccountContextService` propagation so the sidebar reflects changes immediately. Differentiated 403 (permission) vs 502 (retry) error toasts. Logo upload deliberately deferred (button visible, disabled).
- **Org-selector reactivity (US3)** — switching orgs while editing discards changes and reloads the new org in read-only mode.

## Backend changes

| Endpoint | Status | Notes |
|----------|--------|-------|
| `GET /api/orgs/uid/:uid` | Extended | `toCanonicalRecord()` now maps `crunch_base_url` → `crunchBaseUrl` and `updated_at` → `updatedAt` |
| `PUT /api/orgs/uid/:uid` | **New** | Proxies to member-service `PUT /b2b_orgs/{uid}`; camelCase → snake_case transform; strips `name` (locked) and `logoUrl` (deferred); 403 → "You no longer have permission…", 502 → "Unable to save changes. Please try again." |
| `GET /api/orgs/uid/:uid/addresses` | **New** | Returns mock address fixture in v1; contract designed for future upstream swap when member-service exposes address fields |

## Shared additions

- Interfaces: `OrgUpdateRequest`, `OrgAddress`, `OrgAddressesResponse`, `MemberServiceB2bOrgUpdateBody`, `OrgProfileEditableFields`; `crunchBaseUrl` + `updatedAt` on `OrgCanonicalRecord` and `MemberServiceB2bOrgResponse`.
- Constants: `INDUSTRY_OPTIONS`, `SECTOR_OPTIONS`, `ORG_DESCRIPTION_MAX_LENGTH`.
- Helpers: `httpsUrlValidator`, `DisplayValuePipe` (used for the dash `—` placeholder).

## Mock posture

Per option B (chosen during review) the PUT endpoint always hits the real member-service — no mock-write branch. Read endpoints retain the spec-020 `MOCK_ORG_ITEMS=true` behavior for offline browsing. The addresses endpoint is mock-only by necessity (no real upstream).

## FGA model

No `model.yaml` changes. Uses existing `writer` and `auditor` relations on `b2b_org`. Member-service Heimdall gateway enforces `writer` on `PUT /b2b_orgs/{uid}`. Client-side gating uses `OrgRoleGrantsService.writerSet` so the Edit button never appears for auditors.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn check-types` clean
- [x] `yarn format:check` clean
- [x] `yarn build` (SSR + browser) clean
- [x] Pre-commit hooks (check-headers, lint-staged, format:check, lint:check, check-types) all pass
- [x] New Playwright spec `apps/lfx-one/e2e/org-profile.spec.ts` covering view + edit flows
- [ ] Manual verification on dev: navigate to `/org/profile`, verify read-only view renders for auditor + writer; click Edit Profile (writer only); change a field; verify Save enables; save; verify success toast + return to read-only view with updated data; switch org; verify reload
- [ ] Verify differentiated error toasts: trigger 403 by removing writer access mid-session; trigger 502 by upstream outage

## Spec & docs

- [`specs/021-org-profile-edit/spec.md`](../../linuxfoundation/lfx-self-serve/blob/feat/LFXV2-1905/) — 20 FRs, 9 clarifications across 3 sessions, 4 measurable success criteria
- [`specs/021-org-profile-edit/plan.md`](../../linuxfoundation/lfx-self-serve/blob/feat/LFXV2-1905/) — constitution check (8/8 PASS or N/A)
- [`specs/021-org-profile-edit/contracts/`](../../linuxfoundation/lfx-self-serve/blob/feat/LFXV2-1905/) — `bff-put-org-profile.md`, `bff-get-org-addresses.md`

## Closes

LFXV2-1905

Made with [Cursor](https://cursor.com)