### PR TITLE
feat(newsletters): broaden nav + route access to writer/owner

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -207,7 +207,7 @@ export const routes: Routes = [
       {
         path: 'foundation/newsletters',
         data: { lens: 'foundation' },
-        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
+        canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -256,7 +256,7 @@ export const routes: Routes = [
       {
         path: 'project/newsletters',
         data: { lens: 'project' },
-        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
+        canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
 import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
+import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
@@ -206,7 +207,7 @@ export const routes: Routes = [
       {
         path: 'foundation/newsletters',
         data: { lens: 'foundation' },
-        canActivate: [executiveDirectorGuard, projectQueryParamGuard],
+        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -255,7 +256,7 @@ export const routes: Routes = [
       {
         path: 'project/newsletters',
         data: { lens: 'project' },
-        canActivate: [executiveDirectorGuard, projectQueryParamGuard],
+        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -291,7 +292,7 @@ export const routes: Routes = [
       },
       {
         path: 'newsletters',
-        canActivate: [executiveDirectorGuard, lensRedirectGuard],
+        canActivate: [lensRedirectGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -55,6 +55,13 @@ export class MainLayoutComponent {
   // Active lens from service
   protected readonly activeLens = this.lensService.activeLens;
 
+  // Newsletter nav visibility: ED persona always sees it; non-ED users see it
+  // when they have writer (or owner-equivalent) permission on the currently
+  // active foundation/project. canWrite() is reactive to context changes.
+  private readonly canSeeNewsletters: Signal<boolean> = computed(
+    () => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite()
+  );
+
   // Lens-aware sidebar items
   protected readonly sidebarItems = computed((): SidebarMenuItem[] => {
     switch (this.activeLens()) {
@@ -66,7 +73,7 @@ export class MainLayoutComponent {
         // edit role, remove, etc.) is enforced server-side and by per-page UI gating where
         // implemented; pre-existing gaps in those gates are tracked separately.
         const base = this.projectLensItemsWithGovernance;
-        return this.personaService.currentPersona() === 'executive-director' ? [...base, this.projectCommunicationsSection] : base;
+        return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
       }
       case 'org':
         return this.isOrgLensEnabled() ? this.orgLensItems : this.meLensItems;
@@ -267,7 +274,7 @@ export class MainLayoutComponent {
       }
     );
 
-    if (this.personaService.currentPersona() === 'executive-director') {
+    if (this.canSeeNewsletters()) {
       items.push({
         label: 'Communications',
         isSection: true,
@@ -281,7 +288,9 @@ export class MainLayoutComponent {
           },
         ],
       });
+    }
 
+    if (this.personaService.currentPersona() === 'executive-director') {
       items.push({
         label: 'Metrics',
         isSection: true,

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -58,9 +58,7 @@ export class MainLayoutComponent {
   // Newsletter nav visibility: ED persona always sees it; non-ED users see it
   // when they have writer (or owner-equivalent) permission on the currently
   // active foundation/project. canWrite() is reactive to context changes.
-  private readonly canSeeNewsletters: Signal<boolean> = computed(
-    () => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite()
-  );
+  private readonly canSeeNewsletters: Signal<boolean> = this.initCanSeeNewsletters();
 
   // Lens-aware sidebar items
   protected readonly sidebarItems = computed((): SidebarMenuItem[] => {
@@ -501,6 +499,10 @@ export class MainLayoutComponent {
       .subscribe(() => {
         window.location.reload();
       });
+  }
+
+  private initCanSeeNewsletters(): Signal<boolean> {
+    return computed(() => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite());
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -3,7 +3,7 @@
 
 import { Routes } from '@angular/router';
 import { authGuard } from '@shared/guards/auth.guard';
-import { executiveDirectorGuard } from '@shared/guards/executive-director.guard';
+import { newsletterAccessGuard } from '@shared/guards/newsletter-access.guard';
 
 export const NEWSLETTER_ROUTES: Routes = [
   {
@@ -13,25 +13,25 @@ export const NEWSLETTER_ROUTES: Routes = [
   },
   {
     path: 'list',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-list/newsletter-list.component').then((m) => m.NewsletterListComponent),
     data: { preload: false },
   },
   {
     path: 'create',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
   },
   {
     path: ':id/edit',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
   },
   {
     path: ':id/analytics',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },
   },

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { catchError, map, of } from 'rxjs';
 
 import { PersonaService } from '../services/persona.service';
@@ -18,12 +18,14 @@ import { ProjectService } from '../services/project.service';
  *     active foundation/project — `project.writer === true` set by the
  *     backend's FGA-driven role check.
  *
- * The newsletter routes do not carry a `:slug` path param, so writer
- * resolution reads the active context from ProjectContextService rather
- * than the route. Falls back to `/foundation/overview` on denial to match
- * the existing executiveDirectorGuard's redirect behavior.
+ * Slug resolution prefers the URL's `?project=<slug>` query param so deep
+ * links and hard reloads work before the lens has finished syncing the
+ * active context. Falls back to the active context's slug only when no
+ * query param is present (e.g., the bare `/newsletters` lens-redirect
+ * path). Falls back to `/foundation/overview` on denial / unrecoverable
+ * error to match the existing executiveDirectorGuard's behavior.
  */
-export const newsletterAccessGuard: CanActivateFn = () => {
+export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const personaService = inject(PersonaService);
   const projectContextService = inject(ProjectContextService);
   const projectService = inject(ProjectService);
@@ -35,16 +37,27 @@ export const newsletterAccessGuard: CanActivateFn = () => {
     return true;
   }
 
-  const ctx = projectContextService.activeContext();
-  if (!ctx?.slug) {
+  // Prefer the URL's project query param: it's authoritative for the
+  // navigation target and doesn't depend on the lens having synced yet.
+  // Fall back to the active context for cases where the URL doesn't carry
+  // it (e.g., the `/newsletters` lens-redirect parent).
+  const slug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
+  if (!slug) {
     return router.parseUrl('/foundation/overview');
   }
 
-  // Writer / owner check on the active context. project.writer is set
-  // server-side by the FGA-driven authorization check and is true for both
-  // explicit writer grants and owner-equivalent roles.
-  return projectService.getProject(ctx.slug, false).pipe(
+  // Writer / owner check on the resolved project. project.writer is set
+  // server-side by the FGA-driven authorization check and is true for
+  // both explicit writer grants and owner-equivalent roles.
+  return projectService.getProject(slug, false).pipe(
     map((project) => (project?.writer === true ? true : router.parseUrl('/foundation/overview'))),
-    catchError(() => of(router.parseUrl('/foundation/overview')))
+    catchError((err) => {
+      // Surface the failure to Datadog RUM rather than silently bouncing —
+      // a 5xx / transport error looks identical to a legitimate deny from
+      // the user's perspective and we want it triageable.
+      // eslint-disable-next-line no-console
+      console.error('newsletterAccessGuard: writer-permission lookup failed', { slug, error: err });
+      return of(router.parseUrl('/foundation/overview'));
+    })
   );
 };

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { catchError, map, of } from 'rxjs';
+
+import { PersonaService } from '../services/persona.service';
+import { ProjectContextService } from '../services/project-context.service';
+import { ProjectService } from '../services/project.service';
+
+/**
+ * Route guard for the newsletters feature.
+ *
+ * Grants access to:
+ *   - Executive Director persona (fast path, synchronous), OR
+ *   - Users with writer (or owner-equivalent) permission on the currently
+ *     active foundation/project — `project.writer === true` set by the
+ *     backend's FGA-driven role check.
+ *
+ * The newsletter routes do not carry a `:slug` path param, so writer
+ * resolution reads the active context from ProjectContextService rather
+ * than the route. Falls back to `/foundation/overview` on denial to match
+ * the existing executiveDirectorGuard's redirect behavior.
+ */
+export const newsletterAccessGuard: CanActivateFn = () => {
+  const personaService = inject(PersonaService);
+  const projectContextService = inject(ProjectContextService);
+  const projectService = inject(ProjectService);
+  const router = inject(Router);
+
+  // Fast path: ED persona. Synchronous (cookie-seeded) so SSR + first-paint
+  // navigations don't need to await an HTTP round-trip.
+  if (personaService.currentPersona() === 'executive-director') {
+    return true;
+  }
+
+  const ctx = projectContextService.activeContext();
+  if (!ctx?.slug) {
+    return router.parseUrl('/foundation/overview');
+  }
+
+  // Writer / owner check on the active context. project.writer is set
+  // server-side by the FGA-driven authorization check and is true for both
+  // explicit writer grants and owner-equivalent roles.
+  return projectService.getProject(ctx.slug, false).pipe(
+    map((project) => (project?.writer === true ? true : router.parseUrl('/foundation/overview'))),
+    catchError(() => of(router.parseUrl('/foundation/overview')))
+  );
+};

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -4,6 +4,7 @@
 import { Router } from 'express';
 
 import { NewsletterController } from '../controllers/newsletter.controller';
+import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const newsletterController = new NewsletterController();
@@ -31,7 +32,11 @@ router.post('/recipients', (req, res, next) => newsletterController.getRecipient
 router.post('/test-send', (req, res, next) => newsletterController.testSend(req, res, next));
 router.post('/send', (req, res, next) => newsletterController.send(req, res, next));
 
-// AI generation stays in lfx-v2-ui
-router.post('/generate', (req, res, next) => newsletterController.generate(req, res, next));
+// AI generation stays in lfx-v2-ui and doesn't proxy to the Go service, so
+// the downstream FGA check that gates the other endpoints isn't available
+// here. Gate on ED persona to bound LiteLLM cost exposure until /generate
+// accepts a contextUid and the controller can do a writer/owner check
+// against the active project (tracked follow-up).
+router.post('/generate', requireExecutiveDirector, (req, res, next) => newsletterController.generate(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -4,13 +4,14 @@
 import { Router } from 'express';
 
 import { NewsletterController } from '../controllers/newsletter.controller';
-import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const newsletterController = new NewsletterController();
 
-// All newsletter endpoints are Executive Director-only.
-router.use(requireExecutiveDirector);
+// Authorization is enforced by the downstream lfx-v2-newsletter-service (FGA
+// via the forwarded user bearer token) and by the corresponding frontend
+// route guards. Don't gate on persona here — newsletters are accessible to
+// Executive Directors AND writers/owners of the foundation or project.
 
 // List newsletters (drafts + sent) and per-newsletter analytics
 router.get('/', (req, res, next) => newsletterController.listNewsletters(req, res, next));


### PR DESCRIPTION
## Summary

- Broadens the **Newsletters** entry in the left navigation and the corresponding routes from Executive Director-only to **ED OR writer/owner** of the active foundation/project.
- Writers and owners are the persona running the day-to-day communications work in most projects; gating them out of the feature was the only blocker.

