### PR TITLE
feat(newsletters): writer/owner access + lfx-v2-email-service integration

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -5,8 +5,8 @@ import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
 import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
-import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
+import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
 

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -207,7 +207,7 @@ export const routes: Routes = [
       {
         path: 'foundation/newsletters',
         data: { lens: 'foundation' },
-        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
+        canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -256,7 +256,7 @@ export const routes: Routes = [
       {
         path: 'project/newsletters',
         data: { lens: 'project' },
-        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
+        canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
 import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
+import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
@@ -206,7 +207,7 @@ export const routes: Routes = [
       {
         path: 'foundation/newsletters',
         data: { lens: 'foundation' },
-        canActivate: [executiveDirectorGuard, projectQueryParamGuard],
+        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -255,7 +256,7 @@ export const routes: Routes = [
       {
         path: 'project/newsletters',
         data: { lens: 'project' },
-        canActivate: [executiveDirectorGuard, projectQueryParamGuard],
+        canActivate: [projectQueryParamGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
@@ -291,7 +292,7 @@ export const routes: Routes = [
       },
       {
         path: 'newsletters',
-        canActivate: [executiveDirectorGuard, lensRedirectGuard],
+        canActivate: [lensRedirectGuard, newsletterAccessGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -55,6 +55,13 @@ export class MainLayoutComponent {
   // Active lens from service
   protected readonly activeLens = this.lensService.activeLens;
 
+  // Newsletter nav visibility: ED persona always sees it; non-ED users see it
+  // when they have writer (or owner-equivalent) permission on the currently
+  // active foundation/project. canWrite() is reactive to context changes.
+  private readonly canSeeNewsletters: Signal<boolean> = computed(
+    () => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite()
+  );
+
   // Lens-aware sidebar items
   protected readonly sidebarItems = computed((): SidebarMenuItem[] => {
     switch (this.activeLens()) {
@@ -66,7 +73,7 @@ export class MainLayoutComponent {
         // edit role, remove, etc.) is enforced server-side and by per-page UI gating where
         // implemented; pre-existing gaps in those gates are tracked separately.
         const base = this.projectLensItemsWithGovernance;
-        return this.personaService.currentPersona() === 'executive-director' ? [...base, this.projectCommunicationsSection] : base;
+        return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
       }
       case 'org':
         return this.isOrgLensEnabled() ? this.orgLensItems : this.meLensItems;
@@ -267,7 +274,7 @@ export class MainLayoutComponent {
       }
     );
 
-    if (this.personaService.currentPersona() === 'executive-director') {
+    if (this.canSeeNewsletters()) {
       items.push({
         label: 'Communications',
         isSection: true,
@@ -281,7 +288,9 @@ export class MainLayoutComponent {
           },
         ],
       });
+    }
 
+    if (this.personaService.currentPersona() === 'executive-director') {
       items.push({
         label: 'Metrics',
         isSection: true,

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -58,9 +58,7 @@ export class MainLayoutComponent {
   // Newsletter nav visibility: ED persona always sees it; non-ED users see it
   // when they have writer (or owner-equivalent) permission on the currently
   // active foundation/project. canWrite() is reactive to context changes.
-  private readonly canSeeNewsletters: Signal<boolean> = computed(
-    () => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite()
-  );
+  private readonly canSeeNewsletters: Signal<boolean> = this.initCanSeeNewsletters();
 
   // Lens-aware sidebar items
   protected readonly sidebarItems = computed((): SidebarMenuItem[] => {
@@ -501,6 +499,10 @@ export class MainLayoutComponent {
       .subscribe(() => {
         window.location.reload();
       });
+  }
+
+  private initCanSeeNewsletters(): Signal<boolean> {
+    return computed(() => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite());
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -101,6 +101,12 @@ export class NewsletterListComponent {
   );
 
   public constructor() {
+    // Seed statusTab from the `?tab=` query param so post-send navigation
+    // (and any deep links) land on the right tab — defaults to 'draft'.
+    const tabFromQuery = this.route.snapshot.queryParamMap.get('tab');
+    if (tabFromQuery === 'sent' || tabFromQuery === 'draft') {
+      this.statusTab.set(tabFromQuery);
+    }
     this.initLoadOnContextOrTab();
   }
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -253,8 +253,11 @@ export class NewsletterManageComponent {
   }
 
   // `['..']` on a 2-segment route resolves to `/<id>` — anchor to route.parent + explicit 'list' child.
-  private goToList(): void {
-    this.router.navigate(['list'], { relativeTo: this.route.parent });
+  private goToList(tab?: 'draft' | 'sent'): void {
+    this.router.navigate(['list'], {
+      relativeTo: this.route.parent,
+      queryParams: tab ? { tab } : undefined,
+    });
   }
 
   private computeCanProceed(step: number): boolean {
@@ -344,7 +347,10 @@ export class NewsletterManageComponent {
               detail: `Delivered to ${result.sent} ${result.sent === 1 ? 'recipient' : 'recipients'}.`,
             });
           }
-          this.goToList();
+          // Land on the Sent tab on full success; on markSentFailed the row
+          // is still a draft on the Go side, so don't mislead the operator
+          // by routing them to Sent.
+          this.goToList(result.markSentFailed ? 'draft' : 'sent');
         },
         error: (err: HttpErrorResponse) => {
           this.messageService.add({

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -321,7 +321,16 @@ export class NewsletterManageComponent {
       )
       .subscribe({
         next: (result: NewsletterSendResult) => {
-          if (result.failed > 0) {
+          if (result.markSentFailed) {
+            // Emails delivered but the newsletter row didn't flip to "sent".
+            // Tell the operator explicitly — retrying would dispatch duplicates.
+            this.messageService.add({
+              severity: 'warn',
+              summary: 'Sent — status update failed',
+              detail: `Delivered to ${result.sent} ${result.sent === 1 ? 'recipient' : 'recipients'}, but the newsletter status couldn't be updated. Don't retry — contact support to reconcile.`,
+              life: 12000,
+            });
+          } else if (result.failed > 0) {
             this.messageService.add({
               severity: 'warn',
               summary: 'Sent with errors',

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -3,7 +3,7 @@
 
 import { Routes } from '@angular/router';
 import { authGuard } from '@shared/guards/auth.guard';
-import { executiveDirectorGuard } from '@shared/guards/executive-director.guard';
+import { newsletterAccessGuard } from '@shared/guards/newsletter-access.guard';
 
 export const NEWSLETTER_ROUTES: Routes = [
   {
@@ -13,25 +13,25 @@ export const NEWSLETTER_ROUTES: Routes = [
   },
   {
     path: 'list',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-list/newsletter-list.component').then((m) => m.NewsletterListComponent),
     data: { preload: false },
   },
   {
     path: 'create',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
   },
   {
     path: ':id/edit',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
   },
   {
     path: ':id/analytics',
-    canActivate: [authGuard, executiveDirectorGuard],
+    canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },
   },

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { catchError, map, of } from 'rxjs';
 
 import { PersonaService } from '../services/persona.service';
@@ -18,12 +18,14 @@ import { ProjectService } from '../services/project.service';
  *     active foundation/project — `project.writer === true` set by the
  *     backend's FGA-driven role check.
  *
- * The newsletter routes do not carry a `:slug` path param, so writer
- * resolution reads the active context from ProjectContextService rather
- * than the route. Falls back to `/foundation/overview` on denial to match
- * the existing executiveDirectorGuard's redirect behavior.
+ * Slug resolution prefers the URL's `?project=<slug>` query param so deep
+ * links and hard reloads work before the lens has finished syncing the
+ * active context. Falls back to the active context's slug only when no
+ * query param is present (e.g., the bare `/newsletters` lens-redirect
+ * path). Falls back to `/foundation/overview` on denial / unrecoverable
+ * error to match the existing executiveDirectorGuard's behavior.
  */
-export const newsletterAccessGuard: CanActivateFn = () => {
+export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const personaService = inject(PersonaService);
   const projectContextService = inject(ProjectContextService);
   const projectService = inject(ProjectService);
@@ -35,16 +37,27 @@ export const newsletterAccessGuard: CanActivateFn = () => {
     return true;
   }
 
-  const ctx = projectContextService.activeContext();
-  if (!ctx?.slug) {
+  // Prefer the URL's project query param: it's authoritative for the
+  // navigation target and doesn't depend on the lens having synced yet.
+  // Fall back to the active context for cases where the URL doesn't carry
+  // it (e.g., the `/newsletters` lens-redirect parent).
+  const slug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
+  if (!slug) {
     return router.parseUrl('/foundation/overview');
   }
 
-  // Writer / owner check on the active context. project.writer is set
-  // server-side by the FGA-driven authorization check and is true for both
-  // explicit writer grants and owner-equivalent roles.
-  return projectService.getProject(ctx.slug, false).pipe(
+  // Writer / owner check on the resolved project. project.writer is set
+  // server-side by the FGA-driven authorization check and is true for
+  // both explicit writer grants and owner-equivalent roles.
+  return projectService.getProject(slug, false).pipe(
     map((project) => (project?.writer === true ? true : router.parseUrl('/foundation/overview'))),
-    catchError(() => of(router.parseUrl('/foundation/overview')))
+    catchError((err) => {
+      // Surface the failure to Datadog RUM rather than silently bouncing —
+      // a 5xx / transport error looks identical to a legitimate deny from
+      // the user's perspective and we want it triageable.
+      // eslint-disable-next-line no-console
+      console.error('newsletterAccessGuard: writer-permission lookup failed', { slug, error: err });
+      return of(router.parseUrl('/foundation/overview'));
+    })
   );
 };

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -55,7 +55,6 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
       // Surface the failure to Datadog RUM rather than silently bouncing —
       // a 5xx / transport error looks identical to a legitimate deny from
       // the user's perspective and we want it triageable.
-      // eslint-disable-next-line no-console
       console.error('newsletterAccessGuard: writer-permission lookup failed', { slug, error: err });
       return of(router.parseUrl('/foundation/overview'));
     })

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { catchError, map, of } from 'rxjs';
+
+import { PersonaService } from '../services/persona.service';
+import { ProjectContextService } from '../services/project-context.service';
+import { ProjectService } from '../services/project.service';
+
+/**
+ * Route guard for the newsletters feature.
+ *
+ * Grants access to:
+ *   - Executive Director persona (fast path, synchronous), OR
+ *   - Users with writer (or owner-equivalent) permission on the currently
+ *     active foundation/project — `project.writer === true` set by the
+ *     backend's FGA-driven role check.
+ *
+ * The newsletter routes do not carry a `:slug` path param, so writer
+ * resolution reads the active context from ProjectContextService rather
+ * than the route. Falls back to `/foundation/overview` on denial to match
+ * the existing executiveDirectorGuard's redirect behavior.
+ */
+export const newsletterAccessGuard: CanActivateFn = () => {
+  const personaService = inject(PersonaService);
+  const projectContextService = inject(ProjectContextService);
+  const projectService = inject(ProjectService);
+  const router = inject(Router);
+
+  // Fast path: ED persona. Synchronous (cookie-seeded) so SSR + first-paint
+  // navigations don't need to await an HTTP round-trip.
+  if (personaService.currentPersona() === 'executive-director') {
+    return true;
+  }
+
+  const ctx = projectContextService.activeContext();
+  if (!ctx?.slug) {
+    return router.parseUrl('/foundation/overview');
+  }
+
+  // Writer / owner check on the active context. project.writer is set
+  // server-side by the FGA-driven authorization check and is true for both
+  // explicit writer grants and owner-equivalent roles.
+  return projectService.getProject(ctx.slug, false).pipe(
+    map((project) => (project?.writer === true ? true : router.parseUrl('/foundation/overview'))),
+    catchError(() => of(router.parseUrl('/foundation/overview')))
+  );
+};

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -4,21 +4,33 @@
 import { NEWSLETTER_RAW_CONTENT_MAX_LENGTH, NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
 import {
   CreateNewsletterDraftRequest,
+  EmailRecipientRecord,
   GenerateNewsletterRequest,
+  Newsletter,
+  NewsletterAnalytics,
   NewsletterContextType,
+  NewsletterDailyOpens,
   NewsletterListParams,
+  NewsletterRecipient,
   NewsletterRecipientCountPayload,
+  NewsletterSendFailure,
   NewsletterSendPayload,
+  NewsletterSendResult,
   NewsletterStatus,
   NewsletterTestSendPayload,
   UpdateNewsletterDraftRequest,
 } from '@lfx-one/shared/interfaces';
+import { stripHtml } from '@lfx-one/shared/utils';
+import { randomUUID } from 'crypto';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { AiService } from '../services/ai.service';
+import { EmailServiceClient } from '../services/email-service.client';
 import { logger } from '../services/logger.service';
 import { NewsletterServiceClient } from '../services/newsletter-service.client';
+
+const EMAIL_SEND_CONCURRENCY = 5;
 
 const VALID_CONTEXT_TYPES = new Set(['foundation', 'project']);
 const SUBJECT_MAX_LENGTH = 200;
@@ -28,6 +40,7 @@ const CONTEXT_NAME_MAX_LENGTH = 200;
 
 export class NewsletterController {
   private newsletterClient: NewsletterServiceClient = new NewsletterServiceClient();
+  private emailServiceClient: EmailServiceClient = new EmailServiceClient();
   private aiService: AiService = new AiService();
 
   /**
@@ -78,6 +91,10 @@ export class NewsletterController {
   /**
    * POST /api/newsletters/test-send
    * Body: { subject, bodyHtml, toEmail, contextType, contextUid, edReplyEmail }
+   *
+   * Sends a single preview email via lfx-v2-email-service. No group_id is
+   * supplied — test sends auto-generate one server-side and stay out of the
+   * newsletter analytics rollup.
    */
   public async testSend(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'newsletter_test_send', {
@@ -97,10 +114,15 @@ export class NewsletterController {
         });
       }
 
-      const result = await this.newsletterClient.testSend(req, payload);
+      await this.emailServiceClient.sendEmail(req, {
+        to: payload.toEmail,
+        subject: payload.subject,
+        html: payload.bodyHtml,
+        text: stripHtml(payload.bodyHtml),
+      });
 
       logger.success(req, 'newsletter_test_send', startTime, { to: payload.toEmail });
-      res.json(result);
+      res.json({ ok: true });
     } catch (error) {
       next(error);
     }
@@ -109,6 +131,10 @@ export class NewsletterController {
   /**
    * POST /api/newsletters/send
    * Body: { subject, bodyHtml, committeeUids, contextType, contextUid, edReplyEmail }
+   *
+   * Ad-hoc send (no prior saved draft). Creates a draft record on the Go
+   * newsletter-service, fans out one email per recipient via email-service,
+   * then flips the draft to `sent` with the shared group_id.
    */
   public async send(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'newsletter_send', {
@@ -122,9 +148,13 @@ export class NewsletterController {
       this.validateCommonPayload(payload, req.path, 'newsletter_send');
       this.validateCommitteeUids(payload.committeeUids, req.path, 'newsletter_send');
 
-      const result = await this.newsletterClient.send(req, payload);
+      const draft = await this.newsletterClient.createDraft(req, payload as CreateNewsletterDraftRequest);
+
+      const result = await this.dispatchNewsletter(req, draft, 'newsletter_send');
 
       logger.success(req, 'newsletter_send', startTime, {
+        newsletter_id: draft.id,
+        group_id: result.groupId,
         total_recipients: result.totalRecipients,
         sent: result.sent,
         failed: result.failed,
@@ -258,6 +288,10 @@ export class NewsletterController {
   /**
    * POST /api/newsletters/drafts/:id/send
    * Requires If-Match header for optimistic locking.
+   *
+   * Fetches the saved draft, fans out one email per recipient via the
+   * email-service, then PATCHes the Go newsletter-service record with the
+   * shared group_id and status=sent.
    */
   public async sendDraft(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'newsletter_send_draft', { draft_id: req.params['id'] });
@@ -265,9 +299,13 @@ export class NewsletterController {
     try {
       const id = String(req.params['id'] || '');
       const version = parseIfMatch(req);
-      const result = await this.newsletterClient.sendDraft(req, id, version);
+
+      const draft = await this.newsletterClient.getDraft(req, id);
+      const result = await this.dispatchNewsletter(req, draft, 'newsletter_send_draft', version);
+
       logger.success(req, 'newsletter_send_draft', startTime, {
         draft_id: id,
+        group_id: result.groupId,
         total_recipients: result.totalRecipients,
         sent: result.sent,
         failed: result.failed,
@@ -334,6 +372,11 @@ export class NewsletterController {
   /**
    * GET /api/newsletters/:id/analytics
    * Returns engagement analytics for a sent newsletter.
+   *
+   * Source of truth is lfx-v2-email-service: we look up the newsletter to
+   * read its `groupId`, then aggregate per-recipient EmailRecipientRecords
+   * into the existing NewsletterAnalytics shape so the frontend doesn't have
+   * to change.
    */
   public async getAnalytics(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'newsletter_analytics', { newsletter_id: req.params['id'] });
@@ -347,13 +390,31 @@ export class NewsletterController {
           path: req.path,
         });
       }
-      const result = await this.newsletterClient.getAnalytics(req, id);
+
+      const newsletter = await this.newsletterClient.getDraft(req, id);
+
+      let analytics: NewsletterAnalytics;
+      if (!newsletter.groupId) {
+        // Fallback for newsletters sent before this integration shipped, and
+        // for drafts (which legitimately have no engagement data). Returns an
+        // empty NewsletterAnalytics payload so the analytics page renders.
+        logger.debug(req, 'newsletter_analytics', 'Newsletter has no groupId — returning empty analytics', {
+          newsletter_id: id,
+          status: newsletter.status,
+        });
+        analytics = this.buildEmptyAnalytics(newsletter);
+      } else {
+        const records = await this.emailServiceClient.getStatusByGroup(req, newsletter.groupId);
+        analytics = this.buildAnalyticsFromRecords(newsletter, records);
+      }
+
       logger.success(req, 'newsletter_analytics', startTime, {
         newsletter_id: id,
-        unique_opens: result.uniqueOpens,
-        total_opens: result.totalOpens,
+        group_id: newsletter.groupId,
+        unique_opens: analytics.uniqueOpens,
+        total_opens: analytics.totalOpens,
       });
-      res.json(result);
+      res.json(analytics);
     } catch (error) {
       next(error);
     }
@@ -421,6 +482,205 @@ export class NewsletterController {
     } catch (error) {
       next(error);
     }
+  }
+
+  /**
+   * Per-recipient email-service fan-out + sent-state persistence.
+   *
+   * Resolves recipients from the newsletter's committeeUids, mints a UUID
+   * group_id, dispatches one send_email per recipient with bounded
+   * concurrency, then PATCHes the newsletter to status=sent unless every
+   * recipient failed (matches the previous behavior of not flipping status
+   * on total failure).
+   *
+   * Validations BEFORE any email goes out (cheaper to fail here than to
+   * dispatch and then discover the Go service will reject the markSent):
+   *   - Already-sent newsletters are rejected to prevent duplicate-send
+   *     races (e.g., double-clicking "Send now" while the first request
+   *     is in flight).
+   *   - Empty recipient lists are rejected — the UI shouldn't allow this,
+   *     but a committee with zero resolvable members would otherwise mint
+   *     a group_id, send no emails, and silently no-op.
+   */
+  private async dispatchNewsletter(req: Request, newsletter: Newsletter, operation: string, ifMatchVersion?: number): Promise<NewsletterSendResult> {
+    if (newsletter.status === 'sent') {
+      throw ServiceValidationError.forField('status', 'Newsletter has already been sent', {
+        operation,
+        service: 'newsletter_controller',
+        path: req.path,
+      });
+    }
+
+    const recipientsResponse = await this.newsletterClient.getRecipients(req, { committeeUids: newsletter.committeeUids });
+    const recipients = recipientsResponse.recipients;
+
+    if (recipients.length === 0) {
+      throw ServiceValidationError.forField('committeeUids', 'Selected committees resolved to zero recipients; nothing to send', {
+        operation,
+        service: 'newsletter_controller',
+        path: req.path,
+      });
+    }
+
+    const groupId = randomUUID();
+
+    logger.debug(req, operation, 'Dispatching newsletter via email-service', {
+      newsletter_id: newsletter.id,
+      group_id: groupId,
+      recipient_count: recipients.length,
+    });
+
+    const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId);
+
+    if (sent > 0) {
+      const versionToUse = ifMatchVersion ?? newsletter.version;
+      try {
+        await this.newsletterClient.markSent(req, newsletter.id, { groupId, ifMatchVersion: versionToUse });
+      } catch (error) {
+        // Emails went out but the status flip failed. Log loudly so the
+        // group_id stays recoverable from logs and the operator can retry.
+        logger.error(req, operation, Date.now(), error, {
+          newsletter_id: newsletter.id,
+          group_id: groupId,
+          sent,
+          failed: failures.length,
+          message: 'Emails delivered but newsletter mark-sent PATCH failed; group_id captured in logs for manual recovery',
+        });
+        throw error;
+      }
+    }
+
+    return {
+      totalRecipients: recipients.length,
+      sent,
+      failed: failures.length,
+      failures,
+      groupId,
+    };
+  }
+
+  /**
+   * Sends one email per recipient with a bounded number of in-flight
+   * requests. NATS round-trips are fast (~25ms in dev) but a fully parallel
+   * Promise.all would still saturate the connection for large committees.
+   */
+  private async fanOutEmails(
+    req: Request,
+    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml'>,
+    recipients: NewsletterRecipient[],
+    groupId: string
+  ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
+    const text = stripHtml(newsletter.bodyHtml);
+    const failures: NewsletterSendFailure[] = [];
+    let sent = 0;
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+      while (cursor < recipients.length) {
+        const index = cursor++;
+        const recipient = recipients[index];
+
+        try {
+          await this.emailServiceClient.sendEmail(req, {
+            to: recipient.email,
+            subject: newsletter.subject,
+            html: newsletter.bodyHtml,
+            text,
+            group_id: groupId,
+          });
+          sent++;
+        } catch (error) {
+          failures.push({
+            email: recipient.email,
+            reason: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+    };
+
+    const workerCount = Math.min(EMAIL_SEND_CONCURRENCY, recipients.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    return { sent, failures };
+  }
+
+  /**
+   * Empty-shape analytics for newsletters that don't have a groupId yet —
+   * drafts, or sent newsletters that predate this integration.
+   */
+  private buildEmptyAnalytics(newsletter: Newsletter): NewsletterAnalytics {
+    return {
+      newsletterId: newsletter.id,
+      subject: newsletter.subject,
+      status: newsletter.status,
+      sentAt: newsletter.sentAt,
+      totalRecipients: 0,
+      delivered: 0,
+      failed: 0,
+      totalOpens: 0,
+      uniqueOpens: 0,
+      openRate: 0,
+      dailyOpens: [],
+    };
+  }
+
+  /**
+   * Aggregate per-recipient EmailRecipientRecords into the existing
+   * NewsletterAnalytics shape so the frontend (which expects daily-opens
+   * chart data) keeps working unchanged.
+   *
+   * Note: the email-service tracks "opened" as a boolean per recipient (no
+   * multi-open count), so totalOpens == uniqueOpens for our purposes.
+   */
+  private buildAnalyticsFromRecords(newsletter: Newsletter, records: EmailRecipientRecord[]): NewsletterAnalytics {
+    const totalRecipients = records.length;
+    const delivered = records.filter((r) => r.delivered).length;
+    const failed = records.filter((r) => r.failed).length;
+    const opensCount = records.filter((r) => r.opened).length;
+    const openRate = delivered > 0 ? opensCount / delivered : 0;
+
+    const dailyOpens = this.aggregateDailyOpens(records);
+
+    const eventTimestamps: number[] = [];
+    for (const record of records) {
+      if (record.opened_at) {
+        eventTimestamps.push(new Date(record.opened_at).getTime());
+      }
+      if (record.delivered_at) {
+        eventTimestamps.push(new Date(record.delivered_at).getTime());
+      }
+    }
+    const lastEventAt = eventTimestamps.length > 0 ? new Date(Math.max(...eventTimestamps)).toISOString() : undefined;
+
+    return {
+      newsletterId: newsletter.id,
+      subject: newsletter.subject,
+      status: newsletter.status,
+      sentAt: newsletter.sentAt,
+      totalRecipients,
+      delivered,
+      failed,
+      totalOpens: opensCount,
+      uniqueOpens: opensCount,
+      openRate,
+      dailyOpens,
+      lastEventAt,
+    };
+  }
+
+  private aggregateDailyOpens(records: EmailRecipientRecord[]): NewsletterDailyOpens[] {
+    const buckets = new Map<string, number>();
+    for (const record of records) {
+      if (!record.opened || !record.opened_at) {
+        continue;
+      }
+      const day = record.opened_at.slice(0, 10);
+      buckets.set(day, (buckets.get(day) ?? 0) + 1);
+    }
+
+    return Array.from(buckets.entries())
+      .map(([date, opens]) => ({ date, opens, uniqueOpens: opens }))
+      .sort((a, b) => a.date.localeCompare(b.date));
   }
 
   private validateCommonPayload(

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -361,6 +361,7 @@ export class NewsletterController {
         pageToken,
       };
       const result = await this.newsletterClient.listNewsletters(req, params);
+      result.newsletters = await this.newsletterService.enrichListWithEngagement(req, result.newsletters);
 
       logger.success(req, 'newsletter_list', startTime, {
         count: result.newsletters.length,

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -4,33 +4,24 @@
 import { NEWSLETTER_RAW_CONTENT_MAX_LENGTH, NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
 import {
   CreateNewsletterDraftRequest,
-  EmailRecipientRecord,
   GenerateNewsletterRequest,
-  Newsletter,
-  NewsletterAnalytics,
   NewsletterContextType,
-  NewsletterDailyOpens,
   NewsletterListParams,
-  NewsletterRecipient,
   NewsletterRecipientCountPayload,
-  NewsletterSendFailure,
   NewsletterSendPayload,
-  NewsletterSendResult,
   NewsletterStatus,
   NewsletterTestSendPayload,
   UpdateNewsletterDraftRequest,
 } from '@lfx-one/shared/interfaces';
 import { stripHtml } from '@lfx-one/shared/utils';
-import { randomUUID } from 'crypto';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { AiService } from '../services/ai.service';
 import { EmailServiceClient } from '../services/email-service.client';
 import { logger } from '../services/logger.service';
+import { NewsletterService } from '../services/newsletter.service';
 import { NewsletterServiceClient } from '../services/newsletter-service.client';
-
-const EMAIL_SEND_CONCURRENCY = 5;
 
 const VALID_CONTEXT_TYPES = new Set(['foundation', 'project']);
 const SUBJECT_MAX_LENGTH = 200;
@@ -41,6 +32,7 @@ const CONTEXT_NAME_MAX_LENGTH = 200;
 export class NewsletterController {
   private newsletterClient: NewsletterServiceClient = new NewsletterServiceClient();
   private emailServiceClient: EmailServiceClient = new EmailServiceClient();
+  private newsletterService: NewsletterService = new NewsletterService(this.newsletterClient, this.emailServiceClient);
   private aiService: AiService = new AiService();
 
   /**
@@ -121,7 +113,8 @@ export class NewsletterController {
         text: stripHtml(payload.bodyHtml),
       });
 
-      logger.success(req, 'newsletter_test_send', startTime, { to: payload.toEmail });
+      // PII (recipient email) intentionally omitted from log metadata.
+      logger.success(req, 'newsletter_test_send', startTime, {});
       res.json({ ok: true });
     } catch (error) {
       next(error);
@@ -148,9 +141,19 @@ export class NewsletterController {
       this.validateCommonPayload(payload, req.path, 'newsletter_send');
       this.validateCommitteeUids(payload.committeeUids, req.path, 'newsletter_send');
 
-      const draft = await this.newsletterClient.createDraft(req, payload as CreateNewsletterDraftRequest);
+      // Build the create-draft request explicitly so we keep type safety even
+      // if NewsletterSendPayload and CreateNewsletterDraftRequest diverge.
+      const createDraftRequest: CreateNewsletterDraftRequest = {
+        contextType: payload.contextType,
+        contextUid: payload.contextUid,
+        subject: payload.subject,
+        bodyHtml: payload.bodyHtml,
+        edReplyEmail: payload.edReplyEmail,
+        committeeUids: payload.committeeUids,
+      };
+      const draft = await this.newsletterClient.createDraft(req, createDraftRequest);
 
-      const result = await this.dispatchNewsletter(req, draft, 'newsletter_send');
+      const result = await this.newsletterService.dispatchNewsletter(req, draft, 'newsletter_send');
 
       logger.success(req, 'newsletter_send', startTime, {
         newsletter_id: draft.id,
@@ -301,7 +304,7 @@ export class NewsletterController {
       const version = parseIfMatch(req);
 
       const draft = await this.newsletterClient.getDraft(req, id);
-      const result = await this.dispatchNewsletter(req, draft, 'newsletter_send_draft', version);
+      const result = await this.newsletterService.dispatchNewsletter(req, draft, 'newsletter_send_draft', version);
 
       logger.success(req, 'newsletter_send_draft', startTime, {
         draft_id: id,
@@ -392,21 +395,7 @@ export class NewsletterController {
       }
 
       const newsletter = await this.newsletterClient.getDraft(req, id);
-
-      let analytics: NewsletterAnalytics;
-      if (!newsletter.groupId) {
-        // Fallback for newsletters sent before this integration shipped, and
-        // for drafts (which legitimately have no engagement data). Returns an
-        // empty NewsletterAnalytics payload so the analytics page renders.
-        logger.debug(req, 'newsletter_analytics', 'Newsletter has no groupId — returning empty analytics', {
-          newsletter_id: id,
-          status: newsletter.status,
-        });
-        analytics = this.buildEmptyAnalytics(newsletter);
-      } else {
-        const records = await this.emailServiceClient.getStatusByGroup(req, newsletter.groupId);
-        analytics = this.buildAnalyticsFromRecords(newsletter, records);
-      }
+      const analytics = await this.newsletterService.getAnalytics(req, newsletter);
 
       logger.success(req, 'newsletter_analytics', startTime, {
         newsletter_id: id,
@@ -482,205 +471,6 @@ export class NewsletterController {
     } catch (error) {
       next(error);
     }
-  }
-
-  /**
-   * Per-recipient email-service fan-out + sent-state persistence.
-   *
-   * Resolves recipients from the newsletter's committeeUids, mints a UUID
-   * group_id, dispatches one send_email per recipient with bounded
-   * concurrency, then PATCHes the newsletter to status=sent unless every
-   * recipient failed (matches the previous behavior of not flipping status
-   * on total failure).
-   *
-   * Validations BEFORE any email goes out (cheaper to fail here than to
-   * dispatch and then discover the Go service will reject the markSent):
-   *   - Already-sent newsletters are rejected to prevent duplicate-send
-   *     races (e.g., double-clicking "Send now" while the first request
-   *     is in flight).
-   *   - Empty recipient lists are rejected — the UI shouldn't allow this,
-   *     but a committee with zero resolvable members would otherwise mint
-   *     a group_id, send no emails, and silently no-op.
-   */
-  private async dispatchNewsletter(req: Request, newsletter: Newsletter, operation: string, ifMatchVersion?: number): Promise<NewsletterSendResult> {
-    if (newsletter.status === 'sent') {
-      throw ServiceValidationError.forField('status', 'Newsletter has already been sent', {
-        operation,
-        service: 'newsletter_controller',
-        path: req.path,
-      });
-    }
-
-    const recipientsResponse = await this.newsletterClient.getRecipients(req, { committeeUids: newsletter.committeeUids });
-    const recipients = recipientsResponse.recipients;
-
-    if (recipients.length === 0) {
-      throw ServiceValidationError.forField('committeeUids', 'Selected committees resolved to zero recipients; nothing to send', {
-        operation,
-        service: 'newsletter_controller',
-        path: req.path,
-      });
-    }
-
-    const groupId = randomUUID();
-
-    logger.debug(req, operation, 'Dispatching newsletter via email-service', {
-      newsletter_id: newsletter.id,
-      group_id: groupId,
-      recipient_count: recipients.length,
-    });
-
-    const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId);
-
-    if (sent > 0) {
-      const versionToUse = ifMatchVersion ?? newsletter.version;
-      try {
-        await this.newsletterClient.markSent(req, newsletter.id, { groupId, ifMatchVersion: versionToUse });
-      } catch (error) {
-        // Emails went out but the status flip failed. Log loudly so the
-        // group_id stays recoverable from logs and the operator can retry.
-        logger.error(req, operation, Date.now(), error, {
-          newsletter_id: newsletter.id,
-          group_id: groupId,
-          sent,
-          failed: failures.length,
-          message: 'Emails delivered but newsletter mark-sent PATCH failed; group_id captured in logs for manual recovery',
-        });
-        throw error;
-      }
-    }
-
-    return {
-      totalRecipients: recipients.length,
-      sent,
-      failed: failures.length,
-      failures,
-      groupId,
-    };
-  }
-
-  /**
-   * Sends one email per recipient with a bounded number of in-flight
-   * requests. NATS round-trips are fast (~25ms in dev) but a fully parallel
-   * Promise.all would still saturate the connection for large committees.
-   */
-  private async fanOutEmails(
-    req: Request,
-    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml'>,
-    recipients: NewsletterRecipient[],
-    groupId: string
-  ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
-    const text = stripHtml(newsletter.bodyHtml);
-    const failures: NewsletterSendFailure[] = [];
-    let sent = 0;
-    let cursor = 0;
-
-    const worker = async (): Promise<void> => {
-      while (cursor < recipients.length) {
-        const index = cursor++;
-        const recipient = recipients[index];
-
-        try {
-          await this.emailServiceClient.sendEmail(req, {
-            to: recipient.email,
-            subject: newsletter.subject,
-            html: newsletter.bodyHtml,
-            text,
-            group_id: groupId,
-          });
-          sent++;
-        } catch (error) {
-          failures.push({
-            email: recipient.email,
-            reason: error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
-      }
-    };
-
-    const workerCount = Math.min(EMAIL_SEND_CONCURRENCY, recipients.length);
-    await Promise.all(Array.from({ length: workerCount }, () => worker()));
-
-    return { sent, failures };
-  }
-
-  /**
-   * Empty-shape analytics for newsletters that don't have a groupId yet —
-   * drafts, or sent newsletters that predate this integration.
-   */
-  private buildEmptyAnalytics(newsletter: Newsletter): NewsletterAnalytics {
-    return {
-      newsletterId: newsletter.id,
-      subject: newsletter.subject,
-      status: newsletter.status,
-      sentAt: newsletter.sentAt,
-      totalRecipients: 0,
-      delivered: 0,
-      failed: 0,
-      totalOpens: 0,
-      uniqueOpens: 0,
-      openRate: 0,
-      dailyOpens: [],
-    };
-  }
-
-  /**
-   * Aggregate per-recipient EmailRecipientRecords into the existing
-   * NewsletterAnalytics shape so the frontend (which expects daily-opens
-   * chart data) keeps working unchanged.
-   *
-   * Note: the email-service tracks "opened" as a boolean per recipient (no
-   * multi-open count), so totalOpens == uniqueOpens for our purposes.
-   */
-  private buildAnalyticsFromRecords(newsletter: Newsletter, records: EmailRecipientRecord[]): NewsletterAnalytics {
-    const totalRecipients = records.length;
-    const delivered = records.filter((r) => r.delivered).length;
-    const failed = records.filter((r) => r.failed).length;
-    const opensCount = records.filter((r) => r.opened).length;
-    const openRate = delivered > 0 ? opensCount / delivered : 0;
-
-    const dailyOpens = this.aggregateDailyOpens(records);
-
-    const eventTimestamps: number[] = [];
-    for (const record of records) {
-      if (record.opened_at) {
-        eventTimestamps.push(new Date(record.opened_at).getTime());
-      }
-      if (record.delivered_at) {
-        eventTimestamps.push(new Date(record.delivered_at).getTime());
-      }
-    }
-    const lastEventAt = eventTimestamps.length > 0 ? new Date(Math.max(...eventTimestamps)).toISOString() : undefined;
-
-    return {
-      newsletterId: newsletter.id,
-      subject: newsletter.subject,
-      status: newsletter.status,
-      sentAt: newsletter.sentAt,
-      totalRecipients,
-      delivered,
-      failed,
-      totalOpens: opensCount,
-      uniqueOpens: opensCount,
-      openRate,
-      dailyOpens,
-      lastEventAt,
-    };
-  }
-
-  private aggregateDailyOpens(records: EmailRecipientRecord[]): NewsletterDailyOpens[] {
-    const buckets = new Map<string, number>();
-    for (const record of records) {
-      if (!record.opened || !record.opened_at) {
-        continue;
-      }
-      const day = record.opened_at.slice(0, 10);
-      buckets.set(day, (buckets.get(day) ?? 0) + 1);
-    }
-
-    return Array.from(buckets.entries())
-      .map(([date, opens]) => ({ date, opens, uniqueOpens: opens }))
-      .sort((a, b) => a.date.localeCompare(b.date));
   }
 
   private validateCommonPayload(

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -48,10 +48,10 @@ export class NewsletterController {
       const payload = req.body as NewsletterRecipientCountPayload;
       this.validateCommitteeUids(payload?.committeeUids, req.path, 'newsletter_recipient_count');
 
-      const result = await this.newsletterClient.getRecipientCount(req, payload);
+      const recipients = await this.newsletterService.resolveRecipients(req, payload.committeeUids);
 
-      logger.success(req, 'newsletter_recipient_count', startTime, { count: result.count });
-      res.json(result);
+      logger.success(req, 'newsletter_recipient_count', startTime, { count: recipients.length });
+      res.json({ count: recipients.length });
     } catch (error) {
       next(error);
     }
@@ -71,10 +71,10 @@ export class NewsletterController {
       const payload = req.body as NewsletterRecipientCountPayload;
       this.validateCommitteeUids(payload?.committeeUids, req.path, 'newsletter_recipients');
 
-      const result = await this.newsletterClient.getRecipients(req, payload);
+      const recipients = await this.newsletterService.resolveRecipients(req, payload.committeeUids);
 
-      logger.success(req, 'newsletter_recipients', startTime, { count: result.recipients.length });
-      res.json(result);
+      logger.success(req, 'newsletter_recipients', startTime, { count: recipients.length });
+      res.json({ recipients });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -4,6 +4,7 @@
 import { Router } from 'express';
 
 import { NewsletterController } from '../controllers/newsletter.controller';
+import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const newsletterController = new NewsletterController();
@@ -31,7 +32,11 @@ router.post('/recipients', (req, res, next) => newsletterController.getRecipient
 router.post('/test-send', (req, res, next) => newsletterController.testSend(req, res, next));
 router.post('/send', (req, res, next) => newsletterController.send(req, res, next));
 
-// AI generation stays in lfx-v2-ui
-router.post('/generate', (req, res, next) => newsletterController.generate(req, res, next));
+// AI generation stays in lfx-v2-ui and doesn't proxy to the Go service, so
+// the downstream FGA check that gates the other endpoints isn't available
+// here. Gate on ED persona to bound LiteLLM cost exposure until /generate
+// accepts a contextUid and the controller can do a writer/owner check
+// against the active project (tracked follow-up).
+router.post('/generate', requireExecutiveDirector, (req, res, next) => newsletterController.generate(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -4,7 +4,6 @@
 import { Router } from 'express';
 
 import { NewsletterController } from '../controllers/newsletter.controller';
-import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const newsletterController = new NewsletterController();
@@ -32,11 +31,11 @@ router.post('/recipients', (req, res, next) => newsletterController.getRecipient
 router.post('/test-send', (req, res, next) => newsletterController.testSend(req, res, next));
 router.post('/send', (req, res, next) => newsletterController.send(req, res, next));
 
-// AI generation stays in lfx-v2-ui and doesn't proxy to the Go service, so
-// the downstream FGA check that gates the other endpoints isn't available
-// here. Gate on ED persona to bound LiteLLM cost exposure until /generate
-// accepts a contextUid and the controller can do a writer/owner check
-// against the active project (tracked follow-up).
-router.post('/generate', requireExecutiveDirector, (req, res, next) => newsletterController.generate(req, res, next));
+// AI generation. Doesn't proxy to the Go newsletter-service, so there's no
+// downstream FGA check to lean on. Protection layers are the global auth
+// middleware (must be a logged-in user) + the /api rate limit. Writers
+// compose newsletters in the UI and need this too. A tighter writer/owner
+// check tied to a project contextUid is a follow-up.
+router.post('/generate', (req, res, next) => newsletterController.generate(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -4,13 +4,14 @@
 import { Router } from 'express';
 
 import { NewsletterController } from '../controllers/newsletter.controller';
-import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const newsletterController = new NewsletterController();
 
-// All newsletter endpoints are Executive Director-only.
-router.use(requireExecutiveDirector);
+// Authorization is enforced by the downstream lfx-v2-newsletter-service (FGA
+// via the forwarded user bearer token) and by the corresponding frontend
+// route guards. Don't gate on persona here — newsletters are accessible to
+// Executive Directors AND writers/owners of the foundation or project.
 
 // List newsletters (drafts + sent) and per-newsletter analytics
 router.get('/', (req, res, next) => newsletterController.listNewsletters(req, res, next));

--- a/apps/lfx-one/src/server/services/email-service.client.ts
+++ b/apps/lfx-one/src/server/services/email-service.client.ts
@@ -131,11 +131,30 @@ export class EmailServiceClient {
     }
   }
 
+  /**
+   * Detect the email-service's error envelope. Returns true when the response
+   * is a bare object carrying an `error: string` and none of the documented
+   * success fields. Looser than "exactly one key" so the email-service can
+   * add correlation fields (request_id, code, etc.) to its error responses
+   * without us misclassifying them. Tighter than `'error' in parsed` so a
+   * legitimate per-recipient `error` field on an EmailRecipientRecord (which
+   * also carries email_id / group_id) isn't read as a full-request failure.
+   */
   private isErrorEnvelope(parsed: unknown): parsed is { error: string } {
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return false;
     }
     const obj = parsed as Record<string, unknown>;
-    return typeof obj['error'] === 'string' && Object.keys(obj).length === 1;
+    if (typeof obj['error'] !== 'string') {
+      return false;
+    }
+    // The documented success shapes for the three subjects we use:
+    //   send_email                       → email_id + group_id
+    //   get_email_status (by email_id)   → email_id (single record)
+    //   get_email_engagement_analytics   → total_sent + group_id
+    // A response with any of these fields is a success body and the `error`
+    // (if present) is part of that body, not a top-level envelope.
+    const successFields = ['email_id', 'total_sent', 'delivered', 'opened', 'open_count', 'opened_at_list'];
+    return !successFields.some((field) => field in obj);
   }
 }

--- a/apps/lfx-one/src/server/services/email-service.client.ts
+++ b/apps/lfx-one/src/server/services/email-service.client.ts
@@ -31,8 +31,10 @@ export class EmailServiceClient {
    * so analytics queries can aggregate per-newsletter.
    */
   public async sendEmail(req: Request, payload: EmailServiceSendRequest): Promise<EmailServiceSendResponse> {
+    // Recipient email is intentionally omitted from log metadata to keep PII
+    // out of structured logs; group_id is the correlation key, and the
+    // email-service KV holds the recipient indexed by its own email_id.
     logger.debug(req, 'email_service_send_email', 'Sending email via NATS', {
-      to: payload.to,
       group_id: payload.group_id,
       subject_length: payload.subject.length,
     });
@@ -94,8 +96,13 @@ export class EmailServiceClient {
       const responseText = codec.decode(response.data);
       const parsed = JSON.parse(responseText) as T & { error?: string };
 
-      if (parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string') {
-        throw new MicroserviceError(parsed.error, 502, 'EMAIL_SERVICE_ERROR', {
+      // Email-service error envelope is `{error: "<reason>"}` — a bare object
+      // with only the error field. Tighter check than `'error' in parsed` so
+      // a successful response that legitimately includes an error field
+      // (e.g. per-recipient SMTP error attached to an EmailRecipientRecord)
+      // isn't misclassified as a full-request failure.
+      if (this.isErrorEnvelope(parsed)) {
+        throw new MicroserviceError(parsed.error as string, 502, 'EMAIL_SERVICE_ERROR', {
           operation,
           service: 'email-service',
           errorBody: parsed,
@@ -122,5 +129,13 @@ export class EmailServiceClient {
         }
       );
     }
+  }
+
+  private isErrorEnvelope(parsed: unknown): parsed is { error: string } {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return false;
+    }
+    const obj = parsed as Record<string, unknown>;
+    return typeof obj['error'] === 'string' && Object.keys(obj).length === 1;
   }
 }

--- a/apps/lfx-one/src/server/services/email-service.client.ts
+++ b/apps/lfx-one/src/server/services/email-service.client.ts
@@ -1,0 +1,126 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { NatsSubjects } from '@lfx-one/shared/enums';
+import { EmailRecipientRecord, EmailServiceEngagementResponse, EmailServiceSendRequest, EmailServiceSendResponse } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { logger } from './logger.service';
+import { NatsService } from './nats.service';
+
+/**
+ * NATS client for lfx-v2-email-service. Wraps the three request/reply subjects
+ * documented in the email-service README.
+ *
+ * Auth: email-service has no auth surface — NATS-level access is the only gate.
+ * Do NOT pass M2M tokens in the payload.
+ */
+export class EmailServiceClient {
+  private readonly natsService: NatsService;
+
+  public constructor() {
+    this.natsService = new NatsService();
+  }
+
+  /**
+   * Send a single email through the email-service.
+   *
+   * One call per recipient. Newsletter sends share a caller-supplied group_id
+   * so analytics queries can aggregate per-newsletter.
+   */
+  public async sendEmail(req: Request, payload: EmailServiceSendRequest): Promise<EmailServiceSendResponse> {
+    logger.debug(req, 'email_service_send_email', 'Sending email via NATS', {
+      to: payload.to,
+      group_id: payload.group_id,
+      subject_length: payload.subject.length,
+    });
+
+    const result = await this.requestJson<EmailServiceSendResponse>(req, NatsSubjects.EMAIL_SERVICE_SEND_EMAIL, payload, 'email_service_send_email');
+
+    return result;
+  }
+
+  /**
+   * Look up per-recipient delivery + engagement records for a group_id.
+   *
+   * Used by the analytics endpoint to derive the open-rate, daily-opens
+   * time series, and last-event timestamp from per-email opened_at values.
+   */
+  public async getStatusByGroup(req: Request, groupId: string): Promise<EmailRecipientRecord[]> {
+    logger.debug(req, 'email_service_status_by_group', 'Fetching email status by group via NATS', { group_id: groupId });
+
+    const result = await this.requestJson<EmailRecipientRecord[] | EmailRecipientRecord>(
+      req,
+      NatsSubjects.EMAIL_SERVICE_GET_EMAIL_STATUS,
+      { group_id: groupId },
+      'email_service_status_by_group'
+    );
+
+    // The email-service returns an array for group_id queries, but normalize
+    // defensively in case a single record sneaks through.
+    return Array.isArray(result) ? result : [result];
+  }
+
+  /**
+   * Quick group rollup: total_sent, delivered, opened, failed.
+   * Cheaper than getStatusByGroup when the daily-opens chart isn't needed.
+   */
+  public async getEngagement(req: Request, groupId: string): Promise<EmailServiceEngagementResponse> {
+    logger.debug(req, 'email_service_engagement', 'Fetching engagement analytics via NATS', { group_id: groupId });
+
+    return this.requestJson<EmailServiceEngagementResponse>(
+      req,
+      NatsSubjects.EMAIL_SERVICE_GET_EMAIL_ENGAGEMENT_ANALYTICS,
+      { group_id: groupId },
+      'email_service_engagement'
+    );
+  }
+
+  /**
+   * Shared NATS request/reply helper: JSON encode, dispatch with the standard
+   * timeout, decode, and surface the email-service `{error: "..."}` envelope as
+   * a MicroserviceError so the centralized error handler renders a 502.
+   */
+  private async requestJson<T>(req: Request, subject: NatsSubjects, payload: unknown, operation: string): Promise<T> {
+    const codec = this.natsService.getCodec();
+
+    try {
+      const response = await this.natsService.request(subject, codec.encode(JSON.stringify(payload)), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
+
+      const responseText = codec.decode(response.data);
+      const parsed = JSON.parse(responseText) as T & { error?: string };
+
+      if (parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string') {
+        throw new MicroserviceError(parsed.error, 502, 'EMAIL_SERVICE_ERROR', {
+          operation,
+          service: 'email-service',
+          errorBody: parsed,
+        });
+      }
+
+      return parsed as T;
+    } catch (error) {
+      if (error instanceof MicroserviceError) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      const isTimeout = message.includes('timeout') || message.includes('TIMEOUT');
+
+      throw new MicroserviceError(
+        isTimeout ? 'Email service request timed out' : `Email service request failed: ${message}`,
+        isTimeout ? 504 : 502,
+        isTimeout ? 'EMAIL_SERVICE_TIMEOUT' : 'EMAIL_SERVICE_UNAVAILABLE',
+        {
+          operation,
+          service: 'email-service',
+          originalError: error instanceof Error ? error : undefined,
+        }
+      );
+    }
+  }
+}

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -8,9 +8,6 @@ import {
   NewsletterDraftListResponse,
   NewsletterListParams,
   NewsletterListResponse,
-  NewsletterRecipientCount,
-  NewsletterRecipientCountPayload,
-  NewsletterRecipientsResponse,
   UpdateNewsletterDraftRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -69,14 +66,6 @@ export class NewsletterServiceClient {
         'If-Match': `"${params.ifMatchVersion}"`,
       }
     );
-  }
-
-  public async getRecipientCount(req: Request, payload: NewsletterRecipientCountPayload): Promise<NewsletterRecipientCount> {
-    return this.microserviceProxy.proxyRequest<NewsletterRecipientCount>(req, 'LFX_V2_SERVICE', '/newsletters/recipient-count', 'POST', undefined, payload);
-  }
-
-  public async getRecipients(req: Request, payload: NewsletterRecipientCountPayload): Promise<NewsletterRecipientsResponse> {
-    return this.microserviceProxy.proxyRequest<NewsletterRecipientsResponse>(req, 'LFX_V2_SERVICE', '/newsletters/recipients', 'POST', undefined, payload);
   }
 
   public async listNewsletters(req: Request, params: NewsletterListParams): Promise<NewsletterListResponse> {

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -4,7 +4,6 @@
 import {
   CreateNewsletterDraftRequest,
   Newsletter,
-  NewsletterAnalytics,
   NewsletterContextType,
   NewsletterDraftListResponse,
   NewsletterListParams,
@@ -12,9 +11,6 @@ import {
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
   NewsletterRecipientsResponse,
-  NewsletterSendPayload,
-  NewsletterSendResult,
-  NewsletterTestSendPayload,
   UpdateNewsletterDraftRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -55,11 +51,24 @@ export class NewsletterServiceClient {
     await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/newsletters/drafts/${id}`, 'DELETE');
   }
 
-  public async sendDraft(req: Request, id: string, ifMatchVersion: number): Promise<NewsletterSendResult> {
-    return this.microserviceProxy.proxyRequest<NewsletterSendResult>(req, 'LFX_V2_SERVICE', `/newsletters/drafts/${id}/send`, 'POST', undefined, undefined, {
-      ...this.edNameHeader(req),
-      'If-Match': `"${ifMatchVersion}"`,
-    });
+  /**
+   * Flip a draft to `status='sent'` and persist the email-service `groupId`.
+   * Express now owns the actual fan-out to lfx-v2-email-service; the Go service
+   * only stores the resulting state.
+   */
+  public async markSent(req: Request, id: string, params: { groupId: string; ifMatchVersion: number }): Promise<Newsletter> {
+    return this.microserviceProxy.proxyRequest<Newsletter>(
+      req,
+      'LFX_V2_SERVICE',
+      `/newsletters/drafts/${id}/send`,
+      'POST',
+      undefined,
+      { groupId: params.groupId },
+      {
+        ...this.edNameHeader(req),
+        'If-Match': `"${params.ifMatchVersion}"`,
+      }
+    );
   }
 
   public async getRecipientCount(req: Request, payload: NewsletterRecipientCountPayload): Promise<NewsletterRecipientCount> {
@@ -68,30 +77,6 @@ export class NewsletterServiceClient {
 
   public async getRecipients(req: Request, payload: NewsletterRecipientCountPayload): Promise<NewsletterRecipientsResponse> {
     return this.microserviceProxy.proxyRequest<NewsletterRecipientsResponse>(req, 'LFX_V2_SERVICE', '/newsletters/recipients', 'POST', undefined, payload);
-  }
-
-  public async testSend(req: Request, payload: NewsletterTestSendPayload): Promise<{ ok: true }> {
-    return this.microserviceProxy.proxyRequest<{ ok: true }>(
-      req,
-      'LFX_V2_SERVICE',
-      '/newsletters/test-send',
-      'POST',
-      undefined,
-      payload,
-      this.edNameHeader(req)
-    );
-  }
-
-  public async send(req: Request, payload: NewsletterSendPayload): Promise<NewsletterSendResult> {
-    return this.microserviceProxy.proxyRequest<NewsletterSendResult>(
-      req,
-      'LFX_V2_SERVICE',
-      '/newsletters/send',
-      'POST',
-      undefined,
-      payload,
-      this.edNameHeader(req)
-    );
   }
 
   public async listNewsletters(req: Request, params: NewsletterListParams): Promise<NewsletterListResponse> {
@@ -106,12 +91,6 @@ export class NewsletterServiceClient {
       query['pageToken'] = params.pageToken;
     }
     return this.microserviceProxy.proxyRequest<NewsletterListResponse>(req, 'LFX_V2_SERVICE', '/newsletters', 'GET', query);
-  }
-
-  public async getAnalytics(req: Request, id: string): Promise<NewsletterAnalytics> {
-    // Path intentionally not /newsletters/{id}/analytics — Go's mux treats that
-    // as ambiguous with /newsletters/drafts/{id}.
-    return this.microserviceProxy.proxyRequest<NewsletterAnalytics>(req, 'LFX_V2_SERVICE', `/newsletter-analytics/${id}`, 'GET');
   }
 
   /**

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -131,7 +131,7 @@ export class NewsletterService {
         logger.warning(req, 'newsletter_analytics', 'email-service returned no records for groupId; falling back to empty analytics', {
           newsletter_id: newsletter.id,
           group_id: newsletter.groupId,
-          email_service_error: error.message,
+          err: error,
         });
         return this.buildEmptyAnalytics(newsletter);
       }
@@ -189,8 +189,9 @@ export class NewsletterService {
 
   /**
    * Retry markSent on transient failures (network blips, upstream 5xx). Logs
-   * each failure as a warning — the central apiErrorHandler logs the final
-   * error if all attempts fail. Validation-type errors (4xx) are returned
+   * each failure as a warning with `err` (preserves stack via Pino's err
+   * serializer); the central apiErrorHandler logs the final error if all
+   * attempts fail. Validation-type errors (4xx MicroserviceError) surface
    * immediately without retry.
    */
   private async markSentWithRetry(
@@ -209,17 +210,25 @@ export class NewsletterService {
         return;
       } catch (error) {
         lastError = error;
-        const retryable = this.isRetryable(error) && attempt < MARK_SENT_MAX_ATTEMPTS;
-        logger.warning(req, operation, retryable ? 'mark-sent failed; will retry' : 'mark-sent failed; giving up', {
+        const errorRetryable = this.isRetryable(error);
+        const willRetry = errorRetryable && attempt < MARK_SENT_MAX_ATTEMPTS;
+        // Final-attempt message keeps the recovery hint operators search
+        // for ("group_id captured ... for manual recovery"); intermediate
+        // attempts log briefly.
+        const message = willRetry
+          ? 'mark-sent failed; will retry'
+          : 'mark-sent failed after all retries; emails delivered, group_id captured in logs for manual recovery';
+        logger.warning(req, operation, message, {
           newsletter_id: newsletterId,
           group_id: groupId,
           attempt,
-          retryable,
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error_retryable: errorRetryable,
+          will_retry: willRetry,
+          err: error,
           sent,
           failed,
         });
-        if (!retryable) {
+        if (!willRetry) {
           break;
         }
         await this.sleep(MARK_SENT_BACKOFF_BASE_MS * 2 ** (attempt - 1));
@@ -228,14 +237,21 @@ export class NewsletterService {
     throw lastError;
   }
 
+  /**
+   * Anything that's not a clear 4xx is retryable. That covers:
+   *   - 5xx MicroserviceError (upstream availability)
+   *   - Raw transport errors (DNS hiccups, ECONNRESET, ETIMEDOUT,
+   *     "fetch failed"). MicroserviceProxyService re-throws those
+   *     unwrapped — they aren't MicroserviceError at all — so treating
+   *     non-MicroserviceError as retryable catches them.
+   * We deliberately do NOT retry 4xx: those mean the request itself is
+   * wrong (version mismatch, validation) and a retry won't help.
+   */
   private isRetryable(error: unknown): boolean {
-    if (!(error instanceof MicroserviceError)) {
-      return false;
+    if (error instanceof MicroserviceError) {
+      return error.statusCode >= 500 && error.statusCode < 600;
     }
-    // Retry transport / availability errors (5xx). Don't retry 4xx — those
-    // mean the request itself is wrong (version mismatch, validation),
-    // and retrying won't fix it.
-    return error.statusCode >= 500 && error.statusCode < 600;
+    return true;
   }
 
   private sleep(ms: number): Promise<void> {
@@ -261,26 +277,35 @@ export class NewsletterService {
   /**
    * Aggregate per-recipient EmailRecipientRecords into NewsletterAnalytics.
    *
-   * The email-service's opens model is one bit per recipient (no multi-open
-   * count), so totalOpens == uniqueOpens. Both totals and the daily-opens
-   * series use the same `opened && opened_at` predicate so the headline
-   * number always sums to the chart buckets — even if a record arrives
-   * with opened=true but opened_at missing (the README marks opened_at
-   * optional), it's excluded from both, not just the chart.
+   * Open semantics (post lfx-v2-email-service "track all opens" change):
+   *   - `totalOpens` is the sum of `open_count` across all records — i.e.
+   *     every open event, including repeat opens by the same recipient.
+   *   - `uniqueOpens` is the count of recipients with `opened === true` —
+   *     i.e. distinct recipients who opened at least once.
+   *   - `openRate` is `uniqueOpens / delivered` (reach, not frequency).
+   *
+   * For backwards compatibility against the pre-change schema (records
+   * with no `opened_at_list` / `open_count`), `open_count ?? 0` and
+   * `opened_at_list ?? []` degrade to the older "first-open-only" shape:
+   * `totalOpens` reads zero (we have no count) but `uniqueOpens` still
+   * counts `opened === true` records correctly. The daily-opens chart
+   * is empty under that fallback, which is the best we can do without
+   * per-event timestamps.
    */
   private buildAnalyticsFromRecords(newsletter: Newsletter, records: EmailRecipientRecord[]): NewsletterAnalytics {
     const totalRecipients = records.length;
     const delivered = records.filter((r) => r.delivered).length;
     const failed = records.filter((r) => r.failed).length;
-    const opensCount = records.filter((r) => r.opened && r.opened_at).length;
-    const openRate = delivered > 0 ? opensCount / delivered : 0;
+    const uniqueOpens = records.filter((r) => r.opened).length;
+    const totalOpens = records.reduce((sum, r) => sum + (r.open_count ?? 0), 0);
+    const openRate = delivered > 0 ? uniqueOpens / delivered : 0;
 
     const dailyOpens = this.aggregateDailyOpens(records);
 
     const eventTimestamps: number[] = [];
     for (const record of records) {
-      if (record.opened_at) {
-        eventTimestamps.push(new Date(record.opened_at).getTime());
+      if (record.last_opened_at) {
+        eventTimestamps.push(new Date(record.last_opened_at).getTime());
       }
       if (record.delivered_at) {
         eventTimestamps.push(new Date(record.delivered_at).getTime());
@@ -296,26 +321,48 @@ export class NewsletterService {
       totalRecipients,
       delivered,
       failed,
-      totalOpens: opensCount,
-      uniqueOpens: opensCount,
+      totalOpens,
+      uniqueOpens,
       openRate,
       dailyOpens,
       lastEventAt,
     };
   }
 
+  /**
+   * Bucket every open event by UTC day. Two parallel counters per bucket:
+   *   - `opens`: total events that day (matches `totalOpens` headline).
+   *   - `uniqueOpens`: distinct recipients that opened that day, deduped
+   *     by `email_id` (one recipient who opened five times on the same
+   *     day counts once in `uniqueOpens` but five in `opens`).
+   */
   private aggregateDailyOpens(records: EmailRecipientRecord[]): NewsletterDailyOpens[] {
-    const buckets = new Map<string, number>();
+    const opensPerDay = new Map<string, number>();
+    const uniqueOpenersPerDay = new Map<string, Set<string>>();
+
     for (const record of records) {
-      if (!record.opened || !record.opened_at) {
-        continue;
+      const events = record.opened_at_list ?? [];
+      for (const event of events) {
+        if (!event.opened_at) {
+          continue;
+        }
+        const day = event.opened_at.slice(0, 10);
+        opensPerDay.set(day, (opensPerDay.get(day) ?? 0) + 1);
+        let openers = uniqueOpenersPerDay.get(day);
+        if (!openers) {
+          openers = new Set<string>();
+          uniqueOpenersPerDay.set(day, openers);
+        }
+        openers.add(record.email_id);
       }
-      const day = record.opened_at.slice(0, 10);
-      buckets.set(day, (buckets.get(day) ?? 0) + 1);
     }
 
-    return Array.from(buckets.entries())
-      .map(([date, opens]) => ({ date, opens, uniqueOpens: opens }))
+    return Array.from(opensPerDay.keys())
+      .map((date) => ({
+        date,
+        opens: opensPerDay.get(date) ?? 0,
+        uniqueOpens: uniqueOpenersPerDay.get(date)?.size ?? 0,
+      }))
       .sort((a, b) => a.date.localeCompare(b.date));
   }
 }

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -128,9 +128,27 @@ export class NewsletterService {
 
     const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId);
 
+    let markSentFailed = false;
     if (sent > 0) {
       const versionToUse = ifMatchVersion ?? newsletter.version;
-      await this.markSentWithRetry(req, newsletter.id, groupId, versionToUse, operation, sent, failures.length);
+      try {
+        await this.markSentWithRetry(req, newsletter.id, groupId, versionToUse, operation, sent, failures.length);
+      } catch (err) {
+        // Emails went out; persistence failed. Return success with a flag
+        // so the frontend can surface "emails delivered, status update
+        // failed — contact support" instead of a generic error toast.
+        // Re-throwing here would let the operator think nothing was sent
+        // and retry, causing duplicate emails. groupId is captured in
+        // the markSentWithRetry warnings for manual recovery.
+        markSentFailed = true;
+        logger.warning(req, operation, 'send succeeded but mark-sent failed; returning partial-success', {
+          newsletter_id: newsletter.id,
+          group_id: groupId,
+          sent,
+          failed: failures.length,
+          err,
+        });
+      }
     }
 
     return {
@@ -139,6 +157,7 @@ export class NewsletterService {
       failed: failures.length,
       failures,
       groupId,
+      ...(markSentFailed && { markSentFailed: true }),
     };
   }
 

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -1,0 +1,321 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  EmailRecipientRecord,
+  Newsletter,
+  NewsletterAnalytics,
+  NewsletterDailyOpens,
+  NewsletterRecipient,
+  NewsletterSendFailure,
+  NewsletterSendResult,
+} from '@lfx-one/shared/interfaces';
+import { stripHtml } from '@lfx-one/shared/utils';
+import { randomUUID } from 'crypto';
+import { Request } from 'express';
+
+import { MicroserviceError, ServiceValidationError } from '../errors';
+import { EmailServiceClient } from './email-service.client';
+import { logger } from './logger.service';
+import { NewsletterServiceClient } from './newsletter-service.client';
+
+const EMAIL_SEND_CONCURRENCY = 5;
+const MARK_SENT_MAX_ATTEMPTS = 3;
+const MARK_SENT_BACKOFF_BASE_MS = 100;
+
+/**
+ * Business-logic layer for the newsletter send + analytics flow. Orchestrates
+ * lfx-v2-email-service (NATS) for delivery and aggregates per-recipient
+ * engagement records back into the NewsletterAnalytics shape consumed by the
+ * frontend. The controller is intentionally thin and delegates here.
+ */
+export class NewsletterService {
+  private readonly newsletterClient: NewsletterServiceClient;
+  private readonly emailServiceClient: EmailServiceClient;
+
+  public constructor(newsletterClient?: NewsletterServiceClient, emailServiceClient?: EmailServiceClient) {
+    this.newsletterClient = newsletterClient ?? new NewsletterServiceClient();
+    this.emailServiceClient = emailServiceClient ?? new EmailServiceClient();
+  }
+
+  /**
+   * Per-recipient email-service fan-out + sent-state persistence.
+   *
+   * Pre-dispatch guards (cheap, before any email is sent):
+   *   - Already-sent newsletters are rejected to prevent the duplicate-send
+   *     race on double-click. The Go service's status='draft' check would
+   *     catch a stale request too, but only after emails were already out.
+   *   - Empty resolved recipient lists are rejected with a clear error —
+   *     a committee with zero resolvable members would otherwise mint a
+   *     group_id and silently no-op.
+   *
+   * Mark-sent uses a small retry loop to ride out transient NATS / HTTP
+   * blips on the lfx-v2-newsletter-service hop. If every retry exhausts,
+   * we surface the error to the caller; emails are already out and the
+   * group_id stays available in the structured logs for manual recovery.
+   *
+   * NOTE: full operator-retry idempotency (i.e., recovering from
+   * "emails dispatched but mark-sent persistently failed" without
+   * sending duplicates) requires persisting the group_id on the draft
+   * BEFORE the fan-out — that needs an additive endpoint on
+   * lfx-v2-newsletter-service. Tracked as a follow-up.
+   */
+  public async dispatchNewsletter(req: Request, newsletter: Newsletter, operation: string, ifMatchVersion?: number): Promise<NewsletterSendResult> {
+    if (newsletter.status === 'sent') {
+      throw ServiceValidationError.forField('status', 'Newsletter has already been sent', {
+        operation,
+        service: 'newsletter_service',
+        path: req.path,
+      });
+    }
+
+    const recipientsResponse = await this.newsletterClient.getRecipients(req, { committeeUids: newsletter.committeeUids });
+    const recipients = recipientsResponse.recipients;
+
+    if (recipients.length === 0) {
+      throw ServiceValidationError.forField('committeeUids', 'Selected committees resolved to zero recipients; nothing to send', {
+        operation,
+        service: 'newsletter_service',
+        path: req.path,
+      });
+    }
+
+    const groupId = randomUUID();
+
+    logger.debug(req, operation, 'Dispatching newsletter via email-service', {
+      newsletter_id: newsletter.id,
+      group_id: groupId,
+      recipient_count: recipients.length,
+    });
+
+    const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId);
+
+    if (sent > 0) {
+      const versionToUse = ifMatchVersion ?? newsletter.version;
+      await this.markSentWithRetry(req, newsletter.id, groupId, versionToUse, operation, sent, failures.length);
+    }
+
+    return {
+      totalRecipients: recipients.length,
+      sent,
+      failed: failures.length,
+      failures,
+      groupId,
+    };
+  }
+
+  /**
+   * Return engagement analytics for a sent newsletter. Falls back to an empty
+   * NewsletterAnalytics payload (rather than erroring) when:
+   *   - the newsletter has no persisted group_id (drafts, or sent rows
+   *     predating this integration), OR
+   *   - the email-service returns an error envelope (e.g. "not found" if the
+   *     KV record hasn't propagated yet, or the SES event poller hasn't
+   *     recorded any deliveries). The empty payload lets the analytics page
+   *     render without a 502.
+   */
+  public async getAnalytics(req: Request, newsletter: Newsletter): Promise<NewsletterAnalytics> {
+    if (!newsletter.groupId) {
+      logger.debug(req, 'newsletter_analytics', 'Newsletter has no groupId — returning empty analytics', {
+        newsletter_id: newsletter.id,
+        status: newsletter.status,
+      });
+      return this.buildEmptyAnalytics(newsletter);
+    }
+
+    let records: EmailRecipientRecord[];
+    try {
+      records = await this.emailServiceClient.getStatusByGroup(req, newsletter.groupId);
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.code === 'EMAIL_SERVICE_ERROR') {
+        logger.warning(req, 'newsletter_analytics', 'email-service returned no records for groupId; falling back to empty analytics', {
+          newsletter_id: newsletter.id,
+          group_id: newsletter.groupId,
+          email_service_error: error.message,
+        });
+        return this.buildEmptyAnalytics(newsletter);
+      }
+      throw error;
+    }
+
+    return this.buildAnalyticsFromRecords(newsletter, records);
+  }
+
+  /**
+   * Sends one email per recipient with a bounded number of in-flight
+   * requests. Per-recipient failures are captured (not thrown) so a single
+   * bad address can't fail the whole batch — the caller still gets a
+   * partial-success NewsletterSendResult.
+   */
+  private async fanOutEmails(
+    req: Request,
+    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml'>,
+    recipients: NewsletterRecipient[],
+    groupId: string
+  ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
+    const text = stripHtml(newsletter.bodyHtml);
+    const failures: NewsletterSendFailure[] = [];
+    let sent = 0;
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+      while (cursor < recipients.length) {
+        const index = cursor++;
+        const recipient = recipients[index];
+
+        try {
+          await this.emailServiceClient.sendEmail(req, {
+            to: recipient.email,
+            subject: newsletter.subject,
+            html: newsletter.bodyHtml,
+            text,
+            group_id: groupId,
+          });
+          sent++;
+        } catch (error) {
+          failures.push({
+            email: recipient.email,
+            reason: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+    };
+
+    const workerCount = Math.min(EMAIL_SEND_CONCURRENCY, recipients.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    return { sent, failures };
+  }
+
+  /**
+   * Retry markSent on transient failures (network blips, upstream 5xx). Logs
+   * each failure as a warning — the central apiErrorHandler logs the final
+   * error if all attempts fail. Validation-type errors (4xx) are returned
+   * immediately without retry.
+   */
+  private async markSentWithRetry(
+    req: Request,
+    newsletterId: string,
+    groupId: string,
+    ifMatchVersion: number,
+    operation: string,
+    sent: number,
+    failed: number
+  ): Promise<void> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MARK_SENT_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.newsletterClient.markSent(req, newsletterId, { groupId, ifMatchVersion });
+        return;
+      } catch (error) {
+        lastError = error;
+        const retryable = this.isRetryable(error) && attempt < MARK_SENT_MAX_ATTEMPTS;
+        logger.warning(req, operation, retryable ? 'mark-sent failed; will retry' : 'mark-sent failed; giving up', {
+          newsletter_id: newsletterId,
+          group_id: groupId,
+          attempt,
+          retryable,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          sent,
+          failed,
+        });
+        if (!retryable) {
+          break;
+        }
+        await this.sleep(MARK_SENT_BACKOFF_BASE_MS * 2 ** (attempt - 1));
+      }
+    }
+    throw lastError;
+  }
+
+  private isRetryable(error: unknown): boolean {
+    if (!(error instanceof MicroserviceError)) {
+      return false;
+    }
+    // Retry transport / availability errors (5xx). Don't retry 4xx — those
+    // mean the request itself is wrong (version mismatch, validation),
+    // and retrying won't fix it.
+    return error.statusCode >= 500 && error.statusCode < 600;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private buildEmptyAnalytics(newsletter: Newsletter): NewsletterAnalytics {
+    return {
+      newsletterId: newsletter.id,
+      subject: newsletter.subject,
+      status: newsletter.status,
+      sentAt: newsletter.sentAt,
+      totalRecipients: 0,
+      delivered: 0,
+      failed: 0,
+      totalOpens: 0,
+      uniqueOpens: 0,
+      openRate: 0,
+      dailyOpens: [],
+    };
+  }
+
+  /**
+   * Aggregate per-recipient EmailRecipientRecords into NewsletterAnalytics.
+   *
+   * The email-service's opens model is one bit per recipient (no multi-open
+   * count), so totalOpens == uniqueOpens. Both totals and the daily-opens
+   * series use the same `opened && opened_at` predicate so the headline
+   * number always sums to the chart buckets — even if a record arrives
+   * with opened=true but opened_at missing (the README marks opened_at
+   * optional), it's excluded from both, not just the chart.
+   */
+  private buildAnalyticsFromRecords(newsletter: Newsletter, records: EmailRecipientRecord[]): NewsletterAnalytics {
+    const totalRecipients = records.length;
+    const delivered = records.filter((r) => r.delivered).length;
+    const failed = records.filter((r) => r.failed).length;
+    const opensCount = records.filter((r) => r.opened && r.opened_at).length;
+    const openRate = delivered > 0 ? opensCount / delivered : 0;
+
+    const dailyOpens = this.aggregateDailyOpens(records);
+
+    const eventTimestamps: number[] = [];
+    for (const record of records) {
+      if (record.opened_at) {
+        eventTimestamps.push(new Date(record.opened_at).getTime());
+      }
+      if (record.delivered_at) {
+        eventTimestamps.push(new Date(record.delivered_at).getTime());
+      }
+    }
+    const lastEventAt = eventTimestamps.length > 0 ? new Date(Math.max(...eventTimestamps)).toISOString() : undefined;
+
+    return {
+      newsletterId: newsletter.id,
+      subject: newsletter.subject,
+      status: newsletter.status,
+      sentAt: newsletter.sentAt,
+      totalRecipients,
+      delivered,
+      failed,
+      totalOpens: opensCount,
+      uniqueOpens: opensCount,
+      openRate,
+      dailyOpens,
+      lastEventAt,
+    };
+  }
+
+  private aggregateDailyOpens(records: EmailRecipientRecord[]): NewsletterDailyOpens[] {
+    const buckets = new Map<string, number>();
+    for (const record of records) {
+      if (!record.opened || !record.opened_at) {
+        continue;
+      }
+      const day = record.opened_at.slice(0, 10);
+      buckets.set(day, (buckets.get(day) ?? 0) + 1);
+    }
+
+    return Array.from(buckets.entries())
+      .map(([date, opens]) => ({ date, opens, uniqueOpens: opens }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+}

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -6,6 +6,7 @@ import {
   Newsletter,
   NewsletterAnalytics,
   NewsletterDailyOpens,
+  NewsletterListItem,
   NewsletterRecipient,
   NewsletterSendFailure,
   NewsletterSendResult,
@@ -176,6 +177,54 @@ export class NewsletterService {
     }
 
     return this.buildAnalyticsFromRecords(newsletter, records);
+  }
+
+  /**
+   * Overlay live email-service engagement onto the Go service's list rows.
+   *
+   * The Go service stores totalRecipients / uniqueOpens / openRate on the
+   * newsletter row at send time, derived from its own resolveRecipients
+   * call. That call hits the same FGA-filtering problem as the recipient
+   * dropdown — for writers it persists zeros even though Express actually
+   * sent emails. Result: the list table is stale while the detail page is
+   * correct (it reads from email-service).
+   *
+   * Fix: for every sent row with a groupId, fetch the engagement rollup
+   * from email-service in parallel and overlay the three engagement
+   * fields. Drafts and pre-integration sent rows pass through unchanged.
+   */
+  public async enrichListWithEngagement(req: Request, newsletters: NewsletterListItem[]): Promise<NewsletterListItem[]> {
+    const enrichments = await Promise.all(
+      newsletters.map(async (n) => {
+        if (n.status !== 'sent' || !n.groupId) {
+          return null;
+        }
+        try {
+          return await this.emailServiceClient.getEngagement(req, n.groupId);
+        } catch (error) {
+          logger.warning(req, 'newsletter_list_enrich', 'engagement rollup unavailable for newsletter; passing Go-side values through', {
+            newsletter_id: n.id,
+            group_id: n.groupId,
+            err: error,
+          });
+          return null;
+        }
+      })
+    );
+
+    return newsletters.map((n, i) => {
+      const e = enrichments[i];
+      if (!e) {
+        return n;
+      }
+      const openRate = e.delivered > 0 ? e.unique_opened / e.delivered : 0;
+      return {
+        ...n,
+        totalRecipients: e.total_sent,
+        uniqueOpens: e.unique_opened,
+        openRate,
+      };
+    });
   }
 
   /**

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'crypto';
 import { Request } from 'express';
 
 import { MicroserviceError, ServiceValidationError } from '../errors';
+import { CommitteeService } from './committee.service';
 import { EmailServiceClient } from './email-service.client';
 import { logger } from './logger.service';
 import { NewsletterServiceClient } from './newsletter-service.client';
@@ -32,10 +33,47 @@ const MARK_SENT_BACKOFF_BASE_MS = 100;
 export class NewsletterService {
   private readonly newsletterClient: NewsletterServiceClient;
   private readonly emailServiceClient: EmailServiceClient;
+  private readonly committeeService: CommitteeService;
 
-  public constructor(newsletterClient?: NewsletterServiceClient, emailServiceClient?: EmailServiceClient) {
+  public constructor(newsletterClient?: NewsletterServiceClient, emailServiceClient?: EmailServiceClient, committeeService?: CommitteeService) {
     this.newsletterClient = newsletterClient ?? new NewsletterServiceClient();
     this.emailServiceClient = emailServiceClient ?? new EmailServiceClient();
+    this.committeeService = committeeService ?? new CommitteeService();
+  }
+
+  /**
+   * Resolve newsletter recipients (email + first name) from the selected
+   * committees, deduped by lowercased email.
+   *
+   * Done in Express (not the Go newsletter-service) because the Go service's
+   * outbound `/query/resources` call carries a Heimdall-minted JWT that
+   * query-service can't validate as OIDC — FGA filters everything out and
+   * the call returns empty. Express has the user's original Auth0 bearer
+   * token and can call query-service directly with proper identity.
+   *
+   * Filters invalid emails (empty / missing `@`) to match the Go service's
+   * recipient-validation behavior, so the resulting list is safe to fan out
+   * to the email-service without per-recipient validation downstream.
+   */
+  public async resolveRecipients(req: Request, committeeUids: string[]): Promise<NewsletterRecipient[]> {
+    const perCommittee = await Promise.all(committeeUids.map((uid) => this.committeeService.getCommitteeMembers(req, uid)));
+
+    const seen = new Set<string>();
+    const recipients: NewsletterRecipient[] = [];
+    for (const members of perCommittee) {
+      for (const member of members) {
+        const email = (member.email ?? '').trim().toLowerCase();
+        if (!email || !email.includes('@') || seen.has(email)) {
+          continue;
+        }
+        seen.add(email);
+        recipients.push({
+          email,
+          firstName: (member.first_name ?? '').trim() || undefined,
+        });
+      }
+    }
+    return recipients;
   }
 
   /**
@@ -69,8 +107,7 @@ export class NewsletterService {
       });
     }
 
-    const recipientsResponse = await this.newsletterClient.getRecipients(req, { committeeUids: newsletter.committeeUids });
-    const recipients = recipientsResponse.recipients;
+    const recipients = await this.resolveRecipients(req, newsletter.committeeUids);
 
     if (recipients.length === 0) {
       throw ServiceValidationError.forField('committeeUids', 'Selected committees resolved to zero recipients; nothing to send', {

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -25,4 +25,7 @@ export enum NatsSubjects {
   PERSONAS_GET = 'lfx.personas-api.get',
   IMPERSONATION_TOKEN_EXCHANGE = 'lfx.auth-service.impersonation.token_exchange',
   INVITE_ACCEPTED = 'lfx.invite.accepted',
+  EMAIL_SERVICE_SEND_EMAIL = 'lfx.email-service.send_email',
+  EMAIL_SERVICE_GET_EMAIL_STATUS = 'lfx.email-service.get_email_status',
+  EMAIL_SERVICE_GET_EMAIL_ENGAGEMENT_ANALYTICS = 'lfx.email-service.get_email_engagement_analytics',
 }

--- a/packages/shared/src/interfaces/email-service.interface.ts
+++ b/packages/shared/src/interfaces/email-service.interface.ts
@@ -46,7 +46,7 @@ export interface EmailRecipientRecord {
    * Every unique open event for this recipient, keyed server-side by
    * SNS MessageId for dedup. Absent (not present in JSON) when the
    * recipient has never opened — upstream serializes with `omitempty`.
-   * Equivalent to `open_count === opened_at_list?.length ?? 0`.
+   * Equivalent to `open_count === (opened_at_list?.length ?? 0)`.
    */
   opened_at_list?: OpenEvent[];
   /** Total number of times the email was opened (== opened_at_list.length). */

--- a/packages/shared/src/interfaces/email-service.interface.ts
+++ b/packages/shared/src/interfaces/email-service.interface.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Contracts for the lfx-v2-email-service NATS subjects.
+ *
+ * Subjects:
+ *   lfx.email-service.send_email
+ *   lfx.email-service.get_email_status
+ *   lfx.email-service.get_email_engagement_analytics
+ *
+ * See: https://github.com/linuxfoundation/lfx-v2-email-service
+ */
+
+export interface EmailServiceSendRequest {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  group_id?: string;
+}
+
+export interface EmailServiceSendResponse {
+  email_id: string;
+  group_id: string;
+}
+
+export interface EmailRecipientRecord {
+  email_id: string;
+  group_id: string;
+  to: string;
+  subject: string;
+  sent_at: string;
+  delivered: boolean;
+  delivered_at?: string;
+  opened: boolean;
+  opened_at?: string;
+  failed: boolean;
+}
+
+export interface EmailServiceStatusByEmailRequest {
+  email_id: string;
+}
+
+export interface EmailServiceStatusByGroupRequest {
+  group_id: string;
+}
+
+export interface EmailServiceEngagementResponse {
+  group_id: string;
+  total_sent: number;
+  delivered: number;
+  opened: number;
+  failed: number;
+}
+
+export interface EmailServiceErrorResponse {
+  error: string;
+}

--- a/packages/shared/src/interfaces/email-service.interface.ts
+++ b/packages/shared/src/interfaces/email-service.interface.ts
@@ -44,10 +44,11 @@ export interface EmailRecipientRecord {
   opened: boolean;
   /**
    * Every unique open event for this recipient, keyed server-side by
-   * SNS MessageId for dedup. Empty array if never opened. Equivalent to
-   * `open_count === opened_at_list.length`.
+   * SNS MessageId for dedup. Absent (not present in JSON) when the
+   * recipient has never opened — upstream serializes with `omitempty`.
+   * Equivalent to `open_count === opened_at_list?.length ?? 0`.
    */
-  opened_at_list: OpenEvent[];
+  opened_at_list?: OpenEvent[];
   /** Total number of times the email was opened (== opened_at_list.length). */
   open_count: number;
   /** Most recent open timestamp; the server only advances this forward. */

--- a/packages/shared/src/interfaces/email-service.interface.ts
+++ b/packages/shared/src/interfaces/email-service.interface.ts
@@ -25,6 +25,13 @@ export interface EmailServiceSendResponse {
   group_id: string;
 }
 
+export interface OpenEvent {
+  /** SNS MessageId used by the email-service to dedupe replayed SES events. */
+  event_id: string;
+  /** SES-provided open timestamp. */
+  opened_at: string;
+}
+
 export interface EmailRecipientRecord {
   email_id: string;
   group_id: string;
@@ -33,8 +40,18 @@ export interface EmailRecipientRecord {
   sent_at: string;
   delivered: boolean;
   delivered_at?: string;
+  /** True if the recipient opened the email at least once. */
   opened: boolean;
-  opened_at?: string;
+  /**
+   * Every unique open event for this recipient, keyed server-side by
+   * SNS MessageId for dedup. Empty array if never opened. Equivalent to
+   * `open_count === opened_at_list.length`.
+   */
+  opened_at_list: OpenEvent[];
+  /** Total number of times the email was opened (== opened_at_list.length). */
+  open_count: number;
+  /** Most recent open timestamp; the server only advances this forward. */
+  last_opened_at?: string;
   failed: boolean;
 }
 
@@ -50,7 +67,10 @@ export interface EmailServiceEngagementResponse {
   group_id: string;
   total_sent: number;
   delivered: number;
+  /** Total opens across the group — includes repeat opens by the same recipient. */
   opened: number;
+  /** Count of distinct recipients in the group who opened at least once. */
+  unique_opened: number;
   failed: number;
 }
 

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -178,5 +178,8 @@ export * from './org-people.interface';
 // Newsletter interfaces
 export * from './newsletter.interface';
 
+// Email service interfaces
+export * from './email-service.interface';
+
 // Invite interfaces
 export * from './invite.interface';

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -57,6 +57,14 @@ export interface NewsletterSendResult {
   failed: number;
   failures: NewsletterSendFailure[];
   groupId: string;
+  /**
+   * True when emails were delivered to the email-service but the follow-up
+   * PATCH to flip the newsletter to `status='sent'` exhausted its retries.
+   * The send succeeded — recipients received emails — but the newsletter row
+   * still reads as a draft. The frontend should surface this distinctly from
+   * a delivery failure so operators don't retry and cause duplicate sends.
+   */
+  markSentFailed?: boolean;
 }
 
 export type NewsletterStatus = 'draft' | 'sent';

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -56,6 +56,7 @@ export interface NewsletterSendResult {
   sent: number;
   failed: number;
   failures: NewsletterSendFailure[];
+  groupId: string;
 }
 
 export type NewsletterStatus = 'draft' | 'sent';
@@ -74,6 +75,9 @@ export interface Newsletter {
   version: number;
   createdAt: string;
   updatedAt: string;
+  // Set at first send (UUID minted in Express, persisted via the Go newsletter
+  // service). Used to query engagement analytics from lfx-v2-email-service.
+  groupId?: string;
 }
 
 export interface CreateNewsletterDraftRequest {


### PR DESCRIPTION
## Summary

Combines the two parallel newsletter PRs into one shippable unit, plus the recipient + AI-gen fixes uncovered during dev testing.

- **Writer/owner access** — Newsletters nav + route guard + Express auth opens up to writers/owners of the active foundation/project (was ED-only).
- **lfx-v2-email-service integration** — Send + analytics now go through lfx-v2-email-service via NATS. One `send_email` per recipient sharing a UUID `group_id`; analytics derived from per-recipient `EmailRecipientRecord[]` (totals + daily-opens chart from `opened_at_list`).
- **Recipient resolution in Express** — fixes the FGA filter that returned zero recipients when the Go newsletter-service called query-service with its Heimdall-minted JWT. Express now resolves committee members directly using the user's Auth0 bearer (same path the committee tab already uses).
- **AI `/generate` open to writers** — was ED-only; writers need it to compose.

## Dependencies (already deployed in dev)

- `lfx-v2-newsletter-service` PR #9 — `group_id` storage
- `lfx-v2-email-service` PR #8 — multi-open schema

## Supersedes

- #802 (writer access)
- #803 (email-service)

## Test plan

- [x] Lint / build / format / license / post-commit reviewer pair clean across all commits on both source branches
- [x] Smoke-tested in dev: writer can navigate to newsletters, compose, generate (AI), preview recipients (4 members resolved correctly), send test email (delivered via SES)