### PR TITLE
feat(dashboards): add keyword performance table

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -302,7 +302,7 @@
 
                 <!-- Expanded search term rows -->
                 @if (kwExpanded) {
-                  @for (st of row.searchTerms; track $index) {
+                  @for (st of row.searchTerms; track st.searchTerm + '|' + st.matchType) {
                     <div
                       class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                       role="row"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -232,5 +232,104 @@
         </div>
       }
     </div>
+
+    <!-- Keyword performance table -->
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="keyword-performance-section">
+      <div class="flex flex-col gap-0.5">
+        <h4 class="text-sm font-semibold text-gray-900">Keyword performance</h4>
+        <p class="text-[11px] text-gray-400">Google Ads keywords · last 6 months · revenue uses last-touch attribution</p>
+      </div>
+
+      @if (keywordLoading()) {
+        <div class="flex flex-col gap-2" data-testid="keyword-performance-skeleton">
+          @for (i of [1, 2, 3]; track i) {
+            <div class="h-10 animate-pulse rounded bg-gray-100"></div>
+          }
+        </div>
+      } @else if (hasKeywords()) {
+        <div class="overflow-x-auto">
+          <div class="min-w-[1000px]">
+            <div class="flex flex-col gap-0" role="table" aria-label="Keyword performance" data-testid="keyword-performance-table">
+              <!-- Table header -->
+              <div class="flex items-center gap-2 border-b border-gray-200 pb-2" role="row">
+                <span class="w-48 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">KEYWORD</span>
+                <span class="w-20 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">MATCH</span>
+                <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CLICKS</span>
+                <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
+                <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+                <span class="w-14 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CTR</span>
+                <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CPC</span>
+                <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CONV.</span>
+                <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CONV. RATE</span>
+                <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
+                <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
+              </div>
+
+              <!-- Keyword rows -->
+              @for (row of keywordRows(); track row.keyword + '|' + row.matchType) {
+                @let kwKey = row.keyword + '|' + row.matchType;
+                @let kwExpanded = expandedKeywords().has(kwKey);
+                <div
+                  class="flex items-center gap-2 border-b border-gray-100 py-2.5 transition-colors"
+                  [class.cursor-pointer]="row.searchTerms.length > 0"
+                  [class.hover:bg-gray-50]="row.searchTerms.length > 0"
+                  role="row"
+                  [attr.data-testid]="'keyword-row-' + row.keyword"
+                  [attr.aria-expanded]="row.searchTerms.length > 0 ? kwExpanded : null"
+                  (click)="row.searchTerms.length > 0 && toggleKeywordExpand(kwKey)"
+                  (keydown.enter)="row.searchTerms.length > 0 && toggleKeywordExpand(kwKey)"
+                  (keydown.space)="$event.preventDefault(); row.searchTerms.length > 0 && toggleKeywordExpand(kwKey)"
+                  [attr.tabindex]="row.searchTerms.length > 0 ? 0 : null">
+                  <div class="flex w-48 items-center gap-1.5" role="cell">
+                    @if (row.searchTerms.length > 0) {
+                      <i class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform" [class.rotate-90]="kwExpanded" aria-hidden="true"></i>
+                    } @else {
+                      <span class="w-[9px]"></span>
+                    }
+                    <span class="truncate text-xs font-medium text-gray-700">{{ row.keyword }}</span>
+                  </div>
+                  <span class="w-20 truncate text-[11px] text-gray-500" role="cell">{{ row.matchType }}</span>
+                  <span class="w-16 text-right text-xs text-gray-900" role="cell">{{ row.clicks }}</span>
+                  <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
+                  <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.impressions }}</span>
+                  <span class="w-14 text-right text-xs text-gray-500" role="cell">{{ row.ctr }}</span>
+                  <span class="w-16 text-right text-xs text-gray-500" role="cell">{{ row.cpc }}</span>
+                  <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.conversions }}</span>
+                  <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.convRate }}</span>
+                  <span class="w-24 text-right text-xs font-medium text-gray-900" role="cell">{{ row.revenue }}</span>
+                  <span class="flex-1 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
+                </div>
+
+                <!-- Expanded search term rows -->
+                @if (kwExpanded) {
+                  @for (st of row.searchTerms; track $index) {
+                    <div
+                      class="flex items-center gap-2 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
+                      role="row"
+                      [attr.data-testid]="'search-term-row-' + kwKey + '-' + $index">
+                      <span class="w-[10.5rem] truncate text-[11px] text-gray-500" role="cell">{{ st.searchTerm }}</span>
+                      <span class="w-20 truncate text-[11px] text-gray-400" role="cell">{{ st.matchType }}</span>
+                      <span class="w-16 text-right text-[11px] text-gray-500" role="cell">{{ st.clicks }}</span>
+                      <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ st.spend }}</span>
+                      <span class="w-24 text-right text-[11px] text-gray-400" role="cell">{{ st.impressions }}</span>
+                      <span class="w-14 text-right text-[11px] text-gray-400" role="cell">{{ st.ctr }}</span>
+                      <span class="w-16 text-right text-[11px] text-gray-400" role="cell">{{ st.cpc }}</span>
+                      <span class="w-20 text-right text-[11px] text-gray-500" role="cell">{{ st.conversions }}</span>
+                      <span class="w-20" role="cell"></span>
+                      <span class="w-24" role="cell"></span>
+                      <div class="flex-1" role="cell"></div>
+                    </div>
+                  }
+                }
+              }
+            </div>
+          </div>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="keyword-performance-empty">
+          <p class="text-sm text-gray-500">No keyword data available.</p>
+        </div>
+      }
+    </div>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -274,7 +274,7 @@
                   [class.cursor-pointer]="row.searchTerms.length > 0"
                   [class.hover:bg-gray-50]="row.searchTerms.length > 0"
                   role="row"
-                  [attr.data-testid]="'keyword-row-' + row.keyword"
+                  [attr.data-testid]="'keyword-row-' + kwKey"
                   [attr.aria-expanded]="row.searchTerms.length > 0 ? kwExpanded : null"
                   (click)="row.searchTerms.length > 0 && toggleKeywordExpand(kwKey)"
                   (keydown.enter)="row.searchTerms.length > 0 && toggleKeywordExpand(kwKey)"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -12,6 +12,8 @@ import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 import type {
   FilterPillOption,
   FunnelStage,
+  KeywordPerformanceResponse,
+  KeywordRow,
   MarketingImpactFocusProgram,
   PaidCampaignPerformance,
   PaidCampaignRow,
@@ -20,6 +22,7 @@ import type {
   PerformanceSummaryKpi,
   PlatformCampaignRow,
   PlatformPerformanceRow,
+  SearchTermRow,
   SocialReachResponse,
 } from '@lfx-one/shared/interfaces';
 
@@ -61,18 +64,23 @@ export class PerformanceMarketingTabComponent {
 
   // === WritableSignals ===
   protected readonly loading = signal(false);
+  protected readonly keywordLoading = signal(false);
   protected readonly selectedFunnel = signal<FunnelStage>('all');
   protected readonly expandedProjects = signal<Set<string>>(new Set());
   protected readonly expandedPlatforms = signal<Set<string>>(new Set());
+  protected readonly expandedKeywords = signal<Set<string>>(new Set());
 
   // === Computed Signals ===
   protected readonly socialReachData: Signal<SocialReachResponse | null> = this.initSocialReachData();
+  protected readonly keywordData: Signal<KeywordPerformanceResponse | null> = this.initKeywordData();
   protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
   protected readonly projectRows: Signal<PaidProjectRow[]> = this.initProjectRows();
   protected readonly platformRows: Signal<PlatformPerformanceRow[]> = this.initPlatformRows();
   protected readonly platformTotals: Signal<PlatformPerformanceRow | null> = this.initPlatformTotals();
+  protected readonly keywordRows: Signal<KeywordRow[]> = this.initKeywordRows();
   protected readonly hasProjects = computed(() => this.projectRows().length > 0);
   protected readonly hasPlatforms = computed(() => this.platformRows().length > 0);
+  protected readonly hasKeywords = computed(() => this.keywordRows().length > 0);
 
   // === Protected Methods ===
   protected onFunnelChange(funnelId: string): void {
@@ -100,6 +108,18 @@ export class PerformanceMarketingTabComponent {
         next.delete(platform);
       } else {
         next.add(platform);
+      }
+      return next;
+    });
+  }
+
+  protected toggleKeywordExpand(keyword: string): void {
+    this.expandedKeywords.update((current) => {
+      const next = new Set(current);
+      if (next.has(keyword)) {
+        next.delete(keyword);
+      } else {
+        next.add(keyword);
       }
       return next;
     });
@@ -302,6 +322,63 @@ export class PerformanceMarketingTabComponent {
         performanceClass: this.getPerformanceClass(totalPerf),
         campaigns: [],
       };
+    });
+  }
+
+  private initKeywordData(): Signal<KeywordPerformanceResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          this.expandedKeywords.set(new Set());
+          if (!slug) {
+            this.keywordLoading.set(false);
+            return of(null);
+          }
+          this.keywordLoading.set(true);
+          return this.analyticsService.getKeywordPerformance(slug).pipe(
+            catchError(() => of(null)),
+            finalize(() => this.keywordLoading.set(false))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initKeywordRows(): Signal<KeywordRow[]> {
+    return computed(() => {
+      const data = this.keywordData();
+      if (!data?.keywords?.length) return [];
+
+      return data.keywords.map(
+        (k): KeywordRow => ({
+          keyword: k.keyword,
+          matchType: k.matchType,
+          clicks: formatNumber(k.clicks),
+          spend: formatCurrency(k.spend),
+          impressions: formatNumber(k.impressions),
+          ctr: `${(k.ctr ?? 0).toFixed(2)}%`,
+          cpc: formatCurrency(k.cpc),
+          conversions: formatNumber(k.conversions),
+          convRate: `${(k.conversionRate ?? 0).toFixed(2)}%`,
+          revenue: formatCurrency(k.attributedRevenue),
+          roas: `${(k.roas ?? 0).toFixed(2)}x`,
+          searchTerms: (k.searchTerms ?? []).map(
+            (st): SearchTermRow => ({
+              searchTerm: st.searchTerm,
+              matchType: st.matchType,
+              clicks: formatNumber(st.clicks),
+              spend: formatCurrency(st.spend),
+              impressions: formatNumber(st.impressions),
+              ctr: `${(st.ctr ?? 0).toFixed(2)}%`,
+              cpc: formatCurrency(st.cpc),
+              conversions: formatNumber(st.conversions),
+            })
+          ),
+        })
+      );
     });
   }
 

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -61,6 +61,7 @@ import {
   TrainingCertificationSummaryResponse,
   CodeContributionSummaryResponse,
   BoardMeetingParticipationSummaryResponse,
+  KeywordPerformanceResponse,
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
@@ -914,6 +915,17 @@ export class AnalyticsService {
           monthlyLabels: [],
           monthlyRoas: [],
           channelGroups: [],
+        });
+      })
+    );
+  }
+
+  public getKeywordPerformance(foundationSlug: string): Observable<KeywordPerformanceResponse> {
+    return this.http.get<KeywordPerformanceResponse>('/api/analytics/keyword-performance', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          keywords: [],
+          totals: { clicks: 0, spend: 0, impressions: 0, conversions: 0, attributedRevenue: 0 },
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2051,6 +2051,47 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/keyword-performance
+   * Get keyword and search term performance data from Snowflake Platinum tables
+   */
+  public async getKeywordPerformance(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_keyword_performance');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_keyword_performance',
+        });
+      }
+
+      if (foundationSlug.length > NAME_MAX_LENGTH) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug exceeds maximum length', {
+          operation: 'get_keyword_performance',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_keyword_performance',
+        });
+      }
+
+      const response = await this.projectService.getKeywordPerformance(foundationSlug);
+
+      logger.success(req, 'get_keyword_performance', startTime, {
+        foundation_slug: foundationSlug,
+        keyword_count: response.keywords.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/social-media
    * Get social media metrics from Snowflake Platinum tables
    */

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -146,6 +146,9 @@ router.get('/email-ctr', (req, res, next) => analyticsController.getEmailCtr(req
 // Social reach endpoint (marketing dashboard)
 router.get('/social-reach', (req, res, next) => analyticsController.getSocialReach(req, res, next));
 
+// Keyword performance endpoint (marketing dashboard)
+router.get('/keyword-performance', (req, res, next) => analyticsController.getKeywordPerformance(req, res, next));
+
 // Social media endpoint (marketing dashboard)
 router.get('/social-media', (req, res, next) => analyticsController.getSocialMedia(req, res, next));
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -65,6 +65,8 @@ import {
   HealthMetricsAggregatedRow,
   HealthMetricsDailyResponse,
   HealthMetricsRange,
+  KeywordPerformanceResponse,
+  KeywordSummary,
   LifecycleStage,
   MarketingAttributionChannel,
   MarketingAttributionProject,
@@ -5926,6 +5928,181 @@ export class ProjectService {
       document_uid: documentId,
       document_type: documentType,
     });
+  }
+
+  /**
+   * Get keyword performance data from Snowflake Platinum tables.
+   * Queries PAID_ADS_KEYWORD_PERFORMANCE (daily grain, aggregated) and
+   * PAID_ADS_KEYWORD_ATTRIBUTION (monthly grain, aggregated) for attributed revenue.
+   */
+  public async getKeywordPerformance(foundationSlug: string): Promise<KeywordPerformanceResponse> {
+    logger.debug(undefined, 'get_keyword_performance', 'Fetching keyword performance from Snowflake', { foundation_slug: foundationSlug });
+
+    try {
+      const perfQuery = `
+      SELECT
+        KEYWORD_TEXT,
+        KEYWORD_MATCH_TYPE,
+        RECORD_TYPE,
+        SEARCH_TERM,
+        SEARCH_TERM_MATCH_TYPE,
+        SUM(CLICKS) AS CLICKS,
+        SUM(SPEND) AS SPEND,
+        SUM(IMPRESSIONS) AS IMPRESSIONS,
+        SUM(CONVERSIONS) AS CONVERSIONS,
+        SUM(CONVERSIONS_VALUE) AS CONVERSIONS_VALUE,
+        CASE WHEN SUM(IMPRESSIONS) > 0 THEN SUM(CLICKS) / SUM(IMPRESSIONS) * 100 ELSE 0 END AS CTR,
+        CASE WHEN SUM(CLICKS) > 0 THEN SUM(SPEND) / SUM(CLICKS) ELSE 0 END AS CPC,
+        CASE WHEN SUM(CLICKS) > 0 THEN SUM(CONVERSIONS) / SUM(CLICKS) * 100 ELSE 0 END AS CONVERSION_RATE
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE
+      WHERE FOUNDATION_SLUG = ?
+        AND REPORT_DATE >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE, RECORD_TYPE, SEARCH_TERM, SEARCH_TERM_MATCH_TYPE
+      ORDER BY SPEND DESC
+      `;
+
+      const attrQuery = `
+      SELECT
+        KEYWORD_TEXT,
+        KEYWORD_MATCH_TYPE,
+        SUM(KEYWORD_CLICKS) AS KEYWORD_CLICKS,
+        SUM(KEYWORD_SPEND) AS KEYWORD_SPEND,
+        SUM(KEYWORD_IMPRESSIONS) AS KEYWORD_IMPRESSIONS,
+        AVG(CLICK_SHARE_PCT) AS CLICK_SHARE_PCT,
+        SUM(ATTRIBUTED_LT_REVENUE) AS ATTRIBUTED_LT_REVENUE,
+        SUM(ATTRIBUTED_LT_CONVERSIONS) AS ATTRIBUTED_LT_CONVERSIONS,
+        CASE WHEN SUM(KEYWORD_SPEND) > 0 THEN SUM(ATTRIBUTED_LT_REVENUE) / SUM(KEYWORD_SPEND) ELSE 0 END AS ATTRIBUTED_LT_ROAS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_ATTRIBUTION
+      WHERE FOUNDATION_SLUG = ?
+        AND STAT_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
+      ORDER BY KEYWORD_SPEND DESC
+      `;
+
+      interface PerfRow {
+        KEYWORD_TEXT: string;
+        KEYWORD_MATCH_TYPE: string;
+        RECORD_TYPE: string;
+        SEARCH_TERM: string | null;
+        SEARCH_TERM_MATCH_TYPE: string | null;
+        CLICKS: number;
+        SPEND: number;
+        IMPRESSIONS: number;
+        CONVERSIONS: number;
+        CONVERSIONS_VALUE: number;
+        CTR: number;
+        CPC: number;
+        CONVERSION_RATE: number;
+      }
+
+      interface AttrRow {
+        KEYWORD_TEXT: string;
+        KEYWORD_MATCH_TYPE: string;
+        KEYWORD_CLICKS: number;
+        KEYWORD_SPEND: number;
+        KEYWORD_IMPRESSIONS: number;
+        CLICK_SHARE_PCT: number;
+        ATTRIBUTED_LT_REVENUE: number;
+        ATTRIBUTED_LT_CONVERSIONS: number;
+        ATTRIBUTED_LT_ROAS: number;
+      }
+
+      const [perfResult, attrResult] = await Promise.all([
+        this.snowflakeService.execute<PerfRow>(perfQuery, [foundationSlug]),
+        this.snowflakeService.execute<AttrRow>(attrQuery, [foundationSlug]).catch((error) => {
+          logger.warning(undefined, 'get_keyword_performance', 'Attribution query failed, degrading gracefully', {
+            foundation_slug: foundationSlug,
+            err: error,
+          });
+          return { rows: [] as AttrRow[] };
+        }),
+      ]);
+
+      const attrMap = new Map<string, AttrRow>();
+      for (const row of attrResult.rows) {
+        attrMap.set(`${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`, row);
+      }
+
+      const keywordMap = new Map<string, KeywordSummary>();
+      let totalClicks = 0;
+      let totalSpend = 0;
+      let totalImpressions = 0;
+      let totalConversions = 0;
+      let totalAttributedRevenue = 0;
+
+      for (const row of perfResult.rows) {
+        if (row.RECORD_TYPE === 'search_term') {
+          const parentKey = `${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`;
+          const parent = keywordMap.get(parentKey);
+          if (parent && row.SEARCH_TERM) {
+            parent.searchTerms.push({
+              searchTerm: row.SEARCH_TERM,
+              matchType: row.SEARCH_TERM_MATCH_TYPE ?? '',
+              clicks: row.CLICKS ?? 0,
+              spend: Math.round((row.SPEND ?? 0) * 100) / 100,
+              impressions: row.IMPRESSIONS ?? 0,
+              ctr: Math.round((row.CTR ?? 0) * 100) / 100,
+              cpc: Math.round((row.CPC ?? 0) * 100) / 100,
+              conversions: row.CONVERSIONS ?? 0,
+            });
+          }
+          continue;
+        }
+
+        const key = `${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`;
+        const attr = attrMap.get(key);
+        const attributedRevenue = attr?.ATTRIBUTED_LT_REVENUE ?? 0;
+        const roas = attr?.ATTRIBUTED_LT_ROAS ?? 0;
+        const clickSharePct = attr?.CLICK_SHARE_PCT ?? 0;
+
+        const summary: KeywordSummary = {
+          keyword: row.KEYWORD_TEXT,
+          matchType: row.KEYWORD_MATCH_TYPE,
+          clicks: row.CLICKS ?? 0,
+          spend: Math.round((row.SPEND ?? 0) * 100) / 100,
+          impressions: row.IMPRESSIONS ?? 0,
+          ctr: Math.round((row.CTR ?? 0) * 100) / 100,
+          cpc: Math.round((row.CPC ?? 0) * 100) / 100,
+          conversions: row.CONVERSIONS ?? 0,
+          conversionRate: Math.round((row.CONVERSION_RATE ?? 0) * 100) / 100,
+          attributedRevenue: Math.round(attributedRevenue * 100) / 100,
+          roas: Math.round(roas * 100) / 100,
+          clickSharePct: Math.round(clickSharePct * 100) / 100,
+          searchTerms: [],
+        };
+
+        keywordMap.set(key, summary);
+        totalClicks += summary.clicks;
+        totalSpend += summary.spend;
+        totalImpressions += summary.impressions;
+        totalConversions += summary.conversions;
+        totalAttributedRevenue += summary.attributedRevenue;
+      }
+
+      const keywords = [...keywordMap.values()].sort((a, b) => b.spend - a.spend);
+
+      logger.debug(undefined, 'get_keyword_performance', 'Keyword performance fetched', {
+        foundation_slug: foundationSlug,
+        keyword_count: keywords.length,
+      });
+
+      return {
+        keywords,
+        totals: {
+          clicks: totalClicks,
+          spend: Math.round(totalSpend * 100) / 100,
+          impressions: totalImpressions,
+          conversions: totalConversions,
+          attributedRevenue: Math.round(totalAttributedRevenue * 100) / 100,
+        },
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_keyword_performance', 'Failed to fetch keyword performance, returning empty', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return { keywords: [], totals: { clicks: 0, spend: 0, impressions: 0, conversions: 0, attributedRevenue: 0 } };
+    }
   }
 
   // Runs one IN-clause Snowflake query per source table instead of 4 queries per slug, so a 25-foundation summary fires 4 queries rather than 100.

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5941,27 +5941,42 @@ export class ProjectService {
     logger.debug(undefined, 'get_keyword_performance', 'Fetching keyword performance from Snowflake', { foundation_slug: foundationSlug });
 
     try {
+      const isUmbrella = foundationSlug === 'tlf';
+      const foundationFilter = isUmbrella ? '' : 'AND FOUNDATION_SLUG = ?';
+      const foundationParams = isUmbrella ? [] : [foundationSlug];
+
       const perfQuery = `
+      WITH top_keywords AS (
+        SELECT KEYWORD_TEXT, KEYWORD_MATCH_TYPE, SUM(SPEND) AS KEYWORD_SPEND
+        FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE
+        WHERE RECORD_TYPE = 'keyword'
+          AND REPORT_DATE >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+          ${foundationFilter}
+        GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
+        ORDER BY KEYWORD_SPEND DESC
+        LIMIT 500
+      )
       SELECT
-        KEYWORD_TEXT,
-        KEYWORD_MATCH_TYPE,
-        RECORD_TYPE,
-        SEARCH_TERM,
-        SEARCH_TERM_MATCH_TYPE,
-        SUM(CLICKS) AS CLICKS,
-        SUM(SPEND) AS SPEND,
-        SUM(IMPRESSIONS) AS IMPRESSIONS,
-        SUM(CONVERSIONS) AS CONVERSIONS,
-        SUM(CONVERSIONS_VALUE) AS CONVERSIONS_VALUE,
-        CASE WHEN SUM(IMPRESSIONS) > 0 THEN SUM(CLICKS) / SUM(IMPRESSIONS) * 100 ELSE 0 END AS CTR,
-        CASE WHEN SUM(CLICKS) > 0 THEN SUM(SPEND) / SUM(CLICKS) ELSE 0 END AS CPC,
-        CASE WHEN SUM(CLICKS) > 0 THEN SUM(CONVERSIONS) / SUM(CLICKS) * 100 ELSE 0 END AS CONVERSION_RATE
-      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE
-      WHERE FOUNDATION_SLUG = ?
-        AND REPORT_DATE >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
-      GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE, RECORD_TYPE, SEARCH_TERM, SEARCH_TERM_MATCH_TYPE
-      ORDER BY SPEND DESC
-      LIMIT 500
+        p.KEYWORD_TEXT,
+        p.KEYWORD_MATCH_TYPE,
+        p.RECORD_TYPE,
+        p.SEARCH_TERM,
+        p.SEARCH_TERM_MATCH_TYPE,
+        SUM(p.CLICKS) AS CLICKS,
+        SUM(p.SPEND) AS SPEND,
+        SUM(p.IMPRESSIONS) AS IMPRESSIONS,
+        SUM(p.CONVERSIONS) AS CONVERSIONS,
+        SUM(p.CONVERSIONS_VALUE) AS CONVERSIONS_VALUE,
+        CASE WHEN SUM(p.IMPRESSIONS) > 0 THEN SUM(p.CLICKS) / SUM(p.IMPRESSIONS) * 100 ELSE 0 END AS CTR,
+        CASE WHEN SUM(p.CLICKS) > 0 THEN SUM(p.SPEND) / SUM(p.CLICKS) ELSE 0 END AS CPC,
+        CASE WHEN SUM(p.CLICKS) > 0 THEN SUM(p.CONVERSIONS) / SUM(p.CLICKS) * 100 ELSE 0 END AS CONVERSION_RATE
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE p
+      INNER JOIN top_keywords k
+        ON p.KEYWORD_TEXT = k.KEYWORD_TEXT AND p.KEYWORD_MATCH_TYPE = k.KEYWORD_MATCH_TYPE
+      WHERE p.REPORT_DATE >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+        ${foundationFilter}
+      GROUP BY p.KEYWORD_TEXT, p.KEYWORD_MATCH_TYPE, p.RECORD_TYPE, p.SEARCH_TERM, p.SEARCH_TERM_MATCH_TYPE
+      ORDER BY k.KEYWORD_SPEND DESC, p.RECORD_TYPE
       `;
 
       const attrQuery = `
@@ -5971,21 +5986,20 @@ export class ProjectService {
         SUM(KEYWORD_CLICKS) AS KEYWORD_CLICKS,
         SUM(KEYWORD_SPEND) AS KEYWORD_SPEND,
         SUM(KEYWORD_IMPRESSIONS) AS KEYWORD_IMPRESSIONS,
-        AVG(CLICK_SHARE_PCT) AS CLICK_SHARE_PCT,
         SUM(ATTRIBUTED_LT_REVENUE) AS ATTRIBUTED_LT_REVENUE,
         SUM(ATTRIBUTED_LT_CONVERSIONS) AS ATTRIBUTED_LT_CONVERSIONS,
         CASE WHEN SUM(KEYWORD_SPEND) > 0 THEN SUM(ATTRIBUTED_LT_REVENUE) / SUM(KEYWORD_SPEND) ELSE 0 END AS ATTRIBUTED_LT_ROAS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_ATTRIBUTION
-      WHERE FOUNDATION_SLUG = ?
-        AND STAT_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      WHERE STAT_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+        ${foundationFilter}
       GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
       ORDER BY KEYWORD_SPEND DESC
       LIMIT 500
       `;
 
       const [perfResult, attrResult] = await Promise.all([
-        this.snowflakeService.execute<KeywordPerformanceRow>(perfQuery, [foundationSlug]),
-        this.snowflakeService.execute<KeywordAttributionRow>(attrQuery, [foundationSlug]).catch((error) => {
+        this.snowflakeService.execute<KeywordPerformanceRow>(perfQuery, [...foundationParams, ...foundationParams]),
+        this.snowflakeService.execute<KeywordAttributionRow>(attrQuery, foundationParams).catch((error) => {
           logger.warning(undefined, 'get_keyword_performance', 'Attribution query failed, degrading gracefully', {
             foundation_slug: foundationSlug,
             err: error,
@@ -6017,7 +6031,6 @@ export class ProjectService {
         const attr = attrMap.get(key);
         const attributedRevenue = attr?.ATTRIBUTED_LT_REVENUE ?? 0;
         const roas = attr?.ATTRIBUTED_LT_ROAS ?? 0;
-        const clickSharePct = attr?.CLICK_SHARE_PCT ?? 0;
 
         const summary: KeywordSummary = {
           keyword: row.KEYWORD_TEXT,
@@ -6031,7 +6044,6 @@ export class ProjectService {
           conversionRate: Math.round((row.CONVERSION_RATE ?? 0) * 100) / 100,
           attributedRevenue: Math.round(attributedRevenue * 100) / 100,
           roas: Math.round(roas * 100) / 100,
-          clickSharePct: Math.round(clickSharePct * 100) / 100,
           searchTerms: [],
         };
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -65,7 +65,9 @@ import {
   HealthMetricsAggregatedRow,
   HealthMetricsDailyResponse,
   HealthMetricsRange,
+  KeywordAttributionRow,
   KeywordPerformanceResponse,
+  KeywordPerformanceRow,
   KeywordSummary,
   LifecycleStage,
   MarketingAttributionChannel,
@@ -5959,6 +5961,7 @@ export class ProjectService {
         AND REPORT_DATE >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
       GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE, RECORD_TYPE, SEARCH_TERM, SEARCH_TERM_MATCH_TYPE
       ORDER BY SPEND DESC
+      LIMIT 500
       `;
 
       const attrQuery = `
@@ -5977,53 +5980,27 @@ export class ProjectService {
         AND STAT_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
       GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
       ORDER BY KEYWORD_SPEND DESC
+      LIMIT 500
       `;
 
-      interface PerfRow {
-        KEYWORD_TEXT: string;
-        KEYWORD_MATCH_TYPE: string;
-        RECORD_TYPE: string;
-        SEARCH_TERM: string | null;
-        SEARCH_TERM_MATCH_TYPE: string | null;
-        CLICKS: number;
-        SPEND: number;
-        IMPRESSIONS: number;
-        CONVERSIONS: number;
-        CONVERSIONS_VALUE: number;
-        CTR: number;
-        CPC: number;
-        CONVERSION_RATE: number;
-      }
-
-      interface AttrRow {
-        KEYWORD_TEXT: string;
-        KEYWORD_MATCH_TYPE: string;
-        KEYWORD_CLICKS: number;
-        KEYWORD_SPEND: number;
-        KEYWORD_IMPRESSIONS: number;
-        CLICK_SHARE_PCT: number;
-        ATTRIBUTED_LT_REVENUE: number;
-        ATTRIBUTED_LT_CONVERSIONS: number;
-        ATTRIBUTED_LT_ROAS: number;
-      }
-
       const [perfResult, attrResult] = await Promise.all([
-        this.snowflakeService.execute<PerfRow>(perfQuery, [foundationSlug]),
-        this.snowflakeService.execute<AttrRow>(attrQuery, [foundationSlug]).catch((error) => {
+        this.snowflakeService.execute<KeywordPerformanceRow>(perfQuery, [foundationSlug]),
+        this.snowflakeService.execute<KeywordAttributionRow>(attrQuery, [foundationSlug]).catch((error) => {
           logger.warning(undefined, 'get_keyword_performance', 'Attribution query failed, degrading gracefully', {
             foundation_slug: foundationSlug,
             err: error,
           });
-          return { rows: [] as AttrRow[] };
+          return { rows: [] as KeywordAttributionRow[] };
         }),
       ]);
 
-      const attrMap = new Map<string, AttrRow>();
+      const attrMap = new Map<string, KeywordAttributionRow>();
       for (const row of attrResult.rows) {
         attrMap.set(`${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`, row);
       }
 
       const keywordMap = new Map<string, KeywordSummary>();
+      const searchTermRows: KeywordPerformanceRow[] = [];
       let totalClicks = 0;
       let totalSpend = 0;
       let totalImpressions = 0;
@@ -6032,20 +6009,7 @@ export class ProjectService {
 
       for (const row of perfResult.rows) {
         if (row.RECORD_TYPE === 'search_term') {
-          const parentKey = `${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`;
-          const parent = keywordMap.get(parentKey);
-          if (parent && row.SEARCH_TERM) {
-            parent.searchTerms.push({
-              searchTerm: row.SEARCH_TERM,
-              matchType: row.SEARCH_TERM_MATCH_TYPE ?? '',
-              clicks: row.CLICKS ?? 0,
-              spend: Math.round((row.SPEND ?? 0) * 100) / 100,
-              impressions: row.IMPRESSIONS ?? 0,
-              ctr: Math.round((row.CTR ?? 0) * 100) / 100,
-              cpc: Math.round((row.CPC ?? 0) * 100) / 100,
-              conversions: row.CONVERSIONS ?? 0,
-            });
-          }
+          searchTermRows.push(row);
           continue;
         }
 
@@ -6079,6 +6043,23 @@ export class ProjectService {
         totalAttributedRevenue += summary.attributedRevenue;
       }
 
+      for (const row of searchTermRows) {
+        const parentKey = `${row.KEYWORD_TEXT}|${row.KEYWORD_MATCH_TYPE}`;
+        const parent = keywordMap.get(parentKey);
+        if (parent && row.SEARCH_TERM) {
+          parent.searchTerms.push({
+            searchTerm: row.SEARCH_TERM,
+            matchType: row.SEARCH_TERM_MATCH_TYPE ?? '',
+            clicks: row.CLICKS ?? 0,
+            spend: Math.round((row.SPEND ?? 0) * 100) / 100,
+            impressions: row.IMPRESSIONS ?? 0,
+            ctr: Math.round((row.CTR ?? 0) * 100) / 100,
+            cpc: Math.round((row.CPC ?? 0) * 100) / 100,
+            conversions: row.CONVERSIONS ?? 0,
+          });
+        }
+      }
+
       const keywords = [...keywordMap.values()].sort((a, b) => b.spend - a.spend);
 
       logger.debug(undefined, 'get_keyword_performance', 'Keyword performance fetched', {
@@ -6099,7 +6080,7 @@ export class ProjectService {
     } catch (error) {
       logger.warning(undefined, 'get_keyword_performance', 'Failed to fetch keyword performance, returning empty', {
         foundation_slug: foundationSlug,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        err: error,
       });
       return { keywords: [], totals: { clicks: 0, spend: 0, impressions: 0, conversions: 0, attributedRevenue: 0 } };
     }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3331,3 +3331,99 @@ export interface EdEvolutionData {
   paidCampaign: SocialReachResponse;
   attribution?: MarketingAttributionResponse;
 }
+
+// ============================================
+// Keyword Performance (Marketing Impact Dashboard)
+// ============================================
+
+/**
+ * Row from ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE (daily grain).
+ * One row per keyword/search-term per day.
+ */
+export interface KeywordPerformanceRow {
+  RECORD_TYPE: 'keyword' | 'search_term';
+  KEYWORD_TEXT: string;
+  KEYWORD_MATCH_TYPE: string;
+  SEARCH_TERM: string | null;
+  SEARCH_TERM_MATCH_TYPE: string | null;
+  CLICKS: number;
+  SPEND: number;
+  IMPRESSIONS: number;
+  CONVERSIONS: number;
+  CONVERSIONS_VALUE: number;
+  CTR: number;
+  CPC: number;
+  CONVERSION_RATE: number;
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string;
+  CHANNEL: string;
+}
+
+/**
+ * Row from ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_ATTRIBUTION (monthly grain).
+ * One row per keyword per month with attributed revenue.
+ */
+export interface KeywordAttributionRow {
+  KEYWORD_TEXT: string;
+  KEYWORD_MATCH_TYPE: string;
+  STAT_MONTH: string;
+  KEYWORD_CLICKS: number;
+  KEYWORD_SPEND: number;
+  KEYWORD_IMPRESSIONS: number;
+  CLICK_SHARE_PCT: number;
+  ATTRIBUTED_FT_REVENUE: number;
+  ATTRIBUTED_LT_REVENUE: number;
+  ATTRIBUTED_LINEAR_REVENUE: number;
+  ATTRIBUTED_TIME_DECAY_REVENUE: number;
+  ATTRIBUTED_FT_CONVERSIONS: number;
+  ATTRIBUTED_LT_CONVERSIONS: number;
+  ATTRIBUTED_LT_ROAS: number;
+  GOOGLE_CONVERSIONS: number;
+  GOOGLE_CONVERSIONS_VALUE: number;
+  FOUNDATION_ID: string;
+  FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string;
+  CHANNEL: string;
+}
+
+/** Aggregated keyword row for the UI table. */
+export interface KeywordSummary {
+  keyword: string;
+  matchType: string;
+  clicks: number;
+  spend: number;
+  impressions: number;
+  ctr: number;
+  cpc: number;
+  conversions: number;
+  conversionRate: number;
+  attributedRevenue: number;
+  roas: number;
+  clickSharePct: number;
+  searchTerms: SearchTermSummary[];
+}
+
+/** Aggregated search term row nested under a keyword. */
+export interface SearchTermSummary {
+  searchTerm: string;
+  matchType: string;
+  clicks: number;
+  spend: number;
+  impressions: number;
+  ctr: number;
+  cpc: number;
+  conversions: number;
+}
+
+/** API response for the keyword performance endpoint. */
+export interface KeywordPerformanceResponse {
+  keywords: KeywordSummary[];
+  totals: {
+    clicks: number;
+    spend: number;
+    impressions: number;
+    conversions: number;
+    attributedRevenue: number;
+  };
+}

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3366,7 +3366,6 @@ export interface KeywordAttributionRow {
   KEYWORD_CLICKS: number;
   KEYWORD_SPEND: number;
   KEYWORD_IMPRESSIONS: number;
-  CLICK_SHARE_PCT: number;
   ATTRIBUTED_LT_REVENUE: number;
   ATTRIBUTED_LT_CONVERSIONS: number;
   ATTRIBUTED_LT_ROAS: number;
@@ -3385,7 +3384,6 @@ export interface KeywordSummary {
   conversionRate: number;
   attributedRevenue: number;
   roas: number;
-  clickSharePct: number;
   searchTerms: SearchTermSummary[];
 }
 

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3354,10 +3354,6 @@ export interface KeywordPerformanceRow {
   CTR: number;
   CPC: number;
   CONVERSION_RATE: number;
-  FOUNDATION_ID: string;
-  FOUNDATION_NAME: string;
-  FOUNDATION_SLUG: string;
-  CHANNEL: string;
 }
 
 /**
@@ -3367,24 +3363,13 @@ export interface KeywordPerformanceRow {
 export interface KeywordAttributionRow {
   KEYWORD_TEXT: string;
   KEYWORD_MATCH_TYPE: string;
-  STAT_MONTH: string;
   KEYWORD_CLICKS: number;
   KEYWORD_SPEND: number;
   KEYWORD_IMPRESSIONS: number;
   CLICK_SHARE_PCT: number;
-  ATTRIBUTED_FT_REVENUE: number;
   ATTRIBUTED_LT_REVENUE: number;
-  ATTRIBUTED_LINEAR_REVENUE: number;
-  ATTRIBUTED_TIME_DECAY_REVENUE: number;
-  ATTRIBUTED_FT_CONVERSIONS: number;
   ATTRIBUTED_LT_CONVERSIONS: number;
   ATTRIBUTED_LT_ROAS: number;
-  GOOGLE_CONVERSIONS: number;
-  GOOGLE_CONVERSIONS_VALUE: number;
-  FOUNDATION_ID: string;
-  FOUNDATION_NAME: string;
-  FOUNDATION_SLUG: string;
-  CHANNEL: string;
 }
 
 /** Aggregated keyword row for the UI table. */

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -180,3 +180,31 @@ export interface PlatformCampaignRow {
   /** Pre-formatted number string, e.g. "12,345" */
   impressions: string;
 }
+
+/** View-model row for the keyword performance table. */
+export interface KeywordRow {
+  keyword: string;
+  matchType: string;
+  clicks: string;
+  spend: string;
+  impressions: string;
+  ctr: string;
+  cpc: string;
+  conversions: string;
+  convRate: string;
+  revenue: string;
+  roas: string;
+  searchTerms: SearchTermRow[];
+}
+
+/** View-model row for a nested search term under a keyword. */
+export interface SearchTermRow {
+  searchTerm: string;
+  matchType: string;
+  clicks: string;
+  spend: string;
+  impressions: string;
+  ctr: string;
+  cpc: string;
+  conversions: string;
+}


### PR DESCRIPTION
## Summary
- Add keyword performance table to the Performance Marketing tab on the Marketing Impact dashboard
- Full-stack implementation: shared interfaces, Snowflake queries (PAID_ADS_KEYWORD_PERFORMANCE + PAID_ADS_KEYWORD_ATTRIBUTION), Express controller/route, Angular HTTP service, and component with expandable keyword → search term rows
- Two-pass row processing ensures search terms always nest under their parent keyword regardless of query ordering
- Last-touch attribution model for revenue/ROAS via the attribution table, with graceful degradation if attribution data is unavailable

LFXV2-1972

## Test plan
- [ ] Navigate to Marketing Impact → Performance Marketing tab
- [ ] Verify keyword performance table renders with data for a foundation that has Google Ads keywords
- [ ] Verify expandable rows show search terms nested under their parent keyword
- [ ] Verify skeleton loading state displays while data loads
- [ ] Verify empty state ("No keyword data available") for foundations without keyword data
- [ ] Verify keyboard navigation (Enter/Space to expand rows, Tab to navigate)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)