### PR TITLE
fix(invite): remove committed INVITE_SERVICE_JWT_SECRET from chart defaults

### DIFF
--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -288,7 +288,7 @@ environment:
   # The value is used as raw UTF-8 bytes (not base64-decoded) to match how
   # the Go invite service derives the HMAC key ([]byte(secret)).
   INVITE_SERVICE_JWT_SECRET:
-    value: "qtPxtMAVHkg58Odl2j35iGweRNYUXK3PwO6DiDvaIIc="
+    value:
 
   # Snowflake Analytics Configuration
   # Required for analytics endpoints: active-weeks-streak, pull-requests-merged, code-commits


### PR DESCRIPTION
## Summary

- Removes the hardcoded HS256 signing key from `charts/lfx-self-serve/values.yaml`
- A valid key in `values.yaml` lets anyone with repo read access mint well-formed invite JWTs against the dev cluster
- Preserves the documentation comments (encoding contract, relationship to `lfx-v2-invite-service`)
- The value must now be injected at deploy time via ArgoCD secretKeyRef / Kubernetes Secret

## Deploy note

After merging, the `INVITE_SERVICE_JWT_SECRET` env var must be configured in ArgoCD (or equivalent) for the invite acceptance flow to work. The key to use is the same value that was previously committed — it just no longer lives in source.

## Related

Follow-up to #742 (LFXV2-1945) — flagged by @dealako and @copilot-pull-request-reviewer during review.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)