### PR TITLE
feat(meetings): add My Meetings button to meeting join header

### DIFF
--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -40,6 +40,14 @@
               <div class="relative flex items-center gap-4">
                 @if (userService.authenticated()) {
                   <div class="flex items-center gap-4">
+                    <a
+                      routerLink="/meetings"
+                      class="flex items-center gap-2 text-sm font-medium text-gray-600 border border-gray-200 hover:border-gray-300 hover:text-gray-800 hover:bg-gray-50 transition-colors px-3 py-1.5 rounded-md whitespace-nowrap"
+                      data-testid="my-meetings-header-button">
+                      <i class="fa-light fa-calendar text-xs"></i>
+                      My Meetings
+                      <i class="fa-light fa-arrow-up-right text-xs"></i>
+                    </a>
                     <lfx-avatar
                       [image]="userService.user()?.picture"
                       [icon]="'fa-light fa-user'"


### PR DESCRIPTION
## What
Adds a \"My Meetings\" button to the `<lfx-header>` component used on public meeting pages (`/meetings/:id`).

The button sits to the left of the user avatar and is visible whenever the user is authenticated. It includes a calendar icon (left) and an arrow-up-right icon (right), styled with a light gray border and gray hover states.

Clicking the button navigates to `/meetings`, which the existing `lensRedirectGuard` resolves to the user's meetings in their active lens (Me, Project, or Foundation).

## How
Single template change in `header.component.html` — no component logic required since `RouterModule` was already imported and the button is unconditional within the `@if (userService.authenticated())` block.

## Checklist
- [x] License headers present
- [x] `yarn check-types` passes
- [x] `yarn lint:check` passes
- [x] No new dependencies
- [x] SSR-safe (no browser-only APIs)