### PR TITLE
fix(newsletters): match sent email to in-app preview

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
@@ -26,14 +26,7 @@
   </ng-template>
 
   <div class="bg-slate-100 py-6 px-2 min-h-full" data-testid="newsletter-preview-drawer-body">
-    <lfx-newsletter-preview
-      [subject]="subject()"
-      [bodyHtml]="bodyHtml()"
-      [edName]="edName()"
-      [logoUrl]="logoUrl()"
-      [displayName]="displayName()"
-      [edReplyEmail]="edReplyEmail()">
-    </lfx-newsletter-preview>
+    <lfx-newsletter-preview [subject]="subject()" [bodyHtml]="bodyHtml()" [logoUrl]="logoUrl()" [displayName]="displayName()"> </lfx-newsletter-preview>
   </div>
 
   <ng-template #footer>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
@@ -16,10 +16,8 @@ export class NewsletterPreviewDrawerComponent {
   // === Inputs (pass-through to the preview component) ===
   public readonly subject = input.required<string>();
   public readonly bodyHtml = input.required<string>();
-  public readonly edName = input.required<string>();
   public readonly logoUrl = input<string | undefined>(undefined);
   public readonly displayName = input.required<string>();
-  public readonly edReplyEmail = input.required<string>();
 
   // === Model Signals (two-way) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.html
@@ -14,29 +14,7 @@
         </div>
       </div>
 
-      <div class="newsletter-preview__from">
-        From <strong>{{ edName() || 'Executive Director' }}</strong>
-      </div>
-
       <div class="newsletter-preview__body" [innerHTML]="bodyHtml()"></div>
-
-      <div class="newsletter-preview__footer">
-        <div class="newsletter-preview__footer-line">
-          Sent by <strong>{{ edName() || 'Executive Director' }}</strong> on behalf of <strong>{{ displayName() || 'Foundation' }}</strong
-          >.
-        </div>
-        <div class="newsletter-preview__footer-line">
-          To reply, email
-          @if (edReplyEmail()) {
-            <a [href]="'mailto:' + edReplyEmail()">{{ edReplyEmail() }}</a>
-          } @else {
-            <span>your ED.</span>
-          }
-        </div>
-        <div class="newsletter-preview__footer-fine">
-          To unsubscribe from {{ displayName() || 'these' }} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by LFX.
-        </div>
-      </div>
     } @else {
       <div class="newsletter-preview__empty">
         <i class="fa-regular fa-envelope newsletter-preview__empty-icon"></i>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.scss
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.scss
@@ -56,16 +56,6 @@
     line-height: 1.3;
   }
 
-  &__from {
-    padding: 1.25rem 2rem 0;
-    font-size: 0.8125rem;
-    color: theme('colors.gray.500');
-
-    strong {
-      color: theme('colors.gray.900');
-    }
-  }
-
   &__body {
     padding: 1.5rem 2rem 2rem;
     font-size: 1rem;
@@ -153,22 +143,6 @@
         margin: 1.5rem 0 0.5rem;
       }
     }
-  }
-
-  &__footer {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    background-color: theme('colors.gray.50');
-    border-top: 1px solid theme('colors.gray.200');
-    padding: 1.25rem 2rem;
-    font-size: 0.75rem;
-    color: theme('colors.gray.500');
-  }
-
-  &__footer-fine {
-    color: theme('colors.gray.400');
-    font-size: 0.6875rem;
   }
 
   &__empty {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.ts
@@ -12,10 +12,8 @@ export class NewsletterPreviewComponent {
   // Inputs
   public readonly subject = input<string>('');
   public readonly bodyHtml = input<string>('');
-  public readonly edName = input<string>('');
   public readonly logoUrl = input<string | undefined>(undefined);
   public readonly displayName = input<string>('');
-  public readonly edReplyEmail = input<string>('');
 
   // Computed
   public readonly hasContent: Signal<boolean> = computed(() => Boolean(this.subject().trim() || this.bodyHtml().trim()));

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -159,17 +159,10 @@
 
 @if (selectedNewsletter(); as n) {
   <!--
-    Sent previews intentionally do not pass edName / displayName / logoUrl: those values would be
+    Sent previews intentionally do not pass displayName / logoUrl: those values would be
     sourced from the *current* viewer/context, not from what recipients actually saw at send time.
-    The preview component already falls back to neutral labels ("Executive Director" / "Foundation").
-    True fidelity needs a backend snapshot of sender + project at send time — tracked as follow-up.
+    The preview component falls back to a neutral "Foundation" label.
+    True fidelity needs a backend snapshot of project at send time — tracked as follow-up.
   -->
-  <lfx-newsletter-preview-drawer
-    [(visible)]="previewVisible"
-    [subject]="n.subject"
-    [bodyHtml]="n.bodyHtml"
-    [edName]="''"
-    [displayName]="''"
-    [edReplyEmail]="n.edReplyEmail">
-  </lfx-newsletter-preview-drawer>
+  <lfx-newsletter-preview-drawer [(visible)]="previewVisible" [subject]="n.subject" [bodyHtml]="n.bodyHtml" [displayName]="''"> </lfx-newsletter-preview-drawer>
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -159,9 +159,9 @@
 
 @if (selectedNewsletter(); as n) {
   <!--
-    Sent previews intentionally do not pass displayName / logoUrl: those values would be
+    Sent previews intentionally pass an empty displayName and omit logoUrl: those values would be
     sourced from the *current* viewer/context, not from what recipients actually saw at send time.
-    The preview component falls back to a neutral "Foundation" label.
+    The preview component falls back to a neutral "Foundation" label when displayName is empty.
     True fidelity needs a backend snapshot of project at send time — tracked as follow-up.
   -->
   <lfx-newsletter-preview-drawer [(visible)]="previewVisible" [subject]="n.subject" [bodyHtml]="n.bodyHtml" [displayName]="''"> </lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -161,10 +161,8 @@
   [(visible)]="previewDrawerVisible"
   [subject]="form.controls.subject.value"
   [bodyHtml]="form.controls.bodyHtml.value"
-  [edName]="edName()"
   [logoUrl]="logoUrl()"
-  [displayName]="displayName()"
-  [edReplyEmail]="edEmail()">
+  [displayName]="displayName()">
 </lfx-newsletter-preview-drawer>
 
 <p-confirmDialog></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -212,7 +212,6 @@ export class NewsletterManageComponent {
         toEmail: this.edEmail(),
         contextType: this.contextType(),
         contextUid: this.contextUid(),
-        edReplyEmail: this.edEmail(),
       })
       .pipe(
         take(1),

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -79,11 +79,12 @@ export class NewsletterController {
 
   /**
    * POST /api/newsletters/test-send
-   * Body: { subject, bodyHtml, toEmail, contextType, contextUid, edReplyEmail }
+   * Body: { subject, bodyHtml, toEmail, contextType, contextUid }
    *
    * Sends a single preview email via lfx-v2-email-service. No group_id is
    * supplied — test sends auto-generate one server-side and stay out of the
-   * newsletter analytics rollup.
+   * newsletter analytics rollup. edReplyEmail is intentionally not required
+   * here because the rendered email no longer surfaces a reply-to.
    */
   public async testSend(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'newsletter_test_send', {
@@ -93,7 +94,7 @@ export class NewsletterController {
 
     try {
       const payload = req.body as NewsletterTestSendPayload;
-      this.validateCommonPayload(payload, req.path, 'newsletter_test_send');
+      this.validateCommonPayload(payload, req.path, 'newsletter_test_send', false);
 
       if (!payload.toEmail || typeof payload.toEmail !== 'string' || !payload.toEmail.includes('@')) {
         throw ServiceValidationError.forField('toEmail', 'A valid recipient email is required', {
@@ -466,10 +467,17 @@ export class NewsletterController {
     }
   }
 
+  /**
+   * `requireEdReplyEmail=false` is used by the test-send path — the rendered
+   * email no longer surfaces the reply-to address, so we don't make writers
+   * supply one to run a test. The draft / real-send paths still require it
+   * because it's persisted on the Newsletter row in lfx-v2-newsletter-service.
+   */
   private validateCommonPayload(
     payload: { subject?: string; bodyHtml?: string; contextType?: string; contextUid?: string; edReplyEmail?: string },
     path: string,
-    operation: string
+    operation: string,
+    requireEdReplyEmail: boolean = true
   ): void {
     const fieldErrors: Record<string, string> = {};
 
@@ -493,7 +501,7 @@ export class NewsletterController {
       fieldErrors['contextUid'] = 'contextUid is required';
     }
 
-    if (!payload?.edReplyEmail || typeof payload.edReplyEmail !== 'string' || !payload.edReplyEmail.includes('@')) {
+    if (requireEdReplyEmail && (!payload?.edReplyEmail || typeof payload.edReplyEmail !== 'string' || !payload.edReplyEmail.includes('@'))) {
       fieldErrors['edReplyEmail'] = 'A valid edReplyEmail is required';
     }
 

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -13,12 +13,10 @@ import {
   NewsletterTestSendPayload,
   UpdateNewsletterDraftRequest,
 } from '@lfx-one/shared/interfaces';
-import { stripHtml } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { AiService } from '../services/ai.service';
-import { EmailServiceClient } from '../services/email-service.client';
 import { logger } from '../services/logger.service';
 import { NewsletterService } from '../services/newsletter.service';
 import { NewsletterServiceClient } from '../services/newsletter-service.client';
@@ -31,8 +29,7 @@ const CONTEXT_NAME_MAX_LENGTH = 200;
 
 export class NewsletterController {
   private newsletterClient: NewsletterServiceClient = new NewsletterServiceClient();
-  private emailServiceClient: EmailServiceClient = new EmailServiceClient();
-  private newsletterService: NewsletterService = new NewsletterService(this.newsletterClient, this.emailServiceClient);
+  private newsletterService: NewsletterService = new NewsletterService(this.newsletterClient);
   private aiService: AiService = new AiService();
 
   /**
@@ -106,12 +103,7 @@ export class NewsletterController {
         });
       }
 
-      await this.emailServiceClient.sendEmail(req, {
-        to: payload.toEmail,
-        subject: payload.subject,
-        html: payload.bodyHtml,
-        text: stripHtml(payload.bodyHtml),
-      });
+      await this.newsletterService.sendTest(req, payload);
 
       // PII (recipient email) intentionally omitted from log metadata.
       logger.success(req, 'newsletter_test_send', startTime, {});

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -6,7 +6,14 @@ import { stripHtml } from '@lfx-one/shared/utils';
 
 export interface NewsletterEmailChrome {
   subject: string;
-  /** Trusted Quill output — sanitized client-side at write time and stored verbatim. */
+  /**
+   * Newsletter body HTML, interpolated verbatim into the envelope. Trust
+   * boundary: the field is populated by authenticated writers via the
+   * authoring UI; there is no programmatic HTML sanitizer (e.g. DOMPurify /
+   * sanitize-html) between the form and this call. Quill's format whitelist
+   * is not a security sanitizer. If we ever accept body content from a less
+   * privileged source, sanitize upstream of this function.
+   */
   bodyHtml: string;
   edName: string;
   edReplyEmail: string;
@@ -50,7 +57,8 @@ function escapeAttr(value: string): string {
  *     `max-width:600px`, which is the standard Outlook-desktop workaround.
  *   - Chrome strings flow through escapeHtml/escapeAttr because they're
  *     user/operator-controlled (project name, subject, ED display name).
- *   - bodyHtml is interpolated verbatim — already trusted Quill output.
+ *   - bodyHtml is interpolated verbatim — see the NewsletterEmailChrome
+ *     interface for the trust-boundary contract.
  */
 export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -15,8 +15,6 @@ export interface NewsletterEmailChrome {
    * privileged source, sanitize upstream of this function.
    */
   bodyHtml: string;
-  edName: string;
-  edReplyEmail: string;
   displayName: string;
   logoUrl?: string;
   contextType: 'foundation' | 'project';
@@ -28,8 +26,6 @@ const COLOR_BLUE_500 = lfxColors.blue[500];
 const COLOR_BLUE_600 = lfxColors.blue[600];
 const COLOR_GRAY_50 = lfxColors.gray[50];
 const COLOR_GRAY_200 = lfxColors.gray[200];
-const COLOR_GRAY_400 = lfxColors.gray[400];
-const COLOR_GRAY_500 = lfxColors.gray[500];
 const COLOR_GRAY_700 = lfxColors.gray[700];
 const COLOR_GRAY_800 = lfxColors.gray[800];
 const COLOR_GRAY_900 = lfxColors.gray[900];
@@ -136,9 +132,7 @@ function escapeAttr(value: string): string {
 export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
   const subjectSafe = escapeHtml(input.subject || 'Untitled');
-  const edNameSafe = escapeHtml(input.edName || 'Executive Director');
   const displayNameSafe = escapeHtml(input.displayName || fallbackDisplay);
-  const replyEmailSafe = escapeAttr(input.edReplyEmail);
   const styledBody = convertStandaloneCtas(inlineBodyStyles(input.bodyHtml));
 
   const logoCell = input.logoUrl
@@ -179,17 +173,7 @@ ${logoCell}
 </td>
 </tr>
 <tr>
-<td style="padding:24px 40px 0;font-size:13px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">From <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong></td>
-</tr>
-<tr>
 <td style="padding:32px 40px;font-size:16px;color:${COLOR_GRAY_800};line-height:1.65;font-family:${FONT_STACK};">${styledBody}</td>
-</tr>
-<tr>
-<td style="background-color:${COLOR_GRAY_50};border-top:1px solid ${COLOR_GRAY_200};padding:24px 40px;font-size:12px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">
-<div style="margin-bottom:6px;">Sent by <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong> on behalf of <strong style="color:${COLOR_GRAY_900};">${displayNameSafe}</strong>.</div>
-<div style="margin-bottom:6px;">To reply, email <a href="mailto:${replyEmailSafe}" style="color:${COLOR_BLUE_500};text-decoration:underline;">${replyEmailSafe}</a></div>
-<div style="color:${COLOR_GRAY_400};font-size:11px;">To unsubscribe from ${displayNameSafe} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by <span style="font-weight:700;color:${COLOR_BLUE_500};letter-spacing:-0.02em;">LFX</span>.</div>
-</td>
 </tr>
 </table>
 </td>
@@ -200,25 +184,15 @@ ${logoCell}
 }
 
 /**
- * Plain-text counterpart of buildNewsletterEmailHtml. Mirrors the same
- * structure (From / On behalf of / body / reply-to / UNSUBSCRIBE) for clients
- * that prefer text/plain or for `View original` debugging.
+ * Plain-text counterpart of buildNewsletterEmailHtml. Mirrors the header
+ * (foundation/project · Newsletter, subject) and body for clients that prefer
+ * text/plain or for `View original` debugging.
  */
 export function buildNewsletterEmailText(input: NewsletterEmailChrome): string {
   const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
-  const edName = input.edName || 'Executive Director';
   const displayName = input.displayName || fallbackDisplay;
+  const subject = input.subject || 'Untitled';
   const body = stripHtml(input.bodyHtml);
 
-  return [
-    `From: ${edName}`,
-    `On behalf of: ${displayName}`,
-    '',
-    body,
-    '',
-    '---',
-    `To reply, email ${input.edReplyEmail}`,
-    `To unsubscribe from ${displayName} newsletters, reply with UNSUBSCRIBE.`,
-    'Delivered by LFX.',
-  ].join('\n');
+  return [`${displayName} · Newsletter`, subject, '', body].join('\n');
 }

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -22,6 +22,7 @@ export interface NewsletterEmailChrome {
   contextType: 'foundation' | 'project';
 }
 
+const COLOR_WHITE = lfxColors.white;
 const COLOR_BLUE_50 = lfxColors.blue[50];
 const COLOR_BLUE_500 = lfxColors.blue[500];
 const COLOR_BLUE_600 = lfxColors.blue[600];
@@ -67,7 +68,10 @@ function inlineBodyStyles(html: string): string {
   let result = html;
   for (const tag of Object.keys(BODY_TAG_STYLES)) {
     const style = BODY_TAG_STYLES[tag];
-    const regex = new RegExp(`<${tag}(\\s[^>]*)?>`, 'gi');
+    // Allow optional trailing `/` so XHTML-style void tags like `<hr/>` also
+    // get styled — Quill emits `<hr>` today but other authoring paths /
+    // sanitizers can emit the self-closing form.
+    const regex = new RegExp(`<${tag}(\\s[^>]*)?/?>`, 'gi');
     result = result.replace(regex, (match, attrs?: string) => {
       if (attrs && /\sstyle\s*=/i.test(attrs)) {
         return match;
@@ -79,7 +83,7 @@ function inlineBodyStyles(html: string): string {
 }
 
 const CTA_BUTTON_STYLE =
-  `display:inline-block;background-color:${COLOR_BLUE_500};color:#ffffff;padding:12px 28px;` +
+  `display:inline-block;background-color:${COLOR_BLUE_500};color:${COLOR_WHITE};padding:12px 28px;` +
   `border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;letter-spacing:0.02em;`;
 
 /**
@@ -140,7 +144,7 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const logoCell = input.logoUrl
     ? `<td width="56" valign="middle" style="padding-right:16px;width:56px;">` +
       `<img src="${escapeAttr(input.logoUrl)}" alt="${displayNameSafe}" width="56" height="56" ` +
-      `style="display:block;width:56px;height:56px;border-radius:6px;background-color:#ffffff;padding:4px;object-fit:contain;border:0;" />` +
+      `style="display:block;width:56px;height:56px;border-radius:6px;background-color:${COLOR_WHITE};padding:4px;object-fit:contain;border:0;" />` +
       `</td>`
     : '';
 
@@ -160,15 +164,15 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:${COLOR_GRAY_50};padding:24px 12px;">
 <tr>
 <td align="center">
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="680" style="width:680px;max-width:680px;background-color:#ffffff;border:1px solid ${COLOR_GRAY_200};border-radius:8px;overflow:hidden;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="680" style="width:680px;max-width:680px;background-color:${COLOR_WHITE};border:1px solid ${COLOR_GRAY_200};border-radius:8px;overflow:hidden;">
 <tr>
-<td style="${headerBg}color:#ffffff;padding:32px 40px;font-family:${FONT_STACK};">
+<td style="${headerBg}color:${COLOR_WHITE};padding:32px 40px;font-family:${FONT_STACK};">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
 <tr>
 ${logoCell}
 <td valign="middle">
-<div style="font-size:13px;font-weight:600;letter-spacing:0.8px;text-transform:uppercase;opacity:0.9;color:#ffffff;font-family:${FONT_STACK};">${displayNameSafe} &middot; Newsletter</div>
-<div style="font-size:22px;font-weight:700;line-height:1.3;color:#ffffff;margin-top:8px;font-family:${FONT_STACK};">${subjectSafe}</div>
+<div style="font-size:13px;font-weight:600;letter-spacing:0.8px;text-transform:uppercase;opacity:0.9;color:${COLOR_WHITE};font-family:${FONT_STACK};">${displayNameSafe} &middot; Newsletter</div>
+<div style="font-size:22px;font-weight:700;line-height:1.3;color:${COLOR_WHITE};margin-top:8px;font-family:${FONT_STACK};">${subjectSafe}</div>
 </td>
 </tr>
 </table>

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -22,17 +22,85 @@ export interface NewsletterEmailChrome {
   contextType: 'foundation' | 'project';
 }
 
+const COLOR_BLUE_50 = lfxColors.blue[50];
 const COLOR_BLUE_500 = lfxColors.blue[500];
+const COLOR_BLUE_600 = lfxColors.blue[600];
 const COLOR_GRAY_50 = lfxColors.gray[50];
 const COLOR_GRAY_200 = lfxColors.gray[200];
 const COLOR_GRAY_400 = lfxColors.gray[400];
 const COLOR_GRAY_500 = lfxColors.gray[500];
+const COLOR_GRAY_700 = lfxColors.gray[700];
 const COLOR_GRAY_800 = lfxColors.gray[800];
 const COLOR_GRAY_900 = lfxColors.gray[900];
 
 // Email clients reset font-family on every cell; declare the stack everywhere
 // text lives so Outlook desktop in particular doesn't fall back to Times.
 const FONT_STACK = `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif`;
+
+// Per-tag inline styles applied to the Quill body HTML so Gmail/Outlook render
+// h2 underlines, blue-accent blockquotes, branded links etc. — Gmail strips
+// <style> blocks, so each tag has to carry its own `style=` attribute. Mirrors
+// the in-app preview's component SCSS rules.
+const BODY_TAG_STYLES: Record<string, string> = {
+  p: 'margin:0 0 14px;line-height:1.65;',
+  h2: `color:${COLOR_GRAY_900};font-size:22px;font-weight:700;line-height:1.3;letter-spacing:-0.01em;margin:32px 0 12px;padding-bottom:8px;border-bottom:1px solid ${COLOR_GRAY_200};`,
+  h3: `color:${COLOR_GRAY_700};font-size:17px;font-weight:600;line-height:1.4;margin:24px 0 8px;`,
+  ul: 'margin:12px 0 16px;padding-left:32px;list-style-type:disc;',
+  ol: 'margin:12px 0 16px;padding-left:32px;list-style-type:decimal;',
+  li: 'margin:0 0 8px;line-height:1.6;',
+  blockquote: `margin:16px 0;padding:12px 16px;border-left:3px solid ${COLOR_BLUE_500};background-color:${COLOR_BLUE_50};border-radius:0 4px 4px 0;color:${COLOR_GRAY_800};font-style:normal;`,
+  hr: `border:0;border-top:1px dashed ${COLOR_GRAY_200};margin:24px 0;`,
+  a: `color:${COLOR_BLUE_500};text-decoration:underline;`,
+  strong: `color:${COLOR_GRAY_900};font-weight:600;`,
+  b: `color:${COLOR_GRAY_900};font-weight:600;`,
+};
+
+/**
+ * Walk the Quill output and inject inline `style="..."` attributes on each
+ * supported tag. Skips tags that already carry a `style=` attribute so
+ * Quill-emitted overrides (e.g. `text-align:center` on a `<p>`) win — those
+ * paragraphs lose the base margin/line-height but keep their alignment, which
+ * is the right precedence for an authoring tool that intentionally set the
+ * style.
+ */
+function inlineBodyStyles(html: string): string {
+  let result = html;
+  for (const tag of Object.keys(BODY_TAG_STYLES)) {
+    const style = BODY_TAG_STYLES[tag];
+    const regex = new RegExp(`<${tag}(\\s[^>]*)?>`, 'gi');
+    result = result.replace(regex, (match, attrs?: string) => {
+      if (attrs && /\sstyle\s*=/i.test(attrs)) {
+        return match;
+      }
+      return attrs ? `<${tag} style="${style}"${attrs}>` : `<${tag} style="${style}">`;
+    });
+  }
+  return result;
+}
+
+const CTA_BUTTON_STYLE =
+  `display:inline-block;background-color:${COLOR_BLUE_500};color:#ffffff;padding:12px 28px;` +
+  `border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;letter-spacing:0.02em;`;
+
+/**
+ * Convert standalone-link paragraphs into button-pill CTAs. A `<p>` whose only
+ * meaningful content is a single `<a>` (optionally wrapped in
+ * `<strong>` / `<em>` / `<b>` / `<i>`) is treated as a call-to-action and
+ * re-rendered as a centered blue pill. Inline links inside body paragraphs
+ * are left as styled-underline.
+ *
+ * Runs AFTER inlineBodyStyles so it can strip the `style=` that pass added on
+ * the matched `<a>` before injecting the button style.
+ */
+function convertStandaloneCtas(html: string): string {
+  return html.replace(
+    /<p\b[^>]*>\s*(?:<(?:strong|em|b|i)>\s*)*<a\b([^>]*)>([^<]+)<\/a>(?:\s*<\/(?:strong|em|b|i)>)*\s*<\/p>/gi,
+    (_match, aAttrs: string, text: string) => {
+      const cleanedAttrs = aAttrs.replace(/\sstyle\s*=\s*"[^"]*"/i, '');
+      return `<p style="margin:28px 0;text-align:center;"><a${cleanedAttrs} style="${CTA_BUTTON_STYLE}">${text}</a></p>`;
+    }
+  );
+}
 
 function escapeHtml(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
@@ -47,18 +115,19 @@ function escapeAttr(value: string): string {
 /**
  * Build the email's outer HTML envelope mirroring the in-app preview
  * (`newsletter-preview.component.html`): blue header banner with logo + eyebrow
- * + subject, "From <edName>" line, body cell wrapping the Quill HTML, and a
- * footer with sent-by + reply-to + UNSUBSCRIBE.
+ * + subject, "From <edName>" line, body cell wrapping the styled Quill HTML,
+ * and a footer with sent-by + reply-to + UNSUBSCRIBE.
  *
  * Constraints driven by the rendering targets:
  *   - All visual styling is inline (`style="..."`). No `<style>` blocks and no
  *     classes — Gmail/Outlook strip those.
- *   - Layout is table-based with a fixed `width="600"` plus inline
- *     `max-width:600px`, which is the standard Outlook-desktop workaround.
+ *   - Layout is table-based with a fixed `width="680"` plus inline
+ *     `max-width:680px`, the standard Outlook-desktop workaround.
  *   - Chrome strings flow through escapeHtml/escapeAttr because they're
  *     user/operator-controlled (project name, subject, ED display name).
- *   - bodyHtml is interpolated verbatim — see the NewsletterEmailChrome
- *     interface for the trust-boundary contract.
+ *   - bodyHtml is processed by inlineBodyStyles + convertStandaloneCtas before
+ *     interpolation — see the NewsletterEmailChrome interface for the
+ *     trust-boundary contract.
  */
 export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
@@ -66,6 +135,7 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const edNameSafe = escapeHtml(input.edName || 'Executive Director');
   const displayNameSafe = escapeHtml(input.displayName || fallbackDisplay);
   const replyEmailSafe = escapeAttr(input.edReplyEmail);
+  const styledBody = convertStandaloneCtas(inlineBodyStyles(input.bodyHtml));
 
   const logoCell = input.logoUrl
     ? `<td width="56" valign="middle" style="padding-right:16px;width:56px;">` +
@@ -73,6 +143,10 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
       `style="display:block;width:56px;height:56px;border-radius:6px;background-color:#ffffff;padding:4px;object-fit:contain;border:0;" />` +
       `</td>`
     : '';
+
+  // Outlook desktop ignores background-image on <td>; the solid background-color
+  // is the graceful fallback so the header still renders branded.
+  const headerBg = `background-color:${COLOR_BLUE_500};background-image:linear-gradient(135deg, ${COLOR_BLUE_500} 0%, ${COLOR_BLUE_600} 100%);`;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -86,31 +160,31 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:${COLOR_GRAY_50};padding:24px 12px;">
 <tr>
 <td align="center">
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="width:600px;max-width:600px;background-color:#ffffff;border:1px solid ${COLOR_GRAY_200};border-radius:8px;overflow:hidden;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="680" style="width:680px;max-width:680px;background-color:#ffffff;border:1px solid ${COLOR_GRAY_200};border-radius:8px;overflow:hidden;">
 <tr>
-<td style="background-color:${COLOR_BLUE_500};color:#ffffff;padding:24px 32px;font-family:${FONT_STACK};">
+<td style="${headerBg}color:#ffffff;padding:32px 40px;font-family:${FONT_STACK};">
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
 <tr>
 ${logoCell}
 <td valign="middle">
-<div style="font-size:13px;font-weight:600;letter-spacing:0.6px;text-transform:uppercase;opacity:0.9;color:#ffffff;font-family:${FONT_STACK};">${displayNameSafe} &middot; Newsletter</div>
-<div style="font-size:22px;font-weight:700;line-height:1.3;color:#ffffff;margin-top:6px;font-family:${FONT_STACK};">${subjectSafe}</div>
+<div style="font-size:13px;font-weight:600;letter-spacing:0.8px;text-transform:uppercase;opacity:0.9;color:#ffffff;font-family:${FONT_STACK};">${displayNameSafe} &middot; Newsletter</div>
+<div style="font-size:22px;font-weight:700;line-height:1.3;color:#ffffff;margin-top:8px;font-family:${FONT_STACK};">${subjectSafe}</div>
 </td>
 </tr>
 </table>
 </td>
 </tr>
 <tr>
-<td style="padding:20px 32px 0;font-size:13px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">From <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong></td>
+<td style="padding:24px 40px 0;font-size:13px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">From <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong></td>
 </tr>
 <tr>
-<td style="padding:24px 32px 32px;font-size:16px;color:${COLOR_GRAY_800};line-height:1.65;font-family:${FONT_STACK};">${input.bodyHtml}</td>
+<td style="padding:32px 40px;font-size:16px;color:${COLOR_GRAY_800};line-height:1.65;font-family:${FONT_STACK};">${styledBody}</td>
 </tr>
 <tr>
-<td style="background-color:${COLOR_GRAY_50};border-top:1px solid ${COLOR_GRAY_200};padding:20px 32px;font-size:12px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">
+<td style="background-color:${COLOR_GRAY_50};border-top:1px solid ${COLOR_GRAY_200};padding:24px 40px;font-size:12px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">
 <div style="margin-bottom:6px;">Sent by <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong> on behalf of <strong style="color:${COLOR_GRAY_900};">${displayNameSafe}</strong>.</div>
 <div style="margin-bottom:6px;">To reply, email <a href="mailto:${replyEmailSafe}" style="color:${COLOR_BLUE_500};text-decoration:underline;">${replyEmailSafe}</a></div>
-<div style="color:${COLOR_GRAY_400};font-size:11px;">To unsubscribe from ${displayNameSafe} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by LFX.</div>
+<div style="color:${COLOR_GRAY_400};font-size:11px;">To unsubscribe from ${displayNameSafe} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by <span style="font-weight:700;color:${COLOR_BLUE_500};letter-spacing:-0.02em;">LFX</span>.</div>
 </td>
 </tr>
 </table>

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -18,6 +18,17 @@ export interface NewsletterEmailChrome {
   displayName: string;
   logoUrl?: string;
   contextType: 'foundation' | 'project';
+  /**
+   * Opt-in to render the compliance footer (sender attribution, reply-to,
+   * UNSUBSCRIBE). Real recipient-facing sends MUST set this true; test
+   * sends and the in-app preview opt out so the writer-facing surface stays
+   * clean. When true, `edName` and `edReplyEmail` are required.
+   */
+  includeComplianceFooter?: boolean;
+  /** Required when `includeComplianceFooter` is true. */
+  edName?: string;
+  /** Required when `includeComplianceFooter` is true. */
+  edReplyEmail?: string;
 }
 
 const COLOR_WHITE = lfxColors.white;
@@ -26,6 +37,8 @@ const COLOR_BLUE_500 = lfxColors.blue[500];
 const COLOR_BLUE_600 = lfxColors.blue[600];
 const COLOR_GRAY_50 = lfxColors.gray[50];
 const COLOR_GRAY_200 = lfxColors.gray[200];
+const COLOR_GRAY_400 = lfxColors.gray[400];
+const COLOR_GRAY_500 = lfxColors.gray[500];
 const COLOR_GRAY_700 = lfxColors.gray[700];
 const COLOR_GRAY_800 = lfxColors.gray[800];
 const COLOR_GRAY_900 = lfxColors.gray[900];
@@ -102,6 +115,22 @@ function convertStandaloneCtas(html: string): string {
   );
 }
 
+/**
+ * Preserve `<a href="...">label</a>` destinations in the plain-text fallback
+ * by emitting `label (href)`. Skip the parenthesized URL when the label is
+ * already identical to the href (raw URL pasted as link text). Runs before
+ * stripHtml so the URL survives tag removal.
+ */
+function preserveLinkDestinations(html: string): string {
+  return html.replace(/<a\b[^>]*href=(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi, (_match, _quote: string, href: string, label: string) => {
+    const trimmedLabel = label.trim();
+    if (!href || trimmedLabel === href) {
+      return label;
+    }
+    return `${label} (${href})`;
+  });
+}
+
 function escapeHtml(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
@@ -112,13 +141,33 @@ function escapeAttr(value: string): string {
   return escapeHtml(value);
 }
 
+function renderComplianceFooterHtml(input: NewsletterEmailChrome, displayNameSafe: string): string {
+  if (!input.includeComplianceFooter) {
+    return '';
+  }
+  const edNameSafe = escapeHtml(input.edName || 'Executive Director');
+  const replyEmailSafe = escapeAttr(input.edReplyEmail || '');
+  const replyLine = input.edReplyEmail
+    ? `<div style="margin-bottom:6px;">To reply, email <a href="mailto:${replyEmailSafe}" style="color:${COLOR_BLUE_500};text-decoration:underline;">${replyEmailSafe}</a></div>`
+    : '';
+  return `<tr>
+<td style="background-color:${COLOR_GRAY_50};border-top:1px solid ${COLOR_GRAY_200};padding:24px 40px;font-size:12px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">
+<div style="margin-bottom:6px;">Sent by <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong> on behalf of <strong style="color:${COLOR_GRAY_900};">${displayNameSafe}</strong>.</div>
+${replyLine}
+<div style="color:${COLOR_GRAY_400};font-size:11px;">To unsubscribe from ${displayNameSafe} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by <span style="font-weight:700;color:${COLOR_BLUE_500};letter-spacing:-0.02em;">LFX</span>.</div>
+</td>
+</tr>`;
+}
+
 /**
  * Build the email's outer HTML envelope mirroring the in-app preview
  * (`newsletter-preview.component.html`): blue header banner with logo +
  * foundation/project eyebrow + subject, then a body cell wrapping the styled
- * Quill HTML. No From line and no footer — both were intentionally removed
- * from the recipient-facing layout (see commit history if you're restoring
- * the unsubscribe block for compliance reasons).
+ * Quill HTML. A compliance footer (sender attribution + reply-to +
+ * UNSUBSCRIBE) is appended only when `input.includeComplianceFooter` is true
+ * — real recipient-facing sends opt in for CAN-SPAM / GDPR purposes; test
+ * sends and the in-app preview opt out to keep the writer-facing surface
+ * clean.
  *
  * Constraints driven by the rendering targets:
  *   - All visual styling is inline (`style="..."`). No `<style>` blocks and no
@@ -126,7 +175,8 @@ function escapeAttr(value: string): string {
  *   - Layout is table-based with a fixed `width="680"` plus inline
  *     `max-width:680px`, the standard Outlook-desktop workaround.
  *   - Chrome strings flow through escapeHtml/escapeAttr because they're
- *     user/operator-controlled (project/foundation name and subject).
+ *     user/operator-controlled (project/foundation name, subject, sender,
+ *     reply-to).
  *   - bodyHtml is processed by inlineBodyStyles + convertStandaloneCtas before
  *     interpolation — see the NewsletterEmailChrome interface for the
  *     trust-boundary contract.
@@ -136,6 +186,7 @@ export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
   const subjectSafe = escapeHtml(input.subject || 'Untitled');
   const displayNameSafe = escapeHtml(input.displayName || fallbackDisplay);
   const styledBody = convertStandaloneCtas(inlineBodyStyles(input.bodyHtml));
+  const complianceFooter = renderComplianceFooterHtml(input, displayNameSafe);
 
   const logoCell = input.logoUrl
     ? `<td width="56" valign="middle" style="padding-right:16px;width:56px;">` +
@@ -177,6 +228,7 @@ ${logoCell}
 <tr>
 <td style="padding:32px 40px;font-size:16px;color:${COLOR_GRAY_800};line-height:1.65;font-family:${FONT_STACK};">${styledBody}</td>
 </tr>
+${complianceFooter}
 </table>
 </td>
 </tr>
@@ -187,14 +239,27 @@ ${logoCell}
 
 /**
  * Plain-text counterpart of buildNewsletterEmailHtml. Mirrors the header
- * (foundation/project · Newsletter, subject) and body for clients that prefer
- * text/plain or for `View original` debugging.
+ * (foundation/project · Newsletter, subject) and body, preserving link
+ * destinations from the source HTML so text-only clients still see where
+ * each link points. The compliance block (sender / reply-to / UNSUBSCRIBE)
+ * is appended only when `input.includeComplianceFooter` is true.
  */
 export function buildNewsletterEmailText(input: NewsletterEmailChrome): string {
   const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
   const displayName = input.displayName || fallbackDisplay;
   const subject = input.subject || 'Untitled';
-  const body = stripHtml(input.bodyHtml);
+  const body = stripHtml(preserveLinkDestinations(input.bodyHtml));
 
-  return [`${displayName} · Newsletter`, subject, '', body].join('\n');
+  const lines: string[] = [`${displayName} · Newsletter`, subject, '', body];
+
+  if (input.includeComplianceFooter) {
+    const edName = input.edName || 'Executive Director';
+    lines.push('', '---', `Sent by ${edName} on behalf of ${displayName}.`);
+    if (input.edReplyEmail) {
+      lines.push(`To reply, email ${input.edReplyEmail}`);
+    }
+    lines.push(`To unsubscribe from ${displayName} newsletters, reply with UNSUBSCRIBE.`, 'Delivered by LFX.');
+  }
+
+  return lines.join('\n');
 }

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -1,0 +1,138 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { lfxColors } from '@lfx-one/shared/constants';
+import { stripHtml } from '@lfx-one/shared/utils';
+
+export interface NewsletterEmailChrome {
+  subject: string;
+  /** Trusted Quill output — sanitized client-side at write time and stored verbatim. */
+  bodyHtml: string;
+  edName: string;
+  edReplyEmail: string;
+  displayName: string;
+  logoUrl?: string;
+  contextType: 'foundation' | 'project';
+}
+
+const COLOR_BLUE_500 = lfxColors.blue[500];
+const COLOR_GRAY_50 = lfxColors.gray[50];
+const COLOR_GRAY_200 = lfxColors.gray[200];
+const COLOR_GRAY_400 = lfxColors.gray[400];
+const COLOR_GRAY_500 = lfxColors.gray[500];
+const COLOR_GRAY_800 = lfxColors.gray[800];
+const COLOR_GRAY_900 = lfxColors.gray[900];
+
+// Email clients reset font-family on every cell; declare the stack everywhere
+// text lives so Outlook desktop in particular doesn't fall back to Times.
+const FONT_STACK = `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif`;
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+// Same routine as escapeHtml — attributes need the same five characters
+// escaped. Kept as a named alias for call-site readability.
+function escapeAttr(value: string): string {
+  return escapeHtml(value);
+}
+
+/**
+ * Build the email's outer HTML envelope mirroring the in-app preview
+ * (`newsletter-preview.component.html`): blue header banner with logo + eyebrow
+ * + subject, "From <edName>" line, body cell wrapping the Quill HTML, and a
+ * footer with sent-by + reply-to + UNSUBSCRIBE.
+ *
+ * Constraints driven by the rendering targets:
+ *   - All visual styling is inline (`style="..."`). No `<style>` blocks and no
+ *     classes — Gmail/Outlook strip those.
+ *   - Layout is table-based with a fixed `width="600"` plus inline
+ *     `max-width:600px`, which is the standard Outlook-desktop workaround.
+ *   - Chrome strings flow through escapeHtml/escapeAttr because they're
+ *     user/operator-controlled (project name, subject, ED display name).
+ *   - bodyHtml is interpolated verbatim — already trusted Quill output.
+ */
+export function buildNewsletterEmailHtml(input: NewsletterEmailChrome): string {
+  const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
+  const subjectSafe = escapeHtml(input.subject || 'Untitled');
+  const edNameSafe = escapeHtml(input.edName || 'Executive Director');
+  const displayNameSafe = escapeHtml(input.displayName || fallbackDisplay);
+  const replyEmailSafe = escapeAttr(input.edReplyEmail);
+
+  const logoCell = input.logoUrl
+    ? `<td width="56" valign="middle" style="padding-right:16px;width:56px;">` +
+      `<img src="${escapeAttr(input.logoUrl)}" alt="${displayNameSafe}" width="56" height="56" ` +
+      `style="display:block;width:56px;height:56px;border-radius:6px;background-color:#ffffff;padding:4px;object-fit:contain;border:0;" />` +
+      `</td>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>${subjectSafe}</title>
+</head>
+<body style="margin:0;padding:0;background-color:${COLOR_GRAY_50};font-family:${FONT_STACK};">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:${COLOR_GRAY_50};padding:24px 12px;">
+<tr>
+<td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="width:600px;max-width:600px;background-color:#ffffff;border:1px solid ${COLOR_GRAY_200};border-radius:8px;overflow:hidden;">
+<tr>
+<td style="background-color:${COLOR_BLUE_500};color:#ffffff;padding:24px 32px;font-family:${FONT_STACK};">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr>
+${logoCell}
+<td valign="middle">
+<div style="font-size:13px;font-weight:600;letter-spacing:0.6px;text-transform:uppercase;opacity:0.9;color:#ffffff;font-family:${FONT_STACK};">${displayNameSafe} &middot; Newsletter</div>
+<div style="font-size:22px;font-weight:700;line-height:1.3;color:#ffffff;margin-top:6px;font-family:${FONT_STACK};">${subjectSafe}</div>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="padding:20px 32px 0;font-size:13px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">From <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong></td>
+</tr>
+<tr>
+<td style="padding:24px 32px 32px;font-size:16px;color:${COLOR_GRAY_800};line-height:1.65;font-family:${FONT_STACK};">${input.bodyHtml}</td>
+</tr>
+<tr>
+<td style="background-color:${COLOR_GRAY_50};border-top:1px solid ${COLOR_GRAY_200};padding:20px 32px;font-size:12px;color:${COLOR_GRAY_500};font-family:${FONT_STACK};">
+<div style="margin-bottom:6px;">Sent by <strong style="color:${COLOR_GRAY_900};">${edNameSafe}</strong> on behalf of <strong style="color:${COLOR_GRAY_900};">${displayNameSafe}</strong>.</div>
+<div style="margin-bottom:6px;">To reply, email <a href="mailto:${replyEmailSafe}" style="color:${COLOR_BLUE_500};text-decoration:underline;">${replyEmailSafe}</a></div>
+<div style="color:${COLOR_GRAY_400};font-size:11px;">To unsubscribe from ${displayNameSafe} newsletters, reply with <strong>UNSUBSCRIBE</strong>. Delivered by LFX.</div>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>`;
+}
+
+/**
+ * Plain-text counterpart of buildNewsletterEmailHtml. Mirrors the same
+ * structure (From / On behalf of / body / reply-to / UNSUBSCRIBE) for clients
+ * that prefer text/plain or for `View original` debugging.
+ */
+export function buildNewsletterEmailText(input: NewsletterEmailChrome): string {
+  const fallbackDisplay = input.contextType === 'foundation' ? 'Foundation' : 'Project';
+  const edName = input.edName || 'Executive Director';
+  const displayName = input.displayName || fallbackDisplay;
+  const body = stripHtml(input.bodyHtml);
+
+  return [
+    `From: ${edName}`,
+    `On behalf of: ${displayName}`,
+    '',
+    body,
+    '',
+    '---',
+    `To reply, email ${input.edReplyEmail}`,
+    `To unsubscribe from ${displayName} newsletters, reply with UNSUBSCRIBE.`,
+    'Delivered by LFX.',
+  ].join('\n');
+}

--- a/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
+++ b/apps/lfx-one/src/server/helpers/newsletter-email.helper.ts
@@ -114,9 +114,11 @@ function escapeAttr(value: string): string {
 
 /**
  * Build the email's outer HTML envelope mirroring the in-app preview
- * (`newsletter-preview.component.html`): blue header banner with logo + eyebrow
- * + subject, "From <edName>" line, body cell wrapping the styled Quill HTML,
- * and a footer with sent-by + reply-to + UNSUBSCRIBE.
+ * (`newsletter-preview.component.html`): blue header banner with logo +
+ * foundation/project eyebrow + subject, then a body cell wrapping the styled
+ * Quill HTML. No From line and no footer — both were intentionally removed
+ * from the recipient-facing layout (see commit history if you're restoring
+ * the unsubscribe block for compliance reasons).
  *
  * Constraints driven by the rendering targets:
  *   - All visual styling is inline (`style="..."`). No `<style>` blocks and no
@@ -124,7 +126,7 @@ function escapeAttr(value: string): string {
  *   - Layout is table-based with a fixed `width="680"` plus inline
  *     `max-width:680px`, the standard Outlook-desktop workaround.
  *   - Chrome strings flow through escapeHtml/escapeAttr because they're
- *     user/operator-controlled (project name, subject, ED display name).
+ *     user/operator-controlled (project/foundation name and subject).
  *   - bodyHtml is processed by inlineBodyStyles + convertStandaloneCtas before
  *     interpolation — see the NewsletterEmailChrome interface for the
  *     trust-boundary contract.

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -17,6 +17,7 @@ import { Request } from 'express';
 
 import { MicroserviceError, ServiceValidationError } from '../errors';
 import { buildNewsletterEmailHtml, buildNewsletterEmailText, NewsletterEmailChrome } from '../helpers/newsletter-email.helper';
+import { getEffectiveName, getEffectiveUsername } from '../utils/auth-helper';
 import { CommitteeService } from './committee.service';
 import { EmailServiceClient } from './email-service.client';
 import { logger } from './logger.service';
@@ -271,12 +272,16 @@ export class NewsletterService {
     payload: { subject: string; bodyHtml: string; toEmail: string; contextType: NewsletterContextType; contextUid: string }
   ): Promise<void> {
     const chrome = await this.resolveEmailChrome(req, payload.contextType, payload.contextUid);
+    // Test sends opt out of the compliance footer so the operator's preview
+    // inbox matches the writer-facing in-app preview. Real recipient-facing
+    // sends opt in below in `fanOutEmails`.
     const chromeInput: NewsletterEmailChrome = {
       subject: payload.subject,
       bodyHtml: payload.bodyHtml,
       displayName: chrome.displayName,
       logoUrl: chrome.logoUrl,
       contextType: payload.contextType,
+      includeComplianceFooter: false,
     };
 
     await this.emailServiceClient.sendEmail(req, {
@@ -295,20 +300,25 @@ export class NewsletterService {
    */
   private async fanOutEmails(
     req: Request,
-    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml' | 'contextType'>,
+    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml' | 'edReplyEmail' | 'contextType'>,
     recipients: NewsletterRecipient[],
     groupId: string,
-    chrome: { displayName: string; logoUrl: string | undefined }
+    chrome: { edName: string; displayName: string; logoUrl: string | undefined }
   ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
     // Build the rendered HTML + text once; the chrome-wrapped output is the
     // same for every recipient (no personalization yet) so per-recipient
-    // re-rendering would just burn CPU.
+    // re-rendering would just burn CPU. Real recipient-facing sends opt into
+    // the compliance footer (sender attribution + reply-to + UNSUBSCRIBE) so
+    // every dispatch satisfies CAN-SPAM / GDPR opt-out requirements.
     const chromeInput: NewsletterEmailChrome = {
       subject: newsletter.subject,
       bodyHtml: newsletter.bodyHtml,
       displayName: chrome.displayName,
       logoUrl: chrome.logoUrl,
       contextType: newsletter.contextType,
+      includeComplianceFooter: true,
+      edName: chrome.edName,
+      edReplyEmail: newsletter.edReplyEmail,
     };
     const html = buildNewsletterEmailHtml(chromeInput);
     const text = buildNewsletterEmailText(chromeInput);
@@ -347,16 +357,19 @@ export class NewsletterService {
   }
 
   /**
-   * Resolve the per-send chrome (foundation/project name + logo URL) from the
-   * project service. Both foundations and projects are `Project` records
-   * upstream. Lookup failures degrade gracefully — the send is more important
+   * Resolve the per-send chrome (sender display name + foundation/project name
+   * + logo URL). `edName` matches the in-app preview's
+   * `userService.user()?.name` path; `displayName` / `logoUrl` come from the
+   * project service (both foundations and projects are `Project` records
+   * upstream). Lookup failures degrade gracefully — the send is more important
    * than a polished header.
    */
   private async resolveEmailChrome(
     req: Request,
     contextType: NewsletterContextType,
     contextUid: string
-  ): Promise<{ displayName: string; logoUrl: string | undefined }> {
+  ): Promise<{ edName: string; displayName: string; logoUrl: string | undefined }> {
+    const edName = getEffectiveName(req) || getEffectiveUsername(req) || 'Executive Director';
     let displayName = contextType === 'foundation' ? 'Foundation' : 'Project';
     let logoUrl: string | undefined;
 
@@ -372,7 +385,7 @@ export class NewsletterService {
       });
     }
 
-    return { displayName, logoUrl };
+    return { edName, displayName, logoUrl };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -5,21 +5,24 @@ import {
   EmailRecipientRecord,
   Newsletter,
   NewsletterAnalytics,
+  NewsletterContextType,
   NewsletterDailyOpens,
   NewsletterListItem,
   NewsletterRecipient,
   NewsletterSendFailure,
   NewsletterSendResult,
 } from '@lfx-one/shared/interfaces';
-import { stripHtml } from '@lfx-one/shared/utils';
 import { randomUUID } from 'crypto';
 import { Request } from 'express';
 
 import { MicroserviceError, ServiceValidationError } from '../errors';
+import { buildNewsletterEmailHtml, buildNewsletterEmailText, NewsletterEmailChrome } from '../helpers/newsletter-email.helper';
+import { getEffectiveName, getEffectiveUsername } from '../utils/auth-helper';
 import { CommitteeService } from './committee.service';
 import { EmailServiceClient } from './email-service.client';
 import { logger } from './logger.service';
 import { NewsletterServiceClient } from './newsletter-service.client';
+import { ProjectService } from './project.service';
 
 const EMAIL_SEND_CONCURRENCY = 5;
 const MARK_SENT_MAX_ATTEMPTS = 3;
@@ -35,11 +38,18 @@ export class NewsletterService {
   private readonly newsletterClient: NewsletterServiceClient;
   private readonly emailServiceClient: EmailServiceClient;
   private readonly committeeService: CommitteeService;
+  private readonly projectService: ProjectService;
 
-  public constructor(newsletterClient?: NewsletterServiceClient, emailServiceClient?: EmailServiceClient, committeeService?: CommitteeService) {
+  public constructor(
+    newsletterClient?: NewsletterServiceClient,
+    emailServiceClient?: EmailServiceClient,
+    committeeService?: CommitteeService,
+    projectService?: ProjectService
+  ) {
     this.newsletterClient = newsletterClient ?? new NewsletterServiceClient();
     this.emailServiceClient = emailServiceClient ?? new EmailServiceClient();
     this.committeeService = committeeService ?? new CommitteeService();
+    this.projectService = projectService ?? new ProjectService();
   }
 
   /**
@@ -126,7 +136,13 @@ export class NewsletterService {
       recipient_count: recipients.length,
     });
 
-    const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId);
+    // Chrome (sender name, foundation/project name + logo) is identical across
+    // every recipient in the fan-out, so resolve once here rather than per loop
+    // iteration. resolveEmailChrome swallows transient lookup failures and
+    // returns sensible defaults — chrome quality must not block a send.
+    const chrome = await this.resolveEmailChrome(req, newsletter.contextType, newsletter.contextUid);
+
+    const { sent, failures } = await this.fanOutEmails(req, newsletter, recipients, groupId, chrome);
 
     let markSentFailed = false;
     if (sent > 0) {
@@ -247,6 +263,34 @@ export class NewsletterService {
   }
 
   /**
+   * One-shot test send to a single address — same chrome wrap as the real
+   * send so the operator's inbox matches what real recipients will see. No
+   * group_id, so test sends stay out of the analytics rollup.
+   */
+  public async sendTest(
+    req: Request,
+    payload: { subject: string; bodyHtml: string; toEmail: string; contextType: NewsletterContextType; contextUid: string; edReplyEmail: string }
+  ): Promise<void> {
+    const chrome = await this.resolveEmailChrome(req, payload.contextType, payload.contextUid);
+    const chromeInput: NewsletterEmailChrome = {
+      subject: payload.subject,
+      bodyHtml: payload.bodyHtml,
+      edName: chrome.edName,
+      edReplyEmail: payload.edReplyEmail,
+      displayName: chrome.displayName,
+      logoUrl: chrome.logoUrl,
+      contextType: payload.contextType,
+    };
+
+    await this.emailServiceClient.sendEmail(req, {
+      to: payload.toEmail,
+      subject: payload.subject,
+      html: buildNewsletterEmailHtml(chromeInput),
+      text: buildNewsletterEmailText(chromeInput),
+    });
+  }
+
+  /**
    * Sends one email per recipient with a bounded number of in-flight
    * requests. Per-recipient failures are captured (not thrown) so a single
    * bad address can't fail the whole batch — the caller still gets a
@@ -254,11 +298,26 @@ export class NewsletterService {
    */
   private async fanOutEmails(
     req: Request,
-    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml'>,
+    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml' | 'edReplyEmail' | 'contextType'>,
     recipients: NewsletterRecipient[],
-    groupId: string
+    groupId: string,
+    chrome: { edName: string; displayName: string; logoUrl: string | undefined }
   ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
-    const text = stripHtml(newsletter.bodyHtml);
+    // Build the rendered HTML + text once; the chrome-wrapped output is the
+    // same for every recipient (no personalization yet) so per-recipient
+    // re-rendering would just burn CPU.
+    const chromeInput: NewsletterEmailChrome = {
+      subject: newsletter.subject,
+      bodyHtml: newsletter.bodyHtml,
+      edName: chrome.edName,
+      edReplyEmail: newsletter.edReplyEmail,
+      displayName: chrome.displayName,
+      logoUrl: chrome.logoUrl,
+      contextType: newsletter.contextType,
+    };
+    const html = buildNewsletterEmailHtml(chromeInput);
+    const text = buildNewsletterEmailText(chromeInput);
+
     const failures: NewsletterSendFailure[] = [];
     let sent = 0;
     let cursor = 0;
@@ -272,7 +331,7 @@ export class NewsletterService {
           await this.emailServiceClient.sendEmail(req, {
             to: recipient.email,
             subject: newsletter.subject,
-            html: newsletter.bodyHtml,
+            html,
             text,
             group_id: groupId,
           });
@@ -290,6 +349,38 @@ export class NewsletterService {
     await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
     return { sent, failures };
+  }
+
+  /**
+   * Resolve the per-send chrome (sender display name, foundation/project name,
+   * logo URL). edName comes from the OIDC session to match the in-app preview's
+   * `userService.user()?.name` path; displayName + logoUrl come from the
+   * project service (both foundations and projects are `Project` records
+   * upstream). Lookup failures degrade gracefully — the send is more important
+   * than a polished header.
+   */
+  private async resolveEmailChrome(
+    req: Request,
+    contextType: NewsletterContextType,
+    contextUid: string
+  ): Promise<{ edName: string; displayName: string; logoUrl: string | undefined }> {
+    const edName = getEffectiveName(req) || getEffectiveUsername(req) || 'Executive Director';
+    let displayName = contextType === 'foundation' ? 'Foundation' : 'Project';
+    let logoUrl: string | undefined;
+
+    try {
+      const project = await this.projectService.getProjectById(req, contextUid, false);
+      displayName = project?.name || displayName;
+      logoUrl = project?.logo_url || undefined;
+    } catch (error) {
+      logger.warning(req, 'newsletter_resolve_chrome', 'Failed to resolve project chrome, using bare defaults', {
+        context_type: contextType,
+        context_uid: contextUid,
+        err: error,
+      });
+    }
+
+    return { edName, displayName, logoUrl };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -17,7 +17,6 @@ import { Request } from 'express';
 
 import { MicroserviceError, ServiceValidationError } from '../errors';
 import { buildNewsletterEmailHtml, buildNewsletterEmailText, NewsletterEmailChrome } from '../helpers/newsletter-email.helper';
-import { getEffectiveName, getEffectiveUsername } from '../utils/auth-helper';
 import { CommitteeService } from './committee.service';
 import { EmailServiceClient } from './email-service.client';
 import { logger } from './logger.service';
@@ -269,14 +268,12 @@ export class NewsletterService {
    */
   public async sendTest(
     req: Request,
-    payload: { subject: string; bodyHtml: string; toEmail: string; contextType: NewsletterContextType; contextUid: string; edReplyEmail: string }
+    payload: { subject: string; bodyHtml: string; toEmail: string; contextType: NewsletterContextType; contextUid: string }
   ): Promise<void> {
     const chrome = await this.resolveEmailChrome(req, payload.contextType, payload.contextUid);
     const chromeInput: NewsletterEmailChrome = {
       subject: payload.subject,
       bodyHtml: payload.bodyHtml,
-      edName: chrome.edName,
-      edReplyEmail: payload.edReplyEmail,
       displayName: chrome.displayName,
       logoUrl: chrome.logoUrl,
       contextType: payload.contextType,
@@ -298,10 +295,10 @@ export class NewsletterService {
    */
   private async fanOutEmails(
     req: Request,
-    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml' | 'edReplyEmail' | 'contextType'>,
+    newsletter: Pick<Newsletter, 'subject' | 'bodyHtml' | 'contextType'>,
     recipients: NewsletterRecipient[],
     groupId: string,
-    chrome: { edName: string; displayName: string; logoUrl: string | undefined }
+    chrome: { displayName: string; logoUrl: string | undefined }
   ): Promise<{ sent: number; failures: NewsletterSendFailure[] }> {
     // Build the rendered HTML + text once; the chrome-wrapped output is the
     // same for every recipient (no personalization yet) so per-recipient
@@ -309,8 +306,6 @@ export class NewsletterService {
     const chromeInput: NewsletterEmailChrome = {
       subject: newsletter.subject,
       bodyHtml: newsletter.bodyHtml,
-      edName: chrome.edName,
-      edReplyEmail: newsletter.edReplyEmail,
       displayName: chrome.displayName,
       logoUrl: chrome.logoUrl,
       contextType: newsletter.contextType,
@@ -352,19 +347,16 @@ export class NewsletterService {
   }
 
   /**
-   * Resolve the per-send chrome (sender display name, foundation/project name,
-   * logo URL). edName comes from the OIDC session to match the in-app preview's
-   * `userService.user()?.name` path; displayName + logoUrl come from the
-   * project service (both foundations and projects are `Project` records
-   * upstream). Lookup failures degrade gracefully — the send is more important
+   * Resolve the per-send chrome (foundation/project name + logo URL) from the
+   * project service. Both foundations and projects are `Project` records
+   * upstream. Lookup failures degrade gracefully — the send is more important
    * than a polished header.
    */
   private async resolveEmailChrome(
     req: Request,
     contextType: NewsletterContextType,
     contextUid: string
-  ): Promise<{ edName: string; displayName: string; logoUrl: string | undefined }> {
-    const edName = getEffectiveName(req) || getEffectiveUsername(req) || 'Executive Director';
+  ): Promise<{ displayName: string; logoUrl: string | undefined }> {
     let displayName = contextType === 'foundation' ? 'Foundation' : 'Project';
     let logoUrl: string | undefined;
 
@@ -380,7 +372,7 @@ export class NewsletterService {
       });
     }
 
-    return { edName, displayName, logoUrl };
+    return { displayName, logoUrl };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -370,8 +370,8 @@ export class NewsletterService {
 
     try {
       const project = await this.projectService.getProjectById(req, contextUid, false);
-      displayName = project?.name || displayName;
-      logoUrl = project?.logo_url || undefined;
+      displayName = project.name || displayName;
+      logoUrl = project.logo_url || undefined;
     } catch (error) {
       logger.warning(req, 'newsletter_resolve_chrome', 'Failed to resolve project chrome, using bare defaults', {
         context_type: contextType,

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -34,7 +34,6 @@ export interface NewsletterTestSendPayload {
   toEmail: string;
   contextType: NewsletterContextType;
   contextUid: string;
-  edReplyEmail: string;
 }
 
 export interface NewsletterSendPayload {


### PR DESCRIPTION
## Summary

- Wrap sent newsletter emails with the same chrome and inline styling as the in-app preview, so Gmail / Outlook render headings, lists, blockquotes, links etc. instead of the raw Quill body.
- Drop the From line and the unsubscribe footer per UX direction. **Note:** the UNSUBSCRIBE block must be restored before this template ships to real recipients (CAN-SPAM / GDPR).

## Test plan

- [ ] Send a test newsletter and confirm the rendered email matches the in-app preview drawer (header banner + body, no From, no footer).
- [ ] Verify h2 underlines, blue-accent blockquotes, branded bullets, and standalone-link CTAs render in Gmail web.
- [ ] Open in Outlook desktop — header gradient falls back to solid; card stays within 680 px.