### PR TITLE
feat(newsletters): raise AI generation limits for long-form content

### DIFF
--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -1,7 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { AI_AGENDA_SYSTEM_PROMPT, AI_MODEL, AI_NEWSLETTER_SYSTEM_PROMPT, AI_REQUEST_CONFIG, DURATION_ESTIMATION } from '@lfx-one/shared/constants';
+import {
+  AI_AGENDA_SYSTEM_PROMPT,
+  AI_MODEL,
+  AI_NEWSLETTER_SYSTEM_PROMPT,
+  AI_REQUEST_CONFIG,
+  DURATION_ESTIMATION,
+  NEWSLETTER_AI_MAX_TOKENS,
+} from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import {
   GenerateAgendaRequest,
@@ -123,7 +130,12 @@ export class AiService {
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt },
         ],
-        max_tokens: AI_REQUEST_CONFIG.MAX_TOKENS,
+        // Newsletter-specific cap (~3x the shared agenda cap) so long-form
+        // generations don't get truncated mid-output. Bumping the shared
+        // AI_REQUEST_CONFIG.MAX_TOKENS would also raise the agenda ceiling,
+        // which we don't want — agendas have a documented ~2k character
+        // target and shouldn't drift larger.
+        max_tokens: NEWSLETTER_AI_MAX_TOKENS,
         temperature: AI_REQUEST_CONFIG.TEMPERATURE,
         response_format: {
           type: 'json_schema',

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -11,9 +11,17 @@ export const NEWSLETTER_STEP_TITLES: Record<number, string> = {
 
 export const NEWSLETTER_PROMPT_STORAGE_KEY = 'lfx-newsletter-ai-prompt';
 
-export const NEWSLETTER_RAW_CONTENT_MAX_LENGTH = 20_000;
+export const NEWSLETTER_RAW_CONTENT_MAX_LENGTH = 50_000;
 
 // Cap must exceed the default AI_NEWSLETTER_SYSTEM_PROMPT (~6.2k chars) plus reasonable
 // customization headroom — otherwise the default prompt fails the frontend validator on init
 // and the Generate button never enables.
-export const NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH = 10_000;
+export const NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH = 20_000;
+
+// Output-token ceiling for newsletter generation only. Kept separate from
+// AI_REQUEST_CONFIG.MAX_TOKENS so the meeting-agenda flow keeps its
+// conservative 4k cap. Claude Sonnet 4 supports up to 64k output tokens;
+// 12k comfortably covers a ~40k-char HTML newsletter (the JSON schema
+// caps bodyHtml at 100k chars, so we still have room before the schema
+// pushes back).
+export const NEWSLETTER_AI_MAX_TOKENS = 12_000;


### PR DESCRIPTION
## Summary

- Raise newsletter input ceilings: raw content 20k → 50k chars, system-prompt override 10k → 20k chars.
- Add a newsletter-specific output cap (`NEWSLETTER_AI_MAX_TOKENS = 12_000`). Meeting-agenda generation keeps its 4k shared cap.
- Heads-up: touches `apps/lfx-one/src/server/services/ai.service.ts` (protected). Change is a single `max_tokens` binding swap on the existing newsletter call — no structural change.

## Test plan

- [ ] Paste a long source draft (>20k chars) into the AI generator and confirm the form accepts it.
- [ ] Generate a long newsletter and verify the output isn't truncated mid-body.
- [ ] Generate a short meeting agenda and confirm it still respects the 4k cap.