### PR TITLE
fix(surveys): scope results-drawer aggregates to selected project

### DIFF
--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -87,22 +87,19 @@ export class SurveyService {
   }
 
   /**
-   * Fetches a single survey by UID
-   * Resolves project UUID to v1 SFID via NATS before passing as project_id
+   * Fetches a single survey by UID.
+   * Passes project_uid (V2 UUID) directly to upstream — no SFID translation needed.
    */
   public async getSurveyById(req: Request, surveyUid: string, projectId?: string): Promise<Survey> {
     logger.debug(req, 'get_survey_by_id', 'Fetching survey by ID', {
       survey_uid: surveyUid,
-      project_id: projectId,
+      project_uid: projectId,
     });
 
     const params: Record<string, string> = {};
 
     if (projectId) {
-      const sfid = await this.projectService.getProjectSfidByUid(req, projectId);
-      if (sfid) {
-        params['project_id'] = sfid;
-      }
+      params['project_uid'] = projectId;
     }
 
     const survey = await this.microserviceProxy.proxyRequest<Survey>(req, 'LFX_V2_SERVICE', `/surveys/${surveyUid}`, 'GET', params);


### PR DESCRIPTION
## Summary

Survey results drawer was showing whole-campaign aggregates instead of per-project numbers when a user had a specific project selected.

## Root Cause

The Express proxy was resolving the project UUID to a v1 SFID via NATS before forwarding to upstream. When the NATS resolver returned `null` (mapping missing or timeout), the `project_id` filter was silently dropped — causing the upstream to return whole-campaign totals.

Additionally, `lfx-v2-survey-service` accepts `project_uid` (V2 UUID) natively, making the NATS UUID→SFID translation dead code.

## Fix

Drop the NATS SFID lookup. Forward the project UUID directly as `project_uid` to upstream — matching the confirmed OpenAPI contract (`GET /surveys/{uid}?project_uid=<uuid>`).

## Files Changed

- `apps/lfx-one/src/server/services/survey.service.ts` — removed NATS SFID resolution, forward `project_uid` directly

## Testing

Verified upstream contract via `gh api repos/linuxfoundation/lfx-v2-survey-service/contents/gen/http/openapi3.yaml` — `project_uid` (V2 UUID) is the documented query param.

Jira: [LFXV2-2007](https://linuxfoundation.atlassian.net/browse/LFXV2-2007)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2007]: https://linuxfoundation.atlassian.net/browse/LFXV2-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ