### PR TITLE
feat(events): add org lens events page shell

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -134,8 +134,7 @@ export const routes: Routes = [
           {
             path: 'events',
             data: { lens: 'org', title: 'Events', description: 'Events your organization is sponsoring or attending.', icon: 'fa-light fa-calendar' },
-            loadComponent: () =>
-              import('./modules/events/org-events-dashboard/org-events-dashboard.component').then((m) => m.OrgEventsDashboardComponent),
+            loadComponent: () => import('./modules/events/org-events-dashboard/org-events-dashboard.component').then((m) => m.OrgEventsDashboardComponent),
           },
           {
             path: 'training',

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -134,7 +134,8 @@ export const routes: Routes = [
           {
             path: 'events',
             data: { lens: 'org', title: 'Events', description: 'Events your organization is sponsoring or attending.', icon: 'fa-light fa-calendar' },
-            loadComponent: loadOrgPlaceholderPage,
+            loadComponent: () =>
+              import('./modules/events/org-events-dashboard/org-events-dashboard.component').then((m) => m.OrgEventsDashboardComponent),
           },
           {
             path: 'training',

--- a/apps/lfx-one/src/app/modules/events/events-dashboard/events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/events-dashboard/events-dashboard.component.html
@@ -1,7 +1,9 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (isFoundationLens()) {
+@if (isOrgLens()) {
+  <lfx-org-events-dashboard />
+} @else if (isFoundationLens()) {
   <lfx-foundation-event-dashboard />
 } @else {
   <lfx-my-events-dashboard />

--- a/apps/lfx-one/src/app/modules/events/events-dashboard/events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/events-dashboard/events-dashboard.component.ts
@@ -5,15 +5,17 @@ import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/c
 import { LensService } from '@app/shared/services/lens.service';
 import { FoundationEventDashboardComponent } from '../foundation-event-dashboard/foundation-event-dashboard.component';
 import { MyEventsDashboardComponent } from '../my-events-dashboard/my-events-dashboard.component';
+import { OrgEventsDashboardComponent } from '../org-events-dashboard/org-events-dashboard.component';
 
 @Component({
   selector: 'lfx-events-dashboard',
-  imports: [MyEventsDashboardComponent, FoundationEventDashboardComponent],
+  imports: [MyEventsDashboardComponent, FoundationEventDashboardComponent, OrgEventsDashboardComponent],
   templateUrl: './events-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EventsDashboardComponent {
   private readonly lensService = inject(LensService);
 
+  protected readonly isOrgLens = computed(() => this.lensService.activeLens() === 'org');
   protected readonly isFoundationLens = computed(() => this.lensService.activeLens() === 'foundation');
 }

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -1,0 +1,218 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<main class="flex flex-col gap-6 p-6" data-testid="org-events-page">
+
+  <!-- Page Header -->
+  <header class="flex items-start justify-between" data-testid="org-events-header">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-2xl font-semibold text-gray-900" data-testid="org-events-title">
+        @if (companyName()) {
+          Events &mdash; {{ companyName() }}
+        } @else {
+          Events
+        }
+      </h1>
+      <p class="text-sm text-gray-500" data-testid="org-events-subtitle">
+        Your organization's event footprint across LF events.
+      </p>
+    </div>
+    <lfx-discover-events-button testId="org-events-discover-button" />
+  </header>
+
+  <!-- Stat Strip -->
+  <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="org-events-stat-strip">
+    <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+
+      <!-- Total Events -->
+      <button
+        type="button"
+        class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
+        [class.bg-blue-50]="activeStatFilter() === 'total'"
+        [class.ring-2]="activeStatFilter() === 'total'"
+        [class.ring-inset]="activeStatFilter() === 'total'"
+        [class.ring-blue-500]="activeStatFilter() === 'total'"
+        (click)="applyEventsStatFilter('total')"
+        data-testid="org-events-stat-total"
+        aria-label="Filter by total events">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+          <i class="fa-light fa-ticket text-xl" aria-hidden="true"></i>
+        </div>
+        <div class="flex flex-col gap-0.5">
+          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-sm font-normal text-gray-900">Total Events</p>
+        </div>
+      </button>
+
+      <!-- Past Events -->
+      <button
+        type="button"
+        class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
+        [class.bg-blue-50]="activeStatFilter() === 'past'"
+        [class.ring-2]="activeStatFilter() === 'past'"
+        [class.ring-inset]="activeStatFilter() === 'past'"
+        [class.ring-blue-500]="activeStatFilter() === 'past'"
+        (click)="applyEventsStatFilter('past')"
+        data-testid="org-events-stat-past"
+        aria-label="Filter by past events">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+          <i class="fa-light fa-calendar-check text-xl" aria-hidden="true"></i>
+        </div>
+        <div class="flex flex-col gap-0.5">
+          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-sm font-normal text-gray-900">Past Events</p>
+        </div>
+      </button>
+
+      <!-- Registered Events -->
+      <button
+        type="button"
+        class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
+        [class.bg-blue-50]="activeStatFilter() === 'registered'"
+        [class.ring-2]="activeStatFilter() === 'registered'"
+        [class.ring-inset]="activeStatFilter() === 'registered'"
+        [class.ring-blue-500]="activeStatFilter() === 'registered'"
+        (click)="applyEventsStatFilter('registered')"
+        data-testid="org-events-stat-registered"
+        aria-label="Filter by registered events">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
+          <i class="fa-light fa-circle-check text-xl" aria-hidden="true"></i>
+        </div>
+        <div class="flex flex-col gap-0.5">
+          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-sm font-normal text-gray-900">Registered Events</p>
+        </div>
+      </button>
+
+    </div>
+  </lfx-card>
+
+  <!-- Filter Bar -->
+  <div class="bg-white rounded-lg border border-gray-200 p-4" data-testid="org-events-filter-bar">
+    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+      <div class="flex-1 relative">
+        <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" aria-hidden="true"></i>
+        <label for="org-events-search-id" class="sr-only">Search events</label>
+        <input
+          id="org-events-search-id"
+          pInputText
+          type="text"
+          placeholder="Search events..."
+          class="w-full pl-9"
+          data-testid="org-events-search-input"
+          [ngModel]="searchTerm()"
+          (ngModelChange)="searchTerm.set($event)" />
+      </div>
+      <div class="w-full sm:w-48" data-testid="org-events-status-filter">
+        <label for="org-events-status-id" class="sr-only">Filter by status</label>
+        <p-select
+          inputId="org-events-status-id"
+          ariaLabel="Filter by status"
+          [options]="statusOptions"
+          optionLabel="label"
+          optionValue="value"
+          styleClass="w-full"
+          [ngModel]="selectedStatus()"
+          (ngModelChange)="selectedStatus.set($event)" />
+      </div>
+    </div>
+  </div>
+
+  <!-- Tab Strip -->
+  <div
+    role="tablist"
+    aria-label="Events sections"
+    class="flex items-center gap-1 border-b border-gray-200 overflow-x-auto"
+    data-testid="org-events-tab-bar"
+    (keydown)="onTabKeydown($event)">
+    @for (tab of tabs; track tab.id) {
+      <button
+        type="button"
+        role="tab"
+        class="flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap"
+        [id]="'org-events-tab-' + tab.id"
+        [attr.aria-selected]="activeTab() === tab.id"
+        [attr.aria-controls]="'org-events-panel-' + tab.id"
+        [attr.tabindex]="activeTab() === tab.id ? 0 : -1"
+        [attr.data-testid]="'org-events-tab-' + tab.id"
+        [class.border-blue-600]="activeTab() === tab.id"
+        [class.text-blue-600]="activeTab() === tab.id"
+        [class.border-transparent]="activeTab() !== tab.id"
+        [class.text-gray-500]="activeTab() !== tab.id"
+        [class.hover:text-gray-700]="activeTab() !== tab.id"
+        (click)="switchTab(tab.id)">
+        <i [class]="tab.icon" aria-hidden="true"></i>
+        {{ tab.label }}
+      </button>
+    }
+  </div>
+
+  <!-- Tab Panels -->
+  @if (activeTab() === 'upcoming') {
+    <section
+      role="tabpanel"
+      id="org-events-panel-upcoming"
+      aria-labelledby="org-events-tab-upcoming"
+      data-testid="org-events-panel-upcoming">
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-calendar-plus"
+        title="Coming soon"
+        subtitle="Upcoming events for your organization are being built. Check back later."
+        data-testid="org-events-upcoming-coming-soon" />
+    </section>
+  }
+
+  @if (activeTab() === 'past') {
+    <section
+      role="tabpanel"
+      id="org-events-panel-past"
+      aria-labelledby="org-events-tab-past"
+      data-testid="org-events-panel-past">
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-calendar-check"
+        title="Coming soon"
+        subtitle="Past events for your organization are being built. Check back later."
+        data-testid="org-events-past-coming-soon" />
+    </section>
+  }
+
+  <!-- Leaderboards — always visible regardless of active tab -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4" data-testid="org-events-leaderboards">
+
+    <!-- Attendee Leaderboard -->
+    <lfx-card data-testid="org-events-attendee-leaderboard">
+      <ng-template #title>
+        <div class="flex items-center gap-2 text-base font-semibold text-gray-900">
+          <i class="fa-light fa-users text-gray-500" aria-hidden="true"></i>
+          Top Event Attendees &mdash; Last 12 Months
+        </div>
+      </ng-template>
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-users"
+        title="Coming soon"
+        subtitle="Attendee leaderboard is being built."
+        data-testid="org-events-attendee-leaderboard-coming-soon" />
+    </lfx-card>
+
+    <!-- Speaker Leaderboard -->
+    <lfx-card data-testid="org-events-speaker-leaderboard">
+      <ng-template #title>
+        <div class="flex items-center gap-2 text-base font-semibold text-gray-900">
+          <i class="fa-light fa-microphone text-gray-500" aria-hidden="true"></i>
+          Top Event Speakers &mdash; Last 12 Months
+        </div>
+      </ng-template>
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-microphone"
+        title="Coming soon"
+        subtitle="Speaker leaderboard is being built."
+        data-testid="org-events-speaker-leaderboard-coming-soon" />
+    </lfx-card>
+
+  </div>
+
+</main>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -68,25 +68,25 @@
         </div>
       </button>
 
-      <!-- Registered Events -->
+      <!-- Upcoming Events -->
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'registered'"
-        [class.ring-2]="activeStatFilter() === 'registered'"
-        [class.ring-inset]="activeStatFilter() === 'registered'"
-        [class.ring-blue-500]="activeStatFilter() === 'registered'"
-        (click)="applyEventsStatFilter('registered')"
-        data-testid="org-events-stat-registered"
-        aria-label="Filter by registered events">
+        [class.bg-blue-50]="activeStatFilter() === 'upcoming'"
+        [class.ring-2]="activeStatFilter() === 'upcoming'"
+        [class.ring-inset]="activeStatFilter() === 'upcoming'"
+        [class.ring-blue-500]="activeStatFilter() === 'upcoming'"
+        (click)="applyEventsStatFilter('upcoming')"
+        data-testid="org-events-stat-upcoming"
+        aria-label="Filter by upcoming events">
         <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-          <i class="fa-light fa-circle-check text-xl" aria-hidden="true"></i>
+          <i class="fa-light fa-calendar-arrow-right text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.registeredEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.upcomingEvents ?? '&mdash;' }}
           </p>
-          <p class="text-sm font-normal text-gray-900">Registered Events</p>
+          <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
         </div>
       </button>
 

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -36,7 +36,7 @@
         data-testid="org-events-stat-upcoming"
         aria-label="Filter by upcoming events">
         <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-          <i class="fa-light fa-calendar-arrow-right text-xl" aria-hidden="true"></i>
+          <i class="fa-light fa-calendar-plus text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -24,25 +24,25 @@
   <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="org-events-stat-strip">
     <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
 
-      <!-- Total Events -->
+      <!-- Upcoming Events -->
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'total'"
-        [class.ring-2]="activeStatFilter() === 'total'"
-        [class.ring-inset]="activeStatFilter() === 'total'"
-        [class.ring-blue-500]="activeStatFilter() === 'total'"
-        (click)="applyEventsStatFilter('total')"
-        data-testid="org-events-stat-total"
-        aria-label="Filter by total events">
-        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-          <i class="fa-light fa-ticket text-xl" aria-hidden="true"></i>
+        [class.bg-blue-50]="activeStatFilter() === 'upcoming'"
+        [class.ring-2]="activeStatFilter() === 'upcoming'"
+        [class.ring-inset]="activeStatFilter() === 'upcoming'"
+        [class.ring-blue-500]="activeStatFilter() === 'upcoming'"
+        (click)="applyEventsStatFilter('upcoming')"
+        data-testid="org-events-stat-upcoming"
+        aria-label="Filter by upcoming events">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
+          <i class="fa-light fa-calendar-arrow-right text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.totalEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.upcomingEvents ?? '&mdash;' }}
           </p>
-          <p class="text-sm font-normal text-gray-900">Total Events</p>
+          <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
         </div>
       </button>
 
@@ -68,25 +68,25 @@
         </div>
       </button>
 
-      <!-- Upcoming Events -->
+      <!-- Total Events -->
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'upcoming'"
-        [class.ring-2]="activeStatFilter() === 'upcoming'"
-        [class.ring-inset]="activeStatFilter() === 'upcoming'"
-        [class.ring-blue-500]="activeStatFilter() === 'upcoming'"
-        (click)="applyEventsStatFilter('upcoming')"
-        data-testid="org-events-stat-upcoming"
-        aria-label="Filter by upcoming events">
-        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-          <i class="fa-light fa-calendar-arrow-right text-xl" aria-hidden="true"></i>
+        [class.bg-blue-50]="activeStatFilter() === 'total'"
+        [class.ring-2]="activeStatFilter() === 'total'"
+        [class.ring-inset]="activeStatFilter() === 'total'"
+        [class.ring-blue-500]="activeStatFilter() === 'total'"
+        (click)="applyEventsStatFilter('total')"
+        data-testid="org-events-stat-total"
+        aria-label="Filter by total events">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+          <i class="fa-light fa-ticket text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.upcomingEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.totalEvents ?? '&mdash;' }}
           </p>
-          <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
+          <p class="text-sm font-normal text-gray-900">Total Events</p>
         </div>
       </button>
 

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -178,41 +178,5 @@
     </section>
   }
 
-  <!-- Leaderboards — always visible regardless of active tab -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4" data-testid="org-events-leaderboards">
-
-    <!-- Attendee Leaderboard -->
-    <lfx-card data-testid="org-events-attendee-leaderboard">
-      <ng-template #title>
-        <div class="flex items-center gap-2 text-base font-semibold text-gray-900">
-          <i class="fa-light fa-users text-gray-500" aria-hidden="true"></i>
-          Top Event Attendees &mdash; Last 12 Months
-        </div>
-      </ng-template>
-      <lfx-empty-state
-        [withCard]="false"
-        icon="fa-light fa-users"
-        title="Coming soon"
-        subtitle="Attendee leaderboard is being built."
-        data-testid="org-events-attendee-leaderboard-coming-soon" />
-    </lfx-card>
-
-    <!-- Speaker Leaderboard -->
-    <lfx-card data-testid="org-events-speaker-leaderboard">
-      <ng-template #title>
-        <div class="flex items-center gap-2 text-base font-semibold text-gray-900">
-          <i class="fa-light fa-microphone text-gray-500" aria-hidden="true"></i>
-          Top Event Speakers &mdash; Last 12 Months
-        </div>
-      </ng-template>
-      <lfx-empty-state
-        [withCard]="false"
-        icon="fa-light fa-microphone"
-        title="Coming soon"
-        subtitle="Speaker leaderboard is being built."
-        data-testid="org-events-speaker-leaderboard-coming-soon" />
-    </lfx-card>
-
-  </div>
 
 </main>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -39,7 +39,9 @@
           <i class="fa-light fa-ticket text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
-          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
+            {{ eventsSummary()?.totalEvents ?? '&mdash;' }}
+          </p>
           <p class="text-sm font-normal text-gray-900">Total Events</p>
         </div>
       </button>
@@ -59,7 +61,9 @@
           <i class="fa-light fa-calendar-check text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
-          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
+            {{ eventsSummary()?.pastEvents ?? '&mdash;' }}
+          </p>
           <p class="text-sm font-normal text-gray-900">Past Events</p>
         </div>
       </button>
@@ -79,7 +83,9 @@
           <i class="fa-light fa-circle-check text-xl" aria-hidden="true"></i>
         </div>
         <div class="flex flex-col gap-0.5">
-          <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
+            {{ eventsSummary()?.registeredEvents ?? '&mdash;' }}
+          </p>
           <p class="text-sm font-normal text-gray-900">Registered Events</p>
         </div>
       </button>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -28,6 +28,7 @@
         [class.ring-2]="activeStatFilter() === 'upcoming'"
         [class.ring-inset]="activeStatFilter() === 'upcoming'"
         [class.ring-blue-500]="activeStatFilter() === 'upcoming'"
+        [attr.aria-pressed]="activeStatFilter() === 'upcoming'"
         (click)="applyEventsStatFilter('upcoming')"
         data-testid="org-events-stat-upcoming"
         aria-label="Filter by upcoming events">
@@ -36,7 +37,7 @@
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.upcomingEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.upcomingEvents ?? '—' }}
           </p>
           <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
         </div>
@@ -50,6 +51,7 @@
         [class.ring-2]="activeStatFilter() === 'past'"
         [class.ring-inset]="activeStatFilter() === 'past'"
         [class.ring-blue-500]="activeStatFilter() === 'past'"
+        [attr.aria-pressed]="activeStatFilter() === 'past'"
         (click)="applyEventsStatFilter('past')"
         data-testid="org-events-stat-past"
         aria-label="Filter by past events">
@@ -58,7 +60,7 @@
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.pastEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.pastEvents ?? '—' }}
           </p>
           <p class="text-sm font-normal text-gray-900">Past Events</p>
         </div>
@@ -72,6 +74,7 @@
         [class.ring-2]="activeStatFilter() === 'total'"
         [class.ring-inset]="activeStatFilter() === 'total'"
         [class.ring-blue-500]="activeStatFilter() === 'total'"
+        [attr.aria-pressed]="activeStatFilter() === 'total'"
         (click)="applyEventsStatFilter('total')"
         data-testid="org-events-stat-total"
         aria-label="Filter by total events">
@@ -80,7 +83,7 @@
         </div>
         <div class="flex flex-col gap-0.5">
           <p class="text-xl font-medium" [class.text-gray-400]="eventsSummary() === null" [class.text-gray-900]="eventsSummary() !== null">
-            {{ eventsSummary()?.totalEvents ?? '&mdash;' }}
+            {{ eventsSummary()?.totalEvents ?? '—' }}
           </p>
           <p class="text-sm font-normal text-gray-900">Total Events</p>
         </div>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -2,7 +2,6 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <main class="flex flex-col gap-6 p-6" data-testid="org-events-page">
-
   <!-- Page Header -->
   <header class="flex items-start justify-between" data-testid="org-events-header">
     <div class="flex flex-col gap-1">
@@ -13,9 +12,7 @@
           Events
         }
       </h1>
-      <p class="text-sm text-gray-500" data-testid="org-events-subtitle">
-        Your organization's event footprint across LF events.
-      </p>
+      <p class="text-sm text-gray-500" data-testid="org-events-subtitle">Your organization's event footprint across LF events.</p>
     </div>
     <lfx-discover-events-button testId="org-events-discover-button" />
   </header>
@@ -23,7 +20,6 @@
   <!-- Stat Strip -->
   <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="org-events-stat-strip">
     <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-
       <!-- Upcoming Events -->
       <button
         type="button"
@@ -89,7 +85,6 @@
           <p class="text-sm font-normal text-gray-900">Total Events</p>
         </div>
       </button>
-
     </div>
   </lfx-card>
 
@@ -155,11 +150,7 @@
 
   <!-- Tab Panels -->
   @if (activeTab() === 'upcoming') {
-    <section
-      role="tabpanel"
-      id="org-events-panel-upcoming"
-      aria-labelledby="org-events-tab-upcoming"
-      data-testid="org-events-panel-upcoming">
+    <section role="tabpanel" id="org-events-panel-upcoming" aria-labelledby="org-events-tab-upcoming" data-testid="org-events-panel-upcoming">
       <lfx-empty-state
         [withCard]="false"
         icon="fa-light fa-calendar-plus"
@@ -170,11 +161,7 @@
   }
 
   @if (activeTab() === 'past') {
-    <section
-      role="tabpanel"
-      id="org-events-panel-past"
-      aria-labelledby="org-events-tab-past"
-      data-testid="org-events-panel-past">
+    <section role="tabpanel" id="org-events-panel-past" aria-labelledby="org-events-tab-past" data-testid="org-events-panel-past">
       <lfx-empty-state
         [withCard]="false"
         icon="fa-light fa-calendar-check"
@@ -183,6 +170,4 @@
         data-testid="org-events-past-coming-soon" />
     </section>
   }
-
-
 </main>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -3,14 +3,16 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { DEFAULT_ORG_EVENTS_TAB_ID, ORG_EVENTS_STATUS_OPTIONS, ORG_EVENTS_TABS, VALID_ORG_EVENTS_TAB_IDS } from '@lfx-one/shared/constants';
-import type { OrgEventStatFilterId, OrgEventsTabId } from '@lfx-one/shared/interfaces';
+import type { OrgEventStatFilterId, OrgEventsSummary, OrgEventsTabId } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@app/shared/services/account-context.service';
+import { EventsService } from '@app/shared/services/events.service';
+import { catchError, filter, of, switchMap } from 'rxjs';
 import { SelectModule } from 'primeng/select';
 import { InputTextModule } from 'primeng/inputtext';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
@@ -26,6 +28,7 @@ export class OrgEventsDashboardComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly accountContext = inject(AccountContextService);
+  private readonly eventsService = inject(EventsService);
   private readonly platformId = inject(PLATFORM_ID);
 
   // === Template constants ===
@@ -40,6 +43,7 @@ export class OrgEventsDashboardComponent {
   // === Computed / toSignal ===
   protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
   protected readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
+  protected readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
 
   // === Protected methods ===
   protected applyEventsStatFilter(id: OrgEventStatFilterId): void {
@@ -84,5 +88,16 @@ export class OrgEventsDashboardComponent {
       const raw = queryParamMap().get('tab');
       return raw && VALID_ORG_EVENTS_TAB_IDS.has(raw as OrgEventsTabId) ? (raw as OrgEventsTabId) : DEFAULT_ORG_EVENTS_TAB_ID;
     });
+  }
+
+  private initEventsSummary(): Signal<OrgEventsSummary | null> {
+    const accountId$ = toObservable(computed(() => this.accountContext.selectedAccount().accountId));
+    return toSignal(
+      accountId$.pipe(
+        filter((id): id is string => !!id),
+        switchMap((id) => this.eventsService.getOrgEventsSummary(id).pipe(catchError(() => of(null))))
+      ),
+      { initialValue: null }
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -1,0 +1,88 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CardComponent } from '@components/card/card.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { DEFAULT_ORG_EVENTS_TAB_ID, ORG_EVENTS_STATUS_OPTIONS, ORG_EVENTS_TABS, VALID_ORG_EVENTS_TAB_IDS } from '@lfx-one/shared/constants';
+import type { OrgEventStatFilterId, OrgEventsTabId } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@app/shared/services/account-context.service';
+import { SelectModule } from 'primeng/select';
+import { InputTextModule } from 'primeng/inputtext';
+import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
+
+@Component({
+  selector: 'lfx-org-events-dashboard',
+  imports: [FormsModule, CardComponent, EmptyStateComponent, SelectModule, InputTextModule, DiscoverEventsButtonComponent],
+  templateUrl: './org-events-dashboard.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEventsDashboardComponent {
+  // === Private injections ===
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly accountContext = inject(AccountContextService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // === Template constants ===
+  protected readonly tabs = ORG_EVENTS_TABS;
+  protected readonly statusOptions = ORG_EVENTS_STATUS_OPTIONS;
+
+  // === WritableSignals ===
+  protected readonly activeStatFilter = signal<OrgEventStatFilterId | null>(null);
+  protected readonly searchTerm = signal('');
+  protected readonly selectedStatus = signal<string | null>(null);
+
+  // === Computed / toSignal ===
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
+  protected readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
+
+  // === Protected methods ===
+  protected applyEventsStatFilter(id: OrgEventStatFilterId): void {
+    this.activeStatFilter.set(this.activeStatFilter() === id ? null : id);
+  }
+
+  protected switchTab(tabId: OrgEventsTabId): void {
+    if (tabId === this.activeTab()) {
+      return;
+    }
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab: tabId === DEFAULT_ORG_EVENTS_TAB_ID ? null : tabId },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+
+  protected onTabKeydown(event: KeyboardEvent): void {
+    const ids = this.tabs.map((t) => t.id);
+    const idx = ids.indexOf(this.activeTab());
+    let next: number | null = null;
+    if (event.key === 'ArrowRight') next = (idx + 1) % ids.length;
+    else if (event.key === 'ArrowLeft') next = (idx - 1 + ids.length) % ids.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = ids.length - 1;
+    if (next !== null) {
+      event.preventDefault();
+      this.switchTab(ids[next]);
+      if (isPlatformBrowser(this.platformId)) {
+        (document.getElementById(`org-events-tab-${ids[next]}`) as HTMLElement | null)?.focus();
+      }
+    }
+  }
+
+  // === Private initializers ===
+  private initActiveTab(): Signal<OrgEventsTabId> {
+    const queryParamMap = toSignal(this.route.queryParamMap, {
+      initialValue: this.route.snapshot.queryParamMap,
+    });
+    return computed(() => {
+      const raw = queryParamMap().get('tab');
+      return raw && VALID_ORG_EVENTS_TAB_IDS.has(raw as OrgEventsTabId) ? (raw as OrgEventsTabId) : DEFAULT_ORG_EVENTS_TAB_ID;
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -2,26 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { SelectModule } from 'primeng/select';
+import { InputTextModule } from 'primeng/inputtext';
+import { catchError, filter, of, switchMap } from 'rxjs';
+
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { DEFAULT_ORG_EVENTS_TAB_ID, ORG_EVENTS_STATUS_OPTIONS, ORG_EVENTS_TABS, VALID_ORG_EVENTS_TAB_IDS } from '@lfx-one/shared/constants';
 import type { OrgEventStatFilterId, OrgEventsSummary, OrgEventsTabId } from '@lfx-one/shared/interfaces';
-import { AccountContextService } from '@app/shared/services/account-context.service';
-import { EventsService } from '@app/shared/services/events.service';
-import { catchError, filter, of, switchMap } from 'rxjs';
-import { SelectModule } from 'primeng/select';
-import { InputTextModule } from 'primeng/inputtext';
+import { AccountContextService } from '@services/account-context.service';
+import { EventsService } from '@services/events.service';
+
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 
 @Component({
   selector: 'lfx-org-events-dashboard',
   imports: [FormsModule, CardComponent, EmptyStateComponent, SelectModule, InputTextModule, DiscoverEventsButtonComponent],
   templateUrl: './org-events-dashboard.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrgEventsDashboardComponent {
   // === Private injections ===
@@ -32,25 +33,26 @@ export class OrgEventsDashboardComponent {
   private readonly platformId = inject(PLATFORM_ID);
 
   // === Template constants ===
-  protected readonly tabs = ORG_EVENTS_TABS;
-  protected readonly statusOptions = ORG_EVENTS_STATUS_OPTIONS;
+  public readonly tabs = ORG_EVENTS_TABS;
+  public readonly statusOptions = ORG_EVENTS_STATUS_OPTIONS;
 
   // === WritableSignals ===
-  protected readonly activeStatFilter = signal<OrgEventStatFilterId | null>(null);
-  protected readonly searchTerm = signal('');
-  protected readonly selectedStatus = signal<string | null>(null);
+  // activeStatFilter drives card highlight + aria-pressed; filter wiring to the events table arrives in LFXV2-1899
+  public readonly activeStatFilter = signal<OrgEventStatFilterId | null>(null);
+  public readonly searchTerm = signal('');
+  public readonly selectedStatus = signal<string | null>(null);
 
   // === Computed / toSignal ===
-  protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
-  protected readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
-  protected readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
+  public readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
+  public readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
+  public readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
 
-  // === Protected methods ===
-  protected applyEventsStatFilter(id: OrgEventStatFilterId): void {
+  // === Public methods ===
+  public applyEventsStatFilter(id: OrgEventStatFilterId): void {
     this.activeStatFilter.set(this.activeStatFilter() === id ? null : id);
   }
 
-  protected switchTab(tabId: OrgEventsTabId): void {
+  public switchTab(tabId: OrgEventsTabId): void {
     if (tabId === this.activeTab()) {
       return;
     }
@@ -62,7 +64,7 @@ export class OrgEventsDashboardComponent {
     });
   }
 
-  protected onTabKeydown(event: KeyboardEvent): void {
+  public onTabKeydown(event: KeyboardEvent): void {
     const ids = this.tabs.map((t) => t.id);
     const idx = ids.indexOf(this.activeTab());
     let next: number | null = null;

--- a/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
@@ -11,6 +11,9 @@ import { FeatureFlagService } from '../services/feature-flag.service';
 
 /** CanMatch guard for /org/* — waits for the feature-flag client to initialise so deep links don't race the async init. */
 export const orgLensEnabledGuard: CanMatchFn = async () => {
+  // TODO: remove this local-dev bypass before committing — restore LD flag check below
+  return true;
+
   const featureFlagService = inject(FeatureFlagService);
   const router = inject(Router);
 

--- a/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
@@ -11,9 +11,6 @@ import { FeatureFlagService } from '../services/feature-flag.service';
 
 /** CanMatch guard for /org/* — waits for the feature-flag client to initialise so deep links don't race the async init. */
 export const orgLensEnabledGuard: CanMatchFn = async () => {
-  // TODO: remove this local-dev bypass before committing — restore LD flag check below
-  return true;
-
   const featureFlagService = inject(FeatureFlagService);
   const router = inject(Router);
 

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -12,9 +12,12 @@ import {
   GetEventRequestsParams,
   GetEventsParams,
   GetMyEventsParams,
+  GetOrgEventsParams,
   GetUpcomingCountriesResponse,
   MyEventOrganizationsResponse,
   MyEventsResponse,
+  OrgEventsResponse,
+  OrgEventsSummary,
   OrgSearchResponse,
   TravelFundApplication,
   TravelFundApplicationResponse,
@@ -126,6 +129,23 @@ export class EventsService {
     const params = new HttpParams().set('name', name);
 
     return this.http.get<OrgSearchResponse>('/api/events/search-organizations', { params });
+  }
+
+  public getOrgEventsSummary(accountId: string): Observable<OrgEventsSummary> {
+    return this.http.get<OrgEventsSummary>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events/summary`);
+  }
+
+  public getOrgEvents(accountId: string, params: GetOrgEventsParams = {}): Observable<OrgEventsResponse> {
+    let httpParams = new HttpParams();
+
+    if (params.isPast !== undefined) httpParams = httpParams.set('isPast', String(params.isPast));
+    if (params.searchQuery) httpParams = httpParams.set('searchQuery', params.searchQuery);
+    if (params.status) httpParams = httpParams.set('status', params.status);
+    if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
+    if (params.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
+    if (params.sortOrder) httpParams = httpParams.set('sortOrder', params.sortOrder);
+
+    return this.http.get<OrgEventsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events`, { params: httpParams });
   }
 
   public getCertificate(params: GetCertificateParams): Observable<Blob> {

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -135,6 +135,7 @@ export class EventsService {
     return this.http.get<OrgEventsSummary>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events/summary`);
   }
 
+  // Called by the upcoming/past events table — wired in LFXV2-1899.
   public getOrgEvents(accountId: string, params: GetOrgEventsParams = {}): Observable<OrgEventsResponse> {
     let httpParams = new HttpParams();
 

--- a/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
@@ -32,7 +32,7 @@ export class OrgLensEventsController {
         throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events_summary' });
       }
 
-      const summary = await this.service.getOrgEventsSummary(req, accountId, userEmail);
+      const summary = await this.service.getOrgEventsSummary(req, accountId);
 
       logger.success(req, 'get_org_lens_events_summary', startTime, { account_id: accountId });
 

--- a/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, SALESFORCE_ACCOUNT_ID_PATTERN } from '@lfx-one/shared/constants';
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, SALESFORCE_ACCOUNT_ID_PATTERN, VALID_ORG_EVENT_STATUS_VALUES } from '@lfx-one/shared/constants';
 import type { GetOrgEventsOptions } from '@lfx-one/shared/interfaces';
 import type { NextFunction, Request, Response } from 'express';
 
@@ -27,8 +27,7 @@ export class OrgLensEventsController {
     try {
       this.assertAccountId(accountId, 'get_org_lens_events_summary');
 
-      const userEmail = getEffectiveEmail(req);
-      if (!userEmail) {
+      if (!getEffectiveEmail(req)) {
         throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events_summary' });
       }
 
@@ -56,20 +55,22 @@ export class OrgLensEventsController {
         throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events' });
       }
 
-      const rawPageSize = parseInt(String(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE), 10);
-      const rawOffset = parseInt(String(req.query['offset'] ?? 0), 10);
+      const rawPageSize = Number(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE);
+      const rawOffset = Number(req.query['offset'] ?? 0);
       const rawSortOrder = String(req.query['sortOrder'] ?? 'ASC').toUpperCase();
       const rawIsPast = req.query['isPast'];
+      const rawStatus = getStringQueryParam(req, 'status');
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
       const sortOrder = rawSortOrder === 'DESC' ? 'DESC' : 'ASC';
-      const isPast = rawIsPast === 'true' ? true : false;
+      const isPast = rawIsPast === 'true';
+      const status = rawStatus && VALID_ORG_EVENT_STATUS_VALUES.has(rawStatus) ? rawStatus : null;
 
       const options: GetOrgEventsOptions = {
         isPast,
         searchQuery: getStringQueryParam(req, 'searchQuery'),
-        status: getStringQueryParam(req, 'status') ?? null,
+        status,
         pageSize,
         offset,
         sortOrder,

--- a/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
@@ -1,0 +1,101 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, SALESFORCE_ACCOUNT_ID_PATTERN } from '@lfx-one/shared/constants';
+import type { GetOrgEventsOptions } from '@lfx-one/shared/interfaces';
+import type { NextFunction, Request, Response } from 'express';
+
+import { AuthenticationError, ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
+import { logger } from '../services/logger.service';
+import { OrgLensEventsService } from '../services/org-lens-events.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
+
+/** HTTP boundary for GET /api/orgs/:accountId/lens/events. */
+export class OrgLensEventsController {
+  private readonly service: OrgLensEventsService;
+
+  public constructor() {
+    this.service = new OrgLensEventsService();
+  }
+
+  /** GET /api/orgs/:accountId/lens/events/summary */
+  public async getOrgEventsSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_events_summary', { account_id: accountId });
+
+    try {
+      this.assertAccountId(accountId, 'get_org_lens_events_summary');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events_summary' });
+      }
+
+      const summary = await this.service.getOrgEventsSummary(req, accountId, userEmail);
+
+      logger.success(req, 'get_org_lens_events_summary', startTime, { account_id: accountId });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:accountId/lens/events */
+  public async getOrgEvents(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_events', { account_id: accountId });
+
+    try {
+      this.assertAccountId(accountId, 'get_org_lens_events');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events' });
+      }
+
+      const rawPageSize = parseInt(String(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE), 10);
+      const rawOffset = parseInt(String(req.query['offset'] ?? 0), 10);
+      const rawSortOrder = String(req.query['sortOrder'] ?? 'ASC').toUpperCase();
+      const rawIsPast = req.query['isPast'];
+
+      const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
+      const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+      const sortOrder = rawSortOrder === 'DESC' ? 'DESC' : 'ASC';
+      const isPast = rawIsPast === 'true' ? true : false;
+
+      const options: GetOrgEventsOptions = {
+        isPast,
+        searchQuery: getStringQueryParam(req, 'searchQuery'),
+        status: getStringQueryParam(req, 'status') ?? null,
+        pageSize,
+        offset,
+        sortOrder,
+      };
+
+      const response = await this.service.getOrgEvents(req, accountId, userEmail, options);
+
+      logger.success(req, 'get_org_lens_events', startTime, {
+        account_id: accountId,
+        result_count: response.data.length,
+        total: response.total,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private assertAccountId(accountId: string | undefined, operation: string): asserts accountId is string {
+    if (!accountId || typeof accountId !== 'string') {
+      throw ServiceValidationError.forField('accountId', 'accountId path parameter is required', { operation });
+    }
+    if (!SALESFORCE_ACCOUNT_ID_PATTERN.test(accountId)) {
+      throw ServiceValidationError.forField('accountId', 'Invalid Salesforce accountId format', { operation });
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import { OrgIdentityController } from '../controllers/org-identity.controller';
 import { OrgLensBoardCommitteeController } from '../controllers/org-lens-board-committee.controller';
 import { OrgLensDocumentsController } from '../controllers/org-lens-documents.controller';
+import { OrgLensEventsController } from '../controllers/org-lens-events.controller';
 import { OrgLensFoundationsController } from '../controllers/org-lens-foundations.controller';
 import { OrgLensKeyContactsController } from '../controllers/org-lens-key-contacts.controller';
 import { OrgLensMembershipsController } from '../controllers/org-lens-memberships.controller';
@@ -14,6 +15,7 @@ import { OrgLensPeopleController } from '../controllers/org-lens-people.controll
 function buildOrgsRouter(): Router {
   const router = Router();
   const orgLensFoundationsController = new OrgLensFoundationsController();
+  const orgLensEventsController = new OrgLensEventsController();
   const orgLensMembershipsController = new OrgLensMembershipsController();
   const orgLensBoardCommitteeController = new OrgLensBoardCommitteeController();
   const orgLensDocumentsController = new OrgLensDocumentsController();
@@ -29,6 +31,10 @@ function buildOrgsRouter(): Router {
 
   // Spec 024 (uuid-only): all org-lens routes key off `:orgUid`.
   router.get('/:orgUid/lens/foundations-and-projects', (req, res, next) => orgLensFoundationsController.getFoundationsAndProjects(req, res, next));
+  // Spec (LFXV2-1898) — Events page keys off the Salesforce accountId (not the b2b_org uuid), so these routes
+  // intentionally use `:accountId`. /events/summary MUST be registered before /events so Express matches the more-specific path first.
+  router.get('/:accountId/lens/events/summary', (req, res, next) => orgLensEventsController.getOrgEventsSummary(req, res, next));
+  router.get('/:accountId/lens/events', (req, res, next) => orgLensEventsController.getOrgEvents(req, res, next));
   router.get('/:orgUid/lens/memberships/active', (req, res, next) => orgLensMembershipsController.getActiveMemberships(req, res, next));
   router.get('/:orgUid/lens/memberships/expired', (req, res, next) => orgLensMembershipsController.getExpiredMemberships(req, res, next));
   router.get('/:orgUid/lens/memberships/discover', (req, res, next) => orgLensMembershipsController.getDiscoverOpportunities(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -1,0 +1,211 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { GetOrgEventsOptions, OrgEvent, OrgEventsResponse, OrgEventsSummary } from '@lfx-one/shared/interfaces';
+import { formatDateToUTC } from '@lfx-one/shared/utils';
+import type { Request } from 'express';
+
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+
+/** Raw row returned by the org upcoming/past events Snowflake query. */
+interface OrgEventRow {
+  EVENT_ID: string;
+  EVENT_NAME: string;
+  FOUNDATION: string | null;
+  EVENT_START_DATE: Date | string | null;
+  EVENT_END_DATE: Date | string | null;
+  EVENT_LOCATION: string | null;
+  EVENT_CITY: string | null;
+  EVENT_COUNTRY: string | null;
+  EVENT_URL: string | null;
+  EVENT_REGISTRATION_URL: string | null;
+  ORG_ATTENDEE_COUNT: number;
+  IS_REGISTERED: boolean;
+  TOTAL_RECORDS: number;
+}
+
+/** Service for org-lens event list endpoints — queries org employees' event footprint via Snowflake. */
+export class OrgLensEventsService {
+  private readonly snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  /** GET /api/orgs/:accountId/lens/events — paginated list of events for the org. */
+  public async getOrgEvents(req: Request, accountId: string, userEmail: string, options: GetOrgEventsOptions): Promise<OrgEventsResponse> {
+    const { isPast, searchQuery, status, pageSize, offset, sortOrder } = options;
+
+    logger.debug(req, 'get_org_lens_events', 'Building org events query', {
+      account_id: accountId,
+      is_past: isPast,
+      has_search: !!searchQuery,
+      status,
+      page_size: pageSize,
+      offset,
+    });
+
+    const searchQueryFilter = searchQuery ? 'AND o.EVENT_NAME ILIKE ?' : '';
+    let statusFilter = '';
+    if (status === 'registered') {
+      statusFilter = 'AND u.EVENT_ID IS NOT NULL';
+    } else if (status === 'not-registered') {
+      statusFilter = 'AND u.EVENT_ID IS NULL';
+    }
+
+    const isPastCondition = isPast ? 'TRUE' : 'FALSE';
+
+    const sql = `
+      WITH account AS (
+        SELECT ACCOUNT_NAME
+        FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT
+        WHERE ACCOUNT_ID = ?
+        LIMIT 1
+      ),
+      org_events AS (
+        SELECT
+          er.EVENT_ID,
+          er.EVENT_NAME,
+          er.PROJECT_NAME AS FOUNDATION,
+          er.EVENT_START_DATE,
+          er.EVENT_END_DATE,
+          er.EVENT_LOCATION,
+          er.EVENT_CITY,
+          er.EVENT_COUNTRY,
+          er.EVENT_URL,
+          er.EVENT_REGISTRATION_URL,
+          COUNT(DISTINCT er.USER_EMAIL) AS ORG_ATTENDEE_COUNT
+        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS er
+        JOIN account a ON UPPER(er.ACCOUNT_NAME) = UPPER(a.ACCOUNT_NAME)
+        WHERE er.IS_PAST_EVENT = ${isPastCondition}
+          AND er.REGISTRATION_STATUS = 'Accepted'
+        GROUP BY
+          er.EVENT_ID, er.EVENT_NAME, er.PROJECT_NAME,
+          er.EVENT_START_DATE, er.EVENT_END_DATE,
+          er.EVENT_LOCATION, er.EVENT_CITY, er.EVENT_COUNTRY,
+          er.EVENT_URL, er.EVENT_REGISTRATION_URL
+      ),
+      user_reg AS (
+        SELECT EVENT_ID
+        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
+        WHERE USER_EMAIL = ?
+          AND IS_PAST_EVENT = ${isPastCondition}
+          AND REGISTRATION_STATUS = 'Accepted'
+      )
+      SELECT
+        o.EVENT_ID,
+        o.EVENT_NAME,
+        o.FOUNDATION,
+        o.EVENT_START_DATE,
+        o.EVENT_END_DATE,
+        o.EVENT_LOCATION,
+        o.EVENT_CITY,
+        o.EVENT_COUNTRY,
+        o.EVENT_URL,
+        o.EVENT_REGISTRATION_URL,
+        o.ORG_ATTENDEE_COUNT,
+        (u.EVENT_ID IS NOT NULL) AS IS_REGISTERED,
+        COUNT(*) OVER() AS TOTAL_RECORDS
+      FROM org_events o
+      LEFT JOIN user_reg u ON o.EVENT_ID = u.EVENT_ID
+      WHERE 1=1
+        ${searchQueryFilter}
+        ${statusFilter}
+      ORDER BY o.EVENT_START_DATE ${sortOrder}
+      LIMIT ${pageSize} OFFSET ${offset}
+    `;
+
+    const binds: string[] = [accountId, userEmail];
+    if (searchQuery) binds.push(`%${searchQuery}%`);
+
+    let result;
+    try {
+      result = await this.snowflakeService.execute<OrgEventRow>(sql, binds);
+    } catch (error) {
+      logger.warning(req, 'get_org_lens_events', 'Snowflake query failed, returning empty events', {
+        error: error instanceof Error ? error.message : String(error),
+        account_id: accountId,
+      });
+      return { data: [], total: 0, pageSize, offset };
+    }
+
+    const total = result.rows.length > 0 ? result.rows[0].TOTAL_RECORDS : 0;
+    const data = result.rows.map((row) => this.mapRowToOrgEvent(row));
+
+    logger.debug(req, 'get_org_lens_events', 'Fetched org events', { count: data.length, total });
+
+    return { data, total, pageSize, offset };
+  }
+
+  /** GET /api/orgs/:accountId/lens/events/summary — total / past / registered counts for the stat strip. */
+  public async getOrgEventsSummary(req: Request, accountId: string, userEmail: string): Promise<OrgEventsSummary> {
+    logger.debug(req, 'get_org_lens_events_summary', 'Building org events summary query', { account_id: accountId });
+
+    const sql = `
+      WITH account AS (
+        SELECT ACCOUNT_NAME
+        FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT
+        WHERE ACCOUNT_ID = ?
+        LIMIT 1
+      )
+      SELECT
+        COUNT(DISTINCT er.EVENT_ID)                                              AS TOTAL_EVENTS,
+        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = TRUE THEN er.EVENT_ID END)  AS PAST_EVENTS,
+        (
+          SELECT COUNT(DISTINCT EVENT_ID)
+          FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
+          WHERE USER_EMAIL = ?
+            AND REGISTRATION_STATUS = 'Accepted'
+        )                                                                        AS REGISTERED_EVENTS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS er
+      JOIN account a ON UPPER(er.ACCOUNT_NAME) = UPPER(a.ACCOUNT_NAME)
+      WHERE er.REGISTRATION_STATUS = 'Accepted'
+    `;
+
+    interface SummaryRow {
+      TOTAL_EVENTS: number;
+      PAST_EVENTS: number;
+      REGISTERED_EVENTS: number;
+    }
+
+    let result;
+    try {
+      result = await this.snowflakeService.execute<SummaryRow>(sql, [accountId, userEmail]);
+    } catch (error) {
+      logger.warning(req, 'get_org_lens_events_summary', 'Snowflake query failed, returning zero counts', {
+        error: error instanceof Error ? error.message : String(error),
+        account_id: accountId,
+      });
+      return { totalEvents: 0, pastEvents: 0, registeredEvents: 0 };
+    }
+
+    const row = result.rows[0];
+    const summary: OrgEventsSummary = {
+      totalEvents: row?.TOTAL_EVENTS ?? 0,
+      pastEvents: row?.PAST_EVENTS ?? 0,
+      registeredEvents: row?.REGISTERED_EVENTS ?? 0,
+    };
+
+    logger.debug(req, 'get_org_lens_events_summary', 'Fetched org events summary', { ...summary });
+
+    return summary;
+  }
+
+  private mapRowToOrgEvent(row: OrgEventRow): OrgEvent {
+    return {
+      eventId: row.EVENT_ID,
+      eventName: row.EVENT_NAME,
+      foundation: row.FOUNDATION ?? null,
+      eventStartDate: formatDateToUTC(row.EVENT_START_DATE),
+      eventEndDate: row.EVENT_END_DATE ? formatDateToUTC(row.EVENT_END_DATE) : null,
+      eventLocation: row.EVENT_LOCATION ?? null,
+      eventCity: row.EVENT_CITY ?? null,
+      eventCountry: row.EVENT_COUNTRY ?? null,
+      eventUrl: row.EVENT_URL ?? null,
+      eventRegistrationUrl: row.EVENT_REGISTRATION_URL ?? null,
+      orgAttendeeCount: row.ORG_ATTENDEE_COUNT || 0,
+      isRegistered: !!row.IS_REGISTERED,
+    };
+  }
+}

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -138,8 +138,8 @@ export class OrgLensEventsService {
     return { data, total, pageSize, offset };
   }
 
-  /** GET /api/orgs/:accountId/lens/events/summary — total / past / registered counts for the stat strip. */
-  public async getOrgEventsSummary(req: Request, accountId: string, userEmail: string): Promise<OrgEventsSummary> {
+  /** GET /api/orgs/:accountId/lens/events/summary — org-wide total / past / upcoming counts for the stat strip. */
+  public async getOrgEventsSummary(req: Request, accountId: string): Promise<OrgEventsSummary> {
     logger.debug(req, 'get_org_lens_events_summary', 'Building org events summary query', { account_id: accountId });
 
     const sql = `
@@ -150,14 +150,9 @@ export class OrgLensEventsService {
         LIMIT 1
       )
       SELECT
-        COUNT(DISTINCT er.EVENT_ID)                                              AS TOTAL_EVENTS,
-        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = TRUE THEN er.EVENT_ID END)  AS PAST_EVENTS,
-        (
-          SELECT COUNT(DISTINCT EVENT_ID)
-          FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-          WHERE USER_EMAIL = ?
-            AND REGISTRATION_STATUS = 'Accepted'
-        )                                                                        AS REGISTERED_EVENTS
+        COUNT(DISTINCT er.EVENT_ID)                                               AS TOTAL_EVENTS,
+        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = TRUE  THEN er.EVENT_ID END)  AS PAST_EVENTS,
+        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = FALSE THEN er.EVENT_ID END)  AS UPCOMING_EVENTS
       FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS er
       JOIN account a ON UPPER(er.ACCOUNT_NAME) = UPPER(a.ACCOUNT_NAME)
       WHERE er.REGISTRATION_STATUS = 'Accepted'
@@ -166,25 +161,25 @@ export class OrgLensEventsService {
     interface SummaryRow {
       TOTAL_EVENTS: number;
       PAST_EVENTS: number;
-      REGISTERED_EVENTS: number;
+      UPCOMING_EVENTS: number;
     }
 
     let result;
     try {
-      result = await this.snowflakeService.execute<SummaryRow>(sql, [accountId, userEmail]);
+      result = await this.snowflakeService.execute<SummaryRow>(sql, [accountId]);
     } catch (error) {
       logger.warning(req, 'get_org_lens_events_summary', 'Snowflake query failed, returning zero counts', {
         error: error instanceof Error ? error.message : String(error),
         account_id: accountId,
       });
-      return { totalEvents: 0, pastEvents: 0, registeredEvents: 0 };
+      return { totalEvents: 0, pastEvents: 0, upcomingEvents: 0 };
     }
 
     const row = result.rows[0];
     const summary: OrgEventsSummary = {
       totalEvents: row?.TOTAL_EVENTS ?? 0,
       pastEvents: row?.PAST_EVENTS ?? 0,
-      registeredEvents: row?.REGISTERED_EVENTS ?? 0,
+      upcomingEvents: row?.UPCOMING_EVENTS ?? 0,
     };
 
     logger.debug(req, 'get_org_lens_events_summary', 'Fetched org events summary', { ...summary });

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -95,6 +95,8 @@ export class OrgLensEventsService {
       WHERE 1=1
         ${searchQueryFilter}
         ${statusFilter}
+      -- pageSize, offset, and sortOrder are pre-validated by the controller (numeric bounds + allowlist);
+      -- structural keywords cannot be bound via Snowflake ? params, so they are interpolated here.
       ORDER BY o.EVENT_START_DATE ${sortOrder}
       LIMIT ${pageSize} OFFSET ${offset}
     `;

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -1,29 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { GetOrgEventsOptions, OrgEvent, OrgEventsResponse, OrgEventsSummary } from '@lfx-one/shared/interfaces';
+import type { GetOrgEventsOptions, OrgEvent, OrgEventRow, OrgEventsResponse, OrgEventsSummary, OrgEventsSummaryRow } from '@lfx-one/shared/interfaces';
 import { formatDateToUTC } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
-
-/** Raw row returned by the org upcoming/past events Snowflake query. */
-interface OrgEventRow {
-  EVENT_ID: string;
-  EVENT_NAME: string;
-  FOUNDATION: string | null;
-  EVENT_START_DATE: Date | string | null;
-  EVENT_END_DATE: Date | string | null;
-  EVENT_LOCATION: string | null;
-  EVENT_CITY: string | null;
-  EVENT_COUNTRY: string | null;
-  EVENT_URL: string | null;
-  EVENT_REGISTRATION_URL: string | null;
-  ORG_ATTENDEE_COUNT: number;
-  IS_REGISTERED: boolean;
-  TOTAL_RECORDS: number;
-}
 
 /** Service for org-lens event list endpoints — queries org employees' event footprint via Snowflake. */
 export class OrgLensEventsService {
@@ -158,15 +141,9 @@ export class OrgLensEventsService {
       WHERE er.REGISTRATION_STATUS = 'Accepted'
     `;
 
-    interface SummaryRow {
-      TOTAL_EVENTS: number;
-      PAST_EVENTS: number;
-      UPCOMING_EVENTS: number;
-    }
-
     let result;
     try {
-      result = await this.snowflakeService.execute<SummaryRow>(sql, [accountId]);
+      result = await this.snowflakeService.execute<OrgEventsSummaryRow>(sql, [accountId]);
     } catch (error) {
       logger.warning(req, 'get_org_lens_events_summary', 'Snowflake query failed, returning zero counts', {
         error: error instanceof Error ? error.message : String(error),

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -59,6 +59,7 @@ export * from './foundation-projects.constants';
 export * from './marketing-impact.constants';
 export * from './org-people.constants';
 export * from './org-people-key-contacts.constants';
+export * from './org-events.constants';
 export * from './individual-enrollment-catalog';
 export * from './newsletter.constants';
 export * from './vote.constants';

--- a/packages/shared/src/constants/org-events.constants.ts
+++ b/packages/shared/src/constants/org-events.constants.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { FilterOption } from '../interfaces';
+import type { OrgEventsTabConfig, OrgEventsTabId } from '../interfaces/org-events.interface';
+
+/** Org Events page tabs in visible order (`upcoming` is the default). */
+export const ORG_EVENTS_TABS: readonly OrgEventsTabConfig[] = [
+  { id: 'upcoming', label: 'Upcoming', icon: 'fa-light fa-calendar-plus' },
+  { id: 'past', label: 'Past', icon: 'fa-light fa-calendar-check' },
+] as const;
+
+/** Default tab — URL drops `?tab=` when active to keep deep links clean. */
+export const DEFAULT_ORG_EVENTS_TAB_ID: OrgEventsTabId = 'upcoming';
+
+/** Derived from ORG_EVENTS_TABS; used to validate `?tab=` query-param input. */
+export const VALID_ORG_EVENTS_TAB_IDS: ReadonlySet<OrgEventsTabId> = new Set(ORG_EVENTS_TABS.map((t) => t.id));
+
+/** Status filter options for the Org Events filter bar. */
+export const ORG_EVENTS_STATUS_OPTIONS: FilterOption[] = [
+  { label: 'All Statuses', value: null },
+  { label: 'Not Registered', value: 'not-registered' },
+  { label: 'Registered', value: 'registered' },
+  { label: 'Attended', value: 'attended' },
+];

--- a/packages/shared/src/constants/org-events.constants.ts
+++ b/packages/shared/src/constants/org-events.constants.ts
@@ -21,5 +21,7 @@ export const ORG_EVENTS_STATUS_OPTIONS: FilterOption[] = [
   { label: 'All Statuses', value: null },
   { label: 'Not Registered', value: 'not-registered' },
   { label: 'Registered', value: 'registered' },
-  { label: 'Attended', value: 'attended' },
 ];
+
+/** Valid org event status values for server-side validation. */
+export const VALID_ORG_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'not-registered']);

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -180,6 +180,9 @@ export * from './org-people.interface';
 export * from './org-people-key-contacts.interface';
 export * from './org-people-key-contacts.internal.interface';
 
+// Org Events interfaces
+export * from './org-events.interface';
+
 // Newsletter interfaces
 export * from './newsletter.interface';
 

--- a/packages/shared/src/interfaces/org-events.interface.ts
+++ b/packages/shared/src/interfaces/org-events.interface.ts
@@ -7,7 +7,7 @@ import type { OffsetPaginatedResponse } from './api.interface';
 export type OrgEventsTabId = 'upcoming' | 'past';
 
 /** Stat-card filter identifier for the Org Events page. */
-export type OrgEventStatFilterId = 'total' | 'past' | 'registered';
+export type OrgEventStatFilterId = 'total' | 'past' | 'upcoming';
 
 /** Tab definition for the Org Events page. */
 export interface OrgEventsTabConfig {
@@ -49,7 +49,7 @@ export interface GetOrgEventsParams {
 export interface OrgEventsSummary {
   readonly totalEvents: number;
   readonly pastEvents: number;
-  readonly registeredEvents: number;
+  readonly upcomingEvents: number;
 }
 
 /** Backend options for OrgLensEventsService.getOrgEvents. */

--- a/packages/shared/src/interfaces/org-events.interface.ts
+++ b/packages/shared/src/interfaces/org-events.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { OffsetPaginatedResponse } from './api.interface';
+
 /** Tab identifier for the Org Events page tab strip. */
 export type OrgEventsTabId = 'upcoming' | 'past';
 
@@ -12,4 +14,50 @@ export interface OrgEventsTabConfig {
   readonly id: OrgEventsTabId;
   readonly label: string;
   readonly icon: string;
+}
+
+/** A single event in the org events list. */
+export interface OrgEvent {
+  readonly eventId: string;
+  readonly eventName: string;
+  readonly foundation: string | null;
+  readonly eventStartDate: string | null;
+  readonly eventEndDate: string | null;
+  readonly eventLocation: string | null;
+  readonly eventCity: string | null;
+  readonly eventCountry: string | null;
+  readonly eventUrl: string | null;
+  readonly eventRegistrationUrl: string | null;
+  readonly orgAttendeeCount: number;
+  readonly isRegistered: boolean;
+}
+
+/** Paginated response for org events. */
+export type OrgEventsResponse = OffsetPaginatedResponse<OrgEvent>;
+
+/** Frontend query params for GET /api/orgs/:accountId/lens/events. */
+export interface GetOrgEventsParams {
+  readonly isPast?: boolean;
+  readonly searchQuery?: string;
+  readonly status?: string | null;
+  readonly pageSize?: number;
+  readonly offset?: number;
+  readonly sortOrder?: 'ASC' | 'DESC';
+}
+
+/** Summary counts for the Org Events stat strip. */
+export interface OrgEventsSummary {
+  readonly totalEvents: number;
+  readonly pastEvents: number;
+  readonly registeredEvents: number;
+}
+
+/** Backend options for OrgLensEventsService.getOrgEvents. */
+export interface GetOrgEventsOptions {
+  readonly isPast: boolean;
+  readonly searchQuery?: string;
+  readonly status?: string | null;
+  readonly pageSize: number;
+  readonly offset: number;
+  readonly sortOrder: 'ASC' | 'DESC';
 }

--- a/packages/shared/src/interfaces/org-events.interface.ts
+++ b/packages/shared/src/interfaces/org-events.interface.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Tab identifier for the Org Events page tab strip. */
+export type OrgEventsTabId = 'upcoming' | 'past';
+
+/** Stat-card filter identifier for the Org Events page. */
+export type OrgEventStatFilterId = 'total' | 'past' | 'registered';
+
+/** Tab definition for the Org Events page. */
+export interface OrgEventsTabConfig {
+  readonly id: OrgEventsTabId;
+  readonly label: string;
+  readonly icon: string;
+}

--- a/packages/shared/src/interfaces/org-events.interface.ts
+++ b/packages/shared/src/interfaces/org-events.interface.ts
@@ -61,3 +61,27 @@ export interface GetOrgEventsOptions {
   readonly offset: number;
   readonly sortOrder: 'ASC' | 'DESC';
 }
+
+/** Raw row returned by the org upcoming/past events Snowflake query (backend query layer). */
+export interface OrgEventRow {
+  EVENT_ID: string;
+  EVENT_NAME: string;
+  FOUNDATION: string | null;
+  EVENT_START_DATE: Date | string | null;
+  EVENT_END_DATE: Date | string | null;
+  EVENT_LOCATION: string | null;
+  EVENT_CITY: string | null;
+  EVENT_COUNTRY: string | null;
+  EVENT_URL: string | null;
+  EVENT_REGISTRATION_URL: string | null;
+  ORG_ATTENDEE_COUNT: number;
+  IS_REGISTERED: boolean;
+  TOTAL_RECORDS: number;
+}
+
+/** Raw row returned by the org events summary Snowflake query (backend query layer). */
+export interface OrgEventsSummaryRow {
+  TOTAL_EVENTS: number;
+  PAST_EVENTS: number;
+  UPCOMING_EVENTS: number;
+}


### PR DESCRIPTION
Business case: show members of company which events their employees have attended or are registered to attend in the future. This shell provides navigation and summary stats. Future stories will fill in detail table for upcoming and past events, with way to register for relevant events.

This pull request introduces the new Organization Events Dashboard for the Org lens in the LFX One application. It adds both frontend and backend support for viewing an organization's event footprint, including summary statistics and tabbed navigation, and exposes new APIs to retrieve organization event data. The main changes include new Angular components, service methods, and server-side controllers and routes.

**Frontend Features:**

* Added the new `OrgEventsDashboardComponent` and its template, which provides a tabbed dashboard for organization events, summary stats, search/filter controls, and placeholder panels for upcoming features. [[1]](diffhunk://#diff-d237d5c3018efde69d36f09228df2c98873e0b78472b3169170bc31033480743R1-R176) [[2]](diffhunk://#diff-d6145f86737bb3d725ee178c452a52f5703759de2845ab7b24dd4d9aa5c4f6b0R1-R103)
* Updated the main routes and events dashboard logic to load and display the organization events dashboard when in the Org lens. [[1]](diffhunk://#diff-7024cae7d388ac3e48ad5ae104409af252d7c706b9f5970e59fb8b77f3fea169L137-R137) [[2]](diffhunk://#diff-910d7bd762bc77a12e934b75089466ca08e59250a9c0610052f0b103ef4ae428L4-R6) [[3]](diffhunk://#diff-bdc415e9a9a5a52b824e6300150901017ae81481c52a03632e522a04dcd9a9a6R8-R19)
* Extended the `EventsService` with methods to fetch organization events and event summaries from the backend. [[1]](diffhunk://#diff-4b3663733aa5890ec7281a51dda9d99c2b64545e0fe657329267d4139b70d102R15-R20) [[2]](diffhunk://#diff-4b3663733aa5890ec7281a51dda9d99c2b64545e0fe657329267d4139b70d102R134-R150)

**Backend/API Additions:**

* Added a new `OrgLensEventsController` with endpoints for `/api/orgs/:accountId/lens/events` and `/api/orgs/:accountId/lens/events/summary`, including input validation and authentication checks.
* Registered the new controller and endpoints in the organization routes. [[1]](diffhunk://#diff-e4f498bc90d6e43673ff9793cf428207ee6b965971abdd0aee2e4d445ca85cbaR9-R17) [[2]](diffhunk://#diff-e4f498bc90d6e43673ff9793cf428207ee6b965971abdd0aee2e4d445ca85cbaR47-R52)

**Scope notes (for reviewers):**

* **This is a shell.** The Upcoming and Past tab panels render a "Coming soon" empty state — the detail table (event name, foundation, date, location, org/total attendees, speakers, sponsor) is wired in a follow-up story (LFXV2-1899). The stat-card filter mechanics (`applyEventsStatFilter`) and the tab + status + search signals are all in place and compose; they'll drive the table once it lands.
* **Leaderboards were intentionally dropped from this shell** (commit `eacde270`). The original ticket listed Attendee and Speaker leaderboard cards; they are deferred to a later story rather than shipped as empty placeholders here. Not an omission — a scope decision to keep this PR focused on the page shell + summary stats.
* **Stat strip is live**, not placeholder: Upcoming / Past / Total counts are populated from Snowflake via the new `/api/orgs/:accountId/lens/events/summary` endpoint; values render `—` until the summary resolves.
* **`EventsService.getOrgEvents()` + `GetOrgEventsParams` are LFXV2-1899 groundwork.** The backend list endpoint (`/:accountId/lens/events`) is fully wired and reachable, but the frontend method has no caller in this shell yet — the upcoming/past events table that consumes it lands in LFXV2-1899. An inline comment on the method marks this intent.
