### PR TITLE
feat(crowdfunding): display payment methods list and newly added cards

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/add-payment-card-dialog/add-payment-card-dialog.component.ts
@@ -9,6 +9,7 @@ import type { StripeCardCvcElement, StripeCardExpiryElement, StripeCardNumberEle
 
 import { ButtonComponent } from '@components/button/button.component';
 import { STRIPE_ELEMENT_STYLE } from '@lfx-one/shared/constants';
+import { AddPaymentCardResult } from '@lfx-one/shared/interfaces';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { CrowdfundingService } from '@services/crowdfunding.service';
 import { StripeService } from '@services/stripe.service';
@@ -102,7 +103,7 @@ export class AddPaymentCardDialogComponent implements OnDestroy {
 
       const saved = await firstValueFrom(this.crowdfundingService.savePaymentMethod(paymentMethod.id));
 
-      this.dialogRef.close({ added: true, paymentMethod: saved });
+      this.dialogRef.close({ added: true, paymentMethod: saved } satisfies AddPaymentCardResult);
     } catch (err) {
       this.stripeError.set(extractErrorMessage(err, 'Failed to save payment method. Please try again.'));
     } finally {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -4,6 +4,7 @@
 import { Component, DestroyRef, inject, input, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AddPaymentCardResult, PaymentMethod } from '@lfx-one/shared/interfaces';
+import { take } from 'rxjs/operators';
 import { DialogService } from 'primeng/dynamicdialog';
 import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
 import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
@@ -37,7 +38,7 @@ export class PaymentMethodsComponent {
       return;
     }
 
-    ref.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((result: AddPaymentCardResult | undefined) => {
+    ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((result: AddPaymentCardResult | undefined) => {
       if (result?.added && result.paymentMethod) {
         this.cardAdded.emit(result.paymentMethod);
       }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/payment-methods/payment-methods.component.ts
@@ -1,8 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject, input, output } from '@angular/core';
-import { PaymentMethod } from '@lfx-one/shared/interfaces';
+import { Component, DestroyRef, inject, input, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AddPaymentCardResult, PaymentMethod } from '@lfx-one/shared/interfaces';
 import { DialogService } from 'primeng/dynamicdialog';
 import { AddPaymentCardDialogComponent } from '../add-payment-card-dialog/add-payment-card-dialog.component';
 import { PaymentMethodCardComponent } from '../payment-method-card/payment-method-card.component';
@@ -16,18 +17,30 @@ import { PaymentMethodCardComponent } from '../payment-method-card/payment-metho
 })
 export class PaymentMethodsComponent {
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly methods = input.required<PaymentMethod[]>();
   public readonly removeCard = output<PaymentMethod>();
+  public readonly cardAdded = output<PaymentMethod>();
 
   protected openAddCardDialog(): void {
-    this.dialogService.open(AddPaymentCardDialogComponent, {
+    const ref = this.dialogService.open(AddPaymentCardDialogComponent, {
       header: 'Add Payment Card',
       width: '420px',
       modal: true,
       draggable: false,
       resizable: false,
       closeOnEscape: true,
+    });
+
+    if (!ref) {
+      return;
+    }
+
+    ref.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((result: AddPaymentCardResult | undefined) => {
+      if (result?.added && result.paymentMethod) {
+        this.cardAdded.emit(result.paymentMethod);
+      }
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -39,5 +39,5 @@
   </div>
 
   <!-- Payment methods -->
-  <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" />
+  <lfx-payment-methods [methods]="paymentMethods()" (cardAdded)="onCardAdded($event)" (removeCard)="onRemoveCard($event)" />
 </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } 
 import { toSignal } from '@angular/core/rxjs-interop';
 import { environment } from '@environments/environment';
 import { MyDonation, DonationStats, PaymentMethod, RecurringDonation, RecurringDonationsResponse } from '@lfx-one/shared/interfaces';
-import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_DONATION_STATS } from '@lfx-one/shared/constants';
+import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_DONATION_STATS, EMPTY_PAYMENT_METHODS } from '@lfx-one/shared/constants';
 import { CrowdfundingService } from '@app/shared/services/crowdfunding.service';
 import { DonationsStatsBarComponent } from './components/donations-stats-bar/donations-stats-bar.component';
 import { DonationHistoryTableComponent } from './components/donation-history-table/donation-history-table.component';
@@ -40,8 +40,9 @@ export class MyDonationsComponent {
   // ─── Complex Signals ──────────────────────────────────────────────────────
   protected readonly stats: Signal<DonationStats> = this.initStats();
   protected readonly recurringDonations: Signal<RecurringDonation[]> = this.initRecurringDonations();
-  private readonly paymentMethod: Signal<PaymentMethod | null> = this.initPaymentMethod();
-  protected readonly paymentMethods = computed(() => (this.paymentMethod() ? [this.paymentMethod()!] : []));
+  private readonly fetchedPaymentMethods: Signal<PaymentMethod[]> = this.initPaymentMethods();
+  private readonly addedPaymentMethods = signal<PaymentMethod[]>([]);
+  protected readonly paymentMethods = computed(() => [...this.fetchedPaymentMethods(), ...this.addedPaymentMethods()]);
   private readonly donationHistoryState: Signal<{ items: MyDonation[]; hasMore: boolean }> = this.initDonationHistory();
   protected readonly donationHistory = computed(() => this.donationHistoryState().items);
   protected readonly donationHistoryHasMore = computed(() => this.donationHistoryState().hasMore);
@@ -75,14 +76,18 @@ export class MyDonationsComponent {
     void donation;
   }
 
+  protected onCardAdded(card: PaymentMethod): void {
+    this.addedPaymentMethods.update((list) => [...list, card]);
+  }
+
   protected onRemoveCard(card: PaymentMethod): void {
     // TODO: call remove card API
     void card;
   }
 
   // ─── Private Initializers ─────────────────────────────────────────────────
-  private initPaymentMethod(): Signal<PaymentMethod | null> {
-    return toSignal(this.crowdfundingService.getMyPaymentMethod(), { initialValue: null });
+  private initPaymentMethods(): Signal<PaymentMethod[]> {
+    return toSignal(this.crowdfundingService.getMyPaymentMethods(), { initialValue: EMPTY_PAYMENT_METHODS });
   }
 
   private initStats(): Signal<DonationStats> {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -33,6 +33,7 @@ export class MyDonationsComponent {
   // ─── Simple WritableSignals ───────────────────────────────────────────────
   // TODO: derive from API response once cancelled-recurring concept is implemented
   protected readonly cancelledCount = signal(0);
+  private readonly addedPaymentMethods = signal<PaymentMethod[]>([]);
 
   // ─── Pagination Driver ────────────────────────────────────────────────────
   private readonly loadMore$ = new Subject<void>();
@@ -41,7 +42,6 @@ export class MyDonationsComponent {
   protected readonly stats: Signal<DonationStats> = this.initStats();
   protected readonly recurringDonations: Signal<RecurringDonation[]> = this.initRecurringDonations();
   private readonly fetchedPaymentMethods: Signal<PaymentMethod[]> = this.initPaymentMethods();
-  private readonly addedPaymentMethods = signal<PaymentMethod[]>([]);
   protected readonly paymentMethods = computed(() => [...this.fetchedPaymentMethods(), ...this.addedPaymentMethods()]);
   private readonly donationHistoryState: Signal<{ items: MyDonation[]; hasMore: boolean }> = this.initDonationHistory();
   protected readonly donationHistory = computed(() => this.donationHistoryState().items);

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -10,6 +10,7 @@ import {
   EMPTY_CROWDFUNDING_STATS,
   EMPTY_INITIATIVES_RESPONSE,
   EMPTY_MY_DONATIONS,
+  EMPTY_PAYMENT_METHODS,
   EMPTY_RECURRING_DONATIONS,
   EMPTY_TRANSACTION_LIST,
   EMPTY_DONATION_STATS,
@@ -59,8 +60,8 @@ export class CrowdfundingService {
     );
   }
 
-  public getMyPaymentMethod(): Observable<PaymentMethod | null> {
-    return this.http.get<PaymentMethod>('/api/crowdfunding/payment-method').pipe(catchError(() => of(null)));
+  public getMyPaymentMethods(): Observable<PaymentMethod[]> {
+    return this.http.get<PaymentMethod[]>('/api/crowdfunding/payment-method').pipe(catchError(() => of(EMPTY_PAYMENT_METHODS)));
   }
 
   // POST /api/crowdfunding/payment-method — mirrors the crowdfunding-app BFF payload: { paymentMethodId }.

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -72,29 +72,24 @@ export class CrowdfundingController {
   }
 
   // GET /api/crowdfunding/payment-method
-  public async getMyPaymentMethod(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const startTime = logger.startOperation(req, 'get_my_payment_method');
+  public async getMyPaymentMethods(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_my_payment_methods');
 
     try {
       const rawUsername = await getUsernameFromAuth(req);
 
       if (!rawUsername) {
         throw new AuthenticationError('User authentication required', {
-          operation: 'get_my_payment_method',
+          operation: 'get_my_payment_methods',
         });
       }
 
       const username = stripAuthPrefix(rawUsername);
-      const paymentMethod = await this.crowdfundingService.getMyPaymentMethod(req, username);
+      const paymentMethods = await this.crowdfundingService.getMyPaymentMethods(req, username);
 
-      if (!paymentMethod) {
-        res.status(404).json({ message: 'No payment method found' });
-        return;
-      }
+      logger.success(req, 'get_my_payment_methods', startTime, { count: paymentMethods.length });
 
-      logger.success(req, 'get_my_payment_method', startTime);
-
-      res.json(paymentMethod);
+      res.json(paymentMethods);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/mock-data/crowdfunding.mock.ts
+++ b/apps/lfx-one/src/server/mock-data/crowdfunding.mock.ts
@@ -170,13 +170,22 @@ export const MOCK_INITIATIVES: BackendInitiative[] = [
   },
 ];
 
-export const MOCK_PAYMENT_METHOD: PaymentMethod = {
-  paymentMethodId: 'pm_mock_1',
-  brand: 'Visa',
-  lastFour: '4567',
-  expiryMonth: 4,
-  expiryYear: 2026,
-};
+export const MOCK_PAYMENT_METHODS: PaymentMethod[] = [
+  {
+    paymentMethodId: 'pm_mock_1',
+    brand: 'Visa',
+    lastFour: '4567',
+    expiryMonth: 4,
+    expiryYear: 2026,
+  },
+  {
+    paymentMethodId: 'pm_mock_2',
+    brand: 'Mastercard',
+    lastFour: '8901',
+    expiryMonth: 9,
+    expiryYear: 2027,
+  },
+];
 
 export const MOCK_DONATION_STATS: DonationStats = {
   totalDonated: 1450,

--- a/apps/lfx-one/src/server/routes/crowdfunding.route.ts
+++ b/apps/lfx-one/src/server/routes/crowdfunding.route.ts
@@ -11,7 +11,7 @@ const router = Router();
 const crowdfundingController = new CrowdfundingController();
 
 router.post('/payment-method', (req, res, next) => crowdfundingController.saveMyPaymentMethod(req, res, next));
-router.get('/payment-method', (req, res, next) => crowdfundingController.getMyPaymentMethod(req, res, next));
+router.get('/payment-method', (req, res, next) => crowdfundingController.getMyPaymentMethods(req, res, next));
 router.get('/donation-stats', (req, res, next) => crowdfundingController.getMyDonationStats(req, res, next));
 router.get('/recurring-donations', (req, res, next) => crowdfundingController.getMyRecurringDonations(req, res, next));
 router.get('/my-donations', (req, res, next) => crowdfundingController.getMyDonations(req, res, next));

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -21,7 +21,7 @@ import {
   MOCK_DONATION_HISTORY,
   MOCK_DONATION_STATS,
   MOCK_INITIATIVES,
-  MOCK_PAYMENT_METHOD,
+  MOCK_PAYMENT_METHODS,
   MOCK_RECURRING_DONATIONS,
   MOCK_TRANSACTIONS,
 } from '../mock-data/crowdfunding.mock';
@@ -77,15 +77,12 @@ export class CrowdfundingService {
     return mapToInitiativeDetail(initiative);
   }
 
-  public async getMyPaymentMethod(req: Request, username: string): Promise<PaymentMethod | null> {
-    logger.debug(req, 'get_my_payment_method', 'Fetching payment method for user', { username });
+  public async getMyPaymentMethods(req: Request, username: string): Promise<PaymentMethod[]> {
+    logger.debug(req, 'get_my_payment_methods', 'Fetching payment methods for user', { username });
 
-    logger.debug(req, 'get_my_payment_method', 'Returning payment method', {
-      paymentMethodId: MOCK_PAYMENT_METHOD.paymentMethodId,
-      brand: MOCK_PAYMENT_METHOD.brand,
-    });
+    logger.debug(req, 'get_my_payment_methods', 'Returning payment methods', { count: MOCK_PAYMENT_METHODS.length });
 
-    return MOCK_PAYMENT_METHOD;
+    return MOCK_PAYMENT_METHODS;
   }
 
   // Mock for POST /api/crowdfunding/payment-method — replace with upstream proxy once the payment-method service is live.

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -9,6 +9,7 @@ import {
   DonationStats,
   InitiativesResponse,
   MyDonationsResponse,
+  PaymentMethod,
   RecurringDonationsResponse,
 } from '../interfaces/crowdfunding.interface';
 
@@ -68,3 +69,4 @@ export const EMPTY_TRANSACTION_STATE: { items: CrowdfundingTransaction[]; totalC
 export const EMPTY_MY_DONATIONS: MyDonationsResponse = { data: [], total: 0, pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset: 0 };
 export const EMPTY_RECURRING_DONATIONS: RecurringDonationsResponse = { data: [], total: 0, pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset: 0 };
 export const EMPTY_DONATION_STATS: DonationStats = { totalDonated: 0, initiativesSupported: 0, activeRecurringAmount: 0, activeRecurringCount: 0 };
+export const EMPTY_PAYMENT_METHODS: PaymentMethod[] = [];

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -250,6 +250,12 @@ export interface PaymentMethod {
   expiryYear: number;
 }
 
+/** Result emitted when AddPaymentCardDialogComponent closes after a successful add. */
+export interface AddPaymentCardResult {
+  added: boolean;
+  paymentMethod: PaymentMethod;
+}
+
 export interface InitiativeMenuItem {
   label?: string;
   icon?: string;


### PR DESCRIPTION
## Summary

  - Converts the payment-method read path from a single `PaymentMethod | null` to `PaymentMethod[]` across the full stack (server mock, controller, Express route, Angular service, and `MyDonationsComponent`), so
  users with more than one card see all of them.
  - Bridges the `AddPaymentCardDialogComponent` close payload to the UI: after a card is saved, `PaymentMethodsComponent` listens to `DynamicDialogRef.onClose`, emits a `cardAdded` output, and
  `MyDonationsComponent` appends the new card to a local `addedPaymentMethods` signal — no page reload or extra network call required.
  - Drops the GET 404 path for "no payment method found"; the endpoint now returns `200 []` for an empty list, which is semantically correct for a collection endpoint.
  - Adds `AddPaymentCardResult` interface to the shared package to type the dialog close payload, and `EMPTY_PAYMENT_METHODS` constant as the `catchError` / `initialValue` fallback.
  - Seeds the mock data with two cards (Visa + Mastercard) so the multi-card grid is exercised locally.

  ## Test plan

  - [ ] Navigate to My Donations → Payment Methods — confirm both mock cards render in the grid
  - [ ] Click "Add payment card", enter a Stripe test card (`4242 4242 4242 4242`, future expiry, any CVC), submit — confirm the new card appends to the grid immediately without a reload
  - [ ] Cancel / press Escape — confirm the list is unchanged
  - [ ] `yarn check-types && yarn lint:check && yarn build` all pass