### PR TITLE
docs(security): rewrite stewardship spec from first principles

### DIFF
--- a/docs/mockups/admin-stewardships.html
+++ b/docs/mockups/admin-stewardships.html
@@ -1,0 +1,636 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Osprey Program — Admin Dashboard Mockup</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif; color: #0f172a; font-size: 14px; line-height: 1.5; overflow: hidden; height: 100vh; background: #f8fafc; }
+
+  .shell { display: flex; height: 100vh; }
+
+  /* ── Lens Rail (L1) ── */
+  .rail { width: 64px; background: #1e3a5f; display: flex; flex-direction: column; align-items: center; padding: 24px 0; flex-shrink: 0; }
+  .rail-logo { width: 32px; height: 32px; margin-bottom: 16px; display: flex; align-items: center; justify-content: center; }
+  .rail-logo svg { width: 28px; height: 28px; }
+  .rail-divider { width: 24px; border-top: 1px solid rgba(255,255,255,0.35); margin-bottom: 12px; }
+  .rail-buttons { display: flex; flex-direction: column; align-items: center; gap: 12px; flex: 1; }
+  .rail-btn { display: flex; flex-direction: column; align-items: center; gap: 4px; width: 100%; cursor: pointer; transition: color 0.15s; color: rgba(191,219,254,0.75); background: none; border: none; font-family: inherit; padding: 0; }
+  .rail-btn:hover { color: white; }
+  .rail-btn.active { color: white; }
+  .rail-btn-icon { width: 40px; height: 40px; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-size: 18px; transition: background 0.15s; }
+  .rail-btn.active .rail-btn-icon { background: #3b82f6; }
+  .rail-btn:hover:not(.active) .rail-btn-icon { background: rgba(255,255,255,0.1); }
+  .rail-btn-label { font-size: 10px; font-weight: 500; line-height: 1; }
+  .rail-footer { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: auto; }
+  .rail-avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, #f97316, #ea580c); display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 600; cursor: pointer; border: 2px solid rgba(255,255,255,0.2); }
+
+  /* ── Nav Panel (L2) ── */
+  .nav-panel { width: 280px; background: white; border-right: 1px solid #e5e7eb; display: flex; flex-direction: column; flex-shrink: 0; }
+  .nav-scroll { display: flex; flex-direction: column; padding: 16px 0; height: 100%; min-height: 0; overflow-y: auto; }
+  .me-selector { padding: 0 16px; margin-bottom: 24px; }
+  .me-selector-inner { display: flex; gap: 12px; align-items: flex-start; padding: 12px; border-radius: 8px; }
+  .me-avatar { width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #f97316, #ea580c); display: flex; align-items: center; justify-content: center; color: white; font-size: 14px; font-weight: 600; flex-shrink: 0; }
+  .me-name { font-size: 16px; font-weight: 600; color: #111827; line-height: 1.25; letter-spacing: -0.01em; }
+  .me-role { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; padding: 1px 8px; border-radius: 10px; background: #fef3c7; color: #92400e; margin-top: 4px; }
+  .me-role i { font-size: 9px; }
+  .nav-items { display: flex; flex-direction: column; gap: 4px; padding: 0 16px; }
+  .nav-section { width: 100%; margin-top: 8px; }
+  .nav-section-header { display: flex; align-items: center; gap: 8px; padding: 6px 8px; }
+  .nav-section-label { font-size: 12px; font-weight: 500; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap; }
+  .nav-section-line { flex: 1; height: 1px; background: #e5e7eb; }
+  .nav-section-items { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
+  .nav-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; transition: all 0.12s; font-size: 16px; color: #4b5563; font-weight: 400; text-decoration: none; border: none; background: none; width: 100%; text-align: left; font-family: inherit; }
+  .nav-item:hover { background: #f9fafb; }
+  .nav-item.active { background: #dbeafe; font-weight: 500; color: #030712; }
+  .nav-item-icon { width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 15px; }
+  .nav-item .badge { margin-left: auto; font-size: 12px; font-weight: 500; color: #3b82f6; background: #eff6ff; padding: 1px 8px; border-radius: 10px; }
+  /* Admin-highlighted nav item */
+  .nav-item.admin-active { background: #fef3c7; font-weight: 500; color: #78350f; }
+  .nav-item .admin-badge { margin-left: auto; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 6px; border-radius: 3px; background: rgba(146,64,14,0.12); color: #92400e; }
+
+  /* ── Main Content ── */
+  .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
+  .topbar { height: 48px; background: white; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; padding: 0 24px; flex-shrink: 0; gap: 12px; }
+  .topbar-breadcrumb { font-size: 13px; color: #9ca3af; }
+  .topbar-breadcrumb span { color: #0f172a; font-weight: 500; }
+  .topbar-spacer { flex: 1; }
+  .topbar-action { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 13px; color: #4b5563; cursor: pointer; background: white; transition: all 0.12s; }
+  .topbar-action:hover { background: #f9fafb; border-color: #d1d5db; }
+  .topbar-action-primary { display: flex; align-items: center; gap: 6px; padding: 6px 14px; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; color: white; background: #3b82f6; cursor: pointer; transition: all 0.12s; font-family: inherit; }
+  .topbar-action-primary:hover { background: #2563eb; }
+
+  .page { flex: 1; overflow-y: auto; padding: 24px; }
+  .page-header { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 24px; }
+  .page-title { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 4px; }
+  .page-subtitle { font-size: 13px; color: #9ca3af; }
+  .page-title-row { display: flex; align-items: center; gap: 10px; }
+  .program-badge { font-size: 11px; font-weight: 600; padding: 2px 10px; border-radius: 4px; background: #fef3c7; color: #92400e; display: inline-flex; align-items: center; gap: 4px; }
+
+  /* ── Stats (coverage-oriented) ── */
+  .stats { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; margin-bottom: 24px; }
+  .stat-card { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 14px 16px; cursor: pointer; transition: all 0.15s; }
+  .stat-card:hover { border-color: #d1d5db; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+  .stat-card.hero { background: #0f172a; border-color: #0f172a; color: white; }
+  .stat-card.hero .stat-label { color: #94a3b8; }
+  .stat-card.hero .stat-value { color: white; }
+  .stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 4px; display: flex; align-items: center; gap: 6px; }
+  .stat-label i { font-size: 11px; }
+  .stat-value { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+  .stat-delta { font-size: 11px; font-weight: 500; margin-top: 2px; }
+  .stat-delta.up { color: #059669; }
+
+  /* ── Toolbar ── */
+  .toolbar { background: white; border: 1px solid #e5e7eb; border-radius: 8px 8px 0 0; border-bottom: none; }
+  .tabs { display: flex; border-bottom: 1px solid #e5e7eb; padding: 0 16px; }
+  .tab { padding: 10px 16px; font-size: 13px; font-weight: 500; color: #9ca3af; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.12s; display: flex; align-items: center; gap: 6px; }
+  .tab:hover { color: #4b5563; }
+  .tab.active { color: #3b82f6; border-bottom-color: #3b82f6; }
+  .tab-count { font-size: 11px; font-weight: 600; background: #f8fafc; padding: 1px 7px; border-radius: 10px; color: #9ca3af; }
+  .tab.active .tab-count { background: #eff6ff; color: #3b82f6; }
+  .tab-dot { width: 6px; height: 6px; border-radius: 50%; background: #dc2626; }
+
+  .filters { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid #e5e7eb; }
+  .search-input { flex: 1; max-width: 280px; height: 32px; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0 10px 0 32px; font-size: 13px; color: #0f172a; outline: none; background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") 10px center no-repeat; }
+  .search-input:focus { border-color: #3b82f6; }
+  .search-input::placeholder { color: #9ca3af; }
+  .filter-select { height: 32px; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0 28px 0 10px; font-size: 13px; color: #4b5563; background: white; appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 8px center; cursor: pointer; outline: none; }
+  .filters-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .sort-btn { height: 32px; padding: 0 10px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 12px; color: #9ca3af; background: white; cursor: pointer; display: flex; align-items: center; gap: 5px; }
+
+  .bulk-bar { display: flex; align-items: center; gap: 10px; padding: 8px 16px; background: #eff6ff; border-bottom: 1px solid #3b82f6; font-size: 13px; }
+  .bulk-bar-count { font-weight: 600; color: #3b82f6; }
+  .bulk-btn { height: 28px; padding: 0 10px; border-radius: 4px; font-size: 12px; font-weight: 500; cursor: pointer; border: 1px solid; transition: all 0.12s; display: inline-flex; align-items: center; gap: 4px; font-family: inherit; }
+  .bulk-btn-primary { background: #3b82f6; color: white; border-color: #3b82f6; }
+  .bulk-btn-outline { background: white; color: #3b82f6; border-color: #3b82f6; }
+  .bulk-btn-clear { background: none; color: #9ca3af; border: none; margin-left: auto; font-size: 12px; cursor: pointer; font-family: inherit; }
+
+  /* ── Table ── */
+  .table-container { background: white; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px; overflow: hidden; }
+  table { width: 100%; border-collapse: collapse; }
+  thead th { text-align: left; padding: 10px 14px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; background: #f8fafc; border-bottom: 1px solid #e5e7eb; white-space: nowrap; cursor: pointer; user-select: none; }
+  thead th.th-checkbox { width: 40px; cursor: default; }
+  tbody tr { cursor: pointer; transition: background 0.1s; }
+  tbody tr:hover { background: #eff6ff; }
+  tbody tr.selected { background: #dbeafe; }
+  tbody td { padding: 11px 14px; border-bottom: 1px solid #f1f5f9; font-size: 13px; vertical-align: middle; white-space: nowrap; }
+  tbody tr:last-child td { border-bottom: none; }
+
+  .checkbox { width: 16px; height: 16px; border: 1.5px solid #d1d5db; border-radius: 3px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all 0.12s; background: white; }
+  .checkbox:hover { border-color: #3b82f6; }
+  .checkbox.checked { background: #3b82f6; border-color: #3b82f6; color: white; font-size: 10px; }
+  .checkbox.indeterminate { background: #3b82f6; border-color: #3b82f6; }
+  .checkbox.indeterminate::after { content: ''; display: block; width: 8px; height: 2px; background: white; border-radius: 1px; }
+
+  .pkg-name { font-weight: 600; color: #0f172a; }
+  .pkg-purl { font-size: 11px; color: #9ca3af; font-family: 'SF Mono', 'Fira Code', monospace; }
+  .tag { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; white-space: nowrap; }
+  .tag-neutral { background: #f8fafc; color: #9ca3af; border: 1px solid #e5e7eb; }
+  .tag-info { background: #f0f9ff; color: #0284c7; }
+  .tag-warning { background: #fffbeb; color: #d97706; }
+  .tag-danger { background: #fef2f2; color: #dc2626; }
+  .tag-success { background: #ecfdf5; color: #059669; }
+  .ecosystem-tag { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #4b5563; font-weight: 500; }
+  .ecosystem-tag .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .dot-npm { background: #cb3837; }
+  .dot-maven { background: #c71a36; }
+
+  .health-cell { display: flex; align-items: center; gap: 6px; }
+  .health-score { font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .health-score.excellent { color: #059669; }
+  .health-score.healthy { color: #059669; }
+  .health-score.fair { color: #d97706; }
+  .health-score.concerning { color: #d97706; }
+  .health-score.critical { color: #dc2626; }
+  .lifecycle-tag { display: inline-flex; padding: 1px 6px; border-radius: 3px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
+  .lifecycle-active { background: #ecfdf5; color: #059669; }
+  .lifecycle-stable { background: #f0f9ff; color: #0284c7; }
+  .lifecycle-declining { background: #fffbeb; color: #d97706; }
+  .lifecycle-abandoned { background: #fef2f2; color: #dc2626; }
+
+  .owner-cell { display: flex; align-items: center; gap: 6px; }
+  .owner-avatar { width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 600; color: white; }
+  .owner-unassigned { color: #9ca3af; font-style: italic; }
+  .activity-text { font-size: 12px; color: #9ca3af; }
+  .activity-text strong { color: #4b5563; font-weight: 500; }
+
+  .table-footer { display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; border-top: 1px solid #e5e7eb; font-size: 12px; color: #9ca3af; background: white; }
+  .pagination { display: flex; align-items: center; gap: 4px; }
+  .page-btn { width: 28px; height: 28px; border: 1px solid #e5e7eb; border-radius: 4px; background: white; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; color: #4b5563; }
+  .page-btn:hover { background: #f8fafc; }
+  .page-btn.active { background: #3b82f6; color: white; border-color: #3b82f6; }
+
+  /* ── Drawer ── */
+  .drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.2); z-index: 100; opacity: 0; pointer-events: none; transition: opacity 0.2s; }
+  .drawer-overlay.open { opacity: 1; pointer-events: auto; }
+  .drawer { position: fixed; top: 0; right: 0; width: 520px; height: 100vh; background: white; box-shadow: -4px 0 24px rgba(0,0,0,0.12); z-index: 101; transform: translateX(100%); transition: transform 0.25s ease; display: flex; flex-direction: column; }
+  .drawer.open { transform: translateX(0); }
+  .drawer-header { padding: 20px 20px 0; flex-shrink: 0; }
+  .drawer-header-row { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 4px; }
+  .drawer-title { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; }
+  .drawer-close { width: 28px; height: 28px; border: none; background: none; color: #9ca3af; cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 14px; }
+  .drawer-close:hover { background: #f8fafc; color: #0f172a; }
+  .drawer-meta { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; font-size: 12px; color: #9ca3af; flex-wrap: wrap; }
+  .drawer-meta code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 11px; background: #f8fafc; padding: 2px 6px; border-radius: 3px; }
+  .drawer-tabs { display: flex; border-bottom: 1px solid #e5e7eb; padding: 0; }
+  .drawer-tab { padding: 10px 16px; font-size: 13px; font-weight: 500; color: #9ca3af; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.12s; }
+  .drawer-tab:hover { color: #4b5563; }
+  .drawer-tab.active { color: #3b82f6; border-bottom-color: #3b82f6; }
+  .drawer-body { flex: 1; overflow-y: auto; padding: 20px; }
+  .drawer-section { margin-bottom: 24px; }
+  .drawer-section-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 10px; }
+  .drawer-field { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; font-size: 13px; }
+  .drawer-field-label { color: #9ca3af; }
+  .drawer-field-value { font-weight: 500; color: #0f172a; text-align: right; }
+
+  .drawer-footer { padding: 12px 20px; border-top: 1px solid #e5e7eb; display: flex; gap: 8px; flex-shrink: 0; background: white; }
+  .btn { height: 34px; padding: 0 14px; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; transition: all 0.12s; border: none; font-family: inherit; }
+  .btn-primary { background: #3b82f6; color: white; }
+  .btn-primary:hover { background: #2563eb; }
+  .btn-outline { background: white; color: #4b5563; border: 1px solid #e5e7eb; }
+  .btn-outline:hover { background: #f8fafc; border-color: #d1d5db; }
+  .btn-ghost { background: none; color: #9ca3af; border: none; margin-left: auto; }
+  .btn-ghost:hover { color: #4b5563; }
+
+  .mockup-badge { position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); background: #0f172a; color: #e2e8f0; padding: 6px 16px; border-radius: 20px; font-size: 12px; font-weight: 500; z-index: 200; display: flex; align-items: center; gap: 8px; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.08); }
+  .mockup-badge .dot { width: 6px; height: 6px; border-radius: 50%; background: #f59e0b; }
+</style>
+</head>
+<body>
+
+<div class="shell">
+  <!-- ── Lens Rail ── -->
+  <nav class="rail">
+    <div class="rail-logo">
+      <svg viewBox="0 0 24 24" fill="none"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    </div>
+    <div class="rail-divider"></div>
+    <div class="rail-buttons">
+      <button class="rail-btn active">
+        <div class="rail-btn-icon"><i class="fa-solid fa-user"></i></div>
+        <span class="rail-btn-label">Me</span>
+      </button>
+      <button class="rail-btn">
+        <div class="rail-btn-icon"><i class="fa-regular fa-building"></i></div>
+        <span class="rail-btn-label">Org</span>
+      </button>
+      <button class="rail-btn">
+        <div class="rail-btn-icon"><i class="fa-regular fa-layer-group"></i></div>
+        <span class="rail-btn-label">Fdn</span>
+      </button>
+      <button class="rail-btn">
+        <div class="rail-btn-icon"><i class="fa-regular fa-diagram-project"></i></div>
+        <span class="rail-btn-label">Prj</span>
+      </button>
+    </div>
+    <div class="rail-footer">
+      <div class="rail-divider" style="margin-bottom:0;margin-top:0;"></div>
+      <div class="rail-avatar">SK</div>
+    </div>
+  </nav>
+
+  <!-- ── Nav Panel ── -->
+  <nav class="nav-panel">
+    <div class="nav-scroll">
+      <div class="me-selector">
+        <div class="me-selector-inner">
+          <div class="me-avatar">SK</div>
+          <div>
+            <div class="me-name">Sarah Kim</div>
+            <div class="me-role"><i class="fa-solid fa-shield-halved"></i> Osprey Admin</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="nav-items">
+        <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-gauge"></i></div> My Dashboard</a>
+
+        <div class="nav-section">
+          <div class="nav-section-header">
+            <span class="nav-section-label">My Engagement</span>
+            <div class="nav-section-line"></div>
+          </div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-calendar"></i></div> Meetings</a>
+          </div>
+        </div>
+
+        <div class="nav-section">
+          <div class="nav-section-header">
+            <span class="nav-section-label">Security</span>
+            <div class="nav-section-line"></div>
+          </div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-shield-halved"></i></div> My Stewardships <span class="badge">5</span></a>
+            <a class="nav-item admin-active" href="#"><div class="nav-item-icon"><i class="fa-light fa-shield"></i></div> Osprey Program <span class="admin-badge">Admin</span></a>
+          </div>
+        </div>
+
+        <div class="nav-section">
+          <div class="nav-section-header">
+            <span class="nav-section-label">My Account</span>
+            <div class="nav-section-line"></div>
+          </div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-user-pen"></i></div> Profile</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-gear"></i></div> Settings</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ── Main Content ── -->
+  <div class="main">
+    <div class="topbar">
+      <div class="topbar-breadcrumb">Me &rsaquo; <span>Osprey Program</span></div>
+      <div class="topbar-spacer"></div>
+      <div class="topbar-action"><i class="fa-light fa-arrow-up-right-from-square"></i> Open in Insights</div>
+      <button class="topbar-action-primary"><i class="fa-solid fa-plus"></i> Assign steward</button>
+    </div>
+
+    <div class="page">
+      <div class="page-header">
+        <div>
+          <div class="page-title-row">
+            <div class="page-title">Osprey Program</div>
+            <div class="program-badge"><i class="fa-solid fa-shield-halved"></i> OpenSSF</div>
+          </div>
+          <div class="page-subtitle">Coverage and stewardship across npm and Maven ecosystems.</div>
+        </div>
+      </div>
+
+      <!-- Coverage-oriented stats -->
+      <div class="stats">
+        <div class="stat-card hero">
+          <div class="stat-label"><i class="fa-solid fa-cube"></i> Critical packages</div>
+          <div class="stat-value">1,842</div>
+        </div>
+        <div class="stat-card hero">
+          <div class="stat-label"><i class="fa-solid fa-shield-check"></i> Coverage</div>
+          <div class="stat-value">33.2%</div>
+          <div class="stat-delta up">+4.1% this month</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label"><i class="fa-solid fa-user-check"></i> Active stewards</div>
+          <div class="stat-value" style="color:#059669">612</div>
+        </div>
+        <div class="stat-card" style="border-left: 3px solid #dc2626;">
+          <div class="stat-label"><i class="fa-solid fa-circle-exclamation"></i> Unassigned (crit)</div>
+          <div class="stat-value" style="color:#dc2626">1,230</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label"><i class="fa-solid fa-triangle-exclamation"></i> Needs attention</div>
+          <div class="stat-value" style="color:#d97706">47</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label"><i class="fa-solid fa-arrow-up-from-bracket"></i> Escalated</div>
+          <div class="stat-value" style="color:#dc2626">8</div>
+        </div>
+      </div>
+
+      <!-- Toolbar -->
+      <div class="toolbar">
+        <div class="tabs">
+          <div class="tab">All <span class="tab-count">1,842</span></div>
+          <div class="tab active">Unassigned <span class="tab-count">1,230</span></div>
+          <div class="tab">Open <span class="tab-count">94</span></div>
+          <div class="tab">Assessing <span class="tab-count">127</span></div>
+          <div class="tab">Active <span class="tab-count">612</span></div>
+          <div class="tab">Needs attention <span class="tab-dot"></span> <span class="tab-count">47</span></div>
+          <div class="tab">Escalated <span class="tab-count">8</span></div>
+        </div>
+        <div class="filters">
+          <input type="text" class="search-input" placeholder="Search packages, purl, or steward...">
+          <select class="filter-select">
+            <option>All ecosystems</option>
+            <option>npm</option>
+            <option>Maven</option>
+          </select>
+          <select class="filter-select">
+            <option>All lifecycle</option>
+            <option>Active</option>
+            <option>Stable</option>
+            <option>Declining</option>
+            <option>Abandoned</option>
+          </select>
+          <select class="filter-select">
+            <option>All health</option>
+            <option selected>Critical</option>
+            <option>Concerning</option>
+            <option>Fair</option>
+            <option>Healthy</option>
+          </select>
+          <div class="filters-right">
+            <div class="sort-btn"><i class="fa-solid fa-arrow-down-wide-short"></i> Risk priority</div>
+          </div>
+        </div>
+        <div class="bulk-bar">
+          <span class="bulk-bar-count">3 selected</span>
+          <button class="bulk-btn bulk-btn-primary"><i class="fa-solid fa-folder-open"></i> Open for stewardship</button>
+          <button class="bulk-btn bulk-btn-outline"><i class="fa-solid fa-user-plus"></i> Assign steward</button>
+          <button class="bulk-btn-clear">Clear selection</button>
+        </div>
+      </div>
+
+      <!-- Table -->
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th class="th-checkbox"><div class="checkbox indeterminate"></div></th>
+              <th>Package</th>
+              <th>Ecosystem</th>
+              <th>Lifecycle</th>
+              <th>Health</th>
+              <th>Impact</th>
+              <th>Steward</th>
+              <th>Stewardship</th>
+              <th>Last activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="selected" onclick="openDrawer()">
+              <td><div class="checkbox checked"><i class="fa-solid fa-check"></i></div></td>
+              <td><div class="pkg-name">lodash</div><div class="pkg-purl">pkg:npm/lodash</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-declining">Declining</span></td>
+              <td><span class="health-score fair">52 Fair</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">94</span></td>
+              <td><span class="owner-unassigned">&mdash;</span></td>
+              <td><span class="tag tag-neutral">Unassigned</span></td>
+              <td><span class="activity-text">Synced May 28</span></td>
+            </tr>
+            <tr class="selected">
+              <td><div class="checkbox checked"><i class="fa-solid fa-check"></i></div></td>
+              <td><div class="pkg-name">chalk</div><div class="pkg-purl">pkg:npm/chalk</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-stable">Stable</span></td>
+              <td><span class="health-score healthy">72 Healthy</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">76</span></td>
+              <td><span class="owner-unassigned">&mdash;</span></td>
+              <td><span class="tag tag-neutral">Unassigned</span></td>
+              <td><span class="activity-text">Synced May 28</span></td>
+            </tr>
+            <tr class="selected">
+              <td><div class="checkbox checked"><i class="fa-solid fa-check"></i></div></td>
+              <td><div class="pkg-name">debug</div><div class="pkg-purl">pkg:npm/debug</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-declining">Declining</span></td>
+              <td><span class="health-score concerning">42 Concerning</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">96</span></td>
+              <td><span class="owner-unassigned">&mdash;</span></td>
+              <td><span class="tag tag-neutral">Unassigned</span></td>
+              <td><span class="activity-text">Synced May 28</span></td>
+            </tr>
+            <tr onclick="openDrawer()">
+              <td><div class="checkbox"></div></td>
+              <td><div class="pkg-name">minimist</div><div class="pkg-purl">pkg:npm/minimist</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-abandoned">Abandoned</span></td>
+              <td><span class="health-score critical">18 Critical</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">71</span></td>
+              <td><div class="owner-cell"><div class="owner-avatar" style="background: linear-gradient(135deg, #818cf8, #6366f1)">JR</div> Jonathan R.</div></td>
+              <td><span class="tag tag-danger"><i class="fa-solid fa-circle" style="font-size:6px"></i> Escalated</span></td>
+              <td><span class="activity-text"><strong>Escalated</strong> &middot; 1d</span></td>
+            </tr>
+            <tr onclick="openDrawer()">
+              <td><div class="checkbox"></div></td>
+              <td><div class="pkg-name">express</div><div class="pkg-purl">pkg:npm/express</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-active">Active</span></td>
+              <td><span class="health-score healthy">78 Healthy</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">88</span></td>
+              <td><div class="owner-cell"><div class="owner-avatar" style="background: linear-gradient(135deg, #34d399, #059669)">LP</div> Lee Park</div></td>
+              <td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td>
+              <td><span class="activity-text"><strong>Logged progress</strong> &middot; 4h</span></td>
+            </tr>
+            <tr onclick="openDrawer()">
+              <td><div class="checkbox"></div></td>
+              <td><div class="pkg-name">org.slf4j:slf4j-api</div><div class="pkg-purl">pkg:maven/org.slf4j/slf4j-api</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span></td>
+              <td><span class="lifecycle-tag lifecycle-active">Active</span></td>
+              <td><span class="health-score healthy">71 Healthy</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">82</span></td>
+              <td><div class="owner-cell"><div class="owner-avatar" style="background: linear-gradient(135deg, #f97316, #ea580c)">MC</div> Maya Chen</div></td>
+              <td><span class="tag tag-warning"><i class="fa-solid fa-circle" style="font-size:6px"></i> Assessing</span></td>
+              <td><span class="activity-text"><strong>Assessment started</strong> &middot; 2h</span></td>
+            </tr>
+            <tr onclick="openDrawer()">
+              <td><div class="checkbox"></div></td>
+              <td><div class="pkg-name">jackson-databind</div><div class="pkg-purl">pkg:maven/com.fasterxml.jackson.core/jackson-databind</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span></td>
+              <td><span class="lifecycle-tag lifecycle-active">Active</span></td>
+              <td><span class="health-score fair">64 Fair</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">89</span></td>
+              <td><div class="owner-cell"><div class="owner-avatar" style="background: linear-gradient(135deg, #818cf8, #6366f1)">JR</div> Jonathan R.</div></td>
+              <td><span class="tag tag-danger"><i class="fa-solid fa-circle" style="font-size:6px"></i> Needs attention</span></td>
+              <td><span class="activity-text"><strong>New advisory</strong> &middot; 3h</span></td>
+            </tr>
+            <tr onclick="openDrawer()">
+              <td><div class="checkbox"></div></td>
+              <td><div class="pkg-name">glob</div><div class="pkg-purl">pkg:npm/glob</div></td>
+              <td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td>
+              <td><span class="lifecycle-tag lifecycle-declining">Declining</span></td>
+              <td><span class="health-score concerning">38 Concerning</span></td>
+              <td><span style="font-variant-numeric:tabular-nums;">74</span></td>
+              <td><span class="owner-unassigned">&mdash;</span></td>
+              <td><span class="tag tag-info"><i class="fa-solid fa-circle" style="font-size:6px"></i> Open</span></td>
+              <td><span class="activity-text">Opened &middot; 3d</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="table-footer">
+          <span>Showing 1&ndash;8 of 1,230 unassigned critical packages</span>
+          <div class="pagination">
+            <button class="page-btn" disabled><i class="fa-solid fa-chevron-left" style="font-size:10px"></i></button>
+            <button class="page-btn active">1</button>
+            <button class="page-btn">2</button>
+            <button class="page-btn">3</button>
+            <span style="color:#9ca3af">...</span>
+            <button class="page-btn">154</button>
+            <button class="page-btn"><i class="fa-solid fa-chevron-right" style="font-size:10px"></i></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Drawer Overlay -->
+<div class="drawer-overlay" id="drawerOverlay" onclick="closeDrawer()"></div>
+
+<!-- Package drawer (unassigned package - admin triage) -->
+<div class="drawer" id="drawer">
+  <div class="drawer-header">
+    <div class="drawer-header-row">
+      <div class="drawer-title">lodash</div>
+      <button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button>
+    </div>
+    <div class="drawer-meta">
+      <code>pkg:npm/lodash</code>
+      <span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span>
+      <span class="lifecycle-tag lifecycle-declining">Declining</span>
+      <span style="font-size:12px; color:#d97706; font-weight:600;">Health 52</span>
+      <span style="font-size:12px; color:#0f172a; font-weight:600;">Impact 94</span>
+      <span class="tag tag-neutral">Unassigned</span>
+    </div>
+    <div class="drawer-tabs">
+      <div class="drawer-tab active">Overview</div>
+      <div class="drawer-tab">Assessment</div>
+      <div class="drawer-tab">Security</div>
+      <div class="drawer-tab">Provenance</div>
+    </div>
+  </div>
+
+  <div class="drawer-body">
+    <div class="drawer-section">
+      <div class="drawer-section-title">Health Score Breakdown</div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Maintainer Health</span>
+        <span class="drawer-field-value">15 / 40</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Security &amp; Supply Chain</span>
+        <span class="drawer-field-value">22 / 35</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Development Activity</span>
+        <span class="drawer-field-value">15 / 25</span>
+      </div>
+      <div class="drawer-field" style="border-top:1px solid #e5e7eb; padding-top:8px; margin-top:4px;">
+        <span class="drawer-field-label" style="font-weight:600; color:#0f172a;">Total</span>
+        <span class="drawer-field-value" style="font-size:16px;">52 / 100 <span class="tag tag-warning" style="margin-left:4px;">Fair</span></span>
+      </div>
+    </div>
+
+    <div class="drawer-section">
+      <div class="drawer-section-title">Impact Score</div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Impact Score</span>
+        <span class="drawer-field-value" style="font-size:16px;">94 / 100</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Downloads (last month)</span>
+        <span class="drawer-field-value">52,142,891</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Dependent packages</span>
+        <span class="drawer-field-value">142,312</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Dependent repos</span>
+        <span class="drawer-field-value">39,104</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Transitive reach</span>
+        <span class="drawer-field-value">Top 0.01%</span>
+      </div>
+    </div>
+
+    <div class="drawer-section">
+      <div class="drawer-section-title">Key Risk Signals</div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Maintainer bus factor</span>
+        <span class="drawer-field-value" style="color:#dc2626">1 (single maintainer)</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Last release</span>
+        <span class="drawer-field-value" style="color:#dc2626">2021-02-20 (5y ago)</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">SECURITY.md</span>
+        <span class="drawer-field-value" style="color:#dc2626">Missing</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Open advisories</span>
+        <span class="drawer-field-value" style="color:#059669">0</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">OpenSSF Scorecard</span>
+        <span class="drawer-field-value">5.2 / 10</span>
+      </div>
+    </div>
+
+    <div class="drawer-section">
+      <div class="drawer-section-title">Repository</div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Repo</span>
+        <span class="drawer-field-value" style="color:#3b82f6">github.com/lodash/lodash</span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Mapping confidence</span>
+        <span class="drawer-field-value"><span class="tag tag-success">High</span></span>
+      </div>
+      <div class="drawer-field">
+        <span class="drawer-field-label">Last commit</span>
+        <span class="drawer-field-value">2024-09-14</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="drawer-footer">
+    <button class="btn btn-outline"><i class="fa-solid fa-folder-open"></i> Open for stewardship</button>
+    <button class="btn btn-primary"><i class="fa-solid fa-user-plus"></i> Assign steward</button>
+    <button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button>
+  </div>
+</div>
+
+<div class="mockup-badge"><span class="dot"></span> UI Mockup &mdash; Me Lens / Osprey Program (Admin)</div>
+
+<script>
+function openDrawer() {
+  document.getElementById('drawer').classList.add('open');
+  document.getElementById('drawerOverlay').classList.add('open');
+}
+function closeDrawer() {
+  document.getElementById('drawer').classList.remove('open');
+  document.getElementById('drawerOverlay').classList.remove('open');
+}
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
+</script>
+
+</body>
+</html>

--- a/docs/mockups/me-stewardships.html
+++ b/docs/mockups/me-stewardships.html
@@ -1,0 +1,543 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>My Stewardships — LFX Self Serve Mockup</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif; color: #0f172a; font-size: 14px; line-height: 1.5; overflow: hidden; height: 100vh; background: #f8fafc; }
+  .shell { display: flex; height: 100vh; }
+
+  /* ── Lens Rail ── */
+  .rail { width: 64px; background: #1e3a5f; display: flex; flex-direction: column; align-items: center; padding: 24px 0; flex-shrink: 0; }
+  .rail-logo { width: 32px; height: 32px; margin-bottom: 16px; display: flex; align-items: center; justify-content: center; }
+  .rail-logo svg { width: 28px; height: 28px; }
+  .rail-divider { width: 24px; border-top: 1px solid rgba(255,255,255,0.35); margin-bottom: 12px; }
+  .rail-buttons { display: flex; flex-direction: column; align-items: center; gap: 12px; flex: 1; }
+  .rail-btn { display: flex; flex-direction: column; align-items: center; gap: 4px; width: 100%; cursor: pointer; color: rgba(191,219,254,0.75); background: none; border: none; font-family: inherit; padding: 0; transition: color 0.15s; }
+  .rail-btn:hover { color: white; }
+  .rail-btn.active { color: white; }
+  .rail-btn-icon { width: 40px; height: 40px; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-size: 18px; transition: background 0.15s; }
+  .rail-btn.active .rail-btn-icon { background: #3b82f6; }
+  .rail-btn:hover:not(.active) .rail-btn-icon { background: rgba(255,255,255,0.1); }
+  .rail-btn-label { font-size: 10px; font-weight: 500; line-height: 1; }
+  .rail-footer { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: auto; }
+  .rail-avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, #818cf8, #6366f1); display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 600; cursor: pointer; border: 2px solid rgba(255,255,255,0.2); }
+
+  /* ── Nav Panel ── */
+  .nav-panel { width: 280px; background: white; border-right: 1px solid #e5e7eb; display: flex; flex-direction: column; flex-shrink: 0; }
+  .nav-scroll { display: flex; flex-direction: column; padding: 16px 0; height: 100%; min-height: 0; overflow-y: auto; }
+  .me-selector { padding: 0 16px; margin-bottom: 24px; }
+  .me-selector-inner { display: flex; gap: 12px; align-items: flex-start; padding: 12px; border-radius: 8px; }
+  .me-avatar { width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #818cf8, #6366f1); display: flex; align-items: center; justify-content: center; color: white; font-size: 14px; font-weight: 600; flex-shrink: 0; }
+  .me-name { font-size: 16px; font-weight: 600; color: #111827; line-height: 1.25; }
+  .me-persona { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #9ca3af; margin-top: 4px; }
+  .nav-items { display: flex; flex-direction: column; gap: 4px; padding: 0 16px; }
+  .nav-section { width: 100%; margin-top: 8px; }
+  .nav-section-header { display: flex; align-items: center; gap: 8px; padding: 6px 8px; }
+  .nav-section-label { font-size: 12px; font-weight: 500; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap; }
+  .nav-section-line { flex: 1; height: 1px; background: #e5e7eb; }
+  .nav-section-items { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
+  .nav-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; font-size: 16px; color: #4b5563; font-weight: 400; text-decoration: none; border: none; background: none; width: 100%; text-align: left; font-family: inherit; transition: all 0.12s; }
+  .nav-item:hover { background: #f9fafb; }
+  .nav-item.active { background: #dbeafe; font-weight: 500; color: #030712; }
+  .nav-item-icon { width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 15px; }
+  .nav-item .badge { margin-left: auto; font-size: 12px; font-weight: 500; color: #3b82f6; background: #eff6ff; padding: 1px 8px; border-radius: 10px; }
+
+  /* ── Main ── */
+  .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
+  .topbar { height: 48px; background: white; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; padding: 0 24px; flex-shrink: 0; gap: 12px; }
+  .topbar-breadcrumb { font-size: 13px; color: #9ca3af; }
+  .topbar-breadcrumb span { color: #0f172a; font-weight: 500; }
+  .topbar-spacer { flex: 1; }
+  .topbar-action { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 13px; color: #4b5563; cursor: pointer; background: white; }
+  .topbar-action:hover { background: #f9fafb; }
+  .page { flex: 1; overflow-y: auto; padding: 24px; }
+  .page-title { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 4px; }
+  .page-subtitle { font-size: 13px; color: #9ca3af; margin-bottom: 24px; }
+
+  /* ── Stats ── */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px; }
+  .stat-card { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 14px 16px; cursor: pointer; transition: all 0.15s; }
+  .stat-card:hover { border-color: #d1d5db; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+  .stat-card.active { border-color: #3b82f6; background: #eff6ff; }
+  .stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 4px; display: flex; align-items: center; gap: 6px; }
+  .stat-value { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+
+  /* ── Toolbar ── */
+  .toolbar { background: white; border: 1px solid #e5e7eb; border-radius: 8px 8px 0 0; border-bottom: none; }
+  .tabs { display: flex; border-bottom: 1px solid #e5e7eb; padding: 0 16px; }
+  .tab { padding: 10px 16px; font-size: 13px; font-weight: 500; color: #9ca3af; cursor: pointer; border-bottom: 2px solid transparent; display: flex; align-items: center; gap: 6px; transition: all 0.12s; }
+  .tab:hover { color: #4b5563; }
+  .tab.active { color: #3b82f6; border-bottom-color: #3b82f6; }
+  .tab-count { font-size: 11px; font-weight: 600; background: #f8fafc; padding: 1px 7px; border-radius: 10px; color: #9ca3af; }
+  .tab.active .tab-count { background: #eff6ff; color: #3b82f6; }
+  .tab-dot { width: 6px; height: 6px; border-radius: 50%; background: #dc2626; }
+  .filters { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid #e5e7eb; }
+  .search-input { flex: 1; max-width: 280px; height: 32px; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0 10px 0 32px; font-size: 13px; color: #0f172a; outline: none; background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") 10px center no-repeat; }
+  .search-input:focus { border-color: #3b82f6; }
+  .search-input::placeholder { color: #9ca3af; }
+  .filter-select { height: 32px; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0 28px 0 10px; font-size: 13px; color: #4b5563; background: white; appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 8px center; cursor: pointer; outline: none; }
+  .filters-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .sort-btn { height: 32px; padding: 0 10px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 12px; color: #9ca3af; background: white; cursor: pointer; display: flex; align-items: center; gap: 5px; }
+
+  /* ── Table ── */
+  .table-container { background: white; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px; overflow: hidden; }
+  table { width: 100%; border-collapse: collapse; }
+  thead th { text-align: left; padding: 10px 14px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; background: #f8fafc; border-bottom: 1px solid #e5e7eb; white-space: nowrap; }
+  tbody tr { cursor: pointer; transition: background 0.1s; }
+  tbody tr:hover { background: #eff6ff; }
+  tbody td { padding: 11px 14px; border-bottom: 1px solid #f1f5f9; font-size: 13px; vertical-align: middle; white-space: nowrap; }
+  tbody tr:last-child td { border-bottom: none; }
+  .pkg-name { font-weight: 600; color: #0f172a; }
+  .pkg-purl { font-size: 11px; color: #9ca3af; font-family: 'SF Mono', 'Fira Code', monospace; }
+
+  .tag { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; white-space: nowrap; }
+  .tag-neutral { background: #f8fafc; color: #9ca3af; border: 1px solid #e5e7eb; }
+  .tag-info { background: #f0f9ff; color: #0284c7; }
+  .tag-warning { background: #fffbeb; color: #d97706; }
+  .tag-danger { background: #fef2f2; color: #dc2626; }
+  .tag-success { background: #ecfdf5; color: #059669; }
+  .ecosystem-tag { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #4b5563; font-weight: 500; }
+  .ecosystem-tag .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .dot-npm { background: #cb3837; }
+  .dot-maven { background: #c71a36; }
+  .lifecycle-tag { display: inline-flex; padding: 1px 6px; border-radius: 3px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
+  .lifecycle-active { background: #ecfdf5; color: #059669; }
+  .lifecycle-stable { background: #f0f9ff; color: #0284c7; }
+  .lifecycle-declining { background: #fffbeb; color: #d97706; }
+  .lifecycle-abandoned { background: #fef2f2; color: #dc2626; }
+  .hs { font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .hs-excellent { color: #059669; }
+  .hs-healthy { color: #059669; }
+  .hs-fair { color: #d97706; }
+  .hs-concerning { color: #d97706; }
+  .hs-critical { color: #dc2626; }
+  .activity-text { font-size: 12px; color: #9ca3af; }
+  .activity-text strong { color: #4b5563; font-weight: 500; }
+  .table-footer { display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; border-top: 1px solid #e5e7eb; font-size: 12px; color: #9ca3af; }
+  .pagination { display: flex; align-items: center; gap: 4px; }
+  .page-btn { width: 28px; height: 28px; border: 1px solid #e5e7eb; border-radius: 4px; background: white; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; color: #4b5563; }
+  .page-btn.active { background: #3b82f6; color: white; border-color: #3b82f6; }
+
+  /* Tab content panels */
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+
+  /* ── Drawer ── */
+  .drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.2); z-index: 100; opacity: 0; pointer-events: none; transition: opacity 0.2s; }
+  .drawer-overlay.open { opacity: 1; pointer-events: auto; }
+  .drawer { position: fixed; top: 0; right: 0; width: 520px; height: 100vh; background: white; box-shadow: -4px 0 24px rgba(0,0,0,0.12); z-index: 101; transform: translateX(100%); transition: transform 0.25s ease; display: flex; flex-direction: column; }
+  .drawer.open { transform: translateX(0); }
+  .drawer-header { padding: 20px 20px 0; flex-shrink: 0; }
+  .drawer-header-row { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 4px; }
+  .drawer-title { font-size: 18px; font-weight: 700; }
+  .drawer-close { width: 28px; height: 28px; border: none; background: none; color: #9ca3af; cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 14px; }
+  .drawer-close:hover { background: #f8fafc; color: #0f172a; }
+  .drawer-meta { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; font-size: 12px; color: #9ca3af; flex-wrap: wrap; }
+  .drawer-meta code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 11px; background: #f8fafc; padding: 2px 6px; border-radius: 3px; }
+  .drawer-tabs { display: flex; border-bottom: 1px solid #e5e7eb; }
+  .drawer-tab { padding: 10px 16px; font-size: 13px; font-weight: 500; color: #9ca3af; cursor: pointer; border-bottom: 2px solid transparent; }
+  .drawer-tab:hover { color: #4b5563; }
+  .drawer-tab.active { color: #3b82f6; border-bottom-color: #3b82f6; }
+  .drawer-body { flex: 1; overflow-y: auto; padding: 20px; }
+  .drawer-section { margin-bottom: 24px; }
+  .drawer-section-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 10px; }
+  .drawer-field { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; font-size: 13px; }
+  .drawer-field-label { color: #9ca3af; }
+  .drawer-field-value { font-weight: 500; color: #0f172a; text-align: right; }
+  .assessment-list { list-style: none; padding: 0; }
+  .assessment-item { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; border-bottom: 1px solid #f1f5f9; }
+  .assessment-item:last-child { border-bottom: none; }
+  .assessment-severity { width: 4px; border-radius: 2px; min-height: 40px; flex-shrink: 0; margin-top: 2px; }
+  .severity-high { background: #dc2626; }
+  .severity-medium { background: #d97706; }
+  .severity-low { background: #059669; }
+  .assessment-dimension { font-size: 13px; font-weight: 600; color: #0f172a; margin-bottom: 2px; }
+  .assessment-finding { font-size: 12px; color: #64748b; }
+  .remediation-item { display: flex; align-items: flex-start; gap: 8px; padding: 6px 0; font-size: 13px; }
+  .rem-icon { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; flex-shrink: 0; margin-top: 1px; }
+  .rem-done { background: #ecfdf5; color: #059669; border: 1px solid #a7f3d0; }
+  .rem-progress { background: #eff6ff; color: #3b82f6; border: 1px solid #bfdbfe; }
+  .rem-pending { background: white; color: #9ca3af; border: 1px solid #e5e7eb; }
+  .rem-text.done { color: #9ca3af; }
+  .history-section { border-top: 1px solid #e5e7eb; padding: 16px 20px; flex-shrink: 0; max-height: 180px; overflow-y: auto; }
+  .history-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #9ca3af; margin-bottom: 10px; display: flex; align-items: center; gap: 6px; }
+  .history-badge { font-size: 10px; font-weight: 600; background: #f0f9ff; color: #0284c7; padding: 1px 6px; border-radius: 8px; }
+  .history-item { display: flex; gap: 10px; padding: 6px 0; font-size: 12px; }
+  .history-dot { width: 6px; height: 6px; border-radius: 50%; background: #e5e7eb; margin-top: 6px; flex-shrink: 0; }
+  .history-dot.recent { background: #3b82f6; }
+  .history-content { flex: 1; color: #4b5563; }
+  .history-content strong { color: #0f172a; font-weight: 500; }
+  .history-time { color: #9ca3af; font-size: 11px; margin-top: 1px; }
+  .drawer-footer { padding: 12px 20px; border-top: 1px solid #e5e7eb; display: flex; gap: 8px; flex-shrink: 0; background: white; }
+  .btn { height: 34px; padding: 0 14px; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; border: none; font-family: inherit; transition: all 0.12s; }
+  .btn-primary { background: #3b82f6; color: white; }
+  .btn-primary:hover { background: #2563eb; }
+  .btn-outline { background: white; color: #4b5563; border: 1px solid #e5e7eb; }
+  .btn-outline:hover { background: #f8fafc; }
+  .btn-warning { background: #d97706; color: white; }
+  .btn-warning:hover { background: #b45309; }
+  .btn-ghost { background: none; color: #9ca3af; border: none; margin-left: auto; }
+  .btn-ghost:hover { color: #4b5563; }
+  .callout-blue { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 14px 16px; margin-bottom: 20px; }
+  .callout-blue-title { font-size: 13px; font-weight: 600; color: #1e40af; margin-bottom: 6px; }
+  .callout-blue-body { font-size: 13px; color: #1e40af; }
+  .activity-card { background: #f8fafc; border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px 12px; font-size: 13px; margin-bottom: 8px; }
+  .activity-card-meta { font-size: 11px; color: #9ca3af; margin-bottom: 4px; }
+  .mockup-badge { position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); background: #0f172a; color: #e2e8f0; padding: 6px 16px; border-radius: 20px; font-size: 12px; font-weight: 500; z-index: 200; display: flex; align-items: center; gap: 8px; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.08); }
+  .mockup-badge .dot { width: 6px; height: 6px; border-radius: 50%; background: #22c55e; }
+</style>
+</head>
+<body>
+
+<div class="shell">
+  <!-- Lens Rail -->
+  <nav class="rail">
+    <div class="rail-logo"><svg viewBox="0 0 24 24" fill="none"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+    <div class="rail-divider"></div>
+    <div class="rail-buttons">
+      <button class="rail-btn active"><div class="rail-btn-icon"><i class="fa-solid fa-user"></i></div><span class="rail-btn-label">Me</span></button>
+      <button class="rail-btn"><div class="rail-btn-icon"><i class="fa-regular fa-building"></i></div><span class="rail-btn-label">Org</span></button>
+      <button class="rail-btn"><div class="rail-btn-icon"><i class="fa-regular fa-layer-group"></i></div><span class="rail-btn-label">Fdn</span></button>
+      <button class="rail-btn"><div class="rail-btn-icon"><i class="fa-regular fa-diagram-project"></i></div><span class="rail-btn-label">Prj</span></button>
+    </div>
+    <div class="rail-footer"><div class="rail-divider" style="margin:0"></div><div class="rail-avatar">JR</div></div>
+  </nav>
+
+  <!-- Nav Panel -->
+  <nav class="nav-panel">
+    <div class="nav-scroll">
+      <div class="me-selector"><div class="me-selector-inner"><div class="me-avatar">JR</div><div><div class="me-name">Jonathan Reimer</div><div class="me-persona"><i class="fa-light fa-user"></i> Contributor</div></div></div></div>
+      <div class="nav-items">
+        <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-gauge"></i></div> My Dashboard</a>
+        <div class="nav-section"><div class="nav-section-header"><span class="nav-section-label">My Engagement</span><div class="nav-section-line"></div></div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-calendar"></i></div> Meetings <span class="badge">3</span></a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-calendar-star"></i></div> Events</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-users"></i></div> Groups</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-envelope"></i></div> Mailing Lists</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-check-to-slot"></i></div> Votes</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-clipboard-list"></i></div> Surveys</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-file-lines"></i></div> Documents</a>
+          </div>
+        </div>
+        <div class="nav-section"><div class="nav-section-header"><span class="nav-section-label">Security</span><div class="nav-section-line"></div></div>
+          <div class="nav-section-items">
+            <a class="nav-item active" href="#"><div class="nav-item-icon"><i class="fa-light fa-shield-halved"></i></div> My Stewardships <span class="badge">18</span></a>
+          </div>
+        </div>
+        <div class="nav-section"><div class="nav-section-header"><span class="nav-section-label">My Growth</span><div class="nav-section-line"></div></div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-graduation-cap"></i></div> Training &amp; Certifications</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-award"></i></div> Badges</a>
+          </div>
+        </div>
+        <div class="nav-section"><div class="nav-section-header"><span class="nav-section-label">My Account</span><div class="nav-section-line"></div></div>
+          <div class="nav-section-items">
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-user-pen"></i></div> Profile</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-gear"></i></div> Settings</a>
+            <a class="nav-item" href="#"><div class="nav-item-icon"><i class="fa-light fa-receipt"></i></div> Transactions</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Main Content -->
+  <div class="main">
+    <div class="topbar">
+      <div class="topbar-breadcrumb">Me &rsaquo; <span>My Stewardships</span></div>
+      <div class="topbar-spacer"></div>
+      <div class="topbar-action"><i class="fa-light fa-arrow-up-right-from-square"></i> Open in Insights</div>
+    </div>
+
+    <div class="page">
+      <div class="page-title">My Stewardships</div>
+      <div class="page-subtitle">Manage your active package stewardships and browse available work.</div>
+
+      <!-- Stats -->
+      <div class="stats">
+        <div class="stat-card active" onclick="switchTab('active')"><div class="stat-label"><i class="fa-solid fa-shield-check"></i> Active</div><div class="stat-value">12</div></div>
+        <div class="stat-card" onclick="switchTab('assessing')"><div class="stat-label"><i class="fa-solid fa-magnifying-glass"></i> Assessing</div><div class="stat-value">3</div></div>
+        <div class="stat-card" onclick="switchTab('attention')"><div class="stat-label"><i class="fa-solid fa-triangle-exclamation"></i> Needs attention</div><div class="stat-value" style="color:#d97706">2</div></div>
+        <div class="stat-card" onclick="switchTab('escalated')"><div class="stat-label"><i class="fa-solid fa-arrow-up-from-bracket"></i> Escalated</div><div class="stat-value" style="color:#dc2626">1</div></div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="toolbar">
+        <div class="tabs">
+          <div class="tab active" data-tab="active" onclick="switchTab('active')">Active stewardships <span class="tab-count">12</span></div>
+          <div class="tab" data-tab="assessing" onclick="switchTab('assessing')">Assessing <span class="tab-count">3</span></div>
+          <div class="tab" data-tab="attention" onclick="switchTab('attention')">Needs attention <span class="tab-dot"></span> <span class="tab-count">2</span></div>
+          <div class="tab" data-tab="available" onclick="switchTab('available')">Available <span class="tab-count">1,247</span></div>
+          <div class="tab" data-tab="escalated" onclick="switchTab('escalated')">Escalated <span class="tab-count">1</span></div>
+        </div>
+        <div class="filters">
+          <input type="text" class="search-input" placeholder="Search packages...">
+          <select class="filter-select"><option>All ecosystems</option><option>npm</option><option>Maven</option></select>
+          <select class="filter-select"><option>All lifecycle</option><option>Abandoned</option><option>Declining</option><option>Stable</option><option>Active</option></select>
+          <select class="filter-select"><option>All health levels</option><option>Critical</option><option>Concerning</option><option>Fair</option><option>Healthy</option></select>
+          <div class="filters-right"><div class="sort-btn"><i class="fa-solid fa-arrow-down-wide-short"></i> Risk priority</div></div>
+        </div>
+      </div>
+
+      <!-- ═══ TAB: Active ═══ -->
+      <div class="tab-panel active" id="panel-active">
+        <div class="table-container">
+          <table><thead><tr><th>Package</th><th>Ecosystem</th><th>Lifecycle</th><th>Health</th><th>Impact</th><th>Stewardship</th><th>Last activity</th></tr></thead>
+          <tbody>
+            <tr onclick="openDrawer('active-lodash')"><td><div class="pkg-name">lodash</div><div class="pkg-purl">pkg:npm/lodash</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-fair">52 Fair</span></td><td>94</td><td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td><td><span class="activity-text"><strong>Logged progress</strong> &middot; 2h ago</span></td></tr>
+            <tr onclick="openDrawer('active-lodash')"><td><div class="pkg-name">express</div><div class="pkg-purl">pkg:npm/express</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-active">Active</span></td><td><span class="hs hs-healthy">78 Healthy</span></td><td>88</td><td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td><td><span class="activity-text"><strong>Logged progress</strong> &middot; 3d ago</span></td></tr>
+            <tr onclick="openDrawer('active-lodash')"><td><div class="pkg-name">chalk</div><div class="pkg-purl">pkg:npm/chalk</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-stable">Stable</span></td><td><span class="hs hs-healthy">72 Healthy</span></td><td>76</td><td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td><td><span class="activity-text"><strong>Logged progress</strong> &middot; 1w ago</span></td></tr>
+            <tr onclick="openDrawer('active-lodash')"><td><div class="pkg-name">semver</div><div class="pkg-purl">pkg:npm/semver</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-active">Active</span></td><td><span class="hs hs-excellent">85 Excellent</span></td><td>91</td><td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td><td><span class="activity-text"><strong>Logged progress</strong> &middot; 2w ago</span></td></tr>
+            <tr onclick="openDrawer('active-lodash')"><td><div class="pkg-name">glob</div><div class="pkg-purl">pkg:npm/glob</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-concerning">38 Concerning</span></td><td>74</td><td><span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:6px"></i> Active</span></td><td><span class="activity-text"><strong>Logged progress</strong> &middot; 2w ago</span></td></tr>
+          </tbody></table>
+          <div class="table-footer"><span>Showing 1&ndash;5 of 12 active stewardships</span><div class="pagination"><button class="page-btn active">1</button><button class="page-btn">2</button><button class="page-btn">3</button></div></div>
+        </div>
+      </div>
+
+      <!-- ═══ TAB: Assessing ═══ -->
+      <div class="tab-panel" id="panel-assessing">
+        <div class="table-container">
+          <table><thead><tr><th>Package</th><th>Ecosystem</th><th>Lifecycle</th><th>Health</th><th>Impact</th><th>Claimed</th><th>Last activity</th></tr></thead>
+          <tbody>
+            <tr onclick="openDrawer('assessing-slf4j')"><td><div class="pkg-name">org.slf4j:slf4j-api</div><div class="pkg-purl">pkg:maven/org.slf4j/slf4j-api</div></td><td><span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span></td><td><span class="lifecycle-tag lifecycle-active">Active</span></td><td><span class="hs hs-healthy">71 Healthy</span></td><td>82</td><td>Yesterday</td><td><span class="activity-text"><strong>3 of 6 dimensions complete</strong></span></td></tr>
+            <tr onclick="openDrawer('assessing-slf4j')"><td><div class="pkg-name">jackson-databind</div><div class="pkg-purl">pkg:maven/com.fasterxml.jackson.core/jackson-databind</div></td><td><span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span></td><td><span class="lifecycle-tag lifecycle-active">Active</span></td><td><span class="hs hs-fair">64 Fair</span></td><td>89</td><td>2d ago</td><td><span class="activity-text"><strong>1 of 6 dimensions complete</strong></span></td></tr>
+            <tr onclick="openDrawer('assessing-slf4j')"><td><div class="pkg-name">tar</div><div class="pkg-purl">pkg:npm/tar</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-concerning">44 Concerning</span></td><td>72</td><td>3d ago</td><td><span class="activity-text"><strong>0 of 6 dimensions complete</strong></span></td></tr>
+          </tbody></table>
+          <div class="table-footer"><span>Showing 1&ndash;3 of 3 assessments in progress</span><div class="pagination"><button class="page-btn active">1</button></div></div>
+        </div>
+      </div>
+
+      <!-- ═══ TAB: Needs attention ═══ -->
+      <div class="tab-panel" id="panel-attention">
+        <div class="table-container">
+          <table><thead><tr><th>Package</th><th>Ecosystem</th><th>Lifecycle</th><th>Health</th><th>Impact</th><th>Trigger</th><th>Since</th></tr></thead>
+          <tbody>
+            <tr onclick="openDrawer('attention-debug')"><td><div class="pkg-name">debug</div><div class="pkg-purl">pkg:npm/debug</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-concerning">42 Concerning</span></td><td>96</td><td><span class="tag tag-danger">New advisory</span> CVE-2026-1234</td><td>6h ago</td></tr>
+            <tr onclick="openDrawer('attention-debug')"><td><div class="pkg-name">qs</div><div class="pkg-purl">pkg:npm/qs</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-stable">Stable</span></td><td><span class="hs hs-fair">62 Fair</span></td><td>84</td><td><span class="tag tag-warning">Maintainer change</span> ownership transferred</td><td>2d ago</td></tr>
+          </tbody></table>
+          <div class="table-footer"><span>Showing 1&ndash;2 of 2 packages needing attention</span><div class="pagination"><button class="page-btn active">1</button></div></div>
+        </div>
+      </div>
+
+      <!-- ═══ TAB: Available ═══ -->
+      <div class="tab-panel" id="panel-available">
+        <div class="table-container">
+          <table><thead><tr><th>Package</th><th>Ecosystem</th><th>Lifecycle</th><th>Health</th><th>Impact</th><th>Key risk signal</th><th>Opened</th></tr></thead>
+          <tbody>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">node-fetch</div><div class="pkg-purl">pkg:npm/node-fetch</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-abandoned">Abandoned</span></td><td><span class="hs hs-critical">14 Critical</span></td><td>87</td><td><span class="activity-text">No maintainer activity in 2+ years</span></td><td>3d ago</td></tr>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">request</div><div class="pkg-purl">pkg:npm/request</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-abandoned">Abandoned</span></td><td><span class="hs hs-critical">11 Critical</span></td><td>82</td><td><span class="activity-text">Deprecated, 3 open CVEs</span></td><td>5d ago</td></tr>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">colors</div><div class="pkg-purl">pkg:npm/colors</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-abandoned">Abandoned</span></td><td><span class="hs hs-critical">8 Critical</span></td><td>71</td><td><span class="activity-text">Sabotaged by maintainer, no successor</span></td><td>1w ago</td></tr>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">moment</div><div class="pkg-purl">pkg:npm/moment</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-concerning">35 Concerning</span></td><td>93</td><td><span class="activity-text">Maintenance mode, single maintainer</span></td><td>1w ago</td></tr>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">underscore</div><div class="pkg-purl">pkg:npm/underscore</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-declining">Declining</span></td><td><span class="hs hs-concerning">41 Concerning</span></td><td>79</td><td><span class="activity-text">No SECURITY.md, unsigned releases</span></td><td>2w ago</td></tr>
+            <tr onclick="openDrawer('claim-nodefetch')"><td><div class="pkg-name">commons-text</div><div class="pkg-purl">pkg:maven/org.apache.commons/commons-text</div></td><td><span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span></td><td><span class="lifecycle-tag lifecycle-active">Active</span></td><td><span class="hs hs-fair">55 Fair</span></td><td>76</td><td><span class="activity-text">CVE-2022-42889 recurrence risk</span></td><td>2w ago</td></tr>
+          </tbody></table>
+          <div class="table-footer"><span>Showing 1&ndash;6 of 1,247 available packages</span><div class="pagination"><button class="page-btn active">1</button><button class="page-btn">2</button><span style="color:#9ca3af">...</span><button class="page-btn">208</button></div></div>
+        </div>
+      </div>
+
+      <!-- ═══ TAB: Escalated ═══ -->
+      <div class="tab-panel" id="panel-escalated">
+        <div class="table-container">
+          <table><thead><tr><th>Package</th><th>Ecosystem</th><th>Lifecycle</th><th>Health</th><th>Impact</th><th>Escalation reason</th><th>Escalated</th></tr></thead>
+          <tbody>
+            <tr onclick="openDrawer('escalated-minimist')"><td><div class="pkg-name">minimist</div><div class="pkg-purl">pkg:npm/minimist</div></td><td><span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span></td><td><span class="lifecycle-tag lifecycle-abandoned">Abandoned</span></td><td><span class="hs hs-critical">18 Critical</span></td><td>71</td><td><span class="activity-text">Maintainer unresponsive after 3 outreach attempts. Needs fork decision.</span></td><td>1d ago</td></tr>
+          </tbody></table>
+          <div class="table-footer"><span>Showing 1 of 1 escalated stewardship</span><div class="pagination"><button class="page-btn active">1</button></div></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- Drawer Overlay -->
+<div class="drawer-overlay" id="drawerOverlay" onclick="closeDrawer()"></div>
+
+<!-- ═══ DRAWER: Active stewardship (lodash) ═══ -->
+<div class="drawer" id="drawer-active-lodash">
+  <div class="drawer-header">
+    <div class="drawer-header-row"><div class="drawer-title">lodash</div><button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button></div>
+    <div class="drawer-meta"><code>pkg:npm/lodash</code> <span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span> <span class="lifecycle-tag lifecycle-declining">Declining</span> <span style="font-size:12px;color:#d97706;font-weight:600;">Health 52 Fair</span> <span style="font-size:12px;color:#0f172a;font-weight:600;">Impact 94</span> <span class="tag tag-success"><i class="fa-solid fa-circle" style="font-size:5px"></i> Active</span></div>
+    <div class="drawer-tabs"><div class="drawer-tab">Overview</div><div class="drawer-tab active">Assessment</div><div class="drawer-tab">Security</div><div class="drawer-tab">Provenance</div></div>
+  </div>
+  <div class="drawer-body">
+    <div class="drawer-section"><div class="drawer-section-title">Posture Summary</div><div class="drawer-field"><span class="drawer-field-label">Overall risk</span><span class="drawer-field-value"><span class="tag tag-warning">High</span></span></div><p style="font-size:13px;color:#64748b;margin-top:8px;">Single maintainer, no security disclosure process, no signed releases. 4 historical CVEs all patched. Prototype pollution surface remains.</p></div>
+    <div class="drawer-section"><div class="drawer-section-title">Findings</div>
+      <ul class="assessment-list">
+        <li class="assessment-item"><div class="assessment-severity severity-high"></div><div><div class="assessment-dimension">Maintainer health</div><div class="assessment-finding">Single maintainer (jdalton). Last commit 2024-09. Bus factor = 1.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-high"></div><div><div class="assessment-dimension">Security posture</div><div class="assessment-finding">No SECURITY.md, no disclosure process, unsigned releases.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-medium"></div><div><div class="assessment-dimension">Vulnerability exposure</div><div class="assessment-finding">4 historical CVEs (resolved). Prototype pollution surface remains.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-low"></div><div><div class="assessment-dimension">Dependency risk</div><div class="assessment-finding">Zero dependencies. No transitive risk.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-high"></div><div><div class="assessment-dimension">Supply chain integrity</div><div class="assessment-finding">No build provenance. Unsigned releases.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-high"></div><div><div class="assessment-dimension">Release health</div><div class="assessment-finding">Last release 2021-02-20 (5+ years). 200+ open issues.</div></div></li>
+      </ul>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Remediation Plan</div>
+      <div class="remediation-item"><div class="rem-icon rem-done"><i class="fa-solid fa-check"></i></div><div class="rem-text done">File PR to add SECURITY.md with disclosure process</div></div>
+      <div class="remediation-item"><div class="rem-icon rem-progress"><i class="fa-solid fa-spinner"></i></div><div>Contact maintainer re: 2FA and signed releases</div></div>
+      <div class="remediation-item"><div class="rem-icon rem-progress"><i class="fa-solid fa-spinner"></i></div><div>Engage with lodash-es maintainers on security coordination</div></div>
+      <div class="remediation-item"><div class="rem-icon rem-pending"></div><div>Evaluate if fork is needed given maintainer responsiveness</div></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Recent Activity</div>
+      <div class="activity-card"><div class="activity-card-meta">You &middot; 2 hours ago</div>SECURITY.md PR merged. Maintainer responded to 2FA request.</div>
+      <div class="activity-card"><div class="activity-card-meta">You &middot; 5 days ago</div>Filed SECURITY.md PR (#5678). Contacted jdalton via email.</div>
+    </div>
+  </div>
+  <div class="history-section"><div class="history-title">History <span class="history-badge">1 new</span></div><div class="history-item"><div class="history-dot recent"></div><div><div class="history-content"><strong>You</strong> logged remediation progress</div><div class="history-time">2h ago</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> completed assessment &rarr; Active</div><div class="history-time">May 25</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> claimed package</div><div class="history-time">May 22</div></div></div></div>
+  <div class="drawer-footer"><button class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i> Log progress</button><button class="btn btn-warning"><i class="fa-solid fa-arrow-up-from-bracket"></i> Escalate</button><button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button></div>
+</div>
+
+<!-- ═══ DRAWER: Assessing (slf4j) ═══ -->
+<div class="drawer" id="drawer-assessing-slf4j">
+  <div class="drawer-header">
+    <div class="drawer-header-row"><div class="drawer-title">org.slf4j:slf4j-api</div><button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button></div>
+    <div class="drawer-meta"><code>pkg:maven/org.slf4j/slf4j-api</code> <span class="ecosystem-tag"><span class="dot dot-maven"></span> Maven</span> <span class="lifecycle-tag lifecycle-active">Active</span> <span style="font-size:12px;color:#059669;font-weight:600;">Health 71 Healthy</span> <span style="font-size:12px;color:#0f172a;font-weight:600;">Impact 82</span> <span class="tag tag-warning"><i class="fa-solid fa-circle" style="font-size:5px"></i> Assessing</span></div>
+    <div class="drawer-tabs"><div class="drawer-tab">Overview</div><div class="drawer-tab active">Assessment</div><div class="drawer-tab">Security</div><div class="drawer-tab">Provenance</div></div>
+  </div>
+  <div class="drawer-body">
+    <div class="drawer-section"><div class="drawer-section-title">Assessment Progress &mdash; 3 of 6 dimensions</div>
+      <div style="display:flex;gap:3px;margin-bottom:16px;"><div style="flex:1;height:4px;border-radius:2px;background:#059669;"></div><div style="flex:1;height:4px;border-radius:2px;background:#059669;"></div><div style="flex:1;height:4px;border-radius:2px;background:#059669;"></div><div style="flex:1;height:4px;border-radius:2px;background:#e5e7eb;"></div><div style="flex:1;height:4px;border-radius:2px;background:#e5e7eb;"></div><div style="flex:1;height:4px;border-radius:2px;background:#e5e7eb;"></div></div>
+      <ul class="assessment-list">
+        <li class="assessment-item"><div class="assessment-severity severity-low"></div><div style="flex:1"><div class="assessment-dimension">Maintainer health <span class="tag tag-success" style="margin-left:4px;font-size:10px;">Done</span></div><div class="assessment-finding">Ceki Gulcu active. Multiple committers. Responsive to issues within 7 days.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-medium"></div><div style="flex:1"><div class="assessment-dimension">Security posture <span class="tag tag-success" style="margin-left:4px;font-size:10px;">Done</span></div><div class="assessment-finding">SECURITY.md present. No signed releases. Branch protection on main.</div></div></li>
+        <li class="assessment-item"><div class="assessment-severity severity-low"></div><div style="flex:1"><div class="assessment-dimension">Vulnerability exposure <span class="tag tag-success" style="margin-left:4px;font-size:10px;">Done</span></div><div class="assessment-finding">No open advisories. log4j CVEs apply to log4j-core, not slf4j.</div></div></li>
+        <li class="assessment-item" style="cursor:pointer;border-radius:6px;padding:10px;margin:0 -10px;" onmouseover="this.style.background='#f8fafc'" onmouseout="this.style.background=''"><div class="assessment-severity" style="background:#e5e7eb;"></div><div style="flex:1"><div class="assessment-dimension" style="color:#4b5563;">Dependency risk <span class="tag tag-neutral" style="margin-left:4px;font-size:10px;">Pending</span></div><div class="assessment-finding" style="color:#9ca3af;font-style:italic;">Click to start this dimension</div></div></li>
+        <li class="assessment-item" style="cursor:pointer;border-radius:6px;padding:10px;margin:0 -10px;" onmouseover="this.style.background='#f8fafc'" onmouseout="this.style.background=''"><div class="assessment-severity" style="background:#e5e7eb;"></div><div style="flex:1"><div class="assessment-dimension" style="color:#4b5563;">Supply chain integrity <span class="tag tag-neutral" style="margin-left:4px;font-size:10px;">Pending</span></div><div class="assessment-finding" style="color:#9ca3af;font-style:italic;">Click to start this dimension</div></div></li>
+        <li class="assessment-item" style="cursor:pointer;border-radius:6px;padding:10px;margin:0 -10px;" onmouseover="this.style.background='#f8fafc'" onmouseout="this.style.background=''"><div class="assessment-severity" style="background:#e5e7eb;"></div><div style="flex:1"><div class="assessment-dimension" style="color:#4b5563;">Release health <span class="tag tag-neutral" style="margin-left:4px;font-size:10px;">Pending</span></div><div class="assessment-finding" style="color:#9ca3af;font-style:italic;">Click to start this dimension</div></div></li>
+      </ul>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Remediation Plan</div>
+      <p style="font-size:13px;color:#9ca3af;font-style:italic;">Remediation plan will be created after all 6 dimensions are assessed. You can add preliminary items now.</p>
+      <button class="btn btn-outline" style="margin-top:8px;font-size:12px;height:30px;"><i class="fa-solid fa-plus"></i> Add remediation item</button>
+    </div>
+  </div>
+  <div class="history-section"><div class="history-title">History</div><div class="history-item"><div class="history-dot recent"></div><div><div class="history-content"><strong>You</strong> completed vulnerability exposure dimension</div><div class="history-time">2h ago</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> claimed package</div><div class="history-time">Yesterday</div></div></div></div>
+  <div class="drawer-footer"><button class="btn btn-primary" style="opacity:0.4;cursor:not-allowed;" title="Complete all 6 dimensions first"><i class="fa-solid fa-check"></i> Complete assessment (3/6)</button><button class="btn btn-outline"><i class="fa-solid fa-save"></i> Save draft</button><button class="btn btn-outline"><i class="fa-solid fa-ban"></i> Flag blocker</button><button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button></div>
+</div>
+
+<!-- ═══ DRAWER: Needs attention (debug) ═══ -->
+<div class="drawer" id="drawer-attention-debug">
+  <div class="drawer-header">
+    <div class="drawer-header-row"><div class="drawer-title">debug</div><button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button></div>
+    <div class="drawer-meta"><code>pkg:npm/debug</code> <span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span> <span class="lifecycle-tag lifecycle-declining">Declining</span> <span style="font-size:12px;color:#d97706;font-weight:600;">Health 42 Concerning</span> <span style="font-size:12px;color:#0f172a;font-weight:600;">Impact 96</span> <span class="tag tag-danger"><i class="fa-solid fa-circle" style="font-size:5px"></i> Needs attention</span></div>
+    <div class="drawer-tabs"><div class="drawer-tab">Overview</div><div class="drawer-tab">Assessment</div><div class="drawer-tab active">Security</div><div class="drawer-tab">Provenance</div></div>
+  </div>
+  <div class="drawer-body">
+    <div style="background:#fef2f2; border:1px solid #fecaca; border-radius:8px; padding:14px 16px; margin-bottom:20px;">
+      <div style="font-size:13px; font-weight:600; color:#991b1b; margin-bottom:6px;"><i class="fa-solid fa-triangle-exclamation" style="margin-right:4px;"></i> New advisory requires your response</div>
+      <div style="font-size:13px; color:#991b1b;">CVE-2026-1234 (High) was published 6 hours ago affecting debug &lt;4.3.5. Evaluate impact and update your remediation plan.</div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">CVE-2026-1234</div>
+      <div class="drawer-field"><span class="drawer-field-label">Severity</span><span class="drawer-field-value"><span class="tag tag-danger">High</span></span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Affected versions</span><span class="drawer-field-value">&lt; 4.3.5</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Fix available</span><span class="drawer-field-value" style="color:#dc2626">No</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Published</span><span class="drawer-field-value">6 hours ago</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Source</span><span class="drawer-field-value">OSV / GHSA</span></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Existing advisories</div>
+      <div class="drawer-field"><span class="drawer-field-label">Total open</span><span class="drawer-field-value" style="color:#dc2626">1</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Total resolved</span><span class="drawer-field-value">2</span></div>
+    </div>
+  </div>
+  <div class="history-section"><div class="history-title">History <span class="history-badge">1 new</span></div><div class="history-item"><div class="history-dot recent"></div><div><div class="history-content"><strong>System</strong> flagged new advisory CVE-2026-1234</div><div class="history-time">6h ago</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> logged remediation progress</div><div class="history-time">1w ago</div></div></div></div>
+  <div class="drawer-footer"><button class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i> Log response</button><button class="btn btn-warning"><i class="fa-solid fa-arrow-up-from-bracket"></i> Escalate</button><button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button></div>
+</div>
+
+<!-- ═══ DRAWER: Available / Claim (node-fetch) ═══ -->
+<div class="drawer" id="drawer-claim-nodefetch">
+  <div class="drawer-header">
+    <div class="drawer-header-row"><div class="drawer-title">node-fetch</div><button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button></div>
+    <div class="drawer-meta"><code>pkg:npm/node-fetch</code> <span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span> <span class="lifecycle-tag lifecycle-abandoned">Abandoned</span> <span style="font-size:12px;color:#dc2626;font-weight:600;">Health 14 Critical</span> <span style="font-size:12px;color:#0f172a;font-weight:600;">Impact 87</span> <span class="tag tag-info"><i class="fa-solid fa-circle" style="font-size:5px"></i> Open</span></div>
+    <div class="drawer-tabs"><div class="drawer-tab active">Overview</div><div class="drawer-tab">Assessment</div><div class="drawer-tab">Security</div><div class="drawer-tab">Provenance</div></div>
+  </div>
+  <div class="drawer-body">
+    <div class="callout-blue"><div class="callout-blue-title"><i class="fa-solid fa-hand" style="margin-right:4px;"></i> This package needs a steward</div><div class="callout-blue-body">Claiming means you'll perform a security assessment, then take ongoing responsibility for monitoring and driving remediation.</div></div>
+    <div class="drawer-section"><div class="drawer-section-title">Health Score Breakdown</div>
+      <div class="drawer-field"><span class="drawer-field-label">Maintainer Health</span><span class="drawer-field-value" style="color:#dc2626">0 / 40</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Security &amp; Supply Chain</span><span class="drawer-field-value" style="color:#dc2626">8 / 35</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Development Activity</span><span class="drawer-field-value" style="color:#dc2626">6 / 25</span></div>
+      <div class="drawer-field" style="border-top:1px solid #e5e7eb;padding-top:8px;margin-top:4px;"><span class="drawer-field-label" style="font-weight:600;color:#0f172a;">Total</span><span class="drawer-field-value" style="font-size:16px;">14 / 100 <span class="tag tag-danger" style="margin-left:4px;">Critical</span></span></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Impact</div>
+      <div class="drawer-field"><span class="drawer-field-label">Impact Score</span><span class="drawer-field-value">87 / 100</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Downloads (last month)</span><span class="drawer-field-value">41,203,847</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Dependent packages</span><span class="drawer-field-value">12,841</span></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Key Risk Signals</div>
+      <div class="drawer-field"><span class="drawer-field-label">Maintainer activity</span><span class="drawer-field-value" style="color:#dc2626">None in 2+ years</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Open advisories</span><span class="drawer-field-value" style="color:#dc2626">1 (CVE-2024-26141)</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">SECURITY.md</span><span class="drawer-field-value" style="color:#dc2626">Missing</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">OpenSSF Scorecard</span><span class="drawer-field-value">3.1 / 10</span></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">What You'll Do as Steward</div>
+      <ul style="font-size:13px;color:#4b5563;padding-left:18px;">
+        <li style="margin-bottom:6px;"><strong>Assess</strong> the package's full security posture across 6 dimensions</li>
+        <li style="margin-bottom:6px;"><strong>Create</strong> a remediation plan with concrete actions</li>
+        <li style="margin-bottom:6px;"><strong>Drive</strong> remediation &mdash; file PRs, engage maintainers, coordinate fixes</li>
+        <li style="margin-bottom:6px;"><strong>Monitor</strong> for new advisories and respond when they appear</li>
+        <li><strong>Escalate</strong> if the package needs engineering help, funding, or a fork</li>
+      </ul>
+    </div>
+  </div>
+  <div class="drawer-footer"><button class="btn btn-primary" style="flex:1;justify-content:center;"><i class="fa-solid fa-hand"></i> Claim stewardship</button><button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button></div>
+</div>
+
+<!-- ═══ DRAWER: Escalated (minimist) ═══ -->
+<div class="drawer" id="drawer-escalated-minimist">
+  <div class="drawer-header">
+    <div class="drawer-header-row"><div class="drawer-title">minimist</div><button class="drawer-close" onclick="closeDrawer()"><i class="fa-solid fa-xmark"></i></button></div>
+    <div class="drawer-meta"><code>pkg:npm/minimist</code> <span class="ecosystem-tag"><span class="dot dot-npm"></span> npm</span> <span class="lifecycle-tag lifecycle-abandoned">Abandoned</span> <span style="font-size:12px;color:#dc2626;font-weight:600;">Health 18 Critical</span> <span style="font-size:12px;color:#0f172a;font-weight:600;">Impact 71</span> <span class="tag tag-danger"><i class="fa-solid fa-circle" style="font-size:5px"></i> Escalated</span></div>
+    <div class="drawer-tabs"><div class="drawer-tab">Overview</div><div class="drawer-tab active">Assessment</div><div class="drawer-tab">Security</div><div class="drawer-tab">Provenance</div></div>
+  </div>
+  <div class="drawer-body">
+    <div style="background:#fef3c7; border:1px solid #fde68a; border-radius:8px; padding:14px 16px; margin-bottom:20px;">
+      <div style="font-size:13px; font-weight:600; color:#92400e; margin-bottom:6px;"><i class="fa-solid fa-arrow-up-from-bracket" style="margin-right:4px;"></i> Escalated &mdash; waiting for admin decision</div>
+      <div style="font-size:13px; color:#92400e;">Maintainer unresponsive after 3 outreach attempts over 6 weeks. Package has open prototype pollution CVE. Recommending fork evaluation or engineering intervention.</div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Escalation Details</div>
+      <div class="drawer-field"><span class="drawer-field-label">Escalated by</span><span class="drawer-field-value">You</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Escalated</span><span class="drawer-field-value">1 day ago</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Reason</span><span class="drawer-field-value">Maintainer unresponsive</span></div>
+      <div class="drawer-field"><span class="drawer-field-label">Recommendation</span><span class="drawer-field-value">Fork evaluation</span></div>
+    </div>
+    <div class="drawer-section"><div class="drawer-section-title">Outreach History</div>
+      <div class="activity-card"><div class="activity-card-meta">You &middot; 1 day ago</div>Third outreach attempt via GitHub issue + email. No response in 6 weeks. Escalating.</div>
+      <div class="activity-card"><div class="activity-card-meta">You &middot; 3 weeks ago</div>Second outreach via GitHub and npm support. No response.</div>
+      <div class="activity-card"><div class="activity-card-meta">You &middot; 6 weeks ago</div>Initial outreach to maintainer via GitHub issue and email.</div>
+    </div>
+  </div>
+  <div class="history-section"><div class="history-title">History</div><div class="history-item"><div class="history-dot recent"></div><div><div class="history-content"><strong>You</strong> escalated &mdash; maintainer unresponsive</div><div class="history-time">1d ago</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> completed assessment &rarr; Active</div><div class="history-time">May 15</div></div></div><div class="history-item"><div class="history-dot"></div><div><div class="history-content"><strong>You</strong> claimed package</div><div class="history-time">May 10</div></div></div></div>
+  <div class="drawer-footer"><button class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i> Log update</button><button class="btn btn-ghost"><i class="fa-light fa-arrow-up-right-from-square"></i> Insights</button></div>
+</div>
+
+<div class="mockup-badge"><span class="dot"></span> UI Mockup &mdash; Me Lens / My Stewardships</div>
+
+<script>
+function switchTab(tab) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.querySelector(`.tab[data-tab="${tab}"]`).classList.add('active');
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  document.getElementById(`panel-${tab}`).classList.add('active');
+}
+
+let openDrawerId = null;
+function openDrawer(id) {
+  closeDrawer();
+  const el = document.getElementById(`drawer-${id}`);
+  if (el) { el.classList.add('open'); openDrawerId = id; }
+  document.getElementById('drawerOverlay').classList.add('open');
+}
+function closeDrawer() {
+  if (openDrawerId) { document.getElementById(`drawer-${openDrawerId}`).classList.remove('open'); openDrawerId = null; }
+  document.getElementById('drawerOverlay').classList.remove('open');
+}
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDrawer(); });
+</script>
+
+</body>
+</html>

--- a/docs/security-project-adoption.html
+++ b/docs/security-project-adoption.html
@@ -1,0 +1,820 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Osprey Package Stewardship — Self Serve Integration</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1a1a2e;
+    --muted: #64748b;
+    --border: #e2e8f0;
+    --accent: #2563eb;
+    --accent-light: #eff6ff;
+    --success: #059669;
+    --success-bg: #ecfdf5;
+    --warning: #d97706;
+    --warning-bg: #fffbeb;
+    --danger: #dc2626;
+    --danger-bg: #fef2f2;
+    --info: #0284c7;
+    --info-bg: #f0f9ff;
+    --neutral-bg: #f8fafc;
+    --code-bg: #f1f5f9;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif;
+    color: var(--fg);
+    line-height: 1.6;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 48px 24px 96px;
+    background: var(--bg);
+  }
+
+  h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 8px; letter-spacing: -0.02em; }
+  h2 { font-size: 1.25rem; font-weight: 700; margin-top: 48px; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 2px solid var(--border); }
+  h3 { font-size: 1.05rem; font-weight: 600; margin-top: 32px; margin-bottom: 12px; }
+  p { margin-bottom: 12px; }
+  .subtitle { color: var(--muted); font-size: 0.95rem; margin-bottom: 32px; }
+
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; font-size: 0.9rem; }
+  th { text-align: left; padding: 10px 12px; background: var(--neutral-bg); border-bottom: 2px solid var(--border); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+
+  code { font-family: 'SF Mono', 'Fira Code', Consolas, monospace; background: var(--code-bg); padding: 2px 6px; border-radius: 4px; font-size: 0.85em; }
+  pre { background: var(--code-bg); padding: 16px 20px; border-radius: 8px; overflow-x: auto; margin-bottom: 16px; font-size: 0.85rem; line-height: 1.5; border: 1px solid var(--border); }
+  pre code { background: none; padding: 0; }
+
+  ul, ol { margin-bottom: 12px; padding-left: 24px; }
+  li { margin-bottom: 6px; }
+
+  .tag { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; }
+  .tag-neutral { background: var(--neutral-bg); color: var(--muted); border: 1px solid var(--border); }
+  .tag-info { background: var(--info-bg); color: var(--info); }
+  .tag-warning { background: var(--warning-bg); color: var(--warning); }
+  .tag-danger { background: var(--danger-bg); color: var(--danger); }
+  .tag-success { background: var(--success-bg); color: var(--success); }
+
+  .callout { padding: 16px 20px; border-radius: 8px; margin-bottom: 20px; font-size: 0.9rem; border-left: 4px solid; }
+  .callout-info { background: var(--info-bg); border-color: var(--info); }
+  .callout-deferred { background: var(--neutral-bg); border-color: var(--border); color: var(--muted); }
+  .callout-key { background: var(--accent-light); border-color: var(--accent); }
+  .callout strong { display: block; margin-bottom: 4px; }
+
+  .mermaid-container { margin: 20px 0; padding: 24px; background: var(--neutral-bg); border-radius: 8px; border: 1px solid var(--border); overflow-x: auto; }
+
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
+  .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: 20px; }
+  .card { padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg); }
+  .card-title { font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin-bottom: 4px; }
+  .card-value { font-size: 1.1rem; font-weight: 700; }
+
+  .section-anchor { scroll-margin-top: 24px; }
+
+  .toc { background: var(--neutral-bg); border: 1px solid var(--border); border-radius: 8px; padding: 20px 24px; margin-bottom: 32px; }
+  .toc-title { font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin-bottom: 12px; }
+  .toc ul { list-style: none; padding: 0; columns: 2; column-gap: 32px; }
+  .toc li { margin-bottom: 6px; }
+  .toc a { color: var(--accent); text-decoration: none; font-size: 0.9rem; }
+  .toc a:hover { text-decoration: underline; }
+
+  .vs { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 20px 0; }
+  .vs-card { padding: 16px; border-radius: 8px; border: 1px solid var(--border); }
+  .vs-card.old { background: var(--danger-bg); border-color: #fecaca; }
+  .vs-card.new { background: var(--success-bg); border-color: #a7f3d0; }
+  .vs-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
+  .vs-card.old .vs-label { color: var(--danger); }
+  .vs-card.new .vs-label { color: var(--success); }
+
+  @media (max-width: 640px) {
+    .grid-2, .grid-3, .vs { grid-template-columns: 1fr; }
+    .toc ul { columns: 1; }
+    body { padding: 24px 16px 64px; }
+  }
+</style>
+</head>
+<body>
+
+<h1>Osprey Package Stewardship</h1>
+<p class="subtitle">Self Serve Integration Spec &mdash; v1</p>
+
+<nav class="toc">
+  <div class="toc-title">Contents</div>
+  <ul>
+    <li><a href="#context">Context</a></li>
+    <li><a href="#what-stewardship-means">What Stewardship Means</a></li>
+    <li><a href="#actors">Actors</a></li>
+    <li><a href="#entry-points">Entry Points</a></li>
+    <li><a href="#flow">End-to-End Flow</a></li>
+    <li><a href="#state-machine">Stewardship Lifecycle</a></li>
+    <li><a href="#assessment">Assessment Framework</a></li>
+    <li><a href="#steward-flow">Steward Flow</a></li>
+    <li><a href="#admin-flow">Admin Flow</a></li>
+    <li><a href="#role-matrix">Role &amp; Action Matrix</a></li>
+    <li><a href="#drawer">Package Detail Drawer</a></li>
+    <li><a href="#notifications">Notifications</a></li>
+    <li><a href="#permissions">Permissions Model</a></li>
+    <li><a href="#api">API Contract</a></li>
+    <li><a href="#design">Design Direction</a></li>
+    <li><a href="#gaps">Data Pipeline Gaps</a></li>
+    <li><a href="#open">Open Decisions</a></li>
+    <li><a href="#pr-sequence">PR Sequence</a></li>
+    <li><a href="#v2">v2 Roadmap</a></li>
+  </ul>
+</nav>
+
+<!-- ───── Context ───── -->
+<h2 id="context" class="section-anchor">Context</h2>
+
+<p>Project Osprey is an OpenSSF-coordinated effort to harden the world's most critical open source packages before AI-assisted vulnerability discovery makes them easy targets. The first phase covers <strong>npm</strong> and <strong>Maven Central</strong>.</p>
+
+<p>Insights/CDP provides the data layer: package identity, risk signals, maintainer info, repository mapping, and criticality scoring. Self Serve owns the <strong>stewardship workflow</strong>: who is responsible for which packages, what is the security posture of each package, what needs to be remediated, and what is the ongoing status.</p>
+
+<!-- ───── What Stewardship Means ───── -->
+<h2 id="what-stewardship-means" class="section-anchor">What Stewardship Means</h2>
+
+<div class="callout callout-key">
+  <strong>Stewardship is ongoing responsibility, not a one-time review.</strong>
+  A steward becomes the security point person for a critical package. They assess its security posture, drive remediation of gaps, engage with upstream maintainers, and monitor for new threats. Stewardship doesn't "complete" &mdash; it's active for as long as the package is critical.
+</div>
+
+<div class="vs">
+  <div class="vs-card old">
+    <div class="vs-label">Not this (data verification)</div>
+    <ul style="margin:0; padding-left: 18px; font-size: 0.9rem;">
+      <li>Verify upstream repo URL is correct</li>
+      <li>Confirm download counts match</li>
+      <li>Check metadata accuracy</li>
+      <li>Submit checklist &rarr; admin approves &rarr; done</li>
+    </ul>
+  </div>
+  <div class="vs-card new">
+    <div class="vs-label">This (security stewardship)</div>
+    <ul style="margin:0; padding-left: 18px; font-size: 0.9rem;">
+      <li>Assess security posture of the package</li>
+      <li>File issues/PRs for security gaps upstream</li>
+      <li>Engage with maintainers on remediation</li>
+      <li>Monitor for new advisories, respond when they appear</li>
+    </ul>
+  </div>
+</div>
+
+<p>A steward's work has two phases:</p>
+<ol>
+  <li><strong>Initial assessment</strong> &mdash; evaluate the package's security posture across a standard framework, identify gaps, and create a remediation plan.</li>
+  <li><strong>Ongoing stewardship</strong> &mdash; drive remediation, engage with maintainers, monitor for new threats, and escalate packages that need direct intervention (engineering help, funding, or forking).</li>
+</ol>
+
+<!-- ───── Actors ───── -->
+<h2 id="actors" class="section-anchor">Actors</h2>
+
+<table>
+  <thead>
+    <tr><th>Actor</th><th>Who</th><th>Responsibilities</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Osprey Admin</strong></td>
+      <td>OpenSSF staff coordinating the program</td>
+      <td>Triage the package queue, assign stewards, handle escalations, spot-check assessment quality, track coverage across the critical package set</td>
+    </tr>
+    <tr>
+      <td><strong>Steward</strong></td>
+      <td>Any authenticated LFX user</td>
+      <td>Claim packages, perform initial security assessment, drive remediation upstream, engage maintainers, monitor ongoing threats, escalate when needed</td>
+    </tr>
+    <tr>
+      <td><strong>Maintainer</strong> <em>(v2)</em></td>
+      <td>Verified upstream package maintainer</td>
+      <td>Submit their own package for stewardship, collaborate with steward on remediation, verify security contacts</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ───── Entry Points ───── -->
+<h2 id="entry-points" class="section-anchor">Entry Points</h2>
+
+<h3>v1 (ship first)</h3>
+
+<table>
+  <thead>
+    <tr><th>Lens</th><th>Tab</th><th>Who sees it</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Me</strong></td>
+      <td>My Stewardships</td>
+      <td>Any authenticated user</td>
+      <td>Browse available packages, claim stewardship, manage your active stewardships. The contributor workspace.</td>
+    </tr>
+    <tr>
+      <td><strong>Me</strong></td>
+      <td>Osprey Program (admin only)</td>
+      <td>Osprey program admins</td>
+      <td>Admin dashboard: full package queue, coverage metrics, assignments, escalation management, spot-check quality.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>v2 (deferred)</h3>
+
+<table>
+  <thead>
+    <tr><th>Lens</th><th>Tab</th><th>Who sees it</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Project</strong></td>
+      <td>Project Stewardship</td>
+      <td>Maintainers + anyone viewing the project</td>
+      <td>Maintainer submits their project for stewardship. Depends on registry API verification.</td>
+    </tr>
+    <tr>
+      <td><strong>Organization</strong></td>
+      <td>Organization Stewardships</td>
+      <td>Org members</td>
+      <td>Read-only visibility into stewardships involving the organization's members.</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ───── Flow ───── -->
+<h2 id="flow" class="section-anchor">End-to-End Flow</h2>
+
+<div class="mermaid-container">
+  <pre class="mermaid">
+flowchart TD
+  source["Insights / CDP\nnpm + Maven Tier 2 package data"] --> api["Stewardship API\npackages, risk signals"]
+
+  api --> admin["Osprey Program\nadmin dashboard (Me lens)"]
+  api --> me["My Stewardships\ncontributor workspace"]
+
+  admin --> triage["Triage package queue\nidentify coverage gaps"]
+  triage --> detail["Open package detail"]
+  detail --> assign{"Assign or open?"}
+  assign --> direct["Assign steward directly"]
+  assign --> open["Open for stewardship"]
+
+  direct --> assess["Steward performs\ninitial security assessment"]
+  open --> claim["Steward claims package"]
+  me --> claim
+  claim --> assess
+
+  assess --> active["Active stewardship\n(ongoing responsibility)"]
+
+  active --> remediate["Drive remediation upstream\nengage maintainers, file PRs"]
+  active --> monitor["Monitor for new advisories\nrespond to threats"]
+  active --> escalate["Escalate if needed\nengineering help, funding, fork"]
+  escalate --> admin
+  </pre>
+</div>
+
+<!-- ───── State Machine ───── -->
+<h2 id="state-machine" class="section-anchor">Stewardship Lifecycle</h2>
+
+<div class="mermaid-container">
+  <pre class="mermaid">
+stateDiagram-v2
+  [*] --> Unassigned
+  Unassigned --> Open : admin opens for stewardship
+  Unassigned --> Assessing : admin assigns steward directly
+  Open --> Assessing : steward claims package
+  Assessing --> Active : steward completes assessment
+  Assessing --> Blocked : steward flags blocker
+  Active --> Escalated : steward or admin escalates
+  Active --> NeedsAttention : new advisory or maintainer change
+  NeedsAttention --> Active : steward addresses issue
+  NeedsAttention --> Escalated : requires intervention
+  Escalated --> Active : resolved
+  Blocked --> Assessing : blocker resolved
+  Active --> Inactive : package no longer critical or steward steps down
+  </pre>
+</div>
+
+<h3>Canonical Status Mapping</h3>
+
+<table>
+  <thead>
+    <tr><th>Persisted state</th><th>UI label</th><th style="width:50%">Meaning</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>unassigned</code></td>
+      <td><span class="tag tag-neutral">Unassigned</span></td>
+      <td>Package is critical but has no steward. The primary coverage gap.</td>
+    </tr>
+    <tr>
+      <td><code>open</code></td>
+      <td><span class="tag tag-info">Open</span></td>
+      <td>Package is available for a steward to claim.</td>
+    </tr>
+    <tr>
+      <td><code>assessing</code></td>
+      <td><span class="tag tag-warning">Assessing</span></td>
+      <td>Steward is performing the initial security assessment.</td>
+    </tr>
+    <tr>
+      <td><code>active</code></td>
+      <td><span class="tag tag-success">Active</span></td>
+      <td>Steward is actively responsible for this package. The steady state.</td>
+    </tr>
+    <tr>
+      <td><code>needs_attention</code></td>
+      <td><span class="tag tag-danger">Needs attention</span></td>
+      <td>New advisory, maintainer change, or other event requires steward response.</td>
+    </tr>
+    <tr>
+      <td><code>escalated</code></td>
+      <td><span class="tag tag-danger">Escalated</span></td>
+      <td>Package needs intervention beyond the steward's scope: engineering help, funding, or a fork.</td>
+    </tr>
+    <tr>
+      <td><code>blocked</code></td>
+      <td><span class="tag tag-danger">Blocked</span></td>
+      <td>Assessment cannot proceed (e.g., maintainer unresponsive, repo inaccessible).</td>
+    </tr>
+    <tr>
+      <td><code>inactive</code></td>
+      <td><span class="tag tag-neutral">Inactive</span></td>
+      <td>Package is no longer critical, steward stepped down, or stewardship is paused.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>The key difference from a task queue: <strong>most packages should end up in <code>active</code> and stay there.</strong> "Active" is the success state, not a waypoint. The admin dashboard's primary metric is coverage &mdash; what percentage of critical packages have an active steward.</p>
+
+<!-- ───── Assessment Framework ───── -->
+<h2 id="assessment" class="section-anchor">Security Assessment Framework</h2>
+
+<p>The initial assessment is a structured evaluation of a package's security posture, not a metadata verification checklist. The steward evaluates each dimension, documents findings, and proposes a remediation plan for gaps.</p>
+
+<h3>Assessment Dimensions</h3>
+
+<table>
+  <thead>
+    <tr><th>Dimension</th><th>What the steward evaluates</th><th>Example findings</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Maintainer health</strong></td>
+      <td>Is anyone responsive? How fast would a critical CVE get patched? Bus factor?</td>
+      <td>"Single maintainer, last active 8 months ago. No response to security issue filed 3 weeks ago."</td>
+    </tr>
+    <tr>
+      <td><strong>Security posture</strong></td>
+      <td>Does the project have a vulnerability disclosure process? SECURITY.md? 2FA on maintainer accounts? Signed releases?</td>
+      <td>"No SECURITY.md. No disclosure process. Releases are unsigned."</td>
+    </tr>
+    <tr>
+      <td><strong>Vulnerability exposure</strong></td>
+      <td>Open advisories? History of security issues? Known attack surface?</td>
+      <td>"4 historical CVEs, all patched. Prototype pollution surface in utility functions."</td>
+    </tr>
+    <tr>
+      <td><strong>Dependency risk</strong></td>
+      <td>What does this package depend on? Are those dependencies healthy?</td>
+      <td>"12 direct deps, 2 are unmaintained. Transitive dep on vulnerable version of minimist."</td>
+    </tr>
+    <tr>
+      <td><strong>Supply chain integrity</strong></td>
+      <td>Build reproducibility? Provenance attestation? Gap between repo and published artifact?</td>
+      <td>"Published artifact includes code not in the repo. No build provenance."</td>
+    </tr>
+    <tr>
+      <td><strong>Release health</strong></td>
+      <td>Release cadence? Stale? Deprecated? Active development?</td>
+      <td>"Last release 5 years ago. 200+ open issues. Active forks exist."</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Assessment Output</h3>
+
+<p>The steward produces:</p>
+<ol>
+  <li><strong>Posture summary</strong> &mdash; overall risk level (Critical / High / Medium / Low) with narrative justification.</li>
+  <li><strong>Findings</strong> &mdash; specific gaps or risks identified, each with severity and evidence.</li>
+  <li><strong>Remediation plan</strong> &mdash; concrete actions to improve the package's security posture:
+    <ul>
+      <li>File upstream issues/PRs (e.g., add SECURITY.md, enable branch protection)</li>
+      <li>Engage maintainers (e.g., establish contact, propose disclosure process)</li>
+      <li>Escalate (e.g., recommend funding, engineering help, or fork)</li>
+    </ul>
+  </li>
+  <li><strong>Monitoring plan</strong> &mdash; what to watch for going forward (advisories, maintainer activity, dependency changes).</li>
+</ol>
+
+<div class="callout callout-info">
+  <strong>The assessment is the steward's first act, not a gate.</strong>
+  Completing the assessment moves the steward directly to active stewardship &mdash; there is no admin review bottleneck. Admins spot-check quality and can flag issues, but do not gate every assessment. The assessment exists to structure the steward's thinking and create an auditable record, not to create a queue for admin approval.
+</div>
+
+<!-- ───── Steward Flow ───── -->
+<h2 id="steward-flow" class="section-anchor">Steward Flow</h2>
+
+<h3>Phase 1: Claim &amp; Assess</h3>
+<ol>
+  <li>Steward opens Me &rarr; My Stewardships.</li>
+  <li>Browses available packages (ranked by criticality and coverage gaps).</li>
+  <li>Claims a package &rarr; moves to <code>assessing</code>.</li>
+  <li>Performs security assessment across the six dimensions.</li>
+  <li>Documents findings, posture summary, and remediation plan.</li>
+  <li>Completes assessment &rarr; moves directly to <code>active</code>.</li>
+</ol>
+
+<h3>Phase 2: Active Stewardship (ongoing)</h3>
+<ol>
+  <li>Executes remediation plan:
+    <ul>
+      <li>Files upstream issues and PRs for identified gaps</li>
+      <li>Engages maintainers on security improvements</li>
+      <li>Tracks remediation progress</li>
+    </ul>
+  </li>
+  <li>Monitors for new threats:
+    <ul>
+      <li>New advisories trigger <code>needs_attention</code></li>
+      <li>Maintainer changes, ownership transfers, repo archival</li>
+    </ul>
+  </li>
+  <li>Escalates when needed:
+    <ul>
+      <li>Maintainer unresponsive after repeated outreach</li>
+      <li>Critical vulnerability with no path to upstream fix</li>
+      <li>Package needs engineering resources or funding</li>
+    </ul>
+  </li>
+  <li>Updates stewardship status periodically (admin can set cadence).</li>
+</ol>
+
+<!-- ───── Admin Flow ───── -->
+<h2 id="admin-flow" class="section-anchor">Admin Flow</h2>
+
+<p>The admin's primary concern is <strong>coverage</strong>: are the most critical packages being stewarded? Secondary concern is <strong>quality</strong>: are stewards actually driving remediation, not just documenting problems?</p>
+
+<ol>
+  <li>Osprey admin opens Me &rarr; Osprey Program.</li>
+  <li>Sees coverage metrics:</li>
+</ol>
+
+<div class="grid-3">
+  <div class="card"><div class="card-title">Critical packages</div><div class="card-value">1,842</div></div>
+  <div class="card"><div class="card-title">Active stewards</div><div class="card-value" style="color: #059669">612</div></div>
+  <div class="card"><div class="card-title">Coverage</div><div class="card-value">33.2%</div></div>
+  <div class="card"><div class="card-title">Unassigned (critical)</div><div class="card-value" style="color: #dc2626">1,230</div></div>
+  <div class="card"><div class="card-title">Needs attention</div><div class="card-value" style="color: #d97706">47</div></div>
+  <div class="card"><div class="card-title">Escalated</div><div class="card-value" style="color: #dc2626">8</div></div>
+</div>
+
+<ol start="3">
+  <li>Identifies coverage gaps: which critical packages have no steward?</li>
+  <li>Opens packages for stewardship or assigns stewards directly.</li>
+  <li>Spot-checks assessment quality: flags incomplete or low-effort assessments for steward follow-up.</li>
+  <li>Handles escalations: allocate engineering resources, approve funding, decide on forks.</li>
+  <li>Monitors steward activity: are active stewards driving remediation or going quiet?</li>
+  <li>Uses bulk actions for high-volume queue management.</li>
+</ol>
+
+<!-- ───── Role Matrix ───── -->
+<h2 id="role-matrix" class="section-anchor">Role &amp; Action Matrix</h2>
+
+<table>
+  <thead>
+    <tr><th>State</th><th>Steward</th><th>Osprey Admin</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>unassigned</code></td>
+      <td>View</td>
+      <td>Open for stewardship, assign steward, bulk assign</td>
+    </tr>
+    <tr>
+      <td><code>open</code></td>
+      <td>Claim package</td>
+      <td>Assign steward, close availability</td>
+    </tr>
+    <tr>
+      <td><code>assessing</code></td>
+      <td>Document findings, complete assessment, flag blocker</td>
+      <td>Reassign, flag blocker, spot-check</td>
+    </tr>
+    <tr>
+      <td><code>active</code></td>
+      <td>Update status, log remediation progress, escalate</td>
+      <td>Review activity, reassign, escalate</td>
+    </tr>
+    <tr>
+      <td><code>needs_attention</code></td>
+      <td>Investigate and respond, escalate if needed</td>
+      <td>Reassign, escalate</td>
+    </tr>
+    <tr>
+      <td><code>escalated</code></td>
+      <td>Provide context, continue monitoring</td>
+      <td>Allocate resources, approve funding, decide on fork, resolve</td>
+    </tr>
+    <tr>
+      <td><code>blocked</code></td>
+      <td>Add blocker details, resolve if able</td>
+      <td>Resolve, reassign</td>
+    </tr>
+    <tr>
+      <td><code>inactive</code></td>
+      <td>View history</td>
+      <td>Reactivate, reassign</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ───── Drawer ───── -->
+<h2 id="drawer" class="section-anchor">Package Detail Drawer</h2>
+
+<h3>Tabs</h3>
+<ul>
+  <li><strong>Overview</strong>: package identity, purl, ecosystem, criticality score, downloads, dependents, latest release, repository summary.</li>
+  <li><strong>Assessment</strong>: posture summary, findings by dimension, remediation plan, monitoring plan. For <code>active</code> packages: remediation progress and status updates.</li>
+  <li><strong>Security</strong>: OSV/GHSA advisories, critical vulnerability flag, security contact links, vulnerability policy links.</li>
+  <li><strong>Provenance</strong>: declared repository URL, normalized URL, mapping source, confidence level, build provenance status.</li>
+</ul>
+
+<h3>History Timeline</h3>
+<p>Always visible below the active tab content. Includes: status changes, assessment submissions, admin reviews, remediation actions logged, escalation notes, advisory alerts, steward activity updates.</p>
+
+<h3>Sticky Footer Actions</h3>
+<p>Context-dependent based on role and current state:</p>
+<ul>
+  <li>Claim package / Assign steward</li>
+  <li>Complete assessment</li>
+  <li>Log remediation progress</li>
+  <li>Escalate / Mark blocked</li>
+  <li>Open in Insights</li>
+</ul>
+
+<!-- ───── Notifications ───── -->
+<h2 id="notifications" class="section-anchor">Notifications (v1)</h2>
+
+<ul>
+  <li>In-app and email when a package is assigned to me.</li>
+  <li>In-app and email when an admin flags my assessment for follow-up.</li>
+  <li>In-app and email when a new advisory hits a package I steward.</li>
+  <li>In-app and email when an escalation is resolved.</li>
+  <li>Admin: when a steward completes an assessment (for spot-check queue).</li>
+  <li>Admin: when a steward escalates a package.</li>
+</ul>
+
+<div class="callout callout-deferred">
+  <strong>Deferred to v2:</strong> admin digests, activity reminders for inactive stewards, notification grouping.
+</div>
+
+<!-- ───── Permissions ───── -->
+<h2 id="permissions" class="section-anchor">Permissions Model</h2>
+
+<table>
+  <thead>
+    <tr><th>Role</th><th>How determined</th><th>Scope</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Osprey Admin</strong></td>
+      <td>OpenSSF program-level admin role</td>
+      <td>All packages in the Osprey program</td>
+    </tr>
+    <tr>
+      <td><strong>Steward</strong></td>
+      <td>Any authenticated LFX user</td>
+      <td>Packages they've claimed or been assigned</td>
+    </tr>
+    <tr>
+      <td><strong>Maintainer</strong> <em>(v2)</em></td>
+      <td>Registry API verification (npm/Maven)</td>
+      <td>Their own packages</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ───── API ───── -->
+<h2 id="api" class="section-anchor">API Contract</h2>
+
+<p>Minimum API surface:</p>
+
+<table>
+  <thead>
+    <tr><th>Method</th><th>Endpoint</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>GET</code></td><td><code>/api/stewardship/packages</code></td><td>List packages (filters, cursor pagination, sort)</td></tr>
+    <tr><td><code>GET</code></td><td><code>/api/stewardship/packages/:id</code></td><td>Get package detail</td></tr>
+    <tr><td><code>PATCH</code></td><td><code>/api/stewardship/packages/:id</code></td><td>Admin overrides (repo mapping, etc.)</td></tr>
+    <tr><td><code>POST</code></td><td><code>/api/stewardship/packages/:id/stewardships</code></td><td>Create stewardship (claim or assign)</td></tr>
+    <tr><td><code>GET</code></td><td><code>/api/stewardship/stewardships/:id</code></td><td>Get stewardship detail (assessment, history)</td></tr>
+    <tr><td><code>PATCH</code></td><td><code>/api/stewardship/stewardships/:id</code></td><td>Update state, assessment, or status</td></tr>
+    <tr><td><code>POST</code></td><td><code>/api/stewardship/stewardships/:id/complete-assessment</code></td><td>Complete assessment, move to active</td></tr>
+    <tr><td><code>POST</code></td><td><code>/api/stewardship/stewardships/:id/flag</code></td><td>Admin flags assessment for steward follow-up</td></tr>
+    <tr><td><code>POST</code></td><td><code>/api/stewardship/stewardships/:id/escalate</code></td><td>Escalate for intervention</td></tr>
+    <tr><td><code>POST</code></td><td><code>/api/stewardship/stewardships/:id/activity</code></td><td>Log remediation progress or status update</td></tr>
+    <tr><td><code>GET</code></td><td><code>/api/stewardship/my-work</code></td><td>Current user's stewardships</td></tr>
+    <tr><td><code>GET</code></td><td><code>/api/stewardship/summary</code></td><td>Coverage metrics for dashboard</td></tr>
+    <tr style="opacity: 0.5"><td><code>GET</code></td><td><code>/api/stewardship/org/:orgId/stewardships</code></td><td>Organization's stewardships <em>(v2)</em></td></tr>
+    <tr style="opacity: 0.5"><td><code>POST</code></td><td><code>/api/stewardship/packages/:id/submit-for-stewardship</code></td><td>Maintainer submission <em>(v2)</em></td></tr>
+  </tbody>
+</table>
+
+<p>No <code>DELETE</code> endpoints &mdash; all state transitions are patches that preserve history.</p>
+
+<h3>Example Stewardship Record</h3>
+
+<pre><code>{
+  "id": "stw_123",
+  "package_id": "pkg_npm_lodash",
+  "program_id": "osprey",
+  "state": "active",
+  "state_version": 12,
+  "origin": "self_claimed",
+  "owner": {
+    "uid": "user_123",
+    "name": "Maya Chen"
+  },
+  "assessment": {
+    "posture": "high",
+    "summary": "Single maintainer, no security disclosure process, no signed releases. 4 historical CVEs all patched. Prototype pollution attack surface remains.",
+    "findings": [
+      {
+        "dimension": "maintainer_health",
+        "severity": "high",
+        "finding": "Single maintainer (jdalton). Last commit 2024-09. No response to issues in 3+ months.",
+        "evidence": "GitHub activity timeline, npm maintainers list"
+      },
+      {
+        "dimension": "security_posture",
+        "severity": "high",
+        "finding": "No SECURITY.md, no vulnerability disclosure process, unsigned releases.",
+        "evidence": "Repository scan"
+      }
+    ],
+    "remediation_plan": [
+      { "action": "File PR to add SECURITY.md with disclosure process", "status": "done", "url": "https://github.com/lodash/lodash/pull/5678" },
+      { "action": "Contact maintainer re: 2FA and signed releases", "status": "in_progress" },
+      { "action": "Evaluate if fork is needed given maintainer responsiveness", "status": "pending" }
+    ],
+    "completed_at": "2026-05-25T18:30:00Z"
+  },
+  "activity": [
+    {
+      "id": "act_456",
+      "type": "remediation_update",
+      "content": "SECURITY.md PR merged. Maintainer responded to 2FA request, says he'll enable it.",
+      "created_at": "2026-05-28T14:00:00Z"
+    }
+  ],
+  "history": [
+    {
+      "id": "event_789",
+      "type": "state_changed",
+      "from_state": "assessing",
+      "to_state": "active",
+      "actor_uid": "user_123",
+      "created_at": "2026-05-25T18:30:00Z"
+    }
+  ],
+  "created_at": "2026-05-22T09:00:00Z",
+  "updated_at": "2026-05-28T14:00:00Z"
+}</code></pre>
+
+<h3>Concurrency</h3>
+<p>Every stewardship mutation must include <code>state_version</code> for optimistic locking. On conflict, the API returns the latest state so the UI can refresh.</p>
+
+<!-- ───── Design ───── -->
+<h2 id="design" class="section-anchor">Design Direction</h2>
+
+<p>Dense operational layout consistent with existing LFX One dashboards. The admin dashboard is <strong>coverage-oriented</strong>, not throughput-oriented &mdash; the primary visualization is "how much of the critical package set is covered" rather than "how many items were processed this week."</p>
+
+<h3>Visual System</h3>
+<ul>
+  <li>Use existing Tailwind/LFX tokens only. No hard-coded hex values.</li>
+  <li>Tags:
+    <span class="tag tag-neutral">Unassigned</span>
+    <span class="tag tag-info">Open</span>
+    <span class="tag tag-warning">Assessing</span>
+    <span class="tag tag-success">Active</span>
+    <span class="tag tag-danger">Needs attention</span>
+    <span class="tag tag-danger">Escalated</span>
+    <span class="tag tag-danger">Blocked</span>
+    <span class="tag tag-neutral">Inactive</span>
+  </li>
+  <li>Table is the primary surface. Row click opens the detail drawer.</li>
+</ul>
+
+<!-- ───── Gaps ───── -->
+<h2 id="gaps" class="section-anchor">Data Pipeline Gap Analysis</h2>
+
+<div class="callout callout-info">
+  <strong>Covered by CDP Pipeline</strong>
+  Package identity, downloads/dependents, latest version/release, repo mapping, OpenSSF Scorecard, advisories, repo stars/forks/last commit, maintainer info, licenses.
+</div>
+
+<table>
+  <thead>
+    <tr><th>Gap</th><th>Priority</th><th>Detail</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Composite risk score</td>
+      <td><span class="tag tag-danger">High</span></td>
+      <td>Raw signals exist but no composite tier (Critical/High/Medium/Low). Primary sort/filter axis.</td>
+    </tr>
+    <tr>
+      <td>Repo mapping confidence</td>
+      <td><span class="tag tag-danger">High</span></td>
+      <td>deps.dev has the mapping but no confidence signal. Need to derive from source.</td>
+    </tr>
+    <tr>
+      <td>Security contact / policy</td>
+      <td><span class="tag tag-danger">High</span></td>
+      <td>Critical for assessment. Pipeline has maintainers but not SECURITY.md presence or dedicated security contact.</td>
+    </tr>
+    <tr>
+      <td>Build provenance</td>
+      <td><span class="tag tag-warning">Medium</span></td>
+      <td>Supply chain integrity assessment needs provenance attestation data. Not currently collected.</td>
+    </tr>
+    <tr>
+      <td>Maintainer activity recency</td>
+      <td><span class="tag tag-warning">Medium</span></td>
+      <td>Last commit is collected but maintainer-specific response time (to issues, PRs) is not.</td>
+    </tr>
+    <tr>
+      <td>Package deprecation status</td>
+      <td><span class="tag tag-warning">Medium</span></td>
+      <td>npm deprecation flags and Maven relocation. Needed for <code>inactive</code> state.</td>
+    </tr>
+    <tr>
+      <td>Monorepo awareness</td>
+      <td><span class="tag tag-warning">Medium</span></td>
+      <td>Many npm packages map to the same repo. Need grouping to avoid duplicate stewardships.</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ───── Open Decisions ───── -->
+<h2 id="open" class="section-anchor">Open Decisions</h2>
+
+<ul>
+  <li><strong>Which upstream service owns stewardship state?</strong> Leaning: dedicated Osprey workflow service, with Insights/CDP as source-data providers.</li>
+  <li><strong>Who computes composite risk scores?</strong> CDP provides raw signals. Either CDP exposes pre-computed tiers, or the stewardship service computes them.</li>
+  <li><strong>How does the package list sync from CDP?</strong> Batch import, real-time feed, or API pull? Refresh cadence?</li>
+  <li><strong>What triggers <code>needs_attention</code>?</strong> New advisory is clear. What about: maintainer account changes, repo archival, significant dependency changes? Define the event set.</li>
+  <li><strong>How do we track remediation actions across external systems?</strong> Stewards file PRs on GitHub, issues on registries. Do we just log URLs, or do we pull status from those systems?</li>
+  <li><strong>What's the expected steward-to-package ratio?</strong> One steward per package? Or can a steward manage a cluster of related packages (e.g., all of lodash's ecosystem)?</li>
+  <li><strong>How often should active stewards report status?</strong> Monthly? Quarterly? Triggered by events? This affects the <code>inactive</code> detection logic.</li>
+</ul>
+
+<!-- ───── PR Sequence ───── -->
+<h2 id="pr-sequence" class="section-anchor">Suggested PR Sequence</h2>
+
+<ol>
+  <li>Shared types + backend proxy/controller/service once upstream API contract is confirmed.</li>
+  <li>Admin package queue page (Me lens, admin-gated) with coverage metrics and filters/table/drawer in read-only mode.</li>
+  <li>Stewardship lifecycle: claim, assessment, activate.</li>
+  <li>My Stewardships (Me lens): contributor workspace with active stewardship management.</li>
+  <li>Activity logging: remediation progress, status updates, escalations.</li>
+</ol>
+
+<!-- ───── v2 ───── -->
+<h2 id="v2" class="section-anchor">v2 Roadmap</h2>
+
+<div class="callout callout-deferred">
+  <strong>Features explicitly deferred from v1:</strong>
+  <ul style="margin-top:8px; margin-bottom:0;">
+    <li><strong>Project Stewardship</strong> (Project lens) &mdash; maintainer submission flow with registry API verification</li>
+    <li><strong>Organization Stewardships</strong> (Org lens) &mdash; read-only org-wide visibility</li>
+    <li>Automated <code>needs_attention</code> triggers from advisory feeds</li>
+    <li>Steward activity scoring / engagement metrics</li>
+    <li>Remediation tracking with GitHub PR/issue status sync</li>
+    <li>Assignment pool routing and round-robin</li>
+    <li>Saved views (per-user, shareable)</li>
+    <li>Notification digests and activity reminders</li>
+    <li>Package clustering (steward manages related packages together)</li>
+  </ul>
+</div>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'neutral',
+    flowchart: { useMaxWidth: true, htmlLabels: true },
+    themeVariables: {
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif',
+      fontSize: '14px'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/docs/security-project-adoption.md
+++ b/docs/security-project-adoption.md
@@ -1,9 +1,9 @@
-# Self Serve Security Project Adoption
+# Self Serve Security Package Stewardship
 
 ## Context
 
 The Osprey / Tier 2 npm + Maven work needs a Self Serve coordination layer. The
-Slack direction was to build a tool that lets people "adopt a project" so the
+Slack direction was to build a tool that lets people steward a package so the
 review and hardening work can be split across a large set of dependencies.
 
 Insights and CDP should remain the source-data and analytics layer. Self Serve
@@ -15,9 +15,9 @@ workflow, and review status.
 ### Entry Points
 
 - **Me lens:** `My Security Work`
-  - Shows packages/projects I adopted, assigned work, due items, blocked items,
-    and review status.
-- **Foundation lens / Admin Mode:** `Security Adoption`
+  - Shows packages/projects I'm stewarding, assigned work, due items, blocked
+    items, and review status.
+- **Foundation lens / Admin Mode:** `Security Stewardship`
   - ED/admin coordination dashboard for the selected foundation or LF-wide
     Osprey program.
 - **Project lens:** `Security`
@@ -27,28 +27,28 @@ workflow, and review status.
 
 ## End-to-End Flow
 
-The product flow is centered on **creating an adoption from a package security
-signal**. A package signal can exist without an adoption. An adoption starts only
-when an admin assigns a steward, opens the package for contributors, or a
-contributor claims available work.
+The product flow is centered on **creating a stewardship record from a package
+security signal**. A package signal can exist without a stewardship record.
+Stewardship starts only when an admin assigns a steward, opens the package for
+contributors, or a contributor claims available work.
 
 ```mermaid
 flowchart TD
-  source["Insights / CDP data foundation<br/>npm + Maven Tier 2 package data"] --> sync["Security adoption API<br/>packages, risk signals, assignments"]
-  sync --> admin["Foundation Security Adoption<br/>ED / Admin Mode"]
+  source["Insights / CDP data foundation<br/>npm + Maven Tier 2 package data"] --> sync["Security stewardship API<br/>packages, risk signals, assignments"]
+  sync --> admin["Foundation Security Stewardship<br/>ED / Admin Mode"]
   sync --> me["My Security Work<br/>Contributor view"]
 
   admin --> triage["Triage package signal queue<br/>filter by ecosystem, risk, status, owner"]
   triage --> detail["Open package detail drawer"]
-  detail --> assign{"Create adoption<br/>direct assign or open?"}
+  detail --> assign{"Create stewardship<br/>direct assign or open?"}
   assign --> direct["Assign steward"]
-  assign --> open["Open for adoption"]
+  assign --> open["Open for stewardship"]
 
   direct --> assigned["Assigned"]
   open --> discover["Contributor discovers package"]
   me --> discover
-  discover --> adopt["Claim adoption"]
-  adopt --> checklist["Complete verification checklist"]
+  discover --> claim["Claim package"]
+  claim --> checklist["Complete verification checklist"]
   checklist --> submit["Submit for review"]
 
   assigned --> checklist
@@ -59,7 +59,7 @@ flowchart TD
   changes --> blocked["Mark blocked"]
   changes --> complete["Mark complete"]
 
-  checklist --> release["Release / decline with reason"]
+  checklist --> release["Release stewardship / decline with reason"]
   release --> open
   checklist --> stale["Stale by aging policy"]
   stale --> open
@@ -74,20 +74,19 @@ flowchart TD
 ```mermaid
 stateDiagram-v2
   [*] --> Unassigned
-  Unassigned --> OpenForAdoption: admin opens package
+  Unassigned --> OpenForStewardship: admin opens package
   Unassigned --> Assigned: admin assigns owner
-  OpenForAdoption --> Adopted: contributor claims
+  OpenForStewardship --> Claimed: contributor claims
   Assigned --> InProgress: owner starts checklist
-  Assigned --> Declined: owner declines with reason
-  Declined --> Unassigned: admin reopens
-  Declined --> Assigned: admin reassigns
-  Adopted --> InProgress: owner starts checklist
-  Adopted --> Released: owner releases work
-  Released --> OpenForAdoption: available again
+  Assigned --> Returned: owner declines with reason
+  Claimed --> InProgress: owner starts checklist
+  Claimed --> Returned: owner releases work
+  Returned --> OpenForStewardship: available again
+  Returned --> Assigned: admin reassigns
   InProgress --> Submitted: submit for review
-  InProgress --> Released: owner releases work
+  InProgress --> Returned: owner releases work
   InProgress --> Stale: no progress past aging threshold
-  Stale --> OpenForAdoption: auto-release or admin release
+  Stale --> OpenForStewardship: auto-release or admin release
   Stale --> InProgress: owner resumes before release
   Submitted --> ChangesRequested: reviewer requests changes
   Submitted --> Blocked: reviewer marks blocked
@@ -95,16 +94,29 @@ stateDiagram-v2
   Submitted --> Complete: reviewer approves
   InProgress --> Blocked: owner flags blocker
   Blocked --> InProgress: blocker resolved
-  Blocked --> Reassigning: admin changes owner
-  Reassigning --> Assigned: history and notes preserved
+  Blocked --> Assigned: admin reassigns (history preserved)
   Complete --> NeedsReverification: new advisory, maintainer change, age policy, manual reopen
   NeedsReverification --> Unassigned: admin reopens
   NeedsReverification --> Assigned: admin assigns reviewer/steward
-  Unassigned --> NoLongerAdoptable: package removed/deprecated/out of scope
-  OpenForAdoption --> NoLongerAdoptable: package removed/deprecated/out of scope
+  Unassigned --> NoLongerInScope: package removed/deprecated/out of scope
+  OpenForStewardship --> NoLongerInScope: package removed/deprecated/out of scope
   Complete --> [*]
-  NoLongerAdoptable --> [*]
+  NoLongerInScope --> [*]
 ```
+
+State simplifications vs. original:
+
+- **`adopted` → `claimed`**: Avoids confusion with "technology adoption." Clearer
+  intent: the contributor claimed responsibility.
+- **`open_for_adoption` → `open_for_stewardship`**: Consistent rename.
+- **`released` + `declined` → `returned`**: Both return work to the pool with a
+  reason. Differentiate via `returned_reason` (`declined_before_start`,
+  `released_during_work`, `capacity`, `not_the_right_steward`).
+- **`reassigning` removed**: Reassignment is an admin action that atomically
+  moves to `assigned` with a new owner and writes a history event — not a
+  durable state. A transient "reassigning" state creates edge cases (admin
+  abandons mid-reassignment) without clear benefit.
+- **`no_longer_adoptable` → `no_longer_in_scope`**: Consistent rename.
 
 ### Canonical Status Mapping
 
@@ -112,49 +124,65 @@ Persisted API states should stay stable and machine-readable. UI labels can be
 friendlier, but filters, tags, and transitions should map back to this canonical
 set.
 
-| Persisted state        | UI label                 | Meaning                                                                                          |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
-| `unassigned`           | `Unassigned`             | Package is in the queue and has no owner.                                                        |
-| `open_for_adoption`    | `Open` / `Available`     | Package is available for a contributor to adopt.                                                 |
-| `assigned`             | `Assigned`               | Admin assigned an owner, but work has not started.                                               |
-| `adopted`              | `Adopted`                | Contributor adopted the package, but work has not started.                                       |
-| `in_progress`          | `In progress`            | Owner is actively working through the checklist.                                                 |
-| `submitted`            | `In review`              | Owner submitted the checklist for ED/admin review.                                               |
-| `changes_requested`    | `Changes requested`      | Reviewer sent the work back with required updates.                                               |
-| `blocked`              | `Blocked`                | Work cannot proceed until the blocker is resolved.                                               |
-| `stale`                | `Stale`                  | No checklist progress past the stale threshold.                                                  |
-| `released`             | `Released`               | Owner released the adoption back to the open queue.                                              |
-| `declined`             | `Declined`               | Assigned owner declined before starting, with a required reason.                                 |
-| `reassigning`          | `Reassigning`            | Admin is changing owner while preserving prior work history.                                     |
-| `complete`             | `Complete` / `Completed` | Reviewer approved the submission.                                                                |
-| `needs_reverification` | `Needs reverification`   | Completed adoption was reopened by new advisory, maintainer change, age policy, or admin action. |
-| `no_longer_adoptable`  | `No longer adoptable`    | Package is deprecated, transferred, removed, or out of scope.                                    |
+| Persisted state          | UI label                 | Meaning                                                                                               |
+| ------------------------ | ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `unassigned`             | `Unassigned`             | Package is in the queue and has no owner.                                                             |
+| `open_for_stewardship`   | `Open` / `Available`     | Package is available for a contributor to claim.                                                      |
+| `assigned`               | `Assigned`               | Admin assigned an owner, but work has not started.                                                    |
+| `claimed`                | `Claimed`                | Contributor claimed the package, but work has not started.                                            |
+| `in_progress`            | `In progress`            | Owner is actively working through the checklist.                                                      |
+| `submitted`              | `In review`              | Owner submitted the checklist for ED/admin review.                                                    |
+| `changes_requested`      | `Changes requested`      | Reviewer sent the work back with required updates.                                                    |
+| `blocked`                | `Blocked`                | Work cannot proceed until the blocker is resolved.                                                    |
+| `stale`                  | `Stale`                  | No checklist progress past the stale threshold.                                                       |
+| `returned`               | `Returned`               | Owner returned stewardship to the queue with a required reason.                                       |
+| `complete`               | `Complete` / `Completed` | Reviewer approved the submission.                                                                     |
+| `needs_reverification`   | `Needs reverification`   | Completed stewardship was reopened by new advisory, maintainer change, age policy, or admin action.   |
+| `no_longer_in_scope`     | `No longer in scope`     | Package is deprecated, transferred, removed, or out of scope.                                         |
 
 The table filters should use persisted states in query params and request
 payloads. Display-only labels such as `Available` or `Completed`
 should be derived in the UI from the persisted state plus owner context.
 
-`assigned` and `adopted` are behaviorally equivalent once work starts; both move
+`assigned` and `claimed` are behaviorally equivalent once work starts; both move
 to `in_progress` on the first checklist update. Keep both states because the
 provenance matters for reporting: admin-assigned work and contributor-claimed
-work answer different coordination questions.
+work answer different coordination questions. The stewardship record's `origin`
+field (`admin_assigned` | `self_claimed`) preserves this distinction independent
+of current state.
+
+The `returned` state replaces the original `released` and `declined` states. The
+reason for returning is captured in a `returned_reason` field with controlled
+values: `declined_before_start`, `released_during_work`, `capacity`,
+`not_the_right_steward`. This preserves the reporting signal without adding
+extra states and transitions.
 
 ### Aging and Reverification Policy
 
-- Warn owner after 30 days with no checklist progress.
-- Move to `stale` after 45 days with no checklist progress.
-- Release back to `open_for_adoption` after 60 days unless an admin overrides.
-- Allow owners to self-release `adopted` or `in_progress` work with a required
+Default thresholds (configurable per foundation):
+
+- Warn owner after **30 days** with no checklist progress.
+- Move to `stale` after **45 days** with no checklist progress.
+- Release back to `open_for_stewardship` after **60 days** unless an admin
+  overrides.
+
+"Checklist progress" is defined as: any checklist item state change (incomplete
+→ complete or vice versa), or a contributor note added to the stewardship
+record. Opening the drawer or viewing the record does not count as progress.
+
+Additional policies:
+
+- Allow owners to self-release `claimed` or `in_progress` work with a required
   reason.
 - Reopen `complete` as `needs_reverification` when a new advisory appears,
   maintainer/security contact changes, package ownership changes, package status
   changes, or an annual verification policy fires.
-- Preserve adoption history, checklist evidence, comments, blocker reasons, and
-  reviewer notes through reassignment and reverification.
+- Preserve stewardship history, checklist evidence, comments, blocker reasons,
+  and reviewer notes through reassignment and reverification.
 
 ## Admin Flow
 
-1. ED/admin opens `Foundation -> Security Adoption`.
+1. ED/admin opens `Foundation -> Security Stewardship`.
 2. The page shows top metrics:
    - Total packages in scope
    - Unassigned percentage
@@ -164,14 +192,14 @@ work answer different coordination questions.
    - Completed this week
 3. ED/admin filters the work queue:
    - Ecosystem: supported ecosystems
-   - Status: unassigned, open, assigned/adopted, in progress, in review,
+   - Status: unassigned, open, assigned/claimed, in progress, in review,
      changes requested, blocked, stale, complete, needs reverification
    - Risk: critical advisory, high dependents, single maintainer, stale repo
    - Source confidence: declared, deps.dev, heuristic, manual
 4. ED/admin opens a package detail drawer.
-5. ED/admin creates an adoption by assigning a steward or marking the package
-   open for adoption.
-6. ED/admin tracks progress across adopters.
+5. ED/admin creates a stewardship record by assigning a steward or marking the
+   package open for stewardship.
+6. ED/admin tracks progress across stewards.
 7. ED/admin uses bulk actions for high-volume queue management.
 8. ED/admin links back to Insights for analytics-heavy views.
 
@@ -182,21 +210,23 @@ cannot assume one-row-at-a-time triage.
 
 - Table supports multi-select across the current page and filtered result set.
 - Bulk actions:
-  - `Open for adoption`
+  - `Open for stewardship`
   - `Assign steward`
   - `Reassign steward`
   - `Mark blocked`
   - `Apply tag`
-  - `Release stale adoptions`
-- Bulk actions above 500 rows run as async jobs with a progress drawer/toast and
-  a downloadable result summary.
-- Saved views are per-user and shareable by URL. Suggested defaults:
+  - `Release stale stewardships`
+- Bulk actions above a configurable row threshold run as async jobs with a
+  progress drawer/toast and a downloadable result summary. The threshold should
+  be determined during implementation based on actual API response times.
+- Saved views are per-user and shareable by URL. Suggested defaults for v1:
   - `Critical unassigned`
-  - `npm owner unclear`
-  - `Maven needs maintainer`
-  - `Stale adoptions`
+  - `Stale stewardships`
   - `Needs reverification`
-- Server uses optimistic locking on adoption records. If a row changed after it
+- Additional saved views (e.g., ecosystem-specific filters like `npm owner
+  unclear` or `Maven needs maintainer`) can be added as the underlying data
+  matures.
+- Server uses optimistic locking on stewardship records. If a row changed after it
   was loaded, the UI shows conflict copy such as: `This package was just claimed
 by {user}. Refresh to see the latest state.`
 
@@ -211,13 +241,13 @@ from the start.
   - auto-open packages matching critical-risk criteria
   - auto-assign packages with known project maintainers
   - require reviewer pool for high-criticality packages
-- Rules should write normal adoption records so history, review, and analytics
-  remain consistent with manually-created adoptions.
+- Rules should write normal stewardship records so history, review, and
+  analytics remain consistent with manually-created stewardships.
 
 ## Contributor Flow
 
 1. User opens `Me -> My Security Work`.
-2. User sees available packages to adopt plus assigned/adopted packages.
+2. User sees available packages to claim plus assigned/claimed packages.
 3. User opens a package drawer with:
    - Package identity
    - Ecosystem
@@ -226,7 +256,7 @@ from the start.
    - Advisories
    - Maintainer/contact info
    - Suggested verification tasks
-4. User clicks `Claim adoption` or accepts an admin assignment.
+4. User clicks `Claim package` or accepts an admin assignment.
 5. User completes the checklist:
    - Verify upstream repo
    - Verify maintainer/security contacts
@@ -243,7 +273,7 @@ from the start.
 Minimum notification surface:
 
 - In-app and email when work is assigned to me.
-- In-app and email when someone claims work I opened.
+- In-app and email when someone claims a package I opened for stewardship.
 - In-app and email when review is requested from me.
 - In-app and email when my submission is approved, blocked, or has requested
   changes.
@@ -255,30 +285,28 @@ Minimum notification surface:
 
 ## Role and Action Matrix
 
-| State                  | Contributor / owner                                        | ED/admin / reviewer                                                                       |
-| ---------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `unassigned`           | View                                                       | Create adoption, assign steward, open for adoption, bulk assign, mark no longer adoptable |
-| `open_for_adoption`    | Claim adoption                                             | Assign steward, close availability, bulk assign                                           |
-| `assigned`             | Accept/start, decline with reason                          | Reassign, release, mark blocked                                                           |
-| `adopted`              | Start checklist, release                                   | Reassign, release, mark blocked                                                           |
-| `declined`             | View reason, respond if reassigned                         | Reopen to unassigned, reassign, mark no longer adoptable                                  |
-| `in_progress`          | Update checklist, submit for review, mark blocked, release | Reassign, mark blocked, request update                                                    |
-| `submitted`            | View submission, reply to comments                         | Approve, request changes, mark blocked                                                    |
-| `changes_requested`    | Update checklist, reply, resubmit, release                 | Reassign, mark blocked                                                                    |
-| `blocked`              | Add blocker details, resolve if owner can                  | Resolve, reassign, release, mark no longer adoptable                                      |
-| `released`             | View read-only history                                     | Reopen for adoption, assign steward, mark no longer adoptable                             |
-| `stale`                | Resume before release, release                             | Release to open queue, reassign, extend due date                                          |
-| `reassigning`          | View read-only history                                     | Finish reassignment, cancel reassignment, mark no longer adoptable                        |
-| `complete`             | View history                                               | Reopen as needs reverification, open in Insights                                          |
-| `needs_reverification` | Claim if open                                              | Assign steward, open for adoption, mark no longer adoptable                               |
-| `no_longer_adoptable`  | View read-only history                                     | View read-only history, reopen only if package returns to scope                           |
+| State                    | Contributor / owner                                        | ED/admin / reviewer                                                                             |
+| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `unassigned`             | View                                                       | Create stewardship, assign steward, open for stewardship, bulk assign, mark no longer in scope  |
+| `open_for_stewardship`   | Claim package                                              | Assign steward, close availability, bulk assign                                                 |
+| `assigned`               | Accept/start, return with reason                           | Reassign, release, mark blocked                                                                 |
+| `claimed`                | Start checklist, return                                    | Reassign, release, mark blocked                                                                 |
+| `in_progress`            | Update checklist, submit for review, mark blocked, return  | Reassign, mark blocked, request update                                                          |
+| `submitted`              | View submission, reply to comments                         | Approve, request changes, mark blocked                                                          |
+| `changes_requested`      | Update checklist, reply, resubmit, return                  | Reassign, mark blocked                                                                          |
+| `blocked`                | Add blocker details, resolve if owner can                  | Resolve, reassign, release, mark no longer in scope                                             |
+| `returned`               | View read-only history                                     | Reopen for stewardship, assign steward, mark no longer in scope                                 |
+| `stale`                  | Resume before release, return                              | Release to open queue, reassign, extend due date                                                |
+| `complete`               | View history                                               | Reopen as needs reverification, open in Insights                                                |
+| `needs_reverification`   | Claim if open                                              | Assign steward, open for stewardship, mark no longer in scope                                   |
+| `no_longer_in_scope`     | View read-only history                                     | View read-only history, reopen only if package returns to scope                                 |
 
 Review notes:
 
 - `Approve` allows an optional reviewer note.
 - `Request changes` requires a note.
 - `Mark blocked` requires a blocker reason.
-- `Decline`, `Release`, and reassignment require a reason.
+- `Return` and reassignment require a reason.
 
 ### Blocker Reasons
 
@@ -299,9 +327,9 @@ tables. This is not a marketing-style page.
 
 ### Page Header
 
-- Title: `Security Adoption`
-- Subtitle: `Coordinate critical package review and adoption across supported ecosystems.`
-- Primary admin action: `Create adoption`
+- Title: `Security Stewardship`
+- Subtitle: `Coordinate critical package review and stewardship across supported ecosystems.`
+- Primary admin action: `Create stewardship`
 - Secondary action: `Open in Insights`
 
 ### Stats Band
@@ -356,14 +384,19 @@ density. `Last activity` should summarize what changed, for example
 Tabs:
 
 - `Overview`
-- `Adoption`
+- `Stewardship`
 - `Security`
 - `Provenance`
-- `History`
+
+History should be a scrollable timeline at the bottom of the drawer (always
+visible below the active tab content) rather than a separate tab. Reviewers
+check history most often — hiding it behind a tab adds clicks in the most
+common review workflow. The `3 new` unread indicator should appear as a
+section header badge rather than a tab pill.
 
 Sticky footer actions:
 
-- `Claim adoption`
+- `Claim package`
 - `Assign steward`
 - `Submit review`
 - `Mark blocked`
@@ -376,19 +409,20 @@ These designs map directly to existing Self Serve structure: left lens rail,
 operational spacing, `lfx-table`, `lfx-stat-card-grid`, `lfx-filter-pills`,
 `lfx-tag`, `lfx-button`, and drawer-based details.
 
-### Foundation Security Adoption Queue
+### Foundation Security Stewardship Queue
 
 Purpose: ED/admin command center for the Osprey package queue.
 
 ```text
 +------------------------------------------------------------------------------+
-| Security Adoption                              [Create adoption] [Insights] |
-| Coordinate critical package review and adoption across supported ecosystems. |
+| Security Stewardship                        [Create stewardship] [Insights] |
+| Coordinate critical package review and stewardship across supported          |
+| ecosystems.                                                                  |
 +------------------------------------------------------------------------------+
 | [ Total in scope 600k ] [ Unassigned 69.7% ]                                  |
 | [ Critical 1.8k ] [ In review 241 ] [ Stale 93 ] [ Complete this week 32 ]    |
 +------------------------------------------------------------------------------+
-| Saved: [Critical unassigned] [Needs maintainer] [Stale adoptions]            |
+| Saved: [Critical unassigned] [Needs maintainer] [Stale stewardships]         |
 | [Signals] [Unassigned] [Open] [In progress] [In review] [Blocked] [Complete] |
 |                                                                              |
 | Search packages...     Ecosystem: All     Risk: All     Owner: All           |
@@ -403,12 +437,12 @@ Purpose: ED/admin command center for the Osprey package queue.
 Design notes:
 
 - Header is a compact page header, not a hero.
-- Primary action appears only for users who can create adoptions.
+- Primary action appears only for users who can create stewardships.
 - `Open in Insights` is secondary because analytics stays in Insights.
 - Metrics are scan-first and should use understated status color:
   - critical advisory: red
   - blocked: amber
-  - complete/adopted: emerald
+  - complete/claimed: emerald
   - neutral totals: gray/blue
 - Table is the primary surface. No card-per-package view for desktop.
 - Multi-select appears when the user has bulk permissions.
@@ -417,16 +451,16 @@ Design notes:
 
 ### My Security Work
 
-Purpose: contributor workspace for adopted and available work.
+Purpose: contributor workspace for claimed and available work.
 
 ```text
 +------------------------------------------------------------------------------+
 | My Security Work                                                            |
-| Review critical packages you adopted or were assigned.                       |
+| Review critical packages you're stewarding or were assigned.                 |
 +------------------------------------------------------------------------------+
 | [ Assigned to me 18 ] [ Due soon 4 ] [ In review 3 ] [ Blocked 1 ]          |
 +------------------------------------------------------------------------------+
-| [My work] [Available to adopt] [Completed]                                  |
+| [My work] [Available to claim] [Completed]                                  |
 |                                                                              |
 | Search packages...     Foundation: All     Ecosystem: All     Risk: High    |
 +------------------------------------------------------------------------------+
@@ -440,12 +474,12 @@ Purpose: contributor workspace for adopted and available work.
 Design notes:
 
 - This route is task-first and should not require a foundation selector.
-- Available packages should rank by criticality and readiness for adoption.
-- Contributor actions are limited to `Claim adoption`, `Update checklist`,
-  `Submit review`, `Mark blocked`, and `Release`.
+- Available packages should rank by criticality and readiness for stewardship.
+- Contributor actions are limited to `Claim package`, `Update checklist`,
+  `Submit review`, `Mark blocked`, and `Return`.
 - Include Foundation so cross-foundation work is legible.
 - When opening a package drawer, show related peer activity such as
-  `2 other open adoptions in this org` when applicable.
+  `2 other open stewardships in this org` when applicable.
 
 ### Package Detail Drawer
 
@@ -456,8 +490,8 @@ Purpose: one place to inspect package data and act without leaving the queue.
 | lodash                              [Close]  |
 | pkg:npm/lodash     npm     Risk: Critical    |
 +----------------------------------------------+
-| [Overview] [Adoption] [Security] [Provenance]|
-| [History 3 new]                              |
+| [Overview] [Stewardship] [Security]          |
+| [Provenance]                                 |
 +----------------------------------------------+
 | Overview                                     |
 | Downloads last month        52.1M            |
@@ -471,7 +505,7 @@ Purpose: one place to inspect package data and act without leaving the queue.
 | Source: deps.dev + declared URL              |
 | Confidence: High                             |
 +----------------------------------------------+
-| [Claim adoption] [Assign steward] [Block]    |
+| [Claim package] [Assign steward] [Block]     |
 | [Open in Insights]                           |
 +----------------------------------------------+
 ```
@@ -480,23 +514,24 @@ Drawer tab content:
 
 - `Overview`: identity, purl, ecosystem, namespace/name, registry URL,
   criticality score, downloads, dependents, latest release, repo summary.
-- `Adoption`: current owner, status, checklist progress, reviewer, due date,
+- `Stewardship`: current owner, status, checklist progress, reviewer, due date,
   assignment history.
 - `Security`: OSV/GHSA advisories, critical vulnerability flag, security
   contact links, vulnerability policy links.
 - `Provenance`: declared repository URL, normalized repository URL, mapping
   source, confidence, monorepo notes, manual override state.
-- `History`: threaded comments, reviewer notes, contributor notes, blocked
-  reason, audit trail, status changes, package/advisory updates, repo stars,
-  last commit, OpenSSF Scorecard, release cadence, and maintainer
-  responsiveness when available.
 
-If the drawer has unread changes since the viewer last opened it, the `History`
-tab shows a count pill such as `3 new`.
+History timeline (always visible below active tab content): threaded comments,
+reviewer notes, contributor notes, blocked reason, audit trail, status changes,
+package/advisory updates, repo stars, last commit, OpenSSF Scorecard, release
+cadence, and maintainer responsiveness when available.
+
+If the drawer has unread changes since the viewer last opened it, the history
+section header shows a count badge such as `3 new`.
 
 ### Admin Review Drawer State
 
-Purpose: review a submitted adoption without navigating away from the queue.
+Purpose: review a submitted stewardship without navigating away from the queue.
 
 ```text
 +----------------------------------------------+
@@ -545,23 +580,22 @@ Design notes:
   - `fa-shield` for Security
   - `fa-box` or `fa-cube` for Package
   - `fa-triangle-exclamation` for Risk / advisory
-  - `fa-user-check` for Adopted
+  - `fa-user-check` for Claimed / Steward
   - `fa-clock` for In review / due soon
   - `fa-ban` for Blocked
   - `fa-arrow-up-right-from-square` for Insights
 - Tags:
   - `Unassigned`: neutral
   - `Open`: info
-  - `Adopted`: info
+  - `Claimed`: info
   - `In progress`: warning
   - `In review`: warning
   - `Changes requested`: warning
   - `Stale`: warning
   - `Blocked`: danger
-  - `Released`: neutral
-  - `Declined`: neutral
+  - `Returned`: neutral
   - `Needs reverification`: warning
-  - `No longer adoptable`: neutral
+  - `No longer in scope`: neutral
   - `Complete`: success
 - Keep cards at the existing 8px radius or less.
 - Do not put UI cards inside other cards; repeated package rows belong in a
@@ -577,7 +611,7 @@ Design notes:
   - Body: `Clear filters or switch to all statuses.`
 - No assigned work:
   - Title: `No security work assigned`
-  - Body: `Browse available packages to adopt one when you're ready.`
+  - Body: `Browse available packages to claim one when you're ready.`
 - Error:
   - Title: `Failed to load security work`
   - CTA: `Retry`
@@ -641,12 +675,13 @@ Do not build the frontend against mock data. Minimum real API surface:
 - `GET /api/security/packages/:id`
 - `PATCH /api/security/packages/:id`
   - admin package-level overrides such as manual repo mapping corrections
-- `POST /api/security/packages/:id/adoptions`
-- `PATCH /api/security/adoptions/:id`
-- `POST /api/security/adoptions/:id/submit`
-- `POST /api/security/adoptions/:id/review`
+- `POST /api/security/packages/:id/stewardships`
+- `PATCH /api/security/stewardships/:id`
+- `POST /api/security/stewardships/:id/submit`
+- `POST /api/security/stewardships/:id/review`
 - `GET /api/security/my-work`
   - cursor pagination matching `/api/security/packages`
+  - supports `foundation_id` filter for cross-foundation contributors
 - `GET /api/security/summary`
 - `POST /api/security/bulk-jobs`
 - `GET /api/security/bulk-jobs/:id`
@@ -654,14 +689,29 @@ Do not build the frontend against mock data. Minimum real API surface:
 Shared interfaces should live in:
 
 ```text
-packages/shared/src/interfaces/security-adoption.interface.ts
+packages/shared/src/interfaces/security-stewardship.interface.ts
 ```
 
-### Example Adoption Record
+Note: `no_longer_in_scope` is set via `PATCH /api/security/packages/:id` (a
+package-level state change), not via the stewardship endpoints. There is no
+`DELETE` endpoint — all state transitions are patches that preserve history.
+
+### Search Behavior
+
+The search input on `GET /api/security/packages` should support:
+
+- Package name (exact and substring)
+- purl
+- Owner name (when a stewardship exists)
+
+The `q` query param searches across these fields. Ecosystem and status
+filtering remain separate query params.
+
+### Example Stewardship Record
 
 ```json
 {
-  "id": "adopt_123",
+  "id": "stw_123",
   "package_id": "pkg_npm_lodash",
   "scope": {
     "type": "foundation",
@@ -685,17 +735,22 @@ packages/shared/src/interfaces/security-adoption.interface.ts
   ],
   "required_reviewers": 1,
   "due_at": "2026-06-07T00:00:00Z",
+  "checklist_template_id": "core_v1",
   "checklist": [
     {
       "id": "repo_verified",
       "label": "Verify upstream repository",
+      "category": "core",
       "state": "complete",
+      "evidence": "Declared URL and deps.dev both resolve to github.com/lodash/lodash",
       "updated_at": "2026-05-25T18:30:00Z"
     },
     {
       "id": "security_contact",
       "label": "Confirm maintainer/security contact",
+      "category": "core",
       "state": "incomplete",
+      "evidence": null,
       "updated_at": null
     }
   ],
@@ -717,64 +772,141 @@ packages/shared/src/interfaces/security-adoption.interface.ts
 
 ### Concurrency
 
-Every adoption mutation must include `state_version` or equivalent optimistic
+Every stewardship mutation must include `state_version` or equivalent optimistic
 locking metadata. On conflict, the API returns a typed conflict response with
 the latest owner/state summary so the UI can refresh the row without guessing.
 
+Common conflict scenarios that need explicit UX:
+
+- Two admins assign the same package simultaneously.
+- A contributor claims a package that was just assigned by an admin.
+- An admin marks a package `no_longer_in_scope` while a contributor is mid-
+  checklist.
+
+In all cases, the loser sees a conflict toast with the new state and owner, and
+the row refreshes in place without a full page reload.
+
 ### Outbound Events
 
-Self Serve should emit adoption lifecycle events for Insights and reporting even
-if v1 only publishes them internally:
+Self Serve should emit stewardship lifecycle events for Insights and reporting
+even if v1 only publishes them internally:
 
-- `security_adoption.created`
-- `security_adoption.state_changed`
-- `security_adoption.review_requested`
-- `security_adoption.review_completed`
-- `security_adoption.blocked`
-- `security_adoption.released`
-- `security_adoption.needs_reverification`
+- `security_stewardship.created`
+- `security_stewardship.state_changed`
+- `security_stewardship.review_requested`
+- `security_stewardship.review_completed`
+- `security_stewardship.blocked`
+- `security_stewardship.returned`
+- `security_stewardship.needs_reverification`
+- `security_stewardship.stale_warning` (system-initiated, 30-day threshold)
+- `security_stewardship.auto_released` (system-initiated, 60-day threshold)
 
-Each event includes adoption id, package id, scope, previous state, next state,
-actor, owner, reviewer, reason, and timestamp.
+The `stale_warning` and `auto_released` events are system-initiated and distinct
+from actor-initiated `state_changed` events. They should carry the same payload
+shape but with `actor: "system"` and the applicable aging policy threshold.
+
+Each event includes stewardship id, package id, scope, previous state, next
+state, actor, owner, reviewer, reason, and timestamp.
 
 ## Suggested PR Sequence
 
 1. Shared types + backend proxy/controller/service once upstream API contract is
    confirmed.
 2. Admin package queue page with filters/table/drawer in read-only mode.
-3. Adoption actions and `My Security Work`.
+3. Stewardship actions and `My Security Work`.
 4. Review workflow, notes, blocked states, audit trail.
 5. Project-lens package security view after package-to-repo confidence is high
    enough.
 
 ## Open Decisions
 
-- Which upstream service owns the security adoption API: new Osprey/security
+- Which upstream service owns the security stewardship API: new Osprey/security
   service, Insights API, or an existing LFX service?
   - Leaning: dedicated security/Osprey workflow service, with Insights/CDP as
-    source-data providers, because adoption state is workflow data rather than
-    analytics data.
+    source-data providers, because stewardship state is workflow data rather
+    than analytics data.
 - Should this be LF-wide first or foundation-scoped first?
   - Leaning: foundation-scoped first with an LF-wide admin aggregate, because
     review ownership, SLA, and assignment pools will differ by foundation.
-- What roles can assign/review adoption work beyond ED/admin?
+- What roles can assign/review stewardship work beyond ED/admin?
   - Leaning: ED/admin plus delegated security reviewers configured per
-    foundation. Decision needed before API permission work starts.
+    foundation. Decision needed before API permission work starts. Model the
+    delegated reviewer role in v1 even if the UI only exposes ED/admin
+    initially — adding a role later is a schema migration, not a UI tweak.
 - What fields should count as completion across ecosystems?
   - Leaning: shared checklist core plus ecosystem-specific checklist items.
-    Avoid npm/Maven-only field names in shared routes and interfaces.
+    Avoid npm/Maven-only field names in shared routes and interfaces. The
+    `checklist_template_id` and `category` fields in the stewardship record
+    support this.
 - Should Mythos be surfaced directly in the drawer or only linked out?
   - Leaning: link out from the drawer for v1 unless the upstream API provides a
     stable summary field. Self Serve should not become the analytics surface.
 - How much of this is one-time Osprey workflow versus permanent Self Serve
   security surface?
-  - Leaning: build permanent primitives (`package`, `adoption`, `review`,
+  - Leaning: build permanent primitives (`package`, `stewardship`, `review`,
     `history`) and let Osprey be the first program using them.
+- **Who owns composite risk signals?** The UI depends on a composite risk score
+  (Critical/High/Medium/Low), repo mapping confidence, single-maintainer flag,
+  and stale-repo flag. CDP collects the raw ingredients but does not currently
+  expose pre-computed tiers. Decision: CDP provides computed tiers, or Self
+  Serve builds a scoring layer on top of raw data?
+- **How does the package list sync from CDP?** Batch import, real-time feed, or
+  API pull? How often does the package list refresh? What happens when a package
+  is added or removed upstream?
+
+## Data Pipeline Gap Analysis
+
+Cross-referenced the UI requirements against the CDP Tier 2 + Tier 3 data
+currently being implemented. Raw ingredients are mostly covered, but several
+composite or derived signals the UI depends on are not yet in the pipeline.
+
+### Covered by CDP Pipeline
+
+- Package identity (name, ecosystem, purl) — Tier 2 registries
+- Downloads / dependents (impact column) — Tier 3 deps.dev + npm/sonatype
+- Latest version / release date — Tier 2 registries
+- Repo mapping — Tier 2 deps.dev
+- OpenSSF Scorecard — Tier 2 deps.dev
+- Advisories / critical vuln flag — Tier 2 osv.dev / GitHub advisories
+- Repo stars, forks, last commit — Tier 2 GitHub
+- Maintainer info — Tier 2 registries
+- Licenses — Tier 2 registries
+
+### Gaps
+
+| Gap                          | Priority | Detail                                                                                                                                                                                   |
+| ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Composite risk score         | High     | Risk column is the primary sort/filter axis. Raw signals exist (advisories, dependents, scorecard, maintainer count, last commit) but no composite tier. Who computes it?                |
+| Repo mapping confidence      | High     | UI shows confidence level + source. deps.dev has the mapping but does not expose a confidence signal. Need to derive: `declared` = high, `deps.dev inferred` = medium, `heuristic` = low |
+| Security contact / policy    | Medium   | Checklist includes "verify security contacts." Pipeline has maintainers but not SECURITY.md presence, security policy, or dedicated security contact. Small addition to GitHub fetch.     |
+| Package deprecation status   | Medium   | `no_longer_in_scope` needs npm deprecation flags and Maven artifact relocation/removal. Confirm registry `status` field covers these.                                                    |
+| Monorepo awareness           | Medium   | Many npm packages map to the same repo. Without repo → packages cardinality, admin queue shows duplicated work with no grouping.                                                         |
+| Single maintainer flag       | Low      | Derivable from maintainer records. Should be exposed as queryable boolean, not raw records Self Serve counts client-side.                                                                 |
+| Stale repo flag              | Low      | Last commit is collected. Needs threshold definition + computed flag.                                                                                                                     |
+
+## Permissions Model
+
+The role and action matrix above defines what each role can do per state, but
+does not define how roles are determined. This must be resolved before API
+permission work starts.
+
+Proposed model:
+
+- **ED / admin**: Existing LFX foundation-level ED and admin roles. Can triage,
+  assign, review, and bulk-manage within their foundation scope.
+- **Delegated security reviewer**: New role, configured per foundation by an ED.
+  Can review submissions and request changes, but cannot bulk-assign or manage
+  assignment pools.
+- **Contributor**: Any authenticated LFX user. Can claim open packages, work
+  checklists, submit for review, and return stewardship.
+
+The API should enforce foundation-scoped permissions: an ED for Foundation A
+cannot assign packages scoped to Foundation B.
 
 ## Priority Updates From Spec Review
 
 1. Resolve state lifecycle gaps before implementation: `needs_reverification`,
-   `stale`, `released`, `declined`, `reassigning`, and `no_longer_adoptable`.
+   `stale`, `returned`, and `no_longer_in_scope`.
 2. Design for real queue volume: bulk actions, saved views, assignment policies,
    async jobs, and optimistic locking.
 3. Keep an explicit role x state x action matrix in the spec and QA plan.
@@ -782,3 +914,7 @@ actor, owner, reviewer, reason, and timestamp.
    notes textarea.
 5. Keep copy and API fields ecosystem-agnostic so PyPI, RubyGems, Cargo, NuGet,
    and Go modules can join later without route or data-model churn.
+6. Resolve composite risk signal ownership (CDP vs Self Serve scoring layer)
+   before UI implementation — the admin queue is unusable without sortable risk.
+7. Resolve data sync mechanism (batch, real-time, API pull) and refresh cadence
+   from CDP before backend work starts.

--- a/docs/security-project-adoption.md
+++ b/docs/security-project-adoption.md
@@ -1,920 +1,378 @@
-# Self Serve Security Package Stewardship
+# Osprey Package Stewardship — Self Serve Integration
 
 ## Context
 
-The Osprey / Tier 2 npm + Maven work needs a Self Serve coordination layer. The
-Slack direction was to build a tool that lets people steward a package so the
-review and hardening work can be split across a large set of dependencies.
+Project Osprey is an OpenSSF-coordinated effort to harden the world's most
+critical open source packages before AI-assisted vulnerability discovery makes
+them easy targets. The first phase covers npm and Maven Central.
 
-Insights and CDP should remain the source-data and analytics layer. Self Serve
-should own authentication, permissions, assignment, coordination, contributor
-workflow, and review status.
+Insights/CDP provides the data layer: package identity, risk signals,
+maintainer info, repository mapping, and criticality scoring. Self Serve owns
+the **stewardship workflow**: who is responsible for which packages, what is the
+security posture of each package, what needs to be remediated, and what is the
+ongoing status.
 
-## Product Surface
+## What Stewardship Means
 
-### Entry Points
+> **Stewardship is ongoing responsibility, not a one-time review.**
+> A steward becomes the security point person for a critical package. They
+> assess its security posture, drive remediation of gaps, engage with upstream
+> maintainers, and monitor for new threats. Stewardship doesn't "complete" —
+> it's active for as long as the package is critical.
 
-- **Me lens:** `My Security Work`
-  - Shows packages/projects I'm stewarding, assigned work, due items, blocked
-    items, and review status.
-- **Foundation lens / Admin Mode:** `Security Stewardship`
-  - ED/admin coordination dashboard for the selected foundation or LF-wide
-    Osprey program.
-- **Project lens:** `Security`
-  - Placeholder in v1 that links to the foundation queue filtered to known
-    packages for the selected project, then becomes a full package/repo security
-    posture view once package-to-repo mapping confidence is reliable.
+A steward's work has two phases:
+
+1. **Initial assessment** — evaluate the package's security posture across a
+   standard framework, identify gaps, and create a remediation plan.
+2. **Ongoing stewardship** — drive remediation, engage with maintainers,
+   monitor for new threats, and escalate packages that need direct intervention
+   (engineering help, funding, or forking).
+
+## Actors
+
+| Actor | Who | Responsibilities |
+|-------|-----|------------------|
+| **Osprey Admin** | OpenSSF staff coordinating the program | Triage the package queue, assign stewards, handle escalations, spot-check assessment quality, track coverage across the critical package set |
+| **Steward** | Any authenticated LFX user | Claim packages, perform initial security assessment, drive remediation upstream, engage maintainers, monitor ongoing threats, escalate when needed |
+| **Maintainer** *(v2)* | Verified upstream package maintainer | Submit their own package for stewardship, collaborate with steward on remediation, verify security contacts |
+
+## Entry Points
+
+### v1 (ship first)
+
+| Lens | Tab | Who sees it | Purpose |
+|------|-----|-------------|---------|
+| **Me** | My Stewardships | Any authenticated user | Browse available packages, claim stewardship, manage your active stewardships. The contributor workspace. |
+| **Me** | Osprey Program (admin only) | Osprey program admins | Admin dashboard: full package queue, coverage metrics, assignments, escalation management, spot-check quality. |
+
+### v2 (deferred)
+
+| Lens | Tab | Who sees it | Purpose |
+|------|-----|-------------|---------|
+| **Project** | Project Stewardship | Maintainers + anyone viewing the project | Maintainer submits their project for stewardship. Depends on registry API verification. |
+| **Organization** | Organization Stewardships | Org members | Read-only visibility into stewardships involving the organization's members. |
 
 ## End-to-End Flow
 
-The product flow is centered on **creating a stewardship record from a package
-security signal**. A package signal can exist without a stewardship record.
-Stewardship starts only when an admin assigns a steward, opens the package for
-contributors, or a contributor claims available work.
-
 ```mermaid
 flowchart TD
-  source["Insights / CDP data foundation<br/>npm + Maven Tier 2 package data"] --> sync["Security stewardship API<br/>packages, risk signals, assignments"]
-  sync --> admin["Foundation Security Stewardship<br/>ED / Admin Mode"]
-  sync --> me["My Security Work<br/>Contributor view"]
+  source["Insights / CDP\nnpm + Maven Tier 2 package data"] --> api["Stewardship API\npackages, risk signals"]
 
-  admin --> triage["Triage package signal queue<br/>filter by ecosystem, risk, status, owner"]
-  triage --> detail["Open package detail drawer"]
-  detail --> assign{"Create stewardship<br/>direct assign or open?"}
-  assign --> direct["Assign steward"]
+  api --> admin["Osprey Program\nadmin dashboard (Me lens)"]
+  api --> me["My Stewardships\ncontributor workspace"]
+
+  admin --> triage["Triage package queue\nidentify coverage gaps"]
+  triage --> detail["Open package detail"]
+  detail --> assign{"Assign or open?"}
+  assign --> direct["Assign steward directly"]
   assign --> open["Open for stewardship"]
 
-  direct --> assigned["Assigned"]
-  open --> discover["Contributor discovers package"]
-  me --> discover
-  discover --> claim["Claim package"]
-  claim --> checklist["Complete verification checklist"]
-  checklist --> submit["Submit for review"]
+  direct --> assess["Steward performs\ninitial security assessment"]
+  open --> claim["Steward claims package"]
+  me --> claim
+  claim --> assess
 
-  assigned --> checklist
-  submit --> review["ED / admin review"]
-  review --> changes{"Review outcome"}
-  changes --> request["Request changes"]
-  request --> checklist
-  changes --> blocked["Mark blocked"]
-  changes --> complete["Mark complete"]
+  assess --> active["Active stewardship\n(ongoing responsibility)"]
 
-  checklist --> release["Release stewardship / decline with reason"]
-  release --> open
-  checklist --> stale["Stale by aging policy"]
-  stale --> open
-  blocked --> triage
-  complete --> reverify["Needs reverification<br/>new advisory, maintainer change, age policy"]
-  reverify --> triage
-  complete --> insights["Status visible in Self Serve<br/>Analytics link opens Insights"]
+  active --> remediate["Drive remediation upstream\nengage maintainers, file PRs"]
+  active --> monitor["Monitor for new advisories\nrespond to threats"]
+  active --> escalate["Escalate if needed\nengineering help, funding, fork"]
+  escalate --> admin
 ```
 
-## State Model
+## Stewardship Lifecycle
 
 ```mermaid
 stateDiagram-v2
   [*] --> Unassigned
-  Unassigned --> OpenForStewardship: admin opens package
-  Unassigned --> Assigned: admin assigns owner
-  OpenForStewardship --> Claimed: contributor claims
-  Assigned --> InProgress: owner starts checklist
-  Assigned --> Returned: owner declines with reason
-  Claimed --> InProgress: owner starts checklist
-  Claimed --> Returned: owner releases work
-  Returned --> OpenForStewardship: available again
-  Returned --> Assigned: admin reassigns
-  InProgress --> Submitted: submit for review
-  InProgress --> Returned: owner releases work
-  InProgress --> Stale: no progress past aging threshold
-  Stale --> OpenForStewardship: auto-release or admin release
-  Stale --> InProgress: owner resumes before release
-  Submitted --> ChangesRequested: reviewer requests changes
-  Submitted --> Blocked: reviewer marks blocked
-  ChangesRequested --> InProgress: owner updates work
-  Submitted --> Complete: reviewer approves
-  InProgress --> Blocked: owner flags blocker
-  Blocked --> InProgress: blocker resolved
-  Blocked --> Assigned: admin reassigns (history preserved)
-  Complete --> NeedsReverification: new advisory, maintainer change, age policy, manual reopen
-  NeedsReverification --> Unassigned: admin reopens
-  NeedsReverification --> Assigned: admin assigns reviewer/steward
-  Unassigned --> NoLongerInScope: package removed/deprecated/out of scope
-  OpenForStewardship --> NoLongerInScope: package removed/deprecated/out of scope
-  Complete --> [*]
-  NoLongerInScope --> [*]
+  Unassigned --> Open : admin opens for stewardship
+  Unassigned --> Assessing : admin assigns steward directly
+  Open --> Assessing : steward claims package
+  Assessing --> Active : steward completes assessment
+  Assessing --> Blocked : steward flags blocker
+  Active --> Escalated : steward or admin escalates
+  Active --> NeedsAttention : new advisory or maintainer change
+  NeedsAttention --> Active : steward addresses issue
+  NeedsAttention --> Escalated : requires intervention
+  Escalated --> Active : resolved
+  Blocked --> Assessing : blocker resolved
+  Active --> Inactive : package no longer critical or steward steps down
 ```
-
-State simplifications vs. original:
-
-- **`adopted` → `claimed`**: Avoids confusion with "technology adoption." Clearer
-  intent: the contributor claimed responsibility.
-- **`open_for_adoption` → `open_for_stewardship`**: Consistent rename.
-- **`released` + `declined` → `returned`**: Both return work to the pool with a
-  reason. Differentiate via `returned_reason` (`declined_before_start`,
-  `released_during_work`, `capacity`, `not_the_right_steward`).
-- **`reassigning` removed**: Reassignment is an admin action that atomically
-  moves to `assigned` with a new owner and writes a history event — not a
-  durable state. A transient "reassigning" state creates edge cases (admin
-  abandons mid-reassignment) without clear benefit.
-- **`no_longer_adoptable` → `no_longer_in_scope`**: Consistent rename.
 
 ### Canonical Status Mapping
 
-Persisted API states should stay stable and machine-readable. UI labels can be
-friendlier, but filters, tags, and transitions should map back to this canonical
-set.
+| Persisted state | UI label | Meaning |
+|-----------------|----------|---------|
+| `unassigned` | Unassigned | Package is critical but has no steward. The primary coverage gap. |
+| `open` | Open | Package is available for a steward to claim. |
+| `assessing` | Assessing | Steward is performing the initial security assessment. |
+| `active` | Active | Steward is actively responsible for this package. The steady state. |
+| `needs_attention` | Needs attention | New advisory, maintainer change, or other event requires steward response. |
+| `escalated` | Escalated | Package needs intervention beyond the steward's scope: engineering help, funding, or a fork. |
+| `blocked` | Blocked | Assessment cannot proceed (e.g., maintainer unresponsive, repo inaccessible). |
+| `inactive` | Inactive | Package is no longer critical, steward stepped down, or stewardship is paused. |
 
-| Persisted state          | UI label                 | Meaning                                                                                               |
-| ------------------------ | ------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `unassigned`             | `Unassigned`             | Package is in the queue and has no owner.                                                             |
-| `open_for_stewardship`   | `Open` / `Available`     | Package is available for a contributor to claim.                                                      |
-| `assigned`               | `Assigned`               | Admin assigned an owner, but work has not started.                                                    |
-| `claimed`                | `Claimed`                | Contributor claimed the package, but work has not started.                                            |
-| `in_progress`            | `In progress`            | Owner is actively working through the checklist.                                                      |
-| `submitted`              | `In review`              | Owner submitted the checklist for ED/admin review.                                                    |
-| `changes_requested`      | `Changes requested`      | Reviewer sent the work back with required updates.                                                    |
-| `blocked`                | `Blocked`                | Work cannot proceed until the blocker is resolved.                                                    |
-| `stale`                  | `Stale`                  | No checklist progress past the stale threshold.                                                       |
-| `returned`               | `Returned`               | Owner returned stewardship to the queue with a required reason.                                       |
-| `complete`               | `Complete` / `Completed` | Reviewer approved the submission.                                                                     |
-| `needs_reverification`   | `Needs reverification`   | Completed stewardship was reopened by new advisory, maintainer change, age policy, or admin action.   |
-| `no_longer_in_scope`     | `No longer in scope`     | Package is deprecated, transferred, removed, or out of scope.                                         |
+The key difference from a task queue: **most packages should end up in `active`
+and stay there.** "Active" is the success state, not a waypoint. The admin
+dashboard's primary metric is coverage — what percentage of critical packages
+have an active steward.
 
-The table filters should use persisted states in query params and request
-payloads. Display-only labels such as `Available` or `Completed`
-should be derived in the UI from the persisted state plus owner context.
+## Security Assessment Framework
 
-`assigned` and `claimed` are behaviorally equivalent once work starts; both move
-to `in_progress` on the first checklist update. Keep both states because the
-provenance matters for reporting: admin-assigned work and contributor-claimed
-work answer different coordination questions. The stewardship record's `origin`
-field (`admin_assigned` | `self_claimed`) preserves this distinction independent
-of current state.
+The initial assessment is a structured evaluation of a package's security
+posture, not a metadata verification checklist. The steward evaluates each
+dimension, documents findings, and proposes a remediation plan for gaps.
 
-The `returned` state replaces the original `released` and `declined` states. The
-reason for returning is captured in a `returned_reason` field with controlled
-values: `declined_before_start`, `released_during_work`, `capacity`,
-`not_the_right_steward`. This preserves the reporting signal without adding
-extra states and transitions.
+### Assessment Dimensions
 
-### Aging and Reverification Policy
+| Dimension | What the steward evaluates | Example findings |
+|-----------|---------------------------|------------------|
+| **Maintainer health** | Is anyone responsive? How fast would a critical CVE get patched? Bus factor? | "Single maintainer, last active 8 months ago." |
+| **Security posture** | Vulnerability disclosure process? SECURITY.md? 2FA? Signed releases? | "No SECURITY.md. No disclosure process. Unsigned releases." |
+| **Vulnerability exposure** | Open advisories? History of security issues? Known attack surface? | "4 historical CVEs, all patched. Prototype pollution surface." |
+| **Dependency risk** | What does this package depend on? Are those dependencies healthy? | "12 direct deps, 2 unmaintained. Transitive dep on vulnerable minimist." |
+| **Supply chain integrity** | Build reproducibility? Provenance attestation? Repo-to-artifact gap? | "Published artifact includes code not in the repo." |
+| **Release health** | Release cadence? Stale? Deprecated? Active development? | "Last release 5 years ago. 200+ open issues. Active forks exist." |
 
-Default thresholds (configurable per foundation):
+### Assessment Output
 
-- Warn owner after **30 days** with no checklist progress.
-- Move to `stale` after **45 days** with no checklist progress.
-- Release back to `open_for_stewardship` after **60 days** unless an admin
-  overrides.
+The steward produces:
 
-"Checklist progress" is defined as: any checklist item state change (incomplete
-→ complete or vice versa), or a contributor note added to the stewardship
-record. Opening the drawer or viewing the record does not count as progress.
+1. **Posture summary** — overall risk level (Critical / High / Medium / Low)
+   with narrative justification.
+2. **Findings** — specific gaps or risks, each with severity and evidence.
+3. **Remediation plan** — concrete actions:
+   - File upstream issues/PRs (e.g., add SECURITY.md, enable branch protection)
+   - Engage maintainers (e.g., establish contact, propose disclosure process)
+   - Escalate (e.g., recommend funding, engineering help, or fork)
+4. **Monitoring plan** — what to watch for going forward.
 
-Additional policies:
+The assessment is the steward's first act, not a gate. Completing the
+assessment moves the steward directly to active stewardship — there is no
+admin review bottleneck. Admins spot-check quality and can flag issues, but do
+not gate every assessment. The assessment exists to structure the steward's
+thinking and create an auditable record, not to create a queue for admin
+approval.
 
-- Allow owners to self-release `claimed` or `in_progress` work with a required
-  reason.
-- Reopen `complete` as `needs_reverification` when a new advisory appears,
-  maintainer/security contact changes, package ownership changes, package status
-  changes, or an annual verification policy fires.
-- Preserve stewardship history, checklist evidence, comments, blocker reasons,
-  and reviewer notes through reassignment and reverification.
+## Steward Flow
+
+### Phase 1: Claim & Assess
+
+1. Steward opens Me → My Stewardships.
+2. Browses available packages (ranked by criticality and coverage gaps).
+3. Claims a package → moves to `assessing`.
+4. Performs security assessment across the six dimensions.
+5. Documents findings, posture summary, and remediation plan.
+6. Completes assessment → moves directly to `active`.
+
+### Phase 2: Active Stewardship (ongoing)
+
+1. Steward is now the security point person for this package.
+2. Executes remediation plan:
+   - Files upstream issues and PRs for identified gaps
+   - Engages maintainers on security improvements
+   - Tracks remediation progress
+3. Monitors for new threats:
+   - New advisories trigger `needs_attention`
+   - Maintainer changes, ownership transfers, repo archival
+4. Escalates when needed:
+   - Maintainer unresponsive after repeated outreach
+   - Critical vulnerability with no path to upstream fix
+   - Package needs engineering resources or funding
+5. Updates stewardship status periodically (admin can set cadence).
 
 ## Admin Flow
 
-1. ED/admin opens `Foundation -> Security Stewardship`.
-2. The page shows top metrics:
-   - Total packages in scope
-   - Unassigned percentage
-   - Critical packages
-   - In review
-   - Blocked
-   - Completed this week
-3. ED/admin filters the work queue:
-   - Ecosystem: supported ecosystems
-   - Status: unassigned, open, assigned/claimed, in progress, in review,
-     changes requested, blocked, stale, complete, needs reverification
-   - Risk: critical advisory, high dependents, single maintainer, stale repo
-   - Source confidence: declared, deps.dev, heuristic, manual
-4. ED/admin opens a package detail drawer.
-5. ED/admin creates a stewardship record by assigning a steward or marking the
-   package open for stewardship.
-6. ED/admin tracks progress across stewards.
-7. ED/admin uses bulk actions for high-volume queue management.
-8. ED/admin links back to Insights for analytics-heavy views.
+The admin's primary concern is **coverage**: are the most critical packages
+being stewarded? Secondary concern is **quality**: are stewards actually
+driving remediation, not just documenting problems?
 
-### Queue Scale and Bulk Operations
-
-The queue can contain hundreds of thousands of packages, so the admin workflow
-cannot assume one-row-at-a-time triage.
-
-- Table supports multi-select across the current page and filtered result set.
-- Bulk actions:
-  - `Open for stewardship`
-  - `Assign steward`
-  - `Reassign steward`
-  - `Mark blocked`
-  - `Apply tag`
-  - `Release stale stewardships`
-- Bulk actions above a configurable row threshold run as async jobs with a
-  progress drawer/toast and a downloadable result summary. The threshold should
-  be determined during implementation based on actual API response times.
-- Saved views are per-user and shareable by URL. Suggested defaults for v1:
-  - `Critical unassigned`
-  - `Stale stewardships`
-  - `Needs reverification`
-- Additional saved views (e.g., ecosystem-specific filters like `npm owner
-  unclear` or `Maven needs maintainer`) can be added as the underlying data
-  matures.
-- Server uses optimistic locking on stewardship records. If a row changed after it
-  was loaded, the UI shows conflict copy such as: `This package was just claimed
-by {user}. Refresh to see the latest state.`
-
-### Assignment Policies
-
-Manual assignment ships first, but the data model should support routing rules
-from the start.
-
-- Named assignee pools per foundation or project.
-- Optional round-robin assignment inside a pool.
-- Optional rules:
-  - auto-open packages matching critical-risk criteria
-  - auto-assign packages with known project maintainers
-  - require reviewer pool for high-criticality packages
-- Rules should write normal stewardship records so history, review, and
-  analytics remain consistent with manually-created stewardships.
-
-## Contributor Flow
-
-1. User opens `Me -> My Security Work`.
-2. User sees available packages to claim plus assigned/claimed packages.
-3. User opens a package drawer with:
-   - Package identity
-   - Ecosystem
-   - Repository mapping
-   - Downloads/dependents
-   - Advisories
-   - Maintainer/contact info
-   - Suggested verification tasks
-4. User clicks `Claim package` or accepts an admin assignment.
-5. User completes the checklist:
-   - Verify upstream repo
-   - Verify maintainer/security contacts
-   - Confirm latest version / release activity
-   - Flag suspicious/stale metadata
-   - Add notes
-6. User submits for review.
-7. User can release work back to the queue with a required reason if they are
-   not the right steward or no longer have capacity.
-8. ED/admin reviews, requests changes, or marks complete.
-
-## Notifications
-
-Minimum notification surface:
-
-- In-app and email when work is assigned to me.
-- In-app and email when someone claims a package I opened for stewardship.
-- In-app and email when review is requested from me.
-- In-app and email when my submission is approved, blocked, or has requested
-  changes.
-- In-app and email warning before stale auto-release.
-- Admin digest for high-volume queue events, grouped by foundation, status, and
-  saved view.
-- Notification payloads should link directly to the package drawer in the
-  correct lens/context.
+1. Osprey admin opens Me → Osprey Program.
+2. Sees coverage metrics: total critical packages, active stewards, coverage
+   percentage, unassigned critical packages, needs attention, escalated.
+3. Identifies coverage gaps: which critical packages have no steward?
+4. Opens packages for stewardship or assigns stewards directly.
+5. Spot-checks assessment quality: flags incomplete or low-effort assessments
+   for steward follow-up.
+6. Handles escalations: allocate engineering resources, approve funding, decide
+   on forks.
+7. Monitors steward activity: are active stewards driving remediation or going
+   quiet?
+8. Uses bulk actions for high-volume queue management.
 
 ## Role and Action Matrix
 
-| State                    | Contributor / owner                                        | ED/admin / reviewer                                                                             |
-| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `unassigned`             | View                                                       | Create stewardship, assign steward, open for stewardship, bulk assign, mark no longer in scope  |
-| `open_for_stewardship`   | Claim package                                              | Assign steward, close availability, bulk assign                                                 |
-| `assigned`               | Accept/start, return with reason                           | Reassign, release, mark blocked                                                                 |
-| `claimed`                | Start checklist, return                                    | Reassign, release, mark blocked                                                                 |
-| `in_progress`            | Update checklist, submit for review, mark blocked, return  | Reassign, mark blocked, request update                                                          |
-| `submitted`              | View submission, reply to comments                         | Approve, request changes, mark blocked                                                          |
-| `changes_requested`      | Update checklist, reply, resubmit, return                  | Reassign, mark blocked                                                                          |
-| `blocked`                | Add blocker details, resolve if owner can                  | Resolve, reassign, release, mark no longer in scope                                             |
-| `returned`               | View read-only history                                     | Reopen for stewardship, assign steward, mark no longer in scope                                 |
-| `stale`                  | Resume before release, return                              | Release to open queue, reassign, extend due date                                                |
-| `complete`               | View history                                               | Reopen as needs reverification, open in Insights                                                |
-| `needs_reverification`   | Claim if open                                              | Assign steward, open for stewardship, mark no longer in scope                                   |
-| `no_longer_in_scope`     | View read-only history                                     | View read-only history, reopen only if package returns to scope                                 |
+| State | Steward | Osprey Admin |
+|-------|---------|--------------|
+| `unassigned` | View | Open for stewardship, assign steward, bulk assign |
+| `open` | Claim package | Assign steward, close availability |
+| `assessing` | Document findings, complete assessment, flag blocker | Reassign, flag blocker, spot-check |
+| `active` | Update status, log remediation progress, escalate | Review activity, reassign, escalate |
+| `needs_attention` | Investigate and respond, escalate if needed | Reassign, escalate |
+| `escalated` | Provide context, continue monitoring | Allocate resources, approve funding, decide on fork, resolve |
+| `blocked` | Add blocker details, resolve if able | Resolve, reassign |
+| `inactive` | View history | Reactivate, reassign |
 
-Review notes:
+## Package Detail Drawer
 
-- `Approve` allows an optional reviewer note.
-- `Request changes` requires a note.
-- `Mark blocked` requires a blocker reason.
-- `Return` and reassignment require a reason.
+### Tabs
 
-### Blocker Reasons
-
-Use controlled categories plus optional free text:
-
-- `awaiting_maintainer_response`
-- `repo_mapping_unclear`
-- `advisory_disputed`
-- `package_deprecated_or_transferred`
-- `out_of_scope_for_ecosystem`
-- `owner_capacity`
-- `other`
-
-## Design Direction
-
-Use a dense operational layout consistent with existing LFX One dashboards and
-tables. This is not a marketing-style page.
-
-### Page Header
-
-- Title: `Security Stewardship`
-- Subtitle: `Coordinate critical package review and stewardship across supported ecosystems.`
-- Primary admin action: `Create stewardship`
-- Secondary action: `Open in Insights`
-
-### Stats Band
-
-Use compact metric tiles via the existing stat-card patterns. Lead with the two
-numbers that explain scale, then show operational counts.
-
-- Hero metrics:
-  - Total packages in scope
-  - Unassigned percentage
-- Operational metrics:
-  - Critical signals
-  - In review
-  - Stale
-  - Blocked
-  - Complete this week
-
-Use neutral gray, blue, amber, red, and emerald accents. Each tile should show a
-week-over-week delta when the upstream summary API supports it.
-
-### Workspace
-
-Filter row:
-
-- Search input
-- Ecosystem select
-- Status tabs
-- Risk filter
-- Assignment filter
-
-Main table columns:
-
-- Package
-- Ecosystem
-- Risk
-- Impact
-- Repo confidence
-- Advisory
-- Owner
-- Status
-- Last activity
-
-Row click opens a detail drawer.
-
-`Risk` should render as a Critical / High / Medium / Low tag with numeric score
-available on hover. `Impact` combines downloads and dependents to preserve scan
-density. `Last activity` should summarize what changed, for example
-`Status -> In review by A. User · 2h ago`.
-
-### Package Drawer
-
-Tabs:
-
-- `Overview`
-- `Stewardship`
-- `Security`
-- `Provenance`
-
-History should be a scrollable timeline at the bottom of the drawer (always
-visible below the active tab content) rather than a separate tab. Reviewers
-check history most often — hiding it behind a tab adds clicks in the most
-common review workflow. The `3 new` unread indicator should appear as a
-section header badge rather than a tab pill.
-
-Sticky footer actions:
-
-- `Claim package`
-- `Assign steward`
-- `Submit review`
-- `Mark blocked`
-- `Open in Insights`
-
-## Screen Designs
-
-These designs map directly to existing Self Serve structure: left lens rail,
-280px navigation panel, content inside the `MainLayoutComponent` outlet, compact
-operational spacing, `lfx-table`, `lfx-stat-card-grid`, `lfx-filter-pills`,
-`lfx-tag`, `lfx-button`, and drawer-based details.
-
-### Foundation Security Stewardship Queue
-
-Purpose: ED/admin command center for the Osprey package queue.
-
-```text
-+------------------------------------------------------------------------------+
-| Security Stewardship                        [Create stewardship] [Insights] |
-| Coordinate critical package review and stewardship across supported          |
-| ecosystems.                                                                  |
-+------------------------------------------------------------------------------+
-| [ Total in scope 600k ] [ Unassigned 69.7% ]                                  |
-| [ Critical 1.8k ] [ In review 241 ] [ Stale 93 ] [ Complete this week 32 ]    |
-+------------------------------------------------------------------------------+
-| Saved: [Critical unassigned] [Needs maintainer] [Stale stewardships]         |
-| [Signals] [Unassigned] [Open] [In progress] [In review] [Blocked] [Complete] |
-|                                                                              |
-| Search packages...     Ecosystem: All     Risk: All     Owner: All           |
-+------------------------------------------------------------------------------+
-| Package            Ecosystem  Risk      Impact        Repo   Owner   Status |
-| lodash             npm        Critical  52.1M / 142k  High   --      Signal |
-| org.slf4j:slf4j    Maven      Critical  -- / 81k      Med    Maya    Review |
-| express            npm        High      31.4M / 72k   High   Lee     Stale  |
-+------------------------------------------------------------------------------+
-```
-
-Design notes:
-
-- Header is a compact page header, not a hero.
-- Primary action appears only for users who can create stewardships.
-- `Open in Insights` is secondary because analytics stays in Insights.
-- Metrics are scan-first and should use understated status color:
-  - critical advisory: red
-  - blocked: amber
-  - complete/claimed: emerald
-  - neutral totals: gray/blue
-- Table is the primary surface. No card-per-package view for desktop.
-- Multi-select appears when the user has bulk permissions.
-- Bulk actions run as async jobs when the affected row count exceeds the UI
-  threshold.
-
-### My Security Work
-
-Purpose: contributor workspace for claimed and available work.
-
-```text
-+------------------------------------------------------------------------------+
-| My Security Work                                                            |
-| Review critical packages you're stewarding or were assigned.                 |
-+------------------------------------------------------------------------------+
-| [ Assigned to me 18 ] [ Due soon 4 ] [ In review 3 ] [ Blocked 1 ]          |
-+------------------------------------------------------------------------------+
-| [My work] [Available to claim] [Completed]                                  |
-|                                                                              |
-| Search packages...     Foundation: All     Ecosystem: All     Risk: High    |
-+------------------------------------------------------------------------------+
-| Package       Foundation  Status       Checklist  Risk signal   Last activity|
-| react         CNCF        In progress  3 / 6      High impact   Today        |
-| minimist      OpenSSF     Blocked      2 / 6      Advisory      Yesterday    |
-| jackson-core  OpenSSF     Available    --         Low maint.    May 25       |
-+------------------------------------------------------------------------------+
-```
-
-Design notes:
-
-- This route is task-first and should not require a foundation selector.
-- Available packages should rank by criticality and readiness for stewardship.
-- Contributor actions are limited to `Claim package`, `Update checklist`,
-  `Submit review`, `Mark blocked`, and `Return`.
-- Include Foundation so cross-foundation work is legible.
-- When opening a package drawer, show related peer activity such as
-  `2 other open stewardships in this org` when applicable.
-
-### Package Detail Drawer
-
-Purpose: one place to inspect package data and act without leaving the queue.
-
-```text
-+----------------------------------------------+
-| lodash                              [Close]  |
-| pkg:npm/lodash     npm     Risk: Critical    |
-+----------------------------------------------+
-| [Overview] [Stewardship] [Security]          |
-| [Provenance]                                 |
-+----------------------------------------------+
-| Overview                                     |
-| Downloads last month        52.1M            |
-| Dependent packages          142k             |
-| Dependent repos             39k              |
-| Latest version              4.17.21          |
-| Latest release              2021-02-20       |
-|                                              |
-| Repository                                   |
-| github.com/lodash/lodash                     |
-| Source: deps.dev + declared URL              |
-| Confidence: High                             |
-+----------------------------------------------+
-| [Claim package] [Assign steward] [Block]     |
-| [Open in Insights]                           |
-+----------------------------------------------+
-```
-
-Drawer tab content:
-
-- `Overview`: identity, purl, ecosystem, namespace/name, registry URL,
-  criticality score, downloads, dependents, latest release, repo summary.
-- `Stewardship`: current owner, status, checklist progress, reviewer, due date,
-  assignment history.
-- `Security`: OSV/GHSA advisories, critical vulnerability flag, security
+- **Overview**: package identity, purl, ecosystem, criticality score,
+  downloads, dependents, latest release, repository summary.
+- **Assessment**: posture summary, findings by dimension, remediation plan,
+  monitoring plan. For `active` packages: remediation progress and status
+  updates.
+- **Security**: OSV/GHSA advisories, critical vulnerability flag, security
   contact links, vulnerability policy links.
-- `Provenance`: declared repository URL, normalized repository URL, mapping
-  source, confidence, monorepo notes, manual override state.
+- **Provenance**: declared repository URL, normalized URL, mapping source,
+  confidence level, build provenance status.
 
-History timeline (always visible below active tab content): threaded comments,
-reviewer notes, contributor notes, blocked reason, audit trail, status changes,
-package/advisory updates, repo stars, last commit, OpenSSF Scorecard, release
-cadence, and maintainer responsiveness when available.
+### History Timeline
 
-If the drawer has unread changes since the viewer last opened it, the history
-section header shows a count badge such as `3 new`.
+Always visible below the active tab content. Includes: status changes,
+assessment submissions, admin reviews, remediation actions logged, escalation
+notes, advisory alerts, steward activity updates.
 
-### Admin Review Drawer State
+### Sticky Footer Actions
 
-Purpose: review a submitted stewardship without navigating away from the queue.
+Context-dependent based on role and current state:
 
-```text
-+----------------------------------------------+
-| Review submission                            |
-| express               Submitted by A. User   |
-+----------------------------------------------+
-| Checklist                                    |
-| [x] Upstream repo verified                   |
-| [x] Maintainer/security contacts checked     |
-| [x] Latest release confirmed                 |
-| [x] Advisory data reviewed                   |
-| [!] Repo mapping confidence is medium        |
-|                                              |
-| Contributor notes                            |
-| The declared repository redirects to GitHub. |
-| deps.dev maps to the same canonical repo.    |
-+----------------------------------------------+
-| [Request changes] [Mark blocked] [Approve]  |
-+----------------------------------------------+
-```
+- Claim package / Assign steward
+- Complete assessment
+- Log remediation progress
+- Escalate / Mark blocked
+- Open in Insights
 
-Design notes:
+## Notifications (v1)
 
-- Review actions should be explicit and mutually clear.
-- `Approve` moves the item to `Complete`.
-- `Request changes` requires a note.
-- `Mark blocked` requires a reason and optional owner reassignment.
-- `Approve` can include an optional note.
-- Highest-criticality packages can require multiple reviewers when a foundation
-  policy sets `required_reviewers > 1`.
+- In-app and email when a package is assigned to me.
+- In-app and email when an admin flags my assessment for follow-up.
+- In-app and email when a new advisory hits a package I steward.
+- In-app and email when an escalation is resolved.
+- Admin: when a steward completes an assessment (for spot-check queue).
+- Admin: when a steward escalates a package.
 
-## Responsive Behavior
+Deferred to v2: admin digests, activity reminders for inactive stewards,
+notification grouping.
 
-- Desktop: table remains primary, filters in a single horizontal row where
-  space allows, drawer opens from the right.
-- Tablet: filters wrap to two rows; table remains horizontal with the existing
-  `lfx-table` behavior.
-- Mobile: metrics become a two-column grid; filters stack; table rows should
-  collapse into compact rows with package name, ecosystem, status, and primary
-  risk signal visible before opening the drawer.
+## Permissions Model
 
-## Visual System
+| Role | How determined | Scope |
+|------|----------------|-------|
+| **Osprey Admin** | OpenSSF program-level admin role | All packages in the Osprey program |
+| **Steward** | Any authenticated LFX user | Packages they've claimed or been assigned |
+| **Maintainer** *(v2)* | Registry API verification (npm/Maven) | Their own packages |
 
-- Use existing Tailwind/LFX tokens only; no hard-coded brand hex values.
-- Prefer Font Awesome icons already used in the app:
-  - `fa-shield` for Security
-  - `fa-box` or `fa-cube` for Package
-  - `fa-triangle-exclamation` for Risk / advisory
-  - `fa-user-check` for Claimed / Steward
-  - `fa-clock` for In review / due soon
-  - `fa-ban` for Blocked
-  - `fa-arrow-up-right-from-square` for Insights
-- Tags:
-  - `Unassigned`: neutral
-  - `Open`: info
-  - `Claimed`: info
-  - `In progress`: warning
-  - `In review`: warning
-  - `Changes requested`: warning
-  - `Stale`: warning
-  - `Blocked`: danger
-  - `Returned`: neutral
-  - `Needs reverification`: warning
-  - `No longer in scope`: neutral
-  - `Complete`: success
-- Keep cards at the existing 8px radius or less.
-- Do not put UI cards inside other cards; repeated package rows belong in a
-  table, not nested cards.
+## API Contract
 
-## Empty, Loading, and Error States
+Minimum API surface:
 
-- No foundation selected:
-  - Title: `Select a foundation to view security work`
-  - Body: `Use the foundation selector in the sidebar to choose a foundation.`
-- Empty queue:
-  - Title: `No packages match these filters`
-  - Body: `Clear filters or switch to all statuses.`
-- No assigned work:
-  - Title: `No security work assigned`
-  - Body: `Browse available packages to claim one when you're ready.`
-- Error:
-  - Title: `Failed to load security work`
-  - CTA: `Retry`
-- Loading:
-  - Use existing table skeleton behavior with six to ten rows.
+- `GET /api/stewardship/packages` — filters, cursor pagination, sort
+- `GET /api/stewardship/packages/:id`
+- `PATCH /api/stewardship/packages/:id` — admin overrides (repo mapping, etc.)
+- `POST /api/stewardship/packages/:id/stewardships` — create stewardship
+- `GET /api/stewardship/stewardships/:id` — stewardship detail
+- `PATCH /api/stewardship/stewardships/:id` — update state, assessment, status
+- `POST /api/stewardship/stewardships/:id/complete-assessment` — complete assessment, move to active
+- `POST /api/stewardship/stewardships/:id/flag` — admin flags assessment for steward follow-up
+- `POST /api/stewardship/stewardships/:id/escalate` — escalate
+- `POST /api/stewardship/stewardships/:id/activity` — log remediation progress
+- `GET /api/stewardship/my-work` — current user's stewardships
+- `GET /api/stewardship/summary` — coverage metrics for dashboard
 
-## Accessibility
+v2 additions:
 
-- Status must not rely on color alone; every status appears as text in a tag.
-- Package rows are keyboard reachable and open the drawer with Enter/Space.
-- Drawer tabs use tablist semantics and preserve focus when switching tabs.
-- Drawer close returns focus to the triggering table row.
-- Review actions that require notes should focus the note field after selection.
-- Drawer tab changes move focus to the first interactive element in the new tab.
-- Sticky drawer footers use a single labeled `role="group"` landmark so screen
-  readers announce the footer actions once on drawer open.
-- Package queue keyboard shortcuts can support next/previous row navigation
-  (`J` / `K`) after alignment with existing LFX table conventions.
+- `GET /api/stewardship/org/:orgId/stewardships` — organization's stewardships
+- `POST /api/stewardship/packages/:id/submit-for-stewardship` — maintainer
+  submission entry point
 
-## Codebase Fit
-
-Relevant existing patterns:
-
-- `apps/lfx-one/src/app/app.routes.ts` for flat routes under
-  `MainLayoutComponent`.
-- `apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts` for
-  lens-aware sidebar entries.
-- `apps/lfx-one/src/app/modules/dashboards/foundation-projects/` for dense
-  operational table + filters + stats.
-- `apps/lfx-one/src/app/modules/newsletters/` for list/create/detail patterns
-  and ED-only feature routing.
-- `apps/lfx-one/src/app/shared/components/table/`,
-  `stat-card-grid/`, `filter-pills/`, `empty-state/`, `tag/`, and `button/`.
-
-Suggested module:
-
-```text
-apps/lfx-one/src/app/modules/security/
-|-- security.routes.ts
-|-- security-work-dashboard/
-|-- security-admin-dashboard/
-|-- package-detail-drawer/
-`-- components/
-```
-
-Suggested routes:
-
-- `/security` with `data: { lens: 'me' }`
-- `/foundation/security` with `data: { lens: 'foundation' }`, ED/admin gated
-- `/project/security` placeholder initially, linking to the foundation security
-  queue filtered to known packages for the selected project. The placeholder
-  should explain that coverage improves as package-to-repo mapping confidence
-  improves and should include an `Open in Insights` link.
-
-## Backend/API Contract
-
-Do not build the frontend against mock data. Minimum real API surface:
-
-- `GET /api/security/packages`
-  - filters, cursor pagination, sort
-- `GET /api/security/packages/:id`
-- `PATCH /api/security/packages/:id`
-  - admin package-level overrides such as manual repo mapping corrections
-- `POST /api/security/packages/:id/stewardships`
-- `PATCH /api/security/stewardships/:id`
-- `POST /api/security/stewardships/:id/submit`
-- `POST /api/security/stewardships/:id/review`
-- `GET /api/security/my-work`
-  - cursor pagination matching `/api/security/packages`
-  - supports `foundation_id` filter for cross-foundation contributors
-- `GET /api/security/summary`
-- `POST /api/security/bulk-jobs`
-- `GET /api/security/bulk-jobs/:id`
-
-Shared interfaces should live in:
-
-```text
-packages/shared/src/interfaces/security-stewardship.interface.ts
-```
-
-Note: `no_longer_in_scope` is set via `PATCH /api/security/packages/:id` (a
-package-level state change), not via the stewardship endpoints. There is no
-`DELETE` endpoint — all state transitions are patches that preserve history.
-
-### Search Behavior
-
-The search input on `GET /api/security/packages` should support:
-
-- Package name (exact and substring)
-- purl
-- Owner name (when a stewardship exists)
-
-The `q` query param searches across these fields. Ecosystem and status
-filtering remain separate query params.
-
-### Example Stewardship Record
-
-```json
-{
-  "id": "stw_123",
-  "package_id": "pkg_npm_lodash",
-  "scope": {
-    "type": "foundation",
-    "uid": "foundation_123",
-    "name": "Cloud Native Computing Foundation"
-  },
-  "state": "in_progress",
-  "state_version": 7,
-  "origin": "admin_assigned",
-  "owner": {
-    "uid": "user_123",
-    "name": "Maya Chen"
-  },
-  "reviewers": [
-    {
-      "uid": "user_456",
-      "name": "ED Reviewer",
-      "required": true,
-      "approved_at": null
-    }
-  ],
-  "required_reviewers": 1,
-  "due_at": "2026-06-07T00:00:00Z",
-  "checklist_template_id": "core_v1",
-  "checklist": [
-    {
-      "id": "repo_verified",
-      "label": "Verify upstream repository",
-      "category": "core",
-      "state": "complete",
-      "evidence": "Declared URL and deps.dev both resolve to github.com/lodash/lodash",
-      "updated_at": "2026-05-25T18:30:00Z"
-    },
-    {
-      "id": "security_contact",
-      "label": "Confirm maintainer/security contact",
-      "category": "core",
-      "state": "incomplete",
-      "evidence": null,
-      "updated_at": null
-    }
-  ],
-  "blocker_reason": null,
-  "history": [
-    {
-      "id": "event_123",
-      "type": "state_changed",
-      "actor_uid": "user_456",
-      "from_state": "assigned",
-      "to_state": "in_progress",
-      "created_at": "2026-05-25T18:15:00Z"
-    }
-  ],
-  "created_at": "2026-05-25T18:00:00Z",
-  "updated_at": "2026-05-25T18:30:00Z"
-}
-```
+No `DELETE` endpoints — all state transitions are patches that preserve history.
 
 ### Concurrency
 
-Every stewardship mutation must include `state_version` or equivalent optimistic
-locking metadata. On conflict, the API returns a typed conflict response with
-the latest owner/state summary so the UI can refresh the row without guessing.
+Every stewardship mutation must include `state_version` for optimistic locking.
+On conflict, the API returns the latest state so the UI can refresh.
 
-Common conflict scenarios that need explicit UX:
+## Design Direction
 
-- Two admins assign the same package simultaneously.
-- A contributor claims a package that was just assigned by an admin.
-- An admin marks a package `no_longer_in_scope` while a contributor is mid-
-  checklist.
+Dense operational layout consistent with existing LFX One dashboards. The admin
+dashboard is **coverage-oriented**, not throughput-oriented — the primary
+visualization is "how much of the critical package set is covered" rather than
+"how many items were processed this week."
 
-In all cases, the loser sees a conflict toast with the new state and owner, and
-the row refreshes in place without a full page reload.
+### Visual System
 
-### Outbound Events
+- Use existing Tailwind/LFX tokens only. No hard-coded hex values.
+- Tags: `Unassigned` (neutral), `Open` (info), `Assessing` (warning),
+  `Active` (success), `Needs attention` (danger),
+  `Escalated` (danger), `Blocked` (danger), `Inactive` (neutral).
+- Table is the primary surface. Row click opens the detail drawer.
 
-Self Serve should emit stewardship lifecycle events for Insights and reporting
-even if v1 only publishes them internally:
+## Data Pipeline Gap Analysis
 
-- `security_stewardship.created`
-- `security_stewardship.state_changed`
-- `security_stewardship.review_requested`
-- `security_stewardship.review_completed`
-- `security_stewardship.blocked`
-- `security_stewardship.returned`
-- `security_stewardship.needs_reverification`
-- `security_stewardship.stale_warning` (system-initiated, 30-day threshold)
-- `security_stewardship.auto_released` (system-initiated, 60-day threshold)
+### Covered by CDP Pipeline
 
-The `stale_warning` and `auto_released` events are system-initiated and distinct
-from actor-initiated `state_changed` events. They should carry the same payload
-shape but with `actor: "system"` and the applicable aging policy threshold.
+- Package identity (name, ecosystem, purl)
+- Downloads / dependents
+- Latest version / release date
+- Repo mapping
+- OpenSSF Scorecard
+- Advisories / critical vuln flag
+- Repo stars, forks, last commit
+- Maintainer info
+- Licenses
 
-Each event includes stewardship id, package id, scope, previous state, next
-state, actor, owner, reviewer, reason, and timestamp.
+### Gaps
+
+| Gap | Priority | Detail |
+|-----|----------|--------|
+| Composite risk score | High | Raw signals exist but no composite tier. Primary sort/filter axis. |
+| Repo mapping confidence | High | deps.dev has mapping but no confidence signal. |
+| Security contact / policy | High | Critical for assessment. No SECURITY.md or contact data. |
+| Build provenance | Medium | Supply chain assessment needs provenance attestation data. |
+| Maintainer activity recency | Medium | Last commit collected but maintainer response time is not. |
+| Package deprecation status | Medium | npm deprecation flags and Maven relocation. |
+| Monorepo awareness | Medium | Need grouping to avoid duplicate stewardships. |
+
+## Open Decisions
+
+- **Which upstream service owns stewardship state?** Leaning: dedicated Osprey
+  workflow service, with Insights/CDP as source-data providers.
+- **Who computes composite risk scores?** CDP provides raw signals. Either CDP
+  exposes pre-computed tiers, or the stewardship service computes them.
+- **How does the package list sync from CDP?** Batch import, real-time feed, or
+  API pull? Refresh cadence?
+- **What triggers `needs_attention`?** New advisory is clear. What about
+  maintainer account changes, repo archival, significant dependency changes?
+- **How do we track remediation actions across external systems?** Log URLs
+  only, or pull status from GitHub/registries?
+- **What's the expected steward-to-package ratio?** One steward per package, or
+  can a steward manage a cluster of related packages?
+- **How often should active stewards report status?** Monthly? Quarterly?
+  Event-triggered? Affects `inactive` detection.
 
 ## Suggested PR Sequence
 
 1. Shared types + backend proxy/controller/service once upstream API contract is
    confirmed.
-2. Admin package queue page with filters/table/drawer in read-only mode.
-3. Stewardship actions and `My Security Work`.
-4. Review workflow, notes, blocked states, audit trail.
-5. Project-lens package security view after package-to-repo confidence is high
-   enough.
+2. Admin package queue page (Me lens, admin-gated) with coverage metrics and
+   filters/table/drawer in read-only mode.
+3. Stewardship lifecycle: claim, assessment, activate.
+4. My Stewardships (Me lens): contributor workspace with active stewardship
+   management.
+5. Activity logging: remediation progress, status updates, escalations.
 
-## Open Decisions
+## v2 Roadmap
 
-- Which upstream service owns the security stewardship API: new Osprey/security
-  service, Insights API, or an existing LFX service?
-  - Leaning: dedicated security/Osprey workflow service, with Insights/CDP as
-    source-data providers, because stewardship state is workflow data rather
-    than analytics data.
-- Should this be LF-wide first or foundation-scoped first?
-  - Leaning: foundation-scoped first with an LF-wide admin aggregate, because
-    review ownership, SLA, and assignment pools will differ by foundation.
-- What roles can assign/review stewardship work beyond ED/admin?
-  - Leaning: ED/admin plus delegated security reviewers configured per
-    foundation. Decision needed before API permission work starts. Model the
-    delegated reviewer role in v1 even if the UI only exposes ED/admin
-    initially — adding a role later is a schema migration, not a UI tweak.
-- What fields should count as completion across ecosystems?
-  - Leaning: shared checklist core plus ecosystem-specific checklist items.
-    Avoid npm/Maven-only field names in shared routes and interfaces. The
-    `checklist_template_id` and `category` fields in the stewardship record
-    support this.
-- Should Mythos be surfaced directly in the drawer or only linked out?
-  - Leaning: link out from the drawer for v1 unless the upstream API provides a
-    stable summary field. Self Serve should not become the analytics surface.
-- How much of this is one-time Osprey workflow versus permanent Self Serve
-  security surface?
-  - Leaning: build permanent primitives (`package`, `stewardship`, `review`,
-    `history`) and let Osprey be the first program using them.
-- **Who owns composite risk signals?** The UI depends on a composite risk score
-  (Critical/High/Medium/Low), repo mapping confidence, single-maintainer flag,
-  and stale-repo flag. CDP collects the raw ingredients but does not currently
-  expose pre-computed tiers. Decision: CDP provides computed tiers, or Self
-  Serve builds a scoring layer on top of raw data?
-- **How does the package list sync from CDP?** Batch import, real-time feed, or
-  API pull? How often does the package list refresh? What happens when a package
-  is added or removed upstream?
+Features explicitly deferred from v1:
 
-## Data Pipeline Gap Analysis
-
-Cross-referenced the UI requirements against the CDP Tier 2 + Tier 3 data
-currently being implemented. Raw ingredients are mostly covered, but several
-composite or derived signals the UI depends on are not yet in the pipeline.
-
-### Covered by CDP Pipeline
-
-- Package identity (name, ecosystem, purl) — Tier 2 registries
-- Downloads / dependents (impact column) — Tier 3 deps.dev + npm/sonatype
-- Latest version / release date — Tier 2 registries
-- Repo mapping — Tier 2 deps.dev
-- OpenSSF Scorecard — Tier 2 deps.dev
-- Advisories / critical vuln flag — Tier 2 osv.dev / GitHub advisories
-- Repo stars, forks, last commit — Tier 2 GitHub
-- Maintainer info — Tier 2 registries
-- Licenses — Tier 2 registries
-
-### Gaps
-
-| Gap                          | Priority | Detail                                                                                                                                                                                   |
-| ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Composite risk score         | High     | Risk column is the primary sort/filter axis. Raw signals exist (advisories, dependents, scorecard, maintainer count, last commit) but no composite tier. Who computes it?                |
-| Repo mapping confidence      | High     | UI shows confidence level + source. deps.dev has the mapping but does not expose a confidence signal. Need to derive: `declared` = high, `deps.dev inferred` = medium, `heuristic` = low |
-| Security contact / policy    | Medium   | Checklist includes "verify security contacts." Pipeline has maintainers but not SECURITY.md presence, security policy, or dedicated security contact. Small addition to GitHub fetch.     |
-| Package deprecation status   | Medium   | `no_longer_in_scope` needs npm deprecation flags and Maven artifact relocation/removal. Confirm registry `status` field covers these.                                                    |
-| Monorepo awareness           | Medium   | Many npm packages map to the same repo. Without repo → packages cardinality, admin queue shows duplicated work with no grouping.                                                         |
-| Single maintainer flag       | Low      | Derivable from maintainer records. Should be exposed as queryable boolean, not raw records Self Serve counts client-side.                                                                 |
-| Stale repo flag              | Low      | Last commit is collected. Needs threshold definition + computed flag.                                                                                                                     |
-
-## Permissions Model
-
-The role and action matrix above defines what each role can do per state, but
-does not define how roles are determined. This must be resolved before API
-permission work starts.
-
-Proposed model:
-
-- **ED / admin**: Existing LFX foundation-level ED and admin roles. Can triage,
-  assign, review, and bulk-manage within their foundation scope.
-- **Delegated security reviewer**: New role, configured per foundation by an ED.
-  Can review submissions and request changes, but cannot bulk-assign or manage
-  assignment pools.
-- **Contributor**: Any authenticated LFX user. Can claim open packages, work
-  checklists, submit for review, and return stewardship.
-
-The API should enforce foundation-scoped permissions: an ED for Foundation A
-cannot assign packages scoped to Foundation B.
-
-## Priority Updates From Spec Review
-
-1. Resolve state lifecycle gaps before implementation: `needs_reverification`,
-   `stale`, `returned`, and `no_longer_in_scope`.
-2. Design for real queue volume: bulk actions, saved views, assignment policies,
-   async jobs, and optimistic locking.
-3. Keep an explicit role x state x action matrix in the spec and QA plan.
-4. Treat History as a first-class collaboration and audit surface, not a single
-   notes textarea.
-5. Keep copy and API fields ecosystem-agnostic so PyPI, RubyGems, Cargo, NuGet,
-   and Go modules can join later without route or data-model churn.
-6. Resolve composite risk signal ownership (CDP vs Self Serve scoring layer)
-   before UI implementation — the admin queue is unusable without sortable risk.
-7. Resolve data sync mechanism (batch, real-time, API pull) and refresh cadence
-   from CDP before backend work starts.
+- **Project Stewardship** (Project lens) — maintainer submission flow with
+  registry API verification
+- **Organization Stewardships** (Org lens) — read-only org-wide visibility
+- Automated `needs_attention` triggers from advisory feeds
+- Steward activity scoring / engagement metrics
+- Remediation tracking with GitHub PR/issue status sync
+- Assignment pool routing and round-robin
+- Saved views (per-user, shareable)
+- Notification digests and activity reminders
+- Package clustering (steward manages related packages together)


### PR DESCRIPTION
## Summary

- Rewrites the security-project-adoption PDR to reflect the evolved product model: stewardship as ongoing responsibility, not a one-time review queue
- Adds HTML version of the spec for visual review and interactive UI mockups (contributor + admin views)

### Key changes from previous spec

- **ED/Admin role → Osprey Program Admin** (OpenSSF-scoped, not generic foundation EDs)
- **Maintainer actor added** (v2, with registry API verification)
- **State machine**: 8 states with `active` as steady state — no "complete" state, no admin review gate
- **Assessment framework** replaces verification checklist (6 dimensions: maintainer health, security posture, vulnerability exposure, dependency risk, supply chain integrity, release health)
- **Entry points**: My Stewardships + Osprey Program (both in Me lens)
- **Admin dashboard** is coverage-oriented (% of critical packages with active stewards), not throughput-oriented
- **Health Score v2 integration**: Lifecycle, Health, and Impact as three separate table columns

### New files

- `docs/security-project-adoption.html` — visual HTML spec with Mermaid diagrams
- `docs/mockups/me-stewardships.html` — fully interactive contributor mockup (5 working tabs: Active, Assessing, Needs attention, Available, Escalated)
- `docs/mockups/admin-stewardships.html` — admin dashboard mockup with coverage metrics and bulk actions

## Test plan

- [ ] Open `docs/security-project-adoption.html` in a browser to review the spec visually
- [ ] Open `docs/mockups/me-stewardships.html` in a browser — click through all 5 tabs and open drawers
- [ ] Open `docs/mockups/admin-stewardships.html` in a browser — verify coverage stats and drawer