### PR TITLE
feat(helm): add INTERCOM_APP_ID to chart values (LFXV2-2022)

### DIFF
--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -176,6 +176,12 @@ environment:
 | `environment.AI_PROXY_URL` | AI service proxy URL (OpenAI compatible) | **Yes**  | -       |
 | `environment.AI_API_KEY`   | API key for AI service                   | **Yes**  | -       |
 
+#### Runtime Client Configuration
+
+| Parameter                      | Description                                                                                                                                                                              | Required | Default              |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------- |
+| `environment.INTERCOM_APP_ID` | Public Intercom Messenger workspace App ID. Messenger loads only when set; identity verification uses the `http://lfx.dev/claims/intercom` Auth0 claim, not this value. | No       | - (Messenger off) |
+
 #### Snowflake Analytics Configuration
 
 Required for analytics endpoints (active-weeks-streak, pull-requests-merged, code-commits):

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -178,8 +178,8 @@ environment:
 
 #### Runtime Client Configuration
 
-| Parameter                      | Description                                                                                                                                                                              | Required | Default              |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------- |
+| Parameter                     | Description                                                                                                                                                             | Required | Default           |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------- |
 | `environment.INTERCOM_APP_ID` | Public Intercom Messenger workspace App ID. Messenger loads only when set; identity verification uses the `http://lfx.dev/claims/intercom` Auth0 claim, not this value. | No       | - (Messenger off) |
 
 #### Snowflake Analytics Configuration

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -312,6 +312,11 @@ environment:
   AI_API_KEY:
     value:
 
+  # Public Intercom Messenger workspace App ID. Identity verification rides on the
+  # `http://lfx.dev/claims/intercom` Auth0 claim — not on this value.
+  INTERCOM_APP_ID:
+    value:
+
   # Invite JWT signing secret (HS256) — used to verify signed invite tokens.
   # Must match the INVITE_JWT_SECRET configured in lfx-v2-invite-service.
   # The value is used as raw UTF-8 bytes (not base64-decoded) to match how


### PR DESCRIPTION
# Summary

This pull request adds configuration support for integrating the Intercom Messenger into the deployment of the `lfx-self-serve` service. The main changes introduce a new environment variable for the Intercom App ID, allowing the Messenger to be enabled or disabled via configuration.

Intercom Messenger integration:

* Added documentation for the new `environment.INTERCOM_APP_ID` parameter in `README.md`, explaining its purpose, usage, and how it relates to identity verification.
* Added the `INTERCOM_APP_ID` environment variable to `values.yaml`, allowing users to configure the Intercom Messenger App ID at deployment time.