### PR TITLE
fix(dashboards): wire classification filter to pipeline query

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -41,8 +41,10 @@
   </div>
 </div>
 
-<lfx-attribution-section
-  [foundationSlug]="foundationSlug()"
-  [foundationName]="foundationName()"
-  [focusProgram]="focusProgram()"
-  data-testid="overview-tab-attribution-section" />
+@if (!isProjectWebsites()) {
+  <lfx-attribution-section
+    [foundationSlug]="foundationSlug()"
+    [foundationName]="foundationName()"
+    [focusProgram]="focusProgram()"
+    data-testid="overview-tab-attribution-section" />
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -33,6 +33,7 @@ export class OverviewTabComponent {
   protected readonly loading = signal(false);
 
   // === Computed Signals ===
+  protected readonly isProjectWebsites = computed(() => this.focusProgram() === 'projectWebsites');
   protected readonly overviewKpiData: Signal<OverviewKpiData> = this.initOverviewKpiData();
   protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
   protected readonly summaryTitle: Signal<string> = this.initSummaryTitle();
@@ -52,10 +53,11 @@ export class OverviewTabComponent {
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
+          const isWebOnly = focus === 'projectWebsites';
           return forkJoin({
-            revenueImpact: this.analyticsService.getRevenueImpact(slug, classification).pipe(catchError(() => of(null))),
+            revenueImpact: isWebOnly ? of(null) : this.analyticsService.getRevenueImpact(slug, classification).pipe(catchError(() => of(null))),
             brandReach: this.analyticsService.getBrandReach(slug, classification).pipe(catchError(() => of(null))),
-            emailCtr: this.analyticsService.getEmailCtr(slug, classification).pipe(catchError(() => of(null))),
+            emailCtr: isWebOnly ? of(null) : this.analyticsService.getEmailCtr(slug, classification).pipe(catchError(() => of(null))),
           }).pipe(finalize(() => this.loading.set(false)));
         })
       ),

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5068,7 +5068,6 @@ export class ProjectService {
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
 
-      // PIPELINE_SUMMARY does not have LF_SUB_DOMAIN_CLASSIFICATION — always unfiltered
       const pipelineQuery = isUmbrella
         ? `
         SELECT SUM(TOTAL_PIPELINE_YTD) AS TOTAL_PIPELINE_YTD, SUM(WON_REVENUE_YTD) AS WON_REVENUE_YTD,
@@ -5078,14 +5077,18 @@ export class ProjectService {
                AVG(AVG_WON_DEAL_SIZE_YTD) AS AVG_WON_DEAL_SIZE_YTD, AVG(CONVERSION_RATE_YTD) AS CONVERSION_RATE_YTD,
                SUM(WON_REVENUE_PRIOR_YEAR) AS WON_REVENUE_PRIOR_YEAR, AVG(WON_REVENUE_YOY_CHANGE_PCT) AS WON_REVENUE_YOY_CHANGE_PCT
         FROM ANALYTICS.PLATINUM_LFX_ONE.PIPELINE_SUMMARY
+        ${classification ? 'WHERE LF_SUB_DOMAIN_CLASSIFICATION = ?' : ''}
       `
         : `
-        SELECT TOTAL_PIPELINE_YTD, WON_REVENUE_YTD, LOST_REVENUE_YTD, OPEN_PIPELINE_YTD,
-               TOTAL_DEALS_YTD, WON_DEALS_YTD, LOST_DEALS_YTD, OPEN_DEALS_YTD,
-               AVG_WON_DEAL_SIZE_YTD, CONVERSION_RATE_YTD,
-               WON_REVENUE_PRIOR_YEAR, WON_REVENUE_YOY_CHANGE_PCT
+        SELECT SUM(TOTAL_PIPELINE_YTD) AS TOTAL_PIPELINE_YTD, SUM(WON_REVENUE_YTD) AS WON_REVENUE_YTD,
+               SUM(LOST_REVENUE_YTD) AS LOST_REVENUE_YTD, SUM(OPEN_PIPELINE_YTD) AS OPEN_PIPELINE_YTD,
+               SUM(TOTAL_DEALS_YTD) AS TOTAL_DEALS_YTD, SUM(WON_DEALS_YTD) AS WON_DEALS_YTD,
+               SUM(LOST_DEALS_YTD) AS LOST_DEALS_YTD, SUM(OPEN_DEALS_YTD) AS OPEN_DEALS_YTD,
+               AVG(AVG_WON_DEAL_SIZE_YTD) AS AVG_WON_DEAL_SIZE_YTD, AVG(CONVERSION_RATE_YTD) AS CONVERSION_RATE_YTD,
+               SUM(WON_REVENUE_PRIOR_YEAR) AS WON_REVENUE_PRIOR_YEAR, AVG(WON_REVENUE_YOY_CHANGE_PCT) AS WON_REVENUE_YOY_CHANGE_PCT
         FROM ANALYTICS.PLATINUM_LFX_ONE.PIPELINE_SUMMARY
         WHERE FOUNDATION_SLUG = ?
+          ${classificationFilter}
       `;
 
       // PAID_ADS_ATTRIBUTION has LF_SUB_DOMAIN_CLASSIFICATION
@@ -5255,7 +5258,7 @@ export class ProjectService {
             CONVERSION_RATE_YTD: number;
             WON_REVENUE_PRIOR_YEAR: number;
             WON_REVENUE_YOY_CHANGE_PCT: number;
-          }>(pipelineQuery, isUmbrella ? [] : [foundationSlug]),
+          }>(pipelineQuery, isUmbrella ? [...classificationParams] : [foundationSlug, ...classificationParams]),
           this.snowflakeService.execute<{
             TOTAL_SPEND_YTD: number;
             TOTAL_IMPRESSIONS_YTD: number;

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -10,7 +10,6 @@ export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
   { id: 'lfCorporate', label: 'LF Corporate' },
   { id: 'lfEvents', label: 'LF Events' },
   { id: 'lfTraining', label: 'LF Training' },
-  { id: 'lfxPlatform', label: 'LFX Platform' },
   { id: 'projectWebsites', label: 'Project Websites' },
 ];
 
@@ -39,7 +38,6 @@ export const FOCUS_TO_CLASSIFICATION: Record<MarketingImpactFocusProgram, string
   lfCorporate: 'LF Corporate',
   lfEvents: 'LF Events',
   lfTraining: 'LF Training',
-  lfxPlatform: 'LFX Platform',
   projectWebsites: 'Project Websites',
 };
 

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -24,7 +24,7 @@ export interface MarketingImpactTabOption {
 }
 
 /** Focus program identifiers for the Marketing Impact FOCUS filter bar. Values map to Snowflake LF_SUB_DOMAIN_CLASSIFICATION via FOCUS_TO_CLASSIFICATION. */
-export type MarketingImpactFocusProgram = 'all' | 'lfCorporate' | 'lfEvents' | 'lfTraining' | 'lfxPlatform' | 'projectWebsites';
+export type MarketingImpactFocusProgram = 'all' | 'lfCorporate' | 'lfEvents' | 'lfTraining' | 'projectWebsites';
 
 /** Tab identifiers for the Marketing Impact section tabs. */
 export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';


### PR DESCRIPTION
## Summary

LFXV2-2035

- **Pipeline classification filter**: `PIPELINE_SUMMARY` now has `LF_SUB_DOMAIN_CLASSIFICATION`. Wire the focus-program filter into the pipeline query so Attributed Revenue and ROAS respond to classification selection on the Overview tab.
- **Remove LFX Platform**: Remove `lfxPlatform` from focus program options, type union, and classification map.
- **Project Websites behavior**: When "Project Websites" is selected, skip revenue/email API calls and hide the attribution section — only web activity data is relevant.

## Test plan

- [ ] Navigate to Marketing Impact → Overview tab on TLF
- [ ] Select each focus filter (LF Corporate, LF Events, LF Training, Project Websites) and verify Attributed Revenue / ROAS update correctly
- [ ] Verify "LFX Platform" no longer appears in the focus filter bar
- [ ] Verify selecting "Project Websites" hides attribution section and only shows Total Web Sessions KPI card
- [ ] Verify "All programs" still shows all KPI cards and attribution section

🤖 Generated with [Claude Code](https://claude.ai/code)