### PR TITLE
fix(invite): preserve invite token across Auth0 email-verification redirect

### DIFF
--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -435,17 +435,48 @@ function makeAuthDecision(result: AuthMiddlewareResult, req: Request): AuthDecis
   return { action: 'allow' };
 }
 
+const INVITE_TOKEN_COOKIE = 'lfx-invite-token';
+
 /**
  * Executes the authentication decision
  */
 async function executeAuthDecision(decision: AuthDecision, req: Request, res: Response, next: NextFunction): Promise<void> {
   switch (decision.action) {
-    case 'allow':
+    case 'allow': {
+      // After OAuth completes, if an invite token cookie exists and we're not already
+      // on /invite, the email-verification redirect lost the OAuth state — recover by
+      // redirecting to the invite URL and consuming the cookie.
+      const pendingInviteToken = req.cookies?.[INVITE_TOKEN_COOKIE] as string | undefined;
+      if (pendingInviteToken && !req.path.startsWith('/invite')) {
+        res.clearCookie(INVITE_TOKEN_COOKIE, { path: '/' });
+        res.redirect(`/invite?token=${encodeURIComponent(pendingInviteToken)}`);
+        return;
+      }
+      // State was preserved — already landing on /invite with token in URL; clear the cookie.
+      if (pendingInviteToken && req.path.startsWith('/invite')) {
+        res.clearCookie(INVITE_TOKEN_COOKIE, { path: '/' });
+      }
       next();
       break;
+    }
 
     case 'redirect':
       if (decision.redirectUrl) {
+        // Persist the invite token in a short-lived cookie before the OAuth redirect so
+        // it survives Auth0's email-verification flow, which opens in a new context and
+        // loses the OAuth state parameter (and therefore the returnTo URL).
+        if (req.path.startsWith('/invite') && !req.path.startsWith('/invite/error')) {
+          const inviteToken = req.query['token'];
+          if (typeof inviteToken === 'string' && inviteToken.split('.').length === 3) {
+            res.cookie(INVITE_TOKEN_COOKIE, inviteToken, {
+              httpOnly: true,
+              secure: process.env['NODE_ENV'] === 'production',
+              sameSite: 'lax',
+              maxAge: 15 * 60 * 1000, // 15 minutes — enough to complete signup + email verification
+              path: '/',
+            });
+          }
+        }
         // Use OIDC login method which handles the redirect properly
         res.oidc.login({ returnTo: req.originalUrl });
       } else {


### PR DESCRIPTION
## Problem

When a new non-LF user visits `/invite?token=<jwt>`, the auth middleware redirects them to Auth0 to sign up. Auth0 sends a verification email. If the user clicks the verification link in a **different browser or device**, the OAuth `state` parameter (which carries `returnTo=/invite?token=…`) is lost — Auth0 redirects to `/` and the invite token is never processed. The user lands on the LFX home page with no API call made and no `lfx.invite.accepted` event published.

This only affects new users who need to create an account + verify email. Existing users logging in (single OAuth round-trip) are unaffected.

## Fix

Set a short-lived (15 min) `HttpOnly` cookie `lfx-invite-token` before the OAuth redirect in `executeAuthDecision`. After authentication completes:

- If the user landed somewhere other than `/invite` (state was lost): redirect to `/invite?token=<cookie>` and clear the cookie
- If the user already landed on `/invite` (state was preserved, token is in the URL): clear the cookie without a redirect

The cookie uses `SameSite=Lax` so it is sent on the top-level navigation back from the OAuth callback, and `HttpOnly` so it is not accessible from JavaScript.

## Changes

- `apps/lfx-one/src/server/middleware/auth.middleware.ts` — set cookie on invite redirect, consume on allow

## Test plan

- [ ] Existing user visits `/invite?token=<jwt>` → logs in (no email verification) → lands on `/invite?token=<jwt>` → invite accepted normally ✓
- [ ] New user visits `/invite?token=<jwt>` → signs up → verifies email **in the same browser** → lands on `/invite?token=<jwt>` → invite accepted normally ✓
- [ ] New user visits `/invite?token=<jwt>` → signs up → verifies email **in a different browser/device** → lands on `/invite?token=<jwt>` (recovered via cookie) → invite accepted ✓
- [ ] Visiting any page normally (no invite cookie) → unaffected ✓
- [ ] Cookie expires (15 min) before email verification → user lands on home, no redirect loop ✓

## Related

- Closes LFXV2-1945 (original invite flow PR: #742)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)