### PR TITLE
fix(settings): resolve username showing as email in permissions table

### DIFF
--- a/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.ts
@@ -109,10 +109,10 @@ export class UserFormComponent {
 
     // For adding: if manual fields not shown yet, try to lookup user by email first
     if (!this.showManualFields()) {
-      // Try to add user with just email (backend will resolve to username)
+      // Try to add user by email — backend resolves to the real username via directory lookup
       this.permissionsService
         .addUserToProject(project.uid, {
-          username: formValue.email, // Pass email as username, backend will resolve
+          email: formValue.email,
           role: formValue.role,
         } as AddUserToProjectRequest)
         .pipe(take(1))

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -260,11 +260,14 @@ export class ProjectController {
         return;
       }
 
-      // Check if manual user data is provided (for users not found in directory)
+      // Check if manual user data is provided (for users not found in directory).
+      // name is always present for manual adds and never present for directory email lookups,
+      // so it's the correct discriminator — using email alone would misclassify a plain
+      // { email, role } directory-lookup request as a manual add.
       let manualUserInfo: { name: string; email: string; username?: string; avatar?: string } | undefined;
-      if (userData.name || userData.email || userData.avatar) {
+      if (userData.name) {
         manualUserInfo = {
-          name: userData.name || '',
+          name: userData.name,
           email: userData.email || '',
           // username is optional for manually-added users — preserve whatever was provided
           username: userData.username || undefined,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -489,13 +489,11 @@ export class ProjectService {
         // incorrectly turn an intentionally empty username into an email address.
         userInfo = { ...existingUserInfo };
       } else {
-        // Fetch user info from user service via NATS using the original input
+        // Fetch user info from user service via NATS using the original input.
+        // Use the display username from the profile as-is — overwriting it with the NATS
+        // sub caused the username column to show the email when the sub equalled the email.
         const fetchedUserInfo = await this.getUserInfo(req, usernameOrEmail);
-        // Use the backend identifier (sub) for the username in the stored UserInfo for backend consistency
-        userInfo = {
-          ...fetchedUserInfo,
-          username: backendIdentifier, // Use the sub for backend consistency
-        };
+        userInfo = { ...fetchedUserInfo };
       }
 
       if (role === 'manage') {


### PR DESCRIPTION
## Summary

- **Frontend** (`user-form.component.ts`): sent `username: email` instead of `email: email` for directory lookups, routing the email value through the wrong request field
- **Controller** (`project.controller.ts`): `manualUserInfo` detection checked `name || email || avatar`; changed to check `name` only so a plain email lookup is not misclassified as a manual add
- **Service** (`project.service.ts`): overwrote `fetchedUserInfo.username` (real display username) with `backendIdentifier` (NATS sub); when the sub equalled the email the stored username became the email address

## Root cause detail

When adding a directory user, the frontend sent `{ username: "john@example.com", role }`. The service resolved the email to a NATS sub via `resolveEmailToSub`, then **overwrote** the user's display username from `getUserInfo` with that sub. For LFX auth configurations where the sub equals the email, `username = email` was persisted in project settings — which is what the permissions table displayed.

After edit+save, the cache was invalidated and a fresh fetch returned settled data, which is why the username appeared to "fix itself" after an edit.

## Test plan

- [ ] Add a new user to the permissions table by email — username column should show the user's real LFX username, not their email
- [ ] Verify the manual-add flow (user not found in directory) still works: "User Not Found" dialog still appears, and manually-entered name/username/avatar are saved correctly
- [ ] Edit an existing user's role — username should remain unchanged after save
- [ ] Remove a user — should still work correctly after the lookup identifier change

Fixes [LFXV2-2036](https://linuxfoundation.atlassian.net/browse/LFXV2-2036)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-2036]: https://linuxfoundation.atlassian.net/browse/LFXV2-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ