### PR TITLE
fix(newsletters): remove custom context gate from newsletter list

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -6,28 +6,19 @@
     <div class="mb-6">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">Newsletters</h1>
-        @if (hasContext()) {
-          <lfx-button
-            icon="fa-light fa-paper-plane"
-            severity="info"
-            label="Create Newsletter"
-            size="small"
-            (onClick)="goToCreate()"
-            data-testid="newsletter-create-button">
-          </lfx-button>
-        }
+        <lfx-button
+          icon="fa-light fa-paper-plane"
+          severity="info"
+          label="Create Newsletter"
+          size="small"
+          (onClick)="goToCreate()"
+          data-testid="newsletter-create-button">
+        </lfx-button>
       </div>
       <p class="mt-1 text-sm text-gray-500">Send important updates to your groups and see how past newsletters performed.</p>
     </div>
 
-    @if (!hasContext()) {
-      <lfx-empty-state
-        icon="fa-light fa-paper-plane"
-        title="Pick a foundation or project"
-        subtitle="Select a foundation or project from the header to view its newsletters.">
-      </lfx-empty-state>
-    } @else {
-      <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="newsletter-list-card">
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="newsletter-list-card">
         <lfx-card-tabs-bar
           [options]="statusTabOptions"
           [selectedFilter]="statusTab()"
@@ -151,7 +142,6 @@
           }
         </div>
       </lfx-card>
-    }
   </div>
 </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -19,129 +19,129 @@
     </div>
 
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="newsletter-list-card">
-        <lfx-card-tabs-bar
-          [options]="statusTabOptions"
-          [selectedFilter]="statusTab()"
-          (filterChange)="onStatusTabChange($event)"
-          data-testid="newsletter-status-tabs">
-        </lfx-card-tabs-bar>
+      <lfx-card-tabs-bar
+        [options]="statusTabOptions"
+        [selectedFilter]="statusTab()"
+        (filterChange)="onStatusTabChange($event)"
+        data-testid="newsletter-status-tabs">
+      </lfx-card-tabs-bar>
 
-        <div class="px-5 py-5 flex flex-col gap-4">
-          @if (!loading() && !hasNewsletters()) {
-            <lfx-empty-state
-              [withCard]="false"
-              icon="fa-light fa-paper-plane"
-              [title]="statusTab() === 'draft' ? 'No drafts yet' : 'No sent newsletters yet'"
-              [subtitle]="
-                statusTab() === 'draft'
-                  ? 'Start writing your first newsletter and your draft will appear here.'
-                  : 'Send your first newsletter and engagement metrics will show up here.'
-              "
-              ctaLabel="Create newsletter"
-              ctaIcon="fa-light fa-plus"
-              (ctaClick)="goToCreate()">
-            </lfx-empty-state>
-          } @else {
-            <lfx-table [value]="rows()" [loading]="loading()" selectionMode="single" dataKey="id" data-testid="newsletter-list-table">
-              <ng-template #header>
-                <tr>
-                  <th class="w-[40%]">Subject</th>
-                  <th class="w-[15%]">Audience</th>
-                  @if (statusTab() === 'sent') {
-                    <th class="w-[15%]">Sent</th>
-                    <th class="w-[10%] text-right">Recipients</th>
-                    <th class="w-[10%] text-right">Open Rate</th>
-                    <th class="w-[10%]"></th>
-                  } @else {
-                    <th class="w-[20%]">Updated</th>
-                    <th class="w-[10%] text-right">Audience size</th>
-                    <th class="w-[15%]"></th>
-                  }
-                </tr>
-              </ng-template>
+      <div class="px-5 py-5 flex flex-col gap-4">
+        @if (!loading() && !hasNewsletters()) {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-paper-plane"
+            [title]="statusTab() === 'draft' ? 'No drafts yet' : 'No sent newsletters yet'"
+            [subtitle]="
+              statusTab() === 'draft'
+                ? 'Start writing your first newsletter and your draft will appear here.'
+                : 'Send your first newsletter and engagement metrics will show up here.'
+            "
+            ctaLabel="Create newsletter"
+            ctaIcon="fa-light fa-plus"
+            (ctaClick)="goToCreate()">
+          </lfx-empty-state>
+        } @else {
+          <lfx-table [value]="rows()" [loading]="loading()" selectionMode="single" dataKey="id" data-testid="newsletter-list-table">
+            <ng-template #header>
+              <tr>
+                <th class="w-[40%]">Subject</th>
+                <th class="w-[15%]">Audience</th>
+                @if (statusTab() === 'sent') {
+                  <th class="w-[15%]">Sent</th>
+                  <th class="w-[10%] text-right">Recipients</th>
+                  <th class="w-[10%] text-right">Open Rate</th>
+                  <th class="w-[10%]"></th>
+                } @else {
+                  <th class="w-[20%]">Updated</th>
+                  <th class="w-[10%] text-right">Audience size</th>
+                  <th class="w-[15%]"></th>
+                }
+              </tr>
+            </ng-template>
 
-              <ng-template #body let-newsletter>
-                <tr class="cursor-pointer" (click)="goToRow(newsletter)" [attr.data-testid]="'newsletter-row-' + newsletter.id">
-                  <td>
-                    <span class="lfx-table-name-link text-sm text-gray-900 font-medium">
-                      {{ newsletter.subject || 'Untitled draft' }}
-                    </span>
-                  </td>
+            <ng-template #body let-newsletter>
+              <tr class="cursor-pointer" (click)="goToRow(newsletter)" [attr.data-testid]="'newsletter-row-' + newsletter.id">
+                <td>
+                  <span class="lfx-table-name-link text-sm text-gray-900 font-medium">
+                    {{ newsletter.subject || 'Untitled draft' }}
+                  </span>
+                </td>
+                <td>
+                  <span class="text-sm text-gray-700">
+                    {{ newsletter.groupsLabel }}
+                  </span>
+                </td>
+
+                @if (statusTab() === 'sent') {
                   <td>
                     <span class="text-sm text-gray-700">
-                      {{ newsletter.groupsLabel }}
+                      {{ newsletter.sent_at ? (newsletter.sent_at | date: 'MMM d, y') : '—' }}
                     </span>
                   </td>
-
-                  @if (statusTab() === 'sent') {
-                    <td>
-                      <span class="text-sm text-gray-700">
-                        {{ newsletter.sent_at ? (newsletter.sent_at | date: 'MMM d, y') : '—' }}
-                      </span>
-                    </td>
-                    <td class="text-right">
-                      <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
-                    </td>
-                    <td class="text-right">
-                      <span class="text-sm text-gray-700" [pTooltip]="newsletter.openRateTooltip" tooltipPosition="top">
-                        {{ newsletter.openRateLabel }}
-                      </span>
-                    </td>
-                    <td class="text-right">
-                      <div class="flex items-center justify-end gap-2">
-                        <lfx-button
-                          icon="fa-light fa-eye"
-                          severity="secondary"
-                          size="small"
-                          [text]="true"
-                          ariaLabel="View newsletter"
-                          (onClick)="openPreview(newsletter, $event)"
-                          [attr.data-testid]="'newsletter-view-' + newsletter.id"
-                          pTooltip="Open preview of this sent newsletter"
-                          tooltipPosition="top">
-                        </lfx-button>
-                        <lfx-tag value="Sent" severity="success"></lfx-tag>
-                      </div>
-                    </td>
-                  } @else {
-                    <td>
-                      <span class="text-sm text-gray-700">{{ newsletter.updated_at | date: 'MMM d, y' }}</span>
-                    </td>
-                    <td class="text-right">
-                      <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
-                    </td>
-                    <td class="text-right">
+                  <td class="text-right">
+                    <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
+                  </td>
+                  <td class="text-right">
+                    <span class="text-sm text-gray-700" [pTooltip]="newsletter.openRateTooltip" tooltipPosition="top">
+                      {{ newsletter.openRateLabel }}
+                    </span>
+                  </td>
+                  <td class="text-right">
+                    <div class="flex items-center justify-end gap-2">
                       <lfx-button
-                        label="Delete"
-                        severity="danger"
+                        icon="fa-light fa-eye"
+                        severity="secondary"
                         size="small"
                         [text]="true"
-                        (onClick)="onDeleteDraft(newsletter, $event)"
-                        [disabled]="deletingId() === newsletter.id"
-                        [attr.data-testid]="'newsletter-delete-' + newsletter.id">
+                        ariaLabel="View newsletter"
+                        (onClick)="openPreview(newsletter, $event)"
+                        [attr.data-testid]="'newsletter-view-' + newsletter.id"
+                        pTooltip="Open preview of this sent newsletter"
+                        tooltipPosition="top">
                       </lfx-button>
-                    </td>
-                  }
-                </tr>
-              </ng-template>
-            </lfx-table>
+                      <lfx-tag value="Sent" severity="success"></lfx-tag>
+                    </div>
+                  </td>
+                } @else {
+                  <td>
+                    <span class="text-sm text-gray-700">{{ newsletter.updated_at | date: 'MMM d, y' }}</span>
+                  </td>
+                  <td class="text-right">
+                    <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
+                  </td>
+                  <td class="text-right">
+                    <lfx-button
+                      label="Delete"
+                      severity="danger"
+                      size="small"
+                      [text]="true"
+                      (onClick)="onDeleteDraft(newsletter, $event)"
+                      [disabled]="deletingId() === newsletter.id"
+                      [attr.data-testid]="'newsletter-delete-' + newsletter.id">
+                    </lfx-button>
+                  </td>
+                }
+              </tr>
+            </ng-template>
+          </lfx-table>
 
-            @if (canLoadMore()) {
-              <div class="flex justify-center">
-                <lfx-button
-                  label="Load more"
-                  severity="secondary"
-                  size="small"
-                  [text]="true"
-                  [loading]="loadingMore()"
-                  (onClick)="loadMore()"
-                  data-testid="newsletter-load-more">
-                </lfx-button>
-              </div>
-            }
+          @if (canLoadMore()) {
+            <div class="flex justify-center">
+              <lfx-button
+                label="Load more"
+                severity="secondary"
+                size="small"
+                [text]="true"
+                [loading]="loadingMore()"
+                (onClick)="loadMore()"
+                data-testid="newsletter-load-more">
+              </lfx-button>
+            </div>
           }
-        </div>
-      </lfx-card>
+        }
+      </div>
+    </lfx-card>
   </div>
 </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -12,7 +12,7 @@ import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { FilterPillOption, NewsletterListItem, NewsletterRow, NewsletterStatus, NewsletterStatusTabId, ProjectContext } from '@lfx-one/shared/interfaces';
+import { FilterPillOption, NewsletterListItem, NewsletterRow, NewsletterStatus, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -67,14 +67,8 @@ export class NewsletterListComponent {
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
 
   // === Reactive context ===
-  // Newsletters are project-only — the foundation lens hides this feature.
-  // We still expose isFoundationContext so the template can show a
-  // "switch to a project to view newsletters" empty state.
-  public readonly activeContext: Signal<ProjectContext | null> = this.projectContextService.activeContext;
-  public readonly isFoundationContext: Signal<boolean> = this.projectContextService.isFoundationContext;
   public readonly projectUid: Signal<string> = this.projectContextService.activeContextUid;
-  public readonly hasContext: Signal<boolean> = computed(() => this.projectUid().length > 0 && !this.isFoundationContext());
-  protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore());
+  protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore() && !!this.projectUid());
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
 
   // Pre-compute per-row labels so the template doesn't call functions-with-args.
@@ -125,7 +119,7 @@ export class NewsletterListComponent {
 
   protected loadMore(): void {
     const token = this.nextPageToken();
-    if (!token || this.loadingMore() || !this.hasContext()) return;
+    if (!token || this.loadingMore() || !this.projectUid()) return;
     this.loadingMore.set(true);
     this.newsletterService
       .listNewsletters(this.projectUid(), {
@@ -160,7 +154,7 @@ export class NewsletterListComponent {
   }
 
   private runDelete(id: string): void {
-    if (!this.hasContext()) return;
+    if (!this.projectUid()) return;
     this.deletingId.set(id);
     this.newsletterService
       .deleteNewsletter(this.projectUid(), id)
@@ -184,17 +178,15 @@ export class NewsletterListComponent {
   }
 
   private initLoadOnContextOrTab(): void {
-    combineLatest([toObservable(this.projectUid), toObservable(this.isFoundationContext), toObservable(this.statusTab)])
+    combineLatest([toObservable(this.projectUid), toObservable(this.statusTab)])
       .pipe(
-        distinctUntilChanged(
-          ([prevUid, prevFoundation, prevTab], [uid, foundation, tab]) => prevUid === uid && prevFoundation === foundation && prevTab === tab
-        ),
+        distinctUntilChanged(([prevUid, prevTab], [uid, tab]) => prevUid === uid && prevTab === tab),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe(([uid, foundation, status]) => {
+      .subscribe(([uid, status]) => {
         this.previewVisible.set(false);
         this.selectedNewsletter.set(null);
-        if (uid && !foundation) {
+        if (uid) {
           this.loadInitial(status as NewsletterStatus);
         } else {
           this.newsletters.set([]);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -104,16 +104,12 @@ export class NewsletterManageComponent {
   public readonly currentStep: Signal<number> = this.initCurrentStep();
 
   // === Project context ===
-  // Newsletters are project-only. Foundation context is intentionally not
-  // supported — the feature is hidden in the foundation lens and this
-  // component routes back to the list if it boots up with no project.
   public readonly activeContext: Signal<ProjectContext | null> = this.projectContextService.activeContext;
-  public readonly isFoundationContext: Signal<boolean> = this.projectContextService.isFoundationContext;
   public readonly projectUid: Signal<string> = this.projectContextService.activeContextUid;
   public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
   private readonly fetchedLogoUrl = signal<string | undefined>(undefined);
   public readonly logoUrl: Signal<string | undefined> = computed(() => this.activeContext()?.logoUrl || this.fetchedLogoUrl());
-  public readonly hasContext: Signal<boolean> = computed(() => this.projectUid().length > 0 && !this.isFoundationContext());
+  public readonly hasContext: Signal<boolean> = computed(() => this.projectUid().length > 0);
 
   // === Auth-derived ===
   public readonly edName: Signal<string> = computed(() => {


### PR DESCRIPTION
## Summary
- Removes the "Pick a foundation or project" empty state from the newsletter list — the nav gate and route guard already ensure users have write access before reaching the page
- Newsletter list now loads immediately using `activeContextUid` in both foundation and project lens
- Drops `isFoundationContext` / `hasContext` / `activeContext` signals from the component; load logic simplified to a single `[uid, statusTab]` subscription