### PR TITLE
feat(meetings): attendees drawer board member grouping and skeleton loading

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -419,7 +419,7 @@
       <p-drawer
         [(visible)]="showRegistrants"
         position="right"
-        styleClass="lg:w-1/3 w-full"
+        styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
         data-testid="meeting-registrants-drawer"
         (onHide)="drawerGuestCount.set(0)">
         <ng-template #header>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -48,14 +48,91 @@
       }
     </div>
 
-    <!-- Loading State -->
+    <!-- Loading State — skeleton cards -->
     @if (registrantsLoading()) {
-      <div class="flex items-center justify-center py-8">
-        <i class="fa-light fa-circle-notch fa-spin text-2xl text-blue-600"></i>
+      <div class="flex flex-col gap-2 pt-2" data-testid="registrants-skeleton">
+        @for (i of [1, 2, 3]; track i) {
+          <div class="bg-white border border-gray-200 rounded-lg p-4 flex items-center gap-3 shadow-sm animate-pulse">
+            <div class="w-12 h-12 bg-gray-200 rounded-full flex-shrink-0"></div>
+            <div class="flex flex-col gap-2 flex-1 min-w-0">
+              <div class="h-3.5 bg-gray-200 rounded w-2/5"></div>
+              <div class="h-3 bg-gray-100 rounded w-3/5"></div>
+            </div>
+          </div>
+        }
       </div>
     }
 
-    <!-- Registrants Grid -->
+    <!-- Registrant card template — shared between board and guest sections -->
+    <ng-template #registrantCard let-registrant>
+      <div
+        class="bg-white border border-gray-200 rounded-lg p-4 flex flex-col gap-3 shadow-md relative overflow-visible hover:border-blue-500 transition-colors"
+        [ngClass]="{ 'cursor-pointer': meeting().organizer && registrant.type === 'committee' }"
+        [attr.data-testid]="'registrant-' + registrant.uid">
+        <!-- Avatar + Name + LinkedIn + Voting Status -->
+        <div class="flex items-center gap-3">
+          <!-- Avatar with RSVP Badge -->
+          <div class="relative flex-shrink-0">
+            <lfx-avatar
+              [label]="registrant.first_name"
+              [image]="registrant.avatar_url!"
+              styleClass="bg-blue-50 border border-gray-200 w-12 h-12 object-cover"
+              shape="circle"></lfx-avatar>
+
+            <!-- RSVP Status Badge Overlay -->
+            <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
+              @if (registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true) {
+                <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
+              } @else if (registrant.rsvp?.response_type === 'maybe') {
+                <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
+              } @else if (registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false) {
+                <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
+              } @else {
+                <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
+              }
+            </div>
+          </div>
+
+          <!-- Name + Company + Voting Status -->
+          <div class="flex flex-col min-w-0">
+            <div class="flex items-center gap-2">
+              <h3>{{ registrant.first_name }} {{ registrant.last_name }}</h3>
+              @if (registrant.linkedin_profile) {
+                <a
+                  [href]="registrant.linkedin_profile"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex-shrink-0 hover:opacity-70 transition-opacity"
+                  (click)="$event.stopPropagation()"
+                  pTooltip="View LinkedIn Profile"
+                  tooltipPosition="top">
+                  <i class="fa-brands fa-linkedin text-blue-500 text-base"></i>
+                </a>
+              }
+            </div>
+            @if (registrant.job_title || registrant.org_name) {
+              <p class="text-gray-500 text-sm leading-relaxed tracking-tight truncate">
+                @if (registrant.job_title && registrant.org_name) {
+                  {{ registrant.job_title }} at {{ registrant.org_name }}
+                } @else if (registrant.job_title) {
+                  {{ registrant.job_title }}
+                } @else {
+                  {{ registrant.org_name }}
+                }
+              </p>
+            }
+            @if (registrant.committee_voting_status && registrant.committee_voting_status !== 'Observer' && registrant.committee_voting_status !== 'None') {
+              <div class="flex items-center gap-1">
+                <i class="fa-light fa-check-to-slot text-sm text-gray-400 flex-shrink-0"></i>
+                <span class="text-gray-400 text-xs leading-relaxed tracking-tight truncate">{{ registrant.committee_voting_status }}</span>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    </ng-template>
+
+    <!-- Registrants List -->
     @if (!registrantsLoading()) {
       <div class="flex flex-col gap-2">
         @if (!pastMeeting() && showAddRegistrant()) {
@@ -117,6 +194,30 @@
               </div>
             </div>
           }
+        } @else if (hasCommittees() && committeeFilteredRegistrants().length > 0) {
+          <!-- Two-section layout: Board Members above divider, Guests below -->
+          <div class="flex flex-col gap-2" data-testid="board-members-section">
+            <div class="flex items-center gap-2 px-1">
+              <i class="fa-light fa-building-columns text-gray-400 text-xs"></i>
+              <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">Board Members ({{ committeeFilteredRegistrants().length }})</span>
+            </div>
+            @for (registrant of committeeFilteredRegistrants(); track registrant.uid) {
+              <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
+            }
+          </div>
+
+          @if (directFilteredRegistrants().length > 0) {
+            <div class="border-t border-gray-200 my-1"></div>
+            <div class="flex flex-col gap-2" data-testid="guests-section">
+              <div class="flex items-center gap-2 px-1">
+                <i class="fa-light fa-user text-gray-400 text-xs"></i>
+                <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">Guests ({{ directFilteredRegistrants().length }})</span>
+              </div>
+              @for (registrant of directFilteredRegistrants(); track registrant.uid) {
+                <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
+              }
+            </div>
+          }
         } @else {
           @if (filteredRegistrants().length === 0 && !showAddRegistrant()) {
             <div class="flex w-full items-center justify-center gap-4 py-8 col-span-2">
@@ -125,73 +226,7 @@
             </div>
           }
           @for (registrant of filteredRegistrants(); track registrant.uid) {
-            <div
-              class="bg-white border border-gray-200 rounded-lg p-4 flex flex-col gap-3 shadow-md relative overflow-visible hover:border-blue-500 transition-colors"
-              [ngClass]="{ 'cursor-pointer': meeting().organizer && registrant.type === 'committee' }"
-              [attr.data-testid]="'registrant-' + registrant.uid">
-              <!-- Avatar + Name + LinkedIn + Voting Status -->
-              <div class="flex items-center gap-3">
-                <!-- Avatar with RSVP Badge -->
-                <div class="relative flex-shrink-0">
-                  <lfx-avatar
-                    [label]="registrant.first_name"
-                    [image]="registrant.avatar_url!"
-                    styleClass="bg-blue-50 border border-gray-200 w-12 h-12 object-cover"
-                    shape="circle"></lfx-avatar>
-
-                  <!-- RSVP Status Badge Overlay -->
-                  <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
-                    @if (registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true) {
-                      <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
-                    } @else if (registrant.rsvp?.response_type === 'maybe') {
-                      <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
-                    } @else if (registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false) {
-                      <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
-                    } @else {
-                      <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
-                    }
-                  </div>
-                </div>
-
-                <!-- Name + Company + Voting Status -->
-                <div class="flex flex-col min-w-0">
-                  <div class="flex items-center gap-2">
-                    <h3>{{ registrant.first_name }} {{ registrant.last_name }}</h3>
-                    @if (registrant.linkedin_profile) {
-                      <a
-                        [href]="registrant.linkedin_profile"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="flex-shrink-0 hover:opacity-70 transition-opacity"
-                        (click)="$event.stopPropagation()"
-                        pTooltip="View LinkedIn Profile"
-                        tooltipPosition="top">
-                        <i class="fa-brands fa-linkedin text-blue-500 text-base"></i>
-                      </a>
-                    }
-                  </div>
-                  @if (registrant.job_title || registrant.org_name) {
-                    <p class="text-gray-500 text-sm leading-relaxed tracking-tight truncate">
-                      @if (registrant.job_title && registrant.org_name) {
-                        {{ registrant.job_title }} at {{ registrant.org_name }}
-                      } @else if (registrant.job_title) {
-                        {{ registrant.job_title }}
-                      } @else {
-                        {{ registrant.org_name }}
-                      }
-                    </p>
-                  }
-                  @if (
-                    registrant.committee_voting_status && registrant.committee_voting_status !== 'Observer' && registrant.committee_voting_status !== 'None'
-                  ) {
-                    <div class="flex items-center gap-1">
-                      <i class="fa-light fa-check-to-slot text-sm text-gray-400 flex-shrink-0"></i>
-                      <span class="text-gray-400 text-xs leading-relaxed tracking-tight truncate">{{ registrant.committee_voting_status }}</span>
-                    </div>
-                  }
-                </div>
-              </div>
-            </div>
+            <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
           }
         }
       </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -228,7 +228,7 @@
           @if (committeeFilteredRegistrants().length === 0 && directFilteredRegistrants().length === 0 && !showAddRegistrant()) {
             <div class="flex w-full items-center justify-center gap-4 py-8 col-span-2">
               <i class="fa-light fa-users text-2xl text-gray-500"></i>
-              <span class="text-sm text-gray-500">No guests found</span>
+              <span class="text-sm text-gray-500">No members found</span>
             </div>
           }
         } @else {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -194,20 +194,27 @@
               </div>
             </div>
           }
-        } @else if (hasCommittees() && committeeFilteredRegistrants().length > 0) {
-          <!-- Two-section layout: Board Members above divider, Guests below -->
-          <div class="flex flex-col gap-2" data-testid="board-members-section">
-            <div class="flex items-center gap-2 px-1">
-              <i class="fa-light fa-building-columns text-gray-400 text-xs"></i>
-              <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">Board Members ({{ committeeFilteredRegistrants().length }})</span>
+        } @else if (hasCommittees()) {
+          <!-- Two-section layout: Board Members above divider, Guests below.
+               Each section only renders when it has items, so filters that
+               zero out one section don't drop the other section's label. -->
+          @if (committeeFilteredRegistrants().length > 0) {
+            <div class="flex flex-col gap-2" data-testid="board-members-section">
+              <div class="flex items-center gap-2 px-1">
+                <i class="fa-light fa-building-columns text-gray-400 text-xs"></i>
+                <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">Board Members ({{ committeeFilteredRegistrants().length }})</span>
+              </div>
+              @for (registrant of committeeFilteredRegistrants(); track registrant.uid) {
+                <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
+              }
             </div>
-            @for (registrant of committeeFilteredRegistrants(); track registrant.uid) {
-              <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
-            }
-          </div>
+          }
+
+          @if (committeeFilteredRegistrants().length > 0 && directFilteredRegistrants().length > 0) {
+            <div class="border-t border-gray-200 my-1"></div>
+          }
 
           @if (directFilteredRegistrants().length > 0) {
-            <div class="border-t border-gray-200 my-1"></div>
             <div class="flex flex-col gap-2" data-testid="guests-section">
               <div class="flex items-center gap-2 px-1">
                 <i class="fa-light fa-user text-gray-400 text-xs"></i>
@@ -216,6 +223,13 @@
               @for (registrant of directFilteredRegistrants(); track registrant.uid) {
                 <ng-container *ngTemplateOutlet="registrantCard; context: { $implicit: registrant }"></ng-container>
               }
+            </div>
+          }
+
+          @if (committeeFilteredRegistrants().length === 0 && directFilteredRegistrants().length === 0 && !showAddRegistrant()) {
+            <div class="flex w-full items-center justify-center gap-4 py-8 col-span-2">
+              <i class="fa-light fa-users text-2xl text-gray-500"></i>
+              <span class="text-sm text-gray-500">No guests found</span>
             </div>
           }
         } @else {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -67,7 +67,6 @@
     <ng-template #registrantCard let-registrant>
       <div
         class="bg-white border border-gray-200 rounded-lg p-4 flex flex-col gap-3 shadow-md relative overflow-visible hover:border-blue-500 transition-colors"
-        [ngClass]="{ 'cursor-pointer': meeting().organizer && registrant.type === 'committee' }"
         [attr.data-testid]="'registrant-' + registrant.uid">
         <!-- Avatar + Name + LinkedIn + Voting Status -->
         <div class="flex items-center gap-3">

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -93,8 +93,8 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly filteredRegistrants = this.initFilteredRegistrants();
 
   // Committee (board) and direct registrant sections for the two-section layout
-  public readonly committeeFilteredRegistrants: Signal<MeetingRegistrant[]> = this.initCommitteeFilteredRegistrants();
-  public readonly directFilteredRegistrants: Signal<MeetingRegistrant[]> = this.initDirectFilteredRegistrants();
+  public readonly committeeFilteredRegistrants = computed(() => this.filteredRegistrants().filter((r) => r.type === 'committee'));
+  public readonly directFilteredRegistrants = computed(() => this.filteredRegistrants().filter((r) => r.type !== 'committee'));
 
   // Filtered past meeting participants based on search
   public readonly filteredPastParticipants = this.initFilteredPastParticipants();
@@ -356,14 +356,6 @@ export class MeetingRegistrantsDisplayComponent {
         return matchesSearch && matchesRsvp && matchesGroup;
       });
     });
-  }
-
-  private initCommitteeFilteredRegistrants(): Signal<MeetingRegistrant[]> {
-    return computed(() => this.filteredRegistrants().filter((r) => r.type === 'committee'));
-  }
-
-  private initDirectFilteredRegistrants(): Signal<MeetingRegistrant[]> {
-    return computed(() => this.filteredRegistrants().filter((r) => r.type !== 'committee'));
   }
 
   private initFilteredPastParticipants() {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, DestroyRef, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -19,7 +19,7 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 
 @Component({
   selector: 'lfx-meeting-registrants-display',
-  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgClass, NgTemplateOutlet],
+  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgTemplateOutlet],
   templateUrl: './meeting-registrants-display.component.html',
 })
 export class MeetingRegistrantsDisplayComponent {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgClass } from '@angular/common';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { Component, computed, DestroyRef, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -19,7 +19,7 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 
 @Component({
   selector: 'lfx-meeting-registrants-display',
-  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgClass],
+  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgClass, NgTemplateOutlet],
   templateUrl: './meeting-registrants-display.component.html',
 })
 export class MeetingRegistrantsDisplayComponent {
@@ -91,6 +91,10 @@ export class MeetingRegistrantsDisplayComponent {
 
   // Filtered registrants based on search and filters
   public readonly filteredRegistrants = this.initFilteredRegistrants();
+
+  // Committee (board) and direct registrant sections for the two-section layout
+  public readonly committeeFilteredRegistrants: Signal<MeetingRegistrant[]> = this.initCommitteeFilteredRegistrants();
+  public readonly directFilteredRegistrants: Signal<MeetingRegistrant[]> = this.initDirectFilteredRegistrants();
 
   // Filtered past meeting participants based on search
   public readonly filteredPastParticipants = this.initFilteredPastParticipants();
@@ -352,6 +356,14 @@ export class MeetingRegistrantsDisplayComponent {
         return matchesSearch && matchesRsvp && matchesGroup;
       });
     });
+  }
+
+  private initCommitteeFilteredRegistrants(): Signal<MeetingRegistrant[]> {
+    return computed(() => this.filteredRegistrants().filter((r) => r.type === 'committee'));
+  }
+
+  private initDirectFilteredRegistrants(): Signal<MeetingRegistrant[]> {
+    return computed(() => this.filteredRegistrants().filter((r) => r.type !== 'committee'));
   }
 
   private initFilteredPastParticipants() {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -740,7 +740,7 @@
     <p-drawer
       [(visible)]="showRegistrants"
       [position]="drawerPosition()"
-      styleClass="xl:w-1/4 lg:w-1/3 md:w-5/12 sm:w-1/2 w-full"
+      styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
       [modal]="true"
       [showCloseIcon]="false"
       data-testid="meeting-registrants-drawer">


### PR DESCRIPTION
## Summary

- Splits the attendees drawer into two sections for committee-based meetings: **Board Members** (committee registrants) above a visual divider, **Guests** (direct registrants) below — meetings without committees continue using the flat list unchanged
- Replaces the spinner loading state with skeleton placeholder cards that mirror the real card shape, giving users visual feedback on the incoming layout
- Updates attendees drawer widths to spec values (`xl:45% / lg:55% / md:70% / sm:90%`)

Closes LFXV2-1449.

## What was skipped and why

**Physical location chip** — the `Meeting` interface has no `location` or `address` field. Implementing this would require an upstream backend change to expose location data; deferred.

## Test plan

- [ ] Open a meeting with committees — attendees drawer shows two labeled sections with a divider between Board Members and Guests
- [ ] Open a meeting without committees — attendees drawer shows the original flat list (no regression)
- [ ] Trigger the drawer while registrants are loading — skeleton cards appear instead of a spinner
- [ ] Verify RSVP badges, voting status, and LinkedIn links still render correctly on each card
- [ ] Verify drawer opens at wider widths on desktop (45% at xl, 55% at lg)
- [ ] Verify mobile: drawer slides up from the bottom as a bottom sheet

🤖 Generated with [Claude Code](https://claude.ai/code)