### PR TITLE
feat(auth): evict users from write routes on context switch

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -14,7 +14,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, Observable, of, skip, switchMap, take, toArray } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 
 import { CommitteeBasicInfoComponent } from '../components/committee-basic-info/committee-basic-info.component';
@@ -44,6 +44,7 @@ export class CommitteeManageComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
   public committeeId = signal<string | null>(null);
@@ -89,6 +90,14 @@ export class CommitteeManageComponent {
   public readonly committeeLabelPlural = COMMITTEE_LABEL.plural;
 
   public constructor() {
+    toObservable(this.projectContextService.canWrite)
+      .pipe(
+        skip(1),
+        filter((canWrite) => !canWrite),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
     // Initialize step based on mode
     this.currentStep = toSignal(
       this.route.queryParamMap.pipe(

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -14,8 +14,9 @@ import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, Observable, of, skip, switchMap, take, toArray } from 'rxjs';
+import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, Observable, of, switchMap, take, toArray } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
+import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 import { CommitteeBasicInfoComponent } from '../components/committee-basic-info/committee-basic-info.component';
 import { CommitteeCategorySelectionComponent } from '../components/committee-category-selection/committee-category-selection.component';
@@ -44,7 +45,6 @@ export class CommitteeManageComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly destroyRef = inject(DestroyRef);
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
   public committeeId = signal<string | null>(null);
@@ -90,14 +90,7 @@ export class CommitteeManageComponent {
   public readonly committeeLabelPlural = COMMITTEE_LABEL.plural;
 
   public constructor() {
-    toObservable(this.projectContextService.canWrite)
-      .pipe(
-        skip(1),
-        filter((canWrite) => !canWrite),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+    evictOnWriteAccessLoss();
     // Initialize step based on mode
     this.currentStep = toSignal(
       this.route.queryParamMap.pipe(

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -17,10 +17,11 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, filter, Observable, of, skip, switchMap, take, tap, throwError } from 'rxjs';
+import { catchError, filter, Observable, of, switchMap, tap, throwError } from 'rxjs';
 
 import { MailingListBasicInfoComponent } from '../components/mailing-list-basic-info/mailing-list-basic-info.component';
 import { MailingListSettingsComponent } from '../components/mailing-list-settings/mailing-list-settings.component';
+import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 @Component({
   selector: 'lfx-mailing-list-manage',
@@ -44,7 +45,6 @@ export class MailingListManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
-  private readonly destroyRef = inject(DestroyRef);
 
   // Protected constants
   public readonly totalSteps = MAILING_LIST_TOTAL_STEPS;
@@ -79,14 +79,7 @@ export class MailingListManageComponent {
   public currentStep: Signal<number> = this.initCurrentStep();
 
   public constructor() {
-    toObservable(this.projectContextService.canWrite)
-      .pipe(
-        skip(1),
-        filter((canWrite) => !canWrite),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+    evictOnWriteAccessLoss();
   }
 
   public nextStep(): void {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -17,7 +17,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, filter, Observable, of, switchMap, tap, throwError } from 'rxjs';
+import { catchError, filter, Observable, of, skip, switchMap, take, tap, throwError } from 'rxjs';
 
 import { MailingListBasicInfoComponent } from '../components/mailing-list-basic-info/mailing-list-basic-info.component';
 import { MailingListSettingsComponent } from '../components/mailing-list-settings/mailing-list-settings.component';
@@ -44,6 +44,7 @@ export class MailingListManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Protected constants
   public readonly totalSteps = MAILING_LIST_TOTAL_STEPS;
@@ -76,6 +77,17 @@ export class MailingListManageComponent {
   public readonly isLastStep: Signal<boolean> = this.initIsLastStep();
   public readonly initialPublicValue: Signal<boolean | null> = this.initInitialPublicValue();
   public currentStep: Signal<number> = this.initCurrentStep();
+
+  public constructor() {
+    toObservable(this.projectContextService.canWrite)
+      .pipe(
+        skip(1),
+        filter((canWrite) => !canWrite),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+  }
 
   public nextStep(): void {
     const next = this.currentStep() + 1;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -51,7 +51,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, skip, switchMap, take, toArray } from 'rxjs';
 
 import { MeetingDetailsComponent } from '../components/meeting-details/meeting-details.component';
 import { MeetingPlatformFeaturesComponent } from '../components/meeting-platform-features/meeting-platform-features.component';
@@ -140,6 +140,14 @@ export class MeetingManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
+    toObservable(this.projectContextService.canWrite)
+      .pipe(
+        skip(1),
+        filter((canWrite) => !canWrite),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
 
     // Initialize step based on mode
     // In edit mode, read from query parameters

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -51,13 +51,14 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, skip, switchMap, take, toArray } from 'rxjs';
+import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
 
 import { MeetingDetailsComponent } from '../components/meeting-details/meeting-details.component';
 import { MeetingPlatformFeaturesComponent } from '../components/meeting-platform-features/meeting-platform-features.component';
 import { MeetingRegistrantsManagerComponent } from '../components/meeting-registrants-manager/meeting-registrants-manager.component';
 import { MeetingResourcesSummaryComponent } from '../components/meeting-resources-summary/meeting-resources-summary.component';
 import { MeetingTypeSelectionComponent } from '../components/meeting-type-selection/meeting-type-selection.component';
+import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 @Component({
   selector: 'lfx-meeting-manage',
@@ -140,14 +141,7 @@ export class MeetingManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
-    toObservable(this.projectContextService.canWrite)
-      .pipe(
-        skip(1),
-        filter((canWrite) => !canWrite),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+    evictOnWriteAccessLoss();
 
     // Initialize step based on mode
     // In edit mode, read from query parameters

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -16,15 +16,15 @@ import {
 } from '@lfx-one/shared/constants';
 import { Committee, CommitteeReference, CreateSurveyRequest, SurveyDistributionMethod, SurveyReminderType } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
-import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
+import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 import { MessageComponent } from '@components/message/message.component';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, skip, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
 
 import { SurveyAudienceTypeComponent } from '../components/survey-audience-type/survey-audience-type.component';
 import { SurveyEmailDraftComponent } from '../components/survey-email-draft/survey-email-draft.component';
@@ -56,8 +56,6 @@ export class SurveyManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly committeeService = inject(CommitteeService);
   private readonly surveyService = inject(SurveyService);
-  private readonly projectContextService = inject(ProjectContextService);
-  private readonly destroyRef = inject(DestroyRef);
 
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
@@ -87,14 +85,7 @@ export class SurveyManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
-    toObservable(this.projectContextService.canWrite)
-      .pipe(
-        skip(1),
-        filter((canWrite) => !canWrite),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+    evictOnWriteAccessLoss();
   }
 
   public nextStep(): void {

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -16,6 +16,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { Committee, CommitteeReference, CreateSurveyRequest, SurveyDistributionMethod, SurveyReminderType } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
 import { MessageComponent } from '@components/message/message.component';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
@@ -23,7 +24,7 @@ import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, skip, switchMap, take } from 'rxjs';
 
 import { SurveyAudienceTypeComponent } from '../components/survey-audience-type/survey-audience-type.component';
 import { SurveyEmailDraftComponent } from '../components/survey-email-draft/survey-email-draft.component';
@@ -55,6 +56,8 @@ export class SurveyManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly committeeService = inject(CommitteeService);
   private readonly surveyService = inject(SurveyService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
@@ -84,6 +87,14 @@ export class SurveyManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
+    toObservable(this.projectContextService.canWrite)
+      .pipe(
+        skip(1),
+        filter((canWrite) => !canWrite),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
   }
 
   public nextStep(): void {

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -24,11 +24,12 @@ import { VoteService } from '@services/vote.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, skip, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take, tap } from 'rxjs';
 
 import { VoteBasicsComponent } from '../components/vote-basics/vote-basics.component';
 import { VoteQuestionComponent } from '../components/vote-question/vote-question.component';
 import { VoteReviewComponent } from '../components/vote-review/vote-review.component';
+import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 @Component({
   selector: 'lfx-vote-manage',
@@ -56,7 +57,6 @@ export class VoteManageComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly voteService = inject(VoteService);
   private readonly committeeService = inject(CommitteeService);
-  private readonly destroyRef = inject(DestroyRef);
 
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
@@ -91,14 +91,7 @@ export class VoteManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
-    toObservable(this.projectContextService.canWrite)
-      .pipe(
-        skip(1),
-        filter((canWrite) => !canWrite),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
+    evictOnWriteAccessLoss();
   }
 
   public nextStep(): void {

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -24,7 +24,7 @@ import { VoteService } from '@services/vote.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, skip, switchMap, take, tap } from 'rxjs';
 
 import { VoteBasicsComponent } from '../components/vote-basics/vote-basics.component';
 import { VoteQuestionComponent } from '../components/vote-question/vote-question.component';
@@ -56,6 +56,7 @@ export class VoteManageComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly voteService = inject(VoteService);
   private readonly committeeService = inject(CommitteeService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
@@ -90,6 +91,14 @@ export class VoteManageComponent {
 
   public constructor() {
     this.initCommitteeContext();
+    toObservable(this.projectContextService.canWrite)
+      .pipe(
+        skip(1),
+        filter((canWrite) => !canWrite),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
   }
 
   public nextStep(): void {

--- a/apps/lfx-one/src/app/shared/utils/evict-on-write-access-loss.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/evict-on-write-access-loss.util.ts
@@ -1,0 +1,38 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { filter, skip, take } from 'rxjs';
+
+import { ProjectContextService } from '../services/project-context.service';
+
+/**
+ * Reactive eviction helper for write-route manage components.
+ *
+ * Guards are CanActivateFn and only run at navigation time; they do not
+ * re-run when the project-context selector switches context via
+ * Location.replaceState(). This function subscribes to canWrite and
+ * redirects to /foundation/overview if write access is lost mid-session.
+ *
+ * Must be called inside a component constructor (injection context required).
+ *
+ * skip(1) is safe here because canWrite has initialValue: false and Angular
+ * signal dedup collapses consecutive identical values, so the first emission
+ * is always the pre-load false — not a genuine access-lost signal.
+ */
+export function evictOnWriteAccessLoss(): void {
+  const router = inject(Router);
+  const projectContextService = inject(ProjectContextService);
+  const destroyRef = inject(DestroyRef);
+
+  toObservable(projectContextService.canWrite)
+    .pipe(
+      skip(1),
+      filter((canWrite) => !canWrite),
+      take(1),
+      takeUntilDestroyed(destroyRef)
+    )
+    .subscribe(() => router.navigateByUrl('/foundation/overview'));
+}


### PR DESCRIPTION
## Summary

- `writerGuard` is a `CanActivateFn` and does not re-run when the project context selector uses `Location.replaceState()` for mid-session context switches
- Users on a create/edit route who switch to a project without write access would stay on the page indefinitely
- This PR adds a reactive `canWrite` subscriber to each write-route manage component that redirects to `/foundation/overview` as soon as write access is lost mid-session

## Implementation

In each of the five manage components (`committee-manage`, `mailing-list-manage`, `meeting-manage`, `survey-manage`, `vote-manage`), the constructor now subscribes to `ProjectContextService.canWrite`:

```typescript
toObservable(this.projectContextService.canWrite)
  .pipe(
    skip(1),                         // skip initialValue: false before project loads
    filter((canWrite) => !canWrite), // only react when write access is lost
    take(1),                         // redirect once then stop
    takeUntilDestroyed(this.destroyRef)
  )
  .subscribe(() => this.router.navigateByUrl('/foundation/overview'));
```

`skip(1)` is critical — `canWrite` initializes as `false` before the project finishes loading, so without it the component would redirect immediately on mount.

## Test scenario

1. Log in as a user who is a writer on project A but not project B
2. Navigate to project A → open any create/edit route (e.g. `/meetings/create`)
3. Switch the project context to project B via the selector
4. **Expected:** Redirected to `/foundation/overview`
5. **Expected (negative):** Switching from project A to another project where you also have write access keeps you on the page

## Related

- Parent epic: [LFXV2-1654](https://linuxfoundation.atlassian.net/browse/LFXV2-1654) — Permission, Persona & Navigation Model
- Ticket: [LFXV2-2045](https://linuxfoundation.atlassian.net/browse/LFXV2-2045)
- Guard fix PR: #829 (`writerGuard` rewrite + applied to all write routes)

[LFXV2-1654]: https://linuxfoundation.atlassian.net/browse/LFXV2-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ