### PR TITLE
fix(auth): preserve project context in eviction redirect

### DIFF
--- a/apps/lfx-one/src/app/shared/utils/evict-on-write-access-loss.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/evict-on-write-access-loss.util.ts
@@ -34,5 +34,9 @@ export function evictOnWriteAccessLoss(): void {
       take(1),
       takeUntilDestroyed(destroyRef)
     )
-    .subscribe(() => router.navigateByUrl('/foundation/overview'));
+    .subscribe(() => {
+      const slug = projectContextService.activeContext()?.slug;
+      const url = slug ? router.createUrlTree(['/foundation/overview'], { queryParams: { project: slug } }) : router.parseUrl('/foundation/overview');
+      router.navigateByUrl(url);
+    });
 }


### PR DESCRIPTION
## Summary

- `evictOnWriteAccessLoss` was navigating to bare `/foundation/overview` on context-switch eviction, causing the foundation lens to render the last-remembered project (e.g. `aswf`) instead of the one that triggered the access loss (e.g. `agstack`)
- Fix: read `projectContextService.activeContext()?.slug` at eviction time and pass it as `?project=<slug>` via `createUrlTree` — same pattern used in `writerGuard` and `newsletterAccessGuard`

## Root cause

When `canWrite` emits `false` after a context switch, `activeContext()` already reflects the new context (the one the user switched to). Reading the slug at that moment and including it in the redirect preserves which project the user was trying to access when they were evicted.

## Test plan

- [ ] As a writer on project A, navigate to any create/edit route (e.g. `/foundation/meetings/create?project=<A>`)
- [ ] Switch context to project B (where you are not a writer)
- [ ] Should be redirected to `/foundation/overview?project=<B>` — not project A's overview

## Context

Followup bug fix for LFXV2-2045 (#831). The eviction helper was merged without the `?project=` param in the redirect URL.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)