### PR TITLE
feat(org-lens): add people key contacts tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/helpers/key-contacts.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/helpers/key-contacts.helper.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isCanonicalOrgKeyContactRole, ORG_KEY_CONTACT_ROLE_PILL_CLASSES, ORG_KEY_CONTACT_ROLE_PILL_FALLBACK } from '@lfx-one/shared/constants';
+
+/** Tailwind pill classes for a role string; falls back when upstream returns an unknown role. */
+export function rolePillClass(role: string): string {
+  return isCanonicalOrgKeyContactRole(role) ? ORG_KEY_CONTACT_ROLE_PILL_CLASSES[role] : ORG_KEY_CONTACT_ROLE_PILL_FALLBACK;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -1,0 +1,241 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="org-people-key-contacts">
+  <!-- Filter bar -->
+  <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4" data-testid="org-people-key-contacts-filter-bar">
+    <div class="flex-1">
+      <lfx-input-text
+        [form]="filterForm"
+        control="search"
+        placeholder="Search key contacts..."
+        icon="fa-light fa-magnifying-glass"
+        styleClass="w-full"
+        size="small"
+        dataTest="org-people-key-contacts-search-input" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="foundation"
+        size="small"
+        [options]="foundationOptions()"
+        styleClass="w-full"
+        ariaLabel="Filter by foundation"
+        dataTest="org-people-key-contacts-foundation-filter" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="role"
+        size="small"
+        [options]="roleOptions()"
+        styleClass="w-full"
+        ariaLabel="Filter by role"
+        dataTest="org-people-key-contacts-role-filter" />
+    </div>
+  </div>
+
+  @if (fetchError()) {
+    <div role="alert" data-testid="org-people-key-contacts-error">
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-triangle-exclamation"
+        title="Failed to load key contacts"
+        subtitle="Please try again."
+        ctaLabel="Retry"
+        ctaIcon="fa-light fa-arrow-rotate-left"
+        (ctaClick)="retry()" />
+    </div>
+  } @else {
+    <!-- Stat cards -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3" data-testid="org-people-key-contacts-stats">
+      @if (isLoading()) {
+        @for (label of ['Individuals', 'Foundations Covered', 'Unfilled Role Types']; track label) {
+          <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-key-contacts-stat-skeleton">
+            <p-skeleton width="3rem" height="1.5rem" />
+            <div class="mt-2 text-xs text-gray-500">{{ label }}</div>
+          </div>
+        }
+      } @else {
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-key-contacts-stat-individuals">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().individualCount | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Individuals</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-key-contacts-stat-foundations">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().foundationsCovered | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Foundations Covered</div>
+        </div>
+        @let unfilledActive = hasUnfilledRoles();
+        <div
+          class="rounded-lg border p-4"
+          [class.border-red-200]="unfilledActive"
+          [class.bg-red-50]="unfilledActive"
+          [class.border-gray-200]="!unfilledActive"
+          [class.bg-white]="!unfilledActive"
+          data-testid="org-people-key-contacts-stat-unfilled">
+          <div class="text-2xl font-semibold leading-none" [class.text-red-600]="unfilledActive" [class.text-gray-900]="!unfilledActive">
+            {{ stats().unfilledRequiredRoleCount | number }}
+          </div>
+          <div class="mt-1 text-xs text-gray-500">Unfilled Role Types</div>
+        </div>
+      }
+    </div>
+
+    <!-- Table -->
+    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="org-people-key-contacts-table">
+      @if (isLoading()) {
+        <div class="divide-y divide-gray-100" data-testid="org-people-key-contacts-table-skeleton">
+          @for (i of tableSkeletonRows; track i) {
+            <div class="flex items-center gap-4 px-4 py-3">
+              <p-skeleton width="1rem" height="1rem" />
+              <div class="flex flex-1 flex-col gap-2">
+                <p-skeleton width="40%" height="0.875rem" />
+                <p-skeleton width="25%" height="0.75rem" />
+              </div>
+              <p-skeleton width="6rem" height="1.25rem" borderRadius="9999px" />
+              <p-skeleton width="3rem" height="1.25rem" borderRadius="9999px" />
+            </div>
+          }
+        </div>
+      } @else if (sortedGroups().length === 0) {
+        <div class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center" data-testid="org-people-key-contacts-empty">
+          <i class="fa-light fa-address-card text-2xl text-gray-300" aria-hidden="true"></i>
+          @if (isFiltering()) {
+            <p class="text-sm text-gray-700">No key contacts match the current filters.</p>
+            <p class="text-xs text-gray-500">Try clearing the search or changing the dropdown selections.</p>
+          } @else {
+            <p class="text-sm text-gray-700">No key contact data available.</p>
+            <p class="text-xs text-gray-500">Key contacts are sourced from LFX membership records.</p>
+          }
+        </div>
+      } @else {
+        <table class="w-full text-sm" data-testid="org-people-key-contacts-rows">
+          <thead class="bg-gray-50">
+            <tr class="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th class="w-7 px-2 py-3"></th>
+              @let aria = ariaSortMap();
+              @let icons = sortIconMap();
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.name">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('name')">
+                  Name
+                  <i [class]="icons.name" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.roles">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('roles')">
+                  Roles
+                  <i [class]="icons.roles" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.foundations">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('foundations')">
+                  Foundations
+                  <i [class]="icons.foundations" aria-hidden="true"></i>
+                </button>
+              </th>
+              <!--
+                V1 is read-only: no Actions column on the main row and no per-assignment Edit on the
+                expanded sub-table. Spec FR-005's reassign pencil + FR-006's expanded-row Edit pencil
+                are both gated on LFXV2-1677 (broader employee-source typeahead) before they can ship.
+                See spec.md lines 167–199.
+              -->
+            </tr>
+          </thead>
+          <tbody>
+            @for (group of sortedGroups(); track group.email) {
+              @let expanded = !!expansion()[group.email];
+              <tr
+                class="cursor-pointer border-b border-gray-100 hover:bg-gray-50"
+                role="button"
+                tabindex="0"
+                [attr.aria-expanded]="expanded"
+                [attr.aria-label]="'Toggle key contact details for ' + group.displayName"
+                [attr.data-testid]="'org-people-key-contacts-row-' + group.email"
+                (click)="toggleExpansion(group.email)"
+                (keydown)="onRowKeydown($event, group.email)">
+                <td class="px-2 py-3 align-middle">
+                  <i
+                    class="fa-light fa-chevron-right text-gray-400 transition-transform"
+                    [class.rotate-90]="expanded"
+                    [attr.data-testid]="'org-people-key-contacts-expand-' + group.email"
+                    aria-hidden="true"></i>
+                </td>
+                <td class="px-4 py-3">
+                  <button
+                    type="button"
+                    class="bg-transparent p-0 text-left hover:text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    (click)="onPersonClick(group, $event)">
+                    <div class="font-medium text-gray-900">{{ group.displayName }}</div>
+                    @if (group.title) {
+                      <div class="text-xs text-gray-500">{{ group.title }}</div>
+                    }
+                  </button>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex flex-wrap gap-1">
+                    @for (pill of group.rolePills; track pill.role) {
+                      <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="pill.pillClass">{{ pill.role }}</span>
+                    }
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <span class="inline-block rounded-full border border-slate-300 bg-slate-50 px-2.5 py-0.5 text-xs font-semibold text-slate-600">{{
+                    group.foundationCount
+                  }}</span>
+                </td>
+              </tr>
+              @if (expanded) {
+                <tr class="bg-slate-50" [attr.data-testid]="'org-people-key-contacts-expanded-' + group.email">
+                  <td colspan="4" class="p-0 pl-11">
+                    <table class="w-full border-collapse">
+                      <thead>
+                        <!--
+                          Expanded sub-table: Foundation | Contact Role only. Per-assignment Edit pencil
+                          is intentionally omitted in V1 — see spec.md FR-006/FR-009 and V1 status footnote
+                          (lines 167–199): expanded-row add/replace/remove is post-V1, gated on T036 and
+                          LFXV2-1677. The main-row pencil (above) provides writer-gated bulk-reassign.
+                        -->
+                        <tr class="border-b border-gray-200 bg-slate-100 text-left text-xs font-semibold uppercase text-gray-400">
+                          <th class="px-4 py-2.5">Foundation</th>
+                          <th class="px-4 py-2.5">Contact Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        @for (assignment of group.sortedAssignments; track assignment.contactUid) {
+                          <tr class="border-b border-gray-200" [attr.data-testid]="'org-people-key-contacts-subrow-' + assignment.contactUid">
+                            <td class="px-4 py-2.5 text-sm font-medium text-gray-900">
+                              @if (assignment.showFoundationLabel) {
+                                {{ assignment.foundationLabel }}
+                              }
+                            </td>
+                            <td class="px-4 py-2.5">
+                              <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="assignment.pillClass">{{
+                                assignment.role
+                              }}</span>
+                            </td>
+                          </tr>
+                        }
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              }
+            }
+          </tbody>
+        </table>
+      }
+    </div>
+
+    <p class="text-xs text-gray-400" data-testid="org-people-key-contacts-sources">Source: LFX Membership Contact Records</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -155,7 +155,7 @@
             @for (group of sortedGroups(); track group.email) {
               @let expanded = !!expansion()[group.email];
               <tr
-                class="cursor-pointer border-b border-gray-100 hover:bg-gray-50"
+                class="cursor-pointer border-b border-gray-100 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 role="button"
                 tabindex="0"
                 [attr.aria-expanded]="expanded"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -1,0 +1,285 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, map, of, skip, switchMap, tap } from 'rxjs';
+
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
+import { AccountContextService } from '@services/account-context.service';
+import { PersonProfilePanelService } from '@services/person-profile-panel.service';
+import { EMPTY_ORG_KEY_CONTACTS_RESPONSE } from '@lfx-one/shared/constants';
+import type {
+  OrgKeyContactAssignment,
+  OrgKeyContactAssignmentVm,
+  OrgKeyContactDropdownOption,
+  OrgKeyContactPersonGroupVm,
+  OrgKeyContactSortColumn,
+  OrgKeyContactSortDirection,
+  OrgKeyContactsResponse,
+} from '@lfx-one/shared/interfaces';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import { KeyContactsService } from '../../services/key-contacts.service';
+import { rolePillClass } from './helpers/key-contacts.helper';
+
+/** Org Lens — People → Key Contacts tab. V1 is pure-read (stat strip + grouped expandable table); both edit paths are gated on LFXV2-1677. */
+@Component({
+  selector: 'lfx-org-people-key-contacts',
+  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent],
+  templateUrl: './key-contacts.component.html',
+})
+export class KeyContactsComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly dataService = inject(KeyContactsService);
+  private readonly personPanel = inject(PersonProfilePanelService);
+
+  protected readonly tableSkeletonRows: readonly number[] = [0, 1, 2, 3, 4, 5];
+
+  protected readonly filterForm = new FormGroup({
+    search: new FormControl<string>('', { nonNullable: true }),
+    foundation: new FormControl<string>('', { nonNullable: true }),
+    role: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  protected readonly sortColumn = signal<OrgKeyContactSortColumn>('name');
+  protected readonly sortDirection = signal<OrgKeyContactSortDirection>(1);
+  protected readonly expansion = signal<Record<string, boolean>>({});
+  protected readonly retryTrigger = signal<number>(0);
+
+  private readonly loadingState = signal<boolean>(true);
+  protected readonly isLoading = this.loadingState.asReadonly();
+
+  private readonly fetchErrorState = signal<boolean>(false);
+  protected readonly fetchError = this.fetchErrorState.asReadonly();
+
+  // Mirror reactive form into a signal so computeds re-run on input — FormGroup.value is not a signal.
+  private readonly filterValues = toSignal(this.filterForm.valueChanges.pipe(debounceTime(150)), {
+    initialValue: this.filterForm.getRawValue(),
+  });
+
+  // Scoped on b2b_org UUID (not legacy sfid); gated on `!!uid` so skeleton holds until org-selector populates it.
+  private readonly orgUid$ = toObservable(this.accountContext.selectedAccount).pipe(
+    map((account) => account.uid),
+    distinctUntilChanged()
+  );
+
+  protected readonly response: Signal<OrgKeyContactsResponse> = this.initResponse();
+
+  protected readonly stats = computed(() => this.response().stats);
+
+  protected readonly foundationOptions: Signal<OrgKeyContactDropdownOption[]> = computed(() => this.initFoundationOptions());
+  protected readonly roleOptions: Signal<OrgKeyContactDropdownOption[]> = computed(() => this.initRoleOptions());
+  protected readonly groupedPeople: Signal<OrgKeyContactPersonGroupVm[]> = computed(() => this.initGroupedPeople());
+  protected readonly filteredGroups: Signal<OrgKeyContactPersonGroupVm[]> = computed(() => this.initFilteredGroups());
+  protected readonly sortedGroups: Signal<OrgKeyContactPersonGroupVm[]> = computed(() => this.initSortedGroups());
+
+  protected readonly isFiltering: Signal<boolean> = computed(() => this.initIsFiltering());
+
+  protected readonly hasUnfilledRoles: Signal<boolean> = computed(() => this.stats().unfilledRequiredRoleCount > 0);
+
+  protected readonly ariaSortMap: Signal<Record<OrgKeyContactSortColumn, 'ascending' | 'descending' | 'none'>> = computed(() => this.initAriaSortMap());
+  protected readonly sortIconMap: Signal<Record<OrgKeyContactSortColumn, string>> = computed(() => this.initSortIconMap());
+
+  public constructor() {
+    // Clear expansion/filter state only when the org uid actually changes (skip(1) drops the initial sync emission).
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => this.resetAllState());
+  }
+
+  protected onSort(column: OrgKeyContactSortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update((d) => (d === 1 ? -1 : 1));
+      return;
+    }
+    this.sortColumn.set(column);
+    this.sortDirection.set(column === 'name' ? 1 : -1);
+  }
+
+  protected toggleExpansion(email: string): void {
+    this.expansion.update((state) => {
+      const next = { ...state };
+      if (next[email]) delete next[email];
+      else next[email] = true;
+      return next;
+    });
+  }
+
+  protected onRowKeydown(event: KeyboardEvent, email: string): void {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    this.toggleExpansion(email);
+  }
+
+  protected onPersonClick(group: OrgKeyContactPersonGroupVm, event: Event): void {
+    event.stopPropagation();
+    this.personPanel.open(group.displayName);
+  }
+
+  protected retry(): void {
+    this.retryTrigger.update((v) => v + 1);
+  }
+
+  private initFoundationOptions(): OrgKeyContactDropdownOption[] {
+    const slugs = new Map<string, string>();
+    for (const a of this.response().assignments) {
+      if (!slugs.has(a.foundationSlug)) {
+        slugs.set(a.foundationSlug, a.foundationName ?? a.foundationSlug);
+      }
+    }
+    const options = [...slugs.entries()].sort((a, b) => a[1].localeCompare(b[1])).map(([value, label]) => ({ label, value }));
+    return [{ label: 'All Foundations', value: '' }, ...options];
+  }
+
+  private initRoleOptions(): OrgKeyContactDropdownOption[] {
+    const roles = [...new Set(this.response().assignments.map((a) => a.role))].sort((a, b) => a.localeCompare(b));
+    return [{ label: 'All Roles', value: '' }, ...roles.map((role) => ({ label: role, value: role }))];
+  }
+
+  private initGroupedPeople(): OrgKeyContactPersonGroupVm[] {
+    const byEmail = new Map<string, OrgKeyContactAssignment[]>();
+    for (const a of this.response().assignments) {
+      const key = a.email.toLowerCase();
+      const list = byEmail.get(key) ?? [];
+      list.push(a);
+      byEmail.set(key, list);
+    }
+
+    return [...byEmail.values()].map((assignments) => {
+      const first = assignments[0];
+      const roles = [...new Set(assignments.map((a) => a.role))].sort();
+      const foundationSlugs = new Set(assignments.map((a) => a.foundationSlug));
+      const sortedRaw = [...assignments].sort((a, b) => {
+        const slugCmp = a.foundationSlug.localeCompare(b.foundationSlug);
+        if (slugCmp !== 0) return slugCmp;
+        return a.role.localeCompare(b.role);
+      });
+      const sortedAssignments: OrgKeyContactAssignmentVm[] = sortedRaw.map((a, idx) => ({
+        ...a,
+        pillClass: rolePillClass(a.role),
+        showFoundationLabel: idx === 0 || sortedRaw[idx - 1].foundationSlug !== a.foundationSlug,
+        foundationLabel: a.foundationName ?? a.foundationSlug,
+      }));
+      return {
+        email: first.email,
+        displayName: first.displayName,
+        title: first.title,
+        roles,
+        foundationCount: foundationSlugs.size,
+        assignments,
+        canEditAny: assignments.some((a) => a.canEdit),
+        rolePills: roles.map((role) => ({ role, pillClass: rolePillClass(role) })),
+        sortedAssignments,
+      };
+    });
+  }
+
+  private initIsFiltering(): boolean {
+    const values = this.filterValues();
+    const search = (values.search ?? '').trim();
+    return search.length > 0 || !!(values.foundation ?? '') || !!(values.role ?? '');
+  }
+
+  private initFilteredGroups(): OrgKeyContactPersonGroupVm[] {
+    const values = this.filterValues();
+    const q = (values.search ?? '').trim().toLowerCase();
+    const foundation = values.foundation ?? '';
+    const role = values.role ?? '';
+
+    return this.groupedPeople().filter((group) => {
+      if (q) {
+        const inName = group.displayName.toLowerCase().includes(q);
+        const inTitle = (group.title ?? '').toLowerCase().includes(q);
+        const inEmail = group.email.toLowerCase().includes(q);
+        if (!inName && !inTitle && !inEmail) return false;
+      }
+      if (foundation && !group.assignments.some((a) => a.foundationSlug === foundation)) return false;
+      if (role && !group.assignments.some((a) => a.role === role)) return false;
+      return true;
+    });
+  }
+
+  private initSortedGroups(): OrgKeyContactPersonGroupVm[] {
+    const filtered = this.filteredGroups();
+    const col = this.sortColumn();
+    const dir = this.sortDirection();
+    const copy = [...filtered];
+
+    copy.sort((a, b) => {
+      if (col === 'name') {
+        return a.displayName.localeCompare(b.displayName) * dir;
+      }
+      if (col === 'roles') {
+        const ra = a.roles.join(', ');
+        const rb = b.roles.join(', ');
+        const cmp = ra.localeCompare(rb);
+        if (cmp !== 0) return cmp * dir;
+        return a.displayName.localeCompare(b.displayName);
+      }
+      if (a.foundationCount !== b.foundationCount) {
+        return (a.foundationCount - b.foundationCount) * dir;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    return copy;
+  }
+
+  private initAriaSortMap(): Record<OrgKeyContactSortColumn, 'ascending' | 'descending' | 'none'> {
+    const active = this.sortColumn();
+    const direction: 'ascending' | 'descending' = this.sortDirection() === 1 ? 'ascending' : 'descending';
+    return {
+      name: active === 'name' ? direction : 'none',
+      roles: active === 'roles' ? direction : 'none',
+      foundations: active === 'foundations' ? direction : 'none',
+    };
+  }
+
+  private initResponse(): Signal<OrgKeyContactsResponse> {
+    return toSignal(
+      combineLatest([this.orgUid$, toObservable(this.retryTrigger)]).pipe(
+        tap(() => {
+          this.loadingState.set(true);
+          this.fetchErrorState.set(false);
+        }),
+        switchMap(([orgUid]) => {
+          if (!orgUid) {
+            this.loadingState.set(false);
+            return of(EMPTY_ORG_KEY_CONTACTS_RESPONSE);
+          }
+          return this.dataService.getKeyContacts(orgUid).pipe(
+            tap(() => this.loadingState.set(false)),
+            catchError(() => {
+              this.fetchErrorState.set(true);
+              this.loadingState.set(false);
+              return of(EMPTY_ORG_KEY_CONTACTS_RESPONSE);
+            })
+          );
+        })
+      ),
+      { initialValue: EMPTY_ORG_KEY_CONTACTS_RESPONSE }
+    );
+  }
+
+  private initSortIconMap(): Record<OrgKeyContactSortColumn, string> {
+    const active = this.sortColumn();
+    const activeIcon = this.sortDirection() === 1 ? 'fa-light fa-sort-up' : 'fa-light fa-sort-down';
+    const iconFor = (col: OrgKeyContactSortColumn): string => (active === col ? activeIcon : 'fa-light fa-sort');
+    return {
+      name: iconFor('name'),
+      roles: iconFor('roles'),
+      foundations: iconFor('foundations'),
+    };
+  }
+
+  private resetAllState(): void {
+    this.filterForm.reset({ search: '', foundation: '', role: '' });
+    this.sortColumn.set('name');
+    this.sortDirection.set(1);
+    this.expansion.set({});
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -248,7 +248,8 @@ export class KeyContactsComponent {
         }),
         switchMap(([orgUid]) => {
           if (!orgUid) {
-            this.loadingState.set(false);
+            // Hold the skeleton until the org selector populates a uid — flipping loadingState to false here would
+            // briefly render the "no data" empty state on mount before the account-context emits the real uid.
             return of(EMPTY_ORG_KEY_CONTACTS_RESPONSE);
           }
           return this.dataService.getKeyContacts(orgUid).pipe(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -46,15 +46,16 @@ export class KeyContactsComponent {
     role: new FormControl<string>('', { nonNullable: true }),
   });
 
+  // WritableSignals — keep grouped per component-organization.md (writables → computed/toSignal).
   protected readonly sortColumn = signal<OrgKeyContactSortColumn>('name');
   protected readonly sortDirection = signal<OrgKeyContactSortDirection>(1);
   protected readonly expansion = signal<Record<string, boolean>>({});
   protected readonly retryTrigger = signal<number>(0);
-
   private readonly loadingState = signal<boolean>(true);
-  protected readonly isLoading = this.loadingState.asReadonly();
-
   private readonly fetchErrorState = signal<boolean>(false);
+
+  // Computed / toSignal / readonly views — derived signals follow the writable block.
+  protected readonly isLoading = this.loadingState.asReadonly();
   protected readonly fetchError = this.fetchErrorState.asReadonly();
 
   // Mirror reactive form into a signal so computeds re-run on input — FormGroup.value is not a signal.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
@@ -16,20 +16,21 @@
     aria-label="People page sections"
     (keydown)="onTabKeydown($event)">
     @for (tab of tabs; track tab.id) {
+      @let isActive = activeTab() === tab.id;
       <button
         type="button"
         role="tab"
         class="flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap"
         [id]="'org-people-tab-' + tab.id"
-        [attr.aria-selected]="activeTab() === tab.id"
+        [attr.aria-selected]="isActive"
         aria-controls="org-people-tabpanel"
-        [attr.tabindex]="activeTab() === tab.id ? 0 : -1"
+        [attr.tabindex]="isActive ? 0 : -1"
         [attr.data-testid]="'org-people-tab-' + tab.id"
-        [class.border-blue-600]="activeTab() === tab.id"
-        [class.text-blue-600]="activeTab() === tab.id"
-        [class.border-transparent]="activeTab() !== tab.id"
-        [class.text-gray-500]="activeTab() !== tab.id"
-        [class.hover:text-gray-700]="activeTab() !== tab.id"
+        [class.border-blue-600]="isActive"
+        [class.text-blue-600]="isActive"
+        [class.border-transparent]="!isActive"
+        [class.text-gray-500]="!isActive"
+        [class.hover:text-gray-700]="!isActive"
         (click)="switchTab(tab.id)">
         <i [class]="tab.icon" aria-hidden="true"></i>
         {{ tab.label }}
@@ -46,6 +47,8 @@
       <lfx-empty-state icon="fa-light fa-building" [title]="noCompanyEmptyTitle()" data-testid="org-people-no-company-empty-state" />
     } @else if (activeTab() === 'all') {
       <lfx-org-people-all-employees />
+    } @else if (activeTab() === 'contacts') {
+      <lfx-org-people-key-contacts />
     } @else {
       <lfx-empty-state
         [icon]="activeTabConfig().icon"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
@@ -12,10 +12,11 @@ import { AccountContextService } from '@services/account-context.service';
 import type { PeopleTabConfig, PeopleTabId } from '@lfx-one/shared/interfaces';
 
 import { AllEmployeesComponent } from './components/all-employees/all-employees.component';
+import { KeyContactsComponent } from './components/key-contacts/key-contacts.component';
 
 @Component({
   selector: 'lfx-org-people',
-  imports: [EmptyStateComponent, AllEmployeesComponent],
+  imports: [EmptyStateComponent, AllEmployeesComponent, KeyContactsComponent],
   templateUrl: './org-people.component.html',
 })
 export class OrgPeopleComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/key-contacts.service.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/key-contacts.service.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import type { OrgKeyContactsResponse } from '@lfx-one/shared/interfaces';
+
+/** HTTP client for the Org Lens → People → Key Contacts tab GET. V1 is read-only; edit affordances reuse the spec-024 `OrgLensKeyContactsController` writes when LFXV2-1677 lands. */
+@Injectable({ providedIn: 'root' })
+export class KeyContactsService {
+  private readonly http = inject(HttpClient);
+
+  public getKeyContacts(orgUid: string): Observable<OrgKeyContactsResponse> {
+    return this.http.get<OrgKeyContactsResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/people/key-contacts`);
+  }
+}

--- a/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
@@ -8,15 +8,18 @@ import { ServiceValidationError } from '../errors';
 import { assertOrgUid } from '../helpers/org-uid.helper';
 import { logger } from '../services/logger.service';
 import { OrgLensPeopleService } from '../services/org-lens-people.service';
+import { OrgPeopleKeyContactsService } from '../services/org-people-key-contacts.service';
 import { OrgSfidResolver } from '../services/org-sfid-resolver.service';
 
 /** HTTP boundary for the OrgLensPeopleService — validation, lifecycle logging, error propagation. */
 export class OrgLensPeopleController {
   private readonly service: OrgLensPeopleService;
+  private readonly keyContactsService: OrgPeopleKeyContactsService;
   private readonly orgSfidResolver: OrgSfidResolver;
 
   public constructor() {
     this.service = new OrgLensPeopleService();
+    this.keyContactsService = new OrgPeopleKeyContactsService();
     this.orgSfidResolver = new OrgSfidResolver();
   }
 
@@ -71,6 +74,33 @@ export class OrgLensPeopleController {
         code_rows: response.code.length,
         event_rows: response.events.length,
         training_rows: response.training.length,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:orgUid/lens/people/key-contacts — org-wide read for the People tab. Membership-scoped reads + writes live on OrgLensKeyContactsController (spec 024). */
+  public async getKeyContacts(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, 'get_org_lens_people_key_contacts', {
+      org_uid: orgUid,
+    });
+
+    try {
+      assertOrgUid(orgUid, 'get_org_lens_people_key_contacts');
+
+      const response = await this.keyContactsService.getKeyContacts(req, orgUid);
+
+      logger.success(req, 'get_org_lens_people_key_contacts', startTime, {
+        org_uid: orgUid,
+        assignment_count: response.assignments.length,
+        individual_count: response.stats.individualCount,
+        foundations_covered: response.stats.foundationsCovered,
+        unfilled_required_role_count: response.stats.unfilledRequiredRoleCount,
       });
 
       res.setHeader('Cache-Control', 'no-store');

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -46,6 +46,8 @@ function buildOrgsRouter(): Router {
     orgLensKeyContactsController.removeKeyContact(req, res, next)
   );
   router.get('/:orgUid/lens/people/all', (req, res, next) => orgLensPeopleController.getAllEmployees(req, res, next));
+  // Spec 005 (LFXV2-1873) — People → Key Contacts tab (org-wide, read-only). Membership-scoped reads + writes live above on orgLensKeyContactsController.
+  router.get('/:orgUid/lens/people/key-contacts', (req, res, next) => orgLensPeopleController.getKeyContacts(req, res, next));
   router.get('/:orgUid/lens/people/:personKey/detail', (req, res, next) => orgLensPeopleController.getEmployeeDetail(req, res, next));
 
   // Must stay last so specific /uid and /:orgUid/lens routes match first.

--- a/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
@@ -2,37 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 import { ORG_KEY_CONTACT_REQUIRED_ROLES } from '@lfx-one/shared/constants';
-import type { OrgKeyContactAssignment, OrgKeyContactsResponse, OrgKeyContactsStats, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type {
+  KeyContactIndexedDoc,
+  OrgKeyContactAssignment,
+  OrgKeyContactsResponse,
+  OrgKeyContactsStats,
+  ProjectMembershipIndexedDoc,
+  QueryServiceResponse,
+} from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { MicroserviceProxyService } from './microservice-proxy.service';
-
-/** Indexed `key_contact.data` shape on query-service — only the fields we read. */
-interface KeyContactIndexedDoc {
-  uid?: string;
-  membership_uid?: string;
-  email?: string;
-  first_name?: string;
-  last_name?: string;
-  title?: string | null;
-  role?: string;
-  status?: string | null;
-  board_member?: boolean;
-  primary_contact?: boolean;
-  b2b_org_uid?: string;
-}
-
-/** Indexed `project_membership.data` shape on query-service — only the fields we read. */
-interface ProjectMembershipIndexedDoc {
-  uid?: string;
-  project_uid?: string | null;
-  project_slug?: string;
-  project_name?: string | null;
-  status?: string;
-  tier?: string | null;
-  year?: string | null;
-}
 
 /** Org Lens — People → Key Contacts tab. V1 is org-wide and read-only; membership-scoped reads + writes live in OrgLensKeyContactsService (spec 024). */
 export class OrgPeopleKeyContactsService {

--- a/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
@@ -1,0 +1,157 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_KEY_CONTACT_REQUIRED_ROLES } from '@lfx-one/shared/constants';
+import type { OrgKeyContactAssignment, OrgKeyContactsResponse, OrgKeyContactsStats, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { MicroserviceProxyService } from './microservice-proxy.service';
+
+/** Indexed `key_contact.data` shape on query-service — only the fields we read. */
+interface KeyContactIndexedDoc {
+  uid?: string;
+  membership_uid?: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  title?: string | null;
+  role?: string;
+  status?: string | null;
+  board_member?: boolean;
+  primary_contact?: boolean;
+  b2b_org_uid?: string;
+}
+
+/** Indexed `project_membership.data` shape on query-service — only the fields we read. */
+interface ProjectMembershipIndexedDoc {
+  uid?: string;
+  project_uid?: string | null;
+  project_slug?: string;
+  project_name?: string | null;
+  status?: string;
+  tier?: string | null;
+  year?: string | null;
+}
+
+/** Org Lens — People → Key Contacts tab. V1 is org-wide and read-only; membership-scoped reads + writes live in OrgLensKeyContactsService (spec 024). */
+export class OrgPeopleKeyContactsService {
+  private readonly microserviceProxy: MicroserviceProxyService;
+
+  public constructor() {
+    this.microserviceProxy = new MicroserviceProxyService();
+  }
+
+  /** Bundled GET — joins active key_contact rows to their project_membership and computes the filter-independent stat strip (FR-004). Caller passes b2b_org UUID directly because the upstream b2b_org index has no indexed sfid field. */
+  public async getKeyContacts(req: Request, orgUid: string): Promise<OrgKeyContactsResponse> {
+    const tags = `b2b_org_uid:${orgUid}`;
+    const [contacts, memberships] = await Promise.all([
+      fetchAllQueryResources<KeyContactIndexedDoc>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<KeyContactIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'key_contact',
+          tags,
+          per_page: 50,
+          ...(pageToken && { page_token: pageToken }),
+        })
+      ),
+      fetchAllQueryResources<ProjectMembershipIndexedDoc>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<ProjectMembershipIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'project_membership',
+          tags,
+          per_page: 50,
+          ...(pageToken && { page_token: pageToken }),
+        })
+      ),
+    ]);
+
+    // Membership filter is case-sensitive ('Active' only); contact-side is case-insensitive because legacy rows are mixed-case.
+    const membershipByUid = new Map<string, ProjectMembershipIndexedDoc>();
+    for (const m of memberships) {
+      if (!m.uid) continue;
+      if (m.status !== 'Active') continue;
+      membershipByUid.set(m.uid, m);
+    }
+
+    const rawAssignments: OrgKeyContactAssignment[] = [];
+    for (const c of contacts) {
+      if (!c.uid || !c.membership_uid) continue;
+      const membership = membershipByUid.get(c.membership_uid);
+      if (!membership) continue;
+      if (c.status && c.status.toLowerCase() !== 'active') continue;
+
+      const email = (c.email ?? '').trim();
+      const firstName = (c.first_name ?? '').trim();
+      const lastName = (c.last_name ?? '').trim();
+      const displayName = `${firstName} ${lastName}`.trim();
+      if (!email || !displayName) continue;
+
+      const foundationSlug = membership.project_slug ?? '';
+      if (!foundationSlug) continue;
+
+      const role = (c.role ?? '').trim();
+      if (!role) continue;
+
+      rawAssignments.push({
+        contactUid: c.uid,
+        membershipUid: c.membership_uid,
+        email,
+        firstName,
+        lastName,
+        displayName,
+        title: (c.title ?? null) || null,
+        role,
+        foundationSlug,
+        foundationName: this.resolveFoundationName(membership),
+        canEdit: false,
+      });
+    }
+
+    // T010 (PKC-4): if any assignment is missing a foundationName, kick off enrichment.
+    // Today this is a stub that returns an empty map — see T041.
+    const missingSlugs = new Set(rawAssignments.filter((a) => !a.foundationName).map((a) => a.foundationSlug));
+    if (missingSlugs.size > 0) {
+      const enriched = await this.enrichFoundationNames(req, [...missingSlugs]);
+      for (const a of rawAssignments) {
+        if (!a.foundationName && enriched.has(a.foundationSlug)) {
+          a.foundationName = enriched.get(a.foundationSlug) ?? null;
+        }
+      }
+    }
+
+    // T027 writer-FGA check is deferred until LFXV2-1677 lands the edit affordances; `canEdit` stays `false`.
+    return {
+      assignments: rawAssignments,
+      stats: this.computeStats(rawAssignments),
+    };
+  }
+
+  /** Foundation display name lookup — prefers inline `project_name`, otherwise null. */
+  private resolveFoundationName(membership: ProjectMembershipIndexedDoc): string | null {
+    return membership.project_name ?? null;
+  }
+
+  /** T041 stub — Snowflake slug→name fallback if LFXV2-2003 doesn't land; today returns empty (callers tolerate null names). */
+  private async enrichFoundationNames(req: Request, slugs: string[]): Promise<Map<string, string>> {
+    void req;
+    void slugs;
+    return new Map<string, string>();
+  }
+
+  /** PKC-5 — account-level stat strip computed from the full active dataset (filter-independent). */
+  private computeStats(assignments: OrgKeyContactAssignment[]): OrgKeyContactsStats {
+    const emails = new Set<string>();
+    const slugs = new Set<string>();
+    const rolesHeld = new Set<string>();
+    for (const a of assignments) {
+      emails.add(a.email.toLowerCase());
+      slugs.add(a.foundationSlug);
+      rolesHeld.add(a.role);
+    }
+    const unfilled = ORG_KEY_CONTACT_REQUIRED_ROLES.filter((r) => !rolesHeld.has(r)).length;
+    return {
+      individualCount: emails.size,
+      foundationsCovered: slugs.size,
+      unfilledRequiredRoleCount: unfilled,
+    };
+  }
+}

--- a/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
@@ -36,6 +36,11 @@ interface ProjectMembershipIndexedDoc {
 
 /** Org Lens — People → Key Contacts tab. V1 is org-wide and read-only; membership-scoped reads + writes live in OrgLensKeyContactsService (spec 024). */
 export class OrgPeopleKeyContactsService {
+  // Active membership statuses, case-insensitive — mirrors OrgMembershipResolverService so we don't silently drop 'purchased' or mixed-case 'active' memberships.
+  private static readonly activeMembershipStatuses = new Set(['active', 'purchased']);
+  // Match OrgMembershipResolverService's page size so org-wide reads aren't artificially fragmented into more round trips than necessary.
+  private static readonly queryPageSize = 500;
+
   private readonly microserviceProxy: MicroserviceProxyService;
 
   public constructor() {
@@ -45,30 +50,37 @@ export class OrgPeopleKeyContactsService {
   /** Bundled GET — joins active key_contact rows to their project_membership and computes the filter-independent stat strip (FR-004). Caller passes b2b_org UUID directly because the upstream b2b_org index has no indexed sfid field. */
   public async getKeyContacts(req: Request, orgUid: string): Promise<OrgKeyContactsResponse> {
     const tags = `b2b_org_uid:${orgUid}`;
+    // failOnPartial: true on both fetches — stats are computed off the full active dataset, so a dropped page would silently produce wrong counts and missing-join filters.
     const [contacts, memberships] = await Promise.all([
-      fetchAllQueryResources<KeyContactIndexedDoc>(req, (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<KeyContactIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          type: 'key_contact',
-          tags,
-          per_page: 50,
-          ...(pageToken && { page_token: pageToken }),
-        })
+      fetchAllQueryResources<KeyContactIndexedDoc>(
+        req,
+        (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<KeyContactIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'key_contact',
+            tags,
+            per_page: OrgPeopleKeyContactsService.queryPageSize,
+            ...(pageToken && { page_token: pageToken }),
+          }),
+        { failOnPartial: true }
       ),
-      fetchAllQueryResources<ProjectMembershipIndexedDoc>(req, (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<ProjectMembershipIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          type: 'project_membership',
-          tags,
-          per_page: 50,
-          ...(pageToken && { page_token: pageToken }),
-        })
+      fetchAllQueryResources<ProjectMembershipIndexedDoc>(
+        req,
+        (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<ProjectMembershipIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'project_membership',
+            tags,
+            per_page: OrgPeopleKeyContactsService.queryPageSize,
+            ...(pageToken && { page_token: pageToken }),
+          }),
+        { failOnPartial: true }
       ),
     ]);
 
-    // Membership filter is case-sensitive ('Active' only); contact-side is case-insensitive because legacy rows are mixed-case.
+    // Case-insensitive membership status filter — same Set ('active', 'purchased') as OrgMembershipResolverService so we don't drop valid memberships.
     const membershipByUid = new Map<string, ProjectMembershipIndexedDoc>();
     for (const m of memberships) {
       if (!m.uid) continue;
-      if (m.status !== 'Active') continue;
+      if (!OrgPeopleKeyContactsService.activeMembershipStatuses.has((m.status ?? '').toLowerCase())) continue;
       membershipByUid.set(m.uid, m);
     }
 

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -58,6 +58,7 @@ export * from './org-profile.constants';
 export * from './foundation-projects.constants';
 export * from './marketing-impact.constants';
 export * from './org-people.constants';
+export * from './org-people-key-contacts.constants';
 export * from './individual-enrollment-catalog';
 export * from './newsletter.constants';
 export * from './vote.constants';

--- a/packages/shared/src/constants/org-people-key-contacts.constants.ts
+++ b/packages/shared/src/constants/org-people-key-contacts.constants.ts
@@ -25,9 +25,10 @@ export const ORG_KEY_CONTACT_ROLE_PILL_CLASSES: Readonly<Record<OrgKeyContactRol
   'Event Sponsorship Contact': 'bg-orange-50 text-orange-700 border-orange-300',
 };
 
-/** Type guard for arbitrary upstream role strings — narrows to the canonical 9 for safe Record indexing. */
+/** Type guard for arbitrary upstream role strings — narrows to the canonical 9 for safe Record indexing.
+ * Uses `Object.prototype.hasOwnProperty.call` so inherited keys (e.g. `toString`) don't pass the guard. */
 export function isCanonicalOrgKeyContactRole(role: string): role is OrgKeyContactRole {
-  return role in ORG_KEY_CONTACT_ROLE_PILL_CLASSES;
+  return Object.prototype.hasOwnProperty.call(ORG_KEY_CONTACT_ROLE_PILL_CLASSES, role);
 }
 
 /** Fallback pill class for any role string not in the canonical 9. */

--- a/packages/shared/src/constants/org-people-key-contacts.constants.ts
+++ b/packages/shared/src/constants/org-people-key-contacts.constants.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { OrgKeyContactRole, OrgKeyContactsResponse } from '../interfaces/org-people-key-contacts.interface';
+
+/** Five required roles (min ≥ 1) — drives the org-wide Unfilled Role Types stat (PKC-5). */
+export const ORG_KEY_CONTACT_REQUIRED_ROLES: readonly OrgKeyContactRole[] = [
+  'Representative/Voting Contact',
+  'Authorized Signatory',
+  'Billing Contact',
+  'Marketing Contact',
+  'Technical Contact',
+];
+
+/** Tailwind pill classes per canonical role (FR-007a / FR-016 — LFX tokens, not prototype hex). */
+export const ORG_KEY_CONTACT_ROLE_PILL_CLASSES: Readonly<Record<OrgKeyContactRole, string>> = {
+  'Representative/Voting Contact': 'bg-purple-50 text-purple-700 border-purple-300',
+  'Authorized Signatory': 'bg-indigo-50 text-indigo-700 border-indigo-300',
+  'Billing Contact': 'bg-emerald-50 text-emerald-700 border-emerald-300',
+  'Technical Contact': 'bg-sky-50 text-sky-700 border-sky-300',
+  'Marketing Contact': 'bg-amber-50 text-amber-700 border-amber-300',
+  'PO Contact': 'bg-teal-50 text-teal-700 border-teal-300',
+  'PR Contact': 'bg-pink-50 text-pink-700 border-pink-300',
+  'Legal Contact': 'bg-rose-50 text-rose-700 border-rose-300',
+  'Event Sponsorship Contact': 'bg-orange-50 text-orange-700 border-orange-300',
+};
+
+/** Type guard for arbitrary upstream role strings — narrows to the canonical 9 for safe Record indexing. */
+export function isCanonicalOrgKeyContactRole(role: string): role is OrgKeyContactRole {
+  return role in ORG_KEY_CONTACT_ROLE_PILL_CLASSES;
+}
+
+/** Fallback pill class for any role string not in the canonical 9. */
+export const ORG_KEY_CONTACT_ROLE_PILL_FALLBACK = 'bg-slate-50 text-slate-600 border-slate-300';
+
+/** Seed value for `toSignal` so the component never starts in an undefined state. */
+export const EMPTY_ORG_KEY_CONTACTS_RESPONSE: OrgKeyContactsResponse = {
+  assignments: [],
+  stats: {
+    individualCount: 0,
+    foundationsCovered: 0,
+    unfilledRequiredRoleCount: ORG_KEY_CONTACT_REQUIRED_ROLES.length,
+  },
+};

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -178,6 +178,7 @@ export * from './org-people.interface';
 
 // Org People — Key Contacts tab (spec 005)
 export * from './org-people-key-contacts.interface';
+export * from './org-people-key-contacts.internal.interface';
 
 // Newsletter interfaces
 export * from './newsletter.interface';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -176,6 +176,9 @@ export * from './org-key-contacts.internal.interface';
 // Org People interfaces
 export * from './org-people.interface';
 
+// Org People — Key Contacts tab (spec 005)
+export * from './org-people-key-contacts.interface';
+
 // Newsletter interfaces
 export * from './newsletter.interface';
 

--- a/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
@@ -22,7 +22,8 @@ export interface OrgKeyContactAssignment {
   lastName: string;
   displayName: string;
   title: string | null;
-  role: OrgKeyContactRole | string;
+  // Wire-level: any string upstream may send. Narrow to OrgKeyContactRole via isCanonicalOrgKeyContactRole before indexing role-keyed maps.
+  role: string;
   foundationSlug: string;
   foundationName: string | null;
   canEdit: boolean;

--- a/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
@@ -1,0 +1,84 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Canonical member-service role strings — 9 values. */
+export type OrgKeyContactRole =
+  | 'Billing Contact'
+  | 'Marketing Contact'
+  | 'Technical Contact'
+  | 'Representative/Voting Contact'
+  | 'Authorized Signatory'
+  | 'Event Sponsorship Contact'
+  | 'Legal Contact'
+  | 'PR Contact'
+  | 'PO Contact';
+
+/** One row per real key_contact record on an active membership (PKC-3 — not cartesian). */
+export interface OrgKeyContactAssignment {
+  contactUid: string;
+  membershipUid: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+  title: string | null;
+  role: OrgKeyContactRole | string;
+  foundationSlug: string;
+  foundationName: string | null;
+  canEdit: boolean;
+}
+
+/** Account-level stat strip (FR-004 — filter-independent). */
+export interface OrgKeyContactsStats {
+  individualCount: number;
+  foundationsCovered: number;
+  unfilledRequiredRoleCount: number;
+}
+
+/** Bundled GET response for `/api/orgs/:orgUid/lens/people/key-contacts`. */
+export interface OrgKeyContactsResponse {
+  assignments: OrgKeyContactAssignment[];
+  stats: OrgKeyContactsStats;
+}
+
+// ============================================================
+// Client-only view types (NOT on the wire)
+// ============================================================
+
+export type OrgKeyContactSortColumn = 'name' | 'roles' | 'foundations';
+export type OrgKeyContactSortDirection = 1 | -1;
+
+export interface OrgKeyContactDropdownOption {
+  label: string;
+  value: string;
+}
+
+/** Person-grouped main-row view model (derived client-side from `assignments`). */
+export interface OrgKeyContactPersonGroup {
+  email: string;
+  displayName: string;
+  title: string | null;
+  roles: string[];
+  foundationCount: number;
+  assignments: OrgKeyContactAssignment[];
+  canEditAny: boolean;
+}
+
+/** Pre-decorated assignment for the expanded sub-table — pillClass + foundation rowspan flags computed once. */
+export interface OrgKeyContactAssignmentVm extends OrgKeyContactAssignment {
+  pillClass: string;
+  showFoundationLabel: boolean;
+  foundationLabel: string;
+}
+
+/** Pre-decorated role pill for the main-row roles cell — role + Tailwind pill class computed once. */
+export interface OrgKeyContactRolePillVm {
+  role: string;
+  pillClass: string;
+}
+
+/** Pre-decorated person group — main-row VM with role pills and sorted decorated assignments ready for the template. */
+export interface OrgKeyContactPersonGroupVm extends OrgKeyContactPersonGroup {
+  rolePills: OrgKeyContactRolePillVm[];
+  sortedAssignments: OrgKeyContactAssignmentVm[];
+}

--- a/packages/shared/src/interfaces/org-people-key-contacts.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.internal.interface.ts
@@ -1,14 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * Internal (server-only) shapes for the Org People → Key Contacts tab BFF.
- * Mirrors the precedent in `org-key-contacts.internal.interface.ts` (membership-detail
- * surface owned by spec 024) — fields are intentionally optional because query-service
- * search hits can omit any field that wasn't indexed for a given row.
- */
-
-/** Indexed `key_contact.data` shape on query-service — only the fields the org-wide read consumes. */
+/** Indexed `key_contact.data` shape on query-service — server-side only; fields optional because the search index can omit unindexed columns per row. */
 export interface KeyContactIndexedDoc {
   uid?: string;
   membership_uid?: string;
@@ -20,7 +13,7 @@ export interface KeyContactIndexedDoc {
   status?: string | null;
 }
 
-/** Indexed `project_membership.data` shape on query-service — only the fields the org-wide read consumes. */
+/** Indexed `project_membership.data` shape on query-service — server-side only; fields optional because the search index can omit unindexed columns per row. */
 export interface ProjectMembershipIndexedDoc {
   uid?: string;
   project_slug?: string;

--- a/packages/shared/src/interfaces/org-people-key-contacts.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.internal.interface.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Internal (server-only) shapes for the Org People → Key Contacts tab BFF.
+ * Mirrors the precedent in `org-key-contacts.internal.interface.ts` (membership-detail
+ * surface owned by spec 024) — fields are intentionally optional because query-service
+ * search hits can omit any field that wasn't indexed for a given row.
+ */
+
+/** Indexed `key_contact.data` shape on query-service — only the fields the org-wide read consumes. */
+export interface KeyContactIndexedDoc {
+  uid?: string;
+  membership_uid?: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  title?: string | null;
+  role?: string;
+  status?: string | null;
+}
+
+/** Indexed `project_membership.data` shape on query-service — only the fields the org-wide read consumes. */
+export interface ProjectMembershipIndexedDoc {
+  uid?: string;
+  project_slug?: string;
+  project_name?: string | null;
+  status?: string;
+}


### PR DESCRIPTION
## Summary
- New `KeyContactsComponent` registered as the `contacts` branch in the Org People tab strip — person-grouped table with an expandable Foundation × Role sub-table, filter-independent stat strip (Individuals, Foundations Covered, Unfilled Required Role Types), reactive filter form (search + foundation + role), client-side sort/expansion state, retry, and skeleton + empty-state coverage.
- New server service `OrgPeopleKeyContactsService` for the org-wide read; deliberately distinct from `OrgLensKeyContactsService` (which #824 owns for the membership-detail surface). The two have different filters, response shapes, and — eventually — writer semantics.
- The BFF does a paged live read from query-service (`key_contact` ⋈ `project_membership` on `membership_uid`, scoped by `b2b_org_uid`), drops inactive memberships and contacts, and computes stats off the full active dataset (FR-004).
- One new GET endpoint mounted under the spec-024 uuid-only convention: `GET /api/orgs/:orgUid/lens/people/key-contacts`. uid validation reuses the shared `assertOrgUid` helper introduced by #824 — no duplicate validation.

## Out of scope (intentionally)
- **Edit affordances.** Main-row reassign pencil (FR-005) and expanded-row Edit pencil (FR-006/FR-009) are deferred to LFXV2-1677, which will reuse the add/replace/remove writes that #824 already landed on `OrgLensKeyContactsController` (the spec-024 surface). No write endpoints, no write types, no write methods on the client service in this PR.
- **Writer gating.** T027 (`canEdit` flag on each assignment) stays `false` in V1; the FGA hook lands with LFXV2-1677.
- **Foundation slug→name backfill.** `enrichFoundationNames` is a stub returning an empty map (T041). The component already tolerates `foundationName: null` and falls back to the slug in the UI.
- **Unit/integration tests.** No new tests in this PR; will be added in the LFXV2-1677 follow-up alongside the edit affordances. Manual test plan below.

## How this co-exists with #824
- `OrgLensKeyContactsService` (Luis, #824) — **membership-detail** scoped. Returns the 9 catalog rows for one membership + handles all writes via member-service.
- `OrgPeopleKeyContactsService` (this PR) — **org-wide** scoped. Returns the assignments + filter-independent stats for the People tab.
- Both files live side-by-side in `apps/lfx-one/src/server/services/`; the names differentiate the surface they serve. The membership-detail writes will be the writes for the people-tab edits too once LFXV2-1677 wires them.

## Test plan
- [ ] `yarn build` succeeds locally (verified via `pre-push`).
- [ ] Navigate to `/org/<orgUid>/people` for an org with active key contacts → Key Contacts tab is selectable and the stat strip + table render.
- [ ] Filter by search, foundation, and role independently and combined; empty-state copy differentiates "no data" vs "no matches".
- [ ] Sort each column (Name / Roles / Foundations) ascending and descending; default is Name ascending.
- [ ] Expand a person row → expanded sub-table groups assignments by foundation with the foundation label only on the first row of each group.
- [ ] Force a 5xx from the BFF (or pull network) → error empty state with a working Retry button.
- [ ] Switch the selected org via the Org Lens selector → tab resets (filters cleared, expansion cleared, sort back to Name asc, stats recomputed).
- [ ] Verify the `unfilled_required_role_count` math by removing a required role on the dev org; stat card turns red when count > 0.

Generated with [Cursor Composer](https://cursor.com/composer)

[LFXV2-1873]: https://linuxfoundation.atlassian.net/browse/LFXV2-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ