### PR TITLE
feat(events): org events upcoming tab (LFXV2-1899)

### DIFF
--- a/apps/lfx-one/e2e/org-events-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-events-dashboard.spec.ts
@@ -1,0 +1,190 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, test } from '@playwright/test';
+
+const ORG_EVENTS_URL = '/org/events';
+const DATA_LOAD_TIMEOUT = 30_000;
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = '4c46585f-878c-8285-b2e9-2dbfc38ddd9b';
+
+test.setTimeout(120_000);
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+async function stubOrgEventsRoutes(page: Page): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [
+          {
+            accountId: MOCK_ACCOUNT_ID,
+            accountName: 'Red Hat LLC',
+            accountSlug: 'red-hat-llc',
+            membershipTier: '',
+            uid: MOCK_UID,
+          },
+        ],
+        isRootWriter: false,
+      }),
+    })
+  );
+
+  await page.route(`**/api/orgs/${MOCK_ACCOUNT_ID}/lens/events/summary`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ totalEvents: 12, pastEvents: 3, upcomingEvents: 9 }),
+    })
+  );
+
+  await page.route(`**/api/orgs/${MOCK_ACCOUNT_ID}/lens/events?**`, (route) => {
+    const url = new URL(route.request().url());
+    const offset = Number(url.searchParams.get('offset') ?? 0);
+
+    const firstPageData = [
+      {
+        eventId: 'event-1',
+        eventName: 'Open Source Summit',
+        foundation: 'Linux Foundation',
+        eventStartDate: '2026-06-30',
+        eventEndDate: '2026-07-02',
+        eventLocation: null,
+        eventCity: 'Seattle',
+        eventCountry: 'United States',
+        eventUrl: 'https://events.linuxfoundation.org/open-source-summit',
+        eventRegistrationUrl: 'https://events.linuxfoundation.org/open-source-summit/register',
+        orgAttendeeCount: 3,
+        eventRegistrationsGoal: 1500,
+        orgSpeakerAcceptedCount: 1,
+        orgSpeakerSubmittedCount: 2,
+        isOrgSponsor: true,
+      },
+    ];
+
+    const secondPageData = [
+      {
+        eventId: 'event-2',
+        eventName: 'CloudNativeCon',
+        foundation: 'CNCF',
+        eventStartDate: '2026-09-10',
+        eventEndDate: '2026-09-12',
+        eventLocation: null,
+        eventCity: 'San Diego',
+        eventCountry: 'United States',
+        eventUrl: 'https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america',
+        eventRegistrationUrl: null,
+        orgAttendeeCount: 2,
+        eventRegistrationsGoal: 2200,
+        orgSpeakerAcceptedCount: 0,
+        orgSpeakerSubmittedCount: 1,
+        isOrgSponsor: false,
+      },
+    ];
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: offset >= 10 ? secondPageData : firstPageData,
+        total: 12,
+        pageSize: 10,
+        offset,
+      }),
+    });
+  });
+
+  await page.route(`**/api/orgs/${MOCK_ACCOUNT_ID}/lens/events/event-1/attendees*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        eventId: 'event-1',
+        eventName: 'Open Source Summit',
+        total: 1,
+        data: [{ contactId: 'person@example.org', name: 'Jane Doe', jobTitle: 'Engineer' }],
+      }),
+    })
+  );
+
+  await page.route(`**/api/orgs/${MOCK_ACCOUNT_ID}/lens/events/event-1/speakers*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        eventId: 'event-1',
+        eventName: 'Open Source Summit',
+        acceptedCount: 1,
+        submittedCount: 1,
+        data: [{ contactId: 'speaker@example.org', name: 'Alex Speaker', jobTitle: 'Maintainer', status: 'ACCEPTED' }],
+      }),
+    })
+  );
+}
+
+async function gotoOrgEventsPage(page: Page): Promise<void> {
+  await stubOrgEventsRoutes(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.goto(ORG_EVENTS_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+
+  if (!page.url().includes('/org/events')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/events redirected away');
+  }
+}
+
+test.describe('Org Events Dashboard', () => {
+  test('supports sorting, pagination, and action CTAs', async ({ page }) => {
+    await gotoOrgEventsPage(page);
+    await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-upcoming-events-data-table')).toBeVisible();
+    await expect(page.getByTestId('org-upcoming-event-action-event-1').getByRole('link', { name: 'Register' })).toBeVisible();
+
+    const sortRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith(`/api/orgs/${MOCK_ACCOUNT_ID}/lens/events`) && url.searchParams.get('sortField') === 'EVENT_CITY';
+    });
+    await page.getByTestId('sort-location').getByRole('button').click();
+    await sortRequest;
+
+    const pageRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith(`/api/orgs/${MOCK_ACCOUNT_ID}/lens/events`) && url.searchParams.get('offset') === '10';
+    });
+    await page.locator('button[aria-label="Next Page"]').first().click();
+    await pageRequest;
+  });
+
+  test('opens attendee and speaker drawers with non-PII row test ids', async ({ page }) => {
+    await gotoOrgEventsPage(page);
+    await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('org-upcoming-event-attendees-event-1').getByRole('button').click();
+    await expect(page.getByTestId('event-attendees-drawer')).toBeVisible();
+    await expect(page.getByTestId('event-attendee-0')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('event-attendees-drawer')).not.toBeVisible();
+
+    await page.getByTestId('org-upcoming-event-speakers-event-1').getByRole('button').click();
+    await expect(page.getByTestId('event-speakers-drawer')).toBeVisible();
+    await expect(page.getByTestId('event-speaker-0')).toBeVisible();
+  });
+});

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-attendees-drawer/event-attendees-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-attendees-drawer/event-attendees-drawer.component.html
@@ -1,0 +1,78 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
+  data-testid="event-attendees-drawer">
+  <ng-template #header>
+    <div class="flex items-start gap-3 w-full">
+      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+        <i class="fa-light fa-users text-lg" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="event-attendees-drawer-title">{{ companyName() }} Attendees</h2>
+        <p class="text-sm text-gray-500 truncate" data-testid="event-attendees-drawer-subtitle">{{ eventName() }} &middot; {{ attendeeCount() }} attending</p>
+      </div>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-4 h-full">
+    <!-- Search -->
+    <div class="relative">
+      <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" aria-hidden="true"></i>
+      <input
+        pInputText
+        type="text"
+        placeholder="Search people..."
+        aria-label="Search attendees"
+        class="w-full pl-9"
+        data-testid="event-attendees-search"
+        [ngModel]="searchTerm()"
+        (ngModelChange)="searchTerm.set($event)" />
+    </div>
+
+    <!-- List -->
+    @if (loading()) {
+      <div class="flex items-center justify-center py-16">
+        <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+      </div>
+    } @else if (filteredAttendees().length === 0) {
+      <div class="flex flex-col items-center justify-center py-16 text-center">
+        <i class="fa-light fa-users text-3xl text-gray-300 mb-3" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">
+          @if (searchTerm()) {
+            No attendees match your search.
+          } @else {
+            No attendees found for this event.
+          }
+        </p>
+      </div>
+    } @else {
+      <ul class="flex flex-col divide-y divide-gray-100" data-testid="event-attendees-list">
+        @for (attendee of filteredAttendees(); track attendee.contactId; let index = $index) {
+          <li class="flex items-center gap-3 py-3" [attr.data-testid]="'event-attendee-' + index">
+            <!-- Avatar -->
+            <div
+              class="flex items-center justify-center w-9 h-9 rounded-full text-white text-xs font-semibold flex-shrink-0"
+              [class]="attendee.avatarColorClass"
+              aria-hidden="true">
+              {{ attendee.initials }}
+            </div>
+            <!-- Name + title -->
+            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+              <span class="text-sm font-medium text-gray-900 truncate">{{ attendee.name }}</span>
+              @if (attendee.jobTitle) {
+                <span class="text-xs text-gray-500 truncate">{{ attendee.jobTitle }}</span>
+              }
+            </div>
+            <!-- Status badge -->
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-700 flex-shrink-0"> Registered </span>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-attendees-drawer/event-attendees-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-attendees-drawer/event-attendees-drawer.component.ts
@@ -1,0 +1,64 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Component, computed, inject, input, model, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { DrawerModule } from 'primeng/drawer';
+import { InputTextModule } from 'primeng/inputtext';
+import { catchError, combineLatest, finalize, of, skip, switchMap } from 'rxjs';
+
+import type { OrgEventAttendeesDrawerResponse, OrgEventAttendeeVm } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { EventsService } from '@services/events.service';
+import { computePersonAvatarColorClass, computePersonInitials } from '@shared/utils/person-avatar.util';
+
+@Component({
+  selector: 'lfx-event-attendees-drawer',
+  imports: [FormsModule, DrawerModule, InputTextModule],
+  templateUrl: './event-attendees-drawer.component.html',
+})
+export class EventAttendeesDrawerComponent {
+  private readonly eventsService = inject(EventsService);
+  private readonly accountContext = inject(AccountContextService);
+
+  public readonly visible = model<boolean>(false);
+  public readonly eventId = input<string>('');
+  public readonly eventName = input<string>('');
+  public readonly attendeeCount = input<number>(0);
+
+  protected readonly searchTerm = signal('');
+  protected readonly loading = signal(false);
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
+
+  private readonly attendeesData = this.initAttendeesData();
+
+  protected readonly filteredAttendees = computed<OrgEventAttendeeVm[]>(() => {
+    const term = this.searchTerm().toLowerCase().trim();
+    const data = this.attendeesData()?.data ?? [];
+    const matched = !term ? data : data.filter((a) => a.name.toLowerCase().includes(term) || (a.jobTitle ?? '').toLowerCase().includes(term));
+    return matched.map((a) => ({ ...a, initials: computePersonInitials(a.name), avatarColorClass: computePersonAvatarColorClass(a.contactId) }));
+  });
+
+  private initAttendeesData() {
+    return toSignal(
+      combineLatest([toObservable(this.visible), toObservable(this.eventId)]).pipe(
+        skip(1),
+        switchMap(([isVisible, currentEventId]) => {
+          if (!isVisible || !currentEventId) return of(null);
+          const accountId = this.accountContext.selectedAccount().accountId;
+          if (!accountId) return of(null);
+          this.searchTerm.set('');
+          this.loading.set(true);
+          return this.eventsService.getEventAttendees(accountId, currentEventId).pipe(
+            catchError(() => of({ eventId: currentEventId, eventName: this.eventName(), total: 0, data: [] } as OrgEventAttendeesDrawerResponse)),
+            finalize(() => this.loading.set(false))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-speakers-drawer/event-speakers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-speakers-drawer/event-speakers-drawer.component.html
@@ -1,0 +1,84 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
+  data-testid="event-speakers-drawer">
+  <ng-template #header>
+    <div class="flex items-start gap-3 w-full">
+      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+        <i class="fa-light fa-microphone text-lg" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="event-speakers-drawer-title">{{ companyName() }} Speakers</h2>
+        <p class="text-sm text-gray-500 truncate" data-testid="event-speakers-drawer-subtitle">
+          {{ eventName() }} &middot; {{ acceptedCount() }} accepted of {{ submittedCount() }} submitted
+        </p>
+      </div>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-4 h-full">
+    <!-- Search -->
+    <div class="relative">
+      <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" aria-hidden="true"></i>
+      <input
+        pInputText
+        type="text"
+        placeholder="Search people..."
+        aria-label="Search speakers"
+        class="w-full pl-9"
+        data-testid="event-speakers-search"
+        [ngModel]="searchTerm()"
+        (ngModelChange)="searchTerm.set($event)" />
+    </div>
+
+    <!-- List -->
+    @if (loading()) {
+      <div class="flex items-center justify-center py-16">
+        <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+      </div>
+    } @else if (filteredSpeakers().length === 0) {
+      <div class="flex flex-col items-center justify-center py-16 text-center">
+        <i class="fa-light fa-microphone text-3xl text-gray-300 mb-3" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">
+          @if (searchTerm()) {
+            No speakers match your search.
+          } @else {
+            No speakers found for this event.
+          }
+        </p>
+      </div>
+    } @else {
+      <ul class="flex flex-col divide-y divide-gray-100" data-testid="event-speakers-list">
+        @for (speaker of filteredSpeakers(); track speaker.contactId; let index = $index) {
+          <li class="flex items-center gap-3 py-3" [attr.data-testid]="'event-speaker-' + index">
+            <!-- Avatar -->
+            <div
+              class="flex items-center justify-center w-9 h-9 rounded-full text-white text-xs font-semibold flex-shrink-0"
+              [class]="speaker.avatarColorClass"
+              aria-hidden="true">
+              {{ speaker.initials }}
+            </div>
+            <!-- Name + title -->
+            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+              <span class="text-sm font-medium text-gray-900 truncate">{{ speaker.name }}</span>
+              @if (speaker.jobTitle) {
+                <span class="text-xs text-gray-500 truncate">{{ speaker.jobTitle }}</span>
+              }
+            </div>
+            <!-- Status badge -->
+            @if (speaker.status === 'ACCEPTED') {
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-700 flex-shrink-0"> Accepted </span>
+            } @else {
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 flex-shrink-0"> Submitted </span>
+            }
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-speakers-drawer/event-speakers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/event-speakers-drawer/event-speakers-drawer.component.ts
@@ -1,0 +1,67 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Component, computed, inject, input, model, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { DrawerModule } from 'primeng/drawer';
+import { InputTextModule } from 'primeng/inputtext';
+import { catchError, combineLatest, finalize, of, skip, switchMap } from 'rxjs';
+
+import type { OrgEventSpeakersResponse, OrgEventSpeakerVm } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { EventsService } from '@services/events.service';
+import { computePersonAvatarColorClass, computePersonInitials } from '@shared/utils/person-avatar.util';
+
+@Component({
+  selector: 'lfx-event-speakers-drawer',
+  imports: [FormsModule, DrawerModule, InputTextModule],
+  templateUrl: './event-speakers-drawer.component.html',
+})
+export class EventSpeakersDrawerComponent {
+  private readonly eventsService = inject(EventsService);
+  private readonly accountContext = inject(AccountContextService);
+
+  public readonly visible = model<boolean>(false);
+  public readonly eventId = input<string>('');
+  public readonly eventName = input<string>('');
+  public readonly acceptedCount = input<number>(0);
+  public readonly submittedCount = input<number>(0);
+
+  protected readonly searchTerm = signal('');
+  protected readonly loading = signal(false);
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
+
+  private readonly speakersData = this.initSpeakersData();
+
+  protected readonly filteredSpeakers = computed<OrgEventSpeakerVm[]>(() => {
+    const term = this.searchTerm().toLowerCase().trim();
+    const data = this.speakersData()?.data ?? [];
+    const matched = !term ? data : data.filter((s) => s.name.toLowerCase().includes(term) || (s.jobTitle ?? '').toLowerCase().includes(term));
+    return matched.map((s) => ({ ...s, initials: computePersonInitials(s.name), avatarColorClass: computePersonAvatarColorClass(s.contactId) }));
+  });
+
+  private initSpeakersData() {
+    return toSignal(
+      combineLatest([toObservable(this.visible), toObservable(this.eventId)]).pipe(
+        skip(1),
+        switchMap(([isVisible, currentEventId]) => {
+          if (!isVisible || !currentEventId) return of(null);
+          const accountId = this.accountContext.selectedAccount().accountId;
+          if (!accountId) return of(null);
+          this.searchTerm.set('');
+          this.loading.set(true);
+          return this.eventsService.getEventSpeakers(accountId, currentEventId).pipe(
+            catchError(() =>
+              of({ eventId: currentEventId, eventName: this.eventName(), acceptedCount: 0, submittedCount: 0, data: [] } as OrgEventSpeakersResponse)
+            ),
+            finalize(() => this.loading.set(false))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-upcoming-events-table/org-upcoming-events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-upcoming-events-table/org-upcoming-events-table.component.html
@@ -1,0 +1,189 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-table
+  [value]="rows()"
+  [loading]="loading()"
+  [lazy]="true"
+  [paginator]="eventsResponse().total > 0"
+  [rows]="eventsResponse().pageSize"
+  [first]="eventsResponse().offset"
+  [totalRecords]="eventsResponse().total"
+  [rowsPerPageOptions]="rppOptions()"
+  [showCurrentPageReport]="true"
+  [showFirstLastIcon]="false"
+  currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+  paginatorPosition="bottom"
+  (onPage)="onPageChange($event)"
+  data-testid="org-upcoming-events-data-table">
+  <ng-template #header>
+    <tr>
+      <th scope="col" [attr.aria-sort]="sortAriaMap()['EVENT_NAME']" data-testid="sort-event-name">
+        <button
+          type="button"
+          class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium"
+          (click)="onHeaderClick('EVENT_NAME')">
+          Event Name <i [class]="sortIcons()['EVENT_NAME']"></i>
+        </button>
+      </th>
+      <th scope="col" class="text-xs text-gray-500 font-medium">Foundation</th>
+      <th scope="col" [attr.aria-sort]="sortAriaMap()['EVENT_START_DATE']" data-testid="sort-date">
+        <button
+          type="button"
+          class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium"
+          (click)="onHeaderClick('EVENT_START_DATE')">
+          Date <i [class]="sortIcons()['EVENT_START_DATE']"></i>
+        </button>
+      </th>
+      <th scope="col" [attr.aria-sort]="sortAriaMap()['EVENT_CITY']" data-testid="sort-location">
+        <button
+          type="button"
+          class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium"
+          (click)="onHeaderClick('EVENT_CITY')">
+          Location <i [class]="sortIcons()['EVENT_CITY']"></i>
+        </button>
+      </th>
+      <th scope="col" class="text-xs font-medium">
+        <span class="text-gray-500">Event Attendees</span>
+        <span class="block text-gray-400 font-normal">My Org / Goal</span>
+      </th>
+      <th scope="col" class="text-xs font-medium">
+        <span class="text-gray-500">Event Speakers</span>
+        <span class="block text-gray-400 font-normal">Accepted / Submitted</span>
+      </th>
+      <th scope="col" class="text-xs text-gray-500 font-medium">Event Sponsor</th>
+      <th scope="col" class="text-xs text-gray-500 font-medium">Action</th>
+    </tr>
+  </ng-template>
+
+  <ng-template #body let-event let-rowIndex="rowIndex">
+    <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'org-upcoming-event-row-' + event.eventId">
+      <!-- Event Name -->
+      <td>
+        @if (event.eventUrl) {
+          <a
+            [href]="event.eventUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="lfx-table-name-link text-sm"
+            [attr.data-testid]="'org-upcoming-event-name-' + event.eventId">
+            {{ event.eventName }}
+          </a>
+        } @else {
+          <span class="text-sm font-medium text-gray-900" [attr.data-testid]="'org-upcoming-event-name-' + event.eventId">
+            {{ event.eventName }}
+          </span>
+        }
+      </td>
+
+      <!-- Foundation -->
+      <td>
+        @if (event.foundation) {
+          <lfx-tag [value]="event.foundation" styleClass="tag-neutral" [attr.data-testid]="'org-upcoming-event-foundation-' + event.eventId" />
+        } @else {
+          <span class="text-xs text-gray-400">&mdash;</span>
+        }
+      </td>
+
+      <!-- Date -->
+      <td>
+        @if (event.eventStartDate) {
+          <span class="text-sm text-gray-700 whitespace-nowrap">{{ event.dateRange }}</span>
+        } @else {
+          <span class="text-xs text-gray-400">&mdash;</span>
+        }
+      </td>
+
+      <!-- Location -->
+      <td>
+        @if (event.eventCity && event.eventCountry) {
+          <span class="text-sm text-gray-700 whitespace-nowrap">{{ event.eventCity }}, {{ event.eventCountry }}</span>
+        } @else if (event.eventLocation) {
+          <span class="text-sm text-gray-700 whitespace-nowrap">{{ event.eventLocation }}</span>
+        } @else {
+          <span class="text-xs text-gray-400">&mdash;</span>
+        }
+      </td>
+
+      <!-- Event Attendees: My Org / Goal -->
+      <td [attr.data-testid]="'org-upcoming-event-attendees-' + event.eventId">
+        @if (event.orgAttendeeCount > 0) {
+          <button
+            type="button"
+            class="text-sm text-gray-900 whitespace-nowrap hover:underline focus-visible:underline focus-visible:outline-none"
+            (click)="attendeesClick.emit(event)">
+            {{ event.orgAttendeeCount | number }}
+            @if (event.eventRegistrationsGoal !== null) {
+              <span class="text-gray-400"> / {{ event.eventRegistrationsGoal | number }}</span>
+            }
+          </button>
+        } @else {
+          <span class="text-sm text-gray-900 whitespace-nowrap">
+            {{ event.orgAttendeeCount | number }}
+            @if (event.eventRegistrationsGoal !== null) {
+              <span class="text-gray-400"> / {{ event.eventRegistrationsGoal | number }}</span>
+            }
+          </span>
+        }
+      </td>
+
+      <!-- Event Speakers: Accepted / Submitted -->
+      <td [attr.data-testid]="'org-upcoming-event-speakers-' + event.eventId">
+        @if (event.orgSpeakerAcceptedCount > 0 || event.orgSpeakerSubmittedCount > 0) {
+          <button
+            type="button"
+            class="text-sm text-gray-900 whitespace-nowrap hover:underline focus-visible:underline focus-visible:outline-none"
+            (click)="speakersClick.emit(event)">
+            {{ event.orgSpeakerAcceptedCount }} / {{ event.orgSpeakerSubmittedCount }}
+          </button>
+        } @else {
+          <span class="text-sm text-gray-400 whitespace-nowrap">0 / 0</span>
+        }
+      </td>
+
+      <!-- Event Sponsor -->
+      <td [attr.data-testid]="'org-upcoming-event-sponsor-' + event.eventId">
+        <span class="text-sm text-gray-700">{{ event.isOrgSponsor ? 'Yes' : 'No' }}</span>
+      </td>
+
+      <!-- Action -->
+      <td [attr.data-testid]="'org-upcoming-event-action-' + event.eventId">
+        @if (event.eventRegistrationUrl) {
+          <a
+            [href]="event.eventRegistrationUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
+            Register
+          </a>
+        } @else if (event.eventUrl) {
+          <a
+            [href]="event.eventUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
+            View
+          </a>
+        } @else {
+          <span class="text-xs text-gray-400">&mdash;</span>
+        }
+      </td>
+    </tr>
+  </ng-template>
+
+  <ng-template #emptymessage>
+    <tr>
+      <td colspan="8" class="text-center py-10">
+        <div class="flex items-center justify-center p-16">
+          <div class="text-center max-w-md">
+            <div class="text-gray-400 mb-4">
+              <i class="fa-light fa-calendar-plus text-3xl mb-4"></i>
+              <h3 class="text-gray-600 mt-2">No upcoming events</h3>
+              <p class="text-sm text-gray-400 mt-1">No upcoming events were found for your organization.</p>
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
+</lfx-table>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-upcoming-events-table/org-upcoming-events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-upcoming-events-table/org-upcoming-events-table.component.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, input, output } from '@angular/core';
+import { TableComponent } from '@components/table/table.component';
+import { TagComponent } from '@components/tag/tag.component';
+import type { OrgEvent, OrgEventRowVm, OrgEventsResponse, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-org-upcoming-events-table',
+  imports: [TableComponent, TagComponent, DecimalPipe],
+  templateUrl: './org-upcoming-events-table.component.html',
+})
+export class OrgUpcomingEventsTableComponent {
+  public readonly eventsResponse = input.required<OrgEventsResponse>();
+  public readonly loading = input<boolean>(false);
+  public readonly sortField = input<string>('EVENT_START_DATE');
+  public readonly sortOrder = input<'ASC' | 'DESC'>('ASC');
+
+  public readonly pageChange = output<PageChangeEvent>();
+  public readonly sortChange = output<SortChangeEvent>();
+  public readonly attendeesClick = output<OrgEvent>();
+  public readonly speakersClick = output<OrgEvent>();
+
+  protected readonly rppOptions = computed<number[] | undefined>(() => (this.eventsResponse().total > 10 ? [10, 25, 50] : undefined));
+
+  // Pre-bake the formatted date range per row so the template reads a property instead of calling a method each CD cycle.
+  protected readonly rows = computed<OrgEventRowVm[]>(() =>
+    this.eventsResponse().data.map((event) => ({ ...event, dateRange: this.formatDateRange(event.eventStartDate, event.eventEndDate) }))
+  );
+
+  protected readonly sortAriaMap = computed<Record<string, string>>(() => {
+    const field = this.sortField();
+    const order = this.sortOrder();
+    const forField = (f: string): string => {
+      if (field !== f) return 'none';
+      return order === 'ASC' ? 'ascending' : 'descending';
+    };
+    return {
+      EVENT_NAME: forField('EVENT_NAME'),
+      EVENT_START_DATE: forField('EVENT_START_DATE'),
+      EVENT_CITY: forField('EVENT_CITY'),
+    };
+  });
+
+  protected readonly sortIcons = computed(() => {
+    const field = this.sortField();
+    const order = this.sortOrder();
+    const getIcon = (f: string): string => {
+      if (field !== f) return 'fa-light fa-sort text-gray-300';
+      return order === 'ASC' ? 'fa-solid fa-caret-up text-blue-500' : 'fa-solid fa-caret-down text-blue-500';
+    };
+    return {
+      EVENT_NAME: getIcon('EVENT_NAME'),
+      EVENT_START_DATE: getIcon('EVENT_START_DATE'),
+      EVENT_CITY: getIcon('EVENT_CITY'),
+    };
+  });
+
+  protected onPageChange(event: { first: number; rows: number }): void {
+    this.pageChange.emit({ offset: event.first, pageSize: event.rows });
+  }
+
+  protected onHeaderClick(field: string): void {
+    this.sortChange.emit({ field });
+  }
+
+  private formatDateRange(start: string | null, end: string | null): string {
+    if (!start) return '—';
+    const startDate = new Date(start);
+    const singleFormat = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+    if (!end) return singleFormat;
+    const endDate = new Date(end);
+    if (startDate.toISOString().slice(0, 10) === endDate.toISOString().slice(0, 10)) return singleFormat;
+    const sameMonthYear = startDate.getUTCMonth() === endDate.getUTCMonth() && startDate.getUTCFullYear() === endDate.getUTCFullYear();
+    if (sameMonthYear) {
+      const month = startDate.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+      return `${month} ${startDate.getUTCDate()} – ${endDate.getUTCDate()}, ${startDate.getUTCFullYear()}`;
+    }
+    const startStr = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    const endStr = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+    return `${startStr} – ${endStr}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -24,14 +24,14 @@
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'upcoming'"
-        [class.ring-2]="activeStatFilter() === 'upcoming'"
-        [class.ring-inset]="activeStatFilter() === 'upcoming'"
-        [class.ring-blue-500]="activeStatFilter() === 'upcoming'"
-        [attr.aria-pressed]="activeStatFilter() === 'upcoming'"
-        (click)="applyEventsStatFilter('upcoming')"
+        [class.bg-blue-50]="activeTab() === 'upcoming'"
+        [class.ring-2]="activeTab() === 'upcoming'"
+        [class.ring-inset]="activeTab() === 'upcoming'"
+        [class.ring-blue-500]="activeTab() === 'upcoming'"
+        [attr.aria-pressed]="activeTab() === 'upcoming'"
+        (click)="onStatCardClick('upcoming')"
         data-testid="org-events-stat-upcoming"
-        aria-label="Filter by upcoming events">
+        aria-label="Show upcoming events">
         <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
           <i class="fa-light fa-calendar-plus text-xl" aria-hidden="true"></i>
         </div>
@@ -47,14 +47,14 @@
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'past'"
-        [class.ring-2]="activeStatFilter() === 'past'"
-        [class.ring-inset]="activeStatFilter() === 'past'"
-        [class.ring-blue-500]="activeStatFilter() === 'past'"
-        [attr.aria-pressed]="activeStatFilter() === 'past'"
-        (click)="applyEventsStatFilter('past')"
+        [class.bg-blue-50]="activeTab() === 'past'"
+        [class.ring-2]="activeTab() === 'past'"
+        [class.ring-inset]="activeTab() === 'past'"
+        [class.ring-blue-500]="activeTab() === 'past'"
+        [attr.aria-pressed]="activeTab() === 'past'"
+        (click)="onStatCardClick('past')"
         data-testid="org-events-stat-past"
-        aria-label="Filter by past events">
+        aria-label="Show past events">
         <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
           <i class="fa-light fa-calendar-check text-xl" aria-hidden="true"></i>
         </div>
@@ -70,14 +70,9 @@
       <button
         type="button"
         class="flex items-center gap-3 p-4 text-left w-full transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
-        [class.bg-blue-50]="activeStatFilter() === 'total'"
-        [class.ring-2]="activeStatFilter() === 'total'"
-        [class.ring-inset]="activeStatFilter() === 'total'"
-        [class.ring-blue-500]="activeStatFilter() === 'total'"
-        [attr.aria-pressed]="activeStatFilter() === 'total'"
-        (click)="applyEventsStatFilter('total')"
+        (click)="onStatCardClick('total')"
         data-testid="org-events-stat-total"
-        aria-label="Filter by total events">
+        aria-label="Show upcoming events">
         <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
           <i class="fa-light fa-ticket text-xl" aria-hidden="true"></i>
         </div>
@@ -91,86 +86,86 @@
     </div>
   </lfx-card>
 
-  <!-- Filter Bar -->
-  <div class="bg-white rounded-lg border border-gray-200 p-4" data-testid="org-events-filter-bar">
-    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
-      <div class="flex-1 relative">
-        <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" aria-hidden="true"></i>
-        <label for="org-events-search-id" class="sr-only">Search events</label>
-        <input
-          id="org-events-search-id"
-          pInputText
-          type="text"
-          placeholder="Search events..."
-          class="w-full pl-9"
-          data-testid="org-events-search-input"
-          [ngModel]="searchTerm()"
-          (ngModelChange)="searchTerm.set($event)" />
-      </div>
-      <div class="w-full sm:w-48" data-testid="org-events-status-filter">
-        <label for="org-events-status-id" class="sr-only">Filter by status</label>
-        <p-select
-          inputId="org-events-status-id"
-          ariaLabel="Filter by status"
-          [options]="statusOptions"
-          optionLabel="label"
-          optionValue="value"
-          styleClass="w-full"
-          [ngModel]="selectedStatus()"
-          (ngModelChange)="selectedStatus.set($event)" />
+  <!-- Events Card: tabs + search + table all in one -->
+  <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="org-events-main-card">
+    <!-- Tab Pills Bar -->
+    <lfx-card-tabs-bar [options]="tabPillOptions()" [selectedFilter]="activeTab()" (filterChange)="switchTab($event)" data-testid="org-events-tab-pills" />
+
+    <!-- Search and Filters -->
+    <div class="px-5 pt-4 pb-3">
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="flex-1 relative">
+          <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" aria-hidden="true"></i>
+          <label for="org-events-search-id" class="sr-only">Search events</label>
+          <input
+            id="org-events-search-id"
+            pInputText
+            type="text"
+            placeholder="Search events..."
+            class="w-full pl-9"
+            data-testid="org-events-search-input"
+            [ngModel]="searchTerm()"
+            (ngModelChange)="searchTerm.set($event)" />
+        </div>
+        <div class="w-full sm:w-48" data-testid="org-events-status-filter">
+          <label for="org-events-status-id" class="sr-only">Filter by status</label>
+          <p-select
+            inputId="org-events-status-id"
+            ariaLabel="Filter by status"
+            [options]="statusOptions"
+            optionLabel="label"
+            optionValue="value"
+            styleClass="w-full"
+            [ngModel]="selectedStatus()"
+            (ngModelChange)="selectedStatus.set($event)" />
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- Tab Strip -->
-  <div
-    role="tablist"
-    aria-label="Events sections"
-    class="flex items-center gap-1 border-b border-gray-200 overflow-x-auto"
-    data-testid="org-events-tab-bar"
-    (keydown)="onTabKeydown($event)">
-    @for (tab of tabs; track tab.id) {
-      <button
-        type="button"
-        role="tab"
-        class="flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap"
-        [id]="'org-events-tab-' + tab.id"
-        [attr.aria-selected]="activeTab() === tab.id"
-        [attr.aria-controls]="'org-events-panel-' + tab.id"
-        [attr.tabindex]="activeTab() === tab.id ? 0 : -1"
-        [attr.data-testid]="'org-events-tab-' + tab.id"
-        [class.border-blue-600]="activeTab() === tab.id"
-        [class.text-blue-600]="activeTab() === tab.id"
-        [class.border-transparent]="activeTab() !== tab.id"
-        [class.text-gray-500]="activeTab() !== tab.id"
-        [class.hover:text-gray-700]="activeTab() !== tab.id"
-        (click)="switchTab(tab.id)">
-        <i [class]="tab.icon" aria-hidden="true"></i>
-        {{ tab.label }}
-      </button>
-    }
-  </div>
+    <!-- Tab Panels -->
+    <div class="px-5 pb-5">
+      @if (activeTab() === 'upcoming') {
+        <section id="org-events-panel-upcoming" data-testid="org-events-panel-upcoming">
+          <lfx-org-upcoming-events-table
+            [eventsResponse]="upcomingEvents()"
+            [loading]="upcomingEventsLoading()"
+            [sortField]="upcomingSortField()"
+            [sortOrder]="upcomingSortOrder()"
+            (pageChange)="onUpcomingPageChange($event)"
+            (sortChange)="onUpcomingSortChange($event)"
+            (attendeesClick)="onAttendeesClick($event)"
+            (speakersClick)="onSpeakersClick($event)"
+            data-testid="org-events-upcoming-table" />
+        </section>
+      }
 
-  <!-- Tab Panels -->
-  @if (activeTab() === 'upcoming') {
-    <section role="tabpanel" id="org-events-panel-upcoming" aria-labelledby="org-events-tab-upcoming" data-testid="org-events-panel-upcoming">
-      <lfx-empty-state
-        [withCard]="false"
-        icon="fa-light fa-calendar-plus"
-        title="Coming soon"
-        subtitle="Upcoming events for your organization are being built. Check back later."
-        data-testid="org-events-upcoming-coming-soon" />
-    </section>
-  }
+      @if (activeTab() === 'past') {
+        <section id="org-events-panel-past" data-testid="org-events-panel-past">
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-calendar-check"
+            title="Coming soon"
+            subtitle="Past events for your organization are being built. Check back later."
+            data-testid="org-events-past-coming-soon" />
+        </section>
+      }
+    </div>
+  </lfx-card>
 
-  @if (activeTab() === 'past') {
-    <section role="tabpanel" id="org-events-panel-past" aria-labelledby="org-events-tab-past" data-testid="org-events-panel-past">
-      <lfx-empty-state
-        [withCard]="false"
-        icon="fa-light fa-calendar-check"
-        title="Coming soon"
-        subtitle="Past events for your organization are being built. Check back later."
-        data-testid="org-events-past-coming-soon" />
-    </section>
-  }
+  <!-- Drawers -->
+  <lfx-event-attendees-drawer
+    [visible]="attendeesDrawerVisible()"
+    (visibleChange)="attendeesDrawerVisible.set($event)"
+    [eventId]="activeDrawerEvent()?.eventId ?? ''"
+    [eventName]="activeDrawerEvent()?.eventName ?? ''"
+    [attendeeCount]="activeDrawerEvent()?.orgAttendeeCount ?? 0"
+    data-testid="org-events-attendees-drawer" />
+  <lfx-event-speakers-drawer
+    [visible]="speakersDrawerVisible()"
+    (visibleChange)="speakersDrawerVisible.set($event)"
+    [eventId]="activeDrawerEvent()?.eventId ?? ''"
+    [eventName]="activeDrawerEvent()?.eventName ?? ''"
+    [acceptedCount]="activeDrawerEvent()?.orgSpeakerAcceptedCount ?? 0"
+    [submittedCount]="activeDrawerEvent()?.orgSpeakerSubmittedCount ?? 0"
+    data-testid="org-events-speakers-drawer" />
 </main>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -1,27 +1,58 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { SelectModule } from 'primeng/select';
+import { MessageService } from 'primeng/api';
 import { InputTextModule } from 'primeng/inputtext';
-import { catchError, filter, of, switchMap } from 'rxjs';
+import { SelectModule } from 'primeng/select';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, finalize, of, skip, switchMap, tap } from 'rxjs';
 
 import { CardComponent } from '@components/card/card.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { DEFAULT_ORG_EVENTS_TAB_ID, ORG_EVENTS_STATUS_OPTIONS, ORG_EVENTS_TABS, VALID_ORG_EVENTS_TAB_IDS } from '@lfx-one/shared/constants';
-import type { OrgEventStatFilterId, OrgEventsSummary, OrgEventsTabId } from '@lfx-one/shared/interfaces';
+import {
+  DEFAULT_EVENTS_PAGE_SIZE,
+  DEFAULT_ORG_EVENTS_TAB_ID,
+  EMPTY_ORG_EVENTS_RESPONSE,
+  ORG_EVENTS_STATUS_OPTIONS,
+  ORG_EVENTS_TABS,
+  VALID_ORG_EVENTS_TAB_IDS,
+} from '@lfx-one/shared/constants';
+import type {
+  FilterPillOption,
+  OrgEvent,
+  OrgEventStatFilterId,
+  OrgEventsResponse,
+  OrgEventsSummary,
+  OrgEventsTabId,
+  PageChangeEvent,
+  SortChangeEvent,
+} from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { EventsService } from '@services/events.service';
 
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
+import { EventAttendeesDrawerComponent } from './components/event-attendees-drawer/event-attendees-drawer.component';
+import { EventSpeakersDrawerComponent } from './components/event-speakers-drawer/event-speakers-drawer.component';
+import { OrgUpcomingEventsTableComponent } from './components/org-upcoming-events-table/org-upcoming-events-table.component';
 
 @Component({
   selector: 'lfx-org-events-dashboard',
-  imports: [FormsModule, CardComponent, EmptyStateComponent, SelectModule, InputTextModule, DiscoverEventsButtonComponent],
+  imports: [
+    FormsModule,
+    CardComponent,
+    CardTabsBarComponent,
+    EmptyStateComponent,
+    SelectModule,
+    InputTextModule,
+    DiscoverEventsButtonComponent,
+    EventAttendeesDrawerComponent,
+    EventSpeakersDrawerComponent,
+    OrgUpcomingEventsTableComponent,
+  ],
   templateUrl: './org-events-dashboard.component.html',
 })
 export class OrgEventsDashboardComponent {
@@ -30,29 +61,58 @@ export class OrgEventsDashboardComponent {
   private readonly router = inject(Router);
   private readonly accountContext = inject(AccountContextService);
   private readonly eventsService = inject(EventsService);
-  private readonly platformId = inject(PLATFORM_ID);
+  private readonly messageService = inject(MessageService);
 
   // === Template constants ===
-  public readonly tabs = ORG_EVENTS_TABS;
   public readonly statusOptions = ORG_EVENTS_STATUS_OPTIONS;
 
   // === WritableSignals ===
-  // activeStatFilter drives card highlight + aria-pressed; filter wiring to the events table arrives in LFXV2-1899
-  public readonly activeStatFilter = signal<OrgEventStatFilterId | null>(null);
+  public readonly attendeesDrawerVisible = signal(false);
+  public readonly speakersDrawerVisible = signal(false);
+  public readonly activeDrawerEvent = signal<OrgEvent | null>(null);
   public readonly searchTerm = signal('');
   public readonly selectedStatus = signal<string | null>(null);
+  public readonly upcomingEventsLoading = signal(true);
+  public readonly upcomingEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
+  public readonly upcomingSortField = signal('EVENT_START_DATE');
+  public readonly upcomingSortOrder = signal<'ASC' | 'DESC'>('ASC');
 
   // === Computed / toSignal ===
+  // Debounced search feeds the server-side query so typing doesn't fire a request per keystroke.
+  private readonly debouncedSearchTerm = toSignal(toObservable(this.searchTerm).pipe(debounceTime(300), distinctUntilChanged()), { initialValue: '' });
   public readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
   public readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
   public readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
+  public readonly upcomingEvents: Signal<OrgEventsResponse> = this.initUpcomingEvents();
+  public readonly tabPillOptions = computed<FilterPillOption[]>(() => {
+    const summary = this.eventsSummary();
+    return ORG_EVENTS_TABS.map((tab) => {
+      let count: number | null = null;
+      if (summary !== null) {
+        count = tab.id === 'upcoming' ? summary.upcomingEvents : summary.pastEvents;
+      }
+      return { id: tab.id, label: count !== null ? `${tab.label} (${count})` : tab.label };
+    });
+  });
 
-  // === Public methods ===
-  public applyEventsStatFilter(id: OrgEventStatFilterId): void {
-    this.activeStatFilter.set(this.activeStatFilter() === id ? null : id);
+  public constructor() {
+    combineLatest([toObservable(this.debouncedSearchTerm), toObservable(this.selectedStatus)])
+      .pipe(skip(1), takeUntilDestroyed())
+      .subscribe(() => {
+        this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
+      });
   }
 
-  public switchTab(tabId: OrgEventsTabId): void {
+  // === Public methods ===
+  // Stat cards are tab shortcuts: Upcoming/Total jump to the upcoming tab, Past to the past tab.
+  public onStatCardClick(id: OrgEventStatFilterId): void {
+    this.switchTab(id === 'past' ? 'past' : 'upcoming');
+  }
+
+  public switchTab(tabId: string): void {
+    if (!VALID_ORG_EVENTS_TAB_IDS.has(tabId as OrgEventsTabId)) {
+      return;
+    }
     if (tabId === this.activeTab()) {
       return;
     }
@@ -64,21 +124,31 @@ export class OrgEventsDashboardComponent {
     });
   }
 
-  public onTabKeydown(event: KeyboardEvent): void {
-    const ids = this.tabs.map((t) => t.id);
-    const idx = ids.indexOf(this.activeTab());
-    let next: number | null = null;
-    if (event.key === 'ArrowRight') next = (idx + 1) % ids.length;
-    else if (event.key === 'ArrowLeft') next = (idx - 1 + ids.length) % ids.length;
-    else if (event.key === 'Home') next = 0;
-    else if (event.key === 'End') next = ids.length - 1;
-    if (next !== null) {
-      event.preventDefault();
-      this.switchTab(ids[next]);
-      if (isPlatformBrowser(this.platformId)) {
-        (document.getElementById(`org-events-tab-${ids[next]}`) as HTMLElement | null)?.focus();
-      }
+  public onAttendeesClick(event: OrgEvent): void {
+    this.activeDrawerEvent.set(event);
+    this.speakersDrawerVisible.set(false);
+    this.attendeesDrawerVisible.set(true);
+  }
+
+  public onSpeakersClick(event: OrgEvent): void {
+    this.activeDrawerEvent.set(event);
+    this.attendeesDrawerVisible.set(false);
+    this.speakersDrawerVisible.set(true);
+  }
+
+  public onUpcomingPageChange(event: PageChangeEvent): void {
+    this.upcomingEventsLoading.set(true);
+    this.upcomingEventsPage.set(event);
+  }
+
+  public onUpcomingSortChange(event: SortChangeEvent): void {
+    if (this.upcomingSortField() === event.field) {
+      this.upcomingSortOrder.set(this.upcomingSortOrder() === 'ASC' ? 'DESC' : 'ASC');
+    } else {
+      this.upcomingSortField.set(event.field);
+      this.upcomingSortOrder.set('ASC');
     }
+    this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
   }
 
   // === Private initializers ===
@@ -100,6 +170,44 @@ export class OrgEventsDashboardComponent {
         switchMap((id) => this.eventsService.getOrgEventsSummary(id).pipe(catchError(() => of(null))))
       ),
       { initialValue: null }
+    );
+  }
+
+  private initUpcomingEvents(): Signal<OrgEventsResponse> {
+    return toSignal(
+      toObservable(
+        computed(() => {
+          const accountId = this.accountContext.selectedAccount().accountId;
+          if (!accountId) return null;
+          return {
+            accountId,
+            ...this.upcomingEventsPage(),
+            searchQuery: this.debouncedSearchTerm() || undefined,
+            status: this.selectedStatus() ?? null,
+            sortField: this.upcomingSortField(),
+            sortOrder: this.upcomingSortOrder(),
+          };
+        })
+      ).pipe(
+        debounceTime(0),
+        filter((params): params is NonNullable<typeof params> => params !== null),
+        tap(() => this.upcomingEventsLoading.set(true)),
+        switchMap(({ accountId, ...params }) =>
+          this.eventsService.getOrgEvents(accountId, { ...params, isPast: false }).pipe(
+            catchError(() => {
+              this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: 'Failed to load upcoming events. Please try again.',
+              });
+              const { pageSize, offset } = this.upcomingEventsPage();
+              return of({ ...EMPTY_ORG_EVENTS_RESPONSE, pageSize, offset });
+            }),
+            finalize(() => this.upcomingEventsLoading.set(false))
+          )
+        )
+      ),
+      { initialValue: EMPTY_ORG_EVENTS_RESPONSE }
     );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -16,6 +16,8 @@ import {
   GetUpcomingCountriesResponse,
   MyEventOrganizationsResponse,
   MyEventsResponse,
+  OrgEventAttendeesDrawerResponse,
+  OrgEventSpeakersResponse,
   OrgEventsResponse,
   OrgEventsSummary,
   OrgSearchResponse,
@@ -135,6 +137,22 @@ export class EventsService {
     return this.http.get<OrgEventsSummary>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events/summary`);
   }
 
+  public getEventAttendees(accountId: string, eventId: string, searchQuery?: string): Observable<OrgEventAttendeesDrawerResponse> {
+    let httpParams = new HttpParams();
+    if (searchQuery) httpParams = httpParams.set('searchQuery', searchQuery);
+    return this.http.get<OrgEventAttendeesDrawerResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events/${encodeURIComponent(eventId)}/attendees`, {
+      params: httpParams,
+    });
+  }
+
+  public getEventSpeakers(accountId: string, eventId: string, searchQuery?: string): Observable<OrgEventSpeakersResponse> {
+    let httpParams = new HttpParams();
+    if (searchQuery) httpParams = httpParams.set('searchQuery', searchQuery);
+    return this.http.get<OrgEventSpeakersResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events/${encodeURIComponent(eventId)}/speakers`, {
+      params: httpParams,
+    });
+  }
+
   // Called by the upcoming/past events table — wired in LFXV2-1899.
   public getOrgEvents(accountId: string, params: GetOrgEventsParams = {}): Observable<OrgEventsResponse> {
     let httpParams = new HttpParams();
@@ -144,6 +162,7 @@ export class EventsService {
     if (params.status) httpParams = httpParams.set('status', params.status);
     if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
     if (params.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
+    if (params.sortField) httpParams = httpParams.set('sortField', params.sortField);
     if (params.sortOrder) httpParams = httpParams.set('sortOrder', params.sortOrder);
 
     return this.http.get<OrgEventsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events`, { params: httpParams });

--- a/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-events.controller.ts
@@ -27,7 +27,8 @@ export class OrgLensEventsController {
     try {
       this.assertAccountId(accountId, 'get_org_lens_events_summary');
 
-      if (!getEffectiveEmail(req)) {
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
         throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events_summary' });
       }
 
@@ -55,17 +56,19 @@ export class OrgLensEventsController {
         throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_events' });
       }
 
-      const rawPageSize = Number(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE);
-      const rawOffset = Number(req.query['offset'] ?? 0);
+      const rawPageSize = Math.trunc(Number(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE));
+      const rawOffset = Math.trunc(Number(req.query['offset'] ?? 0));
       const rawSortOrder = String(req.query['sortOrder'] ?? 'ASC').toUpperCase();
       const rawIsPast = req.query['isPast'];
       const rawStatus = getStringQueryParam(req, 'status');
+      const rawSortField = getStringQueryParam(req, 'sortField') ?? 'EVENT_START_DATE';
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
       const sortOrder = rawSortOrder === 'DESC' ? 'DESC' : 'ASC';
       const isPast = rawIsPast === 'true';
       const status = rawStatus && VALID_ORG_EVENT_STATUS_VALUES.has(rawStatus) ? rawStatus : null;
+      const sortField = rawSortField;
 
       const options: GetOrgEventsOptions = {
         isPast,
@@ -73,15 +76,81 @@ export class OrgLensEventsController {
         status,
         pageSize,
         offset,
+        sortField,
         sortOrder,
       };
 
-      const response = await this.service.getOrgEvents(req, accountId, userEmail, options);
+      const response = await this.service.getOrgEvents(req, accountId, options);
 
       logger.success(req, 'get_org_lens_events', startTime, {
         account_id: accountId,
         result_count: response.data.length,
         total: response.total,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:accountId/lens/events/:eventId/attendees */
+  public async getEventAttendees(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const eventId = req.params['eventId'];
+    const startTime = logger.startOperation(req, 'get_event_attendees', { account_id: accountId, event_id: eventId });
+
+    try {
+      this.assertAccountId(accountId, 'get_event_attendees');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_event_attendees' });
+      }
+
+      if (!eventId || typeof eventId !== 'string') {
+        throw ServiceValidationError.forField('eventId', 'eventId path parameter is required', { operation: 'get_event_attendees' });
+      }
+
+      const searchQuery = getStringQueryParam(req, 'searchQuery');
+      const response = await this.service.getEventAttendees(req, accountId, eventId, searchQuery ?? undefined);
+
+      logger.success(req, 'get_event_attendees', startTime, { account_id: accountId, event_id: eventId, count: response.total });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:accountId/lens/events/:eventId/speakers */
+  public async getEventSpeakers(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const eventId = req.params['eventId'];
+    const startTime = logger.startOperation(req, 'get_event_speakers', { account_id: accountId, event_id: eventId });
+
+    try {
+      this.assertAccountId(accountId, 'get_event_speakers');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_event_speakers' });
+      }
+
+      if (!eventId || typeof eventId !== 'string') {
+        throw ServiceValidationError.forField('eventId', 'eventId path parameter is required', { operation: 'get_event_speakers' });
+      }
+
+      const searchQuery = getStringQueryParam(req, 'searchQuery');
+      const response = await this.service.getEventSpeakers(req, accountId, eventId, searchQuery ?? undefined);
+
+      logger.success(req, 'get_event_speakers', startTime, {
+        account_id: accountId,
+        event_id: eventId,
+        accepted: response.acceptedCount,
+        submitted: response.submittedCount,
       });
 
       res.setHeader('Cache-Control', 'no-store');

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -37,8 +37,11 @@ function buildOrgsRouter(): Router {
   // `:orgUid` for backward compatibility; the value space is the SFID (validated by assertOrgUid).
   router.get('/:orgUid/lens/foundations-and-projects', (req, res, next) => orgLensFoundationsController.getFoundationsAndProjects(req, res, next));
   // Spec (LFXV2-1898) — Events page keys off the Salesforce accountId (not the b2b_org uuid), so these routes
-  // intentionally use `:accountId`. /events/summary MUST be registered before /events so Express matches the more-specific path first.
+  // intentionally use `:accountId`. /events is an exact path and won't capture /events/summary or the per-event
+  // /attendees and /speakers paths, so ordering isn't strictly required; they're grouped here for readability.
   router.get('/:accountId/lens/events/summary', (req, res, next) => orgLensEventsController.getOrgEventsSummary(req, res, next));
+  router.get('/:accountId/lens/events/:eventId/attendees', (req, res, next) => orgLensEventsController.getEventAttendees(req, res, next));
+  router.get('/:accountId/lens/events/:eventId/speakers', (req, res, next) => orgLensEventsController.getEventSpeakers(req, res, next));
   router.get('/:accountId/lens/events', (req, res, next) => orgLensEventsController.getOrgEvents(req, res, next));
   router.get('/:orgUid/lens/memberships/active', (req, res, next) => orgLensMembershipsController.getActiveMemberships(req, res, next));
   router.get('/:orgUid/lens/memberships/expired', (req, res, next) => orgLensMembershipsController.getExpiredMemberships(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -1,14 +1,27 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { GetOrgEventsOptions, OrgEvent, OrgEventRow, OrgEventsResponse, OrgEventsSummary, OrgEventsSummaryRow } from '@lfx-one/shared/interfaces';
+import type {
+  GetOrgEventsOptions,
+  OrgEvent,
+  OrgEventAttendee,
+  OrgEventAttendeesDrawerResponse,
+  OrgEventAttendeesDrawerRow,
+  OrgEventRow,
+  OrgEventSpeaker,
+  OrgEventSpeakersDrawerRow,
+  OrgEventSpeakersResponse,
+  OrgEventsResponse,
+  OrgEventsSummary,
+  OrgEventsSummaryRow,
+} from '@lfx-one/shared/interfaces';
 import { formatDateToUTC } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
 
-/** Service for org-lens event list endpoints — queries org employees' event footprint via Snowflake. */
+/** Service for org-lens event list endpoints — reads org event footprint from platinum ORG_EVENTS. */
 export class OrgLensEventsService {
   private readonly snowflakeService: SnowflakeService;
 
@@ -17,8 +30,12 @@ export class OrgLensEventsService {
   }
 
   /** GET /api/orgs/:accountId/lens/events — paginated list of events for the org. */
-  public async getOrgEvents(req: Request, accountId: string, userEmail: string, options: GetOrgEventsOptions): Promise<OrgEventsResponse> {
-    const { isPast, searchQuery, status, pageSize, offset, sortOrder } = options;
+  public async getOrgEvents(req: Request, accountId: string, options: GetOrgEventsOptions): Promise<OrgEventsResponse> {
+    const { isPast, searchQuery, status, pageSize, offset, sortField, sortOrder } = options;
+
+    /** Allowlist of columns that may appear in ORDER BY to prevent SQL injection. */
+    const VALID_SORT_COLUMNS: ReadonlySet<string> = new Set(['EVENT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']);
+    const sortColumn = VALID_SORT_COLUMNS.has(sortField) ? sortField : 'EVENT_START_DATE';
 
     logger.debug(req, 'get_org_lens_events', 'Building org events query', {
       account_id: accountId,
@@ -29,79 +46,48 @@ export class OrgLensEventsService {
       offset,
     });
 
-    const searchQueryFilter = searchQuery ? 'AND o.EVENT_NAME ILIKE ?' : '';
+    const searchQueryFilter = searchQuery ? 'AND oe.EVENT_NAME ILIKE ?' : '';
     let statusFilter = '';
     if (status === 'registered') {
-      statusFilter = 'AND u.EVENT_ID IS NOT NULL';
-    } else if (status === 'not-registered') {
-      statusFilter = 'AND u.EVENT_ID IS NULL';
+      statusFilter = 'AND oe.ORG_REGISTRATION_COUNT > 0';
+    } else if (status === 'speaker-submitted') {
+      statusFilter = 'AND oe.ORG_SPEAKER_SUBMITTED_COUNT > 0';
+    } else if (status === 'speaker-accepted') {
+      statusFilter = 'AND oe.ORG_SPEAKER_ACCEPTED_COUNT > 0';
+    } else if (status === 'event-sponsor') {
+      statusFilter = 'AND oe.IS_ORG_SPONSOR = TRUE';
     }
 
-    const isPastCondition = isPast ? 'TRUE' : 'FALSE';
+    const pastCondition = isPast ? 'oe.IS_PAST_EVENT = TRUE' : 'oe.IS_PAST_EVENT = FALSE';
 
     const sql = `
-      WITH account AS (
-        SELECT ACCOUNT_NAME
-        FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT
-        WHERE ACCOUNT_ID = ?
-        LIMIT 1
-      ),
-      org_events AS (
-        SELECT
-          er.EVENT_ID,
-          er.EVENT_NAME,
-          er.PROJECT_NAME AS FOUNDATION,
-          er.EVENT_START_DATE,
-          er.EVENT_END_DATE,
-          er.EVENT_LOCATION,
-          er.EVENT_CITY,
-          er.EVENT_COUNTRY,
-          er.EVENT_URL,
-          er.EVENT_REGISTRATION_URL,
-          COUNT(DISTINCT er.USER_EMAIL) AS ORG_ATTENDEE_COUNT
-        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS er
-        JOIN account a ON UPPER(er.ACCOUNT_NAME) = UPPER(a.ACCOUNT_NAME)
-        WHERE er.IS_PAST_EVENT = ${isPastCondition}
-          AND er.REGISTRATION_STATUS = 'Accepted'
-        GROUP BY
-          er.EVENT_ID, er.EVENT_NAME, er.PROJECT_NAME,
-          er.EVENT_START_DATE, er.EVENT_END_DATE,
-          er.EVENT_LOCATION, er.EVENT_CITY, er.EVENT_COUNTRY,
-          er.EVENT_URL, er.EVENT_REGISTRATION_URL
-      ),
-      user_reg AS (
-        SELECT EVENT_ID
-        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-        WHERE USER_EMAIL = ?
-          AND IS_PAST_EVENT = ${isPastCondition}
-          AND REGISTRATION_STATUS = 'Accepted'
-      )
       SELECT
-        o.EVENT_ID,
-        o.EVENT_NAME,
-        o.FOUNDATION,
-        o.EVENT_START_DATE,
-        o.EVENT_END_DATE,
-        o.EVENT_LOCATION,
-        o.EVENT_CITY,
-        o.EVENT_COUNTRY,
-        o.EVENT_URL,
-        o.EVENT_REGISTRATION_URL,
-        o.ORG_ATTENDEE_COUNT,
-        (u.EVENT_ID IS NOT NULL) AS IS_REGISTERED,
+        oe.EVENT_ID,
+        oe.EVENT_NAME,
+        oe.FOUNDATION_NAME,
+        oe.EVENT_START_DATE,
+        oe.EVENT_END_DATE,
+        oe.EVENT_LOCATION,
+        oe.EVENT_CITY,
+        oe.EVENT_COUNTRY,
+        oe.EVENT_URL,
+        oe.EVENT_REGISTRATION_URL,
+        oe.ORG_REGISTRATION_COUNT,
+        NULLIF(oe.EVENT_REGISTRATIONS_GOAL, 0) AS EVENT_REGISTRATIONS_GOAL,
+        oe.ORG_SPEAKER_ACCEPTED_COUNT,
+        oe.ORG_SPEAKER_SUBMITTED_COUNT,
+        oe.IS_ORG_SPONSOR,
         COUNT(*) OVER() AS TOTAL_RECORDS
-      FROM org_events o
-      LEFT JOIN user_reg u ON o.EVENT_ID = u.EVENT_ID
-      WHERE 1=1
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENTS oe
+      WHERE oe.ACCOUNT_ID = ?
+        AND ${pastCondition}
         ${searchQueryFilter}
         ${statusFilter}
-      -- pageSize, offset, and sortOrder are pre-validated by the controller (numeric bounds + allowlist);
-      -- structural keywords cannot be bound via Snowflake ? params, so they are interpolated here.
-      ORDER BY o.EVENT_START_DATE ${sortOrder}
+      ORDER BY oe.${sortColumn} ${sortOrder}
       LIMIT ${pageSize} OFFSET ${offset}
     `;
 
-    const binds: string[] = [accountId, userEmail];
+    const binds: string[] = [accountId];
     if (searchQuery) binds.push(`%${searchQuery}%`);
 
     let result;
@@ -128,19 +114,12 @@ export class OrgLensEventsService {
     logger.debug(req, 'get_org_lens_events_summary', 'Building org events summary query', { account_id: accountId });
 
     const sql = `
-      WITH account AS (
-        SELECT ACCOUNT_NAME
-        FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_ACCOUNT_CONTEXT
-        WHERE ACCOUNT_ID = ?
-        LIMIT 1
-      )
       SELECT
-        COUNT(DISTINCT er.EVENT_ID)                                               AS TOTAL_EVENTS,
-        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = TRUE  THEN er.EVENT_ID END)  AS PAST_EVENTS,
-        COUNT(DISTINCT CASE WHEN er.IS_PAST_EVENT = FALSE THEN er.EVENT_ID END)  AS UPCOMING_EVENTS
-      FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS er
-      JOIN account a ON UPPER(er.ACCOUNT_NAME) = UPPER(a.ACCOUNT_NAME)
-      WHERE er.REGISTRATION_STATUS = 'Accepted'
+        COUNT(*)                                                                                    AS TOTAL_EVENTS,
+        COUNT(CASE WHEN oe.IS_PAST_EVENT = TRUE  THEN 1 END)                                       AS PAST_EVENTS,
+        COUNT(CASE WHEN oe.IS_PAST_EVENT = FALSE THEN 1 END)                                       AS UPCOMING_EVENTS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENTS oe
+      WHERE oe.ACCOUNT_ID = ?
     `;
 
     let result;
@@ -166,11 +145,117 @@ export class OrgLensEventsService {
     return summary;
   }
 
+  /** GET /api/orgs/:accountId/lens/events/:eventId/attendees — org registrants for a specific event. */
+  public async getEventAttendees(req: Request, accountId: string, eventId: string, searchQuery?: string): Promise<OrgEventAttendeesDrawerResponse> {
+    logger.debug(req, 'get_event_attendees', 'Fetching event attendees', { account_id: accountId, event_id: eventId });
+
+    const searchFilter = searchQuery ? 'AND (UPPER(COALESCE(er.FULL_NAME, er.EMAIL)) LIKE UPPER(?) OR UPPER(er.EMAIL) LIKE UPPER(?))' : '';
+
+    const sql = `
+      SELECT
+        er.EMAIL                                       AS CONTACT_ID,
+        MAX(COALESCE(p.NAME, er.FULL_NAME, er.EMAIL))  AS NAME,
+        MAX(COALESCE(p.TITLE, er.JOB_TITLE))           AS JOB_TITLE,
+        MAX(er.EVENT_NAME)                             AS EVENT_NAME
+      FROM ANALYTICS.SILVER_FACT.EVENT_REGISTRATIONS er
+      LEFT JOIN ANALYTICS.PLATINUM_LFX_ONE.ORG_PEOPLE_ALL p
+        ON UPPER(p.EMAIL) = UPPER(er.EMAIL) AND p.ACCOUNT_ID = ?
+      WHERE er.EVENT_ID = ?
+        AND er.ACCOUNT_ID = ?
+        ${searchFilter}
+      GROUP BY er.EMAIL
+      ORDER BY NAME ASC NULLS LAST
+    `;
+
+    const binds: string[] = [accountId, eventId, accountId];
+    if (searchQuery) {
+      binds.push(`%${searchQuery}%`, `%${searchQuery}%`);
+    }
+
+    let result;
+    try {
+      result = await this.snowflakeService.execute<OrgEventAttendeesDrawerRow>(sql, binds);
+    } catch (error) {
+      logger.warning(req, 'get_event_attendees', 'Snowflake query failed, returning empty attendees', {
+        error: error instanceof Error ? error.message : String(error),
+        account_id: accountId,
+        event_id: eventId,
+      });
+      return { eventId, eventName: '', total: 0, data: [] };
+    }
+
+    const eventName = result.rows[0]?.EVENT_NAME ?? '';
+    const data: OrgEventAttendee[] = result.rows.map((row) => ({
+      contactId: row.CONTACT_ID,
+      name: row.NAME ?? row.CONTACT_ID,
+      jobTitle: row.JOB_TITLE ?? null,
+    }));
+
+    logger.debug(req, 'get_event_attendees', 'Fetched event attendees', { count: data.length, event_id: eventId });
+
+    return { eventId, eventName, total: data.length, data };
+  }
+
+  /** GET /api/orgs/:accountId/lens/events/:eventId/speakers — org speakers (accepted + submitted) for a specific event. */
+  public async getEventSpeakers(req: Request, accountId: string, eventId: string, searchQuery?: string): Promise<OrgEventSpeakersResponse> {
+    logger.debug(req, 'get_event_speakers', 'Fetching event speakers', { account_id: accountId, event_id: eventId });
+
+    const speakerName = "COALESCE(NULLIF(TRIM(es.SPEAKER_FIRST_NAME || ' ' || es.SPEAKER_LAST_NAME), ''), es.SPEAKER_EMAIL)";
+    const searchFilter = searchQuery ? `AND (UPPER(${speakerName}) LIKE UPPER(?) OR UPPER(es.SPEAKER_EMAIL) LIKE UPPER(?))` : '';
+
+    const sql = `
+      SELECT
+        es.SPEAKER_ID                                         AS CONTACT_ID,
+        MAX(${speakerName})                                   AS NAME,
+        MAX(es.JOB_TITLE)                                     AS JOB_TITLE,
+        MAX(CASE WHEN es.SPEAKER_STATUS = 'Accepted' THEN 1 ELSE 0 END) AS IS_ACCEPTED,
+        MAX(es.EVENT_NAME)                                    AS EVENT_NAME
+      FROM ANALYTICS.SILVER_FACT.EVENT_SPEAKERS es
+      WHERE es.EVENT_ID = ?
+        AND es.ACCOUNT_ID = ?
+        ${searchFilter}
+      GROUP BY es.SPEAKER_ID
+      ORDER BY NAME ASC NULLS LAST
+    `;
+
+    const binds: string[] = [eventId, accountId];
+    if (searchQuery) {
+      binds.push(`%${searchQuery}%`, `%${searchQuery}%`);
+    }
+
+    let result;
+    try {
+      result = await this.snowflakeService.execute<OrgEventSpeakersDrawerRow>(sql, binds);
+    } catch (error) {
+      logger.warning(req, 'get_event_speakers', 'Snowflake query failed, returning empty speakers', {
+        error: error instanceof Error ? error.message : String(error),
+        account_id: accountId,
+        event_id: eventId,
+      });
+      return { eventId, eventName: '', acceptedCount: 0, submittedCount: 0, data: [] };
+    }
+
+    const eventName = result.rows[0]?.EVENT_NAME ?? '';
+    const data: OrgEventSpeaker[] = result.rows.map((row) => ({
+      contactId: row.CONTACT_ID,
+      name: row.NAME ?? row.CONTACT_ID,
+      jobTitle: row.JOB_TITLE ?? null,
+      status: row.IS_ACCEPTED ? 'ACCEPTED' : 'SUBMITTED',
+    }));
+
+    const acceptedCount = data.filter((s) => s.status === 'ACCEPTED').length;
+    const submittedCount = data.length;
+
+    logger.debug(req, 'get_event_speakers', 'Fetched event speakers', { accepted: acceptedCount, submitted: submittedCount, event_id: eventId });
+
+    return { eventId, eventName, acceptedCount, submittedCount, data };
+  }
+
   private mapRowToOrgEvent(row: OrgEventRow): OrgEvent {
     return {
       eventId: row.EVENT_ID,
       eventName: row.EVENT_NAME,
-      foundation: row.FOUNDATION ?? null,
+      foundation: row.FOUNDATION_NAME ?? null,
       eventStartDate: formatDateToUTC(row.EVENT_START_DATE),
       eventEndDate: row.EVENT_END_DATE ? formatDateToUTC(row.EVENT_END_DATE) : null,
       eventLocation: row.EVENT_LOCATION ?? null,
@@ -178,8 +263,11 @@ export class OrgLensEventsService {
       eventCountry: row.EVENT_COUNTRY ?? null,
       eventUrl: row.EVENT_URL ?? null,
       eventRegistrationUrl: row.EVENT_REGISTRATION_URL ?? null,
-      orgAttendeeCount: row.ORG_ATTENDEE_COUNT || 0,
-      isRegistered: !!row.IS_REGISTERED,
+      orgAttendeeCount: row.ORG_REGISTRATION_COUNT || 0,
+      eventRegistrationsGoal: row.EVENT_REGISTRATIONS_GOAL ?? null,
+      orgSpeakerAcceptedCount: row.ORG_SPEAKER_ACCEPTED_COUNT || 0,
+      orgSpeakerSubmittedCount: row.ORG_SPEAKER_SUBMITTED_COUNT || 0,
+      isOrgSponsor: !!row.IS_ORG_SPONSOR,
     };
   }
 }

--- a/packages/shared/src/constants/org-events.constants.ts
+++ b/packages/shared/src/constants/org-events.constants.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type { FilterOption } from '../interfaces';
-import type { OrgEventsTabConfig, OrgEventsTabId } from '../interfaces/org-events.interface';
+import type { OrgEventsResponse, OrgEventsTabConfig, OrgEventsTabId } from '../interfaces/org-events.interface';
+import { DEFAULT_EVENTS_PAGE_SIZE } from './events.constants';
 
 /** Org Events page tabs in visible order (`upcoming` is the default). */
 export const ORG_EVENTS_TABS: readonly OrgEventsTabConfig[] = [
@@ -16,12 +17,17 @@ export const DEFAULT_ORG_EVENTS_TAB_ID: OrgEventsTabId = 'upcoming';
 /** Derived from ORG_EVENTS_TABS; used to validate `?tab=` query-param input. */
 export const VALID_ORG_EVENTS_TAB_IDS: ReadonlySet<OrgEventsTabId> = new Set(ORG_EVENTS_TABS.map((t) => t.id));
 
+/** Empty response sentinel for the Org Events list. */
+export const EMPTY_ORG_EVENTS_RESPONSE: OrgEventsResponse = { data: [], total: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE, offset: 0 };
+
 /** Status filter options for the Org Events filter bar. */
 export const ORG_EVENTS_STATUS_OPTIONS: FilterOption[] = [
   { label: 'All Statuses', value: null },
-  { label: 'Not Registered', value: 'not-registered' },
   { label: 'Registered', value: 'registered' },
+  { label: 'Speaker Submitted', value: 'speaker-submitted' },
+  { label: 'Speaker Accepted', value: 'speaker-accepted' },
+  { label: 'Event Sponsor', value: 'event-sponsor' },
 ];
 
 /** Valid org event status values for server-side validation. */
-export const VALID_ORG_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'not-registered']);
+export const VALID_ORG_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'speaker-submitted', 'speaker-accepted', 'event-sponsor']);

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -201,6 +201,9 @@ export * from './org-people-contributors.interface';
 // Org Events interfaces
 export * from './org-events.interface';
 
+// Org Events internal backend query-row shapes
+export * from './org-events-internal.interface';
+
 // Newsletter interfaces
 export * from './newsletter.interface';
 

--- a/packages/shared/src/interfaces/org-events-internal.interface.ts
+++ b/packages/shared/src/interfaces/org-events-internal.interface.ts
@@ -1,0 +1,51 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Internal Snowflake query-row shapes for the Org Lens Events backend service.
+// These mirror raw column names returned by the queries in org-lens-events.service.ts.
+// They live in the shared package because CLAUDE.md prohibits module-level interfaces
+// inside apps/lfx-one/; they are not part of the public API surface consumed by the frontend.
+
+/** Row from ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENTS (platinum_lfx_one_org_events). */
+export interface OrgEventRow {
+  EVENT_ID: string;
+  EVENT_NAME: string;
+  FOUNDATION_NAME: string | null;
+  EVENT_START_DATE: Date | string | null;
+  EVENT_END_DATE: Date | string | null;
+  EVENT_LOCATION: string | null;
+  EVENT_CITY: string | null;
+  EVENT_COUNTRY: string | null;
+  EVENT_URL: string | null;
+  EVENT_REGISTRATION_URL: string | null;
+  ORG_REGISTRATION_COUNT: number;
+  EVENT_REGISTRATIONS_GOAL: number | null;
+  ORG_SPEAKER_ACCEPTED_COUNT: number;
+  ORG_SPEAKER_SUBMITTED_COUNT: number;
+  IS_ORG_SPONSOR: boolean;
+  TOTAL_RECORDS: number;
+}
+
+/** Raw row returned by the org events summary (stat strip) Snowflake query. */
+export interface OrgEventsSummaryRow {
+  TOTAL_EVENTS: number;
+  PAST_EVENTS: number;
+  UPCOMING_EVENTS: number;
+}
+
+/** Raw row returned by the per-event attendees drawer Snowflake query. */
+export interface OrgEventAttendeesDrawerRow {
+  CONTACT_ID: string;
+  NAME: string | null;
+  JOB_TITLE: string | null;
+  EVENT_NAME: string | null;
+}
+
+/** Raw row returned by the per-event speakers drawer Snowflake query. */
+export interface OrgEventSpeakersDrawerRow {
+  CONTACT_ID: string;
+  NAME: string | null;
+  JOB_TITLE: string | null;
+  IS_ACCEPTED: number;
+  EVENT_NAME: string | null;
+}

--- a/packages/shared/src/interfaces/org-events.interface.ts
+++ b/packages/shared/src/interfaces/org-events.interface.ts
@@ -29,11 +29,20 @@ export interface OrgEvent {
   readonly eventUrl: string | null;
   readonly eventRegistrationUrl: string | null;
   readonly orgAttendeeCount: number;
-  readonly isRegistered: boolean;
+  /** Event-wide registration goal/target (EVENT_REGISTRATIONS_GOAL); null when no goal is set. */
+  readonly eventRegistrationsGoal: number | null;
+  readonly orgSpeakerAcceptedCount: number;
+  readonly orgSpeakerSubmittedCount: number;
+  readonly isOrgSponsor: boolean;
 }
 
 /** Paginated response for org events. */
 export type OrgEventsResponse = OffsetPaginatedResponse<OrgEvent>;
+
+/** Org event row with presentation fields pre-baked for template rendering (avoids method calls in template). */
+export interface OrgEventRowVm extends OrgEvent {
+  readonly dateRange: string;
+}
 
 /** Frontend query params for GET /api/orgs/:accountId/lens/events. */
 export interface GetOrgEventsParams {
@@ -42,6 +51,7 @@ export interface GetOrgEventsParams {
   readonly status?: string | null;
   readonly pageSize?: number;
   readonly offset?: number;
+  readonly sortField?: string;
   readonly sortOrder?: 'ASC' | 'DESC';
 }
 
@@ -59,29 +69,50 @@ export interface GetOrgEventsOptions {
   readonly status?: string | null;
   readonly pageSize: number;
   readonly offset: number;
+  readonly sortField: string;
   readonly sortOrder: 'ASC' | 'DESC';
 }
 
-/** Raw row returned by the org upcoming/past events Snowflake query (backend query layer). */
-export interface OrgEventRow {
-  EVENT_ID: string;
-  EVENT_NAME: string;
-  FOUNDATION: string | null;
-  EVENT_START_DATE: Date | string | null;
-  EVENT_END_DATE: Date | string | null;
-  EVENT_LOCATION: string | null;
-  EVENT_CITY: string | null;
-  EVENT_COUNTRY: string | null;
-  EVENT_URL: string | null;
-  EVENT_REGISTRATION_URL: string | null;
-  ORG_ATTENDEE_COUNT: number;
-  IS_REGISTERED: boolean;
-  TOTAL_RECORDS: number;
+/** A single org employee in the per-event attendees drawer. */
+export interface OrgEventAttendee {
+  readonly contactId: string;
+  readonly name: string;
+  readonly jobTitle: string | null;
 }
 
-/** Raw row returned by the org events summary Snowflake query (backend query layer). */
-export interface OrgEventsSummaryRow {
-  TOTAL_EVENTS: number;
-  PAST_EVENTS: number;
-  UPCOMING_EVENTS: number;
+/** Attendee row with presentation fields pre-baked for template rendering (avoids method calls in template). */
+export interface OrgEventAttendeeVm extends OrgEventAttendee {
+  readonly initials: string;
+  readonly avatarColorClass: string;
+}
+
+/** Response for GET /api/orgs/:accountId/lens/events/:eventId/attendees */
+export interface OrgEventAttendeesDrawerResponse {
+  readonly eventId: string;
+  readonly eventName: string;
+  readonly total: number;
+  readonly data: readonly OrgEventAttendee[];
+}
+
+/** A single org employee in the per-event speakers drawer. */
+export interface OrgEventSpeaker {
+  readonly contactId: string;
+  readonly name: string;
+  readonly jobTitle: string | null;
+  readonly status: 'ACCEPTED' | 'SUBMITTED';
+}
+
+/** Speaker row with presentation fields pre-baked for template rendering (avoids method calls in template). */
+export interface OrgEventSpeakerVm extends OrgEventSpeaker {
+  readonly initials: string;
+  readonly avatarColorClass: string;
+}
+
+/** Response for GET /api/orgs/:accountId/lens/events/:eventId/speakers */
+export interface OrgEventSpeakersResponse {
+  readonly eventId: string;
+  readonly eventName: string;
+  readonly acceptedCount: number;
+  readonly submittedCount: number;
+  readonly data: readonly OrgEventSpeaker[];
 }


### PR DESCRIPTION
## Summary

Adds the Org Lens **Events** experience: an upcoming/past events table plus per-event **Attendees** and **Speakers** detail drawers, giving company admins visibility into which LF events their organization has a footprint in — registrations, speakers, and sponsorships — as a signal of how their org engages with the open-source ecosystems they care about.

## What's included

**Frontend components**
- `org-upcoming-events-table` — paginated, sortable table (event name, foundation, date, location, attendees, speakers, sponsor) with a URL-driven Action column and clickable counts that launch the detail drawers.
- `event-attendees-drawer` — slide-out list of org employees registered for an event (avatar, name, title), with search, loading, and empty states.
- `event-speakers-drawer` — slide-out list of org speakers with Accepted/Submitted badges, search, loading, and empty states.
- Stat-strip cards act as tab shortcuts: Upcoming/Total open the upcoming tab, Past opens the past tab.

**Backend (`org-lens-events.service.ts`, `org-lens-events.controller.ts`, `orgs.route.ts`)**
- Endpoints: `GET /api/orgs/:accountId/lens/events` (+ `/summary`), and per-event `…/:eventId/attendees` and `…/:eventId/speakers`. All four enforce `getEffectiveEmail` authentication and validate the Salesforce `accountId` format.
- Server-side pagination, status filter, and an allowlisted `sortField` (`EVENT_NAME` / `EVENT_START_DATE` / `EVENT_CITY`).

**Shared package**
- `org-events.interface.ts`: `OrgEvent`, `OrgEventsSummary`, `OrgEventAttendee(sDrawerResponse)`, `OrgEventSpeaker(sResponse)`, `PageChangeEvent`, `SortChangeEvent`.
- `org-events.constants.ts`: `EMPTY_ORG_EVENTS_RESPONSE`, tab/status constants.

## Data sources
- **Events list + summary (footprint, counts, sponsor flag, goal):** `ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENTS` — the event-grain org-footprint model added by **linuxfoundation/lf-dbt** (`platinum_lfx_one_org_events`, merged & deployed). One row per `(account_id, event_id)` where the org has footprint via registration ∪ speaking ∪ sponsorship.
- **Attendees drawer (per-person detail rows):** `ANALYTICS.SILVER_FACT.EVENT_REGISTRATIONS`, left-joined to `ANALYTICS.PLATINUM_LFX_ONE.ORG_PEOPLE_ALL` for name/title enrichment. The drawer needs row-level people, which the event-grain platinum model does not carry — hence the silver fact read here.
- **Speakers drawer (per-person detail rows):** `ANALYTICS.SILVER_FACT.EVENT_SPEAKERS`, keyed on `SPEAKER_STATUS` (`Accepted` vs any other = Submitted), grouped to one row per `SPEAKER_ID`.

## Locked business rules (Events feature)
- **Footprint** = registration ∪ speaker ∪ sponsor, matched on Salesforce `account_id` only (no conglomerate rollup, no email/domain fallback).
- **Past vs upcoming** by `event_end_date` relative to today.
- **My Org count** includes registrations of every status (cancelled/denied included) — the page shows that the org registered even if members did not ultimately attend; counted at person grain (`COALESCE(user_id, email)`, non-null email).
- **Speakers**: Accepted = `speaker_status = 'Accepted'`; Submitted = any status (distinct speakers).
- **Goal** = the event-wide registration target (`EVENT_REGISTRATIONS_GOAL`), surfaced as `eventRegistrationsGoal`.
- **Sponsor** = authoritative Yes/No from `silver_fact_event_sponsorships` (via the platinum model).
- **Action column** is URL-driven and org-scoped (not a per-user view): **Register** when an event registration URL exists, else **View** when an event URL exists, else —.
- **Foundation** derived from `project_id` (foundation-level project name = foundation name).
- Bevy community events are provisionally excluded for v1.

## Test plan
- [x] Upcoming tab shows real data; tab label shows `(N)` matching the stat strip. The Past tab is intentionally a "Coming soon" placeholder for v1 (no data wired yet).
- [x] Speakers count opens the drawer with Accepted/Submitted badges
- [x] Attendees count opens the drawer (search works; one row per person)
- [x] Pagination, sort, and status filter exercised end-to-end
- [x] `yarn build` (SSR), lint, type-check, and license headers clean
- [x] Playwright coverage in `apps/lfx-one/e2e/org-events-dashboard.spec.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)

