### PR TITLE
fix(mailing-lists): replace generic error with already-subscribed detail (LFXV2-1781)

### DIFF
--- a/apps/lfx-one/src/app/modules/mailing-lists/components/manage-member-modal/manage-member-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/manage-member-modal/manage-member-modal.component.ts
@@ -203,11 +203,12 @@ export class ManageMemberModalComponent {
 
     let detail = defaultMessage;
     if (error instanceof HttpErrorResponse) {
-      if (error.status === 409) {
-        const email = this.form.getRawValue().email as string;
-        detail = `${email} is already subscribed to this mailing list.`;
+      // The already-subscribed conflict only applies when adding a new member
+      if (error.status === 409 && !this.isEditMode()) {
+        const email = (this.form.getRawValue().email as string)?.trim();
+        detail = `${email || 'This email'} is already subscribed to this mailing list.`;
       } else {
-        detail = (error.error as { message?: string })?.message || defaultMessage;
+        detail = this.extractHttpErrorMessage(error, defaultMessage);
       }
     } else if (error instanceof Error) {
       detail = error.message;
@@ -218,5 +219,15 @@ export class ManageMemberModalComponent {
       summary: 'Error',
       detail,
     });
+  }
+
+  // Upstream bodies vary: plain string, { message }, or none — preserve detail where present
+  private extractHttpErrorMessage(error: HttpErrorResponse, defaultMessage: string): string {
+    const body = error.error;
+    if (typeof body === 'string' && body.trim()) {
+      return body;
+    }
+
+    return (body as { message?: string })?.message || defaultMessage;
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/manage-member-modal/manage-member-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/manage-member-modal/manage-member-modal.component.ts
@@ -3,6 +3,7 @@
 
 import { Component, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardSelectorComponent } from '@components/card-selector/card-selector.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -199,12 +200,23 @@ export class ManageMemberModalComponent {
 
   private handleError(error: unknown, defaultMessage: string): void {
     this.submitting.set(false);
-    const errorMessage = error instanceof Error ? error.message : (error as { error?: { message?: string } })?.error?.message || defaultMessage;
+
+    let detail = defaultMessage;
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 409) {
+        const email = this.form.getRawValue().email as string;
+        detail = `${email} is already subscribed to this mailing list.`;
+      } else {
+        detail = (error.error as { message?: string })?.message || defaultMessage;
+      }
+    } else if (error instanceof Error) {
+      detail = error.message;
+    }
 
     this.messageService.add({
       severity: 'error',
       summary: 'Error',
-      detail: errorMessage,
+      detail,
     });
   }
 }


### PR DESCRIPTION
# Summary

When subscribing an email that is already on a mailing list, the API returns a 409 conflict. Previously this showed a generic error message. Now the modal displays a specific message — "<email> is already subscribed to this mailing list." — using the actual address from the form, making it immediately clear to the user what went wrong.