### PR TITLE
feat(meetings): show loading state for Join Meeting CTA while URL fetches

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -315,8 +315,7 @@
                 @if (isLoadingJoinUrl() && !showGuestForm()) {
                   <div class="w-full md:w-[296px]">
                     <lfx-button
-                      class="w-full h-[40px]"
-                      styleClass="w-full"
+                      styleClass="w-full h-[40px]"
                       label="Join Meeting"
                       icon="fa-light fa-video"
                       severity="success"
@@ -329,8 +328,7 @@
                 } @else if (fetchedJoinUrl() && !showGuestForm()) {
                   <div class="w-full md:w-[296px]">
                     <lfx-button
-                      class="w-full h-[40px]"
-                      styleClass="w-full"
+                      styleClass="w-full h-[40px]"
                       label="Join Meeting"
                       icon="fa-light fa-video"
                       severity="success"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -312,7 +312,21 @@
 
               <!-- Right Column: Join Button (immediate meetings) or RSVP (future meetings) -->
               @if (canJoinMeeting() && authenticated()) {
-                @if (fetchedJoinUrl() && !showGuestForm()) {
+                @if (isLoadingJoinUrl() && !showGuestForm()) {
+                  <div class="w-full md:w-[296px]">
+                    <lfx-button
+                      class="w-full h-[40px]"
+                      styleClass="w-full"
+                      label="Join Meeting"
+                      icon="fa-light fa-video"
+                      severity="success"
+                      size="large"
+                      [loading]="true"
+                      [disabled]="true"
+                      [attr.data-testid]="'join-meeting-button-loading'">
+                    </lfx-button>
+                  </div>
+                } @else if (fetchedJoinUrl() && !showGuestForm()) {
                   <div class="w-full md:w-[296px]">
                     <lfx-button
                       class="w-full h-[40px]"


### PR DESCRIPTION
## Summary

- Adds a loading state for the green "Join Meeting" button on the meeting join page while the join URL is being fetched
- Previously the right-column CTA slot was blank for 1–2 seconds after page load; users had no visual feedback that the button was coming
- Uses the existing `[loading]="true"` pattern consistent with all other `lfx-button` loading states in the app

## Changes

- `meeting-join.component.html`: Added `@if (isLoadingJoinUrl() && !showGuestForm())` branch before the existing `fetchedJoinUrl()` branch, rendering the Join Meeting button in a disabled/loading state using the same `severity="success"` styling. No TypeScript changes needed — `isLoadingJoinUrl` signal already existed.

## Test plan

- [ ] Navigate to an active/joinable meeting page — loading button appears briefly then transitions to the active Join Meeting button
- [ ] No layout shift between loading and loaded states (both use `w-full md:w-[296px]`)
- [ ] Error state (when `joinUrlError()` is set) still renders correctly
- [ ] Guest form flow unaffected (`showGuestForm()` gates all branches)
- [ ] Past meetings and future meetings (RSVP section) unaffected

Closes LFXV2-2048

🤖 Generated with [Claude Code](https://claude.ai/code)