### PR TITLE
feat(campaigns): add shared campaign interfaces and constants

### DIFF
--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -48,6 +48,14 @@ export const CAMPAIGN_GOALS: readonly CampaignGoalOption[] = [
 
 export const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
 
+/**
+ * Upper-bound thresholds for each pacing label (percentage of budget spent).
+ * A campaign's pacingPct falls into the first bucket whose threshold it does not exceed:
+ *   pacingPct < 50  → underspending
+ *   pacingPct < 90  → normal
+ *   pacingPct < 100 → constrained
+ *   pacingPct ≥ 100 → overspending (130 marks severe overspending)
+ */
 export const CAMPAIGN_PACING_THRESHOLDS = {
   underspending: 50,
   normal: 90,

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CampaignGoal, CampaignPhase, CampaignPlatform } from '../interfaces/campaign.interface';
+import type { CampaignGoal, CampaignPhase, CampaignPlatform } from '../interfaces';
 
 export interface CampaignTabOption {
   id: CampaignPhase;
@@ -52,6 +52,7 @@ export const CAMPAIGN_PACING_THRESHOLDS = {
   underspending: 50,
   normal: 90,
   constrained: 100,
+  overspending: 130,
 } as const;
 
 export const CAMPAIGN_CHAR_LIMITS = {

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { CampaignGoal, CampaignPhase, CampaignPlatform } from '../interfaces/campaign.interface';
+
+export interface CampaignTabOption {
+  id: CampaignPhase;
+  label: string;
+  icon: string;
+}
+
+export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
+  { id: 'planning', label: 'Planning', icon: 'fa-light fa-clipboard-list' },
+  { id: 'implementation', label: 'Implementation', icon: 'fa-light fa-rocket' },
+  { id: 'monitoring', label: 'Monitoring', icon: 'fa-light fa-chart-mixed' },
+  { id: 'optimization', label: 'Optimization', icon: 'fa-light fa-gauge-high' },
+] as const;
+
+export interface CampaignPlatformOption {
+  id: CampaignPlatform;
+  label: string;
+  icon: string;
+}
+
+export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
+  { id: 'google-ads', label: 'Google Ads', icon: 'fa-brands fa-google' },
+  { id: 'microsoft-ads', label: 'Microsoft Ads', icon: 'fa-brands fa-microsoft' },
+  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin' },
+  { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta' },
+  { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit' },
+  { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield' },
+  { id: 'feathr', label: 'Feathr', icon: 'fa-light fa-bullseye-arrow' },
+  { id: 'twitter-ads', label: 'X / Twitter Ads', icon: 'fa-brands fa-x-twitter' },
+] as const;
+
+export interface CampaignGoalOption {
+  id: CampaignGoal;
+  label: string;
+}
+
+export const CAMPAIGN_GOALS: readonly CampaignGoalOption[] = [
+  { id: 'conversions', label: 'Conversions / Registrations' },
+  { id: 'brand-awareness', label: 'Brand Awareness' },
+  { id: 'traffic', label: 'Traffic / Clicks' },
+  { id: 'lead-generation', label: 'Lead Generation' },
+  { id: 'engagement', label: 'Engagement' },
+] as const;
+
+export const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
+
+export const CAMPAIGN_PACING_THRESHOLDS = {
+  underspending: 50,
+  normal: 90,
+  constrained: 100,
+} as const;
+
+export const CAMPAIGN_CHAR_LIMITS = {
+  searchHeadline: 30,
+  searchDescription: 90,
+  displayHeadline: 40,
+  displayDescription: 90,
+  displayBusinessName: 25,
+  sitelinkHeadline: 25,
+  sitelinkDescription: 35,
+} as const;
+
+export const CAMPAIGN_BUDGET_DEFAULTS = {
+  searchBudgetPct: 70,
+  displayBudgetPct: 30,
+} as const;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -5,6 +5,7 @@ export * from './ai.constants';
 export * from './avatar.constants';
 export * from './api.constants';
 export * from './calendar-colors.constants';
+export * from './campaign.constants';
 export * from './colors.constants';
 export * from './tag.constants';
 export * from './committees.constants';

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1,0 +1,235 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// ---------------------------------------------------------------------------
+// Platform & Phase
+// ---------------------------------------------------------------------------
+
+export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'brave-ads' | 'feathr' | 'twitter-ads';
+
+export type CampaignPhase = 'planning' | 'implementation' | 'monitoring' | 'optimization';
+
+export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited';
+
+export type CampaignType = 'search' | 'demand-gen';
+
+export type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead-generation' | 'engagement';
+
+// ---------------------------------------------------------------------------
+// Brief Pipeline (Planning Phase)
+// ---------------------------------------------------------------------------
+
+export type CampaignSSEEventType = 'status' | 'event' | 'hubspot_utm' | 'copy_token' | 'copy_done' | 'copy_structured' | 'keywords' | 'error' | 'done';
+
+export interface CampaignBriefRequest {
+  url: string;
+  platforms: CampaignPlatform[];
+  campaignGoal?: CampaignGoal;
+  targetAudience?: string;
+  valueProp?: string;
+  totalBudget?: number;
+}
+
+export interface CampaignEventDetails {
+  name: string;
+  dates: string;
+  city: string;
+  countryCode: string;
+  audience: string;
+  themes: string[];
+  registrationUrl: string;
+  speakers: string[];
+  slug: string;
+  formatNotes: string;
+}
+
+export interface CampaignKeyword {
+  term: string;
+  matchType: 'Exact' | 'Phrase' | 'Broad';
+  intentLevel: 'High' | 'Medium' | 'Low';
+  notes: string;
+}
+
+export interface CampaignBriefOutput {
+  eventDetails: CampaignEventDetails;
+  structuredCopy: Record<string, unknown> | null;
+  keywords: CampaignKeyword[];
+  hsUtm: string | null;
+  totalBudget: number | null;
+  driveFolderUrl: string;
+  campaignGoal: CampaignGoal | null;
+}
+
+// ---------------------------------------------------------------------------
+// Campaign Creation (Implementation Phase)
+// ---------------------------------------------------------------------------
+
+export interface CampaignCreateRequest {
+  eventName: string;
+  eventSlug: string;
+  countryCode: string;
+  registrationUrl: string;
+  hsToken?: string;
+  campaignTypes: CampaignType[];
+  budgetUsd: number;
+  searchBudgetPct: number;
+  startDate: string;
+  endDate: string;
+  keywords: CampaignKeyword[];
+  headlines: string[];
+  descriptions: string[];
+  displayHeadlines?: string[];
+  displayDescriptions?: string[];
+  displayBusinessName?: string;
+  displayCallToAction?: string;
+  geoTargets: string[];
+  project?: string;
+  driveFolderUrl?: string;
+}
+
+export interface CampaignCreateResult {
+  type: CampaignType;
+  campaignName: string;
+  campaignId: string;
+  adGroupCount: number;
+  keywordCount: number;
+  adCount: number;
+  googleAdsUrl: string;
+  steps: string[];
+}
+
+export interface CampaignCreateResponse {
+  success: boolean;
+  campaigns: CampaignCreateResult[];
+  errors: string[];
+}
+
+export interface CampaignJobStatus {
+  status: 'running' | 'done';
+  result?: CampaignCreateResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Monitoring
+// ---------------------------------------------------------------------------
+
+export type PacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending';
+
+export type ActionPriority = 'HIGH' | 'MED' | 'LOW';
+
+export interface CampaignMetrics {
+  name: string;
+  shortName: string;
+  eventName: string;
+  adFormat: string;
+  targeting: string;
+  status: CampaignStatus;
+  budgetDay: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  avgCpc: number;
+  conversions: number;
+  pacingPct: number;
+  pacingLabel: PacingLabel;
+  actionRules: CampaignActionItem[];
+}
+
+export interface CampaignActionItem {
+  campaign: string;
+  priority: ActionPriority;
+  issue: string;
+  action: string;
+  owner: string;
+}
+
+export interface CampaignAccountTotals {
+  budgetDay: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+}
+
+export interface CampaignMonitorResponse {
+  pulledAt: string;
+  dateRange: { mode: string };
+  campaigns: CampaignMetrics[];
+  accountTotals: CampaignAccountTotals;
+  actionItems: CampaignActionItem[];
+  message?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Keywords
+// ---------------------------------------------------------------------------
+
+export interface KeywordMetrics {
+  keyword: string;
+  matchType: string;
+  qualityScore: number | null;
+  status: string;
+  adGroup: string;
+  campaign: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  avgCpc: number;
+  spend: number;
+  conversions: number;
+}
+
+export interface KeywordTotals {
+  impressions: number;
+  clicks: number;
+  spend: number;
+  conversions: number;
+  avgCtr: number;
+}
+
+export interface KeywordMetricsResponse {
+  pulledAt: string;
+  days: number;
+  totalKeywords: number;
+  totals: KeywordTotals;
+  keywords: KeywordMetrics[];
+}
+
+// ---------------------------------------------------------------------------
+// Audience Demographics
+// ---------------------------------------------------------------------------
+
+export interface AudienceBucket {
+  label: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  spend: number;
+  conversions: number;
+}
+
+export interface AudienceDemographics {
+  pulledAt: string;
+  days: number;
+  age: AudienceBucket[];
+  gender: AudienceBucket[];
+  device: AudienceBucket[];
+}
+
+// ---------------------------------------------------------------------------
+// HubSpot UTM
+// ---------------------------------------------------------------------------
+
+export interface HubSpotUtmLookupResult {
+  found: boolean;
+  hs_utm: string | null;
+  campaign_name: string;
+  all_matches: { name: string; hs_utm: string }[];
+}
+
+export interface HubSpotUtmCreateResult {
+  created: boolean;
+  hs_utm: string | null;
+  campaign_name: string;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -31,6 +31,9 @@ export * from './meeting.interface';
 // Calendar interfaces
 export * from './calendar.interface';
 
+// Campaign interfaces
+export * from './campaign.interface';
+
 // Search interfaces
 export * from './search.interface';
 


### PR DESCRIPTION
## Summary
- Add `CampaignBriefRequest`, `CampaignCreateRequest`, `CampaignMonitorResponse`, and all campaign-related interfaces to `@lfx-one/shared`
- Add campaign constants: platform options, goals, budget defaults, character limits, tab definitions
- Export from shared package barrel files

Part of campaigns epic LFXV2-2023.
JIRA: LFXV2-2026

🤖 Generated with [Claude Code](https://claude.ai/code)