### PR TITLE
feat(campaigns): add frontend campaign service

### DIFF
--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -64,7 +64,7 @@
               "lodash.isempty",
               "quill-delta"
             ],
-            "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit"]
+            "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit", "google-ads-api"]
           },
           "configurations": {
             "production": {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,197 +3,23 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { SSEEvent } from '@lfx-one/shared/interfaces';
-import { catchError, map, Observable, of, switchMap, takeWhile, timer } from 'rxjs';
+import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
+import {
+  AudienceDemographics,
+  CampaignBriefRequest,
+  CampaignCreateRequest,
+  CampaignCreateResponse,
+  CampaignJobStatus,
+  CampaignSSEEventType,
+  HubSpotUtmCreateResult,
+  HubSpotUtmLookupResult,
+  KeywordMetricsResponse,
+  CampaignMonitorResponse,
+  SSEEvent,
+} from '@lfx-one/shared/interfaces';
+import { filter, map, Observable, of, switchMap, takeWhile, timer } from 'rxjs';
 
 import { SseService } from './sse.service';
-
-// ---------------------------------------------------------------------------
-// Inline campaign types — will move to @lfx-one/shared/interfaces and
-// @lfx-one/shared/constants once the shared-package PR (LFXV2-2026) merges.
-// ---------------------------------------------------------------------------
-
-const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
-
-type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'brave-ads' | 'feathr' | 'twitter-ads';
-
-type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead-generation' | 'engagement';
-
-type CampaignType = 'search' | 'demand-gen';
-
-type CampaignSSEEventType = 'status' | 'event' | 'hubspot_utm' | 'copy_token' | 'copy_done' | 'copy_structured' | 'keywords' | 'error' | 'done';
-
-type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited';
-
-type PacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending';
-
-type ActionPriority = 'HIGH' | 'MED' | 'LOW';
-
-interface CampaignBriefRequest {
-  url: string;
-  platforms: CampaignPlatform[];
-  campaignGoal?: CampaignGoal;
-  targetAudience?: string;
-  valueProp?: string;
-  totalBudget?: number;
-}
-
-interface CampaignKeyword {
-  term: string;
-  matchType: 'Exact' | 'Phrase' | 'Broad';
-  intentLevel: 'High' | 'Medium' | 'Low';
-  notes: string;
-}
-
-interface CampaignCreateRequest {
-  eventName: string;
-  eventSlug: string;
-  countryCode: string;
-  registrationUrl: string;
-  hsToken?: string;
-  campaignTypes: CampaignType[];
-  budgetUsd: number;
-  searchBudgetPct: number;
-  startDate: string;
-  endDate: string;
-  keywords: CampaignKeyword[];
-  headlines: string[];
-  descriptions: string[];
-  displayHeadlines?: string[];
-  displayDescriptions?: string[];
-  displayBusinessName?: string;
-  displayCallToAction?: string;
-  geoTargets: string[];
-  project?: string;
-  driveFolderUrl?: string;
-}
-
-interface CampaignCreateResult {
-  type: CampaignType;
-  campaignName: string;
-  campaignId: string;
-  adGroupCount: number;
-  keywordCount: number;
-  adCount: number;
-  googleAdsUrl: string;
-  steps: string[];
-}
-
-interface CampaignCreateResponse {
-  success: boolean;
-  campaigns: CampaignCreateResult[];
-  errors: string[];
-}
-
-interface CampaignJobStatus {
-  status: 'running' | 'done';
-  result?: CampaignCreateResponse;
-}
-
-interface CampaignActionItem {
-  campaign: string;
-  priority: ActionPriority;
-  issue: string;
-  action: string;
-  owner: string;
-}
-
-interface CampaignMetrics {
-  name: string;
-  shortName: string;
-  eventName: string;
-  adFormat: string;
-  targeting: string;
-  status: CampaignStatus;
-  budgetDay: number;
-  spend: number;
-  impressions: number;
-  clicks: number;
-  ctr: number;
-  avgCpc: number;
-  conversions: number;
-  pacingPct: number;
-  pacingLabel: PacingLabel;
-  actionRules: CampaignActionItem[];
-}
-
-interface CampaignAccountTotals {
-  budgetDay: number;
-  spend: number;
-  impressions: number;
-  clicks: number;
-  conversions: number;
-}
-
-interface CampaignMonitorResponse {
-  pulledAt: string;
-  dateRange: { mode: string };
-  campaigns: CampaignMetrics[];
-  accountTotals: CampaignAccountTotals;
-  actionItems: CampaignActionItem[];
-  message?: string;
-}
-
-interface KeywordMetrics {
-  keyword: string;
-  matchType: string;
-  qualityScore: number | null;
-  status: string;
-  adGroup: string;
-  campaign: string;
-  impressions: number;
-  clicks: number;
-  ctr: number;
-  avgCpc: number;
-  spend: number;
-  conversions: number;
-}
-
-interface KeywordTotals {
-  impressions: number;
-  clicks: number;
-  spend: number;
-  conversions: number;
-  avgCtr: number;
-}
-
-interface KeywordMetricsResponse {
-  pulledAt: string;
-  days: number;
-  totalKeywords: number;
-  totals: KeywordTotals;
-  keywords: KeywordMetrics[];
-}
-
-interface AudienceBucket {
-  label: string;
-  impressions: number;
-  clicks: number;
-  ctr: number;
-  spend: number;
-  conversions: number;
-}
-
-interface AudienceDemographics {
-  pulledAt: string;
-  days: number;
-  age: AudienceBucket[];
-  gender: AudienceBucket[];
-  device: AudienceBucket[];
-}
-
-interface HubSpotUtmLookupResult {
-  found: boolean;
-  hs_utm: string | null;
-  campaign_name: string;
-  all_matches: { name: string; hs_utm: string }[];
-}
-
-interface HubSpotUtmCreateResult {
-  created: boolean;
-  hs_utm: string | null;
-  campaign_name: string;
-}
 
 // ---------------------------------------------------------------------------
 // Service
@@ -212,36 +38,38 @@ export class CampaignService {
   }
 
   public createCampaign(request: CampaignCreateRequest): Observable<{ jobId: string }> {
-    return this.http.post<{ jobId: string }>('/api/campaigns/create', request).pipe(catchError(() => of({ jobId: '' })));
+    return this.http.post<{ jobId: string }>('/api/campaigns/create', request);
   }
 
   public getCreateResult(jobId: string): Observable<CampaignCreateResponse | null> {
+    if (!jobId) {
+      return of(null);
+    }
+
     return this.pollJobStatus(jobId).pipe(
-      map((status) => (status.status === 'done' ? (status.result ?? null) : null)),
-      catchError(() => of(null))
+      filter((status) => status.status === 'done'),
+      map((status) => status.result ?? null)
     );
   }
 
-  public getMonitorData(days: number = 14): Observable<CampaignMonitorResponse | null> {
-    return this.http.get<CampaignMonitorResponse>('/api/campaigns/monitor', { params: { days } }).pipe(catchError(() => of(null)));
+  public getMonitorData(days: number = 14): Observable<CampaignMonitorResponse> {
+    return this.http.get<CampaignMonitorResponse>('/api/campaigns/monitor', { params: { days } });
   }
 
-  public getKeywords(days: number = 14): Observable<KeywordMetricsResponse | null> {
-    return this.http.get<KeywordMetricsResponse>('/api/campaigns/keywords', { params: { days } }).pipe(catchError(() => of(null)));
+  public getKeywords(days: number = 14): Observable<KeywordMetricsResponse> {
+    return this.http.get<KeywordMetricsResponse>('/api/campaigns/keywords', { params: { days } });
   }
 
-  public getAudience(days: number = 14): Observable<AudienceDemographics | null> {
-    return this.http.get<AudienceDemographics>('/api/campaigns/audience', { params: { days } }).pipe(catchError(() => of(null)));
+  public getAudience(days: number = 14): Observable<AudienceDemographics> {
+    return this.http.get<AudienceDemographics>('/api/campaigns/audience', { params: { days } });
   }
 
-  public lookupHubSpotUtm(eventName: string): Observable<HubSpotUtmLookupResult | null> {
-    return this.http.get<HubSpotUtmLookupResult>('/api/campaigns/hubspot/utm', { params: { event_name: eventName } }).pipe(catchError(() => of(null)));
+  public lookupHubSpotUtm(eventName: string): Observable<HubSpotUtmLookupResult> {
+    return this.http.get<HubSpotUtmLookupResult>('/api/campaigns/hubspot/utm', { params: { event_name: eventName } });
   }
 
-  public createHubSpotUtm(eventName: string): Observable<HubSpotUtmCreateResult | null> {
-    return this.http
-      .post<HubSpotUtmCreateResult>('/api/campaigns/hubspot/utm/create', null, { params: { event_name: eventName } })
-      .pipe(catchError(() => of(null)));
+  public createHubSpotUtm(eventName: string): Observable<HubSpotUtmCreateResult> {
+    return this.http.post<HubSpotUtmCreateResult>('/api/campaigns/hubspot/utm/create', {}, { params: { event_name: eventName } });
   }
 
   private pollJobStatus(jobId: string): Observable<CampaignJobStatus> {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -17,7 +17,7 @@ import {
   CampaignMonitorResponse,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
-import { filter, map, Observable, of, switchMap, takeWhile, timer } from 'rxjs';
+import { exhaustMap, filter, map, Observable, of, take, takeWhile, timer } from 'rxjs';
 
 import { SseService } from './sse.service';
 
@@ -73,8 +73,10 @@ export class CampaignService {
   }
 
   private pollJobStatus(jobId: string): Observable<CampaignJobStatus> {
+    const maxPolls = Math.ceil(300_000 / CAMPAIGN_JOB_POLL_INTERVAL_MS);
     return timer(0, CAMPAIGN_JOB_POLL_INTERVAL_MS).pipe(
-      switchMap(() => this.http.get<CampaignJobStatus>(`/api/campaigns/jobs/${encodeURIComponent(jobId)}`)),
+      take(maxPolls),
+      exhaustMap(() => this.http.get<CampaignJobStatus>(`/api/campaigns/jobs/${encodeURIComponent(jobId)}`)),
       takeWhile((status) => status.status === 'running', true)
     );
   }

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -1,0 +1,253 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { SSEEvent } from '@lfx-one/shared/interfaces';
+import { catchError, map, Observable, of, switchMap, takeWhile, timer } from 'rxjs';
+
+import { SseService } from './sse.service';
+
+// ---------------------------------------------------------------------------
+// Inline campaign types — will move to @lfx-one/shared/interfaces and
+// @lfx-one/shared/constants once the shared-package PR (LFXV2-2026) merges.
+// ---------------------------------------------------------------------------
+
+const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
+
+type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'brave-ads' | 'feathr' | 'twitter-ads';
+
+type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead-generation' | 'engagement';
+
+type CampaignType = 'search' | 'demand-gen';
+
+type CampaignSSEEventType = 'status' | 'event' | 'hubspot_utm' | 'copy_token' | 'copy_done' | 'copy_structured' | 'keywords' | 'error' | 'done';
+
+type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited';
+
+type PacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending';
+
+type ActionPriority = 'HIGH' | 'MED' | 'LOW';
+
+interface CampaignBriefRequest {
+  url: string;
+  platforms: CampaignPlatform[];
+  campaignGoal?: CampaignGoal;
+  targetAudience?: string;
+  valueProp?: string;
+  totalBudget?: number;
+}
+
+interface CampaignKeyword {
+  term: string;
+  matchType: 'Exact' | 'Phrase' | 'Broad';
+  intentLevel: 'High' | 'Medium' | 'Low';
+  notes: string;
+}
+
+interface CampaignCreateRequest {
+  eventName: string;
+  eventSlug: string;
+  countryCode: string;
+  registrationUrl: string;
+  hsToken?: string;
+  campaignTypes: CampaignType[];
+  budgetUsd: number;
+  searchBudgetPct: number;
+  startDate: string;
+  endDate: string;
+  keywords: CampaignKeyword[];
+  headlines: string[];
+  descriptions: string[];
+  displayHeadlines?: string[];
+  displayDescriptions?: string[];
+  displayBusinessName?: string;
+  displayCallToAction?: string;
+  geoTargets: string[];
+  project?: string;
+  driveFolderUrl?: string;
+}
+
+interface CampaignCreateResult {
+  type: CampaignType;
+  campaignName: string;
+  campaignId: string;
+  adGroupCount: number;
+  keywordCount: number;
+  adCount: number;
+  googleAdsUrl: string;
+  steps: string[];
+}
+
+interface CampaignCreateResponse {
+  success: boolean;
+  campaigns: CampaignCreateResult[];
+  errors: string[];
+}
+
+interface CampaignJobStatus {
+  status: 'running' | 'done';
+  result?: CampaignCreateResponse;
+}
+
+interface CampaignActionItem {
+  campaign: string;
+  priority: ActionPriority;
+  issue: string;
+  action: string;
+  owner: string;
+}
+
+interface CampaignMetrics {
+  name: string;
+  shortName: string;
+  eventName: string;
+  adFormat: string;
+  targeting: string;
+  status: CampaignStatus;
+  budgetDay: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  avgCpc: number;
+  conversions: number;
+  pacingPct: number;
+  pacingLabel: PacingLabel;
+  actionRules: CampaignActionItem[];
+}
+
+interface CampaignAccountTotals {
+  budgetDay: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+}
+
+interface CampaignMonitorResponse {
+  pulledAt: string;
+  dateRange: { mode: string };
+  campaigns: CampaignMetrics[];
+  accountTotals: CampaignAccountTotals;
+  actionItems: CampaignActionItem[];
+  message?: string;
+}
+
+interface KeywordMetrics {
+  keyword: string;
+  matchType: string;
+  qualityScore: number | null;
+  status: string;
+  adGroup: string;
+  campaign: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  avgCpc: number;
+  spend: number;
+  conversions: number;
+}
+
+interface KeywordTotals {
+  impressions: number;
+  clicks: number;
+  spend: number;
+  conversions: number;
+  avgCtr: number;
+}
+
+interface KeywordMetricsResponse {
+  pulledAt: string;
+  days: number;
+  totalKeywords: number;
+  totals: KeywordTotals;
+  keywords: KeywordMetrics[];
+}
+
+interface AudienceBucket {
+  label: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  spend: number;
+  conversions: number;
+}
+
+interface AudienceDemographics {
+  pulledAt: string;
+  days: number;
+  age: AudienceBucket[];
+  gender: AudienceBucket[];
+  device: AudienceBucket[];
+}
+
+interface HubSpotUtmLookupResult {
+  found: boolean;
+  hs_utm: string | null;
+  campaign_name: string;
+  all_matches: { name: string; hs_utm: string }[];
+}
+
+interface HubSpotUtmCreateResult {
+  created: boolean;
+  hs_utm: string | null;
+  campaign_name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+@Injectable({ providedIn: 'root' })
+export class CampaignService {
+  private readonly http = inject(HttpClient);
+  private readonly sse = inject(SseService);
+
+  public generateBrief(request: CampaignBriefRequest): Observable<SSEEvent<CampaignSSEEventType>> {
+    return this.sse.connect<CampaignSSEEventType>('/api/campaigns/brief/generate', {
+      method: 'POST',
+      body: request,
+    });
+  }
+
+  public createCampaign(request: CampaignCreateRequest): Observable<{ jobId: string }> {
+    return this.http.post<{ jobId: string }>('/api/campaigns/create', request).pipe(catchError(() => of({ jobId: '' })));
+  }
+
+  public getCreateResult(jobId: string): Observable<CampaignCreateResponse | null> {
+    return this.pollJobStatus(jobId).pipe(
+      map((status) => (status.status === 'done' ? (status.result ?? null) : null)),
+      catchError(() => of(null))
+    );
+  }
+
+  public getMonitorData(days: number = 14): Observable<CampaignMonitorResponse | null> {
+    return this.http.get<CampaignMonitorResponse>('/api/campaigns/monitor', { params: { days } }).pipe(catchError(() => of(null)));
+  }
+
+  public getKeywords(days: number = 14): Observable<KeywordMetricsResponse | null> {
+    return this.http.get<KeywordMetricsResponse>('/api/campaigns/keywords', { params: { days } }).pipe(catchError(() => of(null)));
+  }
+
+  public getAudience(days: number = 14): Observable<AudienceDemographics | null> {
+    return this.http.get<AudienceDemographics>('/api/campaigns/audience', { params: { days } }).pipe(catchError(() => of(null)));
+  }
+
+  public lookupHubSpotUtm(eventName: string): Observable<HubSpotUtmLookupResult | null> {
+    return this.http.get<HubSpotUtmLookupResult>('/api/campaigns/hubspot/utm', { params: { event_name: eventName } }).pipe(catchError(() => of(null)));
+  }
+
+  public createHubSpotUtm(eventName: string): Observable<HubSpotUtmCreateResult | null> {
+    return this.http
+      .post<HubSpotUtmCreateResult>('/api/campaigns/hubspot/utm/create', null, { params: { event_name: eventName } })
+      .pipe(catchError(() => of(null)));
+  }
+
+  private pollJobStatus(jobId: string): Observable<CampaignJobStatus> {
+    return timer(0, CAMPAIGN_JOB_POLL_INTERVAL_MS).pipe(
+      switchMap(() => this.http.get<CampaignJobStatus>(`/api/campaigns/jobs/${encodeURIComponent(jobId)}`)),
+      takeWhile((status) => status.status === 'running', true)
+    );
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,27 +3,24 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
   CampaignJobStatus,
+  CampaignMonitorResponse,
   CampaignSSEEventType,
   HubSpotUtmCreateResult,
   HubSpotUtmLookupResult,
   KeywordMetricsResponse,
-  CampaignMonitorResponse,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
-import { exhaustMap, filter, map, Observable, of, take, takeWhile, timer } from 'rxjs';
+import { exhaustMap, last, map, Observable, of, take, takeWhile, timer } from 'rxjs';
 
 import { SseService } from './sse.service';
 
-// ---------------------------------------------------------------------------
-// Service
-// ---------------------------------------------------------------------------
+const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
 
 @Injectable({ providedIn: 'root' })
 export class CampaignService {
@@ -47,8 +44,11 @@ export class CampaignService {
     }
 
     return this.pollJobStatus(jobId).pipe(
-      filter((status) => status.status === 'done'),
-      map((status) => status.result ?? null)
+      last(),
+      map((status) => {
+        if (status.status === 'done') return status.result ?? null;
+        throw new Error('Campaign creation timed out');
+      })
     );
   }
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -1,0 +1,253 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import type { CampaignBriefRequest, CampaignSSEEventType, FlushableResponse } from '@lfx-one/shared/interfaces';
+
+import { ServiceValidationError } from '../errors';
+import { CampaignMetricsService } from '../services/campaign-metrics.service';
+import { CampaignProxyService, validateScrapeUrl } from '../services/campaign-proxy.service';
+import { logger } from '../services/logger.service';
+import { addShutdownHook, isShuttingDown } from '../utils/shutdown';
+
+export class CampaignController {
+  private readonly proxyService = new CampaignProxyService();
+  private readonly metricsService = new CampaignMetricsService();
+  private readonly activeStreams = new Set<Response>();
+
+  public constructor() {
+    addShutdownHook(() => this.closeAllStreams());
+  }
+
+  public async generateBrief(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    if (isShuttingDown()) {
+      res.status(503).json({ status: 'shutting_down' });
+      return;
+    }
+
+    const body = req.body as CampaignBriefRequest;
+
+    if (!body.url || typeof body.url !== 'string' || !body.url.trim()) {
+      const validationError = ServiceValidationError.forField('url', 'url is required', {
+        operation: 'campaign_generate_brief',
+        service: 'campaign_controller',
+        path: req.path,
+      });
+      _next(validationError);
+      return;
+    }
+
+    try {
+      await validateScrapeUrl(body.url);
+    } catch (error) {
+      const validationError = ServiceValidationError.forField('url', error instanceof Error ? error.message : 'Invalid URL', {
+        operation: 'campaign_generate_brief',
+        service: 'campaign_controller',
+        path: req.path,
+      });
+      _next(validationError);
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'campaign_generate_brief', {});
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('Content-Encoding', 'identity');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+    res.socket?.setNoDelay(true);
+
+    const abortController = new AbortController();
+    let clientDisconnected = false;
+
+    this.activeStreams.add(res);
+    res.on('close', () => {
+      clientDisconnected = true;
+      this.activeStreams.delete(res);
+      abortController.abort();
+    });
+
+    const sendEvent = (type: CampaignSSEEventType, data: unknown): void => {
+      if (clientDisconnected || isShuttingDown()) return;
+      res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
+      (res as FlushableResponse).flush?.();
+    };
+
+    try {
+      for await (const event of this.proxyService.streamBrief(req, body, abortController.signal)) {
+        if (clientDisconnected) return;
+        sendEvent(event.type, event.data);
+      }
+
+      logger.success(req, 'campaign_generate_brief', startTime, {});
+    } catch (error) {
+      if (clientDisconnected) return;
+      logger.error(req, 'campaign_generate_brief', startTime, error, {});
+      sendEvent('error', 'Brief generation failed. Please try again.');
+    } finally {
+      this.activeStreams.delete(res);
+      if (!clientDisconnected) {
+        res.end();
+      }
+    }
+  }
+
+  public async createCampaign(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'campaign_create', {});
+
+    try {
+      const result = await this.proxyService.createCampaign(req, req.body);
+      logger.success(req, 'campaign_create', startTime, { jobId: result.jobId });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getJobStatus(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const jobId = req.params['jobId'];
+
+    if (!jobId) {
+      next(ServiceValidationError.forField('jobId', 'jobId is required', { operation: 'campaign_job_status', service: 'campaign_controller' }));
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'campaign_job_status', { jobId });
+
+    try {
+      const status = await this.proxyService.getJobStatus(req, jobId);
+      logger.success(req, 'campaign_job_status', startTime, { jobId, status: status.status });
+      res.json(status);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getMonitorData(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const days = Number(req.query['days']) || 14;
+    const startTime = logger.startOperation(req, 'campaign_monitor', { days });
+
+    try {
+      const data = await this.metricsService.getMonitorData(req, days);
+      logger.success(req, 'campaign_monitor', startTime, {});
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getKeywords(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const days = Number(req.query['days']) || 14;
+    const startTime = logger.startOperation(req, 'campaign_keywords', { days });
+
+    try {
+      const data = await this.metricsService.getKeywords(req, days);
+      logger.success(req, 'campaign_keywords', startTime, {});
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async lookupHubSpotUtm(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const eventName = req.query['event_name'] as string;
+    if (!eventName) {
+      next(ServiceValidationError.forField('event_name', 'event_name is required', { operation: 'hubspot_utm_lookup', service: 'campaign_controller' }));
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'hubspot_utm_lookup', { eventName });
+
+    try {
+      const result = await this.proxyService.lookupHubSpotUtm(req, eventName);
+      logger.success(req, 'hubspot_utm_lookup', startTime, { found: result.found });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async createHubSpotUtm(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const eventName = req.query['event_name'] as string;
+    if (!eventName) {
+      next(ServiceValidationError.forField('event_name', 'event_name is required', { operation: 'hubspot_utm_create', service: 'campaign_controller' }));
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'hubspot_utm_create', { eventName });
+
+    try {
+      const result = await this.proxyService.createHubSpotUtm(req, eventName);
+      logger.success(req, 'hubspot_utm_create', startTime, { created: result.created });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getAudience(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const days = Number(req.query['days']) || 14;
+    const startTime = logger.startOperation(req, 'campaign_audience', { days });
+
+    try {
+      const data = await this.metricsService.getAudience(req, days);
+      logger.success(req, 'campaign_audience', startTime, {});
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private async closeAllStreams(): Promise<void> {
+    const streams = [...this.activeStreams];
+    this.activeStreams.clear();
+    const STREAM_CLOSE_TIMEOUT_MS = 2_000;
+    await Promise.all(
+      streams.map(
+        (res) =>
+          new Promise<void>((resolve) => {
+            let done = false;
+            const finish = (): void => {
+              if (!done) {
+                done = true;
+                resolve();
+              }
+            };
+            const timer = setTimeout(() => {
+              logger.debug(undefined, 'campaign_sse_shutdown_timeout', 'SSE stream close timed out; force-closing', {});
+              try {
+                if (!res.writableEnded) res.end();
+              } catch {
+                /* already ended */
+              }
+              res.socket?.destroy();
+              finish();
+            }, STREAM_CLOSE_TIMEOUT_MS);
+            try {
+              if (!res.writableEnded) {
+                res.write('event: shutdown\ndata: {"reason":"server_shutdown"}\n\n', () => {
+                  clearTimeout(timer);
+                  res.end(finish);
+                });
+              } else {
+                clearTimeout(timer);
+                finish();
+              }
+            } catch (error) {
+              clearTimeout(timer);
+              const isExpected = error instanceof Error && (error.message.includes('write after end') || error.message.includes('Cannot call end'));
+              if (isExpected) {
+                logger.debug(undefined, 'campaign_sse_shutdown_close', 'Stream already closed during shutdown', { err: error });
+              } else {
+                logger.warning(undefined, 'campaign_sse_shutdown_close', 'Unexpected error closing SSE stream', { err: error });
+              }
+              finish();
+            }
+          })
+      )
+    );
+  }
+}

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { CampaignController } from '../controllers/campaign.controller';
+
+const router = Router();
+const campaignController = new CampaignController();
+
+router.post('/brief/generate', (req, res, next) => campaignController.generateBrief(req, res, next));
+router.post('/create', (req, res, next) => campaignController.createCampaign(req, res, next));
+router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(req, res, next));
+router.get('/hubspot/utm', (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));
+router.post('/hubspot/utm/create', (req, res, next) => campaignController.createHubSpotUtm(req, res, next));
+router.get('/monitor', (req, res, next) => campaignController.getMonitorData(req, res, next));
+router.get('/keywords', (req, res, next) => campaignController.getKeywords(req, res, next));
+router.get('/audience', (req, res, next) => campaignController.getAudience(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -22,6 +22,7 @@ import { apiRateLimiter, authRateLimiter, publicApiRateLimiter } from './middlew
 import analyticsRouter from './routes/analytics.route';
 import inviteRouter from './routes/invite.route';
 import badgesRouter from './routes/badges.route';
+import campaignsRouter from './routes/campaigns.route';
 import changelogRouter from './routes/changelog.route';
 import committeesRouter from './routes/committees.route';
 import copilotRouter from './routes/copilot.route';
@@ -231,6 +232,7 @@ app.use('/api/copilot', copilotRouter);
 app.use('/api/documents', documentsRouter);
 app.use('/api/events', eventsRouter);
 app.use('/api/badges', badgesRouter);
+app.use('/api/campaigns', campaignsRouter);
 app.use('/api/impersonate', impersonationRouter);
 app.use('/api/training', trainingRouter);
 app.use('/api/rewards', rewardsRouter);

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -1,0 +1,307 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type {
+  AudienceBucket,
+  AudienceDemographics,
+  CampaignMetrics,
+  CampaignMonitorResponse,
+  KeywordMetrics,
+  KeywordMetricsResponse,
+  PacingLabel,
+} from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { gaqlSearch } from './campaign-proxy.service';
+import { logger } from './logger.service';
+
+// ---------------------------------------------------------------------------
+// CampaignMetricsService — monitoring, keywords, audience demographics
+// ---------------------------------------------------------------------------
+
+export class CampaignMetricsService {
+  // === Monitoring data ===
+
+  public async getMonitorData(req: Request, days: number): Promise<CampaignMonitorResponse> {
+    logger.debug(req, 'campaign_monitor', 'Fetching campaign metrics from Google Ads', { days });
+
+    const { gaqlRange, effectiveDays } = resolveDateRange(days);
+
+    const query = `
+      SELECT campaign.name, campaign.status, campaign_budget.amount_micros,
+             metrics.impressions, metrics.clicks, metrics.cost_micros,
+             metrics.conversions, metrics.ctr, metrics.average_cpc
+      FROM campaign
+      WHERE segments.date DURING ${gaqlRange}
+        AND campaign.advertising_channel_type IN ('SEARCH', 'DEMAND_GEN')
+      ORDER BY metrics.cost_micros DESC`;
+
+    const rows = await gaqlSearch(query);
+    const campaigns = rows.map((row) => parseCampaignMetrics(row, effectiveDays));
+    const actionItems = generateActionItems(campaigns);
+
+    for (const campaign of campaigns) {
+      campaign.actionRules = actionItems.filter((a) => a.campaign === campaign.shortName);
+    }
+
+    return {
+      pulledAt: new Date().toISOString(),
+      dateRange: { mode: `last_${effectiveDays}_days` },
+      campaigns,
+      accountTotals: aggregateTotals(campaigns),
+      actionItems,
+    };
+  }
+
+  // === Keyword metrics ===
+
+  public async getKeywords(req: Request, days: number): Promise<KeywordMetricsResponse> {
+    logger.debug(req, 'campaign_keywords', 'Fetching keyword metrics from Google Ads', { days });
+
+    const { gaqlRange } = resolveDateRange(days);
+
+    const query = `
+      SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
+             ad_group_criterion.quality_info.quality_score, ad_group_criterion.status,
+             ad_group.name, campaign.name,
+             metrics.impressions, metrics.clicks, metrics.ctr,
+             metrics.cost_micros, metrics.conversions
+      FROM keyword_view
+      WHERE segments.date DURING ${gaqlRange}
+      ORDER BY metrics.impressions DESC
+      LIMIT 200`;
+
+    const rows = await gaqlSearch(query);
+    const keywords = rows.map(parseKeywordRow);
+    const totals = {
+      impressions: keywords.reduce((s, k) => s + k.impressions, 0),
+      clicks: keywords.reduce((s, k) => s + k.clicks, 0),
+      spend: keywords.reduce((s, k) => s + k.spend, 0),
+      conversions: keywords.reduce((s, k) => s + k.conversions, 0),
+      avgCtr: 0,
+    };
+    totals.avgCtr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : 0;
+
+    return { pulledAt: new Date().toISOString(), days, totalKeywords: keywords.length, totals, keywords };
+  }
+
+  // === Audience demographics ===
+
+  public async getAudience(req: Request, days: number): Promise<AudienceDemographics> {
+    logger.debug(req, 'campaign_audience', 'Fetching audience demographics from Google Ads', { days });
+
+    const { gaqlRange } = resolveDateRange(days);
+
+    const ageQuery = `SELECT ad_group_criterion.age_range.type, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions
+      FROM age_range_view WHERE segments.date DURING ${gaqlRange}`;
+
+    const genderQuery = `SELECT ad_group_criterion.gender.type, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions
+      FROM gender_view WHERE segments.date DURING ${gaqlRange}`;
+
+    const [ageRows, genderRows] = await Promise.all([gaqlSearch(ageQuery), gaqlSearch(genderQuery)]);
+
+    const age = aggregateDemoBuckets(ageRows, (r) => (extractNested(r, 'adGroupCriterion.ageRange.type') as string) || 'Unknown');
+    const gender = aggregateDemoBuckets(genderRows, (r) => (extractNested(r, 'adGroupCriterion.gender.type') as string) || 'Unknown');
+
+    return { pulledAt: new Date().toISOString(), days, age, gender, device: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveDateRange(days: number): { gaqlRange: string; effectiveDays: number } {
+  if (days <= 7) return { gaqlRange: 'LAST_7_DAYS', effectiveDays: 7 };
+  if (days <= 14) return { gaqlRange: 'LAST_14_DAYS', effectiveDays: 14 };
+  return { gaqlRange: 'LAST_30_DAYS', effectiveDays: 30 };
+}
+
+function extractNested(obj: unknown, path: string): unknown {
+  let current: unknown = obj;
+  for (const key of path.split('.')) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+const VALID_CAMPAIGN_STATUSES = new Set<CampaignMetrics['status']>(['enabled', 'paused', 'removed', 'limited', 'draft']);
+
+function normalizeCampaignStatus(raw: string | undefined): CampaignMetrics['status'] {
+  const status = (raw ?? 'unknown').toLowerCase() as CampaignMetrics['status'];
+  return VALID_CAMPAIGN_STATUSES.has(status) ? status : 'unknown';
+}
+
+function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
+  const r = row as Record<string, unknown>;
+  const name = (extractNested(r, 'campaign.name') as string) || '';
+  const parts = name.split(' | ');
+  const budgetMicros = Number(extractNested(r, 'campaignBudget.amountMicros') || 0);
+  const costMicros = Number(extractNested(r, 'metrics.costMicros') || 0);
+  const impressions = Number(extractNested(r, 'metrics.impressions') || 0);
+  const clicks = Number(extractNested(r, 'metrics.clicks') || 0);
+  const conversions = Number(extractNested(r, 'metrics.conversions') || 0);
+  const budgetDay = budgetMicros / 1_000_000;
+  const spend = costMicros / 1_000_000;
+  const expectedSpend = budgetDay * days;
+  const pacingPct = expectedSpend > 0 ? Math.round((spend / expectedSpend) * 100) : 0;
+
+  let pacingLabel: PacingLabel = 'normal';
+  if (pacingPct < 50) pacingLabel = 'underspending';
+  else if (pacingPct > 100) pacingLabel = 'overspending';
+  else if (pacingPct > 90) pacingLabel = 'constrained';
+
+  return {
+    name,
+    shortName: parts[1] || name,
+    eventName: parts[1] || '',
+    adFormat: parts[5] || '',
+    targeting: parts[4] || '',
+    status: normalizeCampaignStatus(extractNested(r, 'campaign.status') as string | undefined),
+    budgetDay,
+    spend,
+    impressions,
+    clicks,
+    ctr: impressions > 0 ? (clicks / impressions) * 100 : 0,
+    avgCpc: clicks > 0 ? spend / clicks : 0,
+    conversions,
+    pacingPct,
+    pacingLabel,
+    actionRules: [],
+  };
+}
+
+function aggregateTotals(campaigns: CampaignMetrics[]) {
+  return {
+    budgetDay: campaigns.reduce((s, c) => s + c.budgetDay, 0),
+    spend: campaigns.reduce((s, c) => s + c.spend, 0),
+    impressions: campaigns.reduce((s, c) => s + c.impressions, 0),
+    clicks: campaigns.reduce((s, c) => s + c.clicks, 0),
+    conversions: campaigns.reduce((s, c) => s + c.conversions, 0),
+  };
+}
+
+function generateActionItems(campaigns: CampaignMetrics[]) {
+  const items: CampaignMetrics['actionRules'] = [];
+  for (const c of campaigns) {
+    const isSearch = c.adFormat.toLowerCase().includes('search');
+
+    if (c.status === 'limited') {
+      items.push({
+        campaign: c.shortName,
+        priority: 'HIGH',
+        issue: 'Campaign limited by Google',
+        action: 'Switch bid to Maximize Clicks or expand keyword match types',
+        owner: 'ads-manager',
+      });
+    }
+    if (c.budgetDay <= 1 && c.status === 'enabled') {
+      items.push({
+        campaign: c.shortName,
+        priority: 'HIGH',
+        issue: 'Placeholder $1/day budget',
+        action: 'Set real budget before activation',
+        owner: 'stakeholder',
+      });
+    }
+    if (c.status === 'paused') {
+      items.push({ campaign: c.shortName, priority: 'MED', issue: 'Campaign paused', action: 'Verify pause reason or activate', owner: 'ads-manager' });
+    }
+    if (c.pacingLabel === 'underspending' && c.status === 'enabled') {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: `Underspending (${c.pacingPct}% of budget)`,
+        action: 'Broaden targeting or increase bids',
+        owner: 'ads-manager',
+      });
+    }
+    if (c.pacingLabel === 'constrained' && c.status === 'enabled') {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: `Budget constrained (${c.pacingPct}%)`,
+        action: 'Consider budget increase',
+        owner: 'stakeholder',
+      });
+    }
+    if (isSearch && c.ctr < 2 && c.clicks > 50) {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: 'Low Search CTR (<2%)',
+        action: 'Review headline relevance, add negative keywords',
+        owner: 'ads-manager',
+      });
+    }
+    if (!isSearch && c.ctr < 0.3 && c.clicks > 50) {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: 'Low Display CTR (<0.3%)',
+        action: 'Refresh creative, check audience overlap',
+        owner: 'ads-manager',
+      });
+    }
+    if (c.clicks > 100 && c.conversions === 0) {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: 'Clicks with zero conversions',
+        action: 'Audit conversion tracking setup',
+        owner: 'ads-manager',
+      });
+    }
+    if (c.status === 'draft') {
+      items.push({
+        campaign: c.shortName,
+        priority: 'MED',
+        issue: 'Campaign in draft',
+        action: 'Complete setup: upload images, publish, then pause',
+        owner: 'ads-manager',
+      });
+    }
+  }
+  const priorityOrder: Record<string, number> = { HIGH: 0, MED: 1, LOW: 2 };
+  items.sort((a, b) => (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3));
+  return items;
+}
+
+function parseKeywordRow(row: unknown): KeywordMetrics {
+  const r = row as Record<string, unknown>;
+  const costMicros = Number(extractNested(r, 'metrics.costMicros') || 0);
+  const clicks = Number(extractNested(r, 'metrics.clicks') || 0);
+  return {
+    keyword: (extractNested(r, 'adGroupCriterion.keyword.text') as string) || '',
+    matchType: (extractNested(r, 'adGroupCriterion.keyword.matchType') as string) || '',
+    qualityScore: (extractNested(r, 'adGroupCriterion.qualityInfo.qualityScore') as number) ?? null,
+    status: (extractNested(r, 'adGroupCriterion.status') as string) || '',
+    adGroup: (extractNested(r, 'adGroup.name') as string) || '',
+    campaign: (extractNested(r, 'campaign.name') as string) || '',
+    impressions: Number(extractNested(r, 'metrics.impressions') || 0),
+    clicks,
+    ctr: Number(extractNested(r, 'metrics.ctr') || 0) * 100,
+    avgCpc: clicks > 0 ? costMicros / 1_000_000 / clicks : 0,
+    spend: costMicros / 1_000_000,
+    conversions: Number(extractNested(r, 'metrics.conversions') || 0),
+  };
+}
+
+function aggregateDemoBuckets(rows: unknown[], labelExtractor: (row: Record<string, unknown>) => string): AudienceBucket[] {
+  const buckets = new Map<string, AudienceBucket>();
+
+  for (const row of rows) {
+    const r = row as Record<string, unknown>;
+    const label = labelExtractor(r) || 'Unknown';
+    const existing = buckets.get(label) || { label, impressions: 0, clicks: 0, ctr: 0, spend: 0, conversions: 0 };
+    existing.impressions += Number(extractNested(r, 'metrics.impressions') || 0);
+    existing.clicks += Number(extractNested(r, 'metrics.clicks') || 0);
+    existing.spend += Number(extractNested(r, 'metrics.costMicros') || 0) / 1_000_000;
+    existing.conversions += Number(extractNested(r, 'metrics.conversions') || 0);
+    existing.ctr = existing.impressions > 0 ? (existing.clicks / existing.impressions) * 100 : 0;
+    buckets.set(label, existing);
+  }
+
+  return [...buckets.values()];
+}

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -24,8 +24,71 @@ import { GoogleAdsApi, enums } from 'google-ads-api';
 
 import type { Customer } from 'google-ads-api';
 
+// ---------------------------------------------------------------------------
+// Required environment variables — log warnings at startup for missing ones
+// ---------------------------------------------------------------------------
+
+const REQUIRED_ENV_VARS = ['GADS_CLIENT_ID', 'GADS_CLIENT_SECRET', 'GADS_DEVELOPER_TOKEN', 'GADS_CUSTOMER_ID', 'GADS_REFRESH_TOKEN'];
+
+for (const envVar of REQUIRED_ENV_VARS) {
+  if (!process.env[envVar]) {
+    logger.warning(undefined, 'campaign_proxy_init', `Missing environment variable: ${envVar} — Google Ads features will not work`, { envVar });
+  }
+}
+
 function getEnv(key: string): string {
   return process.env[key] || '';
+}
+
+// ---------------------------------------------------------------------------
+// SSRF validation for user-provided URLs
+// ---------------------------------------------------------------------------
+
+const PRIVATE_IP_PATTERNS = [
+  /^localhost$/i,
+  /^127\.\d+\.\d+\.\d+$/,
+  /^0\.\d+\.\d+\.\d+$/,
+  /^10\.\d+\.\d+\.\d+$/,
+  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+  /^192\.168\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/, // link-local / AWS IMDS
+  /^::1$/,
+  /^f[cd][0-9a-f]{2}:/i, // IPv6 ULA (fc00::/7 covers both fc and fd)
+  /^fe80:/i, // IPv6 link-local
+];
+
+export async function validateScrapeUrl(url: string): Promise<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid URL format');
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Only HTTPS URLs are allowed');
+  }
+
+  const port = parsed.port ? Number(parsed.port) : 443;
+  if (port !== 80 && port !== 443) {
+    throw new Error('Only ports 80 and 443 are allowed');
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (PRIVATE_IP_PATTERNS.some((p) => p.test(hostname))) {
+    throw new Error('URLs targeting private/internal hosts are not allowed');
+  }
+
+  const { promises: dns } = await import('node:dns');
+  const addresses4 = await dns.resolve4(hostname).catch(() => []);
+  const addresses6 = await dns.resolve6(hostname).catch(() => []);
+  for (const addr of [...addresses4, ...addresses6]) {
+    if (PRIVATE_IP_PATTERNS.some((p) => p.test(addr))) {
+      throw new Error('Blocked host: resolves to private IP');
+    }
+  }
+
+  return `https://${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
 }
 
 let gadsClient: GoogleAdsApi | null = null;
@@ -33,16 +96,10 @@ let gadsCustomer: Customer | null = null;
 
 function getGadsClient(): GoogleAdsApi {
   if (!gadsClient) {
-    const clientId = getEnv('GADS_CLIENT_ID');
-    const clientSecret = getEnv('GADS_CLIENT_SECRET');
-    const developerToken = getEnv('GADS_DEVELOPER_TOKEN');
-    if (!clientId || !clientSecret || !developerToken) {
-      throw new Error('Google Ads credentials not configured — set GADS_CLIENT_ID, GADS_CLIENT_SECRET, and GADS_DEVELOPER_TOKEN');
-    }
     gadsClient = new GoogleAdsApi({
-      client_id: clientId,
-      client_secret: clientSecret,
-      developer_token: developerToken,
+      client_id: getEnv('GADS_CLIENT_ID'),
+      client_secret: getEnv('GADS_CLIENT_SECRET'),
+      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
     });
   }
   return gadsClient;
@@ -124,10 +181,6 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
-
-  if (best.score === 0) {
-    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
-  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -212,7 +265,7 @@ async function aiChat(systemPrompt: string, userPrompt: string, maxTokens = 4096
       max_tokens: maxTokens,
       temperature: 0.7,
     }),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!response.ok) {
@@ -221,9 +274,6 @@ async function aiChat(systemPrompt: string, userPrompt: string, maxTokens = 4096
   }
 
   const data = (await response.json()) as { choices: { message: { content: string } }[] };
-  if (!data.choices?.length || !data.choices[0]?.message?.content) {
-    throw new Error('AI proxy returned empty or malformed response');
-  }
   return data.choices[0].message.content;
 }
 
@@ -248,7 +298,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
+    signal,
   });
 
   if (!response.ok || !response.body) {
@@ -266,7 +316,8 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split('\n');
       buffer = lines.pop() || '';
-      for (const line of lines) {
+      for (const rawLine of lines) {
+        const line = rawLine.replace(/\r$/, '');
         if (!line.startsWith('data: ') || line === 'data: [DONE]') continue;
         try {
           const parsed = JSON.parse(line.slice(6)) as { choices: { delta: { content?: string } }[] };
@@ -393,65 +444,6 @@ const GEO_TARGET_MAP: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// SSRF protection for user-supplied URLs
-// ---------------------------------------------------------------------------
-
-const PRIVATE_IP_PATTERNS = [/^127\./, /^10\./, /^172\.(1[6-9]|2\d|3[01])\./, /^192\.168\./, /^169\.254\./, /^0\./, /^::1$/, /^fc[0-9a-f]{2}:/i, /^fe80:/i];
-
-const BLOCKED_HOSTNAMES = new Set(['localhost', '[::1]']);
-
-const ALLOWED_PORTS = new Set(['', '80', '443']);
-
-async function validateScrapeUrl(rawUrl: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    throw new Error('Invalid URL');
-  }
-
-  if (parsed.protocol !== 'https:') {
-    throw new Error('Only HTTPS URLs are allowed');
-  }
-
-  if (!ALLOWED_PORTS.has(parsed.port)) {
-    throw new Error(`Non-standard port not allowed: ${parsed.port}`);
-  }
-
-  const hostname = parsed.hostname.toLowerCase();
-
-  if (BLOCKED_HOSTNAMES.has(hostname) || hostname === '0.0.0.0' || hostname === '::1') {
-    throw new Error('Blocked host: private/internal address');
-  }
-
-  if (PRIVATE_IP_PATTERNS.some((re) => re.test(hostname))) {
-    throw new Error('Blocked host: private IP range');
-  }
-
-  const { promises: dns } = await import('node:dns');
-  try {
-    const addresses = await dns.resolve4(hostname).catch(() => [] as string[]);
-    const addresses6 = await dns.resolve6(hostname).catch(() => [] as string[]);
-    for (const addr of [...addresses, ...addresses6]) {
-      if (PRIVATE_IP_PATTERNS.some((re) => re.test(addr))) {
-        throw new Error('Blocked host: resolves to private IP');
-      }
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('Blocked host')) throw error;
-    throw new Error(`DNS resolution failed for ${hostname}`);
-  }
-
-  const allowlist = getEnv('CAMPAIGN_BRIEF_SCRAPE_HOST_ALLOWLIST');
-  if (allowlist) {
-    const allowed = allowlist.split(',').map((h) => h.trim().toLowerCase());
-    if (!allowed.includes(hostname)) {
-      throw new Error(`Host not in allowlist: ${hostname}`);
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // CampaignProxyService — brief generation + campaign creation
 // ---------------------------------------------------------------------------
 
@@ -485,22 +477,22 @@ export class CampaignProxyService {
   public async *streamBrief(req: Request, body: CampaignBriefRequest, signal: AbortSignal): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     yield { type: 'status', data: `Scraping ${body.url}...` };
 
+    let safeUrl: string;
     try {
-      await validateScrapeUrl(body.url);
+      safeUrl = await validateScrapeUrl(body.url);
     } catch (error) {
-      yield { type: 'error', data: `Blocked URL: ${error instanceof Error ? error.message : 'Invalid URL'}` };
+      yield { type: 'error', data: `Invalid URL: ${error instanceof Error ? error.message : 'Unknown error'}` };
       return;
     }
 
     let html = '';
     try {
-      const scrapeResponse = await fetch(body.url, {
+      const scrapeResponse = await fetch(safeUrl, {
         headers: { 'User-Agent': 'Mozilla/5.0 (compatible; LFX/1.0)' },
         signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)]),
-        redirect: 'error',
       });
       if (!scrapeResponse.ok) {
-        yield { type: 'error', data: `Event page returned ${scrapeResponse.status}` };
+        yield { type: 'error', data: `Event page returned HTTP ${scrapeResponse.status}` };
         return;
       }
       html = await scrapeResponse.text();
@@ -537,8 +529,7 @@ export class CampaignProxyService {
       }
     }
 
-    const platforms = body.platforms?.length ? body.platforms : (['google-ads'] as const);
-    const platformList = platforms.join(', ');
+    const platformList = (body.platforms || ['google-ads']).join(', ');
     yield { type: 'status', data: `Generating copy for ${platformList}...` };
 
     const userPrompt = buildCopyPrompt(body, eventDetails);
@@ -573,7 +564,7 @@ export class CampaignProxyService {
       return;
     }
 
-    if (platforms.includes('google-ads')) {
+    if (body.platforms?.includes('google-ads') || !body.platforms) {
       yield { type: 'status', data: 'Generating keyword list...' };
 
       try {
@@ -626,48 +617,45 @@ export class CampaignProxyService {
 
   public async getJobStatus(_req: Request, jobId: string): Promise<CampaignJobStatus> {
     const job = jobs.get(jobId);
-    if (!job) return { status: 'not_found' };
+    if (!job) return { status: 'done', result: { success: false, campaigns: [], errors: ['Job not found'] } };
     return job;
   }
 
   // === Private: campaign creation orchestration ===
 
   private async executeCampaignCreation(jobId: string, body: CampaignCreateRequest): Promise<void> {
-    const startTime = Date.now();
-    let hsToken = body.hsToken;
-    if (!hsToken) {
+    if (!body.hsToken) {
       try {
         const hsUtm = await resolveHubSpotUtm(body.eventName);
-        if (hsUtm) hsToken = hsUtm;
+        if (hsUtm) body.hsToken = hsUtm;
       } catch {
         // HubSpot unavailable — fall back to event slug for UTM
       }
     }
 
-    const effectiveBody = hsToken ? { ...body, hsToken } : body;
     const results: CampaignCreateResult[] = [];
     const errors: string[] = [];
 
     for (const campaignType of body.campaignTypes) {
       try {
-        const result = campaignType === 'search' ? await this.createSearchCampaign(effectiveBody) : await this.createDemandGenCampaign(effectiveBody);
+        const result = campaignType === 'search' ? await this.createSearchCampaign(body) : await this.createDemandGenCampaign(body);
         results.push(result);
       } catch (error: unknown) {
         if (getGadsErrorCode(error) === 'DUPLICATE_CAMPAIGN_NAME') {
           try {
-            const retryBody = { ...effectiveBody, eventName: `${effectiveBody.eventName} ${Date.now().toString(36).slice(-4)}` };
+            const retryBody = { ...body, eventName: `${body.eventName}-${Date.now().toString(36).slice(-4)}` };
             const result = campaignType === 'search' ? await this.createSearchCampaign(retryBody) : await this.createDemandGenCampaign(retryBody);
             results.push(result);
             continue;
           } catch (retryError: unknown) {
             const detail = extractGadsErrorMessage(retryError);
-            logger.error(undefined, 'campaign_create_type', startTime, retryError as Error, { campaignType, detail });
+            logger.error(undefined, 'campaign_create_type', Date.now(), retryError as Error, { campaignType, detail });
             errors.push(`${campaignType}: ${detail}`);
             continue;
           }
         }
         const detail = extractGadsErrorMessage(error);
-        logger.error(undefined, 'campaign_create_type', startTime, error as Error, { campaignType, detail });
+        logger.error(undefined, 'campaign_create_type', Date.now(), error as Error, { campaignType, detail });
         errors.push(`${campaignType}: ${detail}`);
       }
     }
@@ -678,7 +666,7 @@ export class CampaignProxyService {
   private async createSearchCampaign(body: CampaignCreateRequest): Promise<CampaignCreateResult> {
     const steps: string[] = [];
     const customer = getCustomer();
-    const searchPct = Math.max(0.1, Math.min(1.0, body.searchBudgetPct / 100));
+    const { searchPct } = normalizeBudgetSplit(body.searchBudgetPct, body.campaignTypes);
     const budgetMicros = Math.round(body.budgetUsd * searchPct * 1_000_000);
     const campaignName = buildCampaignName(body, 'Search');
 
@@ -691,7 +679,7 @@ export class CampaignProxyService {
         explicitly_shared: false,
       },
     ]);
-    const budgetResource = budgetResult.results[0].resource_name;
+    const budgetResource = budgetResult.results[0].resource_name ?? '';
     steps.push(`Created budget: $${(budgetMicros / 1_000_000).toFixed(2)}/day`);
 
     // 2. Create campaign
@@ -701,9 +689,9 @@ export class CampaignProxyService {
         advertising_channel_type: enums.AdvertisingChannelType.SEARCH,
         status: enums.CampaignStatus.PAUSED,
         campaign_budget: budgetResource,
-        start_date_time: body.startDate,
-        end_date_time: body.endDate,
-        bidding_strategy_type: enums.BiddingStrategyType.MAXIMIZE_CONVERSIONS,
+        start_date_time: `${body.startDate} 00:00:00`,
+        end_date_time: `${body.endDate} 23:59:59`,
+        maximize_conversions: {},
         network_settings: {
           target_google_search: true,
           target_search_network: true,
@@ -737,7 +725,7 @@ export class CampaignProxyService {
         status: enums.AdGroupStatus.ENABLED,
       },
     ]);
-    const adGroupResource = adGroupResult.results[0].resource_name;
+    const adGroupResource = adGroupResult.results[0].resource_name ?? '';
     steps.push('Created ad group');
 
     // 5. Add keywords
@@ -764,7 +752,10 @@ export class CampaignProxyService {
         ad_group: adGroupResource,
         ad: {
           responsive_search_ad: {
-            headlines: headlines.map((h) => ({ text: h.slice(0, 30) })),
+            headlines: headlines.map((h, i) => ({
+              text: h.slice(0, 30),
+              pinned_field: i < 3 ? HEADLINE_PIN_FIELDS[i] : undefined,
+            })),
             descriptions: descriptions.map((d) => ({ text: d.slice(0, 90) })),
           },
           final_urls: [finalUrl],
@@ -789,7 +780,7 @@ export class CampaignProxyService {
   private async createDemandGenCampaign(body: CampaignCreateRequest): Promise<CampaignCreateResult> {
     const steps: string[] = [];
     const customer = getCustomer();
-    const displayPct = Math.max(0.1, Math.min(1.0, 1 - body.searchBudgetPct / 100));
+    const { displayPct } = normalizeBudgetSplit(body.searchBudgetPct, body.campaignTypes);
     const budgetMicros = Math.round(body.budgetUsd * displayPct * 1_000_000);
     const campaignName = buildCampaignName(body, 'DemandGen');
 
@@ -801,7 +792,7 @@ export class CampaignProxyService {
         explicitly_shared: false,
       },
     ]);
-    const budgetResource = budgetResult.results[0].resource_name;
+    const budgetResource = budgetResult.results[0].resource_name ?? '';
     steps.push(`Created budget: $${(budgetMicros / 1_000_000).toFixed(2)}/day`);
 
     const campaignResult = await customer.campaigns.create([
@@ -810,9 +801,9 @@ export class CampaignProxyService {
         advertising_channel_type: enums.AdvertisingChannelType.DEMAND_GEN,
         status: enums.CampaignStatus.PAUSED,
         campaign_budget: budgetResource,
-        start_date_time: body.startDate,
-        end_date_time: body.endDate,
-        bidding_strategy_type: enums.BiddingStrategyType.MAXIMIZE_CONVERSIONS,
+        start_date_time: `${body.startDate} 00:00:00`,
+        end_date_time: `${body.endDate} 23:59:59`,
+        target_spend: {},
       },
     ]);
     const campaignResource = campaignResult.results[0].resource_name ?? '';
@@ -827,7 +818,7 @@ export class CampaignProxyService {
         status: enums.AdGroupStatus.ENABLED,
       },
     ]);
-    const adGroupResource = adGroupResult.results[0].resource_name;
+    const adGroupResource = adGroupResult.results[0].resource_name ?? '';
     steps.push('Created ad group');
 
     // Geo targeting at ad group level (Demand Gen doesn't support campaign-level location criteria)
@@ -867,10 +858,20 @@ export class CampaignProxyService {
 // ---------------------------------------------------------------------------
 
 function resolveMatchType(matchType: string): number {
-  const normalized = matchType.toLowerCase();
-  if (normalized === 'exact') return enums.KeywordMatchType.EXACT;
-  if (normalized === 'phrase') return enums.KeywordMatchType.PHRASE;
+  if (matchType === 'Exact') return enums.KeywordMatchType.EXACT;
+  if (matchType === 'Phrase') return enums.KeywordMatchType.PHRASE;
   return enums.KeywordMatchType.BROAD;
+}
+
+const HEADLINE_PIN_FIELDS = [enums.ServedAssetFieldType.HEADLINE_1, enums.ServedAssetFieldType.HEADLINE_2, enums.ServedAssetFieldType.HEADLINE_3];
+
+function normalizeBudgetSplit(searchBudgetPct: number, campaignTypes: string[]): { searchPct: number; displayPct: number } {
+  const hasSearch = campaignTypes.includes('search');
+  const hasDisplay = campaignTypes.includes('demand-gen');
+  if (hasSearch && !hasDisplay) return { searchPct: 1, displayPct: 0 };
+  if (!hasSearch && hasDisplay) return { searchPct: 0, displayPct: 1 };
+  const raw = Math.max(0, Math.min(100, searchBudgetPct)) / 100;
+  return { searchPct: raw, displayPct: 1 - raw };
 }
 
 function truncateAdCopy(obj: Record<string, unknown>): void {
@@ -1012,14 +1013,19 @@ const REGION_MAP: Record<string, string> = {
   BR: 'LATAM',
 };
 
+function sanitizeDelimiter(value: string): string {
+  return value.replace(/\|/g, '-');
+}
+
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
+  const region = REGION_MAP[body.countryCode] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';
-  const project = body.project || 'Linux Foundation';
+  const project = sanitizeDelimiter(body.project || 'Linux Foundation');
+  const eventName = sanitizeDelimiter(body.eventName);
   const dateSuffix = body.startDate || new Date().toISOString().split('T')[0];
-  return `Events | ${body.eventName} | ${region} | Conversions | ${targeting} | ${adFormat} | ${project} | ${funnel} | ${dateSuffix}`;
+  return `Events | ${eventName} | ${region} | Conversions | ${targeting} | ${adFormat} | ${project} | ${funnel} | ${dateSuffix}`;
 }
 
 function buildFinalUrl(body: CampaignCreateRequest, platform = 'search'): string {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -96,10 +96,16 @@ let gadsCustomer: Customer | null = null;
 
 function getGadsClient(): GoogleAdsApi {
   if (!gadsClient) {
+    const clientId = getEnv('GADS_CLIENT_ID');
+    const clientSecret = getEnv('GADS_CLIENT_SECRET');
+    const developerToken = getEnv('GADS_DEVELOPER_TOKEN');
+    if (!clientId || !clientSecret || !developerToken) {
+      throw new Error('Google Ads credentials not configured (GADS_CLIENT_ID, GADS_CLIENT_SECRET, GADS_DEVELOPER_TOKEN)');
+    }
     gadsClient = new GoogleAdsApi({
-      client_id: getEnv('GADS_CLIENT_ID'),
-      client_secret: getEnv('GADS_CLIENT_SECRET'),
-      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
+      client_id: clientId,
+      client_secret: clientSecret,
+      developer_token: developerToken,
     });
   }
   return gadsClient;
@@ -181,6 +187,10 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
+
+  if (best.score === 0) {
+    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
+  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -273,8 +283,12 @@ async function aiChat(systemPrompt: string, userPrompt: string, maxTokens = 4096
     throw new Error(`AI request failed (${response.status}): ${text}`);
   }
 
-  const data = (await response.json()) as { choices: { message: { content: string } }[] };
-  return data.choices[0].message.content;
+  const data = (await response.json()) as { choices?: { message?: { content?: string } }[] };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error('AI proxy returned an empty or malformed response');
+  }
+  return content;
 }
 
 async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: AbortSignal, maxTokens = 4096): AsyncGenerator<string> {
@@ -298,7 +312,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal,
+    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
   });
 
   if (!response.ok || !response.body) {
@@ -487,10 +501,26 @@ export class CampaignProxyService {
 
     let html = '';
     try {
-      const scrapeResponse = await fetch(safeUrl, {
+      let scrapeResponse = await fetch(safeUrl, {
         headers: { 'User-Agent': 'Mozilla/5.0 (compatible; LFX/1.0)' },
         signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)]),
+        redirect: 'manual',
       });
+
+      // Follow redirects manually to validate each target against SSRF
+      let redirectCount = 0;
+      while (scrapeResponse.status >= 300 && scrapeResponse.status < 400 && redirectCount < 5) {
+        const location = scrapeResponse.headers.get('location');
+        if (!location) break;
+        const redirectUrl = await validateScrapeUrl(new URL(location, safeUrl).href);
+        scrapeResponse = await fetch(redirectUrl, {
+          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; LFX/1.0)' },
+          signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)]),
+          redirect: 'manual',
+        });
+        redirectCount++;
+      }
+
       if (!scrapeResponse.ok) {
         yield { type: 'error', data: `Event page returned HTTP ${scrapeResponse.status}` };
         return;
@@ -1018,7 +1048,7 @@ function sanitizeDelimiter(value: string): string {
 }
 
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode] || 'Global';
+  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -41,7 +41,7 @@ export type CampaignSSEEventType =
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms: CampaignPlatform[];
+  platforms?: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -9,7 +9,7 @@ export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' |
 
 export type CampaignPhase = 'planning' | 'implementation' | 'monitoring' | 'optimization';
 
-export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited';
+export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited' | 'unknown';
 
 export type CampaignType = 'search' | 'demand-gen';
 
@@ -27,11 +27,21 @@ export interface CampaignTabOption {
 // Brief Pipeline (Planning Phase)
 // ---------------------------------------------------------------------------
 
-export type CampaignSSEEventType = 'status' | 'event' | 'hubspot_utm' | 'copy_token' | 'copy_done' | 'copy_structured' | 'keywords' | 'error' | 'done';
+export type CampaignSSEEventType =
+  | 'status'
+  | 'event'
+  | 'hubspot_utm'
+  | 'copy_token'
+  | 'copy_done'
+  | 'copy_structured'
+  | 'keywords'
+  | 'error'
+  | 'done'
+  | 'shutdown';
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms?: CampaignPlatform[];
+  platforms: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;
@@ -113,7 +123,7 @@ export interface CampaignCreateResponse {
 }
 
 export interface CampaignJobStatus {
-  status: 'running' | 'done' | 'not_found';
+  status: 'running' | 'done';
   result?: CampaignCreateResponse;
 }
 

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -19,6 +19,9 @@ export * from './components.interface';
 // Auth interfaces
 export * from './auth.interface';
 
+// Campaign interfaces
+export * from './campaign.interface';
+
 // API interfaces
 export * from './api.interface';
 


### PR DESCRIPTION
## Summary
- Add `CampaignService` with SSE brief streaming, campaign CRUD, monitoring, keywords, audience, and HubSpot UTM methods
- Service calls `/api/campaigns/*` endpoints (backend added in separate PR)
- Campaign types inlined until shared-package PR (LFXV2-2026) merges

Part of campaigns epic LFXV2-2023.
JIRA: LFXV2-2028

🤖 Generated with [Claude Code](https://claude.ai/code)