### PR TITLE
feat(campaigns): add planning tab with AI brief generator

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -375,11 +375,13 @@ export class PlanningTabComponent implements OnInit {
     this.hsNotFound.set(false);
     this.hsUtm.set(null);
 
+    const capturedEvent = eventName;
     this.campaignService
       .lookupHubSpotUtm(eventName)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (result: HubSpotUtmLookupResult | null) => {
+          if (this.lastLookedUpEvent !== capturedEvent) return;
           if (result?.found && result.hs_utm) {
             this.hsUtm.set(result.hs_utm);
             this.hsMatches.set(result.all_matches ?? []);
@@ -391,6 +393,7 @@ export class PlanningTabComponent implements OnInit {
           this.hsSearching.set(false);
         },
         error: () => {
+          if (this.lastLookedUpEvent !== capturedEvent) return;
           this.hsStatus.set('HubSpot lookup failed');
           this.hsSearching.set(false);
         },

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -14,13 +14,14 @@ import type {
   CampaignBriefOutput,
   CampaignEventDetails,
   CampaignGoal,
+  CampaignGoalOption,
   CampaignKeyword,
   CampaignPlatform,
+  CampaignPlatformOption,
   CampaignSSEEventType,
   HubSpotUtmLookupResult,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
-import type { CampaignGoalOption, CampaignPlatformOption } from '@lfx-one/shared/constants';
 
 type PlanningStep = 'input' | 'generating' | 'review';
 
@@ -128,22 +129,25 @@ export class PlanningTabComponent implements OnInit {
     if (!this.lastLookedUpEvent) return;
     this.hsCreating.set(true);
     this.hsStatus.set(null);
-    this.campaignService.createHubSpotUtm(this.lastLookedUpEvent).subscribe({
-      next: (result) => {
-        if (result?.created && result.hs_utm) {
-          this.hsUtm.set(result.hs_utm);
-          this.hsNotFound.set(false);
-          this.hsStatus.set(`Created: ${result.campaign_name}`);
-        } else {
-          this.hsStatus.set('Failed to create campaign');
-        }
-        this.hsCreating.set(false);
-      },
-      error: () => {
-        this.hsStatus.set('Create failed');
-        this.hsCreating.set(false);
-      },
-    });
+    this.campaignService
+      .createHubSpotUtm(this.lastLookedUpEvent)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          if (result?.created && result.hs_utm) {
+            this.hsUtm.set(result.hs_utm);
+            this.hsNotFound.set(false);
+            this.hsStatus.set(`Created: ${result.campaign_name}`);
+          } else {
+            this.hsStatus.set('Failed to create campaign');
+          }
+          this.hsCreating.set(false);
+        },
+        error: () => {
+          this.hsStatus.set('Create failed');
+          this.hsCreating.set(false);
+        },
+      });
   }
 
   protected generate(): void {
@@ -371,23 +375,26 @@ export class PlanningTabComponent implements OnInit {
     this.hsNotFound.set(false);
     this.hsUtm.set(null);
 
-    this.campaignService.lookupHubSpotUtm(eventName).subscribe({
-      next: (result: HubSpotUtmLookupResult | null) => {
-        if (result?.found && result.hs_utm) {
-          this.hsUtm.set(result.hs_utm);
-          this.hsMatches.set(result.all_matches ?? []);
-          this.hsStatus.set(`Found: ${result.campaign_name}`);
-        } else {
-          this.hsNotFound.set(true);
-          this.hsStatus.set('No matching campaign in HubSpot');
-        }
-        this.hsSearching.set(false);
-      },
-      error: () => {
-        this.hsStatus.set('HubSpot lookup failed');
-        this.hsSearching.set(false);
-      },
-    });
+    this.campaignService
+      .lookupHubSpotUtm(eventName)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result: HubSpotUtmLookupResult | null) => {
+          if (result?.found && result.hs_utm) {
+            this.hsUtm.set(result.hs_utm);
+            this.hsMatches.set(result.all_matches ?? []);
+            this.hsStatus.set(`Found: ${result.campaign_name}`);
+          } else {
+            this.hsNotFound.set(true);
+            this.hsStatus.set('No matching campaign in HubSpot');
+          }
+          this.hsSearching.set(false);
+        },
+        error: () => {
+          this.hsStatus.set('HubSpot lookup failed');
+          this.hsSearching.set(false);
+        },
+      });
   }
 
   private handleSSEEvent(event: SSEEvent<CampaignSSEEventType>): void {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,6 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
   CampaignBriefRequest,
@@ -19,9 +20,6 @@ import {
 import { exhaustMap, last, map, Observable, of, take, takeWhile, timer } from 'rxjs';
 
 import { SseService } from './sse.service';
-
-const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
-
 
 @Injectable({ providedIn: 'root' })
 export class CampaignService {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,6 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
   CampaignBriefRequest,

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,7 +3,6 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
   CampaignBriefRequest,

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -22,6 +22,7 @@ import { SseService } from './sse.service';
 
 const CAMPAIGN_JOB_POLL_INTERVAL_MS = 2000;
 
+
 @Injectable({ providedIn: 'root' })
 export class CampaignService {
   private readonly http = inject(HttpClient);

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -735,7 +735,15 @@ export class CampaignProxyService {
 
     const response = { success: errors.length === 0, campaigns: results, errors };
     completeJob(jobId, response);
-    logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length, errorCount: errors.length });
+    if (errors.length > 0) {
+      logger.warning(undefined, 'campaign_create', `Campaign creation completed with ${errors.length} error(s)`, {
+        jobId,
+        campaignCount: results.length,
+        errorCount: errors.length,
+      });
+    } else {
+      logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length });
+    }
   }
 
   private async createSearchCampaign(body: CampaignCreateRequest): Promise<CampaignCreateResult> {
@@ -1146,5 +1154,7 @@ function extractGadsErrorMessage(error: unknown): string {
 
   if (code && friendlyMessages[code]) return friendlyMessages[code];
 
-  return 'Campaign creation failed. Please try again or contact support.';
+  return code
+    ? `Campaign creation failed (error code: ${code}). Please try again or contact support.`
+    : 'Campaign creation failed. Please try again or contact support.';
 }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -159,6 +159,7 @@ interface HubSpotUtmResult {
   hsUtm: string | null;
   campaignName: string;
   campaignId: string | null;
+  allMatches: { name: string; hsUtm: string }[];
 }
 
 function hsHeaders(): Record<string, string> {
@@ -192,7 +193,7 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
   const results = data.results ?? [];
 
   if (results.length === 0) {
-    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
+    return { found: false, hsUtm: null, campaignName: '', campaignId: null, allMatches: [] };
   }
 
   const queryLower = eventName.toLowerCase();
@@ -208,13 +209,20 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
   });
 
   scored.sort((a, b) => b.score - a.score);
-  const best = scored[0];
+  const matches = scored.filter((s) => s.score > 0);
 
-  if (best.score === 0) {
-    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
+  if (matches.length === 0) {
+    return { found: false, hsUtm: null, campaignName: '', campaignId: null, allMatches: [] };
   }
 
-  return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
+  const best = matches[0];
+  return {
+    found: true,
+    hsUtm: best.hsUtm,
+    campaignName: best.name,
+    campaignId: best.id,
+    allMatches: matches.map((m) => ({ name: m.name, hsUtm: m.hsUtm })),
+  };
 }
 
 async function hubspotCreateCampaign(eventName: string): Promise<HubSpotUtmResult> {
@@ -260,7 +268,7 @@ async function hubspotCreateCampaign(eventName: string): Promise<HubSpotUtmResul
     hsUtm = buildUtmTokenFallback(campaignUuid, eventName);
   }
 
-  return { found: true, hsUtm, campaignName: eventName, campaignId };
+  return { found: true, hsUtm, campaignName: eventName, campaignId, allMatches: [{ name: eventName, hsUtm: hsUtm! }] };
 }
 
 async function resolveHubSpotUtm(eventName: string): Promise<string | null> {
@@ -500,7 +508,7 @@ export class CampaignProxyService {
       found: result.found,
       hs_utm: result.hsUtm,
       campaign_name: result.campaignName,
-      all_matches: result.found && result.hsUtm ? [{ name: result.campaignName, hs_utm: result.hsUtm }] : [],
+      all_matches: result.allMatches.map((m) => ({ name: m.name, hs_utm: m.hsUtm })),
     };
   }
 
@@ -686,6 +694,7 @@ export class CampaignProxyService {
   // === Private: campaign creation orchestration ===
 
   private async executeCampaignCreation(jobId: string, body: CampaignCreateRequest): Promise<void> {
+    const startTime = logger.startOperation(undefined, 'campaign_create', { jobId, types: body.campaignTypes });
     const effectiveBody = { ...body };
     if (!effectiveBody.hsToken) {
       try {
@@ -724,7 +733,9 @@ export class CampaignProxyService {
       }
     }
 
-    completeJob(jobId, { success: errors.length === 0, campaigns: results, errors });
+    const response = { success: errors.length === 0, campaigns: results, errors };
+    completeJob(jobId, response);
+    logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length, errorCount: errors.length });
   }
 
   private async createSearchCampaign(body: CampaignCreateRequest): Promise<CampaignCreateResult> {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -104,7 +104,8 @@ export async function validateScrapeUrl(url: string): Promise<string> {
     throw new Error('DNS resolution failed — cannot verify host safety');
   }
   for (const addr of [...addresses4, ...addresses6]) {
-    if (PRIVATE_IP_PATTERNS.some((p) => p.test(addr))) {
+    const checkAddr = addr.replace(/^::ffff:/i, '');
+    if (PRIVATE_IP_PATTERNS.some((p) => p.test(checkAddr))) {
       throw new Error('Blocked host: resolves to private IP');
     }
   }
@@ -1133,18 +1134,6 @@ function extractGadsErrorMessage(error: unknown): string {
   };
 
   if (code && friendlyMessages[code]) return friendlyMessages[code];
-
-  if (error instanceof Error) return error.message;
-
-  const e = error as Record<string, unknown>;
-  if (Array.isArray(e['errors']) && e['errors'].length > 0) {
-    const first = e['errors'][0] as Record<string, unknown>;
-    const msg = typeof first['message'] === 'string' ? first['message'] : '';
-    if (msg) return msg;
-  }
-
-  if (typeof e['message'] === 'string' && e['message']) return e['message'];
-  if (typeof e['details'] === 'string' && e['details']) return e['details'];
 
   return 'Campaign creation failed. Please try again or contact support.';
 }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -740,7 +740,7 @@ export class CampaignProxyService {
         jobId,
         campaignCount: results.length,
         errorCount: errors.length,
-        durationMs: Date.now() - startTime,
+        duration_ms: Date.now() - startTime,
       });
     } else {
       logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length });
@@ -1155,7 +1155,9 @@ function extractGadsErrorMessage(error: unknown): string {
 
   if (code && friendlyMessages[code]) return friendlyMessages[code];
 
-  return code
-    ? `Campaign creation failed (error code: ${code}). Please try again or contact support.`
-    : 'Campaign creation failed. Please try again or contact support.';
+  const originalMessage = error instanceof Error ? error.message : '';
+
+  if (code) return `Campaign creation failed (error code: ${code}). Please try again or contact support.`;
+  if (originalMessage) return originalMessage;
+  return 'Campaign creation failed. Please try again or contact support.';
 }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -124,9 +124,9 @@ function getGadsClient(): GoogleAdsApi {
       throw new Error('Google Ads credentials not configured (GADS_CLIENT_ID, GADS_CLIENT_SECRET, GADS_DEVELOPER_TOKEN)');
     }
     gadsClient = new GoogleAdsApi({
-      client_id: getEnv('GADS_CLIENT_ID'),
-      client_secret: getEnv('GADS_CLIENT_SECRET'),
-      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
+      client_id: clientId,
+      client_secret: clientSecret,
+      developer_token: developerToken,
     });
   }
   return gadsClient;
@@ -208,6 +208,10 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
+
+  if (best.score === 0) {
+    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
+  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -329,7 +333,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal,
+    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
   });
 
   if (!response.ok || !response.body) {
@@ -1084,7 +1088,7 @@ function sanitizeDelimiter(value: string): string {
 }
 
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode] || 'Global';
+  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -709,7 +709,7 @@ export class CampaignProxyService {
     const errors: string[] = [];
 
     for (const campaignType of effectiveBody.campaignTypes) {
-      const startTime = Date.now();
+      const typeStartTime = Date.now();
       try {
         const result = campaignType === 'search' ? await this.createSearchCampaign(effectiveBody) : await this.createDemandGenCampaign(effectiveBody);
         results.push(result);
@@ -722,13 +722,13 @@ export class CampaignProxyService {
             continue;
           } catch (retryError: unknown) {
             const detail = extractGadsErrorMessage(retryError);
-            logger.error(undefined, 'campaign_create_type', startTime, retryError as Error, { campaignType, detail });
+            logger.error(undefined, 'campaign_create_type', typeStartTime, retryError as Error, { campaignType, detail });
             errors.push(`${campaignType}: ${detail}`);
             continue;
           }
         }
         const detail = extractGadsErrorMessage(error);
-        logger.error(undefined, 'campaign_create_type', startTime, error as Error, { campaignType, detail });
+        logger.error(undefined, 'campaign_create_type', typeStartTime, error as Error, { campaignType, detail });
         errors.push(`${campaignType}: ${detail}`);
       }
     }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -124,9 +124,9 @@ function getGadsClient(): GoogleAdsApi {
       throw new Error('Google Ads credentials not configured (GADS_CLIENT_ID, GADS_CLIENT_SECRET, GADS_DEVELOPER_TOKEN)');
     }
     gadsClient = new GoogleAdsApi({
-      client_id: clientId,
-      client_secret: clientSecret,
-      developer_token: developerToken,
+      client_id: getEnv('GADS_CLIENT_ID'),
+      client_secret: getEnv('GADS_CLIENT_SECRET'),
+      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
     });
   }
   return gadsClient;
@@ -208,10 +208,6 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
-
-  if (best.score === 0) {
-    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
-  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -333,7 +329,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
+    signal,
   });
 
   if (!response.ok || !response.body) {
@@ -1088,7 +1084,7 @@ function sanitizeDelimiter(value: string): string {
 }
 
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
+  const region = REGION_MAP[body.countryCode] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -740,6 +740,7 @@ export class CampaignProxyService {
         jobId,
         campaignCount: results.length,
         errorCount: errors.length,
+        durationMs: Date.now() - startTime,
       });
     } else {
       logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length });

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CampaignGoal, CampaignPlatform, CampaignTabOption } from '../interfaces/campaign.interface';
+import type { CampaignGoal, CampaignGoalOption, CampaignPlatform, CampaignPlatformOption, CampaignTabOption } from '../interfaces/campaign.interface';
 
 /** Tab definitions for the Campaigns page tab navigation. */
 export const CAMPAIGN_TABS: CampaignTabOption[] = [
@@ -10,13 +10,6 @@ export const CAMPAIGN_TABS: CampaignTabOption[] = [
   { id: 'monitoring', label: 'Monitoring', icon: 'fa-light fa-chart-mixed' },
   { id: 'optimization', label: 'Optimization', icon: 'fa-light fa-gauge-high' },
 ] as const;
-
-export interface CampaignPlatformOption {
-  id: CampaignPlatform;
-  label: string;
-  icon: string;
-  disabled?: boolean;
-}
 
 export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'google-ads', label: 'Google Ads', icon: 'fa-brands fa-google' },
@@ -28,11 +21,6 @@ export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'feathr', label: 'Feathr', icon: 'fa-light fa-bullseye-arrow', disabled: true },
   { id: 'twitter-ads', label: 'X / Twitter Ads', icon: 'fa-brands fa-x-twitter', disabled: true },
 ] as const;
-
-export interface CampaignGoalOption {
-  id: CampaignGoal;
-  label: string;
-}
 
 export const CAMPAIGN_GOALS: readonly CampaignGoalOption[] = [
   { id: 'conversions', label: 'Conversions / Registrations' },

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CampaignGoal, CampaignGoalOption, CampaignPlatform, CampaignPlatformOption, CampaignTabOption } from '../interfaces/campaign.interface';
+import type { CampaignGoalOption, CampaignPlatformOption, CampaignTabOption } from '../interfaces/campaign.interface';
 
 /** Tab definitions for the Campaigns page tab navigation. */
 export const CAMPAIGN_TABS: CampaignTabOption[] = [

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -41,7 +41,7 @@ export type CampaignSSEEventType =
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms: CampaignPlatform[];
+  platforms?: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -41,7 +41,7 @@ export type CampaignSSEEventType =
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms?: CampaignPlatform[];
+  platforms: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -23,6 +23,18 @@ export interface CampaignTabOption {
   icon: string;
 }
 
+export interface CampaignPlatformOption {
+  id: CampaignPlatform;
+  label: string;
+  icon: string;
+  disabled?: boolean;
+}
+
+export interface CampaignGoalOption {
+  id: CampaignGoal;
+  label: string;
+}
+
 // ---------------------------------------------------------------------------
 // Brief Pipeline (Planning Phase)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add the **Planning tab** component — the AI-powered campaign brief generator that accepts an event URL, scrapes event details via SSE streaming, and generates structured ad copy for Google Ads (Search RSA + Demand Gen)
- Include shared campaign types (`campaign.interface.ts`), constants with platform definitions and `disabled` flags for "Coming soon" labels (`campaign.constants.ts`), and the frontend `CampaignService` for SSE brief generation and HubSpot UTM lookup/create
- Add a minimal campaigns shell component with 4-phase tabs (Planning, Implementation, Monitoring, Optimization) — only Planning is functional; other tabs show "Coming soon" placeholders
- Wire up the `foundation/campaigns` route behind `executiveDirectorGuard`

### Planning tab features
- Event URL input with live HubSpot UTM token lookup and campaign creation
- Platform selector with Google Ads enabled and 7 other platforms marked "Coming soon"
- Campaign goal, target audience, value prop, budget, and Drive folder inputs
- SSE streaming generation with live status log, event details card, and real-time copy preview
- Review step with read-only and edit modes for Search RSA headlines/descriptions, Demand Gen copy, and keyword table
- Proceed to Implementation output emitter for cross-tab data flow

LFXV2-2031


Generated with [Claude Code](https://claude.ai/code)