### PR TITLE
fix(newsletters): back nav to sent tab, confirm dialog keys, empty chart

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.html
@@ -61,4 +61,4 @@
   (generated)="onGenerated($event)">
 </lfx-newsletter-generate-drawer>
 
-<p-confirmDialog data-testid="newsletter-content-confirm-dialog"></p-confirmDialog>
+<p-confirmDialog key="newsletter-content-step" data-testid="newsletter-content-confirm-dialog"></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.ts
@@ -55,6 +55,7 @@ export class NewsletterContentStepComponent {
     const hasBody = this.bodyFilled();
     if (hasSubject || hasBody) {
       this.confirmationService.confirm({
+        key: 'newsletter-content-step',
         header: 'Replace existing content?',
         message: 'This will overwrite your current subject and body with the AI-generated newsletter. You can still edit the result before sending.',
         icon: 'pi pi-exclamation-triangle',

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
@@ -74,6 +74,11 @@
               <i class="fa-light fa-chart-line text-3xl"></i>
               <span class="text-sm">No opens recorded yet.</span>
             </div>
+          } @else if (!hasDailyBreakdown()) {
+            <div class="flex flex-col items-center justify-center py-12 gap-2 text-gray-500">
+              <i class="fa-light fa-chart-line text-3xl"></i>
+              <span class="text-sm">Daily breakdown not available yet. Check back shortly.</span>
+            </div>
           } @else if (canRenderChart() && chartData()) {
             <div class="h-80">
               <lfx-chart type="line" [data]="chartData()" [options]="chartOptions()" height="320px"></lfx-chart>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -41,6 +41,10 @@ export class NewsletterAnalyticsComponent {
   // === Computed (complex bodies extracted to private init* methods) ===
   protected readonly openRatePercent: Signal<number | null> = this.initOpenRatePercent();
   protected readonly hasOpens = computed(() => (this.analytics()?.total_opens ?? 0) > 0);
+  // Upstream can return a non-zero `total_opens` rollup with an empty `daily_opens`
+  // (e.g. shortly after send, before the daily bucketing job completes). Gate the
+  // chart on real per-day data so we never render an empty axis with no series.
+  protected readonly hasDailyBreakdown = computed(() => (this.analytics()?.daily_opens?.length ?? 0) > 0);
   protected readonly chartData: Signal<NewsletterChartData | null> = this.initChartData();
   protected readonly chartOptions: Signal<Record<string, unknown>> = this.initChartOptions();
 
@@ -98,8 +102,12 @@ export class NewsletterAnalyticsComponent {
   }
 
   // `['..']` on a 2-segment route resolves to `/<id>` — anchor to route.parent + explicit 'list' child.
+  // Analytics is only reachable from the Sent tab, so anchor Back there explicitly.
   protected goBack(): void {
-    this.router.navigate(['list'], { relativeTo: this.route.parent });
+    this.router.navigate(['list'], {
+      relativeTo: this.route.parent,
+      queryParams: { tab: 'sent' },
+    });
   }
 
   private initOpenRatePercent(): Signal<number | null> {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -145,7 +145,7 @@
   </div>
 </div>
 
-<p-confirmDialog></p-confirmDialog>
+<p-confirmDialog key="newsletter-list"></p-confirmDialog>
 
 @if (selectedNewsletter(); as n) {
   <!--

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -142,6 +142,7 @@ export class NewsletterListComponent {
   protected onDeleteDraft(item: NewsletterListItem, event: Event): void {
     event.stopPropagation();
     this.confirmationService.confirm({
+      key: 'newsletter-list',
       header: 'Delete draft?',
       message: `Are you sure you want to delete "${item.subject || 'Untitled draft'}"? This action cannot be undone.`,
       icon: 'pi pi-trash',

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -164,4 +164,4 @@
   [displayName]="displayName()">
 </lfx-newsletter-preview-drawer>
 
-<p-confirmDialog></p-confirmDialog>
+<p-confirmDialog key="newsletter-manage"></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -241,6 +241,7 @@ export class NewsletterManageComponent {
     const count = this.recipientCount();
     const recipientLabel = count !== null && count > 0 ? `${count} ${count === 1 ? 'recipient' : 'recipients'}` : 'the selected groups';
     this.confirmationService.confirm({
+      key: 'newsletter-manage',
       header: 'Send newsletter?',
       message: `This will send your newsletter to ${recipientLabel}. Once sent, it can't be undone.`,
       icon: 'pi pi-paper-plane',


### PR DESCRIPTION
## Summary

Three small newsletter-module fixes.

- **Analytics → Back lands on the Sent tab.** Was navigating to the list with no tab hint, defaulting to Drafts. Now passes `?tab=sent`, which the existing `newsletter-list` constructor already consumes. Analytics is only reachable from Sent, so the anchor is unambiguous.
- **AI "Replace existing content?" dialog needed multiple clicks.** Two keyless `<p-confirmDialog>` instances were mounted on the manage page at the same time (parent + child), and PrimeNG's `ConfirmationService` broadcasts to every keyless dialog — both opened stacked, so the first click only dismissed the top one. Fixed by scoping each `<p-confirmDialog>` in the newsletters module with a unique `key=` and the matching `key:` in the `confirmationService.confirm({...})` call.
- **Empty "Opens over time" chart.** When the upstream rollup returned a non-zero `total_opens` with an empty `daily_opens`, the chart rendered an empty axis. Added a `hasDailyBreakdown` gate and a distinct empty state ("Daily breakdown not available yet. Check back shortly.") so the section no longer looks broken.

The third item is the UI cover for the upstream gap that linuxfoundation/lfx-v2-newsletter-service#16 addresses; once that PR lands and is deployed, the empty state will only surface during the brief gap between send and email-service group-index propagation.

## Test plan

- [ ] Newsletters → click any Sent row → analytics → Back → confirm Sent tab is selected and URL has `?tab=sent`.
- [ ] On a draft with existing subject + body, Generate with AI → confirm a single dialog appears, Keep current / Replace each respond on the first click.
- [ ] Manage page Send (with valid recipients) → "Send newsletter?" still opens, Send now / Cancel each respond on the first click.
- [ ] List page delete a draft → "Delete draft?" opens, Delete / Cancel each respond on the first click.
- [x] `yarn check-types && yarn lint:check` clean.