### PR TITLE
fix(meetings): show ai summary when approval not required

### DIFF
--- a/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
+++ b/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Past-meeting AI summary visibility — LFXV2-2052.
+ *
+ * The bug: AI summaries were gated on `approved` alone, so a summary whose
+ * meeting never required approval ("Require AI Summary Approval" disabled) stayed
+ * hidden from non-organizers / unauthenticated viewers because nobody approved it.
+ *
+ * The fix extracts the gate into two pure helpers in `@lfx-one/shared/utils`:
+ *   - isPastMeetingSummaryVisible      → approved OR approval not required
+ *   - isPastMeetingSummaryAwaitingApproval → requires approval AND not approved
+ *
+ * These drive the "See AI Summary" affordance and the organizer review / "Pending"
+ * banner across meeting-card, meeting-join, and past-meeting-details.
+ *
+ * NOTE: this repo has no unit-test runner wired up (angular.json has no `test`
+ * target and there are no co-located *.spec.ts unit files), so the visibility
+ * logic is verified here in the Playwright suite against the extracted helpers —
+ * the single source of truth the three view surfaces consume. Covers the
+ * approved-only, requires_approval-only, and neither cases the ticket calls for.
+ */
+
+// Deep import the Angular-free helper module directly (not the '@lfx-one/shared/utils'
+// barrel) so the suite can load the pure logic without bootstrapping Angular.
+import { isPastMeetingSummaryAwaitingApproval, isPastMeetingSummaryVisible } from '@lfx-one/shared/utils/past-meeting-summary.utils';
+import { expect, test } from '@playwright/test';
+
+interface ApprovalFlags {
+  approved: boolean;
+  requires_approval: boolean;
+}
+
+const summary = (approved: boolean, requires_approval: boolean): ApprovalFlags => ({ approved, requires_approval });
+
+test.describe('past-meeting AI summary visibility (LFXV2-2052)', () => {
+  test('approved-only: approved summary is visible and not awaiting approval', () => {
+    // Approval was required and granted — the classic visible case.
+    const s = summary(true, true);
+    expect(isPastMeetingSummaryVisible(s)).toBe(true);
+    expect(isPastMeetingSummaryAwaitingApproval(s)).toBe(false);
+  });
+
+  test('requires_approval-only: unapproved + requires approval stays hidden and pending', () => {
+    // The only state in which the summary is withheld from viewers.
+    const s = summary(false, true);
+    expect(isPastMeetingSummaryVisible(s)).toBe(false);
+    expect(isPastMeetingSummaryAwaitingApproval(s)).toBe(true);
+  });
+
+  test('neither: approval not required is visible without ever being approved (the bug fix)', () => {
+    // "Require AI Summary Approval" was never enabled — must be visible to all,
+    // and must NOT show a "Pending" badge.
+    const s = summary(false, false);
+    expect(isPastMeetingSummaryVisible(s)).toBe(true);
+    expect(isPastMeetingSummaryAwaitingApproval(s)).toBe(false);
+  });
+
+  test('approved without requiring approval is visible and not pending', () => {
+    const s = summary(true, false);
+    expect(isPastMeetingSummaryVisible(s)).toBe(true);
+    expect(isPastMeetingSummaryAwaitingApproval(s)).toBe(false);
+  });
+
+  test('missing summary is neither visible nor awaiting approval', () => {
+    expect(isPastMeetingSummaryVisible(null)).toBe(false);
+    expect(isPastMeetingSummaryVisible(undefined)).toBe(false);
+    expect(isPastMeetingSummaryAwaitingApproval(null)).toBe(false);
+    expect(isPastMeetingSummaryAwaitingApproval(undefined)).toBe(false);
+  });
+});

--- a/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
+++ b/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// Generated with [Claude Code](https://claude.ai/code)
+
 /**
  * Past-meeting AI summary visibility — LFXV2-2052.
  *

--- a/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
+++ b/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
@@ -26,15 +26,10 @@
 
 // Deep import the Angular-free helper module directly (not the '@lfx-one/shared/utils'
 // barrel) so the suite can load the pure logic without bootstrapping Angular.
-import { isPastMeetingSummaryAwaitingApproval, isPastMeetingSummaryVisible } from '@lfx-one/shared/utils/past-meeting-summary.utils';
+import { isPastMeetingSummaryAwaitingApproval, isPastMeetingSummaryVisible, SummaryApprovalFlags } from '@lfx-one/shared/utils/past-meeting-summary.utils';
 import { expect, test } from '@playwright/test';
 
-interface ApprovalFlags {
-  approved: boolean;
-  requires_approval: boolean;
-}
-
-const summary = (approved: boolean, requires_approval: boolean): ApprovalFlags => ({ approved, requires_approval });
+const summary = (approved: boolean, requires_approval: boolean): SummaryApprovalFlags => ({ approved, requires_approval });
 
 test.describe('past-meeting AI summary visibility (LFXV2-2052)', () => {
   test('approved-only: approved summary is visible and not awaiting approval', () => {

--- a/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
+++ b/apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts
@@ -26,7 +26,7 @@
 
 // Deep import the Angular-free helper module directly (not the '@lfx-one/shared/utils'
 // barrel) so the suite can load the pure logic without bootstrapping Angular.
-import { isPastMeetingSummaryAwaitingApproval, isPastMeetingSummaryVisible, SummaryApprovalFlags } from '@lfx-one/shared/utils/past-meeting-summary.utils';
+import { isPastMeetingSummaryAwaitingApproval, isPastMeetingSummaryVisible, type SummaryApprovalFlags } from '@lfx-one/shared/utils/past-meeting-summary.utils';
 import { expect, test } from '@playwright/test';
 
 const summary = (approved: boolean, requires_approval: boolean): SummaryApprovalFlags => ({ approved, requires_approval });

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -123,7 +123,7 @@
     }
 
     <!-- AI Summary Review Banner for Organizers -->
-    @if (pastMeeting() && meeting().organizer && hasSummary() && !summaryApproved()) {
+    @if (pastMeeting() && meeting().organizer && hasSummary() && summaryAwaitingApproval()) {
       <div class="flex items-center gap-2.5 px-3.5 py-3 bg-blue-50 border border-blue-200 rounded-md mb-3">
         <i class="fa-light fa-sparkles text-base text-blue-600 flex-shrink-0 mt-0.5"></i>
         <div class="flex-1 flex items-center justify-between gap-3">
@@ -247,7 +247,7 @@
                 (click)="openRecordingModal()">
               </lfx-button>
             }
-            @if (hasSummary() && summaryApproved()) {
+            @if (hasSummary() && summaryVisible()) {
               <lfx-button
                 class="w-full"
                 icon="fa-light fa-sparkles"
@@ -345,7 +345,7 @@
                 (click)="openRecordingModal()">
               </lfx-button>
             }
-            @if (hasSummary() && summaryApproved()) {
+            @if (hasSummary() && summaryVisible()) {
               <lfx-button
                 class="w-full"
                 icon="fa-light fa-sparkles"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -43,6 +43,8 @@ import {
   getCurrentOrNextOccurrence,
   getPastMeetingTranscriptUrl,
   getUpcomingMeetingStartTime,
+  isPastMeetingSummaryAwaitingApproval,
+  isPastMeetingSummaryVisible,
   Meeting,
   MeetingAttachment,
   MeetingCancelOccurrenceResult,
@@ -135,6 +137,8 @@ export class MeetingCardComponent implements OnInit {
   // Computed values for template
   public readonly summaryContent: Signal<string | null> = this.initSummaryContent();
   public readonly summaryApproved: Signal<boolean> = this.initSummaryApproved();
+  public readonly summaryVisible: Signal<boolean> = this.initSummaryVisible();
+  public readonly summaryAwaitingApproval: Signal<boolean> = this.initSummaryAwaitingApproval();
   public readonly hasSummary: Signal<boolean> = this.initHasSummary();
   public readonly recordingShareUrl: Signal<string | null> = this.initRecordingShareUrl();
   public readonly hasRecording: Signal<boolean> = this.initHasRecording();
@@ -698,6 +702,17 @@ export class MeetingCardComponent implements OnInit {
 
   private initSummaryApproved(): Signal<boolean> {
     return computed(() => this.summary()?.approved || false);
+  }
+
+  // Visible to all viewers once approved, or whenever the meeting never required
+  // approval — only a requires-approval summary that isn't approved stays hidden.
+  private initSummaryVisible(): Signal<boolean> {
+    return computed(() => isPastMeetingSummaryVisible(this.summary()));
+  }
+
+  // Drives the organizer-only review banner: requires approval and not yet approved.
+  private initSummaryAwaitingApproval(): Signal<boolean> {
+    return computed(() => isPastMeetingSummaryAwaitingApproval(this.summary()));
   }
 
   private initHasSummary(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -467,7 +467,7 @@
                           <span>AI Summary</span>
                           @if (pastMeetingSummary()?.approved) {
                             <span class="text-xs font-medium text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded-full">Approved</span>
-                          } @else {
+                          } @else if (summaryAwaitingApproval()) {
                             <span class="text-xs font-medium text-amber-600 bg-amber-100 px-1.5 py-0.5 rounded-full">Pending</span>
                           }
                         </button>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -24,6 +24,7 @@ import {
   getActiveOccurrences,
   getCurrentOrNextOccurrence,
   hasMeetingEnded,
+  isPastMeetingSummaryAwaitingApproval,
   Meeting,
   MEETING_TYPE_CONFIGS,
   getPastMeetingTranscriptUrl,
@@ -179,6 +180,7 @@ export class MeetingJoinComponent implements OnInit {
   protected isPastMeeting: Signal<boolean>;
   protected pastMeetingSummary: Signal<PastMeetingSummary | null>;
   protected hasSummaryContent: Signal<boolean>;
+  protected summaryAwaitingApproval: Signal<boolean>;
   private pastMeetingRecording: Signal<PastMeetingRecording | null>;
   protected pastMeetingAttachments: Signal<PastMeetingAttachment[]>;
   protected primaryRecordingUrl: Signal<string | null>;
@@ -277,6 +279,7 @@ export class MeetingJoinComponent implements OnInit {
     this.isPastMeeting = this.initializeIsPastMeeting();
     this.pastMeetingSummary = this.initializePastMeetingSummary();
     this.hasSummaryContent = this.initializeHasSummaryContent();
+    this.summaryAwaitingApproval = this.initializeSummaryAwaitingApproval();
     this.pastMeetingRecording = this.initializePastMeetingRecording();
     this.pastMeetingAttachments = this.initializePastMeetingAttachments();
     this.primaryRecordingUrl = this.initializePrimaryRecordingUrl();
@@ -1123,6 +1126,12 @@ export class MeetingJoinComponent implements OnInit {
       const data = this.pastMeetingSummary()?.summary_data;
       return !!(data?.edited_content || data?.content);
     });
+  }
+
+  // "Pending" only applies when the summary requires approval and isn't approved
+  // yet — summaries that never required approval are not pending.
+  private initializeSummaryAwaitingApproval(): Signal<boolean> {
+    return computed(() => isPastMeetingSummaryAwaitingApproval(this.pastMeetingSummary()));
   }
 
   private initializeTranscriptUrl(): Signal<string | null> {

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -162,7 +162,7 @@
             <span class="text-sm font-medium text-gray-700">AI Summary</span>
             @if (summaryApproved()) {
               <span class="text-xs font-medium text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded-full">Approved</span>
-            } @else {
+            } @else if (summaryAwaitingApproval()) {
               <span class="text-xs font-medium text-amber-600 bg-amber-100 px-1.5 py-0.5 rounded-full">Pending</span>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   EnrichedPastMeetingParticipant,
   getPastMeetingTranscriptUrl,
+  isPastMeetingSummaryAwaitingApproval,
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
@@ -115,6 +116,7 @@ export class PastMeetingDetailsComponent {
   public hasSummary = this.initHasSummary();
   public summaryContent = this.initSummaryContent();
   public summaryApproved = this.initSummaryApproved();
+  public summaryAwaitingApproval = this.initSummaryAwaitingApproval();
 
   // Public methods
   public goBack(): void {
@@ -341,6 +343,12 @@ export class PastMeetingDetailsComponent {
 
   private initSummaryApproved(): Signal<boolean> {
     return computed(() => this.summary()?.approved || false);
+  }
+
+  // "Pending" only applies when the summary requires approval and isn't approved
+  // yet — summaries that never required approval are not pending.
+  private initSummaryAwaitingApproval(): Signal<boolean> {
+    return computed(() => isPastMeetingSummaryAwaitingApproval(this.summary()));
   }
 
   private initHasSummary(): Signal<boolean> {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
 export * from './meeting.utils';
+export * from './past-meeting-summary.utils';
 export * from './rsvp-calculator.util';
 export * from './string.utils';
 export * from './url.utils';

--- a/packages/shared/src/utils/past-meeting-summary.utils.ts
+++ b/packages/shared/src/utils/past-meeting-summary.utils.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { PastMeetingSummary } from '../interfaces';
+
+/**
+ * AI summary approval gating, kept free of Angular imports so the pure logic can
+ * be exercised in isolation (e.g. the Playwright suite) without bootstrapping the
+ * Angular runtime — see meeting.utils.ts for the Angular-coupled summary helpers.
+ */
+
+type SummaryApprovalFlags = Pick<PastMeetingSummary, 'approved' | 'requires_approval'>;
+
+/**
+ * Determines whether a past-meeting AI summary should be visible to viewers.
+ *
+ * A summary is viewable once it is approved, OR when the meeting never required
+ * approval in the first place. Only a summary that requires approval and has not
+ * yet been approved stays hidden (pending organizer review). This is the gate
+ * that lets non-organizers and unauthenticated viewers see summaries whose
+ * meeting had "Require AI Summary Approval" disabled.
+ *
+ * @param summary - The past meeting summary (or null/undefined when not loaded)
+ * @returns true when the summary is approved or approval is not required
+ */
+export function isPastMeetingSummaryVisible(summary: SummaryApprovalFlags | null | undefined): boolean {
+  if (!summary) return false;
+  return summary.approved || !summary.requires_approval;
+}
+
+/**
+ * Determines whether a past-meeting AI summary is awaiting organizer approval.
+ *
+ * True only when the summary requires approval and has not yet been approved —
+ * the single state in which the summary stays hidden from non-organizers and the
+ * organizer review banner / "Pending" badge should appear.
+ *
+ * @param summary - The past meeting summary (or null/undefined when not loaded)
+ * @returns true when approval is required and not yet granted
+ */
+export function isPastMeetingSummaryAwaitingApproval(summary: SummaryApprovalFlags | null | undefined): boolean {
+  if (!summary) return false;
+  return summary.requires_approval && !summary.approved;
+}

--- a/packages/shared/src/utils/past-meeting-summary.utils.ts
+++ b/packages/shared/src/utils/past-meeting-summary.utils.ts
@@ -11,7 +11,7 @@ import type { PastMeetingSummary } from '../interfaces';
  * Angular runtime — see meeting.utils.ts for the Angular-coupled summary helpers.
  */
 
-type SummaryApprovalFlags = Pick<PastMeetingSummary, 'approved' | 'requires_approval'>;
+export type SummaryApprovalFlags = Pick<PastMeetingSummary, 'approved' | 'requires_approval'>;
 
 /**
  * Determines whether a past-meeting AI summary should be visible to viewers.

--- a/packages/shared/src/utils/past-meeting-summary.utils.ts
+++ b/packages/shared/src/utils/past-meeting-summary.utils.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// Generated with [Claude Code](https://claude.ai/code)
+
 import type { PastMeetingSummary } from '../interfaces';
 
 /**


### PR DESCRIPTION
## What & why

Fixes **LFXV2-2052**. AI meeting summaries required approval even when "Require AI Summary Approval" was never enabled, so they stayed hidden from non-organizer / non-logged-in viewers because nobody approved them.

The `meeting-card` gated the "See AI Summary" affordance on `approved` alone, so a summary that doesn't require approval was hidden unless explicitly approved.

## Root cause (investigation)

`requires_approval` / `approved` flow through the BFF untouched — frontend service → controller (`res.json(summary)`) → BFF service → `transformV1SummaryToV2` (`requires_approval: summary.requires_approval ?? raw.requires_approval ?? false`). **`requires_approval` is NOT derived from the meeting's `ai_summary_require_approval`** — it is set independently by the upstream summary pipeline.

So the separately-reported observation (`requires_approval=true` on meetings configured with `ai_summary_require_approval=false`) is an **upstream data bug in `lfx-v2-meeting-service`** and should be tracked in its own ticket. The frontend gate fix here is still required and correct regardless.

## Changes

- New Angular-free helpers in `@lfx-one/shared/utils/past-meeting-summary.utils.ts`:
  - `isPastMeetingSummaryVisible` = `approved || !requires_approval`
  - `isPastMeetingSummaryAwaitingApproval` = `requires_approval && !approved`
- **meeting-card**: "See AI Summary" now gates on `hasSummary() && summaryVisible()`; the organizer review banner on `hasSummary() && summaryAwaitingApproval()`.
- **meeting-join** and **past-meeting-details** (the latter was not named in the ticket but had the identical issue — included for consistency): the "Pending" badge now only shows when genuinely awaiting approval, instead of on every unapproved summary.

## Out of scope

- **Task 3 (default recording/AI on)** intentionally **not** included — it requires defaulting `recording_enabled`/`zoom_ai_enabled` to true, which has recording-cost implications. Left out pending explicit confirmation.

## Testing

- `yarn check-types`, `yarn lint`, `yarn build` all pass.
- Added `apps/lfx-one/e2e/past-meeting-ai-summary-visibility.spec.ts` (5 cases: approved-only / requires_approval-only / neither / approved-without-requiring / null) — 5/5 pass.
- Note: the repo has no unit-test runner wired up (`angular.json` has no `test` target), so the extracted gate logic is verified in the Playwright suite against the pure helpers.

## Reviewer note

The new spec deep-imports `@lfx-one/shared/utils/past-meeting-summary.utils` rather than the `@lfx-one/shared/utils` barrel **on purpose**: the barrel re-exports Angular-coupled siblings (`form.utils` → `@angular/common`) which fail to load in Playwright's Node context (Angular JIT error). The deep path is the documented, intentional trade-off; app code still imports via the barrel.

Draft until batch integration validation passes.
