### PR TITLE
fix(search): rank member search by name relevance

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -23,6 +23,7 @@ import {
   OrganizationResolveResult,
   UserSearchResult,
 } from '@lfx-one/shared/interfaces';
+import { rankUserSearchResults } from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
@@ -290,7 +291,11 @@ export class AddMemberDialogComponent {
             return of([] as UserSearchResult[]);
           }
           this.searchLoading.set(true);
-          return this.searchService.searchUsers(q.trim(), 'committee_member').pipe(
+          const trimmedQuery = q.trim();
+          return this.searchService.searchUsers(trimmedQuery, 'committee_member').pipe(
+            // Re-rank so name matches surface first and incidental email/alias
+            // matches (upstream over-match) are demoted/dropped.
+            map((users) => rankUserSearchResults(users, trimmedQuery)),
             tap(() => this.searchLoading.set(false)),
             catchError(() => {
               this.searchLoading.set(false);

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -294,7 +294,7 @@ export class AddMemberDialogComponent {
           const trimmedQuery = q.trim();
           return this.searchService.searchUsers(trimmedQuery, 'committee_member').pipe(
             // Re-rank so name matches surface first and incidental email/alias
-            // matches (upstream over-match) are demoted/dropped.
+            // matches (upstream over-match) are demoted below them.
             map((users) => rankUserSearchResults(users, trimmedQuery)),
             tap(() => this.searchLoading.set(false)),
             catchError(() => {

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -5,6 +5,7 @@ import { Component, effect, inject, input, output, Signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { UserSearchResult } from '@lfx-one/shared/interfaces';
+import { rankUserSearchResults } from '@lfx-one/shared/utils';
 import { SearchService } from '@services/search.service';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
 import { catchError, debounceTime, distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
@@ -66,8 +67,9 @@ export class UserSearchComponent {
           return of([]);
         }
 
-        // Use the search type from input
-        return this.searchService.searchUsers(trimmedTerm, this.searchType());
+        // Use the search type from input, then re-rank so name matches surface
+        // first and incidental email/alias matches (upstream over-match) are demoted.
+        return this.searchService.searchUsers(trimmedTerm, this.searchType()).pipe(map((users) => rankUserSearchResults(users, trimmedTerm)));
       }),
       map((users: UserSearchResult[]) => {
         // Add displayName field for the autocomplete to show

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,11 +50,13 @@
     "build:production": "tsc",
     "build:staging": "tsc",
     "watch": "tsc --watch",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@fullcalendar/core": "^6.1.19",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "@angular/core": "^20.3.15",

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -13,3 +13,4 @@ export * from './survey.enum';
 export * from './event.enum';
 export * from './project-funding.enum';
 export * from './project-stage.enum';
+export * from './search.enum';

--- a/packages/shared/src/enums/search.enum.ts
+++ b/packages/shared/src/enums/search.enum.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Relevance tiers for a user search result against a query.
+ * Lower values rank higher (sort ascending).
+ */
+export enum UserSearchRelevance {
+  /** Query equals a name field (first, last, or full name). */
+  ExactName = 0,
+  /** Query is a prefix of a name field. */
+  NamePrefix = 1,
+  /** Query appears as a substring of the full name. */
+  NameSubstring = 2,
+  /** Query matches the LFID username. */
+  UsernameMatch = 3,
+  /** Query matches only the email (incidental for a name search). */
+  EmailMatch = 4,
+  /** No contiguous match in any searchable field (upstream ngram/alias noise). */
+  Incidental = 5,
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -31,3 +31,4 @@ export * from './identity.utils';
 export * from './enrollment.utils';
 export * from './org-selector.utils';
 export * from './sfuuid.utils';
+export * from './search.utils';

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -27,6 +27,8 @@ const bob = user({ uid: '2', first_name: 'Bob', last_name: 'Brown', email: 'bob.
 const emailOnly = user({ uid: '3', first_name: 'Dana', last_name: 'Reyes', email: 'dreyes-il@example.com' });
 // Neither name nor email contains "il" — pure upstream ngram/alias noise.
 const noise = user({ uid: '4', first_name: 'Grace', last_name: 'Hopper', email: 'grace@example.com' });
+// Only the LFID username contains "il".
+const usernameOnly = user({ uid: '5', first_name: 'Sam', last_name: 'Park', email: 'sam.park@example.com', username: 'silke99' });
 
 describe('scoreUserSearchResult', () => {
   it('scores an exact name match highest', () => {
@@ -44,7 +46,11 @@ describe('scoreUserSearchResult', () => {
     expect(scoreUserSearchResult(ilona, 'ai')).toBe(UserSearchRelevance.NameSubstring);
   });
 
-  it('scores an email-only match below name matches', () => {
+  it('scores a username-only match above email', () => {
+    expect(scoreUserSearchResult(usernameOnly, 'il')).toBe(UserSearchRelevance.UsernameMatch);
+  });
+
+  it('scores an email-only match below name and username matches', () => {
     expect(scoreUserSearchResult(emailOnly, 'il')).toBe(UserSearchRelevance.EmailMatch);
   });
 
@@ -58,15 +64,16 @@ describe('scoreUserSearchResult', () => {
 });
 
 describe('rankUserSearchResults', () => {
-  it('sorts name matches above email-only matches and drops non-matches for a name query', () => {
-    const ranked = rankUserSearchResults([emailOnly, bob, ilona], 'il');
-    // Ilona (name prefix) first, then the email-only match. Bob has no "il" and is dropped.
-    expect(ranked.map((r) => r.uid)).toEqual(['1', '3']);
+  it('orders name > username > email > incidental for a name query', () => {
+    const ranked = rankUserSearchResults([noise, emailOnly, usernameOnly, ilona], 'il');
+    expect(ranked.map((r) => r.uid)).toEqual(['1', '5', '3', '4']);
   });
 
-  it('drops pure-incidental (ngram noise) matches for a name query', () => {
+  it('demotes pure-incidental matches to the bottom rather than dropping them', () => {
     const ranked = rankUserSearchResults([noise, ilona], 'il');
-    expect(ranked.map((r) => r.uid)).toEqual(['1']);
+    // Both retained — incidental is never hard-filtered (it may be a legitimate
+    // alias hit the client cannot see) — but it sorts last.
+    expect(ranked.map((r) => r.uid)).toEqual(['1', '4']);
   });
 
   it('keeps stable order within the same relevance tier', () => {
@@ -76,9 +83,15 @@ describe('rankUserSearchResults', () => {
     expect(rankUserSearchResults([b, a], 'il').map((r) => r.uid)).toEqual(['b', 'a']);
   });
 
-  it('does not hide results for an explicit email query (contains "@")', () => {
-    const ranked = rankUserSearchResults([noise, emailOnly], 'il@example.com');
-    // Nothing dropped; both retained even though names do not match.
+  it('caps results to the limit, letting demoted noise fall off', () => {
+    const noiseRows = Array.from({ length: 12 }, (_, i) => user({ uid: `n${i}`, first_name: 'Zed', last_name: 'Zane', email: `z${i}@example.com` }));
+    const ranked = rankUserSearchResults([...noiseRows, ilona], 'il', { limit: 1 });
+    // The single real match wins the only slot; noise is demoted and cut.
+    expect(ranked.map((r) => r.uid)).toEqual(['1']);
+  });
+
+  it('returns every ranked result when limit is Infinity', () => {
+    const ranked = rankUserSearchResults([noise, ilona], 'il', { limit: Infinity });
     expect(ranked).toHaveLength(2);
   });
 

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -83,16 +83,12 @@ describe('rankUserSearchResults', () => {
     expect(rankUserSearchResults([b, a], 'il').map((r) => r.uid)).toEqual(['b', 'a']);
   });
 
-  it('caps results to the limit, letting demoted noise fall off', () => {
+  it('retains every result (no cap), sorting real matches above demoted noise', () => {
     const noiseRows = Array.from({ length: 12 }, (_, i) => user({ uid: `n${i}`, first_name: 'Zed', last_name: 'Zane', email: `z${i}@example.com` }));
-    const ranked = rankUserSearchResults([...noiseRows, ilona], 'il', { limit: 1 });
-    // The single real match wins the only slot; noise is demoted and cut.
-    expect(ranked.map((r) => r.uid)).toEqual(['1']);
-  });
-
-  it('returns every ranked result when limit is Infinity', () => {
-    const ranked = rankUserSearchResults([noise, ilona], 'il', { limit: Infinity });
-    expect(ranked).toHaveLength(2);
+    const ranked = rankUserSearchResults([...noiseRows, ilona], 'il');
+    // The real match floats to the top; nothing is dropped or capped.
+    expect(ranked).toHaveLength(13);
+    expect(ranked[0].uid).toBe('1');
   });
 
   it('ranks email matches first for an email query', () => {

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -1,0 +1,96 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { UserSearchResult } from '../interfaces';
+import { rankUserSearchResults, scoreUserSearchResult, UserSearchRelevance } from './search.utils';
+
+function user(partial: Partial<UserSearchResult>): UserSearchResult {
+  return {
+    uid: partial.uid ?? 'uid',
+    email: partial.email ?? '',
+    first_name: partial.first_name ?? '',
+    last_name: partial.last_name ?? '',
+    job_title: partial.job_title ?? null,
+    organization: partial.organization ?? null,
+    committee: partial.committee ?? null,
+    type: partial.type ?? 'committee_member',
+    username: partial.username ?? null,
+  };
+}
+
+const ilona = user({ uid: '1', first_name: 'Ilona', last_name: 'Maier', email: 'ilona.maier@example.com' });
+// Name and email share no "il" — used as a clean non-match for "il" queries.
+const bob = user({ uid: '2', first_name: 'Bob', last_name: 'Brown', email: 'bob.brown@example.com' });
+// Name shares no contiguous "il"; only the email incidentally contains it.
+const emailOnly = user({ uid: '3', first_name: 'Dana', last_name: 'Reyes', email: 'dreyes-il@example.com' });
+// Neither name nor email contains "il" — pure upstream ngram/alias noise.
+const noise = user({ uid: '4', first_name: 'Grace', last_name: 'Hopper', email: 'grace@example.com' });
+
+describe('scoreUserSearchResult', () => {
+  it('scores an exact name match highest', () => {
+    expect(scoreUserSearchResult(ilona, 'ilona')).toBe(UserSearchRelevance.ExactName);
+    expect(scoreUserSearchResult(ilona, 'ilona maier')).toBe(UserSearchRelevance.ExactName);
+  });
+
+  it('scores a name-prefix match', () => {
+    expect(scoreUserSearchResult(ilona, 'il')).toBe(UserSearchRelevance.NamePrefix);
+    expect(scoreUserSearchResult(bob, 'bro')).toBe(UserSearchRelevance.NamePrefix);
+  });
+
+  it('scores a name substring (mid-name) match', () => {
+    // "ai" is inside "maier" but not a prefix of any name field.
+    expect(scoreUserSearchResult(ilona, 'ai')).toBe(UserSearchRelevance.NameSubstring);
+  });
+
+  it('scores an email-only match below name matches', () => {
+    expect(scoreUserSearchResult(emailOnly, 'il')).toBe(UserSearchRelevance.EmailMatch);
+  });
+
+  it('scores no contiguous match as incidental', () => {
+    expect(scoreUserSearchResult(noise, 'il')).toBe(UserSearchRelevance.Incidental);
+  });
+
+  it('is case insensitive', () => {
+    expect(scoreUserSearchResult(ilona, 'ILONA')).toBe(UserSearchRelevance.ExactName);
+  });
+});
+
+describe('rankUserSearchResults', () => {
+  it('sorts name matches above email-only matches and drops non-matches for a name query', () => {
+    const ranked = rankUserSearchResults([emailOnly, bob, ilona], 'il');
+    // Ilona (name prefix) first, then the email-only match. Bob has no "il" and is dropped.
+    expect(ranked.map((r) => r.uid)).toEqual(['1', '3']);
+  });
+
+  it('drops pure-incidental (ngram noise) matches for a name query', () => {
+    const ranked = rankUserSearchResults([noise, ilona], 'il');
+    expect(ranked.map((r) => r.uid)).toEqual(['1']);
+  });
+
+  it('keeps stable order within the same relevance tier', () => {
+    const a = user({ uid: 'a', first_name: 'Ila', last_name: 'A', email: 'a@example.com' });
+    const b = user({ uid: 'b', first_name: 'Ilb', last_name: 'B', email: 'b@example.com' });
+    expect(rankUserSearchResults([a, b], 'il').map((r) => r.uid)).toEqual(['a', 'b']);
+    expect(rankUserSearchResults([b, a], 'il').map((r) => r.uid)).toEqual(['b', 'a']);
+  });
+
+  it('does not hide results for an explicit email query (contains "@")', () => {
+    const ranked = rankUserSearchResults([noise, emailOnly], 'il@example.com');
+    // Nothing dropped; both retained even though names do not match.
+    expect(ranked).toHaveLength(2);
+  });
+
+  it('ranks email matches first for an email query', () => {
+    const match = user({ uid: 'm', first_name: 'Zoe', last_name: 'Quinn', email: 'find-me@corp.com' });
+    const nonMatch = user({ uid: 'n', first_name: 'Al', last_name: 'King', email: 'other@corp.com' });
+    const ranked = rankUserSearchResults([nonMatch, match], 'find-me@corp.com');
+    expect(ranked[0].uid).toBe('m');
+  });
+
+  it('returns results unchanged for an empty query', () => {
+    const input = [bob, ilona];
+    expect(rankUserSearchResults(input, '   ')).toBe(input);
+  });
+});

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { UserSearchResult } from '../interfaces';
 import { rankUserSearchResults, scoreUserSearchResult, UserSearchRelevance } from './search.utils';
 
+/** Builds a UserSearchResult fixture, defaulting every field so tests set only what they assert on. */
 function user(partial: Partial<UserSearchResult>): UserSearchResult {
   return {
     uid: partial.uid ?? 'uid',

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -3,8 +3,9 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { UserSearchRelevance } from '../enums';
 import { UserSearchResult } from '../interfaces';
-import { rankUserSearchResults, scoreUserSearchResult, UserSearchRelevance } from './search.utils';
+import { rankUserSearchResults, scoreUserSearchResult } from './search.utils';
 
 /** Builds a UserSearchResult fixture, defaulting every field so tests set only what they assert on. */
 function user(partial: Partial<UserSearchResult>): UserSearchResult {

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -25,13 +25,6 @@ export enum UserSearchRelevance {
 /** Minimal user shape needed to rank a search result. */
 type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email' | 'username'>;
 
-/**
- * Default cap on ranked results handed to a typeahead. Demoted upstream
- * ngram/alias noise sorts to the bottom and falls off this limit, while real
- * matches (which sort first) survive. Pass `{ limit: Infinity }` to opt out.
- */
-const DEFAULT_RESULT_LIMIT = 10;
-
 function normalize(value: string | null | undefined): string {
   return (value ?? '').trim().toLowerCase();
 }
@@ -80,32 +73,26 @@ export function scoreUserSearchResult(user: RankableUser, query: string): UserSe
  * inside unrelated emails. This client-side pass mitigates that by sorting
  * exact > name-prefix > name-substring > username > email > incidental.
  *
- * It **demotes** rather than drops: low-relevance rows sort to the bottom and
- * fall off `limit`, so real matches always win the visible slots — but a
- * legitimate hit on an upstream alias the client can't see (a field outside
- * name/username/email) is never hard-filtered out. Email queries (containing
- * `@`) need no special case: name fields won't match, so genuine email hits
- * naturally rank above the rest.
+ * It **demotes** rather than drops or caps: low-relevance rows sort to the
+ * bottom but are never removed, so a legitimate hit on an upstream alias the
+ * client can't see (a field outside name/username/email) is never hard-filtered
+ * out. Email queries (containing `@`) need no special case: name fields won't
+ * match, so genuine email hits naturally rank above the rest. Limiting the
+ * visible count, if desired, is left to the UI layer as a deliberate decision.
  *
  * Ordering is stable: results within the same tier keep their upstream order.
  *
  * @param results Upstream results to rank.
  * @param query  Raw user query (normalized internally).
- * @param options.limit Max results to return; defaults to {@link DEFAULT_RESULT_LIMIT}.
- *   Pass `Infinity` to return every ranked result.
  */
-export function rankUserSearchResults<T extends RankableUser>(results: T[], query: string, options?: { limit?: number }): T[] {
+export function rankUserSearchResults<T extends RankableUser>(results: T[], query: string): T[] {
   const q = normalize(query);
   if (!q) {
     return results;
   }
 
-  const limit = options?.limit ?? DEFAULT_RESULT_LIMIT;
-
-  const ranked = results
+  return results
     .map((result, index) => ({ result, index, score: scoreUserSearchResult(result, q) }))
     .sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score))
     .map((entry) => entry.result);
-
-  return ranked.slice(0, limit);
 }

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -1,0 +1,97 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { UserSearchResult } from '../interfaces';
+
+/**
+ * Relevance tiers for a user search result against a query.
+ * Lower values rank higher (sort ascending).
+ */
+export enum UserSearchRelevance {
+  /** Query equals a name field (first, last, or full name). */
+  ExactName = 0,
+  /** Query is a prefix of a name field. */
+  NamePrefix = 1,
+  /** Query appears as a substring of the full name. */
+  NameSubstring = 2,
+  /** Query matches only the email (incidental for a name search). */
+  EmailMatch = 3,
+  /** No contiguous match in name or email (upstream ngram/alias noise). */
+  Incidental = 4,
+}
+
+/** Minimal user shape needed to rank a search result. */
+type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email'>;
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+/**
+ * Scores a single user against a query. The query is normalized (lowercased,
+ * trimmed) internally, so it is safe to call with raw input.
+ * Exposed for testing and reuse; callers normally use {@link rankUserSearchResults}.
+ */
+export function scoreUserSearchResult(user: RankableUser, query: string): UserSearchRelevance {
+  const q = normalize(query);
+  if (!q) {
+    return UserSearchRelevance.Incidental;
+  }
+
+  const first = normalize(user.first_name);
+  const last = normalize(user.last_name);
+  const full = `${first} ${last}`.trim();
+  const email = normalize(user.email);
+
+  if (first === q || last === q || full === q) {
+    return UserSearchRelevance.ExactName;
+  }
+  if (first.startsWith(q) || last.startsWith(q) || full.startsWith(q)) {
+    return UserSearchRelevance.NamePrefix;
+  }
+  if (full.includes(q)) {
+    return UserSearchRelevance.NameSubstring;
+  }
+  if (email.includes(q)) {
+    return UserSearchRelevance.EmailMatch;
+  }
+  return UserSearchRelevance.Incidental;
+}
+
+/**
+ * Re-ranks (and lightly filters) user search results so name matches surface
+ * first and incidental email/alias matches are demoted.
+ *
+ * The upstream query service matches `name` against `name_and_aliases` (which
+ * folds in email and uses ngram subfields), so a query like "il" can match
+ * inside unrelated emails. This client-side pass mitigates that:
+ *
+ * - **Name queries** (no `@`): sorted exact > prefix > name-substring >
+ *   email-match; results with no contiguous match in name or email are dropped
+ *   as upstream noise. Email-only matches are kept but demoted below name hits.
+ * - **Email queries** (contains `@`): treated as an explicit email lookup —
+ *   nothing is dropped; results are only sorted by email relevance so the
+ *   legitimate search is never hidden.
+ *
+ * Ordering is stable: results within the same tier keep their upstream order.
+ */
+export function rankUserSearchResults<T extends RankableUser>(results: T[], query: string): T[] {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) {
+    return results;
+  }
+
+  const isEmailQuery = normalizedQuery.includes('@');
+
+  const scored = results.map((result, index) => ({
+    result,
+    index,
+    score: scoreUserSearchResult(result, normalizedQuery),
+  }));
+
+  // For name queries, drop pure-incidental matches (ngram/alias noise). For
+  // email queries, keep everything — the user is searching by email on purpose.
+  const retained = isEmailQuery ? scored : scored.filter((entry) => entry.score !== UserSearchRelevance.Incidental);
+
+  return retained.sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score)).map((entry) => entry.result);
+}

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -14,14 +14,23 @@ export enum UserSearchRelevance {
   NamePrefix = 1,
   /** Query appears as a substring of the full name. */
   NameSubstring = 2,
+  /** Query matches the LFID username. */
+  UsernameMatch = 3,
   /** Query matches only the email (incidental for a name search). */
-  EmailMatch = 3,
-  /** No contiguous match in name or email (upstream ngram/alias noise). */
-  Incidental = 4,
+  EmailMatch = 4,
+  /** No contiguous match in any searchable field (upstream ngram/alias noise). */
+  Incidental = 5,
 }
 
 /** Minimal user shape needed to rank a search result. */
-type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email'>;
+type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email' | 'username'>;
+
+/**
+ * Default cap on ranked results handed to a typeahead. Demoted upstream
+ * ngram/alias noise sorts to the bottom and falls off this limit, while real
+ * matches (which sort first) survive. Pass `{ limit: Infinity }` to opt out.
+ */
+const DEFAULT_RESULT_LIMIT = 10;
 
 function normalize(value: string | null | undefined): string {
   return (value ?? '').trim().toLowerCase();
@@ -41,6 +50,7 @@ export function scoreUserSearchResult(user: RankableUser, query: string): UserSe
   const first = normalize(user.first_name);
   const last = normalize(user.last_name);
   const full = `${first} ${last}`.trim();
+  const username = normalize(user.username);
   const email = normalize(user.email);
 
   if (first === q || last === q || full === q) {
@@ -52,6 +62,9 @@ export function scoreUserSearchResult(user: RankableUser, query: string): UserSe
   if (full.includes(q)) {
     return UserSearchRelevance.NameSubstring;
   }
+  if (username.includes(q)) {
+    return UserSearchRelevance.UsernameMatch;
+  }
   if (email.includes(q)) {
     return UserSearchRelevance.EmailMatch;
   }
@@ -59,39 +72,40 @@ export function scoreUserSearchResult(user: RankableUser, query: string): UserSe
 }
 
 /**
- * Re-ranks (and lightly filters) user search results so name matches surface
- * first and incidental email/alias matches are demoted.
+ * Re-ranks user search results so name matches surface first and incidental
+ * email/alias matches are demoted.
  *
  * The upstream query service matches `name` against `name_and_aliases` (which
  * folds in email and uses ngram subfields), so a query like "il" can match
- * inside unrelated emails. This client-side pass mitigates that:
+ * inside unrelated emails. This client-side pass mitigates that by sorting
+ * exact > name-prefix > name-substring > username > email > incidental.
  *
- * - **Name queries** (no `@`): sorted exact > prefix > name-substring >
- *   email-match; results with no contiguous match in name or email are dropped
- *   as upstream noise. Email-only matches are kept but demoted below name hits.
- * - **Email queries** (contains `@`): treated as an explicit email lookup —
- *   nothing is dropped; results are only sorted by email relevance so the
- *   legitimate search is never hidden.
+ * It **demotes** rather than drops: low-relevance rows sort to the bottom and
+ * fall off `limit`, so real matches always win the visible slots — but a
+ * legitimate hit on an upstream alias the client can't see (a field outside
+ * name/username/email) is never hard-filtered out. Email queries (containing
+ * `@`) need no special case: name fields won't match, so genuine email hits
+ * naturally rank above the rest.
  *
  * Ordering is stable: results within the same tier keep their upstream order.
+ *
+ * @param results Upstream results to rank.
+ * @param query  Raw user query (normalized internally).
+ * @param options.limit Max results to return; defaults to {@link DEFAULT_RESULT_LIMIT}.
+ *   Pass `Infinity` to return every ranked result.
  */
-export function rankUserSearchResults<T extends RankableUser>(results: T[], query: string): T[] {
-  const normalizedQuery = normalize(query);
-  if (!normalizedQuery) {
+export function rankUserSearchResults<T extends RankableUser>(results: T[], query: string, options?: { limit?: number }): T[] {
+  const q = normalize(query);
+  if (!q) {
     return results;
   }
 
-  const isEmailQuery = normalizedQuery.includes('@');
+  const limit = options?.limit ?? DEFAULT_RESULT_LIMIT;
 
-  const scored = results.map((result, index) => ({
-    result,
-    index,
-    score: scoreUserSearchResult(result, normalizedQuery),
-  }));
+  const ranked = results
+    .map((result, index) => ({ result, index, score: scoreUserSearchResult(result, q) }))
+    .sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score))
+    .map((entry) => entry.result);
 
-  // For name queries, drop pure-incidental matches (ngram/alias noise). For
-  // email queries, keep everything — the user is searching by email on purpose.
-  const retained = isEmailQuery ? scored : scored.filter((entry) => entry.score !== UserSearchRelevance.Incidental);
-
-  return retained.sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score)).map((entry) => entry.result);
+  return ranked.slice(0, limit);
 }

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -25,6 +25,7 @@ export enum UserSearchRelevance {
 /** Minimal user shape needed to rank a search result. */
 type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email' | 'username'>;
 
+/** Null-safe normalization for case-insensitive comparison: coalesces nullish to '', trims, lowercases. */
 function normalize(value: string | null | undefined): string {
   return (value ?? '').trim().toLowerCase();
 }

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -1,26 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { UserSearchRelevance } from '../enums';
 import { UserSearchResult } from '../interfaces';
-
-/**
- * Relevance tiers for a user search result against a query.
- * Lower values rank higher (sort ascending).
- */
-export enum UserSearchRelevance {
-  /** Query equals a name field (first, last, or full name). */
-  ExactName = 0,
-  /** Query is a prefix of a name field. */
-  NamePrefix = 1,
-  /** Query appears as a substring of the full name. */
-  NameSubstring = 2,
-  /** Query matches the LFID username. */
-  UsernameMatch = 3,
-  /** Query matches only the email (incidental for a name search). */
-  EmailMatch = 4,
-  /** No contiguous match in any searchable field (upstream ngram/alias noise). */
-  Incidental = 5,
-}
 
 /** Minimal user shape needed to rank a search result. */
 type RankableUser = Pick<UserSearchResult, 'first_name' | 'last_name' | 'email' | 'username'>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -12,5 +12,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "**/*.spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,6 +3202,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.25.6":
   version: 0.25.6
   resolution: "@esbuild/aix-ppc64@npm:0.25.6"
@@ -4290,6 +4318,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     date-fns-tz: "npm:^3.2.0"
     typescript: "npm:5.8.3"
+    vitest: "npm:^4.1.8"
   peerDependencies:
     "@angular/core": ^20.3.15
     "@angular/forms": ^20.3.15
@@ -4624,6 +4653,18 @@ __metadata:
     "@napi-rs/nice-win32-x64-msvc":
       optional: true
   checksum: 10c0/517eacfd5d5de191f1469a6caad9f9e26924b25079550149fc792fb09d15184013a8a81966a666f08c0a93fbb17a458d50ba9e2e9d6a61141c6c515d083733b2
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
   languageName: node
   linkType: hard
 
@@ -5259,6 +5300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-project/types@npm:0.133.0"
+  checksum: 10c0/70c57ba58644f7ec217b670c301801f4d06995f4ccdba6b2bd106ea3e5ee49d616573e6ef8d55530b87571a960696543687f3850e87ad173d3f88965c30cdd63
+  languageName: node
+  linkType: hard
+
 "@panva/asn1.js@npm:^1.0.0":
   version: 1.0.0
   resolution: "@panva/asn1.js@npm:1.0.0"
@@ -5634,6 +5682,122 @@ __metadata:
   version: 1.1.1
   resolution: "@protobufjs/utf8@npm:1.1.1"
   checksum: 10c0/641fc145f00626405e8984b6e90b9edcbcc072ffc82d0647ca3176e09c730b2d022f988e65f011a7a17e2e4d77cde7733643aa10d8ac2bfa30f134dbcad553fd
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.3"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.3"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -6662,6 +6826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:^0.3.13":
   version: 0.3.17
   resolution: "@swc/helpers@npm:0.3.17"
@@ -6735,6 +6906,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.2
+  resolution: "@tybys/wasm-util@npm:0.10.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+  languageName: node
+  linkType: hard
+
 "@types/body-parser@npm:*":
   version: 1.19.6
   resolution: "@types/body-parser@npm:1.19.6"
@@ -6770,6 +6950,16 @@ __metadata:
   version: 0.12.5
   resolution: "@types/caseless@npm:0.12.5"
   checksum: 10c0/b1f8b8a38ce747b643115d37a40ea824c658bd7050e4b69427a10e9d12d1606ed17a0f6018241c08291cd59f70aeb3c1f3754ad61e45f8dbba708ec72dde7ec8
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
   languageName: node
   linkType: hard
 
@@ -6811,6 +7001,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.7":
   version: 3.7.7
   resolution: "@types/eslint-scope@npm:3.7.7"
@@ -6842,6 +7039,13 @@ __metadata:
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -7489,6 +7693,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/expect@npm:4.1.8"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/f7bf6c720d2427c3bd0b35472ebd84d963be7d09ecf52a0fb05e8c4d5d0c9ee164a8c28eee6360947be1b245b47faefab54560cb98e5cb678c1c1074260b9149
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/mocker@npm:4.1.8"
+  dependencies:
+    "@vitest/spy": "npm:4.1.8"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f8cb2b8b55dc2cba0b2399aeee528b0187042f22cbc2d50a4fd6141f5aa246ebc41700f45dd1d73eca44ddfb57dcde48b2eb317bfbb1198f5ab2cc4fd04b2ea0
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/pretty-format@npm:4.1.8"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/553c456692a4b9ae13cd116c234c74b4495e0f1a0d5c51ffc3fab8ea085e3550769967e29db79bdac0cf127b1bf88b7f70bfba3dcc72be6bddf834433e30cc91
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/runner@npm:4.1.8"
+  dependencies:
+    "@vitest/utils": "npm:4.1.8"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/706808a4b7b95ea9a9268fc152dd39e15a9a754f37c7990aea167486a9094caa913dae454771ae02c18dccfabd667f8cc38eed33a1307a79d32a89878b5bcce1
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/snapshot@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/ba4c32112491d42d24986f921c50ede5edbdb4b7eafa16c72cf8d2c9ecc44121fdb3d9365236747a9841f0d6776affc6457470fcbb082df9dbc28c24792a0c6d
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/spy@npm:4.1.8"
+  checksum: 10c0/3c10c0325a09d16bc0e77c0be96c47c15416186e33332880c0d1dd0a51d51a866091067b81f2a2ef6fb422a7760e6cf15c04d91a0eca4d59f62e8c8401fa53fc
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/utils@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/acda9d3d640c1ebc81afb358ac30589d7d7d583af81e2d09419f0af9cbe41f3ce0b90527326943bf0da51614be5fc31afcd32259f6beb32b3417999d6ef380f3
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
   version: 1.14.1
   resolution: "@webassemblyjs/ast@npm:1.14.1"
@@ -8075,6 +8361,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "ast-types@npm:^0.13.4":
   version: 0.13.4
   resolution: "ast-types@npm:0.13.4"
@@ -8630,6 +8923,13 @@ __metadata:
   version: 1.0.30001760
   resolution: "caniuse-lite@npm:1.0.30001760"
   checksum: 10c0/cee26dff5c5b15ba073ab230200e43c0d4e88dc3bac0afe0c9ab963df70aaa876c3e513dde42a027f317136bf6e274818d77b073708b74c5807dfad33c029d3c
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -9540,6 +9840,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^2.0.3":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
+  languageName: node
+  linkType: hard
+
 "detect-node@npm:^2.0.4":
   version: 2.1.0
   resolution: "detect-node@npm:2.1.0"
@@ -9886,6 +10193,13 @@ __metadata:
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10c0/93bcf2454fa72d67fe3ccd0abef8ce7933f5840a319513418a643dd8e9c6aa8f49709cecfae02ded722805dd327232d30723a807cc52e6809d6ac697c62c29fb
   languageName: node
   linkType: hard
 
@@ -10284,6 +10598,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -10362,6 +10685,13 @@ __metadata:
   dependencies:
     homedir-polyfill: "npm:^1.0.1"
   checksum: 10c0/205a60497422746d1c3acbc1d65bd609b945066f239a2b785e69a7a651ac4cbeb4e08555b1ea0023abbe855e6fcb5bbf27d0b371367fdccd303d4fb2b4d66845
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -12932,6 +13262,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-android-arm64@npm:1.32.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss@npm:1.32.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.32.0"
+    lightningcss-darwin-arm64: "npm:1.32.0"
+    lightningcss-darwin-x64: "npm:1.32.0"
+    lightningcss-freebsd-x64: "npm:1.32.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
+    lightningcss-linux-arm64-gnu: "npm:1.32.0"
+    lightningcss-linux-arm64-musl: "npm:1.32.0"
+    lightningcss-linux-x64-gnu: "npm:1.32.0"
+    lightningcss-linux-x64-musl: "npm:1.32.0"
+    lightningcss-win32-arm64-msvc: "npm:1.32.0"
+    lightningcss-win32-x64-msvc: "npm:1.32.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:^3.0.0, lilconfig@npm:^3.1.3":
   version: 3.1.3
   resolution: "lilconfig@npm:3.1.3"
@@ -13345,7 +13795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:0.30.21":
+"magic-string@npm:0.30.21, magic-string@npm:^0.30.21":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -14287,6 +14737,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "obug@npm:2.1.1"
+  checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
 "oidc-token-hash@npm:^5.0.1":
   version: 5.1.0
   resolution: "oidc-token-hash@npm:5.1.0"
@@ -14701,6 +15158,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "pdfkit@npm:^0.15.0":
   version: 0.15.2
   resolution: "pdfkit@npm:0.15.2"
@@ -14732,6 +15196,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -15192,7 +15663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11":
+"postcss@npm:^8.3.11, postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -15938,6 +16409,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:1.0.3":
+  version: 1.0.3
+  resolution: "rolldown@npm:1.0.3"
+  dependencies:
+    "@oxc-project/types": "npm:=0.133.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-x64": "npm:1.0.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/5f9dd47b7abf203b16bc600db68542f245e974c800e59ff50b76157d1dada1403657690435b036fabca88e93d13a67c31abe5cfaa6f61ce33717f61720204cdf
+  languageName: node
+  linkType: hard
+
 "rollup@npm:4.52.3":
   version: 4.52.3
   resolution: "rollup@npm:4.52.3"
@@ -16569,6 +17098,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.3":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -16866,6 +17402,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
@@ -16884,6 +17427,13 @@ __metadata:
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -17334,10 +17884,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.0.0":
   version: 1.0.1
   resolution: "tinyexec@npm:1.0.1"
   checksum: 10c0/e1ec3c8194a0427ce001ba69fd933d0c957e2b8994808189ed8020d3e0c01299aea8ecf0083cc514ecbf90754695895f2b5c0eac07eb2d0c406f7d4fbb8feade
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.2.4
+  resolution: "tinyexec@npm:1.2.4"
+  checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
   languageName: node
   linkType: hard
 
@@ -17358,6 +17922,23 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -17918,6 +18499,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.0.16
+  resolution: "vite@npm:8.0.16"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.15"
+    rolldown: "npm:1.0.3"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.1.18
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/d75be3fbe2f63e6a8145325970338afaf0dd4d96ba9175c13f9a286fd5f95afc489401b693e4fa6c0899a4dd0e137be91cdf9401a40a635563911ad5036e3467
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "vitest@npm:4.1.8"
+  dependencies:
+    "@vitest/expect": "npm:4.1.8"
+    "@vitest/mocker": "npm:4.1.8"
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/runner": "npm:4.1.8"
+    "@vitest/snapshot": "npm:4.1.8"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.8
+    "@vitest/browser-preview": 4.1.8
+    "@vitest/browser-webdriverio": 4.1.8
+    "@vitest/coverage-istanbul": 4.1.8
+    "@vitest/coverage-v8": 4.1.8
+    "@vitest/ui": 4.1.8
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/f459c500f8818c7a2318cd23228b4e5c0b5efb25bf8e5cb7f116c6d26e51482b2f800a8bb19837c0b5f0d05c51519edbf502bc8ceb5bd86868e8facf1d2c498e
+  languageName: node
+  linkType: hard
+
 "vizion@npm:~2.2.1":
   version: 2.2.1
   resolution: "vizion@npm:2.2.1"
@@ -18192,6 +18898,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/e556e4cd8b7dbf5df52408c9a9dd5ac6518c8c5267c8953f5b0564073c66ed5bf9503b14d876d0e9c7844d4db9725fb0dcf45d6e911e17e26ab363dc3965ae7b
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Member/person search (adding members to groups, assigning roles) over-matches: typing `il` returns everyone with an incidental `i`/`l` hit — including matches **inside the email address** — surfacing unrelated people instead of the intended name match (LFXV2-2058).

**Root cause (upstream, not this repo):** the BFF (`server/services/search.service.ts`) is a thin proxy — it sends `name=` or `tags=email:` to the `LFX_V2_SERVICE` `/query/resources` endpoint and only de-dupes. The over-match lives in **`lfx-v2-query-service`** (`internal/infrastructure/opensearch/template.go`), which matches `name` via a `multi_match` `"type": "bool_prefix"` over `name_and_aliases` plus its `._2gram`/`._3gram` shingle subfields. Aliases fold in email and the ngram subfields loosen matching, so a name query matches inside unrelated emails/aliases.

The proper fix (restrict matched fields, only search email when `tags=email:` is used, rank exact > prefix > substring server-side) belongs upstream in `lfx-v2-query-service`. **Follow-up ticket to be filed against that repo.** This PR is the client-side mitigation we can ship from the BFF in the meantime.

## What this PR does

- Adds `rankUserSearchResults()` in `@lfx-one/shared/utils` — a pure client-side re-rank that sorts results **exact name > name-prefix > name-substring > username > email > incidental**, so intended matches surface first and incidental email/alias hits are demoted to the bottom.
  - **Demotes, never drops or caps:** low-relevance rows sort last but are always retained, so a legitimate hit on an upstream alias the client can't see is never hidden. (Two `fix(review)` commits tightened this from an initial drop-then-cap approach after review feedback.)
  - **Email queries** (query contains `@`) need no special case — name fields won't match, so genuine email hits naturally rank above the rest; the explicit email search is never demoted away.
- Wires the helper into both search entry points: `user-search.component.ts` and the committee `add-member-dialog.component.ts` result streams.

## Tests

- Adds **Vitest** to `packages/shared` (the package's first unit-test runner — flagging so the team can ratify the choice) with a `test` script wired into the existing `turbo run test`. Specs (`*.spec.ts`) are excluded from the production `tsc` build via `tsconfig.json`.
- 13 unit tests covering prefix, mid-name substring, username-only, email-only, incidental (ngram noise), stable tiering, no-cap retention, the `@` email-query path, and empty-query passthrough.

## Protected files

- `packages/shared/package.json` + `yarn.lock` — adds Vitest as a **devDependency** of the shared package only (does not ship). Flagging for code-owner awareness.

## Validation

`yarn lint` ✅ · `yarn format` ✅ · shared `vitest` 13/13 ✅ · `yarn build` ✅ (both packages) · DCO + GPG signed on all 3 commits, rebased on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
