### PR TITLE
feat(campaigns): add metrics service, controller, and route

### DIFF
--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -153,7 +153,7 @@ export class CampaignController {
   }
 
   public async lookupHubSpotUtm(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const eventName = req.query['event_name'] as string;
+    const eventName = typeof req.query['event_name'] === 'string' ? req.query['event_name'] : '';
     if (!eventName) {
       next(ServiceValidationError.forField('event_name', 'event_name is required', { operation: 'hubspot_utm_lookup', service: 'campaign_controller' }));
       return;
@@ -171,7 +171,7 @@ export class CampaignController {
   }
 
   public async createHubSpotUtm(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const eventName = req.query['event_name'] as string;
+    const eventName = typeof req.query['event_name'] === 'string' ? req.query['event_name'] : '';
     if (!eventName) {
       next(ServiceValidationError.forField('event_name', 'event_name is required', { operation: 'hubspot_utm_create', service: 'campaign_controller' }));
       return;

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -103,6 +103,7 @@ export class CampaignMetricsService {
     const age = aggregateDemoBuckets(ageRows, (r) => (extractNested(r, 'adGroupCriterion.ageRange.type') as string) || 'Unknown');
     const gender = aggregateDemoBuckets(genderRows, (r) => (extractNested(r, 'adGroupCriterion.gender.type') as string) || 'Unknown');
 
+    // Device demographics require a separate GAQL query against user_location_view — not yet implemented
     return { pulledAt: new Date().toISOString(), days, age, gender, device: [] };
   }
 }

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -58,7 +58,7 @@ export class CampaignMetricsService {
   public async getKeywords(req: Request, days: number): Promise<KeywordMetricsResponse> {
     logger.debug(req, 'campaign_keywords', 'Fetching keyword metrics from Google Ads', { days });
 
-    const { gaqlRange } = resolveDateRange(days);
+    const { gaqlRange, effectiveDays } = resolveDateRange(days);
 
     const query = `
       SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
@@ -82,7 +82,7 @@ export class CampaignMetricsService {
     };
     totals.avgCtr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : 0;
 
-    return { pulledAt: new Date().toISOString(), days, totalKeywords: keywords.length, totals, keywords };
+    return { pulledAt: new Date().toISOString(), days: effectiveDays, totalKeywords: keywords.length, totals, keywords };
   }
 
   // === Audience demographics ===

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -90,7 +90,7 @@ export class CampaignMetricsService {
   public async getAudience(req: Request, days: number): Promise<AudienceDemographics> {
     logger.debug(req, 'campaign_audience', 'Fetching audience demographics from Google Ads', { days });
 
-    const { gaqlRange } = resolveDateRange(days);
+    const { gaqlRange, effectiveDays } = resolveDateRange(days);
 
     const ageQuery = `SELECT ad_group_criterion.age_range.type, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions
       FROM age_range_view WHERE segments.date DURING ${gaqlRange}`;
@@ -104,7 +104,7 @@ export class CampaignMetricsService {
     const gender = aggregateDemoBuckets(genderRows, (r) => (extractNested(r, 'adGroupCriterion.gender.type') as string) || 'Unknown');
 
     // Device demographics require a separate GAQL query against user_location_view — not yet implemented
-    return { pulledAt: new Date().toISOString(), days, age, gender, device: [] };
+    return { pulledAt: new Date().toISOString(), days: effectiveDays, age, gender, device: [] };
   }
 }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -415,7 +415,7 @@ function createJob(): string {
   setTimeout(() => {
     const job = jobs.get(jobId);
     if (job?.status === 'running') {
-      completeJob(jobId, { success: false, campaigns: [], errors: ['Job timed out after 5 minutes'] });
+      failJob(jobId, 'Job timed out after 5 minutes');
     }
   }, JOB_TIMEOUT_MS);
 
@@ -424,6 +424,11 @@ function createJob(): string {
 
 function completeJob(jobId: string, result: CampaignCreateResponse): void {
   jobs.set(jobId, { status: 'done', result });
+  setTimeout(() => jobs.delete(jobId), JOB_TTL_MS);
+}
+
+function failJob(jobId: string, error: string): void {
+  jobs.set(jobId, { status: 'error', error });
   setTimeout(() => jobs.delete(jobId), JOB_TTL_MS);
 }
 
@@ -649,11 +654,7 @@ export class CampaignProxyService {
     const jobId = createJob();
 
     this.executeCampaignCreation(jobId, body).catch((error) => {
-      completeJob(jobId, {
-        success: false,
-        campaigns: [],
-        errors: [error instanceof Error ? error.message : 'Campaign creation failed'],
-      });
+      failJob(jobId, error instanceof Error ? error.message : 'Campaign creation failed');
     });
 
     return { jobId };

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -87,8 +87,22 @@ export async function validateScrapeUrl(url: string): Promise<string> {
   }
 
   const { promises: dns } = await import('node:dns');
-  const addresses4 = await dns.resolve4(hostname).catch(() => []);
-  const addresses6 = await dns.resolve6(hostname).catch(() => []);
+  let addresses4: string[];
+  let addresses6: string[];
+  try {
+    [addresses4, addresses6] = await Promise.all([
+      dns.resolve4(hostname).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOTFOUND' || err.code === 'ENODATA') return [];
+        throw err;
+      }),
+      dns.resolve6(hostname).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOTFOUND' || err.code === 'ENODATA') return [];
+        throw err;
+      }),
+    ]);
+  } catch {
+    throw new Error('DNS resolution failed — cannot verify host safety');
+  }
   for (const addr of [...addresses4, ...addresses6]) {
     if (PRIVATE_IP_PATTERNS.some((p) => p.test(addr))) {
       throw new Error('Blocked host: resolves to private IP');
@@ -728,7 +742,8 @@ export class CampaignProxyService {
         explicitly_shared: false,
       },
     ]);
-    const budgetResource = budgetResult.results[0].resource_name ?? '';
+    const budgetResource = budgetResult.results[0]?.resource_name;
+    if (!budgetResource) throw new Error('Budget creation did not return a resource_name');
     steps.push(`Created budget: $${(budgetMicros / 1_000_000).toFixed(2)}/day`);
 
     // 2. Create campaign
@@ -748,7 +763,8 @@ export class CampaignProxyService {
         },
       },
     ]);
-    const campaignResource = campaignResult.results[0].resource_name ?? '';
+    const campaignResource = campaignResult.results[0]?.resource_name;
+    if (!campaignResource) throw new Error('Campaign creation did not return a resource_name');
     const campaignId = campaignResource.split('/').pop() || '';
     steps.push(`Created campaign: ${campaignName}`);
 
@@ -774,7 +790,8 @@ export class CampaignProxyService {
         status: enums.AdGroupStatus.ENABLED,
       },
     ]);
-    const adGroupResource = adGroupResult.results[0].resource_name ?? '';
+    const adGroupResource = adGroupResult.results[0]?.resource_name;
+    if (!adGroupResource) throw new Error('Ad group creation did not return a resource_name');
     steps.push('Created ad group');
 
     // 5. Add keywords
@@ -841,7 +858,8 @@ export class CampaignProxyService {
         explicitly_shared: false,
       },
     ]);
-    const budgetResource = budgetResult.results[0].resource_name ?? '';
+    const budgetResource = budgetResult.results[0]?.resource_name;
+    if (!budgetResource) throw new Error('Budget creation did not return a resource_name');
     steps.push(`Created budget: $${(budgetMicros / 1_000_000).toFixed(2)}/day`);
 
     const campaignResult = await customer.campaigns.create([
@@ -855,7 +873,8 @@ export class CampaignProxyService {
         target_spend: {},
       },
     ]);
-    const campaignResource = campaignResult.results[0].resource_name ?? '';
+    const campaignResource = campaignResult.results[0]?.resource_name;
+    if (!campaignResource) throw new Error('Campaign creation did not return a resource_name');
     const campaignId = campaignResource.split('/').pop() || '';
     steps.push(`Created Demand Gen campaign: ${campaignName}`);
 
@@ -867,7 +886,8 @@ export class CampaignProxyService {
         status: enums.AdGroupStatus.ENABLED,
       },
     ]);
-    const adGroupResource = adGroupResult.results[0].resource_name ?? '';
+    const adGroupResource = adGroupResult.results[0]?.resource_name;
+    if (!adGroupResource) throw new Error('Ad group creation did not return a resource_name');
     steps.push('Created ad group');
 
     // Geo targeting at ad group level (Demand Gen doesn't support campaign-level location criteria)

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -497,6 +497,13 @@ export class CampaignProxyService {
 
   public async *streamBrief(req: Request, body: CampaignBriefRequest, signal: AbortSignal): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
+
+    const unsupported = (body.platforms ?? []).filter((p) => p !== 'google-ads');
+    if (unsupported.length > 0) {
+      yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Only google-ads is currently supported.` };
+      return;
+    }
+
     yield { type: 'status', data: `Scraping ${body.url}...` };
 
     let safeUrl: string;
@@ -517,11 +524,12 @@ export class CampaignProxyService {
 
       // Follow redirects manually to validate each target against SSRF
       let redirectCount = 0;
+      let currentUrl = safeUrl;
       while (scrapeResponse.status >= 300 && scrapeResponse.status < 400 && redirectCount < 5) {
         const location = scrapeResponse.headers.get('location');
         if (!location) break;
-        const redirectUrl = await validateScrapeUrl(new URL(location, safeUrl).href);
-        scrapeResponse = await fetch(redirectUrl, {
+        currentUrl = await validateScrapeUrl(new URL(location, currentUrl).href);
+        scrapeResponse = await fetch(currentUrl, {
           headers: { 'User-Agent': 'Mozilla/5.0 (compatible; LFX/1.0)' },
           signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)]),
           redirect: 'manual',

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -30,9 +30,15 @@ import type { Customer } from 'google-ads-api';
 
 const REQUIRED_ENV_VARS = ['GADS_CLIENT_ID', 'GADS_CLIENT_SECRET', 'GADS_DEVELOPER_TOKEN', 'GADS_CUSTOMER_ID', 'GADS_REFRESH_TOKEN'];
 
-for (const envVar of REQUIRED_ENV_VARS) {
-  if (!process.env[envVar]) {
-    logger.warning(undefined, 'campaign_proxy_init', `Missing environment variable: ${envVar} — Google Ads features will not work`, { envVar });
+let envChecked = false;
+
+function checkRequiredEnv(req?: Request): void {
+  if (envChecked) return;
+  envChecked = true;
+  for (const envVar of REQUIRED_ENV_VARS) {
+    if (!process.env[envVar]) {
+      logger.warning(req, 'campaign_proxy_init', `Missing environment variable: ${envVar} — Google Ads features will not work`, { envVar });
+    }
   }
 }
 
@@ -53,6 +59,7 @@ const PRIVATE_IP_PATTERNS = [
   /^192\.168\.\d+\.\d+$/,
   /^169\.254\.\d+\.\d+$/, // link-local / AWS IMDS
   /^::1$/,
+  /^::ffff:\d+\.\d+\.\d+\.\d+$/i, // IPv4-mapped IPv6
   /^f[cd][0-9a-f]{2}:/i, // IPv6 ULA (fc00::/7 covers both fc and fd)
   /^fe80:/i, // IPv6 link-local
 ];
@@ -489,6 +496,7 @@ export class CampaignProxyService {
   // === Brief generation (SSE stream) ===
 
   public async *streamBrief(req: Request, body: CampaignBriefRequest, signal: AbortSignal): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
+    checkRequiredEnv(req);
     yield { type: 'status', data: `Scraping ${body.url}...` };
 
     let safeUrl: string;
@@ -594,7 +602,7 @@ export class CampaignProxyService {
       return;
     }
 
-    if (body.platforms?.includes('google-ads') || !body.platforms) {
+    if (body.platforms?.includes('google-ads') || !body.platforms || body.platforms.length === 0) {
       yield { type: 'status', data: 'Generating keyword list...' };
 
       try {
@@ -647,17 +655,18 @@ export class CampaignProxyService {
 
   public async getJobStatus(_req: Request, jobId: string): Promise<CampaignJobStatus> {
     const job = jobs.get(jobId);
-    if (!job) return { status: 'done', result: { success: false, campaigns: [], errors: ['Job not found'] } };
+    if (!job) return { status: 'not_found', error: 'Job not found' };
     return job;
   }
 
   // === Private: campaign creation orchestration ===
 
   private async executeCampaignCreation(jobId: string, body: CampaignCreateRequest): Promise<void> {
-    if (!body.hsToken) {
+    const effectiveBody = { ...body };
+    if (!effectiveBody.hsToken) {
       try {
-        const hsUtm = await resolveHubSpotUtm(body.eventName);
-        if (hsUtm) body.hsToken = hsUtm;
+        const hsUtm = await resolveHubSpotUtm(effectiveBody.eventName);
+        if (hsUtm) effectiveBody.hsToken = hsUtm;
       } catch {
         // HubSpot unavailable — fall back to event slug for UTM
       }
@@ -666,26 +675,27 @@ export class CampaignProxyService {
     const results: CampaignCreateResult[] = [];
     const errors: string[] = [];
 
-    for (const campaignType of body.campaignTypes) {
+    for (const campaignType of effectiveBody.campaignTypes) {
+      const startTime = Date.now();
       try {
-        const result = campaignType === 'search' ? await this.createSearchCampaign(body) : await this.createDemandGenCampaign(body);
+        const result = campaignType === 'search' ? await this.createSearchCampaign(effectiveBody) : await this.createDemandGenCampaign(effectiveBody);
         results.push(result);
       } catch (error: unknown) {
         if (getGadsErrorCode(error) === 'DUPLICATE_CAMPAIGN_NAME') {
           try {
-            const retryBody = { ...body, eventName: `${body.eventName}-${Date.now().toString(36).slice(-4)}` };
+            const retryBody = { ...effectiveBody, eventName: `${effectiveBody.eventName}-${Date.now().toString(36).slice(-4)}` };
             const result = campaignType === 'search' ? await this.createSearchCampaign(retryBody) : await this.createDemandGenCampaign(retryBody);
             results.push(result);
             continue;
           } catch (retryError: unknown) {
             const detail = extractGadsErrorMessage(retryError);
-            logger.error(undefined, 'campaign_create_type', Date.now(), retryError as Error, { campaignType, detail });
+            logger.error(undefined, 'campaign_create_type', startTime, retryError as Error, { campaignType, detail });
             errors.push(`${campaignType}: ${detail}`);
             continue;
           }
         }
         const detail = extractGadsErrorMessage(error);
-        logger.error(undefined, 'campaign_create_type', Date.now(), error as Error, { campaignType, detail });
+        logger.error(undefined, 'campaign_create_type', startTime, error as Error, { campaignType, detail });
         errors.push(`${campaignType}: ${detail}`);
       }
     }
@@ -888,8 +898,9 @@ export class CampaignProxyService {
 // ---------------------------------------------------------------------------
 
 function resolveMatchType(matchType: string): number {
-  if (matchType === 'Exact') return enums.KeywordMatchType.EXACT;
-  if (matchType === 'Phrase') return enums.KeywordMatchType.PHRASE;
+  const normalized = matchType.toLowerCase();
+  if (normalized === 'exact') return enums.KeywordMatchType.EXACT;
+  if (normalized === 'phrase') return enums.KeywordMatchType.PHRASE;
   return enums.KeywordMatchType.BROAD;
 }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -103,9 +103,9 @@ function getGadsClient(): GoogleAdsApi {
       throw new Error('Google Ads credentials not configured (GADS_CLIENT_ID, GADS_CLIENT_SECRET, GADS_DEVELOPER_TOKEN)');
     }
     gadsClient = new GoogleAdsApi({
-      client_id: getEnv('GADS_CLIENT_ID'),
-      client_secret: getEnv('GADS_CLIENT_SECRET'),
-      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
+      client_id: clientId,
+      client_secret: clientSecret,
+      developer_token: developerToken,
     });
   }
   return gadsClient;
@@ -187,6 +187,10 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
+
+  if (best.score === 0) {
+    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
+  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -308,7 +312,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal,
+    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
   });
 
   if (!response.ok || !response.body) {
@@ -1044,7 +1048,7 @@ function sanitizeDelimiter(value: string): string {
 }
 
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode] || 'Global';
+  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -103,9 +103,9 @@ function getGadsClient(): GoogleAdsApi {
       throw new Error('Google Ads credentials not configured (GADS_CLIENT_ID, GADS_CLIENT_SECRET, GADS_DEVELOPER_TOKEN)');
     }
     gadsClient = new GoogleAdsApi({
-      client_id: clientId,
-      client_secret: clientSecret,
-      developer_token: developerToken,
+      client_id: getEnv('GADS_CLIENT_ID'),
+      client_secret: getEnv('GADS_CLIENT_SECRET'),
+      developer_token: getEnv('GADS_DEVELOPER_TOKEN'),
     });
   }
   return gadsClient;
@@ -187,10 +187,6 @@ async function hubspotSearchCampaign(eventName: string): Promise<HubSpotUtmResul
 
   scored.sort((a, b) => b.score - a.score);
   const best = scored[0];
-
-  if (best.score === 0) {
-    return { found: false, hsUtm: null, campaignName: '', campaignId: null };
-  }
 
   return { found: true, hsUtm: best.hsUtm, campaignName: best.name, campaignId: best.id };
 }
@@ -312,7 +308,7 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
       temperature: 0.7,
       stream: true,
     }),
-    signal: AbortSignal.any([signal, AbortSignal.timeout(120_000)]),
+    signal,
   });
 
   if (!response.ok || !response.body) {
@@ -1048,7 +1044,7 @@ function sanitizeDelimiter(value: string): string {
 }
 
 function buildCampaignName(body: CampaignCreateRequest, campaignType: string): string {
-  const region = REGION_MAP[body.countryCode.toUpperCase()] || 'Global';
+  const region = REGION_MAP[body.countryCode] || 'Global';
   const adFormat = campaignType === 'Search' ? 'Search' : 'DG Display';
   const targeting = campaignType === 'Search' ? 'Prospecting' : 'Intent';
   const funnel = campaignType === 'Search' ? 'BoFU' : 'MoFU';

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -25,7 +25,7 @@ import { GoogleAdsApi, enums } from 'google-ads-api';
 import type { Customer } from 'google-ads-api';
 
 // ---------------------------------------------------------------------------
-// Required environment variables — log warnings at startup for missing ones
+// Required environment variables — log warnings on first use for missing ones
 // ---------------------------------------------------------------------------
 
 const REQUIRED_ENV_VARS = ['GADS_CLIENT_ID', 'GADS_CLIENT_SECRET', 'GADS_DEVELOPER_TOKEN', 'GADS_CUSTOMER_ID', 'GADS_REFRESH_TOKEN'];

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -41,7 +41,7 @@ export type CampaignSSEEventType =
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms: CampaignPlatform[];
+  platforms?: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -41,7 +41,7 @@ export type CampaignSSEEventType =
 
 export interface CampaignBriefRequest {
   url: string;
-  platforms?: CampaignPlatform[];
+  platforms: CampaignPlatform[];
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -19,9 +19,6 @@ export * from './components.interface';
 // Auth interfaces
 export * from './auth.interface';
 
-// Campaign interfaces
-export * from './campaign.interface';
-
 // API interfaces
 export * from './api.interface';
 


### PR DESCRIPTION
## Summary
- Add `CampaignMetricsService` for monitoring data, keyword metrics, and audience demographics from Google Ads
- Add `CampaignController` with 8 endpoints: SSE brief streaming, campaign creation, job polling, monitoring, keywords, audience, HubSpot UTM lookup/create
- Add campaign route mounted at `/api/campaigns`
- Mount campaign router in Express server
- Add `google-ads-api` to `externalDependencies` for SSR compatibility

Part of campaigns epic LFXV2-2023.
JIRA: LFXV2-2030

> Replaces closed PR #841 (base branch was deleted when #838 merged).

🤖 Generated with [Claude Code](https://claude.ai/code)