### PR TITLE
fix(meetings): show next occurrence date on recurring meeting cards

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -42,6 +42,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   getCurrentOrNextOccurrence,
   getPastMeetingTranscriptUrl,
+  getUpcomingMeetingStartTime,
   Meeting,
   MeetingAttachment,
   MeetingCancelOccurrenceResult,
@@ -631,27 +632,24 @@ export class MeetingCardComponent implements OnInit {
       const meeting = this.meeting();
 
       if (!this.pastMeeting()) {
-        // For upcoming meetings, use current occurrence (next upcoming occurrence) or meeting start_time
-        const currentOccurrence = this.occurrence();
-        if (currentOccurrence?.start_time) {
-          return currentOccurrence.start_time;
-        }
-        if (meeting?.start_time) {
-          return meeting.start_time;
-        }
-      } else {
-        // For past meetings, use occurrence input or fallback to scheduled_start_time/start_time
-        const occurrence = this.occurrence();
-        if (occurrence?.start_time) {
-          return occurrence.start_time;
-        }
-        if (meeting?.start_time) {
-          return meeting.start_time;
-        }
-        // Handle past meetings that use scheduled_start_time (type-safe check)
-        if ('scheduled_start_time' in meeting && meeting.scheduled_start_time) {
-          return meeting.scheduled_start_time;
-        }
+        // For upcoming meetings prefer the resolved current/next occurrence, then the
+        // upstream-computed next-occurrence start, and only then the series origin. Falling
+        // straight to meeting.start_time made recurring cards show the first/created date when
+        // the list payload's occurrences array wasn't usable (LFXV2-2054).
+        return getUpcomingMeetingStartTime(meeting, this.occurrence());
+      }
+
+      // For past meetings, use occurrence input or fallback to scheduled_start_time/start_time
+      const occurrence = this.occurrence();
+      if (occurrence?.start_time) {
+        return occurrence.start_time;
+      }
+      if (meeting?.start_time) {
+        return meeting.start_time;
+      }
+      // Handle past meetings that use scheduled_start_time (type-safe check)
+      if ('scheduled_start_time' in meeting && meeting.scheduled_start_time) {
+        return meeting.scheduled_start_time;
       }
 
       return null;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -228,6 +228,11 @@ export interface Meeting {
   attended_count?: number;
   /** Meeting occurrences */
   occurrences: MeetingOccurrence[];
+  /** RFC3339 start time of the next upcoming occurrence (server-computed by the meeting service).
+   * Present on both the query-service list payload and the ITX detail payload; empty/absent when
+   * no future occurrence exists. Lets recurring cards show the next scheduled date instead of the
+   * series origin (`start_time`) when the list payload's `occurrences` array isn't usable. */
+  next_occurrence_start_time?: string;
   /** Current user's RSVP for this meeting (null when the user hasn't responded).
    * Populated by /api/user/meetings only. Absent on other Meeting-returning endpoints. */
   my_rsvp?: MeetingRsvp | null;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -229,7 +229,7 @@ export interface Meeting {
   /** Meeting occurrences */
   occurrences: MeetingOccurrence[];
   /** RFC3339 start time of the next upcoming occurrence (server-computed by the meeting service).
-   * Present on both the query-service list payload and the ITX detail payload; empty/absent when
+   * Present on both the query-service list payload and the ITX detail payload; empty or absent when
    * no future occurrence exists. Lets recurring cards show the next scheduled date instead of the
    * series origin (`start_time`) when the list payload's `occurrences` array isn't usable. */
   next_occurrence_start_time?: string;

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -206,6 +206,35 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
 }
 
 /**
+ * Resolves the start time a card/list should display for an UPCOMING meeting — the next
+ * scheduled occurrence, not the recurring series origin.
+ *
+ * Order of preference:
+ * 1. `occurrence.start_time` — an already-resolved occurrence (an explicit selection, or the
+ *    current/next occurrence from {@link getCurrentOrNextOccurrence} when the `occurrences`
+ *    array is present and usable, e.g. on the ITX-backed detail view).
+ * 2. `meeting.next_occurrence_start_time` — the upstream-computed next-occurrence start. Present
+ *    on both the query-service list payload and the ITX detail payload; empty when no future
+ *    occurrence exists. This is what keeps a recurring card from falling back to the series
+ *    origin when the list payload's `occurrences` array isn't usable (it carries `is_cancelled`
+ *    rather than `status`, and isn't guaranteed to be projected on every list response).
+ * 3. `meeting.start_time` — one-time meetings and the final fallback.
+ *
+ * @param meeting The meeting object
+ * @param occurrence Optional already-resolved occurrence (explicit or current/next)
+ * @returns The start time to display, or null when none is available
+ */
+export function getUpcomingMeetingStartTime(meeting: Meeting, occurrence?: MeetingOccurrence | null): string | null {
+  if (occurrence?.start_time) {
+    return occurrence.start_time;
+  }
+  if (meeting?.next_occurrence_start_time) {
+    return meeting.next_occurrence_start_time;
+  }
+  return meeting?.start_time ?? null;
+}
+
+/**
  * Check if a meeting can be joined based on current time
  * @param meeting The meeting object
  * @param occurrence Optional specific occurrence (for recurring meetings)

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -206,7 +206,7 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
 }
 
 /**
- * Resolves the start time a card/list should display for an UPCOMING meeting — the next
+ * Resolves the start time a card/list should display for an upcoming meeting — the next
  * scheduled occurrence, not the recurring series origin.
  *
  * Order of preference:


### PR DESCRIPTION
## What

Recurring meeting cards (project / committee / dashboard lists) showed the meeting's original **series start** date instead of the **next scheduled occurrence** — the date the user actually attends next. The detail view was already correct.

Fixes **LFXV2-2054**.

## Root cause

Cards resolve their start time via `getCurrentOrNextOccurrence(meeting)`, which scans `meeting.occurrences`. When that yields nothing usable, `initMeetingStartTime()` fell straight back to `meeting.start_time` — the recurring series origin, which reads as the "created" date.

Both list and detail payloads originate from the meeting-service's indexed `MeetingEventData`, but:
- The **list** (query-service `/query/resources`, `type: v1_meeting`) indexes occurrences with an `is_cancelled` boolean, **not** the `status` (`'available'|'cancel'`) field the frontend's `getActiveOccurrences` filters on — so the list occurrence array isn't reliably usable.
- The **detail** (ITX `/itx/meetings/:id`) returns occurrences with `status`, so it resolves correctly.

The upstream meeting added a server-computed scalar **`next_occurrence_start_time`** ("RFC3339 start time of the next upcoming occurrence; empty when none"), present on **both** payloads — and the frontend wasn't using it.

## Fix

- **`packages/shared/src/interfaces/meeting.interface.ts`** — add `next_occurrence_start_time?: string` to `Meeting` (mirrors the upstream field; verified against `lfx-v2-meeting-service` OpenAPI).
- **`packages/shared/src/utils/meeting.utils.ts`** — new pure helper `getUpcomingMeetingStartTime(meeting, occurrence?)`: prefers a resolved occurrence's `start_time` → `meeting.next_occurrence_start_time` → `meeting.start_time`.
- **`meeting-card.component.ts`** — `initMeetingStartTime()` upcoming branch delegates to the helper. Past-meeting logic (occurrence / `scheduled_start_time`) is unchanged, so past cards don't regress.

Robust whether or not the list occurrence array is usable, and aligns with the field upstream added for exactly this purpose.

## Testing

- `yarn format` / `yarn lint` / `yarn check-types` / `yarn build` — all green.
- No unit tests added: the repo has no unit-test harness (zero `.spec.ts`, no `test` target in `angular.json`; testing is Playwright E2E only). The fix logic is isolated in the pure `getUpcomingMeetingStartTime` helper so it's trivially unit-testable once a harness exists.

## Notes

- Older indexed meetings may lack `next_occurrence_start_time` until reindexed (upstream has a reindex script); those fall back to existing behavior — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)