### PR TITLE
feat(profile): add Linux.com email alias management

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -131,9 +131,7 @@
       @case ('claimed') {
         <lfx-message severity="success" icon="fa-light fa-circle-check" styleClass="mb-6" title="Your Linux.com email is active">
           <ng-template #content>
-            <p class="text-sm">
-              Email sent to your alias is forwarded to the address below.
-            </p>
+            <p class="text-sm">Email sent to your alias is forwarded to the address below.</p>
           </ng-template>
         </lfx-message>
 

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -82,13 +82,13 @@
                 </div>
                 <span class="text-sm text-gray-600 shrink-0">&#64;{{ domain() }}</span>
               </div>
-              @if (claimForm.get('alias')?.touched && claimForm.get('alias')?.invalid) {
+              @if (claimForm.controls.alias.touched && claimForm.controls.alias.invalid) {
                 <div class="text-red-600 text-xs" data-testid="linux-email-alias-error">
-                  @if (claimForm.get('alias')?.errors?.['required']) {
+                  @if (claimForm.controls.alias.errors?.['required']) {
                     An alias is required.
-                  } @else if (claimForm.get('alias')?.errors?.['aliasReserved']) {
+                  } @else if (claimForm.controls.alias.errors?.['aliasReserved']) {
                     That alias is reserved. Please choose another.
-                  } @else if (claimForm.get('alias')?.errors?.['aliasMaxLength']) {
+                  } @else if (claimForm.controls.alias.errors?.['aliasMaxLength']) {
                     Aliases can be at most 64 characters.
                   } @else {
                     Use letters, numbers, dots, and hyphens only.
@@ -109,7 +109,7 @@
                 appendTo="body"
                 data-testid="linux-email-claim-forward-select"></lfx-select>
               <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
-              @if (claimForm.get('forwardTo')?.touched && claimForm.get('forwardTo')?.invalid) {
+              @if (claimForm.controls.forwardTo.touched && claimForm.controls.forwardTo.invalid) {
                 <div class="text-red-600 text-xs" data-testid="linux-email-claim-forward-error">Please choose a forwarding address.</div>
               }
             </div>
@@ -170,7 +170,7 @@
                   data-testid="linux-email-forward-save-button"></lfx-button>
               </div>
               <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
-              @if (editForm.get('forwardTo')?.touched && editForm.get('forwardTo')?.invalid) {
+              @if (editForm.controls.forwardTo.touched && editForm.controls.forwardTo.invalid) {
                 <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
               }
             </form>

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -1,0 +1,187 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="w-full" data-testid="profile-linux-email">
+  @if (loading()) {
+    <div class="flex flex-col gap-2 items-center justify-center py-12" data-testid="profile-linux-email-loading-container">
+      <i class="fa-light fa-circle-notch fa-spin text-4xl text-blue-400" data-testid="profile-linux-email-loading-spinner"></i>
+      <span class="ml-3 text-gray-600">Loading your Linux.com email…</span>
+    </div>
+  } @else {
+    @switch (state()) {
+      <!-- Service unavailable -->
+      @case ('service_unavailable') {
+        <lfx-message severity="warn" icon="fa-light fa-triangle-exclamation" styleClass="mb-6" title="Service temporarily unavailable">
+          <ng-template #content>
+            <div class="flex flex-col gap-3 items-start">
+              <p class="text-sm">We couldn't reach the Linux.com email service right now. Please try again in a moment.</p>
+              <lfx-button
+                size="small"
+                label="Retry"
+                icon="fa-light fa-rotate-right"
+                severity="secondary"
+                variant="outlined"
+                (onClick)="retry()"
+                data-testid="linux-email-retry-button"></lfx-button>
+            </div>
+          </ng-template>
+        </lfx-message>
+      }
+
+      <!-- Not purchased -->
+      @case ('not_purchased') {
+        <lfx-message severity="info" icon="fa-light fa-info-circle" styleClass="mb-6" title="Get a Linux.com email address">
+          <ng-template #content>
+            <p class="text-sm">
+              A personal <strong>&#64;{{ domain() }}</strong> address forwards email to any inbox you choose. The Lifetime Linux.com Email Alias is a one-time
+              add-on for Individual Supporters.
+            </p>
+          </ng-template>
+        </lfx-message>
+
+        <lfx-card>
+          <div class="flex flex-col gap-4 items-start" data-testid="linux-email-purchase-panel">
+            <div>
+              <h3 class="text-base font-medium text-gray-900">You haven't purchased a Linux.com email alias add-on</h3>
+              <p class="text-sm text-gray-500 mt-1">Purchase the add-on to claim your personal &#64;{{ domain() }} address.</p>
+            </div>
+            <lfx-button
+              label="Purchase Email"
+              icon="fa-light fa-cart-shopping"
+              severity="info"
+              (onClick)="purchase()"
+              data-testid="linux-email-purchase-button"></lfx-button>
+          </div>
+        </lfx-card>
+      }
+
+      <!-- Purchased but not yet claimed -->
+      @case ('purchased_unclaimed') {
+        <lfx-message severity="info" icon="fa-light fa-info-circle" styleClass="mb-6" title="Claim your Linux.com email address">
+          <ng-template #content>
+            <p class="text-sm">
+              Choose an alias and the address you'd like your &#64;{{ domain() }} email forwarded to. Your alias can't be changed after claiming.
+            </p>
+          </ng-template>
+        </lfx-message>
+
+        <lfx-card>
+          <form [formGroup]="claimForm" (ngSubmit)="claim()" class="flex flex-col gap-4" data-testid="linux-email-claim-form">
+            <div class="flex flex-col gap-1">
+              <label class="block text-sm font-medium text-gray-700">Alias</label>
+              <div class="flex items-center gap-2">
+                <div class="flex-1">
+                  <lfx-input-text
+                    control="alias"
+                    [form]="claimForm"
+                    placeholder="your-alias"
+                    type="text"
+                    size="small"
+                    styleClass="w-full"
+                    data-testid="linux-email-alias-input"></lfx-input-text>
+                </div>
+                <span class="text-sm text-gray-600 shrink-0">&#64;{{ domain() }}</span>
+              </div>
+              @if (claimForm.get('alias')?.touched && claimForm.get('alias')?.invalid) {
+                <div class="text-red-600 text-xs" data-testid="linux-email-alias-error">
+                  @if (claimForm.get('alias')?.errors?.['required']) {
+                    An alias is required.
+                  } @else if (claimForm.get('alias')?.errors?.['aliasReserved']) {
+                    That alias is reserved. Please choose another.
+                  } @else if (claimForm.get('alias')?.errors?.['aliasMaxLength']) {
+                    Aliases can be at most 64 characters.
+                  } @else {
+                    Use letters, numbers, dots, and hyphens only.
+                  }
+                </div>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="block text-sm font-medium text-gray-700">Forward to</label>
+              <lfx-select
+                [form]="claimForm"
+                control="forwardTo"
+                [options]="forwardOptions()"
+                placeholder="Select a verified email"
+                size="small"
+                styleClass="w-full"
+                appendTo="body"
+                data-testid="linux-email-claim-forward-select"></lfx-select>
+              <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
+              @if (claimForm.get('forwardTo')?.touched && claimForm.get('forwardTo')?.invalid) {
+                <div class="text-red-600 text-xs" data-testid="linux-email-claim-forward-error">Please choose a forwarding address.</div>
+              }
+            </div>
+
+            <lfx-button
+              type="submit"
+              label="Claim alias"
+              icon="fa-light fa-check"
+              severity="info"
+              class="self-start"
+              [disabled]="claimForm.invalid || claiming()"
+              [loading]="claiming()"
+              data-testid="linux-email-claim-button"></lfx-button>
+          </form>
+        </lfx-card>
+      }
+
+      <!-- Claimed -->
+      @case ('claimed') {
+        <lfx-message severity="success" icon="fa-light fa-circle-check" styleClass="mb-6" title="Your Linux.com email is active">
+          <ng-template #content>
+            <p class="text-sm">
+              Email sent to your alias is forwarded to the address below.
+            </p>
+          </ng-template>
+        </lfx-message>
+
+        <lfx-card>
+          <div class="flex flex-col gap-6">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm font-medium text-gray-700">Your alias</span>
+              <span class="text-base font-medium text-gray-900" data-testid="linux-email-claimed-address">{{ email() }}</span>
+            </div>
+
+            <form
+              [formGroup]="editForm"
+              (ngSubmit)="updateForward()"
+              class="flex flex-col gap-1 border-t border-gray-200 pt-4"
+              data-testid="linux-email-forward-form">
+              <label class="block text-sm font-medium text-gray-700">Forward to</label>
+              <div class="flex gap-3">
+                <div class="flex-1">
+                  <lfx-select
+                    [form]="editForm"
+                    control="forwardTo"
+                    [options]="forwardOptions()"
+                    placeholder="Select a verified email"
+                    size="small"
+                    styleClass="w-full"
+                    appendTo="body"
+                    data-testid="linux-email-forward-select"></lfx-select>
+                </div>
+                <lfx-button
+                  type="submit"
+                  label="Save"
+                  icon="fa-light fa-check"
+                  severity="info"
+                  [disabled]="editForm.invalid || savingForward()"
+                  [loading]="savingForward()"
+                  data-testid="linux-email-forward-save-button"></lfx-button>
+              </div>
+              <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
+              @if (editForm.get('forwardTo')?.touched && editForm.get('forwardTo')?.invalid) {
+                <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
+              }
+            </form>
+          </div>
+        </lfx-card>
+      }
+    }
+  }
+</div>
+
+<!-- Toast messages -->
+<p-toast position="top-right" />

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -62,7 +62,7 @@ export class ProfileLinuxEmailComponent {
 
   // Derived view state
   public state = computed(() => this.data().alias?.state ?? null);
-  public domain = computed(() => this.data().alias?.domain ?? 'linux.com');
+  public domain = computed(() => this.data().alias?.domain ?? '');
   public email = computed(() => this.data().alias?.email ?? null);
 
   // Verified emails the user can forward to (primary first, default selection).
@@ -156,6 +156,10 @@ export class ProfileLinuxEmailComponent {
   }
 
   public retry(): void {
+    // Clear the one-shot re-auth guard so a Retry can re-trigger Flow C for the forward target.
+    if (isPlatformBrowser(this.platformId)) {
+      sessionStorage.removeItem(this.reauthFlagKey);
+    }
     this.refresh.next();
   }
 
@@ -178,7 +182,9 @@ export class ProfileLinuxEmailComponent {
         switchMap(() => {
           this.loading.set(true);
           return forkJoin({
-            alias: this.userService.getLinuxAlias().pipe(catchError(() => of(null))),
+            alias: this.userService
+              .getLinuxAlias()
+              .pipe(catchError(() => of<LinuxAliasData | null>({ state: 'service_unavailable', domain: '', alias: null, email: null, forwardTo: null }))),
             emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
             identities: this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))),
           }).pipe(
@@ -221,8 +227,11 @@ export class ProfileLinuxEmailComponent {
     const primary = (emails?.primary_email ?? '').toLowerCase().trim();
 
     if (alias?.state === 'claimed') {
-      // Normalize so the default matches a (normalized) forwardOptions value.
-      this.editForm.patchValue({ forwardTo: (alias.forwardTo ?? emails?.primary_email ?? '').toLowerCase().trim() });
+      // When re-auth is still required and the real target hasn't loaded, leave the selection
+      // empty rather than guessing the primary email — a guessed value could overwrite the real
+      // forward on Save. Otherwise normalize so the default matches a (normalized) forwardOptions value.
+      const forwardTo = alias.forwardAuthRequired && !alias.forwardTo ? '' : (alias.forwardTo ?? emails?.primary_email ?? '').toLowerCase().trim();
+      this.editForm.patchValue({ forwardTo });
     } else if (alias?.state === 'purchased_unclaimed' && primary) {
       this.claimForm.patchValue({ forwardTo: primary });
     }

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -13,18 +13,12 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MessageComponent } from '@components/message/message.component';
 import { SelectComponent } from '@components/select/select.component';
-import { EmailManagementData, EnrichedIdentity, LinuxAliasData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
+import { EmailManagementData, EnrichedIdentity, LinuxAliasData, LinuxEmailData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
 import { linuxAliasValidator } from '@lfx-one/shared/validators';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 import { BehaviorSubject, catchError, finalize, forkJoin, of, switchMap, tap } from 'rxjs';
-
-interface LinuxEmailData {
-  alias: LinuxAliasData | null;
-  emails: EmailManagementData | null;
-  identities: EnrichedIdentity[];
-}
 
 @Component({
   selector: 'lfx-profile-linux-email',
@@ -227,10 +221,11 @@ export class ProfileLinuxEmailComponent {
     const primary = (emails?.primary_email ?? '').toLowerCase().trim();
 
     if (alias?.state === 'claimed') {
-      // When re-auth is still required and the real target hasn't loaded, leave the selection
-      // empty rather than guessing the primary email — a guessed value could overwrite the real
-      // forward on Save. Otherwise normalize so the default matches a (normalized) forwardOptions value.
-      const forwardTo = alias.forwardAuthRequired && !alias.forwardTo ? '' : (alias.forwardTo ?? emails?.primary_email ?? '').toLowerCase().trim();
+      // Select only a real forward target. When it hasn't loaded (re-auth pending, or the
+      // forwards-service was unreachable), leave the selection empty rather than guessing the
+      // primary email — a guessed value could overwrite the real forward on Save. Normalize so
+      // the default matches a (normalized) forwardOptions value.
+      const forwardTo = (alias.forwardTo ?? '').toLowerCase().trim();
       this.editForm.patchValue({ forwardTo });
     } else if (alias?.state === 'purchased_unclaimed' && primary) {
       this.claimForm.patchValue({ forwardTo: primary });

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -36,6 +36,9 @@ export class ProfileLinuxEmailComponent {
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
 
+  // One-shot guard (sessionStorage key) so a tokenless re-auth round-trip can't loop.
+  private readonly reauthFlagKey = 'linux-email:forward-reauth-attempted';
+
   // Refresh mechanism
   private refresh = new BehaviorSubject<void>(undefined);
 
@@ -179,13 +182,38 @@ export class ProfileLinuxEmailComponent {
             emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
             identities: this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))),
           }).pipe(
-            tap(({ alias, emails }) => this.applyFormDefaults(alias, emails)),
+            tap(({ alias, emails }) => {
+              this.applyFormDefaults(alias, emails);
+              this.maybeReauthForForward(alias);
+            }),
             finalize(() => this.loading.set(false))
           );
         })
       ),
       { initialValue: { alias: null, emails: null, identities: [] } }
     );
+  }
+
+  /**
+   * A claimed alias always has a forward target, but the server can only read it
+   * with a Flow C management token. When that token is absent the server flags
+   * `forwardAuthRequired`; redirect once to load the real target instead of
+   * silently showing the primary email. The one-shot guard prevents a loop if the
+   * round-trip returns still tokenless (or the user cancels).
+   */
+  private maybeReauthForForward(alias: LinuxAliasData | null): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    if (alias?.state !== 'claimed') return;
+
+    if (!alias.forwardAuthRequired) {
+      // Token present (or flow disabled) — clear the guard for next time.
+      sessionStorage.removeItem(this.reauthFlagKey);
+      return;
+    }
+
+    if (!alias.authorizeUrl || sessionStorage.getItem(this.reauthFlagKey)) return;
+    sessionStorage.setItem(this.reauthFlagKey, '1');
+    window.location.href = alias.authorizeUrl;
   }
 
   /** Default the forward selection to the current target (if any) or the primary email. */

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -1,0 +1,198 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { MessageComponent } from '@components/message/message.component';
+import { SelectComponent } from '@components/select/select.component';
+import { EmailManagementData, EnrichedIdentity, LinuxAliasData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
+import { linuxAliasValidator } from '@lfx-one/shared/validators';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+import { BehaviorSubject, catchError, finalize, forkJoin, of, switchMap, tap } from 'rxjs';
+
+interface LinuxEmailData {
+  alias: LinuxAliasData | null;
+  emails: EmailManagementData | null;
+  identities: EnrichedIdentity[];
+}
+
+@Component({
+  selector: 'lfx-profile-linux-email',
+  imports: [ReactiveFormsModule, CardComponent, InputTextComponent, SelectComponent, MessageComponent, ButtonComponent, ToastModule],
+  templateUrl: './profile-linux-email.component.html',
+})
+export class ProfileLinuxEmailComponent {
+  private readonly userService = inject(UserService);
+  private readonly messageService = inject(MessageService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // Refresh mechanism
+  private refresh = new BehaviorSubject<void>(undefined);
+
+  // Forms
+  public claimForm = new FormGroup({
+    alias: new FormControl('', [Validators.required, linuxAliasValidator()]),
+    forwardTo: new FormControl('', [Validators.required, Validators.email]),
+  });
+
+  public editForm = new FormGroup({
+    forwardTo: new FormControl('', [Validators.required, Validators.email]),
+  });
+
+  // State signals
+  public loading = signal(false);
+  public claiming = signal(false);
+  public savingForward = signal(false);
+
+  // Data signals
+  public data: Signal<LinuxEmailData> = this.initData();
+
+  // Derived view state
+  public state = computed(() => this.data().alias?.state ?? null);
+  public domain = computed(() => this.data().alias?.domain ?? 'linux.com');
+  public email = computed(() => this.data().alias?.email ?? null);
+
+  // Verified emails the user can forward to (primary first, default selection).
+  // Sourced from the same verified identities shown in the Identities tab —
+  // every email-type identity plus the primary. Username identities (e.g.
+  // GitHub) are excluded since you can't forward email to them, and the claimed
+  // alias is excluded since you can't forward an address to itself.
+  public forwardOptions = computed((): LinuxForwardOption[] => {
+    const { alias, emails, identities } = this.data();
+
+    const aliasEmail = alias?.email?.toLowerCase().trim();
+    const seen = new Set<string>();
+    const options: LinuxForwardOption[] = [];
+
+    const add = (address: string | undefined, isPrimary: boolean): void => {
+      const value = address?.toLowerCase().trim();
+      if (!value || value === aliasEmail || seen.has(value)) return;
+      seen.add(value);
+      options.push({ label: isPrimary ? `${address} (Primary)` : address!, value: address! });
+    };
+
+    add(emails?.primary_email, true);
+    for (const identity of identities) {
+      if (identity.type === 'email' && identity.displayState === 'verified') add(identity.value, false);
+    }
+
+    // Preserve a pre-existing external forwarding target so the user still sees it.
+    const current = alias?.forwardTo;
+    if (current && !seen.has(current.toLowerCase().trim())) {
+      options.push({ label: current, value: current });
+    }
+
+    return options;
+  });
+
+  // Public methods
+
+  public purchase(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    const url = this.data().alias?.purchaseUrl;
+    if (url) {
+      window.open(url, '_blank', 'noopener');
+    }
+  }
+
+  public claim(): void {
+    if (this.claimForm.invalid) {
+      this.claimForm.markAllAsTouched();
+      return;
+    }
+
+    const alias = this.claimForm.value.alias!.trim().toLowerCase();
+    const forwardTo = this.claimForm.value.forwardTo!.trim();
+    this.claiming.set(true);
+
+    this.userService
+      .claimLinuxAlias({ alias, forwardTo })
+      .pipe(finalize(() => this.claiming.set(false)))
+      .subscribe({
+        next: () => {
+          this.claimForm.reset();
+          this.refresh.next();
+          this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Your Linux.com alias is active.' });
+        },
+        error: (err: HttpErrorResponse) => this.handleError(err, 'Failed to claim your alias. Please try again.'),
+      });
+  }
+
+  public updateForward(): void {
+    if (this.editForm.invalid) {
+      this.editForm.markAllAsTouched();
+      return;
+    }
+
+    const forwardTo = this.editForm.value.forwardTo!.trim();
+    this.savingForward.set(true);
+
+    this.userService
+      .updateLinuxForward(forwardTo)
+      .pipe(finalize(() => this.savingForward.set(false)))
+      .subscribe({
+        next: () => {
+          this.refresh.next();
+          this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Forwarding address updated.' });
+        },
+        error: (err: HttpErrorResponse) => this.handleError(err, 'Failed to update your forwarding address. Please try again.'),
+      });
+  }
+
+  public retry(): void {
+    this.refresh.next();
+  }
+
+  // Private methods
+
+  private handleError(err: HttpErrorResponse, fallback: string): void {
+    // Flow C: redirect to authorize when a management token is required.
+    if (err.error?.error === 'management_token_required' && err.error?.authorize_url) {
+      if (isPlatformBrowser(this.platformId)) {
+        window.location.href = err.error.authorize_url;
+      }
+      return;
+    }
+    this.messageService.add({ severity: 'error', summary: 'Error', detail: err.error?.message || fallback });
+  }
+
+  private initData(): Signal<LinuxEmailData> {
+    return toSignal(
+      this.refresh.pipe(
+        switchMap(() => {
+          this.loading.set(true);
+          return forkJoin({
+            alias: this.userService.getLinuxAlias().pipe(catchError(() => of(null))),
+            emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
+            identities: this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))),
+          }).pipe(
+            tap(({ alias, emails }) => this.applyFormDefaults(alias, emails)),
+            finalize(() => this.loading.set(false))
+          );
+        })
+      ),
+      { initialValue: { alias: null, emails: null, identities: [] } }
+    );
+  }
+
+  /** Default the forward selection to the current target (if any) or the primary email. */
+  private applyFormDefaults(alias: LinuxAliasData | null, emails: EmailManagementData | null): void {
+    const primary = emails?.primary_email ?? '';
+
+    if (alias?.state === 'claimed') {
+      this.editForm.patchValue({ forwardTo: alias.forwardTo ?? primary });
+    } else if (alias?.state === 'purchased_unclaimed' && primary) {
+      this.claimForm.patchValue({ forwardTo: primary });
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -78,7 +78,9 @@ export class ProfileLinuxEmailComponent {
       const value = address?.toLowerCase().trim();
       if (!value || value === aliasEmail || seen.has(value)) return;
       seen.add(value);
-      options.push({ label: isPrimary ? `${address} (Primary)` : address!, value: address! });
+      // Use the normalized value for the option value so selection matches the
+      // (lowercased/trimmed) forward target regardless of source casing.
+      options.push({ label: isPrimary ? `${address} (Primary)` : address!, value });
     };
 
     add(emails?.primary_email, true);
@@ -88,8 +90,9 @@ export class ProfileLinuxEmailComponent {
 
     // Preserve a pre-existing external forwarding target so the user still sees it.
     const current = alias?.forwardTo;
-    if (current && !seen.has(current.toLowerCase().trim())) {
-      options.push({ label: current, value: current });
+    const currentValue = current?.toLowerCase().trim();
+    if (current && currentValue && !seen.has(currentValue)) {
+      options.push({ label: current, value: currentValue });
     }
 
     return options;
@@ -187,10 +190,11 @@ export class ProfileLinuxEmailComponent {
 
   /** Default the forward selection to the current target (if any) or the primary email. */
   private applyFormDefaults(alias: LinuxAliasData | null, emails: EmailManagementData | null): void {
-    const primary = emails?.primary_email ?? '';
+    const primary = (emails?.primary_email ?? '').toLowerCase().trim();
 
     if (alias?.state === 'claimed') {
-      this.editForm.patchValue({ forwardTo: alias.forwardTo ?? primary });
+      // Normalize so the default matches a (normalized) forwardOptions value.
+      this.editForm.patchValue({ forwardTo: (alias.forwardTo ?? emails?.primary_email ?? '').toLowerCase().trim() });
     } else if (alias?.state === 'purchased_unclaimed' && primary) {
       this.claimForm.patchValue({ forwardTo: primary });
     }

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -29,6 +29,12 @@ export const PROFILE_ROUTES: Routes = [
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
       },
 
+      // Linux.com Email tab
+      {
+        path: 'linux-email',
+        loadComponent: () => import('./linux-email/profile-linux-email.component').then((m) => m.ProfileLinuxEmailComponent),
+      },
+
       // Direct-URL-only routes (no tab, but still accessible)
       {
         path: 'password',

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -10,10 +10,12 @@ import {
   ChangePasswordRequest,
   ProjectAffiliationPatchBody,
   CombinedProfile,
+  ClaimAliasRequest,
   CreateUserPermissionRequest,
   EmailManagementData,
   EnrichedIdentity,
   Impersonator,
+  LinuxAliasData,
   Meeting,
   PastMeeting,
   ProfileAuthStatus,
@@ -121,6 +123,29 @@ export class UserService {
    */
   public setPrimaryEmail(email: string): Observable<{ message: string }> {
     return this.http.put<{ message: string }>(`/api/profile/emails/${encodeURIComponent(email)}/primary`, {}).pipe(take(1));
+  }
+
+  // Linux.com email alias methods
+
+  /**
+   * Resolve the user's Linux.com alias state (purchase + claim + forward).
+   */
+  public getLinuxAlias(): Observable<LinuxAliasData> {
+    return this.http.get<LinuxAliasData>('/api/profile/linux-email').pipe(take(1));
+  }
+
+  /**
+   * Claim a Linux.com alias and set its forwarding target.
+   */
+  public claimLinuxAlias(body: ClaimAliasRequest): Observable<LinuxAliasData> {
+    return this.http.post<LinuxAliasData>('/api/profile/linux-email/claim', body).pipe(take(1));
+  }
+
+  /**
+   * Update the forwarding target for an already-claimed alias.
+   */
+  public updateLinuxForward(forwardTo: string): Observable<{ forwardTo: string }> {
+    return this.http.put<{ forwardTo: string }>('/api/profile/linux-email/forward', { forwardTo }).pipe(take(1));
   }
 
   // Password management methods

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -7,17 +7,21 @@ import {
   CDP_PLATFORM_ICONS,
   CDP_PLATFORM_TO_TYPE_MAP,
   CDP_TO_AUTH0_PROVIDER_MAP,
+  PURCHASE_LINUX_URL,
 } from '@lfx-one/shared/constants';
 import {
   Auth0Identity,
   CdpIdentity,
   CdpWorkExperienceRequest,
+  ClaimAliasRequest,
   CombinedProfile,
   EmailManagementData,
   EnrichedIdentity,
   IdentityDisplayState,
+  LinuxAliasData,
   ProfileAuthStatus,
   ProfileUpdateRequest,
+  UpdateForwardRequest,
   UserEmail,
   UserMetadata,
   UserMetadataUpdateRequest,
@@ -27,15 +31,21 @@ import {
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, AuthorizationError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
+import { getLinuxForwardDomain } from '../helpers/linux-forward.helper';
 import { Auth0Service } from '../services/auth0.service';
 import { CdpService } from '../services/cdp.service';
 import { EmailVerificationService } from '../services/email-verification.service';
+import { EnrollmentService } from '../services/enrollment.service';
+import { ForwardsService } from '../services/forwards.service';
 import { logger } from '../services/logger.service';
 import { ProfileAuthService } from '../services/profile-auth.service';
 import { SocialVerificationService } from '../services/social-verification.service';
 import { UserService } from '../services/user.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
+
+// Basic RFC-ish email shape check shared by the linux-email handlers.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
 
 // Maps auth-service error strings to user-facing responses. First match wins; if
 // none match, the password-change path falls back to a generic 502.
@@ -76,12 +86,15 @@ export class ProfileController {
     '/profile/emails',
     '/profile/identities',
     '/profile/password',
+    '/profile/linux-email',
     '/settings',
   ]);
 
   private auth0Service: Auth0Service = new Auth0Service();
   private cdpService: CdpService = new CdpService();
   private emailVerificationService: EmailVerificationService = new EmailVerificationService();
+  private enrollmentService: EnrollmentService = new EnrollmentService();
+  private forwardsService: ForwardsService = new ForwardsService();
   private profileAuthService: ProfileAuthService = new ProfileAuthService();
   private socialVerificationService: SocialVerificationService = new SocialVerificationService();
   private userService: UserService = new UserService();
@@ -460,6 +473,197 @@ export class ProfileController {
       logger.success(req, 'set_primary_email', startTime, { email: emailAddress });
 
       res.status(200).json({ message: 'Primary email updated successfully' });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/profile/linux-email - Resolve the user's Linux.com alias state.
+   *
+   * Composes three signals into one of four states: the claimed alias (from
+   * auth-service `user_emails.read`), the forwarding target (from
+   * forwards-service `get_forward`), and the add-on purchase (from
+   * member-service). Alias presence wins — a claimed alias short-circuits the
+   * purchase lookup.
+   */
+  public async getLinuxAlias(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_linux_alias');
+    const domain = getLinuxForwardDomain();
+
+    try {
+      const userSub = req.oidc?.user?.['sub'] as string | undefined;
+      if (!userSub) {
+        return next(
+          ServiceValidationError.forField('user_id', 'User authentication required', {
+            operation: 'get_linux_alias',
+            service: 'profile_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const emails = await this.emailVerificationService.getUserEmails(req, userSub);
+      if (emails === null) {
+        logger.success(req, 'get_linux_alias', startTime, { state: 'service_unavailable' });
+        res.json(this.linuxAliasState('service_unavailable', domain));
+        return;
+      }
+
+      const suffix = `@${domain}`;
+      const aliasEmail = emails.alternate_emails.find((e) => e.email.toLowerCase().trim().endsWith(suffix));
+
+      if (aliasEmail) {
+        const email = aliasEmail.email.toLowerCase().trim();
+        const alias = email.slice(0, -suffix.length);
+        // forwards-service requires a Management-API-audience JWT (Flow C token), same as add_alias.
+        // Read the current target best-effort: without a management token in session we still report
+        // the claimed state from user_emails.read; forwardTo stays null until the user re-authorizes.
+        const managementToken = this.profileAuthService.getManagementToken(req);
+        const forward = managementToken ? await this.forwardsService.getForward(req, managementToken, domain) : null;
+
+        logger.success(req, 'get_linux_alias', startTime, { state: 'claimed' });
+        res.json({ state: 'claimed', domain, alias, email, forwardTo: forward?.target_email ?? null } satisfies LinuxAliasData);
+        return;
+      }
+
+      const purchased = await this.enrollmentService.hasLinuxComAddon(req);
+      const state = purchased ? 'purchased_unclaimed' : 'not_purchased';
+
+      logger.success(req, 'get_linux_alias', startTime, { state });
+      res.json(this.linuxAliasState(state, domain));
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /api/profile/linux-email/claim - Claim an alias and set its forward.
+   *
+   * Two-step, non-atomic by design (mirrors the legacy flow): `add_alias`
+   * (auth-service, Flow C token) then `set_target` (forwards-service). If the
+   * forward step fails after a successful claim, we surface a 502 — the next GET
+   * returns `claimed` with no forward, and the user completes it via the edit
+   * path.
+   */
+  public async claimLinuxAlias(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'claim_linux_alias');
+    const domain = getLinuxForwardDomain();
+
+    try {
+      const body = (req.body ?? {}) as Partial<ClaimAliasRequest>;
+      const alias = typeof body.alias === 'string' ? body.alias.trim().toLowerCase() : '';
+      const forwardTo = typeof body.forwardTo === 'string' ? body.forwardTo.trim() : '';
+
+      if (!alias) {
+        return next(ServiceValidationError.forField('alias', 'Alias is required', { operation: 'claim_linux_alias', service: 'profile_controller' }));
+      }
+      if (!EMAIL_REGEX.test(forwardTo)) {
+        return next(
+          ServiceValidationError.forField('forwardTo', 'A valid forwarding email address is required', {
+            operation: 'claim_linux_alias',
+            service: 'profile_controller',
+          })
+        );
+      }
+
+      // Availability pre-check (best-effort; add_alias is authoritative).
+      const availability = await this.forwardsService.checkAlias(req, alias, domain);
+      if (availability?.exists) {
+        res.status(409).json({ error: 'alias_not_available', message: 'That alias is already taken. Please choose another.' });
+        return;
+      }
+
+      const managementToken = this.profileAuthService.getManagementToken(req);
+      if (!managementToken) {
+        if (!this.profileAuthService.isProfileAuthConfigured()) {
+          res.status(501).json({ error: 'profile_auth_not_configured', message: 'Claiming a Linux.com alias is not available in this environment.' });
+          return;
+        }
+        res.status(403).json({
+          error: 'management_token_required',
+          message: 'Profile authorization required to claim a Linux.com alias',
+          authorize_url: `/api/profile/auth/start?returnTo=${encodeURIComponent((req.headers['referer'] as string) || '/profile/linux-email')}`,
+        });
+        return;
+      }
+
+      const claim = await this.emailVerificationService.addAlias(req, managementToken, alias, domain);
+      if (!claim.success) {
+        const { status, message } = this.mapAddAliasError(claim.error);
+        res.status(status).json({ error: claim.error ?? 'add_alias_failed', message });
+        return;
+      }
+
+      const email = claim.email ?? `${alias}@${domain}`;
+
+      // forwards-service requires the same Management-API-audience token as add_alias.
+      const forward = await this.forwardsService.setTarget(req, managementToken, forwardTo, domain);
+      if (!forward || forward.error) {
+        // Alias is claimed but forwarding could not be set — recoverable via the edit path.
+        return next(
+          new MicroserviceError('Alias claimed, but forwarding could not be set. Please set your forwarding address again.', 502, 'FORWARD_SET_FAILED', {
+            operation: 'claim_linux_alias',
+            service: 'profile_controller',
+          })
+        );
+      }
+
+      logger.success(req, 'claim_linux_alias', startTime, { domain });
+      res.status(200).json({ state: 'claimed', domain, alias, email, forwardTo: forward.target_email ?? forwardTo } satisfies LinuxAliasData);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * PUT /api/profile/linux-email/forward - Update the forwarding target for an
+   * already-claimed alias (idempotent set_target).
+   */
+  public async updateLinuxForward(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'update_linux_forward');
+    const domain = getLinuxForwardDomain();
+
+    try {
+      const body = (req.body ?? {}) as Partial<UpdateForwardRequest>;
+      const forwardTo = typeof body.forwardTo === 'string' ? body.forwardTo.trim() : '';
+
+      if (!EMAIL_REGEX.test(forwardTo)) {
+        return next(
+          ServiceValidationError.forField('forwardTo', 'A valid forwarding email address is required', {
+            operation: 'update_linux_forward',
+            service: 'profile_controller',
+          })
+        );
+      }
+
+      // forwards-service requires a Management-API-audience JWT (Flow C token), same as add_alias.
+      const managementToken = this.profileAuthService.getManagementToken(req);
+      if (!managementToken) {
+        if (!this.profileAuthService.isProfileAuthConfigured()) {
+          res.status(501).json({ error: 'profile_auth_not_configured', message: 'Updating your forwarding address is not available in this environment.' });
+          return;
+        }
+        res.status(403).json({
+          error: 'management_token_required',
+          message: 'Profile authorization required to update your forwarding address',
+          authorize_url: `/api/profile/auth/start?returnTo=${encodeURIComponent((req.headers['referer'] as string) || '/profile/linux-email')}`,
+        });
+        return;
+      }
+
+      const forward = await this.forwardsService.setTarget(req, managementToken, forwardTo, domain);
+      if (!forward || forward.error) {
+        return next(
+          new MicroserviceError(forward?.error || 'Failed to update forwarding address', 502, 'FORWARD_SET_FAILED', {
+            operation: 'update_linux_forward',
+            service: 'profile_controller',
+          })
+        );
+      }
+
+      logger.success(req, 'update_linux_forward', startTime, { domain });
+      res.status(200).json({ forwardTo: forward.target_email ?? forwardTo });
     } catch (error) {
       next(error);
     }
@@ -1880,6 +2084,38 @@ export class ProfileController {
     }
 
     return { enriched, cdpPostsQueued };
+  }
+
+  /** Build a LinuxAliasData for a non-claimed state (no alias/forward yet). */
+  private linuxAliasState(state: 'not_purchased' | 'purchased_unclaimed' | 'service_unavailable', domain: string): LinuxAliasData {
+    return {
+      state,
+      domain,
+      alias: null,
+      email: null,
+      forwardTo: null,
+      ...(state === 'not_purchased' ? { purchaseUrl: PURCHASE_LINUX_URL } : {}),
+    };
+  }
+
+  /** Map an auth-service add_alias error code to an HTTP status + user message. */
+  private mapAddAliasError(code: string | undefined): { status: number; message: string } {
+    switch (code) {
+      case 'already_claimed':
+        return { status: 409, message: 'You already have a Linux.com alias on your account.' };
+      case 'alias_not_available':
+        return { status: 409, message: 'That alias is already taken. Please choose another.' };
+      case 'alias_reserved':
+        return { status: 400, message: 'That alias is reserved. Please choose another.' };
+      case 'alias_invalid':
+        return { status: 400, message: 'That alias is not valid. Use letters, numbers, dots, and hyphens only.' };
+      case 'domain_not_allowed':
+        return { status: 400, message: 'Linux.com aliases are not available in this environment.' };
+      case 'alias_service_unavailable':
+        return { status: 503, message: 'The alias service is temporarily unavailable. Please try again later.' };
+      default:
+        return { status: 502, message: 'Failed to claim the alias. Please try again.' };
+    }
   }
 
   private normalizeProfileReturnTo(raw: unknown): string {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -7,6 +7,7 @@ import {
   CDP_PLATFORM_ICONS,
   CDP_PLATFORM_TO_TYPE_MAP,
   CDP_TO_AUTH0_PROVIDER_MAP,
+  EMAIL_REGEX,
   PURCHASE_LINUX_URL,
 } from '@lfx-one/shared/constants';
 import {
@@ -43,9 +44,6 @@ import { SocialVerificationService } from '../services/social-verification.servi
 import { UserService } from '../services/user.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
-
-// Basic RFC-ish email shape check shared by the linux-email handlers.
-const EMAIL_REGEX = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
 
 // Maps auth-service error strings to user-facing responses. First match wins; if
 // none match, the password-change path falls back to a generic 502.
@@ -524,6 +522,16 @@ export class ProfileController {
         // the claimed state from user_emails.read; forwardTo stays null until the user re-authorizes.
         const managementToken = this.profileAuthService.getManagementToken(req);
         const forward = managementToken ? await this.forwardsService.getForward(req, managementToken, domain) : null;
+
+        // A claimed alias always has a forward target. If we had a management token but the read
+        // still came back null, the forwards-service was unreachable (timeout/no-responder) — degrade
+        // to service_unavailable (retry panel) rather than emitting a claimed state with a null
+        // forward, which the client could misread and overwrite on Save.
+        if (managementToken && forward === null) {
+          logger.success(req, 'get_linux_alias', startTime, { state: 'service_unavailable' });
+          res.json(this.linuxAliasState('service_unavailable', domain));
+          return;
+        }
 
         // A claimed alias always has a forward target, but reading it needs the Flow C
         // management token. When it's absent (and the flow is configured), tell the client

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -430,8 +430,7 @@ export class ProfileController {
         );
       }
 
-      const emailRegex = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
-      if (!emailRegex.test(emailAddress)) {
+      if (!EMAIL_REGEX.test(emailAddress)) {
         return next(
           ServiceValidationError.forField('email', 'Invalid email format', {
             operation: 'set_primary_email',
@@ -489,9 +488,9 @@ export class ProfileController {
    */
   public async getLinuxAlias(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_linux_alias');
-    const domain = getLinuxForwardDomain();
 
     try {
+      const domain = getLinuxForwardDomain('get_linux_alias', 'profile_controller');
       const userSub = req.oidc?.user?.['sub'] as string | undefined;
       if (!userSub) {
         return next(
@@ -548,9 +547,9 @@ export class ProfileController {
    */
   public async claimLinuxAlias(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'claim_linux_alias');
-    const domain = getLinuxForwardDomain();
 
     try {
+      const domain = getLinuxForwardDomain('claim_linux_alias', 'profile_controller');
       const body = (req.body ?? {}) as Partial<ClaimAliasRequest>;
       const alias = typeof body.alias === 'string' ? body.alias.trim().toLowerCase() : '';
       const forwardTo = typeof body.forwardTo === 'string' ? body.forwardTo.trim() : '';
@@ -565,6 +564,14 @@ export class ProfileController {
             service: 'profile_controller',
           })
         );
+      }
+
+      // Enforce the purchase gate server-side: a direct call must not bypass the
+      // add-on requirement the UI gates on (mirrors the not_purchased state in getLinuxAlias).
+      const purchased = await this.enrollmentService.hasLinuxComAddon(req);
+      if (!purchased) {
+        res.status(403).json({ error: 'addon_required', message: 'A Linux.com email add-on is required to claim an alias.' });
+        return;
       }
 
       // Availability pre-check (best-effort; add_alias is authoritative).
@@ -622,9 +629,9 @@ export class ProfileController {
    */
   public async updateLinuxForward(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'update_linux_forward');
-    const domain = getLinuxForwardDomain();
 
     try {
+      const domain = getLinuxForwardDomain('update_linux_forward', 'profile_controller');
       const body = (req.body ?? {}) as Partial<UpdateForwardRequest>;
       const forwardTo = typeof body.forwardTo === 'string' ? body.forwardTo.trim() : '';
 
@@ -1707,8 +1714,7 @@ export class ProfileController {
         return next(validationError);
       }
 
-      const emailRegex = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
-      if (!emailRegex.test(email)) {
+      if (!EMAIL_REGEX.test(email)) {
         const validationError = ServiceValidationError.forField('email', 'Invalid email format', {
           operation: 'send_email_verification',
           service: 'profile_controller',

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -510,7 +510,11 @@ export class ProfileController {
       }
 
       const suffix = `@${domain}`;
-      const aliasEmail = emails.alternate_emails.find((e) => e.email.toLowerCase().trim().endsWith(suffix));
+      // Scan alternate emails first; also cover the edge case where the claimed alias is the
+      // user's primary email, which would otherwise be missed and read as unclaimed.
+      const aliasEmail =
+        emails.alternate_emails.find((e) => e.email.toLowerCase().trim().endsWith(suffix)) ??
+        (emails.primary_email?.toLowerCase().trim().endsWith(suffix) ? { email: emails.primary_email } : undefined);
 
       if (aliasEmail) {
         const email = aliasEmail.email.toLowerCase().trim();
@@ -543,7 +547,16 @@ export class ProfileController {
         return;
       }
 
-      const purchased = await this.enrollmentService.hasLinuxComAddon(req);
+      // Degrade to service_unavailable if the purchase lookup fails, so the tab keeps its
+      // 4-state contract (renders the retry panel) instead of erroring out via next(error).
+      let purchased: boolean;
+      try {
+        purchased = await this.enrollmentService.hasLinuxComAddon(req);
+      } catch {
+        logger.success(req, 'get_linux_alias', startTime, { state: 'service_unavailable' });
+        res.json(this.linuxAliasState('service_unavailable', domain));
+        return;
+      }
       const state = purchased ? 'purchased_unclaimed' : 'not_purchased';
 
       logger.success(req, 'get_linux_alias', startTime, { state });

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -521,8 +521,25 @@ export class ProfileController {
         const managementToken = this.profileAuthService.getManagementToken(req);
         const forward = managementToken ? await this.forwardsService.getForward(req, managementToken, domain) : null;
 
+        // A claimed alias always has a forward target, but reading it needs the Flow C
+        // management token. When it's absent (and the flow is configured), tell the client
+        // to re-authorize so it can load the real target instead of defaulting to primary.
+        const forwardAuthRequired = !managementToken && this.profileAuthService.isProfileAuthConfigured();
+
         logger.success(req, 'get_linux_alias', startTime, { state: 'claimed' });
-        res.json({ state: 'claimed', domain, alias, email, forwardTo: forward?.target_email ?? null } satisfies LinuxAliasData);
+        res.json({
+          state: 'claimed',
+          domain,
+          alias,
+          email,
+          forwardTo: forward?.target_email ?? null,
+          ...(forwardAuthRequired
+            ? {
+                forwardAuthRequired: true,
+                authorizeUrl: `/api/profile/auth/start?returnTo=${encodeURIComponent((req.headers['referer'] as string) || '/profile/linux-email')}`,
+              }
+            : {}),
+        } satisfies LinuxAliasData);
         return;
       }
 

--- a/apps/lfx-one/src/server/helpers/linux-forward.helper.ts
+++ b/apps/lfx-one/src/server/helpers/linux-forward.helper.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+/**
+ * Resolve the active Linux.com forwarding domain for this environment.
+ *
+ * The v2 forwards-service and auth-service require the caller to supply the
+ * domain explicitly on every request, and gate it against their own server-side
+ * allow-lists (`FORWARDS_DOMAINS` / `ALLOWED_ALIAS_DOMAINS`). We mirror that
+ * here so the same code runs in every stage: prod uses `linux.com`, dev/staging
+ * set `LINUX_FORWARD_DOMAIN=hurrdurr.org`. The value must line up with the two
+ * upstream allow-lists or claims fail with `domain_not_allowed`.
+ */
+export function getLinuxForwardDomain(): string {
+  return (process.env['LINUX_FORWARD_DOMAIN'] || 'linux.com').trim().toLowerCase();
+}

--- a/apps/lfx-one/src/server/helpers/linux-forward.helper.ts
+++ b/apps/lfx-one/src/server/helpers/linux-forward.helper.ts
@@ -3,16 +3,31 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
+import { MicroserviceError } from '../errors';
+
 /**
  * Resolve the active Linux.com forwarding domain for this environment.
  *
  * The v2 forwards-service and auth-service require the caller to supply the
  * domain explicitly on every request, and gate it against their own server-side
- * allow-lists (`FORWARDS_DOMAINS` / `ALLOWED_ALIAS_DOMAINS`). We mirror that
- * here so the same code runs in every stage: prod uses `linux.com`, dev/staging
- * set `LINUX_FORWARD_DOMAIN=hurrdurr.org`. The value must line up with the two
- * upstream allow-lists or claims fail with `domain_not_allowed`.
+ * allow-lists (`FORWARDS_DOMAINS` / `ALLOWED_ALIAS_DOMAINS`). The domain is
+ * read from `LINUX_FORWARD_DOMAIN`, which must be set in every stage (prod
+ * `linux.com`, dev/staging e.g. `example.org`) and line up with the two upstream
+ * allow-lists, or claims fail with `domain_not_allowed`.
+ *
+ * Fails fast with a 503 when the env var is missing, mirroring
+ * `getApiGatewayBaseUrl`, so a misconfiguration surfaces immediately rather than
+ * silently defaulting to a domain the upstream may reject.
  */
-export function getLinuxForwardDomain(): string {
-  return (process.env['LINUX_FORWARD_DOMAIN'] || 'linux.com').trim().toLowerCase();
+export function getLinuxForwardDomain(operation: string, service: string): string {
+  const domain = (process.env['LINUX_FORWARD_DOMAIN'] || '').trim().toLowerCase();
+
+  if (!domain) {
+    throw new MicroserviceError('LINUX_FORWARD_DOMAIN environment variable is not configured', 503, 'LINUX_FORWARD_DOMAIN_MISCONFIGURED', {
+      operation,
+      service,
+    });
+  }
+
+  return domain;
 }

--- a/apps/lfx-one/src/server/routes/profile.route.ts
+++ b/apps/lfx-one/src/server/routes/profile.route.ts
@@ -41,6 +41,17 @@ router.put('/emails/:emailId/primary', (req, res, next) => profileController.set
 // GET /api/profile/developer - Get current user's developer token information
 router.get('/developer', (req, res, next) => profileController.getDeveloperTokenInfo(req, res, next));
 
+// Linux.com email alias routes (backed by auth-service + forwards-service via NATS)
+
+// GET /api/profile/linux-email - Resolve the user's Linux.com alias state
+router.get('/linux-email', (req, res, next) => profileController.getLinuxAlias(req, res, next));
+
+// POST /api/profile/linux-email/claim - Claim an alias and set its forwarding target
+router.post('/linux-email/claim', (req, res, next) => profileController.claimLinuxAlias(req, res, next));
+
+// PUT /api/profile/linux-email/forward - Update the forwarding target for a claimed alias
+router.put('/linux-email/forward', (req, res, next) => profileController.updateLinuxForward(req, res, next));
+
 // POST /api/profile/reset-password - Send password reset email via LF Login service
 router.post('/reset-password', (req, res, next) => profileController.sendPasswordResetEmail(req, res, next));
 

--- a/apps/lfx-one/src/server/services/email-verification.service.ts
+++ b/apps/lfx-one/src/server/services/email-verification.service.ts
@@ -4,6 +4,7 @@
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
+  AddAliasNatsResponse,
   Auth0Identity,
   EmailManagementData,
   LinkIdentityNatsResponse,
@@ -378,6 +379,47 @@ export class EmailVerificationService {
         error: 'Internal server error',
         message: 'Failed to update primary email. Please try again.',
       };
+    }
+  }
+
+  /**
+   * Claim a system-managed alias (e.g. `<alias>@linux.com`) as a verified
+   * linked identity on the caller's account, via auth-service `add_alias`.
+   *
+   * Requires a management token carrying the `update:current_user_identities`
+   * scope (the same Flow C token used by link/unlink/set-primary), since the
+   * claim creates and links an Auth0 identity. Once claimed the alias is
+   * immutable and surfaces in `user_emails.read` as an alternate email.
+   *
+   * @param req - Express request object for logging
+   * @param managementToken - Flow C management token (update:current_user_identities)
+   * @param alias - Local part of the desired address (no `@` or domain)
+   * @param domain - Domain to claim under; must be in auth-service ALLOWED_ALIAS_DOMAINS
+   */
+  public async addAlias(req: Request, managementToken: string, alias: string, domain: string): Promise<AddAliasNatsResponse> {
+    const codec = this.natsService.getCodec();
+
+    logger.debug(req, 'add_alias', 'Claiming alias via NATS', { domain });
+
+    try {
+      const payload = JSON.stringify({ user: { auth_token: managementToken }, alias, domain });
+      const response = await this.natsService.request(NatsSubjects.ADD_ALIAS, codec.encode(payload), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
+
+      const parsed: AddAliasNatsResponse = JSON.parse(codec.decode(response.data));
+
+      logger.debug(req, 'add_alias', 'Received add alias response', { success: parsed.success, error: parsed.error });
+
+      return parsed;
+    } catch (error) {
+      logger.warning(req, 'add_alias', 'NATS add alias failed', { domain, err: error });
+
+      if (error instanceof Error && (error.message.includes('timeout') || error.message.includes('503'))) {
+        return { success: false, error: 'alias_service_unavailable' };
+      }
+
+      return { success: false, error: 'internal_error' };
     }
   }
 

--- a/apps/lfx-one/src/server/services/enrollment.service.ts
+++ b/apps/lfx-one/src/server/services/enrollment.service.ts
@@ -3,7 +3,7 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { TLF_INDIVIDUAL_SUPPORTER } from '@lfx-one/shared/constants';
+import { LINUX_COM_ADDON_PRODUCT_ID, TLF_INDIVIDUAL_SUPPORTER } from '@lfx-one/shared/constants';
 import { EnrollmentMembership, IndividualEnrollment, RawMembership } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 import { MicroserviceError } from '../errors';
@@ -60,6 +60,31 @@ export class EnrollmentService {
         membership: membershipMap.get(TLF_INDIVIDUAL_SUPPORTER.productId) ?? null,
       },
     ];
+  }
+
+  /**
+   * Whether the user has purchased the Lifetime Linux.com Email Alias add-on.
+   *
+   * The add-on is modeled as "lifetime" (EndDate = 2099, no auto-renew), so we
+   * check for the presence of an Active/Purchased record rather than an expiry
+   * window. Used to gate the Linux.com email tab between `not_purchased` and the
+   * (un)claimed states.
+   */
+  public async hasLinuxComAddon(req: Request): Promise<boolean> {
+    const baseUrl = getApiGatewayBaseUrl('get_linux_addon_membership', ENROLLMENT_SERVICE);
+    const url = `${baseUrl}/member-service/v2/me/memberships?productID=${LINUX_COM_ADDON_PRODUCT_ID}&status=Purchased,Active&membershipType=Individual`;
+
+    logger.debug(req, 'get_linux_addon_membership', 'Checking Linux.com add-on purchase from member-service');
+
+    const data = await gatewayFetch<{ Data?: RawMembership[]; data?: RawMembership[] }>(req, url, {
+      operation: 'get_linux_addon_membership',
+      service: ENROLLMENT_SERVICE,
+      errorMessage: 'Linux.com add-on membership fetch failed',
+      errorCode: 'LINUX_ADDON_MEMBERSHIP_FETCH_FAILED',
+    });
+
+    const rawMemberships: RawMembership[] = data?.Data ?? data?.data ?? [];
+    return rawMemberships.some((m) => m.Product?.ID === LINUX_COM_ADDON_PRODUCT_ID && VALID_STATUSES.has(m.Status as EnrollmentMembership['Status']));
   }
 
   public async updateAutoRenew(req: Request, membershipId: string, autoRenew: boolean): Promise<void> {

--- a/apps/lfx-one/src/server/services/forwards.service.ts
+++ b/apps/lfx-one/src/server/services/forwards.service.ts
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { NatsSubjects } from '@lfx-one/shared/enums';
+import { CheckAliasNatsResponse, GetForwardNatsResponse, SetTargetNatsResponse } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+import { NatsService } from './nats.service';
+
+/**
+ * Client for the lfx-v2-forwards-service over NATS request/reply.
+ *
+ * Stateless proxy to forwardemail.net that owns the `<alias>@<domain> → target`
+ * routing. Alias *ownership* is owned by the auth-service (system-managed linked
+ * identity); forwards-service verifies it by forwarding the caller's token to
+ * auth-service `user_emails.read`, so the caller supplies the user's JWT and the
+ * active domain.
+ *
+ * Token requirement: `getForward`/`setTarget` validate the JWT against
+ * forwards-service `AUTH0_AUDIENCE` (the Auth0 **Management API** audience) with
+ * a strict exact-match, so `authToken` must be the **Flow C management token**
+ * (same one `add_alias` uses) — not the plain user bearer token. `checkAlias`
+ * needs no auth.
+ *
+ * Follows the same conventions as `email-verification.service.ts`: shared
+ * `NatsService`, string codec, 5s timeout, and graceful degradation — a NATS
+ * timeout / no-responder surfaces as a service-unavailable signal rather than
+ * throwing, so the controller can render the `service_unavailable` state.
+ */
+export class ForwardsService {
+  private natsService: NatsService;
+
+  public constructor() {
+    this.natsService = new NatsService();
+  }
+
+  /**
+   * Check whether an alias is already taken on the domain (unauthenticated).
+   * Returns null when the forwards-service is unreachable.
+   */
+  public async checkAlias(req: Request, alias: string, domain: string): Promise<CheckAliasNatsResponse | null> {
+    const codec = this.natsService.getCodec();
+
+    logger.debug(req, 'forwards_check_alias', 'Checking alias availability via NATS', { domain });
+
+    try {
+      const payload = JSON.stringify({ alias, domain });
+      const response = await this.natsService.request(NatsSubjects.FORWARDS_CHECK_ALIAS, codec.encode(payload), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
+
+      return JSON.parse(codec.decode(response.data)) as CheckAliasNatsResponse;
+    } catch (error) {
+      logger.warning(req, 'forwards_check_alias', 'NATS check alias failed', { domain, err: error });
+      return null;
+    }
+  }
+
+  /**
+   * Read the current forwarding target for the caller's alias on the domain.
+   * Returns null when the forwards-service is unreachable.
+   */
+  public async getForward(req: Request, authToken: string, domain: string): Promise<GetForwardNatsResponse | null> {
+    const codec = this.natsService.getCodec();
+
+    logger.debug(req, 'forwards_get_forward', 'Reading forward target via NATS', { domain });
+
+    try {
+      const payload = JSON.stringify({ user: { auth_token: authToken }, domain });
+      const response = await this.natsService.request(NatsSubjects.FORWARDS_GET_FORWARD, codec.encode(payload), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
+
+      return JSON.parse(codec.decode(response.data)) as GetForwardNatsResponse;
+    } catch (error) {
+      logger.warning(req, 'forwards_get_forward', 'NATS get forward failed', { domain, err: error });
+      return null;
+    }
+  }
+
+  /**
+   * Create or update (idempotent) the forwarding target for the caller's alias.
+   * Returns null when the forwards-service is unreachable.
+   */
+  public async setTarget(req: Request, authToken: string, forwardTo: string, domain: string): Promise<SetTargetNatsResponse | null> {
+    const codec = this.natsService.getCodec();
+
+    logger.debug(req, 'forwards_set_target', 'Setting forward target via NATS', { domain });
+
+    try {
+      const payload = JSON.stringify({ user: { auth_token: authToken }, domain, target_email: forwardTo });
+      const response = await this.natsService.request(NatsSubjects.FORWARDS_SET_TARGET, codec.encode(payload), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
+
+      return JSON.parse(codec.decode(response.data)) as SetTargetNatsResponse;
+    } catch (error) {
+      logger.warning(req, 'forwards_set_target', 'NATS set target failed', { domain, err: error });
+      return null;
+    }
+  }
+}

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -65,3 +65,4 @@ export * from './individual-enrollment-catalog';
 export * from './newsletter.constants';
 export * from './vote.constants';
 export * from './docs.constant';
+export * from './linux-email.constants';

--- a/packages/shared/src/constants/linux-email.constants.ts
+++ b/packages/shared/src/constants/linux-email.constants.ts
@@ -7,10 +7,10 @@
  * Linux.com email alias add-on constants.
  *
  * The forwarding *domain* is intentionally NOT defined here — it is resolved
- * server-side from the `LINUX_FORWARD_DOMAIN` env var so it can differ per
- * environment (prod `linux.com`, dev/staging `hurrdurr.org`). Only the SFDC
- * product identity and the purchase CTA, which are constant across stages,
- * live in shared code.
+ * server-side from the `LINUX_FORWARD_DOMAIN` env var (required in every stage,
+ * e.g. prod `linux.com`, dev/staging `example.org`) so it can differ per
+ * environment. Only the SFDC product identity and the purchase CTA, which are
+ * constant across stages, live in shared code.
  */
 
 /** SFDC product id for the Lifetime Linux.com Email Alias add-on. */

--- a/packages/shared/src/constants/linux-email.constants.ts
+++ b/packages/shared/src/constants/linux-email.constants.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+/**
+ * Linux.com email alias add-on constants.
+ *
+ * The forwarding *domain* is intentionally NOT defined here — it is resolved
+ * server-side from the `LINUX_FORWARD_DOMAIN` env var so it can differ per
+ * environment (prod `linux.com`, dev/staging `hurrdurr.org`). Only the SFDC
+ * product identity and the purchase CTA, which are constant across stages,
+ * live in shared code.
+ */
+
+/** SFDC product id for the Lifetime Linux.com Email Alias add-on. */
+export const LINUX_COM_ADDON_PRODUCT_ID = '01t2M000005wBazQAE';
+
+/** SFDC product id for the prerequisite TLF Individual Supporter membership. */
+export const TLF_INDIVIDUAL_SUPPORTER_PRODUCT_ID = '01t2M000005wBb0QAE';
+
+/** membership-ui purchase flow for the add-on (same across stages). */
+export const PURCHASE_LINUX_URL = `https://enrollment.lfx.linuxfoundation.org/?project=tlf&product=${LINUX_COM_ADDON_PRODUCT_ID}`;
+
+/** Max length of an alias local part (matches v2 auth-service / forwards-service). */
+export const LINUX_ALIAS_MAX_LENGTH = 64;
+
+/**
+ * Characters banned in an alias local part (matches v2 services). Includes
+ * characters that break RFC 5322 local parts or allow quoted-form bypass.
+ */
+export const LINUX_ALIAS_BANNED_CHARS = ['"', '/', '*', '$', '^', ':', '@', ' ', ';', '(', ')', '<', '>', '[', ']', ',', '\\'] as const;
+
+/**
+ * Reserved alias local parts rejected by the v2 services (case-insensitive).
+ * Kept in sync so the client rejects them before the round-trip; `check_alias`
+ * / `add_alias` remain the source of truth.
+ */
+export const LINUX_ALIAS_RESERVED_NAMES = [
+  'postmaster',
+  'abuse',
+  'hostmaster',
+  'admin',
+  'administrator',
+  'noreply',
+  'no-reply',
+  'root',
+  'mailer-daemon',
+  'linux',
+  'linuxfoundation',
+  'lf',
+  'security',
+  'support',
+  'info',
+  'webmaster',
+  'ops',
+  'devops',
+  'itx-system',
+] as const;

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -10,6 +10,7 @@ export const PROFILE_TABS: ProfileTab[] = [
   { id: 'attribution', label: 'Work history & Affiliations', route: 'attribution' },
   { id: 'identities', label: 'Identities', route: 'identities' },
   { id: 'individual-enrollment', label: 'Individual Enrollment', route: 'individual-enrollment' },
+  { id: 'linux-email', label: 'Linux.com Email', route: 'linux-email' },
 ];
 
 /**

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -25,4 +25,10 @@ export enum NatsSubjects {
   PERSONAS_GET = 'lfx.personas-api.get',
   IMPERSONATION_TOKEN_EXCHANGE = 'lfx.auth-service.impersonation.token_exchange',
   INVITE_ACCEPTED = 'lfx.invite.accepted',
+  // Alias claim (auth-service) — claims <alias>@<domain> as a system-managed linked identity
+  ADD_ALIAS = 'lfx.auth-service.add_alias',
+  // Email forwarding (forwards-service) — stateless proxy to forwardemail.net
+  FORWARDS_CHECK_ALIAS = 'lfx.forwards-service.check_alias',
+  FORWARDS_SET_TARGET = 'lfx.forwards-service.set_target',
+  FORWARDS_GET_FORWARD = 'lfx.forwards-service.get_forward',
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -194,3 +194,6 @@ export * from './invite.interface';
 
 // Docs portal interfaces (build artifacts + runtime models for /docs)
 export * from './docs.interface';
+
+// Linux.com email alias interfaces
+export * from './linux-email.interface';

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -3,6 +3,9 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
+import type { EnrichedIdentity } from './profile.interface';
+import type { EmailManagementData } from './user-profile.interface';
+
 /**
  * Linux.com (vanity) email alias forwarding.
  *
@@ -19,6 +22,13 @@
 
 /** The four states the Linux.com email tab can render. */
 export type LinuxAliasState = 'not_purchased' | 'purchased_unclaimed' | 'claimed' | 'service_unavailable';
+
+/** Aggregate data the Linux.com email tab component renders from. */
+export interface LinuxEmailData {
+  alias: LinuxAliasData | null;
+  emails: EmailManagementData | null;
+  identities: EnrichedIdentity[];
+}
 
 /** Aggregate state returned by `GET /api/profile/linux-email`. */
 export interface LinuxAliasData {

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+/**
+ * Linux.com (vanity) email alias forwarding.
+ *
+ * The feature is backed by two v2 NATS services:
+ * - auth-service `add_alias` — claims `<alias>@<domain>` as a system-managed
+ *   Auth0 linked identity (immutable; surfaces in `user_emails.read`).
+ * - forwards-service `check_alias` / `set_target` / `get_forward` — stateless
+ *   proxy to forwardemail.net that owns the routing to a destination address.
+ *
+ * The forwarding domain is environment-specific (prod `linux.com`,
+ * dev/staging `hurrdurr.org`) and is resolved server-side, then returned to the
+ * client in `LinuxAliasData.domain`. The UI never assumes a literal domain.
+ */
+
+/** The four states the Linux.com email tab can render. */
+export type LinuxAliasState = 'not_purchased' | 'purchased_unclaimed' | 'claimed' | 'service_unavailable';
+
+/** Aggregate state returned by `GET /api/profile/linux-email`. */
+export interface LinuxAliasData {
+  state: LinuxAliasState;
+  /** Active forwarding domain, env-driven (e.g. `linux.com` or `hurrdurr.org`). */
+  domain: string;
+  /** Local part of the claimed alias (e.g. `jsmith`), or null when unclaimed. */
+  alias: string | null;
+  /** Full claimed address `${alias}@${domain}`, or null when unclaimed. */
+  email: string | null;
+  /** Current forwarding destination, or null when not yet set. */
+  forwardTo: string | null;
+  /** membership-ui CTA URL, present only in the `not_purchased` state. */
+  purchaseUrl?: string;
+}
+
+/** Body for `POST /api/profile/linux-email/claim`. */
+export interface ClaimAliasRequest {
+  alias: string;
+  forwardTo: string;
+}
+
+/** Body for `PUT /api/profile/linux-email/forward`. */
+export interface UpdateForwardRequest {
+  forwardTo: string;
+}
+
+/** A selectable forwarding destination (one of the user's verified emails). */
+export interface LinuxForwardOption {
+  label: string;
+  value: string;
+}
+
+// --- NATS contract types (mirror the v2 service reply payloads) ---
+
+/** Reply from forwards-service `check_alias`. */
+export interface CheckAliasNatsResponse {
+  exists?: boolean;
+  alias?: string;
+  error?: string;
+}
+
+/** Reply from auth-service `add_alias`. */
+export interface AddAliasNatsResponse {
+  success: boolean;
+  email?: string;
+  error?: string;
+}
+
+/** Reply from forwards-service `set_target`. */
+export interface SetTargetNatsResponse {
+  alias?: string;
+  target_email?: string;
+  updated_at?: string;
+  error?: string;
+}
+
+/** Reply from forwards-service `get_forward`. */
+export interface GetForwardNatsResponse {
+  found?: boolean;
+  alias?: string;
+  target_email?: string;
+  error?: string;
+}

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -29,10 +29,18 @@ export interface LinuxAliasData {
   alias: string | null;
   /** Full claimed address `${alias}@${domain}`, or null when unclaimed. */
   email: string | null;
-  /** Current forwarding destination, or null when not yet set. */
+  /** Current forwarding destination, or null when not yet set / not readable without re-auth. */
   forwardTo: string | null;
   /** membership-ui CTA URL, present only in the `not_purchased` state. */
   purchaseUrl?: string;
+  /**
+   * True in the `claimed` state when the forwarding target could not be read
+   * because no profile-management token is in session. The client should
+   * redirect to `authorizeUrl` (Flow C) to load the real target.
+   */
+  forwardAuthRequired?: boolean;
+  /** Flow C authorization URL to call when `forwardAuthRequired` is true. */
+  authorizeUrl?: string;
 }
 
 /** Body for `POST /api/profile/linux-email/claim`. */

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -13,7 +13,7 @@
  *   proxy to forwardemail.net that owns the routing to a destination address.
  *
  * The forwarding domain is environment-specific (prod `linux.com`,
- * dev/staging `hurrdurr.org`) and is resolved server-side, then returned to the
+ * dev/staging `example.org`) and is resolved server-side, then returned to the
  * client in `LinuxAliasData.domain`. The UI never assumes a literal domain.
  */
 
@@ -23,7 +23,7 @@ export type LinuxAliasState = 'not_purchased' | 'purchased_unclaimed' | 'claimed
 /** Aggregate state returned by `GET /api/profile/linux-email`. */
 export interface LinuxAliasData {
   state: LinuxAliasState;
-  /** Active forwarding domain, env-driven (e.g. `linux.com` or `hurrdurr.org`). */
+  /** Active forwarding domain, env-driven (e.g. `linux.com` or `example.org`). */
   domain: string;
   /** Local part of the claimed alias (e.g. `jsmith`), or null when unclaimed. */
   alias: string | null;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -3,6 +3,7 @@
 
 export * from './date.validators';
 export * from './https-url.validator';
+export * from './linux-alias.validator';
 export * from './mailing-list.validators';
 export * from './meeting.validators';
 export * from './vote.validators';

--- a/packages/shared/src/validators/linux-alias.validator.ts
+++ b/packages/shared/src/validators/linux-alias.validator.ts
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { LINUX_ALIAS_BANNED_CHARS, LINUX_ALIAS_MAX_LENGTH, LINUX_ALIAS_RESERVED_NAMES } from '../constants/linux-email.constants';
+
+/**
+ * Validates a Linux.com alias local part against the same rules the v2
+ * auth-service / forwards-service enforce, so bad input is rejected before the
+ * NATS round-trip. The server's `check_alias` remains the source of truth.
+ *
+ * Returns one of: `{ aliasRequired }`, `{ aliasMaxLength }`,
+ * `{ aliasInvalidChars }`, or `{ aliasReserved }`.
+ */
+export function linuxAliasValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (value === null || value === undefined || value === '') return null; // defer to required validator
+
+    if (typeof value !== 'string') return { aliasInvalidChars: true };
+
+    const normalized = value.trim().toLowerCase();
+
+    if (normalized.length === 0) return { aliasRequired: true };
+    if (normalized.length > LINUX_ALIAS_MAX_LENGTH) return { aliasMaxLength: { requiredLength: LINUX_ALIAS_MAX_LENGTH, actualLength: normalized.length } };
+
+    if (LINUX_ALIAS_BANNED_CHARS.some((char) => normalized.includes(char))) return { aliasInvalidChars: true };
+
+    if (LINUX_ALIAS_RESERVED_NAMES.includes(normalized as (typeof LINUX_ALIAS_RESERVED_NAMES)[number])) return { aliasReserved: true };
+
+    return null;
+  };
+}

--- a/packages/shared/src/validators/linux-alias.validator.ts
+++ b/packages/shared/src/validators/linux-alias.validator.ts
@@ -12,7 +12,7 @@ import { LINUX_ALIAS_BANNED_CHARS, LINUX_ALIAS_MAX_LENGTH, LINUX_ALIAS_RESERVED_
  * auth-service / forwards-service enforce, so bad input is rejected before the
  * NATS round-trip. The server's `check_alias` remains the source of truth.
  *
- * Returns one of: `{ aliasRequired }`, `{ aliasMaxLength }`,
+ * Returns one of: `{ required }`, `{ aliasMaxLength }`,
  * `{ aliasInvalidChars }`, or `{ aliasReserved }`.
  */
 export function linuxAliasValidator(): ValidatorFn {
@@ -24,7 +24,7 @@ export function linuxAliasValidator(): ValidatorFn {
 
     const normalized = value.trim().toLowerCase();
 
-    if (normalized.length === 0) return { aliasRequired: true };
+    if (normalized.length === 0) return { required: true };
     if (normalized.length > LINUX_ALIAS_MAX_LENGTH) return { aliasMaxLength: { requiredLength: LINUX_ALIAS_MAX_LENGTH, actualLength: normalized.length } };
 
     if (LINUX_ALIAS_BANNED_CHARS.some((char) => normalized.includes(char))) return { aliasInvalidChars: true };


### PR DESCRIPTION
## Summary
- Adds a **Linux.com Email** tab to the profile module to claim and manage a vanity `<alias>@<domain>` forwarding address.
- Backed by the v2 NATS services: `add_alias` (auth-service) for the system-managed alias identity, and `check_alias` / `set_target` / `get_forward` (forwards-service) for the forwardemail routing. Reuses the existing auth-service NATS client pattern (`email-verification.service`).
- Four UI states: not-purchased / purchased-unclaimed / claimed / service-unavailable. Purchase is gated via a member-service add-on check; unpurchased shows a CTA to membership-ui.
- "Forward to" is a dropdown of the user's **verified email identities** (defaults to primary). Alias claim is **one-time** (immutable upstream); only the forwarding target is editable.
- Forwarding domain is environment-driven via `LINUX_FORWARD_DOMAIN` (set per environment) and never hard-coded.
- `add_alias` / `set_target` / `get_forward` use the Flow C management token (Auth0 Management API audience), which forwards-service validates.

## Dependencies (deploy ordering)
- **lfx-v2-argocd:** `LINUX_FORWARD_DOMAIN` set per env, and `read:current_user` added to `PROFILE_SCOPE` (needed so forwards-service can verify alias ownership). Required before deployed envs work.
- **auth-service:** its M2M client needs the `read:users` (+ create/update/delete:users) Management API grant (applied in dev).
- **forwards-service:** editing the forward target is currently blocked by a decode bug in `set_target` (forwardemail PUT response, `wireAlias.domain` string-vs-object) — tracked as LFXV2-1919. Claim, initial forward set, and reads work; edit completes once that fix ships.

## Test plan
- [ ] Tab appears under `/profile` for an authenticated user and renders the correct state.
- [ ] Not-purchased → "Purchase Email" opens membership-ui in a new tab.
- [ ] Purchased-unclaimed → claim form validates the alias (reserved / length / charset) and forwarding email; claiming creates the alias.
- [ ] Claimed → alias shown read-only; forwarding dropdown lists verified emails and defaults to primary.
- [ ] The claimed alias also appears as an alternate on the `/profile/email` tab.
- [ ] Service-unavailable → NATS/upstream failure shows the retry panel, no crash.

Jira: LFXV2-1663
