### PR TITLE
feat(votes): remove Draft tab in personal vote view (LFXV2-2069)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="votes-table-card">
-  <lfx-card-tabs-bar [options]="statusTabOptions" [selectedFilter]="statusTab()" (filterChange)="onStatusTabChange($event)" data-testid="votes-status-tabs">
+  <lfx-card-tabs-bar [options]="statusTabOptions()" [selectedFilter]="statusTab()" (filterChange)="onStatusTabChange($event)" data-testid="votes-status-tabs">
   </lfx-card-tabs-bar>
 
   @if (loading() || votes().length > 0) {

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -59,12 +59,6 @@ export class VotesTableComponent {
   protected readonly voteLabel = VOTE_LABEL;
   protected readonly PollStatus = PollStatus;
   protected readonly VoteResponseStatus = VoteResponseStatus;
-  protected readonly statusTabOptions: FilterPillOption[] = [
-    { id: 'all', label: 'All' },
-    { id: PollStatus.ACTIVE, label: 'Active' },
-    { id: PollStatus.DISABLED, label: 'Draft' },
-    { id: PollStatus.ENDED, label: 'Ended' },
-  ];
 
   // === Inputs ===
   public readonly votes = input.required<Vote[]>();
@@ -79,6 +73,8 @@ export class VotesTableComponent {
   public readonly projectOptions = input<{ label: string; value: string | null }[]>([]);
   public readonly showFoundationFilter = input<boolean>(false);
   public readonly showProjectFilter = input<boolean>(false);
+  // Draft tab is only meaningful in management contexts (project/committee lens); hide it in the Me lens.
+  public readonly showDraftTab = input<boolean>(true);
 
   // === Outputs ===
   public readonly viewVote = output<string>();
@@ -103,6 +99,7 @@ export class VotesTableComponent {
   private readonly filterState = signal<VoteFilterState>({ search: '', status: null, group: null });
 
   // === Computed Signals ===
+  protected readonly statusTabOptions: Signal<FilterPillOption[]> = this.initStatusTabOptions();
   protected readonly displayedVotes: Signal<Vote[]> = this.initDisplayedVotes();
   protected readonly isFiltered = computed(() => {
     if (this.lazy()) return false;
@@ -196,6 +193,20 @@ export class VotesTableComponent {
   }
 
   // === Private Initializers ===
+  private initStatusTabOptions(): Signal<FilterPillOption[]> {
+    return computed(() => {
+      const base: FilterPillOption[] = [
+        { id: 'all', label: 'All' },
+        { id: PollStatus.ACTIVE, label: 'Active' },
+      ];
+      if (this.showDraftTab()) {
+        base.push({ id: PollStatus.DISABLED, label: 'Draft' });
+      }
+      base.push({ id: PollStatus.ENDED, label: 'Ended' });
+      return base;
+    });
+  }
+
   private initFormSubscriptions(): void {
     combineLatest([
       this.searchForm.valueChanges.pipe(

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe } from '@angular/common';
-import { Component, computed, DestroyRef, inject, input, output, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, output, signal, Signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
@@ -115,6 +115,11 @@ export class VotesTableComponent {
   // === Constructor ===
   public constructor() {
     this.initFormSubscriptions();
+    effect(() => {
+      if (!this.showDraftTab() && this.statusTab() === PollStatus.DISABLED) {
+        untracked(() => this.statusTab.set('all'));
+      }
+    });
   }
 
   // === Protected Methods ===

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -53,6 +53,7 @@
         [projectOptions]="projectOptions()"
         [showFoundationFilter]="showFoundationFilter()"
         [showProjectFilter]="showProjectFilter()"
+        [showDraftTab]="!isMeLens()"
         (foundationFilterChange)="onFoundationFilterChange($event)"
         (projectFilterChange)="onProjectFilterChange($event)"
         (viewVote)="onViewVote($event)"


### PR DESCRIPTION
# Summary

The Draft tab (backed by `PollStatus.DISABLED`) is only relevant in management contexts like the project or committee lens, where maintainers create and manage polls. In the Me lens, contributors have no need to see draft polls — showing the tab was confusing and exposed an irrelevant filter.

This change converts `statusTabOptions` from a static array to a computed signal gated on a new `showDraftTab` input. The votes-dashboard passes `[showDraftTab]="!isMeLens()"`, so the tab is present everywhere except the Me lens without touching any other lens's behaviour.