### PR TITLE
fix(newsletters): preserve clipboard links on paste into AI content

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.html
@@ -36,6 +36,7 @@
       <lfx-textarea
         [form]="form"
         control="rawContent"
+        (paste)="onRawContentPaste($event)"
         placeholder="• Released v2.4 last week, big perf wins
 • Welcome new maintainers Alice and Bob
 • Upcoming community call: Thursday at 10am PT

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.ts
@@ -15,6 +15,7 @@ import {
   NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH,
 } from '@lfx-one/shared/constants';
 import { GenerateNewsletterResponse } from '@lfx-one/shared/interfaces';
+import { htmlClipboardToText } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -106,6 +107,32 @@ export class NewsletterGenerateDrawerComponent {
         // Silently ignore storage errors (private browsing, quota).
       }
     }
+  }
+
+  // Preserve hyperlinks when pasting rich content. A textarea would otherwise drop
+  // hrefs and keep only visible text, hiding URLs from the AI generator downstream.
+  public onRawContentPaste(event: ClipboardEvent): void {
+    const html = event.clipboardData?.getData('text/html') ?? '';
+    if (!html) return;
+
+    const textarea = event.target as HTMLTextAreaElement | null;
+    if (!textarea) return;
+
+    event.preventDefault();
+
+    const converted = htmlClipboardToText(html);
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? textarea.value.length;
+    const current = textarea.value;
+    const next = current.slice(0, start) + converted + current.slice(end);
+
+    this.form.controls.rawContent.setValue(next);
+
+    const caret = start + converted.length;
+    queueMicrotask(() => {
+      textarea.setSelectionRange(caret, caret);
+      textarea.focus();
+    });
   }
 
   public onGenerate(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-generate-drawer/newsletter-generate-drawer.component.ts
@@ -109,32 +109,6 @@ export class NewsletterGenerateDrawerComponent {
     }
   }
 
-  // Preserve hyperlinks when pasting rich content. A textarea would otherwise drop
-  // hrefs and keep only visible text, hiding URLs from the AI generator downstream.
-  public onRawContentPaste(event: ClipboardEvent): void {
-    const html = event.clipboardData?.getData('text/html') ?? '';
-    if (!html) return;
-
-    const textarea = event.target as HTMLTextAreaElement | null;
-    if (!textarea) return;
-
-    event.preventDefault();
-
-    const converted = htmlClipboardToText(html);
-    const start = textarea.selectionStart ?? textarea.value.length;
-    const end = textarea.selectionEnd ?? textarea.value.length;
-    const current = textarea.value;
-    const next = current.slice(0, start) + converted + current.slice(end);
-
-    this.form.controls.rawContent.setValue(next);
-
-    const caret = start + converted.length;
-    queueMicrotask(() => {
-      textarea.setSelectionRange(caret, caret);
-      textarea.focus();
-    });
-  }
-
   public onGenerate(): void {
     if (!this.canGenerate()) return;
     this.generating.set(true);
@@ -174,6 +148,38 @@ export class NewsletterGenerateDrawerComponent {
           });
         },
       });
+  }
+
+  // Preserve hyperlinks when pasting rich content. A textarea would otherwise drop
+  // hrefs and keep only visible text, hiding URLs from the AI generator downstream.
+  protected onRawContentPaste(event: ClipboardEvent): void {
+    const html = event.clipboardData?.getData('text/html') ?? '';
+    if (!html) return;
+
+    const textarea = event.target;
+    if (!(textarea instanceof HTMLTextAreaElement)) return;
+
+    event.preventDefault();
+
+    const converted = htmlClipboardToText(html);
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? textarea.value.length;
+    const current = textarea.value;
+    const next = current.slice(0, start) + converted + current.slice(end);
+
+    const control = this.form.controls.rawContent;
+    control.setValue(next);
+    // setValue bypasses the value accessor, so dirty/touched would not flip
+    // the way a native paste does. Set them explicitly so validators that gate
+    // on touched (e.g., error display) behave consistently with manual typing.
+    control.markAsDirty();
+    control.markAsTouched();
+
+    const caret = start + converted.length;
+    queueMicrotask(() => {
+      textarea.setSelectionRange(caret, caret);
+      textarea.focus();
+    });
   }
 
   private restoreCustomPrompt(): void {

--- a/packages/shared/src/utils/html-utils.spec.ts
+++ b/packages/shared/src/utils/html-utils.spec.ts
@@ -75,7 +75,7 @@ describe('htmlClipboardToText', () => {
   });
 
   it('decodes decimal numeric entities (em dash, NBSP, smart quote)', () => {
-    expect(htmlClipboardToText('hello&#8212;world&#160;&#8217;tis')).toBe("hello—world ’tis");
+    expect(htmlClipboardToText('hello&#8212;world&#160;&#8217;tis')).toBe('hello—world ’tis');
   });
 
   it('decodes hexadecimal numeric entities', () => {

--- a/packages/shared/src/utils/html-utils.spec.ts
+++ b/packages/shared/src/utils/html-utils.spec.ts
@@ -1,0 +1,93 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { htmlClipboardToText, stripHtml } from './html-utils';
+
+describe('stripHtml', () => {
+  it('removes tags and decodes entities', () => {
+    expect(stripHtml('<p>Hello &amp; <strong>World</strong></p>')).toBe('Hello & World');
+  });
+
+  it('returns empty string for null / undefined / empty', () => {
+    expect(stripHtml(null)).toBe('');
+    expect(stripHtml(undefined)).toBe('');
+    expect(stripHtml('')).toBe('');
+  });
+});
+
+describe('htmlClipboardToText', () => {
+  it('returns empty string for null / undefined / empty', () => {
+    expect(htmlClipboardToText(null)).toBe('');
+    expect(htmlClipboardToText(undefined)).toBe('');
+    expect(htmlClipboardToText('')).toBe('');
+  });
+
+  it('converts an anchor with distinct text to Markdown', () => {
+    expect(htmlClipboardToText('<a href="https://docs.example.com/guide">contributor guide</a>')).toBe('[contributor guide](https://docs.example.com/guide)');
+  });
+
+  it('renders a bare URL when the anchor text equals the href', () => {
+    expect(htmlClipboardToText('<a href="https://x.com">https://x.com</a>')).toBe('https://x.com');
+  });
+
+  it('uses just the text when the anchor has no href', () => {
+    expect(htmlClipboardToText('<a>no href here</a>')).toBe('no href here');
+  });
+
+  it('uses just the text when the href is empty', () => {
+    expect(htmlClipboardToText('<a href="">link text</a>')).toBe('link text');
+  });
+
+  it('preserves multiple anchors in one block', () => {
+    const html = '<p>See <a href="https://a.com">A</a> and <a href="https://b.com">B</a>.</p>';
+    expect(htmlClipboardToText(html)).toBe('See [A](https://a.com) and [B](https://b.com).');
+  });
+
+  it('strips nested formatting inside anchor text', () => {
+    expect(htmlClipboardToText('<a href="https://x.com"><strong>bold</strong> link</a>')).toBe('[bold link](https://x.com)');
+  });
+
+  it('handles single-quoted href values', () => {
+    expect(htmlClipboardToText("<a href='https://x.com'>x</a>")).toBe('[x](https://x.com)');
+  });
+
+  it('still finds the href when other attributes come first', () => {
+    expect(htmlClipboardToText('<a class="link" data-foo="bar" href="https://x.com">x</a>')).toBe('[x](https://x.com)');
+  });
+
+  it('decodes entities in plain text', () => {
+    expect(htmlClipboardToText('cats &amp; dogs')).toBe('cats & dogs');
+  });
+
+  it('decodes entities inside anchor text', () => {
+    expect(htmlClipboardToText('<a href="https://x.com">cats &amp; dogs</a>')).toBe('[cats & dogs](https://x.com)');
+  });
+
+  it('turns block boundaries into newlines', () => {
+    expect(htmlClipboardToText('<p>Hello</p><p>World</p>')).toBe('Hello\nWorld');
+  });
+
+  it('turns <br> into a newline', () => {
+    expect(htmlClipboardToText('Line 1<br>Line 2<br/>Line 3')).toBe('Line 1\nLine 2\nLine 3');
+  });
+
+  it('preserves list-item line breaks', () => {
+    const html = '<ul><li>First item with <a href="https://a.com">A</a></li><li>Second item</li></ul>';
+    expect(htmlClipboardToText(html)).toBe('First item with [A](https://a.com)\nSecond item');
+  });
+
+  it('collapses runs of 3+ newlines to 2', () => {
+    expect(htmlClipboardToText('<p>A</p><br><br><br><br><p>B</p>')).toBe('A\n\nB');
+  });
+
+  it('strips remaining tags but keeps surrounding text', () => {
+    expect(htmlClipboardToText('<span style="color:red">red text</span>')).toBe('red text');
+  });
+
+  it('handles a Notion-style mixed paragraph with a link and inline formatting', () => {
+    const html = '<p>Check out the <a href="https://example.com/post">new post</a> — <strong>big</strong> update!</p>';
+    expect(htmlClipboardToText(html)).toBe('Check out the [new post](https://example.com/post) — big update!');
+  });
+});

--- a/packages/shared/src/utils/html-utils.spec.ts
+++ b/packages/shared/src/utils/html-utils.spec.ts
@@ -65,6 +65,23 @@ describe('htmlClipboardToText', () => {
     expect(htmlClipboardToText('<a href="https://x.com">cats &amp; dogs</a>')).toBe('[cats & dogs](https://x.com)');
   });
 
+  it('decodes entities inside href so query-string URLs survive', () => {
+    expect(htmlClipboardToText('<a href="https://example.com?a=1&amp;b=2">link</a>')).toBe('[link](https://example.com?a=1&b=2)');
+  });
+
+  it('collapses to a bare URL when text and href differ only by entity encoding', () => {
+    const html = '<a href="https://example.com?a=1&amp;b=2">https://example.com?a=1&amp;b=2</a>';
+    expect(htmlClipboardToText(html)).toBe('https://example.com?a=1&b=2');
+  });
+
+  it('decodes decimal numeric entities (em dash, NBSP, smart quote)', () => {
+    expect(htmlClipboardToText('hello&#8212;world&#160;&#8217;tis')).toBe("hello—world ’tis");
+  });
+
+  it('decodes hexadecimal numeric entities', () => {
+    expect(htmlClipboardToText('em dash &#x2014; and ndash &#x2013;')).toBe('em dash — and ndash –');
+  });
+
   it('turns block boundaries into newlines', () => {
     expect(htmlClipboardToText('<p>Hello</p><p>World</p>')).toBe('Hello\nWorld');
   });

--- a/packages/shared/src/utils/html-utils.ts
+++ b/packages/shared/src/utils/html-utils.ts
@@ -1,45 +1,52 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+  nbsp: ' ',
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
 /**
  * Decodes a small set of named HTML entities plus all numeric ones (decimal
- * and hex) into their character equivalents. Pure string ops — SSR-safe.
- *
- * Intended to be called once per value; callers that need multiple passes
- * should fold their pipeline so this runs as the final step.
+ * and hex) in a single regex pass. Single-pass is load-bearing: chaining
+ * replacements would let a decoded `&` get re-interpreted as the start of a
+ * fresh entity (e.g., `&amp;#39;` → `&#39;` → `'`), which is the
+ * double-unescape pattern CodeQL flags. Pure string ops — SSR-safe.
  */
 function decodeHtmlEntities(s: string): string {
-  return (
-    s
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&apos;/g, "'")
-      // Numeric entities — common in clipboard HTML from Word, Google Docs, Notion
-      // (em dash &#8212;, NBSP &#160;, smart quotes, etc.).
-      .replace(/&#(\d+);/g, (_match, n: string) => String.fromCodePoint(Number(n)))
-      .replace(/&#x([\da-fA-F]+);/g, (_match, h: string) => String.fromCodePoint(parseInt(h, 16)))
-  );
+  return s.replace(/&(#\d+|#x[\da-fA-F]+|[a-z]+);/gi, (match, body: string) => {
+    const lower = body.toLowerCase();
+    if (lower.startsWith('#x')) {
+      const code = parseInt(lower.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+    if (lower.startsWith('#')) {
+      const code = Number(lower.slice(1));
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+    return NAMED_HTML_ENTITIES[lower] ?? match;
+  });
 }
 
 /**
- * Strips HTML-like tag sequences until the string is stable. Looping is
- * required because a single regex pass can leave behind a partial tag when
- * the input contains nested or malformed angle-bracket sequences (e.g.,
- * `<<script>foo</script>>` → `>foo>` after one pass; further passes are
- * no-ops). This is the canonical incomplete-multi-character-sanitization
- * mitigation pattern.
+ * Strips HTML-like tag sequences until the string is stable. The inner
+ * `[^<>]*` class is load-bearing: it disallows nested `<` inside a tag body,
+ * which prevents the engine from trying every `<` position on adversarial
+ * inputs like `<<<<<<<>` (the polynomial-regex pattern CodeQL flags). Looping
+ * handles the residual case where one pass leaves a partial tag — each pass
+ * runs in linear time, and the loop converges in a small constant number of
+ * passes for any realistic input.
  */
 function stripTagsToStable(s: string): string {
   let prev: string;
   let current = s;
   do {
     prev = current;
-    current = current.replace(/<[^>]*>/g, '');
+    current = current.replace(/<[^<>]*>/g, '');
   } while (current !== prev);
   return current;
 }
@@ -76,12 +83,11 @@ export function stripHtml(html: string | null | undefined): string {
  *
  * Output destination: the returned string flows into `textarea.value` /
  * `form.setValue()` and is treated as plain text by the browser. It is never
- * injected as `innerHTML`, so partial-decode patterns cannot become an XSS
- * vector in this context.
+ * injected as `innerHTML`.
  *
  * Pipeline order matters:
- *   1. Carry anchor href/text through encoded — bare URL collapse compares
- *      encoded-with-encoded, which stays correct under entity equivalence.
+ *   1. Carry anchor href/text through encoded — the `text === href` bare-URL
+ *      collapse stays correct under entity equivalence.
  *   2. Strip remaining tags in a stable loop.
  *   3. Decode entities exactly once at the end, so no character is
  *      double-unescaped.
@@ -102,10 +108,10 @@ export function stripHtml(html: string | null | undefined): string {
 export function htmlClipboardToText(html: string | null | undefined): string {
   if (!html) return '';
 
-  // Capture the full anchor tag first, then extract href via a bounded inner
-  // regex on the captured tag string. Avoids superlinear backtracking that the
-  // combined single-regex form can exhibit on malformed clipboard HTML.
-  let result = html.replace(/<a\b[^>]*>([\s\S]*?)<\/a>/gi, (match, inner: string) => {
+  // Capture the full anchor tag first (with `[^<>]*` inside the open tag to
+  // avoid polynomial backtracking on `<<<<<...>` inputs), then extract href
+  // via a bounded inner regex on the captured tag string.
+  let result = html.replace(/<a\b[^<>]*>([\s\S]*?)<\/a>/gi, (match, inner: string) => {
     const hrefMatch = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(match);
     const href = (hrefMatch?.[1] ?? hrefMatch?.[2] ?? '').trim();
     const text = stripTagsToStable(inner).trim();

--- a/packages/shared/src/utils/html-utils.ts
+++ b/packages/shared/src/utils/html-utils.ts
@@ -2,6 +2,28 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Decodes a small set of named HTML entities plus all numeric ones (decimal
+ * and hex) into their character equivalents. Pure string ops — SSR-safe.
+ */
+function decodeHtmlEntities(s: string): string {
+  return (
+    s
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&#x27;/g, "'")
+      .replace(/&apos;/g, "'")
+      // Numeric entities — common in clipboard HTML from Word, Google Docs, Notion
+      // (em dash &#8212;, NBSP &#160;, smart quotes, etc.).
+      .replace(/&#(\d+);/g, (_match, n: string) => String.fromCodePoint(Number(n)))
+      .replace(/&#x([\da-fA-F]+);/g, (_match, h: string) => String.fromCodePoint(parseInt(h, 16)))
+  );
+}
+
+/**
  * Strips HTML tags and decodes common HTML entities from a string.
  * This function works in both browser and Node.js (SSR) environments.
  *
@@ -19,23 +41,7 @@
  */
 export function stripHtml(html: string | null | undefined): string {
   if (!html) return '';
-
-  return (
-    html
-      // Remove HTML tags
-      .replace(/<[^>]*>/g, '')
-      // Decode common HTML entities
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&apos;/g, "'")
-      // Trim whitespace
-      .trim()
-  );
+  return decodeHtmlEntities(html.replace(/<[^>]*>/g, '')).trim();
 }
 
 /**
@@ -46,6 +52,12 @@ export function stripHtml(html: string | null | undefined): string {
  * `[text](url)` (or bare `url` when the visible text equals the href) so the
  * URLs can flow through plain-text fields (e.g., AI prompt inputs) and be
  * surfaced again downstream. SSR-safe — pure string operations, no DOM APIs.
+ *
+ * Output destination: the returned string flows into `textarea.value` /
+ * `form.setValue()` and is treated as plain text by the browser. It is never
+ * injected as `innerHTML`, so partial-decode patterns (e.g., decoded `<script>`
+ * surviving in the output) cannot become an XSS vector. CodeQL alerts on the
+ * decode/strip chain are false positives in this context.
  *
  * @param html - The HTML string from `clipboardData.getData('text/html')`
  * @returns Plain text with anchors rewritten, block boundaries turned into
@@ -63,11 +75,12 @@ export function stripHtml(html: string | null | undefined): string {
 export function htmlClipboardToText(html: string | null | undefined): string {
   if (!html) return '';
 
-  let result = html;
-
-  // Rewrite anchors first — must happen before tag stripping so we can read href.
-  result = result.replace(/<a\b[^>]*?\bhref\s*=\s*("([^"]*)"|'([^']*)')[^>]*>([\s\S]*?)<\/a>/gi, (_match, _quotedHref, hrefDouble, hrefSingle, inner) => {
-    const href = (hrefDouble ?? hrefSingle ?? '').trim();
+  // Capture the full anchor tag first, then extract href via a bounded inner
+  // regex. This avoids superlinear backtracking that the single combined regex
+  // can exhibit on malformed clipboard HTML (e.g., unclosed href attributes).
+  let result = html.replace(/<a\b[^>]*>([\s\S]*?)<\/a>/gi, (match, inner: string) => {
+    const hrefMatch = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(match);
+    const href = decodeHtmlEntities((hrefMatch?.[1] ?? hrefMatch?.[2] ?? '').trim());
     const text = decodeHtmlEntities(inner.replace(/<[^>]*>/g, '')).trim();
     if (!href) return text;
     if (!text || text === href) return href;
@@ -81,23 +94,11 @@ export function htmlClipboardToText(html: string | null | undefined): string {
   // Strip remaining tags.
   result = result.replace(/<[^>]*>/g, '');
 
-  // Decode entities.
+  // Decode entities on the surviving text.
   result = decodeHtmlEntities(result);
 
   // Collapse runs of 3+ newlines down to 2.
   result = result.replace(/\n{3,}/g, '\n\n');
 
   return result.trim();
-}
-
-function decodeHtmlEntities(s: string): string {
-  return s
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&apos;/g, "'");
 }

--- a/packages/shared/src/utils/html-utils.ts
+++ b/packages/shared/src/utils/html-utils.ts
@@ -37,3 +37,67 @@ export function stripHtml(html: string | null | undefined): string {
       .trim()
   );
 }
+
+/**
+ * Converts clipboard HTML to plain text while preserving hyperlinks.
+ *
+ * A `<textarea>` strips HTML on paste, so anchor `href` URLs are lost — only
+ * the visible text survives. This helper rewrites anchors to a Markdown-style
+ * `[text](url)` (or bare `url` when the visible text equals the href) so the
+ * URLs can flow through plain-text fields (e.g., AI prompt inputs) and be
+ * surfaced again downstream. SSR-safe — pure string operations, no DOM APIs.
+ *
+ * @param html - The HTML string from `clipboardData.getData('text/html')`
+ * @returns Plain text with anchors rewritten, block boundaries turned into
+ *   newlines, remaining tags stripped, and entities decoded.
+ *
+ * @example
+ * ```typescript
+ * htmlClipboardToText('<p>See <a href="https://x.com/y">our guide</a> for more.</p>')
+ * // Returns: "See [our guide](https://x.com/y) for more."
+ *
+ * htmlClipboardToText('<a href="https://x.com">https://x.com</a>')
+ * // Returns: "https://x.com"
+ * ```
+ */
+export function htmlClipboardToText(html: string | null | undefined): string {
+  if (!html) return '';
+
+  let result = html;
+
+  // Rewrite anchors first — must happen before tag stripping so we can read href.
+  result = result.replace(/<a\b[^>]*?\bhref\s*=\s*("([^"]*)"|'([^']*)')[^>]*>([\s\S]*?)<\/a>/gi, (_match, _quotedHref, hrefDouble, hrefSingle, inner) => {
+    const href = (hrefDouble ?? hrefSingle ?? '').trim();
+    const text = decodeHtmlEntities(inner.replace(/<[^>]*>/g, '')).trim();
+    if (!href) return text;
+    if (!text || text === href) return href;
+    return `[${text}](${href})`;
+  });
+
+  // Block-level boundaries → newlines (before stripping remaining tags).
+  result = result.replace(/<br\s*\/?>/gi, '\n');
+  result = result.replace(/<\/(p|div|li|tr|h[1-6])>/gi, '\n');
+
+  // Strip remaining tags.
+  result = result.replace(/<[^>]*>/g, '');
+
+  // Decode entities.
+  result = decodeHtmlEntities(result);
+
+  // Collapse runs of 3+ newlines down to 2.
+  result = result.replace(/\n{3,}/g, '\n\n');
+
+  return result.trim();
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&apos;/g, "'");
+}

--- a/packages/shared/src/utils/html-utils.ts
+++ b/packages/shared/src/utils/html-utils.ts
@@ -4,6 +4,9 @@
 /**
  * Decodes a small set of named HTML entities plus all numeric ones (decimal
  * and hex) into their character equivalents. Pure string ops — SSR-safe.
+ *
+ * Intended to be called once per value; callers that need multiple passes
+ * should fold their pipeline so this runs as the final step.
  */
 function decodeHtmlEntities(s: string): string {
   return (
@@ -24,6 +27,24 @@ function decodeHtmlEntities(s: string): string {
 }
 
 /**
+ * Strips HTML-like tag sequences until the string is stable. Looping is
+ * required because a single regex pass can leave behind a partial tag when
+ * the input contains nested or malformed angle-bracket sequences (e.g.,
+ * `<<script>foo</script>>` → `>foo>` after one pass; further passes are
+ * no-ops). This is the canonical incomplete-multi-character-sanitization
+ * mitigation pattern.
+ */
+function stripTagsToStable(s: string): string {
+  let prev: string;
+  let current = s;
+  do {
+    prev = current;
+    current = current.replace(/<[^>]*>/g, '');
+  } while (current !== prev);
+  return current;
+}
+
+/**
  * Strips HTML tags and decodes common HTML entities from a string.
  * This function works in both browser and Node.js (SSR) environments.
  *
@@ -41,7 +62,7 @@ function decodeHtmlEntities(s: string): string {
  */
 export function stripHtml(html: string | null | undefined): string {
   if (!html) return '';
-  return decodeHtmlEntities(html.replace(/<[^>]*>/g, '')).trim();
+  return decodeHtmlEntities(stripTagsToStable(html)).trim();
 }
 
 /**
@@ -55,9 +76,15 @@ export function stripHtml(html: string | null | undefined): string {
  *
  * Output destination: the returned string flows into `textarea.value` /
  * `form.setValue()` and is treated as plain text by the browser. It is never
- * injected as `innerHTML`, so partial-decode patterns (e.g., decoded `<script>`
- * surviving in the output) cannot become an XSS vector. CodeQL alerts on the
- * decode/strip chain are false positives in this context.
+ * injected as `innerHTML`, so partial-decode patterns cannot become an XSS
+ * vector in this context.
+ *
+ * Pipeline order matters:
+ *   1. Carry anchor href/text through encoded — bare URL collapse compares
+ *      encoded-with-encoded, which stays correct under entity equivalence.
+ *   2. Strip remaining tags in a stable loop.
+ *   3. Decode entities exactly once at the end, so no character is
+ *      double-unescaped.
  *
  * @param html - The HTML string from `clipboardData.getData('text/html')`
  * @returns Plain text with anchors rewritten, block boundaries turned into
@@ -76,12 +103,12 @@ export function htmlClipboardToText(html: string | null | undefined): string {
   if (!html) return '';
 
   // Capture the full anchor tag first, then extract href via a bounded inner
-  // regex. This avoids superlinear backtracking that the single combined regex
-  // can exhibit on malformed clipboard HTML (e.g., unclosed href attributes).
+  // regex on the captured tag string. Avoids superlinear backtracking that the
+  // combined single-regex form can exhibit on malformed clipboard HTML.
   let result = html.replace(/<a\b[^>]*>([\s\S]*?)<\/a>/gi, (match, inner: string) => {
     const hrefMatch = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(match);
-    const href = decodeHtmlEntities((hrefMatch?.[1] ?? hrefMatch?.[2] ?? '').trim());
-    const text = decodeHtmlEntities(inner.replace(/<[^>]*>/g, '')).trim();
+    const href = (hrefMatch?.[1] ?? hrefMatch?.[2] ?? '').trim();
+    const text = stripTagsToStable(inner).trim();
     if (!href) return text;
     if (!text || text === href) return href;
     return `[${text}](${href})`;
@@ -91,10 +118,10 @@ export function htmlClipboardToText(html: string | null | undefined): string {
   result = result.replace(/<br\s*\/?>/gi, '\n');
   result = result.replace(/<\/(p|div|li|tr|h[1-6])>/gi, '\n');
 
-  // Strip remaining tags.
-  result = result.replace(/<[^>]*>/g, '');
+  // Strip remaining tags in a stable loop.
+  result = stripTagsToStable(result);
 
-  // Decode entities on the surviving text.
+  // Decode entities exactly once.
   result = decodeHtmlEntities(result);
 
   // Collapse runs of 3+ newlines down to 2.


### PR DESCRIPTION
## Summary

Textarea drops anchor `href` on paste, so URLs vanish before the AI generator sees them. Intercept paste in the **Generate with AI** drawer and rewrite `<a href="URL">TEXT</a>` to `[TEXT](URL)` (bare URL when text matches href).

## Test plan

- [ ] Open Generate with AI drawer, paste from a page with inline links → Markdown `[text](url)` appears
- [ ] Paste plain text from a terminal → unchanged
- [ ] Generate → AI response surfaces the URLs as proper links