### PR TITLE
fix(meetings): sort past meetings most-recent-first

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -15,13 +15,12 @@ import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
 import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
-import { addMinutesToDate } from '@lfx-one/shared/utils';
+import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
 import { VoteService } from '@services/vote.service';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { getCurrentOrNextOccurrence, hasMeetingEnded } from '@lfx-one/shared/utils';
 import { catchError, debounceTime, distinctUntilChanged, filter, finalize, forkJoin, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { IcalSubscribeDialogComponent } from '../ical-subscribe-dialog/ical-subscribe-dialog.component';
@@ -100,7 +99,14 @@ export class CommitteeMeetingsComponent {
       filter(({ time, uid }) => time === 'past' && !!uid),
       distinctUntilChanged((a, b) => a.uid === b.uid),
       tap(() => this.pastMeetingsLoading.set(true)),
-      switchMap(({ uid }) => this.meetingService.getPastMeetingsByCommittee(uid!).pipe(finalize(() => this.pastMeetingsLoading.set(false))))
+      // Sort client-side: the query-service can't sort past meetings by start_time (only name/updated),
+      // so the descending date order must be applied here to render most-recent-first. (LFXV2-2053)
+      switchMap(({ uid }) =>
+        this.meetingService.getPastMeetingsByCommittee(uid!).pipe(
+          map((meetings) => sortPastMeetingsDescending(meetings)),
+          finalize(() => this.pastMeetingsLoading.set(false))
+        )
+      )
     ),
     { initialValue: [] }
   );

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -15,7 +15,7 @@ import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
 import { Lens, Meeting, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
-import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded } from '@lfx-one/shared/utils';
+import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
@@ -476,7 +476,14 @@ export class MeetingsDashboardComponent {
     return toSignal(
       merge(meLens$, firstPage$, nextPage$).pipe(
         tap((response) => this.pastPageToken.set(response.page_token)),
-        scan((acc: PastMeeting[], response: PageResult<PastMeeting>) => (response.reset ? response.data : [...acc, ...response.data]), [])
+        // Sort the full accumulator (not just the incoming page) descending by date: the upstream
+        // query-service can't sort past meetings by start_time, and the name-based page cursor means
+        // a freshly loaded page may contain meetings more recent than ones already shown. Re-sorting
+        // the merged list keeps the rendered order most-recent-first across "Load More". (LFXV2-2053)
+        scan(
+          (acc: PastMeeting[], response: PageResult<PastMeeting>) => sortPastMeetingsDescending(response.reset ? response.data : [...acc, ...response.data]),
+          []
+        )
       ),
       { initialValue: [] }
     );

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// meeting.utils transitively imports @angular/common/http (HttpParams), whose declarations need the
+// Angular JIT compiler when loaded outside an Angular bootstrap (as under Vitest). Importing the
+// compiler first provides that facade so the module can be imported.
+import '@angular/compiler';
+
+import { describe, expect, it } from 'vitest';
+
+import { PastMeeting } from '../interfaces';
+import { sortPastMeetingsDescending } from './meeting.utils';
+
+/**
+ * Builds a minimal PastMeeting fixture. The sort only reads `scheduled_start_time`/`start_time`,
+ * so only those plus an identifying `uid` are set; the rest is cast to satisfy the interface.
+ */
+function pastMeeting(partial: { uid: string; scheduled_start_time?: string; start_time?: string }): PastMeeting {
+  return {
+    uid: partial.uid,
+    scheduled_start_time: partial.scheduled_start_time as string,
+    start_time: partial.start_time as string,
+  } as PastMeeting;
+}
+
+const uids = (meetings: PastMeeting[]): string[] => meetings.map((m) => m.uid);
+
+describe('sortPastMeetingsDescending', () => {
+  it('orders past meetings most-recent-first by scheduled_start_time', () => {
+    const input = [
+      pastMeeting({ uid: 'oldest', scheduled_start_time: '2026-01-01T10:00:00Z' }),
+      pastMeeting({ uid: 'newest', scheduled_start_time: '2026-03-01T10:00:00Z' }),
+      pastMeeting({ uid: 'middle', scheduled_start_time: '2026-02-01T10:00:00Z' }),
+    ];
+
+    expect(uids(sortPastMeetingsDescending(input))).toEqual(['newest', 'middle', 'oldest']);
+  });
+
+  it('falls back to start_time when scheduled_start_time is absent', () => {
+    const input = [pastMeeting({ uid: 'a', start_time: '2026-01-01T10:00:00Z' }), pastMeeting({ uid: 'b', start_time: '2026-05-01T10:00:00Z' })];
+
+    expect(uids(sortPastMeetingsDescending(input))).toEqual(['b', 'a']);
+  });
+
+  it('prefers scheduled_start_time over start_time when both are present', () => {
+    const input = [
+      // start_time would sort this first, but scheduled_start_time (the authoritative field) is older
+      pastMeeting({ uid: 'scheduled-older', scheduled_start_time: '2026-01-01T10:00:00Z', start_time: '2026-09-01T10:00:00Z' }),
+      pastMeeting({ uid: 'scheduled-newer', scheduled_start_time: '2026-06-01T10:00:00Z', start_time: '2026-02-01T10:00:00Z' }),
+    ];
+
+    expect(uids(sortPastMeetingsDescending(input))).toEqual(['scheduled-newer', 'scheduled-older']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      pastMeeting({ uid: 'oldest', scheduled_start_time: '2026-01-01T10:00:00Z' }),
+      pastMeeting({ uid: 'newest', scheduled_start_time: '2026-03-01T10:00:00Z' }),
+    ];
+    const originalOrder = uids(input);
+
+    sortPastMeetingsDescending(input);
+
+    expect(uids(input)).toEqual(originalOrder);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(sortPastMeetingsDescending([])).toEqual([]);
+  });
+
+  it('keeps a globally descending order when pages are appended out of date order (paginated case)', () => {
+    // Mirrors the dashboard scan: a name-cursor page may arrive with meetings more recent than
+    // ones already loaded, so the merged accumulator must be re-sorted to stay most-recent-first.
+    const page1 = [
+      pastMeeting({ uid: 'p1-feb', scheduled_start_time: '2026-02-01T10:00:00Z' }),
+      pastMeeting({ uid: 'p1-jan', scheduled_start_time: '2026-01-01T10:00:00Z' }),
+    ];
+    const page2 = [
+      pastMeeting({ uid: 'p2-may', scheduled_start_time: '2026-05-01T10:00:00Z' }),
+      pastMeeting({ uid: 'p2-mar', scheduled_start_time: '2026-03-01T10:00:00Z' }),
+    ];
+
+    const merged = sortPastMeetingsDescending([...page1, ...page2]);
+
+    expect(uids(merged)).toEqual(['p2-may', 'p2-mar', 'p1-feb', 'p1-jan']);
+  });
+});

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -8,6 +8,7 @@ import {
   CustomRecurrencePattern,
   Meeting,
   MeetingOccurrence,
+  PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
   RecurrenceSummary,
@@ -342,6 +343,22 @@ export function hasMeetingEnded(meeting: Meeting, occurrence?: MeetingOccurrence
   const startTime = new Date(meeting.start_time);
   const endTime = new Date(startTime.getTime() + meeting.duration * 60000 + buffer);
   return now > endTime;
+}
+
+/**
+ * Sorts past meetings most-recent-first (descending by `scheduled_start_time`, falling back to
+ * `start_time` when absent).
+ *
+ * The upstream query-service only supports name/updated sorts — there is no `start_time` sort — so
+ * past-meeting date ordering must be applied client-side (see LFXV2-2053). Returns a new array; the
+ * input is not mutated.
+ */
+export function sortPastMeetingsDescending<T extends PastMeeting>(meetings: T[]): T[] {
+  return [...meetings].sort((a, b) => {
+    const timeA = new Date(a.scheduled_start_time ?? a.start_time).getTime();
+    const timeB = new Date(b.scheduled_start_time ?? b.start_time).getTime();
+    return timeB - timeA;
+  });
 }
 
 /**


### PR DESCRIPTION
## What & why

Past meetings rendered in the wrong order — not most-recent-first — both in the global meetings list and within the groups (committee) meetings view.

**Root cause:** the upstream query-service can't sort past meetings by date. Its `sort` enum only supports `name_asc | name_desc | updated_asc | updated_desc` — there is no `start_time` sort (`sort=name_desc` is a *name* sort, not a date sort). Upcoming meetings are already sorted client-side; past meetings had no equivalent, so they came back in name order.

## Changes

- **`packages/shared/src/utils/meeting.utils.ts`** — new `sortPastMeetingsDescending<T extends PastMeeting>()`: descending by `scheduled_start_time`, falling back to `start_time`. Non-mutating (copies before sorting).
- **`meetings-dashboard.component.ts`** — sort the **full accumulator** in the past-meetings `scan` (covers Me lens, foundation/project lens, and "Load More"). Re-sorting the merged list — not just the incoming page — keeps global most-recent-first order even though the page cursor is name-based.
- **`committee-meetings.component.ts`** (groups view) — sort the `pastMeetings` source signal; `filteredMeetings` inherits the order.
- Upcoming sort untouched (still ascending/soonest-first). Stats and calendar past signals left alone — order is irrelevant for counts/calendar events.

## Testing

New unit tests in `packages/shared/src/utils/meeting.utils.spec.ts` (6 cases, all passing): descending sort, `start_time` fallback, `scheduled_start_time` precedence, non-mutation, empty input, and an out-of-order paginated-merge case mirroring the dashboard `scan`.

Validated: `./check-headers.sh`, `yarn format:check`, `yarn lint:check`, `yarn build` all green.

JIRA: LFXV2-2053
