### PR TITLE
fix(meetings): apply guest filters to past-meeting participants

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -17,9 +17,9 @@
       </div>
 
       <!-- Filter Dropdowns -->
-      @if (!pastMeeting()) {
-        <div class="flex flex-wrap items-start gap-2">
-          <!-- RSVP Filter -->
+      <div class="flex flex-wrap items-start gap-2">
+        @if (!pastMeeting()) {
+          <!-- RSVP Filter (upcoming meetings) -->
           <lfx-select
             [form]="filterForm"
             control="rsvpFilter"
@@ -30,22 +30,46 @@
             placeholder="RSVP"
             data-testid="rsvp-filter-select">
           </lfx-select>
+        } @else {
+          <!-- Attendance Filter (past meetings) -->
+          <lfx-select
+            [form]="filterForm"
+            control="attendanceFilter"
+            [options]="attendanceFilterOptions"
+            optionLabel="label"
+            optionValue="value"
+            [styleClass]="'text-[10px]'"
+            placeholder="Attendance"
+            data-testid="attendance-filter-select">
+          </lfx-select>
 
-          <!-- Group Filter (only show if meeting has committees) -->
-          @if (hasCommittees()) {
-            <lfx-select
-              [form]="filterForm"
-              control="groupFilter"
-              [options]="groupFilterOptions()"
-              optionLabel="label"
-              optionValue="value"
-              [styleClass]="'text-[10px]'"
-              placeholder="Group"
-              data-testid="group-filter-select">
-            </lfx-select>
-          }
-        </div>
-      }
+          <!-- Invitation Filter (past meetings) -->
+          <lfx-select
+            [form]="filterForm"
+            control="invitationFilter"
+            [options]="invitationFilterOptions"
+            optionLabel="label"
+            optionValue="value"
+            [styleClass]="'text-[10px]'"
+            placeholder="Invitation"
+            data-testid="invitation-filter-select">
+          </lfx-select>
+        }
+
+        <!-- Group Filter (only show if meeting has committees) -->
+        @if (hasCommittees()) {
+          <lfx-select
+            [form]="filterForm"
+            control="groupFilter"
+            [options]="groupFilterOptions()"
+            optionLabel="label"
+            optionValue="value"
+            [styleClass]="'text-[10px]'"
+            placeholder="Group"
+            data-testid="group-filter-select">
+          </lfx-select>
+        }
+      </div>
     </div>
 
     <!-- Loading State — skeleton cards -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -8,7 +8,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
-import { CommitteeMember, EnrichedPastMeetingParticipant, Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared';
+import { CommitteeMember, EnrichedPastMeetingParticipant, Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared/interfaces';
 import { filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -301,17 +301,31 @@ export class MeetingRegistrantsDisplayComponent {
             committeeMembers$,
           ]).pipe(
             map(([participants, committeeMembers]) => {
-              const memberByEmail = new Map(committeeMembers.map((member) => [member.email?.trim().toLowerCase(), member]));
+              // A participant can sit on multiple committees, so group all member records by
+              // email rather than keeping a single last-wins entry. committeeMembers is already
+              // ordered by the meeting's committee order, so the first record is the primary one.
+              const membersByEmail = new Map<string, CommitteeMember[]>();
+              for (const member of committeeMembers) {
+                const key = member.email?.trim().toLowerCase();
+                if (!key) continue;
+                const existing = membersByEmail.get(key);
+                if (existing) {
+                  existing.push(member);
+                } else {
+                  membersByEmail.set(key, [member]);
+                }
+              }
               return participants
                 .map((participant) => {
-                  const member = memberByEmail.get(participant.email?.trim().toLowerCase());
+                  const members = membersByEmail.get(participant.email?.trim().toLowerCase()) ?? [];
+                  const primary = members[0];
                   const enriched: EnrichedPastMeetingParticipant = {
                     ...participant,
-                    committee_uid: member?.committee_uid ?? null,
-                    committee_name: member?.committee_name ?? null,
-                    committee_role: member?.role?.name ?? null,
-                    committee_voting_status: member?.voting?.status ?? null,
-                    committee_category: member?.committee_category ?? null,
+                    committee_uids: members.map((member) => member.committee_uid).filter(Boolean),
+                    committee_name: primary?.committee_name ?? null,
+                    committee_role: primary?.role?.name ?? null,
+                    committee_voting_status: primary?.voting?.status ?? null,
+                    committee_category: primary?.committee_category ?? null,
                   };
                   return enriched;
                 })

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -8,12 +8,13 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
-import { Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared';
-import { markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
+import { CommitteeMember, EnrichedPastMeetingParticipant, Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared';
+import { filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
+import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, pairwise, startWith, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, debounceTime, filter, finalize, map, of, pairwise, startWith, switchMap, take, tap } from 'rxjs';
 
 import { RegistrantFormComponent } from '../registrant-form/registrant-form.component';
 
@@ -24,6 +25,7 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 })
 export class MeetingRegistrantsDisplayComponent {
   private readonly meetingService = inject(MeetingService);
+  private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -44,7 +46,7 @@ export class MeetingRegistrantsDisplayComponent {
   private readonly optimisticRegistrants: WritableSignal<MeetingRegistrant[]> = signal<MeetingRegistrant[]>([]);
   private readonly externallyManaged: Signal<boolean> = computed(() => this.initialRegistrants() !== null);
   private readonly internalRegistrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
-  public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
+  public readonly pastMeetingParticipants: Signal<EnrichedPastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
   public readonly registrants: Signal<MeetingRegistrant[]> = this.initRegistrants();
   public readonly registrantsLoading: Signal<boolean> = computed(() => {
     if (this.externallyManaged() && !this.pastMeeting()) {
@@ -63,9 +65,14 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly searchControl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
   public readonly rsvpFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
   public readonly groupFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
+  // Past-meeting-only controls — past participants carry attendance/invitation, not RSVP responses.
+  public readonly attendanceFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
+  public readonly invitationFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
   public readonly filterForm: FormGroup = new FormGroup({
     rsvpFilter: this.rsvpFilterControl,
     groupFilter: this.groupFilterControl,
+    attendanceFilter: this.attendanceFilterControl,
+    invitationFilter: this.invitationFilterControl,
   });
 
   // Filter options
@@ -74,6 +81,18 @@ export class MeetingRegistrantsDisplayComponent {
     { label: 'Accepted', value: 'yes' },
     { label: 'Declined', value: 'no' },
     { label: 'Pending', value: 'pending' },
+  ];
+
+  // Past-meeting attendance / invitation options (mirror the past-meeting-details filters)
+  public readonly attendanceFilterOptions = [
+    { label: 'All Attendees', value: 'all' },
+    { label: 'Attended', value: 'attended' },
+    { label: 'Did Not Attend', value: 'absent' },
+  ];
+  public readonly invitationFilterOptions = [
+    { label: 'All Invites', value: 'all' },
+    { label: 'Invited', value: 'invited' },
+    { label: 'Not Invited', value: 'uninvited' },
   ];
 
   // Group (Committee) filter options computed from meeting committees
@@ -88,6 +107,8 @@ export class MeetingRegistrantsDisplayComponent {
   // Filter signals from form controls
   public readonly rsvpFilter: Signal<string> = toSignal(this.rsvpFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
   public readonly groupFilter: Signal<string> = toSignal(this.groupFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
+  public readonly attendanceFilter: Signal<string> = toSignal(this.attendanceFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
+  public readonly invitationFilter: Signal<string> = toSignal(this.invitationFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
 
   // Filtered registrants based on search and filters
   public readonly filteredRegistrants = this.initFilteredRegistrants();
@@ -258,20 +279,46 @@ export class MeetingRegistrantsDisplayComponent {
     );
   }
 
-  private initPastMeetingParticipantsList(): Signal<PastMeetingParticipant[]> {
+  private initPastMeetingParticipantsList(): Signal<EnrichedPastMeetingParticipant[]> {
     return toSignal(
       this.refresh$.pipe(
         takeUntilDestroyed(),
         filter((refresh) => refresh && this.pastMeeting()),
         switchMap(() => {
           this.internalLoading.set(true);
-          return this.meetingService
-            .getPastMeetingParticipants(this.meeting().id)
-            .pipe(catchError(() => of([])))
-            .pipe(
-              map((participants) => participants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as PastMeetingParticipant[]),
-              finalize(() => this.internalLoading.set(false))
-            );
+          const meeting = this.meeting();
+          // Past participants carry no committee association — enrich them by joining the
+          // meeting's committee members on email so the group filter has something to match.
+          const committeeUids = ((meeting as Meeting).committees || []).map((committee) => committee.uid).filter(Boolean);
+          const committeeMembers$ = committeeUids.length
+            ? combineLatest(
+                committeeUids.map((uid) => this.committeeService.getCommitteeMembers(uid).pipe(catchError(() => of([] as CommitteeMember[]))))
+              ).pipe(map((memberLists) => memberLists.flat()))
+            : of([] as CommitteeMember[]);
+
+          return combineLatest([
+            this.meetingService.getPastMeetingParticipants(meeting.id).pipe(catchError(() => of([] as PastMeetingParticipant[]))),
+            committeeMembers$,
+          ]).pipe(
+            map(([participants, committeeMembers]) => {
+              const memberByEmail = new Map(committeeMembers.map((member) => [member.email?.trim().toLowerCase(), member]));
+              return participants
+                .map((participant) => {
+                  const member = memberByEmail.get(participant.email?.trim().toLowerCase());
+                  const enriched: EnrichedPastMeetingParticipant = {
+                    ...participant,
+                    committee_uid: member?.committee_uid ?? null,
+                    committee_name: member?.committee_name ?? null,
+                    committee_role: member?.role?.name ?? null,
+                    committee_voting_status: member?.voting?.status ?? null,
+                    committee_category: member?.committee_category ?? null,
+                  };
+                  return enriched;
+                })
+                .sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0);
+            }),
+            finalize(() => this.internalLoading.set(false))
+          );
         })
       ),
       { initialValue: [] }
@@ -359,20 +406,13 @@ export class MeetingRegistrantsDisplayComponent {
   }
 
   private initFilteredPastParticipants() {
-    return computed(() => {
-      const participants = this.pastMeetingParticipants();
-      const query = this.searchQuery().toLowerCase().trim();
-
-      if (!query) {
-        return participants;
-      }
-
-      return participants.filter(
-        (participant) =>
-          participant.first_name?.toLowerCase().includes(query) ||
-          participant.last_name?.toLowerCase().includes(query) ||
-          participant.email?.toLowerCase().includes(query)
-      );
-    });
+    return computed(() =>
+      filterPastMeetingParticipants(this.pastMeetingParticipants(), {
+        search: this.searchQuery(),
+        attendance: this.attendanceFilter() as 'all' | 'attended' | 'absent',
+        invitation: this.invitationFilter() as 'all' | 'invited' | 'uninvited',
+        group: this.groupFilter(),
+      })
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -8,7 +8,16 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
-import { CommitteeMember, EnrichedPastMeetingParticipant, Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared/interfaces';
+import {
+  CommitteeMember,
+  EnrichedPastMeetingParticipant,
+  Meeting,
+  MeetingRegistrant,
+  PastMeeting,
+  PastMeetingParticipant,
+  PastParticipantAttendanceFilter,
+  PastParticipantInvitationFilter,
+} from '@lfx-one/shared/interfaces';
 import { filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -66,8 +75,12 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly rsvpFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
   public readonly groupFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
   // Past-meeting-only controls — past participants carry attendance/invitation, not RSVP responses.
-  public readonly attendanceFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
-  public readonly invitationFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
+  public readonly attendanceFilterControl: FormControl<PastParticipantAttendanceFilter> = new FormControl<PastParticipantAttendanceFilter>('all', {
+    nonNullable: true,
+  });
+  public readonly invitationFilterControl: FormControl<PastParticipantInvitationFilter> = new FormControl<PastParticipantInvitationFilter>('all', {
+    nonNullable: true,
+  });
   public readonly filterForm: FormGroup = new FormGroup({
     rsvpFilter: this.rsvpFilterControl,
     groupFilter: this.groupFilterControl,
@@ -107,8 +120,18 @@ export class MeetingRegistrantsDisplayComponent {
   // Filter signals from form controls
   public readonly rsvpFilter: Signal<string> = toSignal(this.rsvpFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
   public readonly groupFilter: Signal<string> = toSignal(this.groupFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
-  public readonly attendanceFilter: Signal<string> = toSignal(this.attendanceFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
-  public readonly invitationFilter: Signal<string> = toSignal(this.invitationFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
+  public readonly attendanceFilter: Signal<PastParticipantAttendanceFilter> = toSignal(
+    this.attendanceFilterControl.valueChanges.pipe(startWith('all' as const)),
+    {
+      initialValue: 'all',
+    }
+  );
+  public readonly invitationFilter: Signal<PastParticipantInvitationFilter> = toSignal(
+    this.invitationFilterControl.valueChanges.pipe(startWith('all' as const)),
+    {
+      initialValue: 'all',
+    }
+  );
 
   // Filtered registrants based on search and filters
   public readonly filteredRegistrants = this.initFilteredRegistrants();
@@ -423,8 +446,8 @@ export class MeetingRegistrantsDisplayComponent {
     return computed(() =>
       filterPastMeetingParticipants(this.pastMeetingParticipants(), {
         search: this.searchQuery(),
-        attendance: this.attendanceFilter() as 'all' | 'attended' | 'absent',
-        invitation: this.invitationFilter() as 'all' | 'invited' | 'uninvited',
+        attendance: this.attendanceFilter(),
+        invitation: this.invitationFilter(),
         group: this.groupFilter(),
       })
     );

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -714,8 +714,12 @@ export interface PastMeetingParticipant {
  * Past meeting participant enriched with committee membership data from meeting registrants
  */
 export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
-  /** Committee UID (from committee member data) — used to match the group filter */
-  committee_uid?: string | null;
+  /**
+   * All committee UIDs this participant belongs to (from committee member data) — used to
+   * match the group filter. An array because a participant can sit on multiple committees;
+   * the singular `committee_*` display fields below reflect the first/primary committee.
+   */
+  committee_uids?: string[] | null;
   /** Committee name (from committee member data) */
   committee_name?: string | null;
   /** Role within the committee (from committee member data) */
@@ -730,7 +734,7 @@ export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
  * Filter criteria for the past-meeting participant list.
  * @description Mirrors the upcoming-registrant filters, mapped to the fields a past
  *   participant actually carries: attendance (`is_attended`), invitation (`is_invited`),
- *   and committee association (`committee_uid`, from enrichment).
+ *   and committee association (`committee_uids`, from enrichment).
  */
 export interface PastParticipantFilters {
   /** Free-text query matched against name, email, and organization. */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -730,6 +730,11 @@ export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
   committee_category?: string | null;
 }
 
+/** Attendance filter for the past-meeting participant list. */
+export type PastParticipantAttendanceFilter = 'all' | 'attended' | 'absent';
+/** Invitation filter for the past-meeting participant list. */
+export type PastParticipantInvitationFilter = 'all' | 'invited' | 'uninvited';
+
 /**
  * Filter criteria for the past-meeting participant list.
  * @description Mirrors the upcoming-registrant filters, mapped to the fields a past
@@ -740,9 +745,9 @@ export interface PastParticipantFilters {
   /** Free-text query matched against name, email, and organization. */
   search?: string;
   /** Attendance filter: `all`, `attended` (is_attended), or `absent` (not attended). */
-  attendance?: 'all' | 'attended' | 'absent';
+  attendance?: PastParticipantAttendanceFilter;
   /** Invitation filter: `all`, `invited` (is_invited), or `uninvited` (not invited). */
-  invitation?: 'all' | 'invited' | 'uninvited';
+  invitation?: PastParticipantInvitationFilter;
   /** Committee UID to filter by, or `all` for no committee filter. */
   group?: string;
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -714,6 +714,8 @@ export interface PastMeetingParticipant {
  * Past meeting participant enriched with committee membership data from meeting registrants
  */
 export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
+  /** Committee UID (from committee member data) — used to match the group filter */
+  committee_uid?: string | null;
   /** Committee name (from committee member data) */
   committee_name?: string | null;
   /** Role within the committee (from committee member data) */
@@ -722,6 +724,23 @@ export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
   committee_voting_status?: string | null;
   /** Committee category (from committee member data) */
   committee_category?: string | null;
+}
+
+/**
+ * Filter criteria for the past-meeting participant list.
+ * @description Mirrors the upcoming-registrant filters, mapped to the fields a past
+ *   participant actually carries: attendance (`is_attended`), invitation (`is_invited`),
+ *   and committee association (`committee_uid`, from enrichment).
+ */
+export interface PastParticipantFilters {
+  /** Free-text query matched against name, email, and organization. */
+  search?: string;
+  /** Attendance filter: `all`, `attended` (is_attended), or `absent` (not attended). */
+  attendance?: 'all' | 'attended' | 'absent';
+  /** Invitation filter: `all`, `invited` (is_invited), or `uninvited` (not invited). */
+  invitation?: 'all' | 'invited' | 'uninvited';
+  /** Committee UID to filter by, or `all` for no committee filter. */
+  group?: string;
 }
 
 /**

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './form.utils';
 export * from './html-utils';
 export * from './meeting.utils';
 export * from './past-meeting-summary.utils';
+export * from './past-meeting.utils';
 export * from './rsvp-calculator.util';
 export * from './string.utils';
 export * from './url.utils';

--- a/packages/shared/src/utils/past-meeting.utils.spec.ts
+++ b/packages/shared/src/utils/past-meeting.utils.spec.ts
@@ -1,0 +1,129 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { EnrichedPastMeetingParticipant } from '../interfaces';
+import { filterPastMeetingParticipants } from './past-meeting.utils';
+
+/** Builds an EnrichedPastMeetingParticipant fixture, defaulting every field so tests set only what they assert on. */
+function participant(partial: Partial<EnrichedPastMeetingParticipant>): EnrichedPastMeetingParticipant {
+  return {
+    uid: partial.uid ?? 'uid',
+    meeting_id: partial.meeting_id ?? 'meeting-1',
+    meeting_and_occurrence_id: partial.meeting_and_occurrence_id ?? 'meeting-1-0',
+    past_meeting_id: partial.past_meeting_id ?? 'past-1',
+    email: partial.email ?? '',
+    first_name: partial.first_name ?? '',
+    last_name: partial.last_name ?? '',
+    host: partial.host ?? false,
+    job_title: partial.job_title,
+    org_name: partial.org_name,
+    is_attended: partial.is_attended ?? false,
+    is_invited: partial.is_invited ?? false,
+    org_is_member: partial.org_is_member ?? false,
+    org_is_project_member: partial.org_is_project_member ?? false,
+    avatar_url: partial.avatar_url,
+    username: partial.username,
+    created_at: partial.created_at ?? '2024-01-01T00:00:00Z',
+    updated_at: partial.updated_at ?? '2024-01-01T00:00:00Z',
+    committee_uid: partial.committee_uid ?? null,
+    committee_name: partial.committee_name ?? null,
+    committee_role: partial.committee_role ?? null,
+    committee_voting_status: partial.committee_voting_status ?? null,
+    committee_category: partial.committee_category ?? null,
+  };
+}
+
+// Attended + invited, on the "board" committee, works at Acme.
+const ada = participant({
+  uid: '1',
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  email: 'ada@example.com',
+  org_name: 'Acme',
+  is_attended: true,
+  is_invited: true,
+  committee_uid: 'board',
+});
+// Invited but did not attend, no committee.
+const bob = participant({
+  uid: '2',
+  first_name: 'Bob',
+  last_name: 'Brown',
+  email: 'bob@example.com',
+  org_name: 'Globex',
+  is_attended: false,
+  is_invited: true,
+});
+// Attended without an invite (walk-in), on the "tsc" committee.
+const cara = participant({
+  uid: '3',
+  first_name: 'Cara',
+  last_name: 'Diaz',
+  email: 'cara@example.com',
+  org_name: 'Acme',
+  is_attended: true,
+  is_invited: false,
+  committee_uid: 'tsc',
+});
+
+const everyone = [ada, bob, cara];
+
+const uids = (list: EnrichedPastMeetingParticipant[]): string[] => list.map((p) => p.uid);
+
+describe('filterPastMeetingParticipants', () => {
+  it('returns every participant when no filters are supplied', () => {
+    expect(filterPastMeetingParticipants(everyone)).toEqual(everyone);
+  });
+
+  it('returns every participant when all filters are explicitly "all"', () => {
+    expect(filterPastMeetingParticipants(everyone, { search: '', attendance: 'all', invitation: 'all', group: 'all' })).toEqual(everyone);
+  });
+
+  it('matches search against first name, last name, email, and organization', () => {
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'ada' }))).toEqual(['1']);
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'brown' }))).toEqual(['2']);
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'cara@example.com' }))).toEqual(['3']);
+    // Organization "Acme" is shared by Ada and Cara.
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'acme' }))).toEqual(['1', '3']);
+  });
+
+  it('treats search as case-insensitive and trims whitespace', () => {
+    expect(uids(filterPastMeetingParticipants(everyone, { search: '  LOVELACE  ' }))).toEqual(['1']);
+  });
+
+  it('returns an empty list when the search matches nothing', () => {
+    expect(filterPastMeetingParticipants(everyone, { search: 'nonexistent' })).toEqual([]);
+  });
+
+  it('filters by attendance', () => {
+    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended' }))).toEqual(['1', '3']);
+    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'absent' }))).toEqual(['2']);
+  });
+
+  it('filters by invitation', () => {
+    expect(uids(filterPastMeetingParticipants(everyone, { invitation: 'invited' }))).toEqual(['1', '2']);
+    expect(uids(filterPastMeetingParticipants(everyone, { invitation: 'uninvited' }))).toEqual(['3']);
+  });
+
+  it('filters by committee group', () => {
+    expect(uids(filterPastMeetingParticipants(everyone, { group: 'board' }))).toEqual(['1']);
+    expect(uids(filterPastMeetingParticipants(everyone, { group: 'tsc' }))).toEqual(['3']);
+    // No participant is associated with an unknown committee.
+    expect(filterPastMeetingParticipants(everyone, { group: 'unknown' })).toEqual([]);
+  });
+
+  it('combines search, attendance, invitation, and group with AND semantics', () => {
+    // Acme + attended + invited + board -> only Ada (Cara is uninvited, on tsc).
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'acme', attendance: 'attended', invitation: 'invited', group: 'board' }))).toEqual(['1']);
+    // Acme + attended, with no invitation/group constraint -> Ada and Cara.
+    expect(uids(filterPastMeetingParticipants(everyone, { search: 'acme', attendance: 'attended' }))).toEqual(['1', '3']);
+    // Attended + invited narrows attended (Ada, Cara) down to the invited one (Ada).
+    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended', invitation: 'invited' }))).toEqual(['1']);
+  });
+
+  it('returns an empty list when given no participants', () => {
+    expect(filterPastMeetingParticipants([], { search: 'ada' })).toEqual([]);
+  });
+});

--- a/packages/shared/src/utils/past-meeting.utils.spec.ts
+++ b/packages/shared/src/utils/past-meeting.utils.spec.ts
@@ -27,7 +27,7 @@ function participant(partial: Partial<EnrichedPastMeetingParticipant>): Enriched
     username: partial.username,
     created_at: partial.created_at ?? '2024-01-01T00:00:00Z',
     updated_at: partial.updated_at ?? '2024-01-01T00:00:00Z',
-    committee_uid: partial.committee_uid ?? null,
+    committee_uids: partial.committee_uids ?? null,
     committee_name: partial.committee_name ?? null,
     committee_role: partial.committee_role ?? null,
     committee_voting_status: partial.committee_voting_status ?? null,
@@ -44,7 +44,7 @@ const ada = participant({
   org_name: 'Acme',
   is_attended: true,
   is_invited: true,
-  committee_uid: 'board',
+  committee_uids: ['board'],
 });
 // Invited but did not attend, no committee.
 const bob = participant({
@@ -65,10 +65,21 @@ const cara = participant({
   org_name: 'Acme',
   is_attended: true,
   is_invited: false,
-  committee_uid: 'tsc',
+  committee_uids: ['tsc'],
+});
+// Sits on two committees (board + tsc) — must match the group filter for either.
+const dora = participant({
+  uid: '4',
+  first_name: 'Dora',
+  last_name: 'Evans',
+  email: 'dora@example.com',
+  org_name: 'Initech',
+  is_attended: true,
+  is_invited: true,
+  committee_uids: ['board', 'tsc'],
 });
 
-const everyone = [ada, bob, cara];
+const everyone = [ada, bob, cara, dora];
 
 const uids = (list: EnrichedPastMeetingParticipant[]): string[] => list.map((p) => p.uid);
 
@@ -98,29 +109,36 @@ describe('filterPastMeetingParticipants', () => {
   });
 
   it('filters by attendance', () => {
-    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended' }))).toEqual(['1', '3']);
+    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended' }))).toEqual(['1', '3', '4']);
     expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'absent' }))).toEqual(['2']);
   });
 
   it('filters by invitation', () => {
-    expect(uids(filterPastMeetingParticipants(everyone, { invitation: 'invited' }))).toEqual(['1', '2']);
+    expect(uids(filterPastMeetingParticipants(everyone, { invitation: 'invited' }))).toEqual(['1', '2', '4']);
     expect(uids(filterPastMeetingParticipants(everyone, { invitation: 'uninvited' }))).toEqual(['3']);
   });
 
-  it('filters by committee group', () => {
-    expect(uids(filterPastMeetingParticipants(everyone, { group: 'board' }))).toEqual(['1']);
-    expect(uids(filterPastMeetingParticipants(everyone, { group: 'tsc' }))).toEqual(['3']);
+  it('filters by committee group, including participants on multiple committees', () => {
+    // Dora (4) sits on both board and tsc, so she matches either group.
+    expect(uids(filterPastMeetingParticipants(everyone, { group: 'board' }))).toEqual(['1', '4']);
+    expect(uids(filterPastMeetingParticipants(everyone, { group: 'tsc' }))).toEqual(['3', '4']);
     // No participant is associated with an unknown committee.
     expect(filterPastMeetingParticipants(everyone, { group: 'unknown' })).toEqual([]);
   });
 
+  it('excludes participants with no committee association from any specific group', () => {
+    // Bob (2) has committee_uids null — he never matches a specific group, only "all".
+    expect(uids(filterPastMeetingParticipants([bob], { group: 'board' }))).toEqual([]);
+    expect(uids(filterPastMeetingParticipants([bob], { group: 'all' }))).toEqual(['2']);
+  });
+
   it('combines search, attendance, invitation, and group with AND semantics', () => {
-    // Acme + attended + invited + board -> only Ada (Cara is uninvited, on tsc).
+    // Acme + attended + invited + board -> only Ada (Cara is uninvited, Dora is Initech).
     expect(uids(filterPastMeetingParticipants(everyone, { search: 'acme', attendance: 'attended', invitation: 'invited', group: 'board' }))).toEqual(['1']);
     // Acme + attended, with no invitation/group constraint -> Ada and Cara.
     expect(uids(filterPastMeetingParticipants(everyone, { search: 'acme', attendance: 'attended' }))).toEqual(['1', '3']);
-    // Attended + invited narrows attended (Ada, Cara) down to the invited one (Ada).
-    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended', invitation: 'invited' }))).toEqual(['1']);
+    // Attended + invited -> Ada and Dora (Cara is uninvited).
+    expect(uids(filterPastMeetingParticipants(everyone, { attendance: 'attended', invitation: 'invited' }))).toEqual(['1', '4']);
   });
 
   it('returns an empty list when given no participants', () => {

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { EnrichedPastMeetingParticipant, PastParticipantFilters } from '../interfaces';
+
+/**
+ * Filters past-meeting participants by search, attendance, invitation, and committee group.
+ *
+ * The past-meeting guest list reuses the upcoming-registrant filter UI, but past
+ * participants carry different fields: they have no RSVP response, only attendance
+ * (`is_attended`) and invitation (`is_invited`) flags, plus an optional committee
+ * association attached during enrichment (`committee_uid`). This mirrors the upcoming
+ * `initFilteredRegistrants` logic against those fields. Each criterion defaults to
+ * "all" when omitted, so a call with no filters returns the full list.
+ *
+ * @param participants - The (optionally enriched) past participants to filter.
+ * @param filters - The active filter criteria; any omitted criterion is treated as `all`.
+ * @returns The participants matching every active criterion, in input order.
+ */
+export function filterPastMeetingParticipants(
+  participants: EnrichedPastMeetingParticipant[],
+  filters: PastParticipantFilters = {}
+): EnrichedPastMeetingParticipant[] {
+  const query = (filters.search ?? '').toLowerCase().trim();
+  const attendance = filters.attendance ?? 'all';
+  const invitation = filters.invitation ?? 'all';
+  const group = filters.group ?? 'all';
+
+  return participants.filter((participant) => {
+    const matchesSearch =
+      !query ||
+      !!participant.first_name?.toLowerCase().includes(query) ||
+      !!participant.last_name?.toLowerCase().includes(query) ||
+      !!participant.email?.toLowerCase().includes(query) ||
+      !!participant.org_name?.toLowerCase().includes(query);
+
+    let matchesAttendance = true;
+    if (attendance === 'attended') {
+      matchesAttendance = participant.is_attended === true;
+    } else if (attendance === 'absent') {
+      matchesAttendance = participant.is_attended === false;
+    }
+
+    let matchesInvitation = true;
+    if (invitation === 'invited') {
+      matchesInvitation = participant.is_invited === true;
+    } else if (invitation === 'uninvited') {
+      matchesInvitation = participant.is_invited === false;
+    }
+
+    const matchesGroup = group === 'all' || participant.committee_uid === group;
+
+    return matchesSearch && matchesAttendance && matchesInvitation && matchesGroup;
+  });
+}

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -8,10 +8,11 @@ import { EnrichedPastMeetingParticipant, PastParticipantFilters } from '../inter
  *
  * The past-meeting guest list reuses the upcoming-registrant filter UI, but past
  * participants carry different fields: they have no RSVP response, only attendance
- * (`is_attended`) and invitation (`is_invited`) flags, plus an optional committee
- * association attached during enrichment (`committee_uid`). This mirrors the upcoming
- * `initFilteredRegistrants` logic against those fields. Each criterion defaults to
- * "all" when omitted, so a call with no filters returns the full list.
+ * (`is_attended`) and invitation (`is_invited`) flags, plus the committee UIDs attached
+ * during enrichment (`committee_uids`). This mirrors the upcoming `initFilteredRegistrants`
+ * logic against those fields. Each criterion defaults to "all" when omitted, so a call with
+ * no filters returns the full list. A participant on multiple committees matches the group
+ * filter for any of them.
  *
  * @param participants - The (optionally enriched) past participants to filter.
  * @param filters - The active filter criteria; any omitted criterion is treated as `all`.
@@ -48,7 +49,7 @@ export function filterPastMeetingParticipants(
       matchesInvitation = participant.is_invited === false;
     }
 
-    const matchesGroup = group === 'all' || participant.committee_uid === group;
+    const matchesGroup = group === 'all' || (participant.committee_uids?.includes(group) ?? false);
 
     return matchesSearch && matchesAttendance && matchesInvitation && matchesGroup;
   });


### PR DESCRIPTION
## Summary

Opening **Guests** on a past meeting appeared to "lose all the filters" — the RSVP/group filters that work for upcoming meetings did nothing, and the filter dropdowns were hidden entirely for past meetings.

Root cause: past-meeting guests used a search-only filter path, and the template gated the filter UI behind `@if (!pastMeeting())`. Past participants (`PastMeetingParticipant`) also carry no RSVP response and no committee association, so the upcoming-registrant filters can't be mirrored 1:1.

## Changes

- **Past-meeting filter UI is now shown**, mapped to the fields a past participant actually has:
  - **Attendance** filter — All / Attended / Did Not Attend (`is_attended`)
  - **Invitation** filter — All / Invited / Not Invited (`is_invited`)
  - These mirror the `past-meeting-details` screen. The RSVP dropdown stays upcoming-only.
- **Group (committee) filter now works for past meetings.** Past participants are enriched with committee data by joining the meeting's committee members on email. A guest can sit on **multiple** committees, so enrichment collects all committee UIDs into `committee_uids[]` and the group filter matches membership for any of them.
- Filter logic extracted to a pure, fully unit-tested `filterPastMeetingParticipants()` in `@lfx-one/shared`.
- Upcoming-meeting behavior is unchanged.

## Files

- `meeting-registrants-display.component.{ts,html}` — past-meeting filter controls + committee enrichment
- `packages/shared/src/interfaces/meeting.interface.ts` — `committee_uids` on `EnrichedPastMeetingParticipant`, new `PastParticipantFilters`
- `packages/shared/src/utils/past-meeting.utils.ts` (+ spec) — the filter util, 11 vitest cases (search/attendance/invitation/group, multi-committee, no-committee, AND-combination, empty input)

## Testing

- `yarn check-types`, `yarn lint:check`, `yarn build`, shared `vitest` — all green.
- Reviewed clean by the post-commit + full-branch convention/learnings sweeps.

## Status

**Draft** — pending batch integration validation (tested together with LFXV2-2053). Will mark ready-for-review once that passes.

Jira: [LFXV2-2055](https://linuxfoundation.atlassian.net/browse/LFXV2-2055)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2055]: https://linuxfoundation.atlassian.net/browse/LFXV2-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ