### PR TITLE
feat: added stripe key env variable to chart values

### DIFF
--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -383,3 +383,7 @@ environment:
   # HubSpot Configuration (Campaign UTM Tracking)
   HUBSPOT_ACCESS_TOKEN:
     value:
+
+  # Stripe publishable key
+  STRIPE_PUBLISHABLE_KEY:
+    value:


### PR DESCRIPTION
## Description
  
  Adds the `STRIPE_PUBLISHABLE_KEY` environment variable to the Helm
  chart's `values.yaml` so the Stripe publishable key can be configured
  per environment.

  The server already reads this variable (`server.ts`) to expose the
  publishable key to the frontend's Stripe Elements integration introduced
  in the crowdfunding add-payment-card drawer (#797). Without it declared
  in the chart, the key resolves to an empty string in deployed
  environments and the payment card form cannot initialize Stripe.

  ## Changes
  
  - Declare `STRIPE_PUBLISHABLE_KEY` under `environment` in
    `charts/lfx-self-serve/values.yaml`

  ## Testing
  
  - Set `STRIPE_PUBLISHABLE_KEY` in the deployment values and confirm the
    value flows through to `runtimeConfig.stripePublishableKey` and the
    Stripe Elements card form initializes.

  ## Notes
  
  - Value is intentionally left blank in `values.yaml`; the real key is
    injected per environment via deployment configuration / secrets.
