### PR TITLE
fix(campaigns): add breadcrumb and fix metrics parsing

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -1,10 +1,36 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6 p-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-xl font-semibold text-gray-900">Campaigns</h1>
+<div class="flex flex-col gap-6 p-6" data-testid="campaigns-page">
+  <!-- Header -->
+  <div class="flex flex-col gap-3">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center gap-2 text-sm" aria-label="Breadcrumb" data-testid="campaigns-breadcrumb">
+      <span class="text-gray-400">Campaigns</span>
+      <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
+      <span class="text-gray-400">Paid Performance</span>
+      <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
+      <span class="font-semibold text-gray-900">Events Campaigns</span>
+    </nav>
+
+    <!-- Platform & Use Case Selectors -->
+    <div class="flex items-center gap-3" data-testid="campaigns-selectors">
+      <select
+        class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
+        disabled
+        data-testid="campaigns-platform-select">
+        <option>Paid Performance</option>
+      </select>
+      <select
+        class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
+        disabled
+        data-testid="campaigns-usecase-select">
+        <option>Events Campaigns</option>
+      </select>
+    </div>
   </div>
+
+  <hr class="border-gray-200" />
 
   <!-- Tab Navigation -->
   <div class="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Campaign tabs" data-testid="campaigns-tab-nav">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -4,6 +4,7 @@
 <div class="flex flex-col gap-6 p-6" data-testid="campaigns-page">
   <!-- Header -->
   <div class="flex flex-col gap-3">
+    <h1 class="sr-only">Events Campaigns</h1>
     <!-- Breadcrumb -->
     <nav class="flex items-center gap-2 text-sm" aria-label="Breadcrumb" data-testid="campaigns-breadcrumb">
       <span class="text-gray-400">Campaigns</span>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -10,7 +10,7 @@
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
       <span class="text-gray-400">Paid Performance</span>
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
-      <span class="font-semibold text-gray-900">Events Campaigns</span>
+      <span class="font-semibold text-gray-900" aria-current="page">Events Campaigns</span>
     </nav>
 
     <!-- Platform & Use Case Selectors -->
@@ -18,12 +18,14 @@
       <select
         class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
         disabled
+        aria-label="Campaign platform"
         data-testid="campaigns-platform-select">
         <option>Paid Performance</option>
       </select>
       <select
         class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
         disabled
+        aria-label="Campaign use case"
         data-testid="campaigns-usecase-select">
         <option>Events Campaigns</option>
       </select>

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { parseCampaignName } from '@lfx-one/shared/constants';
+import { GADS_STATUS_ENUM, parseCampaignName, VALID_CAMPAIGN_STATUSES } from '@lfx-one/shared/constants';
 import type {
   AudienceBucket,
   AudienceDemographics,
@@ -38,10 +38,12 @@ export class CampaignMetricsService {
       FROM campaign
       WHERE segments.date DURING ${gaqlRange}
         AND campaign.advertising_channel_type IN ('SEARCH', 'DEMAND_GEN')
+        AND campaign.status IN ('ENABLED', 'PAUSED')
+        AND metrics.impressions > 0
       ORDER BY metrics.cost_micros DESC`;
 
     const rows = await gaqlSearch(query);
-    const campaigns = rows.map((row) => parseCampaignMetrics(row, effectiveDays));
+    const campaigns = rows.map((row) => parseCampaignMetrics(row, effectiveDays)).filter((c) => !c.name.toLowerCase().startsWith('zz'));
     const actionItems = generateActionItems(campaigns);
 
     return {
@@ -70,7 +72,7 @@ export class CampaignMetricsService {
       FROM keyword_view
       WHERE segments.date DURING ${gaqlRange}
       ORDER BY metrics.impressions DESC
-      LIMIT 200`;
+      LIMIT 50`;
 
     const rows = await gaqlSearch(query);
     const keywords = rows.map(parseKeywordRow);
@@ -104,8 +106,8 @@ export class CampaignMetricsService {
 
     const [ageRows, genderRows, deviceRows] = await Promise.all([gaqlSearch(ageQuery), gaqlSearch(genderQuery), gaqlSearch(deviceQuery)]);
 
-    const age = aggregateDemoBuckets(ageRows, (r) => (extractNested(r, 'adGroupCriterion.ageRange.type') as string) || 'Unknown');
-    const gender = aggregateDemoBuckets(genderRows, (r) => (extractNested(r, 'adGroupCriterion.gender.type') as string) || 'Unknown');
+    const age = aggregateDemoBuckets(ageRows, (r) => (extractNested(r, 'ad_group_criterion.age_range.type') as string) || 'Unknown');
+    const gender = aggregateDemoBuckets(genderRows, (r) => (extractNested(r, 'ad_group_criterion.gender.type') as string) || 'Unknown');
     const device = aggregateDemoBuckets(deviceRows, (r) => (extractNested(r, 'segments.device') as string) || 'Unknown');
 
     return { pulledAt: new Date().toISOString(), days: effectiveDays, age, gender, device };
@@ -131,10 +133,11 @@ function extractNested(obj: unknown, path: string): unknown {
   return current;
 }
 
-const VALID_CAMPAIGN_STATUSES = new Set<CampaignMetrics['status']>(['enabled', 'paused', 'removed', 'limited', 'draft']);
-
-function normalizeCampaignStatus(raw: string | undefined): CampaignMetrics['status'] {
-  const status = (raw ?? 'unknown').toLowerCase() as CampaignMetrics['status'];
+function normalizeCampaignStatus(raw: unknown): CampaignMetrics['status'] {
+  if (typeof raw === 'number' || (typeof raw === 'string' && /^\d+$/.test(raw))) {
+    return GADS_STATUS_ENUM[Number(raw)] ?? 'unknown';
+  }
+  const status = String(raw ?? 'unknown').toLowerCase() as CampaignMetrics['status'];
   return VALID_CAMPAIGN_STATUSES.has(status) ? status : 'unknown';
 }
 
@@ -159,8 +162,8 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
   const name = (extractNested(r, 'campaign.name') as string) || '';
   const parsed = parseCampaignName(name);
   const campaignId = String(extractNested(r, 'campaign.id') || '');
-  const budgetMicros = Number(extractNested(r, 'campaignBudget.amountMicros') || 0);
-  const costMicros = Number(extractNested(r, 'metrics.costMicros') || 0);
+  const budgetMicros = Number(extractNested(r, 'campaign_budget.amount_micros') || 0);
+  const costMicros = Number(extractNested(r, 'metrics.cost_micros') || 0);
   const impressions = Number(extractNested(r, 'metrics.impressions') || 0);
   const clicks = Number(extractNested(r, 'metrics.clicks') || 0);
   const conversions = Number(extractNested(r, 'metrics.conversions') || 0);
@@ -169,8 +172,8 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
   const expectedSpend = budgetDay * days;
   const pacingPct = expectedSpend > 0 ? Math.round((spend / expectedSpend) * 100) : 0;
 
-  const startDate = (extractNested(r, 'campaign.startDate') as string) || '';
-  const endDate = (extractNested(r, 'campaign.endDate') as string) || '';
+  const startDate = (extractNested(r, 'campaign.start_date') as string) || '';
+  const endDate = (extractNested(r, 'campaign.end_date') as string) || '';
 
   let pacingLabel: PacingLabel = 'normal';
   if (pacingPct < 50) pacingLabel = 'underspending';
@@ -183,7 +186,7 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
     eventName: parsed.baseName,
     adFormat: parsed.adFormat,
     targeting: parsed.targeting,
-    status: normalizeCampaignStatus(extractNested(r, 'campaign.status') as string | undefined),
+    status: normalizeCampaignStatus(extractNested(r, 'campaign.status')),
     startDate,
     endDate,
     budgetDay,
@@ -355,17 +358,17 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
 
 function parseKeywordRow(row: unknown): KeywordMetrics {
   const r = row as Record<string, unknown>;
-  const costMicros = Number(extractNested(r, 'metrics.costMicros') || 0);
+  const costMicros = Number(extractNested(r, 'metrics.cost_micros') || 0);
   const clicks = Number(extractNested(r, 'metrics.clicks') || 0);
   const campaignId = String(extractNested(r, 'campaign.id') || '');
   return {
-    keyword: (extractNested(r, 'adGroupCriterion.keyword.text') as string) || '',
-    matchType: (extractNested(r, 'adGroupCriterion.keyword.matchType') as string) || '',
-    qualityScore: (extractNested(r, 'adGroupCriterion.qualityInfo.qualityScore') as number) ?? null,
-    status: (extractNested(r, 'adGroupCriterion.status') as string) || '',
-    adGroup: (extractNested(r, 'adGroup.name') as string) || '',
-    adGroupId: String(extractNested(r, 'adGroup.id') || ''),
-    criterionId: String(extractNested(r, 'adGroupCriterion.criterionId') || ''),
+    keyword: (extractNested(r, 'ad_group_criterion.keyword.text') as string) || '',
+    matchType: (extractNested(r, 'ad_group_criterion.keyword.match_type') as string) || '',
+    qualityScore: (extractNested(r, 'ad_group_criterion.quality_info.quality_score') as number) ?? null,
+    status: (extractNested(r, 'ad_group_criterion.status') as string) || '',
+    adGroup: (extractNested(r, 'ad_group.name') as string) || '',
+    adGroupId: String(extractNested(r, 'ad_group.id') || ''),
+    criterionId: String(extractNested(r, 'ad_group_criterion.criterion_id') || ''),
     campaign: (extractNested(r, 'campaign.name') as string) || '',
     campaignId,
     googleAdsUrl: buildGoogleAdsUrl(campaignId),
@@ -387,7 +390,7 @@ function aggregateDemoBuckets(rows: unknown[], labelExtractor: (row: Record<stri
     const existing = buckets.get(label) || { label, impressions: 0, clicks: 0, ctr: 0, spend: 0, conversions: 0 };
     existing.impressions += Number(extractNested(r, 'metrics.impressions') || 0);
     existing.clicks += Number(extractNested(r, 'metrics.clicks') || 0);
-    existing.spend += Number(extractNested(r, 'metrics.costMicros') || 0) / 1_000_000;
+    existing.spend += Number(extractNested(r, 'metrics.cost_micros') || 0) / 1_000_000;
     existing.conversions += Number(extractNested(r, 'metrics.conversions') || 0);
     existing.ctr = existing.impressions > 0 ? (existing.clicks / existing.impressions) * 100 : 0;
     buckets.set(label, existing);

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -34,7 +34,7 @@ export class CampaignMetricsService {
              campaign.start_date, campaign.end_date,
              campaign_budget.amount_micros,
              metrics.impressions, metrics.clicks, metrics.cost_micros,
-             metrics.conversions, metrics.ctr, metrics.average_cpc
+             metrics.conversions
       FROM campaign
       WHERE segments.date DURING ${gaqlRange}
         AND campaign.advertising_channel_type IN ('SEARCH', 'DEMAND_GEN')

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CampaignGoalOption, CampaignPlatformOption, CampaignTabOption, ParsedCampaignName } from '../interfaces/campaign.interface';
+import type { CampaignGoalOption, CampaignPlatformOption, CampaignStatus, CampaignTabOption, ParsedCampaignName } from '../interfaces/campaign.interface';
 
 /** Tab definitions for the Campaigns page tab navigation. */
 export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
@@ -61,6 +61,14 @@ export const CAMPAIGN_BUDGET_DEFAULTS = {
   searchBudgetPct: 70,
   displayBudgetPct: 30,
 } as const;
+
+export const VALID_CAMPAIGN_STATUSES = new Set<CampaignStatus>(['enabled', 'paused', 'removed', 'limited', 'draft']);
+
+export const GADS_STATUS_ENUM: Partial<Record<number, CampaignStatus>> = {
+  2: 'enabled',
+  3: 'paused',
+  4: 'removed',
+};
 
 // ---------------------------------------------------------------------------
 // Campaign Name Convention

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -62,7 +62,7 @@ export const CAMPAIGN_BUDGET_DEFAULTS = {
   displayBudgetPct: 30,
 } as const;
 
-export const VALID_CAMPAIGN_STATUSES = new Set<CampaignStatus>(['enabled', 'paused', 'removed', 'limited', 'draft']);
+export const VALID_CAMPAIGN_STATUSES: ReadonlySet<CampaignStatus> = new Set<CampaignStatus>(['enabled', 'paused', 'removed', 'limited', 'draft']);
 
 export const GADS_STATUS_ENUM: Partial<Record<number, CampaignStatus>> = {
   2: 'enabled',


### PR DESCRIPTION
## Summary
- Replace plain "Campaigns" h1 with breadcrumb navigation (`Campaigns > Paid Performance > Events Campaigns`) and disabled platform/use-case selector dropdowns
- Fix campaign-metrics.service.ts bugs shipped in PR #846:
  - Use snake_case paths in `extractNested()` to match Google Ads API response keys (was using camelCase, causing all metrics to return $0.00)
  - Widen GAQL filter to `campaign.status IN ('ENABLED', 'PAUSED')` so `generateActionItems()` can surface paused-campaign alerts (REMOVED campaigns excluded since they have no actionable state)
  - Add `metrics.impressions > 0` GAQL filter
  - Filter out `zz`-prefixed test campaigns from results
  - Fix `normalizeCampaignStatus` to handle non-string enum values from API
  - Reduce keyword limit from 200 to 50

LFXV2-2033

🤖 Generated with [Claude Code](https://claude.ai/code)