### PR TITLE
feat(campaigns): add optimization tab with keyword actions

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -44,8 +44,8 @@
         <lfx-implementation-tab [briefData]="briefOutput()" data-testid="campaigns-implementation-tab" />
       } @else if (tab.id === 'insights') {
         <lfx-monitoring-tab data-testid="campaigns-insights-tab" />
-      } @else {
-        <p class="text-sm text-gray-500">{{ tab.label }} tab content will be added in subsequent PRs.</p>
+      } @else if (tab.id === 'optimization') {
+        <lfx-optimization-tab data-testid="campaigns-optimization-tab" />
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -9,11 +9,12 @@ import type { CampaignBriefOutput, CampaignTab } from '@lfx-one/shared/interface
 
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
 import { MonitoringTabComponent } from './components/monitoring-tab/monitoring-tab.component';
+import { OptimizationTabComponent } from './components/optimization-tab/optimization-tab.component';
 import { PlanningTabComponent } from './components/planning-tab/planning-tab.component';
 
 @Component({
   selector: 'lfx-campaigns',
-  imports: [PlanningTabComponent, ImplementationTabComponent, MonitoringTabComponent],
+  imports: [PlanningTabComponent, ImplementationTabComponent, MonitoringTabComponent, OptimizationTabComponent],
   templateUrl: './campaigns.component.html',
   styleUrl: './campaigns.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -1,0 +1,390 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="optimization-tab">
+  <!-- Controls -->
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-2" data-testid="optimization-date-range">
+      @for (days of dateRangeOptions; track days) {
+        <button
+          type="button"
+          (click)="setDateRange(days)"
+          [class]="
+            selectedDays() === days
+              ? 'rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white'
+              : 'rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200'
+          "
+          [attr.data-testid]="'optimization-range-' + days">
+          {{ days }}d
+        </button>
+      }
+    </div>
+    <div class="flex items-center gap-3">
+      @if (pulledAt()) {
+        <span class="text-xs text-gray-400" data-testid="optimization-pulled-at">Last pulled: {{ pulledAt() }}</span>
+      }
+      <button
+        type="button"
+        (click)="refresh()"
+        [disabled]="loading()"
+        class="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        data-testid="optimization-refresh"
+        aria-label="Refresh optimization data">
+        <i class="fa-light fa-arrows-rotate" [class.fa-spin]="loading()" aria-hidden="true"></i>
+        Refresh
+      </button>
+    </div>
+  </div>
+
+  @if (loading() && !monitorData()) {
+    <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-12" data-testid="optimization-loading">
+      <div class="flex items-center gap-2 text-sm text-gray-500">
+        <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+        Loading optimization data...
+      </div>
+    </div>
+  } @else if (error()) {
+    <div class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-red-300 bg-red-50 p-12" data-testid="optimization-error">
+      <i class="fa-light fa-triangle-exclamation text-3xl text-red-400" aria-hidden="true"></i>
+      <p class="text-sm font-medium text-red-700">Failed to load optimization data</p>
+      <p class="max-w-md text-center text-xs text-red-500">{{ error() }}</p>
+      <button
+        type="button"
+        (click)="fetchData()"
+        class="mt-2 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
+        data-testid="optimization-retry">
+        Retry
+      </button>
+    </div>
+  } @else if (!hasCampaigns()) {
+    <div
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-12"
+      data-testid="optimization-empty">
+      <i class="fa-light fa-gauge-high text-3xl text-gray-400" aria-hidden="true"></i>
+      <p class="text-sm text-gray-500">No active campaigns found for the selected date range.</p>
+    </div>
+  } @else {
+    <!-- Summary Cards -->
+    <div class="grid grid-cols-2 gap-4 md:grid-cols-4" data-testid="optimization-summary">
+      <div class="rounded-lg border border-gray-200 bg-white p-4">
+        <p class="text-xs font-medium text-gray-500">Action Items</p>
+        <p class="text-lg font-semibold text-gray-900">{{ actionItems().length }}</p>
+      </div>
+      <div class="rounded-lg border border-red-200 bg-red-50 p-4">
+        <p class="text-xs font-medium text-red-600">High Priority</p>
+        <p class="text-lg font-semibold text-red-700" data-testid="optimization-high-count">{{ highCount() }}</p>
+      </div>
+      <div class="rounded-lg border border-amber-200 bg-amber-50 p-4">
+        <p class="text-xs font-medium text-amber-600">Medium Priority</p>
+        <p class="text-lg font-semibold text-amber-700" data-testid="optimization-med-count">{{ medCount() }}</p>
+      </div>
+      <div class="rounded-lg border border-gray-200 bg-white p-4">
+        <p class="text-xs font-medium text-gray-500">Active Campaigns</p>
+        <p class="text-lg font-semibold text-gray-900">{{ campaigns().length }}</p>
+      </div>
+    </div>
+
+    <!-- Action Items Table -->
+    @if (hasActionItems()) {
+      <div class="flex flex-col gap-3" data-testid="optimization-action-items">
+        <h4 class="text-sm font-semibold text-gray-900">Action Items</h4>
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 bg-gray-50">
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Priority</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Campaign</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Issue</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Recommended Action</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Spend</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Pacing</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (item of actionItems(); track $index) {
+                  <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'action-item-row-' + $index">
+                    <td class="px-4 py-3">
+                      <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" [class]="priorityClass(item.priority)">
+                        {{ item.priority }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <p class="font-medium text-gray-900">{{ item.eventName || item.campaigns[0] }}</p>
+                    </td>
+                    <td class="px-4 py-3 text-gray-700">{{ item.issue }}</td>
+                    <td class="px-4 py-3 text-gray-700">{{ item.action }}</td>
+                    <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(item.metrics.spend) }}</td>
+                    <td class="px-4 py-3 text-right">
+                      <span
+                        class="text-sm font-medium"
+                        [class]="item.metrics.pacingPct < 50 ? 'text-red-600' : item.metrics.pacingPct > 100 ? 'text-red-600' : 'text-gray-700'">
+                        {{ item.metrics.pacingPct }}%
+                      </span>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    } @else {
+      <div
+        class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-green-300 bg-green-50 p-8"
+        data-testid="optimization-no-actions">
+        <i class="fa-light fa-circle-check text-2xl text-green-500" aria-hidden="true"></i>
+        <p class="text-sm font-medium text-green-700">All campaigns are performing well</p>
+        <p class="text-xs text-green-600">No action items detected for the selected date range.</p>
+      </div>
+    }
+
+    <!-- Wasted Keyword Spend -->
+    <div class="flex flex-col gap-3" data-testid="optimization-wasted-keywords">
+      <div class="flex items-center gap-2">
+        <h4 class="text-sm font-semibold text-gray-900">Keywords Spending Without Conversions</h4>
+        @if (hasWastedKeywords()) {
+          <span class="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">{{ wastedKeywords().length }}</span>
+        }
+      </div>
+      @if (keywordsLoading() && !keywordsData()) {
+        <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-8">
+          <div class="flex items-center gap-2 text-sm text-gray-500">
+            <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+            Loading keyword data...
+          </div>
+        </div>
+      } @else if (!hasWastedKeywords()) {
+        <div class="flex items-center gap-2 rounded-lg border border-dashed border-green-300 bg-green-50 px-4 py-3">
+          <i class="fa-light fa-circle-check text-green-500" aria-hidden="true"></i>
+          <p class="text-sm text-green-700">All keywords with spend are generating conversions.</p>
+        </div>
+      } @else {
+        <div class="flex justify-end">
+          <button
+            type="button"
+            (click)="bulkKeywordAction(wastedKeywords(), 'pause')"
+            class="flex items-center gap-1.5 rounded-md border border-red-300 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-100"
+            data-testid="optimization-bulk-pause-wasted">
+            <i class="fa-light fa-pause" aria-hidden="true"></i>
+            Pause All ({{ wastedKeywords().length }})
+          </button>
+        </div>
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 bg-gray-50">
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Keyword</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Match</th>
+                  <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">QS</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Campaign</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Spend</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Clicks</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">CTR</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Avg CPC</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Conv.</th>
+                  <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (kw of wastedKeywords(); track kw.keyword + '-' + kw.campaignId) {
+                  <tr class="border-b border-gray-100 last:border-0">
+                    <td class="px-4 py-2.5">
+                      <p class="font-medium text-gray-900">{{ kw.keyword }}</p>
+                    </td>
+                    <td class="px-4 py-2.5">
+                      <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                        {{ kw.matchType }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-center">
+                      <span class="text-sm font-medium" [class]="qualityScoreClass(kw.qualityScore)">
+                        {{ kw.qualityScore ?? '–' }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ eventLabel(kw.campaign) }}</td>
+                    <td class="px-4 py-2.5 text-right font-medium text-red-600">{{ formatCurrency(kw.spend) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatPct(kw.ctr) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.avgCpc) }}</td>
+                    <td class="px-4 py-2.5 text-right font-medium text-red-600">0</td>
+                    <td class="px-4 py-2.5 text-center">
+                      @if (getActionResult(kw); as result) {
+                        <span class="text-xs font-medium" [class]="result.success ? 'text-green-600' : 'text-red-600'">
+                          {{ result.success ? 'Done' : 'Failed' }}
+                        </span>
+                      } @else if (isActionInProgress(kw)) {
+                        <i class="fa-light fa-spinner-third fa-spin text-gray-400" aria-hidden="true"></i>
+                      } @else {
+                        <div class="flex items-center justify-center gap-1">
+                          <button
+                            type="button"
+                            (click)="executeKeywordAction(kw, 'pause')"
+                            class="rounded px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50"
+                            title="Pause this keyword">
+                            <i class="fa-light fa-pause" aria-hidden="true"></i>
+                          </button>
+                          <button
+                            type="button"
+                            (click)="executeKeywordAction(kw, 'remove')"
+                            class="rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+                            title="Remove this keyword">
+                            <i class="fa-light fa-trash" aria-hidden="true"></i>
+                          </button>
+                        </div>
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      }
+    </div>
+
+    <!-- Low Quality Score Keywords -->
+    @if (hasLowQualityKeywords()) {
+      <div class="flex flex-col gap-3" data-testid="optimization-low-qs">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <h4 class="text-sm font-semibold text-gray-900">Low Quality Score Keywords</h4>
+            <span class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">{{ lowQualityKeywords().length }}</span>
+          </div>
+          <button
+            type="button"
+            (click)="bulkKeywordAction(lowQualityKeywords(), 'pause')"
+            class="flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-100"
+            data-testid="optimization-bulk-pause-low-qs">
+            <i class="fa-light fa-pause" aria-hidden="true"></i>
+            Pause All ({{ lowQualityKeywords().length }})
+          </button>
+        </div>
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 bg-gray-50">
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Keyword</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Match</th>
+                  <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">Quality Score</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Campaign</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Impr.</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Clicks</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Spend</th>
+                  <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (kw of lowQualityKeywords(); track kw.keyword + '-' + kw.campaignId) {
+                  <tr class="border-b border-gray-100 last:border-0">
+                    <td class="px-4 py-2.5 font-medium text-gray-900">{{ kw.keyword }}</td>
+                    <td class="px-4 py-2.5">
+                      <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                        {{ kw.matchType }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-center">
+                      <span class="text-sm font-semibold" [class]="qualityScoreClass(kw.qualityScore)"> {{ kw.qualityScore }}/10 </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ eventLabel(kw.campaign) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.impressions) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.spend) }}</td>
+                    <td class="px-4 py-2.5 text-center">
+                      @if (getActionResult(kw); as result) {
+                        <span class="text-xs font-medium" [class]="result.success ? 'text-green-600' : 'text-red-600'">
+                          {{ result.success ? 'Done' : 'Failed' }}
+                        </span>
+                      } @else if (isActionInProgress(kw)) {
+                        <i class="fa-light fa-spinner-third fa-spin text-gray-400" aria-hidden="true"></i>
+                      } @else {
+                        <div class="flex items-center justify-center gap-1">
+                          <button
+                            type="button"
+                            (click)="executeKeywordAction(kw, 'pause')"
+                            class="rounded px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50"
+                            title="Pause this keyword">
+                            <i class="fa-light fa-pause" aria-hidden="true"></i>
+                          </button>
+                          <button
+                            type="button"
+                            (click)="executeKeywordAction(kw, 'remove')"
+                            class="rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+                            title="Remove this keyword">
+                            <i class="fa-light fa-trash" aria-hidden="true"></i>
+                          </button>
+                        </div>
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- Display Campaign Performance -->
+    @if (hasDisplayCampaigns()) {
+      <div class="flex flex-col gap-3" data-testid="optimization-display-campaigns">
+        <div class="flex items-center gap-2">
+          <h4 class="text-sm font-semibold text-gray-900">Display / Demand Gen Campaign Performance</h4>
+          <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">{{ displayCampaigns().length }}</span>
+        </div>
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 bg-gray-50">
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Campaign</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Format</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Impr.</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Clicks</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">CTR</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Spend</th>
+                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Conv.</th>
+                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Pacing</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (c of displayCampaigns(); track c.campaignId) {
+                  <tr class="border-b border-gray-100 last:border-0">
+                    <td class="px-4 py-2.5">
+                      <p class="font-medium text-gray-900">{{ c.eventName || c.name }}</p>
+                      <p class="text-xs text-gray-400">{{ c.targeting }}</p>
+                    </td>
+                    <td class="px-4 py-2.5">
+                      <span class="inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700">
+                        {{ c.adFormat }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(c.impressions) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(c.clicks) }}</td>
+                    <td class="px-4 py-2.5 text-right" [class]="c.ctr < 0.3 ? 'font-medium text-red-600' : 'text-gray-700'">
+                      {{ formatPct(c.ctr) }}
+                    </td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(c.spend) }}</td>
+                    <td class="px-4 py-2.5 text-right" [class]="c.conversions === 0 ? 'font-medium text-red-600' : 'text-gray-700'">
+                      {{ formatNumber(c.conversions) }}
+                    </td>
+                    <td class="px-4 py-2.5">
+                      <div class="flex items-center gap-2">
+                        <div class="h-2 w-16 overflow-hidden rounded-full bg-gray-200">
+                          <div class="h-full rounded-full" [class]="pacingClass(c)" [style.width.%]="Math.min(c.pacingPct, 100)"></div>
+                        </div>
+                        <span class="text-xs text-gray-500">{{ c.pacingPct }}%</span>
+                      </div>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -105,7 +105,7 @@
                 @for (item of actionItems(); track $index) {
                   <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'action-item-row-' + $index">
                     <td class="px-4 py-3">
-                      <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" [class]="priorityClass(item.priority)">
+                      <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" [class]="item.priority | priorityClass">
                         {{ item.priority }}
                       </span>
                     </td>
@@ -114,7 +114,7 @@
                     </td>
                     <td class="px-4 py-3 text-gray-700">{{ item.issue }}</td>
                     <td class="px-4 py-3 text-gray-700">{{ item.action }}</td>
-                    <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(item.metrics.spend) }}</td>
+                    <td class="px-4 py-3 text-right text-gray-700">{{ item.metrics.spend | adsCurrency }}</td>
                     <td class="px-4 py-3 text-right">
                       <span
                         class="text-sm font-medium"
@@ -204,22 +204,22 @@
                       </span>
                     </td>
                     <td class="px-4 py-2.5 text-center">
-                      <span class="text-sm font-medium" [class]="qualityScoreClass(kw.qualityScore)">
+                      <span class="text-sm font-medium" [class]="kw.qualityScore | qualityScoreClass">
                         {{ kw.qualityScore ?? '–' }}
                       </span>
                     </td>
-                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ eventLabel(kw.campaign) }}</td>
-                    <td class="px-4 py-2.5 text-right font-medium text-red-600">{{ formatCurrency(kw.spend) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatPct(kw.ctr) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.avgCpc) }}</td>
+                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ kw.campaign | eventLabel }}</td>
+                    <td class="px-4 py-2.5 text-right font-medium text-red-600">{{ kw.spend | adsCurrency }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.clicks | number }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.ctr | adsPct }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.avgCpc | adsCurrency }}</td>
                     <td class="px-4 py-2.5 text-right font-medium text-red-600">0</td>
                     <td class="px-4 py-2.5 text-center">
-                      @if (getActionResult(kw); as result) {
+                      @if (actionResults()[kw.adGroupId + '-' + kw.criterionId]; as result) {
                         <span class="text-xs font-medium" [class]="result.success ? 'text-green-600' : 'text-red-600'">
                           {{ result.success ? 'Done' : 'Failed' }}
                         </span>
-                      } @else if (isActionInProgress(kw)) {
+                      } @else if (actionInProgress()[kw.adGroupId + '-' + kw.criterionId]) {
                         <i class="fa-light fa-spinner-third fa-spin text-gray-400" aria-hidden="true"></i>
                       } @else {
                         <div class="flex items-center justify-center gap-1">
@@ -291,18 +291,18 @@
                       </span>
                     </td>
                     <td class="px-4 py-2.5 text-center">
-                      <span class="text-sm font-semibold" [class]="qualityScoreClass(kw.qualityScore)"> {{ kw.qualityScore }}/10 </span>
+                      <span class="text-sm font-semibold" [class]="kw.qualityScore | qualityScoreClass"> {{ kw.qualityScore }}/10 </span>
                     </td>
-                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ eventLabel(kw.campaign) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.impressions) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.spend) }}</td>
+                    <td class="px-4 py-2.5 text-xs text-gray-500">{{ kw.campaign | eventLabel }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.impressions | number }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.clicks | number }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ kw.spend | adsCurrency }}</td>
                     <td class="px-4 py-2.5 text-center">
-                      @if (getActionResult(kw); as result) {
+                      @if (actionResults()[kw.adGroupId + '-' + kw.criterionId]; as result) {
                         <span class="text-xs font-medium" [class]="result.success ? 'text-green-600' : 'text-red-600'">
                           {{ result.success ? 'Done' : 'Failed' }}
                         </span>
-                      } @else if (isActionInProgress(kw)) {
+                      } @else if (actionInProgress()[kw.adGroupId + '-' + kw.criterionId]) {
                         <i class="fa-light fa-spinner-third fa-spin text-gray-400" aria-hidden="true"></i>
                       } @else {
                         <div class="flex items-center justify-center gap-1">
@@ -366,19 +366,19 @@
                         {{ c.adFormat }}
                       </span>
                     </td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(c.impressions) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(c.clicks) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ c.impressions | number }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ c.clicks | number }}</td>
                     <td class="px-4 py-2.5 text-right" [class]="c.ctr < 0.3 ? 'font-medium text-red-600' : 'text-gray-700'">
-                      {{ formatPct(c.ctr) }}
+                      {{ c.ctr | adsPct }}
                     </td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(c.spend) }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700">{{ c.spend | adsCurrency }}</td>
                     <td class="px-4 py-2.5 text-right" [class]="c.conversions === 0 ? 'font-medium text-red-600' : 'text-gray-700'">
-                      {{ formatNumber(c.conversions) }}
+                      {{ c.conversions | number }}
                     </td>
                     <td class="px-4 py-2.5">
                       <div class="flex items-center gap-2">
                         <div class="h-2 w-16 overflow-hidden rounded-full bg-gray-200">
-                          <div class="h-full rounded-full" [class]="pacingClass(c)" [style.width.%]="Math.min(c.pacingPct, 100)"></div>
+                          <div class="h-full rounded-full" [class]="c | pacingClass" [style.width.%]="c.displayPacingPct"></div>
                         </div>
                         <span class="text-xs text-gray-500">{{ c.pacingPct }}%</span>
                       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -227,14 +227,16 @@
                             type="button"
                             (click)="executeKeywordAction(kw, 'pause')"
                             class="rounded px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50"
-                            title="Pause this keyword">
+                            title="Pause this keyword"
+                            aria-label="Pause this keyword">
                             <i class="fa-light fa-pause" aria-hidden="true"></i>
                           </button>
                           <button
                             type="button"
                             (click)="executeKeywordAction(kw, 'remove')"
                             class="rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
-                            title="Remove this keyword">
+                            title="Remove this keyword"
+                            aria-label="Remove this keyword">
                             <i class="fa-light fa-trash" aria-hidden="true"></i>
                           </button>
                         </div>
@@ -310,14 +312,16 @@
                             type="button"
                             (click)="executeKeywordAction(kw, 'pause')"
                             class="rounded px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50"
-                            title="Pause this keyword">
+                            title="Pause this keyword"
+                            aria-label="Pause this keyword">
                             <i class="fa-light fa-pause" aria-hidden="true"></i>
                           </button>
                           <button
                             type="button"
                             (click)="executeKeywordAction(kw, 'remove')"
                             class="rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
-                            title="Remove this keyword">
+                            title="Remove this keyword"
+                            aria-label="Remove this keyword">
                             <i class="fa-light fa-trash" aria-hidden="true"></i>
                           </button>
                         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -154,6 +154,11 @@
             Loading keyword data...
           </div>
         </div>
+      } @else if (keywordsError()) {
+        <div class="flex items-center gap-2 rounded-lg border border-dashed border-red-300 bg-red-50 px-4 py-3">
+          <i class="fa-light fa-triangle-exclamation text-red-500" aria-hidden="true"></i>
+          <p class="text-sm text-red-700">{{ keywordsError() }}</p>
+        </div>
       } @else if (!hasWastedKeywords()) {
         <div class="flex items-center gap-2 rounded-lg border border-dashed border-green-300 bg-green-50 px-4 py-3">
           <i class="fa-light fa-circle-check text-green-500" aria-hidden="true"></i>
@@ -188,7 +193,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (kw of wastedKeywords(); track kw.keyword + '-' + kw.campaignId) {
+                @for (kw of wastedKeywords(); track kw.adGroupId + '-' + kw.criterionId) {
                   <tr class="border-b border-gray-100 last:border-0">
                     <td class="px-4 py-2.5">
                       <p class="font-medium text-gray-900">{{ kw.keyword }}</p>
@@ -277,7 +282,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (kw of lowQualityKeywords(); track kw.keyword + '-' + kw.campaignId) {
+                @for (kw of lowQualityKeywords(); track kw.adGroupId + '-' + kw.criterionId) {
                   <tr class="border-b border-gray-100 last:border-0">
                     <td class="px-4 py-2.5 font-medium text-gray-900">{{ kw.keyword }}</td>
                     <td class="px-4 py-2.5">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -1,25 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CAMPAIGN_PACING_THRESHOLDS, parseCampaignName } from '@lfx-one/shared/constants';
-import type {
-  CampaignActionItem,
-  CampaignMetrics,
-  CampaignMonitorResponse,
-  KeywordActionType,
-  KeywordMetrics,
-  KeywordMetricsResponse,
-} from '@lfx-one/shared/interfaces';
+import type { CampaignMonitorResponse, DateRangeOption, KeywordActionType, KeywordMetrics, KeywordMetricsResponse } from '@lfx-one/shared/interfaces';
+import { AdsCurrencyPipe, AdsPctPipe, EventLabelPipe, PacingClassPipe, PriorityClassPipe, QualityScoreClassPipe } from '@pipes/campaign-optimization.pipe';
 import { CampaignService } from '@services/campaign.service';
 import type { Subscription } from 'rxjs';
 
-type DateRangeOption = 7 | 14 | 30;
-
 @Component({
   selector: 'lfx-optimization-tab',
-  imports: [],
+  imports: [DecimalPipe, AdsCurrencyPipe, AdsPctPipe, EventLabelPipe, PacingClassPipe, PriorityClassPipe, QualityScoreClassPipe],
   templateUrl: './optimization-tab.component.html',
   styleUrl: './optimization-tab.component.scss',
 })
@@ -29,7 +21,6 @@ export class OptimizationTabComponent implements OnInit {
   private monitorSub: Subscription | null = null;
   private keywordsSub: Subscription | null = null;
 
-  protected readonly Math = Math;
   protected readonly dateRangeOptions: DateRangeOption[] = [7, 14, 30];
 
   protected readonly selectedDays = signal<DateRangeOption>(30);
@@ -60,10 +51,11 @@ export class OptimizationTabComponent implements OnInit {
     return all.filter((k) => k.qualityScore !== null && k.qualityScore <= 4).sort((a, b) => (a.qualityScore ?? 0) - (b.qualityScore ?? 0));
   });
 
-  protected readonly displayCampaigns = computed<CampaignMetrics[]>(() => {
+  protected readonly displayCampaigns = computed(() => {
     return this.campaigns()
       .filter((c) => !c.adFormat.toLowerCase().includes('search'))
-      .sort((a, b) => a.ctr - b.ctr);
+      .sort((a, b) => a.ctr - b.ctr)
+      .map((c) => ({ ...c, displayPacingPct: Math.min(c.pacingPct, 100) }));
   });
 
   protected readonly hasWastedKeywords = computed(() => this.wastedKeywords().length > 0);
@@ -197,55 +189,5 @@ export class OptimizationTabComponent implements OnInit {
           });
         },
       });
-  }
-
-  protected isActionInProgress(kw: KeywordMetrics): boolean {
-    return this.actionInProgress()[`${kw.adGroupId}-${kw.criterionId}`] ?? false;
-  }
-
-  protected getActionResult(kw: KeywordMetrics): { success: boolean; message: string } | null {
-    return this.actionResults()[`${kw.adGroupId}-${kw.criterionId}`] ?? null;
-  }
-
-  protected priorityClass(priority: CampaignActionItem['priority']): string {
-    switch (priority) {
-      case 'HIGH':
-        return 'bg-red-100 text-red-700';
-      case 'MED':
-        return 'bg-amber-100 text-amber-700';
-      default:
-        return 'bg-gray-100 text-gray-600';
-    }
-  }
-
-  protected pacingClass(campaign: CampaignMetrics): string {
-    const pct = campaign.pacingPct;
-    if (pct < CAMPAIGN_PACING_THRESHOLDS.underspending) return 'bg-red-500';
-    if (pct <= CAMPAIGN_PACING_THRESHOLDS.normal) return 'bg-green-500';
-    if (pct <= CAMPAIGN_PACING_THRESHOLDS.constrained) return 'bg-amber-500';
-    return 'bg-red-500';
-  }
-
-  protected qualityScoreClass(score: number | null): string {
-    if (score === null) return 'text-gray-400';
-    if (score >= 7) return 'text-green-700';
-    if (score >= 4) return 'text-amber-700';
-    return 'text-red-700';
-  }
-
-  protected eventLabel(campaignName: string): string {
-    return parseCampaignName(campaignName).baseName || campaignName;
-  }
-
-  protected formatCurrency(value: number): string {
-    return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  }
-
-  protected formatNumber(value: number): string {
-    return value.toLocaleString('en-US');
-  }
-
-  protected formatPct(value: number): string {
-    return `${value.toFixed(2)}%`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -39,6 +39,7 @@ export class OptimizationTabComponent implements OnInit {
 
   protected readonly keywordsLoading = signal(false);
   protected readonly keywordsData = signal<KeywordMetricsResponse | null>(null);
+  protected readonly keywordsError = signal<string | null>(null);
 
   protected readonly actionItems = computed(() => this.monitorData()?.actionItems ?? []);
   protected readonly campaigns = computed(() => this.monitorData()?.campaigns ?? []);
@@ -107,6 +108,8 @@ export class OptimizationTabComponent implements OnInit {
       });
 
     this.keywordsLoading.set(true);
+    this.keywordsData.set(null);
+    this.keywordsError.set(null);
     this.keywordsSub = this.campaignService
       .getKeywords(days)
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -115,7 +118,8 @@ export class OptimizationTabComponent implements OnInit {
           this.keywordsData.set(data);
           this.keywordsLoading.set(false);
         },
-        error: () => {
+        error: (err) => {
+          this.keywordsError.set(err?.error?.message || err?.message || 'Failed to load keyword data');
           this.keywordsLoading.set(false);
         },
       });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -1,0 +1,247 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CAMPAIGN_PACING_THRESHOLDS, parseCampaignName } from '@lfx-one/shared/constants';
+import type {
+  CampaignActionItem,
+  CampaignMetrics,
+  CampaignMonitorResponse,
+  KeywordActionType,
+  KeywordMetrics,
+  KeywordMetricsResponse,
+} from '@lfx-one/shared/interfaces';
+import { CampaignService } from '@services/campaign.service';
+import type { Subscription } from 'rxjs';
+
+type DateRangeOption = 7 | 14 | 30;
+
+@Component({
+  selector: 'lfx-optimization-tab',
+  imports: [],
+  templateUrl: './optimization-tab.component.html',
+  styleUrl: './optimization-tab.component.scss',
+})
+export class OptimizationTabComponent implements OnInit {
+  private readonly campaignService = inject(CampaignService);
+  private readonly destroyRef = inject(DestroyRef);
+  private monitorSub: Subscription | null = null;
+  private keywordsSub: Subscription | null = null;
+
+  protected readonly Math = Math;
+  protected readonly dateRangeOptions: DateRangeOption[] = [7, 14, 30];
+
+  protected readonly selectedDays = signal<DateRangeOption>(30);
+  protected readonly loading = signal(false);
+  protected readonly monitorData = signal<CampaignMonitorResponse | null>(null);
+  protected readonly error = signal<string | null>(null);
+
+  protected readonly keywordsLoading = signal(false);
+  protected readonly keywordsData = signal<KeywordMetricsResponse | null>(null);
+
+  protected readonly actionItems = computed(() => this.monitorData()?.actionItems ?? []);
+  protected readonly campaigns = computed(() => this.monitorData()?.campaigns ?? []);
+  protected readonly hasActionItems = computed(() => this.actionItems().length > 0);
+  protected readonly hasCampaigns = computed(() => this.campaigns().length > 0);
+  protected readonly pulledAt = computed(() => this.monitorData()?.pulledAt ?? '');
+
+  protected readonly highCount = computed(() => this.actionItems().filter((i) => i.priority === 'HIGH').length);
+  protected readonly medCount = computed(() => this.actionItems().filter((i) => i.priority === 'MED').length);
+
+  protected readonly wastedKeywords = computed<KeywordMetrics[]>(() => {
+    const all = this.keywordsData()?.keywords ?? [];
+    return all.filter((k) => k.spend > 0 && k.conversions === 0).sort((a, b) => b.spend - a.spend);
+  });
+
+  protected readonly lowQualityKeywords = computed<KeywordMetrics[]>(() => {
+    const all = this.keywordsData()?.keywords ?? [];
+    return all.filter((k) => k.qualityScore !== null && k.qualityScore <= 4).sort((a, b) => (a.qualityScore ?? 0) - (b.qualityScore ?? 0));
+  });
+
+  protected readonly displayCampaigns = computed<CampaignMetrics[]>(() => {
+    return this.campaigns()
+      .filter((c) => !c.adFormat.toLowerCase().includes('search'))
+      .sort((a, b) => a.ctr - b.ctr);
+  });
+
+  protected readonly hasWastedKeywords = computed(() => this.wastedKeywords().length > 0);
+  protected readonly hasLowQualityKeywords = computed(() => this.lowQualityKeywords().length > 0);
+  protected readonly hasDisplayCampaigns = computed(() => this.displayCampaigns().length > 0);
+
+  protected readonly actionInProgress = signal<Record<string, boolean>>({});
+  protected readonly actionResults = signal<Record<string, { success: boolean; message: string }>>({});
+
+  public ngOnInit(): void {
+    this.fetchData();
+  }
+
+  protected setDateRange(days: DateRangeOption): void {
+    this.selectedDays.set(days);
+    this.fetchData();
+  }
+
+  protected refresh(): void {
+    this.fetchData();
+  }
+
+  protected fetchData(): void {
+    this.monitorSub?.unsubscribe();
+    this.keywordsSub?.unsubscribe();
+    this.loading.set(true);
+    this.error.set(null);
+    const days = this.selectedDays();
+
+    this.monitorSub = this.campaignService
+      .getMonitorData(days)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.monitorData.set(data);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.error.set(err?.error?.message || err?.message || 'Failed to load optimization data');
+          this.loading.set(false);
+        },
+      });
+
+    this.keywordsLoading.set(true);
+    this.keywordsSub = this.campaignService
+      .getKeywords(days)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.keywordsData.set(data);
+          this.keywordsLoading.set(false);
+        },
+        error: () => {
+          this.keywordsLoading.set(false);
+        },
+      });
+  }
+
+  protected executeKeywordAction(kw: KeywordMetrics, action: KeywordActionType): void {
+    const key = `${kw.adGroupId}-${kw.criterionId}`;
+    this.actionInProgress.update((map) => ({ ...map, [key]: true }));
+
+    this.campaignService
+      .executeKeywordActions({
+        action,
+        keywords: [{ campaignId: kw.campaignId, adGroupId: kw.adGroupId, criterionId: kw.criterionId, action }],
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.actionInProgress.update((map) => ({ ...map, [key]: false }));
+          const result = res.results[0];
+          this.actionResults.update((map) => ({
+            ...map,
+            [key]: { success: result?.success ?? false, message: result?.message ?? 'Unknown result' },
+          }));
+        },
+        error: (err) => {
+          this.actionInProgress.update((map) => ({ ...map, [key]: false }));
+          this.actionResults.update((map) => ({
+            ...map,
+            [key]: { success: false, message: err?.error?.message || err?.message || 'Action failed' },
+          }));
+        },
+      });
+  }
+
+  protected bulkKeywordAction(keywords: KeywordMetrics[], action: KeywordActionType): void {
+    const items = keywords.map((kw) => ({ campaignId: kw.campaignId, adGroupId: kw.adGroupId, criterionId: kw.criterionId, action }));
+    const keys = keywords.map((kw) => `${kw.adGroupId}-${kw.criterionId}`);
+
+    this.actionInProgress.update((map) => {
+      const updated = { ...map };
+      for (const key of keys) updated[key] = true;
+      return updated;
+    });
+
+    this.campaignService
+      .executeKeywordActions({ action, keywords: items })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.actionInProgress.update((map) => {
+            const updated = { ...map };
+            for (const key of keys) updated[key] = false;
+            return updated;
+          });
+          this.actionResults.update((map) => {
+            const updated = { ...map };
+            for (let i = 0; i < keys.length; i++) {
+              const result = res.results[i];
+              updated[keys[i]] = { success: result?.success ?? false, message: result?.message ?? 'Done' };
+            }
+            return updated;
+          });
+        },
+        error: (err) => {
+          this.actionInProgress.update((map) => {
+            const updated = { ...map };
+            for (const key of keys) updated[key] = false;
+            return updated;
+          });
+          const msg = err?.error?.message || err?.message || 'Bulk action failed';
+          this.actionResults.update((map) => {
+            const updated = { ...map };
+            for (const key of keys) updated[key] = { success: false, message: msg };
+            return updated;
+          });
+        },
+      });
+  }
+
+  protected isActionInProgress(kw: KeywordMetrics): boolean {
+    return this.actionInProgress()[`${kw.adGroupId}-${kw.criterionId}`] ?? false;
+  }
+
+  protected getActionResult(kw: KeywordMetrics): { success: boolean; message: string } | null {
+    return this.actionResults()[`${kw.adGroupId}-${kw.criterionId}`] ?? null;
+  }
+
+  protected priorityClass(priority: CampaignActionItem['priority']): string {
+    switch (priority) {
+      case 'HIGH':
+        return 'bg-red-100 text-red-700';
+      case 'MED':
+        return 'bg-amber-100 text-amber-700';
+      default:
+        return 'bg-gray-100 text-gray-600';
+    }
+  }
+
+  protected pacingClass(campaign: CampaignMetrics): string {
+    const pct = campaign.pacingPct;
+    if (pct < CAMPAIGN_PACING_THRESHOLDS.underspending) return 'bg-red-500';
+    if (pct <= CAMPAIGN_PACING_THRESHOLDS.normal) return 'bg-green-500';
+    if (pct <= CAMPAIGN_PACING_THRESHOLDS.constrained) return 'bg-amber-500';
+    return 'bg-red-500';
+  }
+
+  protected qualityScoreClass(score: number | null): string {
+    if (score === null) return 'text-gray-400';
+    if (score >= 7) return 'text-green-700';
+    if (score >= 4) return 'text-amber-700';
+    return 'text-red-700';
+  }
+
+  protected eventLabel(campaignName: string): string {
+    return parseCampaignName(campaignName).baseName || campaignName;
+  }
+
+  protected formatCurrency(value: number): string {
+    return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+
+  protected formatNumber(value: number): string {
+    return value.toLocaleString('en-US');
+  }
+
+  protected formatPct(value: number): string {
+    return `${value.toFixed(2)}%`;
+  }
+}

--- a/apps/lfx-one/src/app/shared/pipes/campaign-optimization.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/campaign-optimization.pipe.ts
@@ -1,0 +1,62 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { CAMPAIGN_PACING_THRESHOLDS, parseCampaignName } from '@lfx-one/shared/constants';
+import type { CampaignActionItem, CampaignMetrics } from '@lfx-one/shared/interfaces';
+
+@Pipe({ name: 'priorityClass' })
+export class PriorityClassPipe implements PipeTransform {
+  public transform(priority: CampaignActionItem['priority']): string {
+    switch (priority) {
+      case 'HIGH':
+        return 'bg-red-100 text-red-700';
+      case 'MED':
+        return 'bg-amber-100 text-amber-700';
+      default:
+        return 'bg-gray-100 text-gray-600';
+    }
+  }
+}
+
+@Pipe({ name: 'qualityScoreClass' })
+export class QualityScoreClassPipe implements PipeTransform {
+  public transform(score: number | null): string {
+    if (score === null) return 'text-gray-400';
+    if (score >= 7) return 'text-green-700';
+    if (score >= 4) return 'text-amber-700';
+    return 'text-red-700';
+  }
+}
+
+@Pipe({ name: 'pacingClass' })
+export class PacingClassPipe implements PipeTransform {
+  public transform(campaign: CampaignMetrics): string {
+    const pct = campaign.pacingPct;
+    if (pct < CAMPAIGN_PACING_THRESHOLDS.underspending) return 'bg-red-500';
+    if (pct <= CAMPAIGN_PACING_THRESHOLDS.normal) return 'bg-green-500';
+    if (pct <= CAMPAIGN_PACING_THRESHOLDS.constrained) return 'bg-amber-500';
+    return 'bg-red-500';
+  }
+}
+
+@Pipe({ name: 'eventLabel' })
+export class EventLabelPipe implements PipeTransform {
+  public transform(campaignName: string): string {
+    return parseCampaignName(campaignName).baseName || campaignName;
+  }
+}
+
+@Pipe({ name: 'adsCurrency' })
+export class AdsCurrencyPipe implements PipeTransform {
+  public transform(value: number): string {
+    return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+}
+
+@Pipe({ name: 'adsPct' })
+export class AdsPctPipe implements PipeTransform {
+  public transform(value: number): string {
+    return `${value.toFixed(2)}%`;
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -6,6 +6,8 @@ import { inject, Injectable } from '@angular/core';
 import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
+  BulkKeywordActionRequest,
+  BulkKeywordActionResponse,
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
@@ -71,6 +73,10 @@ export class CampaignService {
 
   public createHubSpotUtm(eventName: string): Observable<HubSpotUtmCreateResult> {
     return this.http.post<HubSpotUtmCreateResult>('/api/campaigns/hubspot/utm/create', {}, { params: { event_name: eventName } });
+  }
+
+  public executeKeywordActions(request: BulkKeywordActionRequest): Observable<BulkKeywordActionResponse> {
+    return this.http.post<BulkKeywordActionResponse>('/api/campaigns/keywords/actions', request);
   }
 
   private pollJobStatus(jobId: string): Observable<CampaignJobStatus> {

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -216,6 +216,18 @@ export class CampaignController {
       return;
     }
 
+    for (const kw of body.keywords) {
+      if (!kw.campaignId || !kw.adGroupId || !kw.criterionId) {
+        next(
+          ServiceValidationError.forField('keywords', 'each keyword must include campaignId, adGroupId, and criterionId', {
+            operation: 'keyword_actions',
+            service: 'campaign_controller',
+          })
+        );
+        return;
+      }
+    }
+
     const startTime = logger.startOperation(req, 'keyword_actions', { action: body.action, count: body.keywords.length });
 
     try {

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -217,7 +217,7 @@ export class CampaignController {
     }
 
     for (const kw of body.keywords) {
-      if (!kw.campaignId || !kw.adGroupId || !kw.criterionId) {
+      if (!kw || typeof kw !== 'object' || !kw.campaignId || !kw.adGroupId || !kw.criterionId) {
         next(
           ServiceValidationError.forField('keywords', 'each keyword must include campaignId, adGroupId, and criterionId', {
             operation: 'keyword_actions',

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -3,7 +3,7 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import type { CampaignBriefRequest, CampaignSSEEventType, FlushableResponse } from '@lfx-one/shared/interfaces';
+import type { BulkKeywordActionRequest, CampaignBriefRequest, CampaignSSEEventType, FlushableResponse } from '@lfx-one/shared/interfaces';
 
 import { ServiceValidationError } from '../errors';
 import { CampaignMetricsService } from '../services/campaign-metrics.service';
@@ -198,6 +198,30 @@ export class CampaignController {
       const data = await this.metricsService.getAudience(req, days);
       logger.success(req, 'campaign_audience', startTime, {});
       res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async executeKeywordActions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const body = req.body as BulkKeywordActionRequest;
+
+    if (!body.keywords || !Array.isArray(body.keywords) || body.keywords.length === 0) {
+      next(ServiceValidationError.forField('keywords', 'keywords array is required', { operation: 'keyword_actions', service: 'campaign_controller' }));
+      return;
+    }
+
+    if (!body.action || !['pause', 'remove'].includes(body.action)) {
+      next(ServiceValidationError.forField('action', 'action must be "pause" or "remove"', { operation: 'keyword_actions', service: 'campaign_controller' }));
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'keyword_actions', { action: body.action, count: body.keywords.length });
+
+    try {
+      const result = await this.proxyService.executeKeywordActions(req, body);
+      logger.success(req, 'keyword_actions', startTime, { succeeded: result.succeeded, failed: result.failed });
+      res.json(result);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -16,5 +16,6 @@ router.post('/hubspot/utm/create', (req, res, next) => campaignController.create
 router.get('/monitor', (req, res, next) => campaignController.getMonitorData(req, res, next));
 router.get('/keywords', (req, res, next) => campaignController.getKeywords(req, res, next));
 router.get('/audience', (req, res, next) => campaignController.getAudience(req, res, next));
+router.post('/keywords/actions', (req, res, next) => campaignController.executeKeywordActions(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -63,7 +63,8 @@ export class CampaignMetricsService {
     const query = `
       SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
              ad_group_criterion.quality_info.quality_score, ad_group_criterion.status,
-             ad_group.name, campaign.name, campaign.id,
+             ad_group_criterion.criterion_id,
+             ad_group.name, ad_group.id, campaign.name, campaign.id,
              metrics.impressions, metrics.clicks, metrics.ctr,
              metrics.cost_micros, metrics.conversions
       FROM keyword_view
@@ -230,8 +231,8 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'HIGH',
-        issue: 'Campaign limited by Google',
-        action: 'Switch bid to Maximize Clicks or expand keyword match types',
+        issue: `Campaign limited by Google — only ${c.impressions.toLocaleString()} impressions on $${c.budgetDay.toFixed(2)}/day budget`,
+        action: 'Switch bid strategy to Maximize Clicks, or expand keyword match types to increase eligible auctions',
         metrics: baseMetrics,
       });
     }
@@ -241,8 +242,8 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'HIGH',
-        issue: 'Placeholder $1/day budget',
-        action: 'Set real budget before activation',
+        issue: `Budget is $${c.budgetDay.toFixed(2)}/day — this is a placeholder and won't generate meaningful traffic`,
+        action: 'Set a real daily budget (typically $10–50/day for events) before expecting results',
         metrics: baseMetrics,
       });
     }
@@ -252,8 +253,8 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: 'Campaign paused',
-        action: 'Verify pause reason or activate',
+        issue: `Campaign is paused — spent $${c.spend.toFixed(2)} before pause`,
+        action: 'Check if this was intentionally paused or if the event is still upcoming and needs reactivation',
         metrics: baseMetrics,
       });
     }
@@ -263,8 +264,8 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: `Underspending (${c.pacingPct}% of budget)`,
-        action: 'Broaden targeting or increase bids',
+        issue: `Only spending ${c.pacingPct}% of $${c.budgetDay.toFixed(2)}/day budget — $${c.spend.toFixed(2)} spent vs $${(c.budgetDay * 30).toFixed(2)} expected`,
+        action: 'Broaden targeting (locations, audiences), add broad match keywords, or increase bids to win more auctions',
         metrics: baseMetrics,
       });
     }
@@ -274,41 +275,63 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: `Budget constrained (${c.pacingPct}%)`,
-        action: 'Consider budget increase',
+        issue: `Spending ${c.pacingPct}% of budget — demand exceeds $${c.budgetDay.toFixed(2)}/day cap, ads stop showing mid-day`,
+        action: 'Increase daily budget to capture missed impressions, or narrow targeting to focus spend on highest-value audiences',
         metrics: baseMetrics,
       });
     }
-    if (isSearch && c.ctr < 2 && c.clicks > 50) {
+    if (isSearch && c.ctr < 2 && c.clicks > 10) {
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: 'Low Search CTR (<2%)',
-        action: 'Review headline relevance, add negative keywords',
+        issue: `Search CTR is ${c.ctr.toFixed(2)}% (benchmark: 2%+) — ${c.clicks} clicks from ${c.impressions.toLocaleString()} impressions`,
+        action: 'Improve headline relevance to search intent, add negative keywords to filter irrelevant queries',
         metrics: baseMetrics,
       });
     }
-    if (!isSearch && c.ctr < 0.3 && c.clicks > 50) {
+    if (!isSearch && c.ctr < 0.3 && c.impressions > 1000) {
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: 'Low Display CTR (<0.3%)',
-        action: 'Refresh creative, check audience overlap',
+        issue: `Display CTR is ${c.ctr.toFixed(2)}% (benchmark: 0.3%+) — ${c.clicks} clicks from ${c.impressions.toLocaleString()} impressions`,
+        action: 'Refresh creative assets, check for audience overlap across campaigns, or narrow placement targeting',
         metrics: baseMetrics,
       });
     }
-    if (c.clicks > 100 && c.conversions === 0) {
+    if (c.clicks > 20 && c.conversions === 0) {
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: 'Clicks with zero conversions',
-        action: 'Audit conversion tracking setup',
+        issue: `${c.clicks} clicks ($${c.spend.toFixed(2)} spent) but 0 conversions — traffic is not converting`,
+        action: 'Verify conversion tracking is firing correctly, check landing page load speed, and review if the CTA matches the ad promise',
+        metrics: baseMetrics,
+      });
+    }
+    if (c.avgCpc > 5 && c.clicks > 10) {
+      items.push({
+        eventName: c.eventName,
+        campaigns: [c.shortName],
+        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        priority: 'MED',
+        issue: `Avg CPC is $${c.avgCpc.toFixed(2)} — spending $${c.spend.toFixed(2)} for only ${c.clicks} clicks`,
+        action: 'Switch to a Target CPA or Maximize Clicks bid strategy, add long-tail keywords with lower competition',
+        metrics: baseMetrics,
+      });
+    }
+    if (c.impressions > 0 && c.clicks === 0) {
+      items.push({
+        eventName: c.eventName,
+        campaigns: [c.shortName],
+        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        priority: 'MED',
+        issue: `${c.impressions.toLocaleString()} impressions but 0 clicks — ads are showing but no one is clicking`,
+        action: 'Rewrite ad copy to be more compelling, ensure headlines match search intent, test different CTAs',
         metrics: baseMetrics,
       });
     }
@@ -318,8 +341,8 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
         campaigns: [c.shortName],
         campaignUrls: { [c.shortName]: c.googleAdsUrl },
         priority: 'MED',
-        issue: 'Campaign in draft',
-        action: 'Complete setup: upload images, publish, then pause',
+        issue: `Campaign is still in draft — $${c.budgetDay.toFixed(2)}/day budget allocated but not running`,
+        action: 'Upload creative assets, review ad groups, publish the campaign (then pause if not ready to go live)',
         metrics: baseMetrics,
       });
     }
@@ -341,6 +364,8 @@ function parseKeywordRow(row: unknown): KeywordMetrics {
     qualityScore: (extractNested(r, 'adGroupCriterion.qualityInfo.qualityScore') as number) ?? null,
     status: (extractNested(r, 'adGroupCriterion.status') as string) || '',
     adGroup: (extractNested(r, 'adGroup.name') as string) || '',
+    adGroupId: String(extractNested(r, 'adGroup.id') || ''),
+    criterionId: String(extractNested(r, 'adGroupCriterion.criterionId') || ''),
     campaign: (extractNested(r, 'campaign.name') as string) || '',
     campaignId,
     googleAdsUrl: buildGoogleAdsUrl(campaignId),

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -4,6 +4,8 @@
 import { AI_MODEL } from '@lfx-one/shared/constants';
 
 import type {
+  BulkKeywordActionRequest,
+  BulkKeywordActionResponse,
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
@@ -11,6 +13,7 @@ import type {
   CampaignJobStatus,
   CampaignKeyword,
   CampaignSSEEventType,
+  KeywordActionResponse,
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
@@ -689,6 +692,55 @@ export class CampaignProxyService {
     const job = jobs.get(jobId);
     if (!job) return { status: 'not_found', error: 'Job not found' };
     return job;
+  }
+
+  // === Keyword actions (pause / remove) ===
+
+  public async executeKeywordActions(req: Request, body: BulkKeywordActionRequest): Promise<BulkKeywordActionResponse> {
+    checkRequiredEnv(req);
+    const customer = getCustomer();
+    const customerId = getEnv('GADS_CUSTOMER_ID');
+    const results: KeywordActionResponse[] = [];
+
+    for (const kw of body.keywords) {
+      try {
+        const resourceName = `customers/${customerId}/adGroupCriteria/${kw.adGroupId}~${kw.criterionId}`;
+
+        if (body.action === 'remove') {
+          await customer.adGroupCriteria.remove([resourceName]);
+        } else {
+          await customer.adGroupCriteria.update([
+            {
+              resource_name: resourceName,
+              status: enums.AdGroupCriterionStatus.PAUSED,
+            },
+          ]);
+        }
+
+        results.push({
+          success: true,
+          action: body.action,
+          keyword: `Criterion ${kw.criterionId}`,
+          message: `Keyword ${body.action === 'remove' ? 'removed' : 'paused'} successfully`,
+        });
+      } catch (error) {
+        results.push({
+          success: false,
+          action: body.action,
+          keyword: `Criterion ${kw.criterionId}`,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+
+    const succeeded = results.filter((r) => r.success).length;
+    return {
+      success: succeeded === results.length,
+      total: results.length,
+      succeeded,
+      failed: results.length - succeeded,
+      results,
+    };
   }
 
   // === Private: campaign creation orchestration ===

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -13,6 +13,8 @@ export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limit
 
 export type CampaignType = 'search' | 'demand-gen';
 
+export type DateRangeOption = 7 | 14 | 30;
+
 export type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead-generation' | 'engagement';
 
 export type CampaignTab = CampaignPhase;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -232,6 +232,8 @@ export interface KeywordMetrics {
   qualityScore: number | null;
   status: string;
   adGroup: string;
+  adGroupId: string;
+  criterionId: string;
   campaign: string;
   campaignId: string;
   googleAdsUrl: string;
@@ -295,6 +297,39 @@ export interface ImpressionShareMetrics {
   rankLostShare: number | null;
   impressions: number;
   clicks: number;
+}
+
+// ---------------------------------------------------------------------------
+// Optimization Actions
+// ---------------------------------------------------------------------------
+
+export type KeywordActionType = 'pause' | 'remove';
+
+export interface KeywordActionRequest {
+  campaignId: string;
+  adGroupId: string;
+  criterionId: string;
+  action: KeywordActionType;
+}
+
+export interface KeywordActionResponse {
+  success: boolean;
+  action: KeywordActionType;
+  keyword: string;
+  message: string;
+}
+
+export interface BulkKeywordActionRequest {
+  keywords: KeywordActionRequest[];
+  action: KeywordActionType;
+}
+
+export interface BulkKeywordActionResponse {
+  success: boolean;
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: KeywordActionResponse[];
 }
 
 export interface SearchTermMetrics {


### PR DESCRIPTION
## Summary

- Add optimization tab to the campaigns page (PR 9 in the Campaigns epic LFXV2-2023)
- Action items now show **data-specific descriptions** with actual metrics (spend, clicks, CPC, CTR, impressions) interpolated into both issue descriptions and actionable recommendations — no more vague "review" language
- Add **keyword action buttons** (pause/remove) backed by Google Ads API `customer.adGroupCriteria` mutations, supporting both individual and bulk operations
- Full-stack implementation: shared interfaces → backend service → controller → route → frontend service → Angular component

### Optimization Tab Features
- **Summary cards**: total action items, wasted spend, low quality keywords, display campaigns
- **Action items table**: priority-sorted (HIGH/MED) with specific, data-driven descriptions
- **Wasted keywords table**: keywords with clicks but zero conversions, with pause/remove action buttons
- **Low quality score keywords table**: keywords with QS < 5, with pause/remove action buttons  
- **Bulk operations**: "Pause All" button for batch keyword actions with progress tracking
- **Display campaign performance**: overview of demand-gen campaigns

### Backend Changes
- `campaign-proxy.service.ts`: added `executeKeywordActions()` using Google Ads API (`adGroupCriteria.update/remove`)
- `campaign-metrics.service.ts`: enhanced action item generation with 11 data-specific rules, added `adGroupId` and `criterionId` to keyword query
- `campaign.controller.ts`: added `executeKeywordActions()` endpoint with validation
- `campaigns.route.ts`: added `POST /api/campaigns/keywords/actions`

### Shared Interface Changes
- Added `KeywordActionType`, `KeywordActionRequest`, `KeywordActionResponse`, `BulkKeywordActionRequest`, `BulkKeywordActionResponse` types
- Added `adGroupId` and `criterionId` to `KeywordMetrics` interface

## Test plan
- [ ] Navigate to `/foundation/campaigns` and select the Optimization tab
- [ ] Verify summary cards render with data from the monitor/keywords endpoints
- [ ] Verify action items show specific metrics (e.g., "Search CTR is 1.23% — 45 clicks from 3,600 impressions")
- [ ] Verify wasted keywords table shows keywords with clicks > 0 and conversions === 0
- [ ] Verify low QS keywords table shows keywords with qualityScore < 5
- [ ] Verify pause/remove buttons trigger the keyword actions endpoint
- [ ] Verify bulk "Pause All" operates on all wasted keywords with progress feedback

🤖 Generated with [Claude Code](https://claude.ai/code)