### PR TITLE
feat(org-people): enable edit and bulk reassign on key contacts tab

### DIFF
--- a/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
@@ -9,8 +9,8 @@ const PEOPLE_KEY_CONTACTS_URL = '/org/people?tab=contacts';
 const DATA_LOAD_TIMEOUT = 30_000;
 const TOAST_TIMEOUT = 10_000;
 
-const MOCK_UID = '4c46585f-878c-8285-b2e9-2dbfc38ddd9b';
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = MOCK_ACCOUNT_ID;
 const MOCK_ACCOUNT_NAME = 'Acme Industries';
 const MOCK_ACCOUNT_SLUG = 'acme-industries';
 

--- a/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
@@ -1,25 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * Org People — Reassign Key Contact Roles E2E (LFXV2-2067 main-row pencil).
- *
- * Covers the user-perspective acceptance criteria for the bulk-reassign flow scoped to ONE PERSON
- * across N (membership, role-TYPE) tuples. Out of scope here: the expanded-row spec-024 4-state
- * modal, which is exercised by `org-membership-key-contacts.spec.ts`.
- *
- * Coverage map (18 user-perspective points):
- *   1–14, 17 baseline → "modal opens with the expected anatomy"
- *   17 reactive label → "save button label and subtitle update as roles toggle"
- *   15, 16            → "employee typeahead populates the name fields on selection"
- *   18 success+loading → "save fans out PUTs, shows the spinner, closes on full success"
- *   18 error           → "save failure keeps the modal open with a retryable inline error"
- *
- * Prerequisites:
- * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
- * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
- * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
- */
+/** Reassign Key Contact Roles modal E2E (LFXV2-2067 main-row pencil). */
 
 import { expect, Page, Route, test } from '@playwright/test';
 
@@ -108,10 +90,7 @@ const MOCK_EMPLOYEES = [
 
 test.setTimeout(120_000);
 
-/**
- * Bail out gracefully if Auth0 redirected the test (no TEST_USERNAME/TEST_PASSWORD set).
- * Mirrors the helper used by org-profile.spec.ts.
- */
+/** Skip the test when Auth0 redirected (no TEST_USERNAME/TEST_PASSWORD configured). */
 function skipWhenAuthMissing(page: Page): void {
   try {
     const { hostname } = new URL(page.url());
@@ -123,10 +102,7 @@ function skipWhenAuthMissing(page: Page): void {
   }
 }
 
-/**
- * Persona + role-grants stubs so `selectedAccount().uid` resolves and `canEdit()` returns true.
- * Mirrors `stubOrgProfileContext` from org-profile.spec.ts but scoped to this fixture's org.
- */
+/** Stubs persona + role-grants so `selectedAccount().uid` resolves and `canEdit()` returns true. */
 async function stubAccountContext(page: Page, opts: { writers: string[] } = { writers: [MOCK_UID] }): Promise<void> {
   await page.route('**/api/user/personas*', (route) =>
     route.fulfill({
@@ -179,10 +155,7 @@ async function stubEmployees(page: Page, employees: unknown[] = MOCK_EMPLOYEES, 
   });
 }
 
-/**
- * Stub the slug-keyed PUT proxy. The handler decides per-request what to return so individual tests
- * can compose loading-delays, partial failures, etc. Each route listener installs once per test.
- */
+/** Stubs the slug-keyed PUT proxy; the handler decides what to return per request. */
 async function stubReassignPut(page: Page, handler: (route: Route) => Promise<void> | void): Promise<void> {
   await page.route(/\/api\/orgs\/[^/]+\/lens\/key-contacts\/membership\/[^/]+\/[^/]+$/, async (route) => {
     if (route.request().method() !== 'PUT') return route.fallback();
@@ -356,7 +329,15 @@ test.describe('Org People → Key Contacts — Reassign Key Contact Roles modal 
             minContacts: 0,
             maxContacts: 10,
             people: [
-              { personId: 'kc-replacement-id', firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', email: MOCK_REPLACEMENT_EMAIL, jobTitle: null, initials: 'CD' },
+              {
+                personId: 'kc-replacement-id',
+                firstName: 'Cara',
+                lastName: 'Dev',
+                fullName: 'Cara Dev',
+                email: MOCK_REPLACEMENT_EMAIL,
+                jobTitle: null,
+                initials: 'CD',
+              },
             ],
           },
         }),

--- a/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts
@@ -1,0 +1,429 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org People — Reassign Key Contact Roles E2E (LFXV2-2067 main-row pencil).
+ *
+ * Covers the user-perspective acceptance criteria for the bulk-reassign flow scoped to ONE PERSON
+ * across N (membership, role-TYPE) tuples. Out of scope here: the expanded-row spec-024 4-state
+ * modal, which is exercised by `org-membership-key-contacts.spec.ts`.
+ *
+ * Coverage map (18 user-perspective points):
+ *   1–14, 17 baseline → "modal opens with the expected anatomy"
+ *   17 reactive label → "save button label and subtitle update as roles toggle"
+ *   15, 16            → "employee typeahead populates the name fields on selection"
+ *   18 success+loading → "save fans out PUTs, shows the spinner, closes on full success"
+ *   18 error           → "save failure keeps the modal open with a retryable inline error"
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
+ */
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const PEOPLE_KEY_CONTACTS_URL = '/org/people?tab=contacts';
+const DATA_LOAD_TIMEOUT = 30_000;
+const TOAST_TIMEOUT = 10_000;
+
+const MOCK_UID = '4c46585f-878c-8285-b2e9-2dbfc38ddd9b';
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_ACCOUNT_NAME = 'Acme Industries';
+const MOCK_ACCOUNT_SLUG = 'acme-industries';
+
+// Three roles across two foundations — gives concrete numbers for the subtitle and Save Changes label.
+const MOCK_PERSON_EMAIL = 'ada.tester@example.com';
+const MOCK_REPLACEMENT_EMAIL = 'cara.dev@example.com';
+
+// Stable role keys: `${membershipUid}:${contactType}` (mirrors `buildReassignRoleOptions` in the component).
+const ROLE_KEY_MARKETING_CNCF = 'msp-cncf:marketing';
+const ROLE_KEY_TECHNICAL_CNCF = 'msp-cncf:technical';
+const ROLE_KEY_LEGAL_EBPF = 'msp-ebpf:legal';
+
+const MOCK_KEY_CONTACTS_RESPONSE = {
+  assignments: [
+    {
+      contactUid: 'kc-marketing-cncf',
+      membershipUid: 'msp-cncf',
+      email: MOCK_PERSON_EMAIL,
+      firstName: 'Ada',
+      lastName: 'Tester',
+      displayName: 'Ada Tester',
+      title: 'Director, Open Source',
+      role: 'Marketing Contact',
+      foundationSlug: 'cncf',
+      foundationName: 'Cloud Native Computing Foundation',
+    },
+    {
+      contactUid: 'kc-technical-cncf',
+      membershipUid: 'msp-cncf',
+      email: MOCK_PERSON_EMAIL,
+      firstName: 'Ada',
+      lastName: 'Tester',
+      displayName: 'Ada Tester',
+      title: 'Director, Open Source',
+      role: 'Technical Contact',
+      foundationSlug: 'cncf',
+      foundationName: 'Cloud Native Computing Foundation',
+    },
+    {
+      contactUid: 'kc-legal-ebpf',
+      membershipUid: 'msp-ebpf',
+      email: MOCK_PERSON_EMAIL,
+      firstName: 'Ada',
+      lastName: 'Tester',
+      displayName: 'Ada Tester',
+      title: 'Director, Open Source',
+      role: 'Legal Contact',
+      foundationSlug: 'ebpf',
+      foundationName: 'eBPF Foundation',
+    },
+  ],
+  stats: {
+    individualCount: 1,
+    foundationsCovered: 2,
+    unfilledRequiredRoleCount: 0,
+  },
+};
+
+const MOCK_EMPLOYEES = [
+  {
+    email: MOCK_REPLACEMENT_EMAIL,
+    firstName: 'Cara',
+    lastName: 'Dev',
+    fullName: 'Cara Dev',
+    jobTitle: 'Senior Engineer',
+    initials: 'CD',
+  },
+  {
+    email: 'evan.qa@example.com',
+    firstName: 'Evan',
+    lastName: 'QA',
+    fullName: 'Evan QA',
+    jobTitle: 'QA Lead',
+    initials: 'EQ',
+  },
+];
+
+test.setTimeout(120_000);
+
+/**
+ * Bail out gracefully if Auth0 redirected the test (no TEST_USERNAME/TEST_PASSWORD set).
+ * Mirrors the helper used by org-profile.spec.ts.
+ */
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+/**
+ * Persona + role-grants stubs so `selectedAccount().uid` resolves and `canEdit()` returns true.
+ * Mirrors `stubOrgProfileContext` from org-profile.spec.ts but scoped to this fixture's org.
+ */
+async function stubAccountContext(page: Page, opts: { writers: string[] } = { writers: [MOCK_UID] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [
+          {
+            accountId: MOCK_ACCOUNT_ID,
+            accountName: MOCK_ACCOUNT_NAME,
+            accountSlug: MOCK_ACCOUNT_SLUG,
+            membershipTier: '',
+            uid: MOCK_UID,
+          },
+        ],
+        isRootWriter: false,
+      }),
+    })
+  );
+
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: opts.writers,
+        auditors: [],
+        cascadingWriters: [],
+        cascadingAuditors: [],
+        username: 'e2e-org-people-reassign',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubKeyContactsList(page: Page, body: unknown = MOCK_KEY_CONTACTS_RESPONSE): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/key-contacts$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function stubEmployees(page: Page, employees: unknown[] = MOCK_EMPLOYEES, status = 200): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/key-contacts\/employees$/, (route) => {
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees }) });
+  });
+}
+
+/**
+ * Stub the slug-keyed PUT proxy. The handler decides per-request what to return so individual tests
+ * can compose loading-delays, partial failures, etc. Each route listener installs once per test.
+ */
+async function stubReassignPut(page: Page, handler: (route: Route) => Promise<void> | void): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/key-contacts\/membership\/[^/]+\/[^/]+$/, async (route) => {
+    if (route.request().method() !== 'PUT') return route.fallback();
+    await handler(route);
+  });
+}
+
+async function gotoKeyContactsTab(page: Page): Promise<void> {
+  // Install stubs first; reload so the persona/role-grants fetches go through the mocks (mirrors org-profile S1).
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PEOPLE_KEY_CONTACTS_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  if (!page.url().includes('/org/people')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/people redirected away');
+  }
+
+  // Wait for the contacts panel to mount before any assertion.
+  await expect(page.getByTestId('org-people-panel-contacts')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.describe('Org People → Key Contacts — Reassign Key Contact Roles modal (LFXV2-2067)', () => {
+  test('opens with the expected anatomy and reflects the fixture counts', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubKeyContactsList(page);
+    await stubEmployees(page);
+
+    await gotoKeyContactsTab(page);
+
+    // (1, 2) Tab loaded; the row for Ada Tester is visible because the fixture seeded it.
+    const mainRow = page.getByTestId(`org-people-key-contacts-row-${MOCK_PERSON_EMAIL}`);
+    await expect(mainRow).toBeVisible();
+
+    // (3) Pencil renders on the main row (canEdit() true via writers stub).
+    const pencil = page.getByTestId(`org-people-key-contacts-reassign-${MOCK_PERSON_EMAIL}`);
+    await expect(pencil).toBeVisible();
+
+    // (4, 5) Click the pencil → modal mounts.
+    await pencil.click();
+    const modal = page.getByTestId('reassign-key-contact-modal');
+    await expect(modal).toBeVisible();
+
+    // (6) Exactly one modal title with the canonical copy.
+    const title = page.getByTestId('reassign-key-contact-title');
+    await expect(title).toHaveCount(1);
+    await expect(title).toHaveText('Reassign Key Contact Roles');
+
+    // (7) Subtitle reflects the fixture: 3 roles across 2 foundations.
+    await expect(page.getByTestId('reassign-key-contact-subtitle')).toHaveText('3 roles across 2 foundations');
+
+    // (8, 9) Current contact card with the prescribed subheading + avatar/name/email.
+    const currentCard = page.getByTestId('reassign-key-contact-current');
+    await expect(currentCard).toBeVisible();
+    // Heading copy is the exact prototype string; text-transform: uppercase is CSS so we assert the source-cased string.
+    await expect(currentCard).toContainText('Current Contact');
+    await expect(currentCard).toContainText('Will Be Removed From Selected Roles');
+    await expect(page.getByTestId('reassign-key-contact-current-avatar')).toHaveText('AT'); // Ada Tester
+    await expect(page.getByTestId('reassign-key-contact-current-name')).toHaveText('Ada Tester');
+    await expect(page.getByTestId('reassign-key-contact-current-email')).toHaveText(MOCK_PERSON_EMAIL);
+
+    // (10) "Select all" checkbox preselected — assert against the underlying <input> PrimeNG renders.
+    const selectAll = page.getByTestId('reassign-key-contact-select-all');
+    await expect(selectAll).toBeVisible();
+    await expect(selectAll.locator('input[type=checkbox]')).toBeChecked();
+
+    // (11) The role list contains exactly the 3 fixture rows, all preselected.
+    const list = page.getByTestId('reassign-key-contact-roles-list');
+    await expect(list).toBeVisible();
+    for (const key of [ROLE_KEY_MARKETING_CNCF, ROLE_KEY_TECHNICAL_CNCF, ROLE_KEY_LEGAL_EBPF]) {
+      await expect(page.getByTestId(`reassign-key-contact-role-row-${key}`)).toBeVisible();
+      await expect(page.getByTestId(`reassign-key-contact-role-checkbox-${key}`).locator('input[type=checkbox]')).toBeChecked();
+    }
+    // Foundation labels render alongside the role pills (one per row).
+    await expect(list).toContainText('Marketing Contact');
+    await expect(list).toContainText('Technical Contact');
+    await expect(list).toContainText('Legal Contact');
+    await expect(list).toContainText('Cloud Native Computing Foundation');
+    await expect(list).toContainText('eBPF Foundation');
+
+    // (12) Info banner appears below the list with the canonical copy.
+    const banner = page.getByTestId('reassign-key-contact-info-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveText("The person you assign below will replace the current contact in every role you've checked above.");
+
+    // (13, 14) Assign-to section with three required form fields below the banner.
+    const assignForm = page.getByTestId('reassign-key-contact-assign-form');
+    await expect(assignForm).toBeVisible();
+    await expect(page.getByTestId('reassign-key-contact-email-input')).toBeVisible();
+    await expect(page.getByTestId('reassign-key-contact-first-name-input')).toBeVisible();
+    await expect(page.getByTestId('reassign-key-contact-last-name-input')).toBeVisible();
+
+    // (17) Action buttons at the bottom; primary label echoes the checked count (default = all 3).
+    await expect(page.getByTestId('reassign-key-contact-cancel')).toBeVisible();
+    await expect(page.getByTestId('reassign-key-contact-primary-button')).toHaveText(/Save Changes \(3 roles\)/);
+  });
+
+  test('save button label and subtitle update live as roles are toggled', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubKeyContactsList(page);
+    await stubEmployees(page);
+
+    await gotoKeyContactsTab(page);
+    await page.getByTestId(`org-people-key-contacts-reassign-${MOCK_PERSON_EMAIL}`).click();
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeVisible();
+
+    const subtitle = page.getByTestId('reassign-key-contact-subtitle');
+    const primary = page.getByTestId('reassign-key-contact-primary-button');
+
+    // Drop the Legal/eBPF row → 2 roles, 1 foundation; pluralization stays plural.
+    await page.getByTestId(`reassign-key-contact-role-checkbox-${ROLE_KEY_LEGAL_EBPF}`).click();
+    await expect(subtitle).toHaveText('2 roles across 1 foundation');
+    await expect(primary).toHaveText(/Save Changes \(2 roles\)/);
+
+    // Drop one more (Technical/CNCF) → 1 role, 1 foundation; both go singular.
+    await page.getByTestId(`reassign-key-contact-role-checkbox-${ROLE_KEY_TECHNICAL_CNCF}`).click();
+    await expect(subtitle).toHaveText('1 role across 1 foundation');
+    await expect(primary).toHaveText(/Save Changes \(1 role\)/);
+
+    // Drop the last one → none checked; primary disabled and label echoes 0.
+    await page.getByTestId(`reassign-key-contact-role-checkbox-${ROLE_KEY_MARKETING_CNCF}`).click();
+    await expect(subtitle).toHaveText('0 roles across 0 foundations');
+    await expect(primary).toBeDisabled();
+  });
+
+  test('employee typeahead suggests matches and selecting one prefills first/last name', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubKeyContactsList(page);
+    await stubEmployees(page);
+
+    await gotoKeyContactsTab(page);
+    await page.getByTestId(`org-people-key-contacts-reassign-${MOCK_PERSON_EMAIL}`).click();
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeVisible();
+
+    // (15) Type into the email field → suggestions list opens and shows the match.
+    await page.getByTestId('reassign-key-contact-email-input').fill('cara');
+    const suggestions = page.getByTestId('reassign-key-contact-employee-suggestions');
+    await expect(suggestions).toBeVisible();
+    const option = page.getByTestId(`reassign-key-contact-employee-option-${MOCK_REPLACEMENT_EMAIL}`);
+    await expect(option).toBeVisible();
+
+    // (16) Click the suggestion → email/first/last fields prefill from the chosen employee.
+    await option.click();
+    await expect(page.getByTestId('reassign-key-contact-email-input')).toHaveValue(MOCK_REPLACEMENT_EMAIL);
+    await expect(page.getByTestId('reassign-key-contact-first-name-input')).toHaveValue('Cara');
+    await expect(page.getByTestId('reassign-key-contact-last-name-input')).toHaveValue('Dev');
+    // Suggestion list closes after a selection.
+    await expect(suggestions).toBeHidden();
+  });
+
+  test('save fans out PUTs, shows the spinner, then closes the modal and toasts on full success', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubKeyContactsList(page);
+    await stubEmployees(page);
+
+    // Track the fan-out so we can assert one PUT per checked role (3 here, since "Select all" stays on).
+    const putCalls: string[] = [];
+    await stubReassignPut(page, async (route) => {
+      putCalls.push(route.request().url());
+      // Small delay so the spinner has time to render before the resolution closes the modal.
+      await new Promise((r) => setTimeout(r, 200));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          contact: {
+            contactType: 'marketing',
+            contactTypeLabel: 'Marketing Contact',
+            minContacts: 0,
+            maxContacts: 10,
+            people: [
+              { personId: 'kc-replacement-id', firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', email: MOCK_REPLACEMENT_EMAIL, jobTitle: null, initials: 'CD' },
+            ],
+          },
+        }),
+      });
+    });
+
+    await gotoKeyContactsTab(page);
+    await page.getByTestId(`org-people-key-contacts-reassign-${MOCK_PERSON_EMAIL}`).click();
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeVisible();
+
+    // Pick the replacement person via typeahead (also exercises the prefill path, but minimally).
+    await page.getByTestId('reassign-key-contact-email-input').fill('cara');
+    await page.getByTestId(`reassign-key-contact-employee-option-${MOCK_REPLACEMENT_EMAIL}`).click();
+
+    // (18 — loading) Click Save → spinner becomes visible while the fan-out is in flight.
+    await page.getByTestId('reassign-key-contact-primary-button').click();
+    await expect(page.getByTestId('reassign-key-contact-primary-spinner')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('reassign-key-contact-primary-button')).toBeDisabled();
+
+    // (18 — success) Modal closes once every PUT resolves.
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeHidden({ timeout: TOAST_TIMEOUT });
+
+    // Success toast container becomes visible (PrimeNG MessageService dispatches by `key`).
+    await expect(page.getByTestId('org-people-key-contacts-toast-success')).toBeVisible({ timeout: TOAST_TIMEOUT });
+
+    // One PUT per checked role. Default is all 3 selected; the modal does not reuse calls.
+    expect(putCalls).toHaveLength(3);
+    // Each foundation slug in the URL is one of the fixture's slugs (defensive parsing — we don't pin order).
+    const slugSet = new Set(putCalls.map((u) => u.match(/\/membership\/([^/]+)\//)?.[1]));
+    expect(slugSet).toEqual(new Set(['cncf', 'ebpf']));
+  });
+
+  test('save failure keeps the modal open with a retryable inline error and no false success toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubKeyContactsList(page);
+    await stubEmployees(page);
+
+    // Every PUT fails — collapses to the modal's "Could not save changes" path because the BFF
+    // surfaces nothing else and Promise.allSettled treats every leg as rejected.
+    await stubReassignPut(page, (route) =>
+      route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'KEY_CONTACT_WRITE_FAILED', message: "Couldn't save right now. Please try again.", conflict: false } }),
+      })
+    );
+
+    await gotoKeyContactsTab(page);
+    await page.getByTestId(`org-people-key-contacts-reassign-${MOCK_PERSON_EMAIL}`).click();
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeVisible();
+
+    await page.getByTestId('reassign-key-contact-email-input').fill('cara');
+    await page.getByTestId(`reassign-key-contact-employee-option-${MOCK_REPLACEMENT_EMAIL}`).click();
+
+    await page.getByTestId('reassign-key-contact-primary-button').click();
+
+    // (18 — error) Inline save error surfaces; modal stays open so the user can retry without reopening.
+    const saveError = page.getByTestId('reassign-key-contact-save-error');
+    await expect(saveError).toBeVisible({ timeout: TOAST_TIMEOUT });
+    await expect(saveError).toContainText("Couldn't save right now. Please try again.");
+    await expect(page.getByTestId('reassign-key-contact-modal')).toBeVisible();
+
+    // Spinner clears once the parent rejects so the user can re-click Save.
+    await expect(page.getByTestId('reassign-key-contact-primary-spinner')).toBeHidden();
+    await expect(page.getByTestId('reassign-key-contact-primary-button')).toBeEnabled();
+
+    // No success toast on failure (negative assertion guards against accidental dispatches in the parent).
+    await expect(page.getByTestId('org-people-key-contacts-toast-success')).toBeHidden();
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.html
@@ -1,0 +1,216 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (person; as currentPerson) {
+  <div class="flex max-h-[80vh] flex-col gap-5 p-5" data-testid="reassign-key-contact-modal">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-lg font-semibold text-gray-900" id="reassign-key-contact-title" data-testid="reassign-key-contact-title">
+          Reassign Key Contact Roles
+        </h3>
+        <p class="text-xs text-gray-500" data-testid="reassign-key-contact-subtitle">{{ subtitle() }}</p>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="reassign-key-contact-close"
+        aria-label="Close"
+        (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg"></i>
+      </button>
+    </div>
+
+    <!-- Current Contact card -->
+    <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="reassign-key-contact-current">
+      <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Contact &middot; Will Be Removed From Selected Roles</div>
+      <div class="flex items-center gap-3">
+        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white" data-testid="reassign-key-contact-current-avatar">
+          {{ currentPerson.initials }}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold text-gray-900" data-testid="reassign-key-contact-current-name">{{ currentPerson.fullName }}</span>
+          <span class="text-xs text-gray-600" data-testid="reassign-key-contact-current-email">{{ currentPerson.email }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Select roles to reassign -->
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <h4 class="text-sm font-semibold text-gray-900">Select roles to reassign</h4>
+        <label class="flex cursor-pointer items-center gap-2 text-xs text-blue-600">
+          <p-checkbox
+            [binary]="true"
+            [ngModel]="allChecked()"
+            (ngModelChange)="toggleSelectAll()"
+            [disabled]="isSaving()"
+            inputId="reassign-key-contact-select-all"
+            data-testid="reassign-key-contact-select-all" />
+          <span>Select all</span>
+        </label>
+      </div>
+
+      <div class="flex max-h-[260px] flex-col gap-2 overflow-y-auto pr-1" data-testid="reassign-key-contact-roles-list">
+        @for (role of roles; track role.key) {
+          <div
+            class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+            [attr.data-testid]="'reassign-key-contact-role-row-' + role.key">
+            <p-checkbox
+              [binary]="true"
+              [ngModel]="isRoleChecked(role.key)"
+              (ngModelChange)="toggleRole(role.key)"
+              [disabled]="isSaving()"
+              [attr.data-testid]="'reassign-key-contact-role-checkbox-' + role.key" />
+            <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="role.pillClass">{{ role.role }}</span>
+            <span class="flex-1 text-sm text-gray-700">&middot; {{ role.foundationName }}</span>
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Info banner -->
+    <div
+      class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900"
+      role="status"
+      data-testid="reassign-key-contact-info-banner">
+      <i class="fa-light fa-circle-info mt-0.5 text-blue-600"></i>
+      <span>The person you assign below will replace the current contact in every role you've checked above.</span>
+    </div>
+
+    <!-- Assign to -->
+    <div class="flex flex-col gap-3" data-testid="reassign-key-contact-assign-form" (keydown)="onFormKeydown($event)">
+      <h4 class="text-sm font-semibold text-gray-900">Assign to</h4>
+
+      <div class="relative flex flex-col gap-1">
+        <label for="reassign-key-contact-email" class="text-xs font-medium text-gray-700">Email <span class="text-red-500">*</span></label>
+        <span class="relative">
+          <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+          <input
+            id="reassign-key-contact-email"
+            pInputText
+            type="email"
+            placeholder="Enter the employee's email address..."
+            class="w-full pl-8"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls="reassign-key-contact-employee-suggestions-id"
+            [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-describedby]="
+              (emailFormatError() ? 'reassign-key-contact-email-error-id' : null) || (duplicateError() ? 'reassign-key-contact-duplicate-error-id' : null)
+            "
+            [attr.aria-invalid]="!!emailFormatError() || !!duplicateError()"
+            data-testid="reassign-key-contact-email-input"
+            [disabled]="isSaving()"
+            [ngModel]="emailField()"
+            (ngModelChange)="onEmailChange($event)"
+            (focus)="onEmailFocus()"
+            (blur)="onEmailBlur()"
+            autocomplete="off" />
+        </span>
+        @if (suggestionsOpen() && filteredEmployees().length > 0) {
+          <ul
+            id="reassign-key-contact-employee-suggestions-id"
+            role="listbox"
+            aria-label="Employee suggestions"
+            class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            data-testid="reassign-key-contact-employee-suggestions">
+            @for (emp of filteredEmployees(); track emp.email) {
+              <li role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [attr.data-testid]="'reassign-key-contact-employee-option-' + emp.email"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="onSelectEmployee(emp)">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">{{ emp.initials }}</div>
+                  <div class="flex min-w-0 flex-col">
+                    <span class="truncate text-sm font-medium text-gray-900">{{ emp.fullName }}</span>
+                    <span class="truncate text-xs text-gray-500">{{ emp.email }}</span>
+                  </div>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+        @if (employeeSearchUnavailable()) {
+          <p class="text-xs text-gray-500" data-testid="reassign-key-contact-search-unavailable">
+            Employee search is unavailable. You can still enter the contact's details manually.
+          </p>
+        }
+        @if (emailFormatError()) {
+          <p id="reassign-key-contact-email-error-id" class="text-xs text-red-600" data-testid="reassign-key-contact-email-error">
+            {{ emailFormatError() }}
+          </p>
+        }
+        @if (duplicateError()) {
+          <p id="reassign-key-contact-duplicate-error-id" class="text-xs text-red-600" data-testid="reassign-key-contact-duplicate-error">
+            {{ duplicateError() }}
+          </p>
+        }
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label for="reassign-key-contact-first-name" class="text-xs font-medium text-gray-700">First Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-key-contact-first-name"
+            pInputText
+            type="text"
+            placeholder="First name"
+            [ngModel]="firstNameField()"
+            (ngModelChange)="firstNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="reassign-key-contact-first-name-input"
+            autocomplete="off" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="reassign-key-contact-last-name" class="text-xs font-medium text-gray-700">Last Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-key-contact-last-name"
+            pInputText
+            type="text"
+            placeholder="Last name"
+            [ngModel]="lastNameField()"
+            (ngModelChange)="lastNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="reassign-key-contact-last-name-input"
+            autocomplete="off" />
+        </div>
+      </div>
+    </div>
+
+    @if (saveError()) {
+      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700" role="alert" data-testid="reassign-key-contact-save-error">
+        {{ saveError() }}
+      </div>
+    }
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        class="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="reassign-key-contact-cancel"
+        (click)="onCancel()">
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        [disabled]="!saveEnabled()"
+        data-testid="reassign-key-contact-primary-button"
+        (click)="onSave()">
+        @if (isSaving()) {
+          <i class="fa-light fa-spinner fa-spin" data-testid="reassign-key-contact-primary-spinner"></i>
+        }
+        {{ primaryButtonLabel() }}
+      </button>
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.html
@@ -6,9 +6,7 @@
     <!-- Header -->
     <div class="flex items-start justify-between gap-4">
       <div class="flex flex-col gap-1">
-        <h3 class="text-lg font-semibold text-gray-900" id="reassign-key-contact-title" data-testid="reassign-key-contact-title">
-          Reassign Key Contact Roles
-        </h3>
+        <h3 class="text-lg font-semibold text-gray-900" id="reassign-key-contact-title" data-testid="reassign-key-contact-title">Reassign Key Contact Roles</h3>
         <p class="text-xs text-gray-500" data-testid="reassign-key-contact-subtitle">{{ subtitle() }}</p>
       </div>
       <button
@@ -26,7 +24,9 @@
     <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="reassign-key-contact-current">
       <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Contact &middot; Will Be Removed From Selected Roles</div>
       <div class="flex items-center gap-3">
-        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white" data-testid="reassign-key-contact-current-avatar">
+        <div
+          class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white"
+          data-testid="reassign-key-contact-current-avatar">
           {{ currentPerson.initials }}
         </div>
         <div class="flex flex-col">
@@ -53,13 +53,12 @@
       </div>
 
       <div class="flex max-h-[260px] flex-col gap-2 overflow-y-auto pr-1" data-testid="reassign-key-contact-roles-list">
+        @let checkedMap = checkedKeyMap();
         @for (role of roles; track role.key) {
-          <div
-            class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
-            [attr.data-testid]="'reassign-key-contact-role-row-' + role.key">
+          <div class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2" [attr.data-testid]="'reassign-key-contact-role-row-' + role.key">
             <p-checkbox
               [binary]="true"
-              [ngModel]="isRoleChecked(role.key)"
+              [ngModel]="checkedMap[role.key]"
               (ngModelChange)="toggleRole(role.key)"
               [disabled]="isSaving()"
               [attr.data-testid]="'reassign-key-contact-role-checkbox-' + role.key" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectorRef, Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { OrgLensMembershipsService } from '@services/org-lens-memberships.service';
@@ -27,7 +27,6 @@ import { take } from 'rxjs';
   templateUrl: './reassign-key-contact-roles-modal.component.html',
 })
 export class ReassignKeyContactRolesModalComponent {
-  private readonly cdr = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
   private readonly membershipsService = inject(OrgLensMembershipsService);
   private readonly dialogConfig = inject<DynamicDialogConfig<ReassignKeyContactRolesDialogData>>(DynamicDialogConfig);
@@ -178,7 +177,6 @@ export class ReassignKeyContactRolesModalComponent {
       .catch((e: unknown) => {
         this.isSaving.set(false);
         this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
-        this.cdr.markForCheck();
       });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
@@ -19,18 +19,7 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { take } from 'rxjs';
 
-/**
- * LFXV2-2067 — main-row "Reassign Key Contact Roles" modal.
- *
- * Scoped to ONE PERSON across N (membership, role-TYPE) tuples. The parent owns the fan-out write
- * (one PUT per selected role via `replaceKeyContactBySlug`) and reconciles the table on resolve;
- * this modal stays open during the call and surfaces a retryable inline error if the parent rejects.
- *
- * Mirrors `ReassignBoardRolesModalComponent` (board seats) for layout/state parity, and the
- * `EditKeyContactModalComponent` employee-search corpus for the "Assign to" typeahead. Uses the
- * same transitional org-key-contacts-as-employees corpus until LFXV2-1677 lands the canonical
- * employee feed.
- */
+/** LFXV2-2067 — bulk-reassign one person's N (membership, role-TYPE) tuples; parent fans out the PUTs. */
 @Component({
   selector: 'lfx-reassign-key-contact-roles-modal',
   standalone: true,
@@ -49,71 +38,33 @@ export class ReassignKeyContactRolesModalComponent {
   protected readonly roles: readonly ReassignKeyContactRolesRoleOption[] = this.dialogConfig.data?.roles ?? [];
   private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
 
-  // === Selection state ===
-  /** Per-(membership, role-TYPE) checkbox state. Default: all selected — matches the prototype's
-   *  "Select all preselected" intent so the most common workflow (full reassign) is one click. */
+  // Default: all selected so the most common workflow (full reassign) is one click.
   protected readonly selectedKeys = signal<Set<ReassignKeyContactRolesRoleKey>>(new Set(this.roles.map((r) => r.key)));
 
-  // === Form state ===
   protected readonly emailField = signal('');
   protected readonly firstNameField = signal('');
   protected readonly lastNameField = signal('');
-  protected readonly emailTouched = signal(false);
   protected readonly emailFormatError = signal<string | null>(null);
   protected readonly duplicateError = signal<string | null>(null);
 
-  // === Save / typeahead state ===
   protected readonly isSaving = signal(false);
   protected readonly saveError = signal<string | null>(null);
   protected readonly employees = signal<KeyContactEmployee[]>([]);
   protected readonly employeeSearchUnavailable = signal(false);
   protected readonly suggestionsOpen = signal(false);
 
-  // === Derived signals ===
   protected readonly checkedCount: Signal<number> = computed(() => this.selectedKeys().size);
-
-  protected readonly checkedFoundationCount: Signal<number> = computed(() => {
-    const selected = this.selectedKeys();
-    const slugs = new Set<string>();
-    for (const r of this.roles) if (selected.has(r.key)) slugs.add(r.foundationSlug);
-    return slugs.size;
-  });
-
   protected readonly allChecked: Signal<boolean> = computed(() => this.roles.length > 0 && this.selectedKeys().size === this.roles.length);
-
   protected readonly noneChecked: Signal<boolean> = computed(() => this.selectedKeys().size === 0);
-
-  protected readonly subtitle: Signal<string> = computed(() => {
-    const n = this.checkedCount();
-    const m = this.checkedFoundationCount();
-    return `${n} ${n === 1 ? 'role' : 'roles'} across ${m} ${m === 1 ? 'foundation' : 'foundations'}`;
-  });
-
-  protected readonly primaryButtonLabel: Signal<string> = computed(() => {
-    if (this.isSaving()) return 'Reassigning…';
-    const n = this.checkedCount();
-    return `Save Changes (${n} ${n === 1 ? 'role' : 'roles'})`;
-  });
-
-  /** Hide the current contact's own email from the typeahead — reassigning Hideo to Hideo is a no-op. */
-  private readonly excludedEmails = computed(() => {
-    const set = new Set<string>();
-    const currentEmail = this.person?.email?.trim().toLowerCase();
-    if (currentEmail) set.add(currentEmail);
-    return set;
-  });
-
-  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => {
-    const query = this.emailField().trim().toLowerCase();
-    if (!query) return [];
-    const excluded = this.excludedEmails();
-    return this.employees()
-      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
-      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
-      .slice(0, 8);
-  });
-
+  protected readonly checkedFoundationCount: Signal<number> = computed(() => this.initCheckedFoundationCount());
+  protected readonly subtitle: Signal<string> = computed(() => this.initSubtitle());
+  protected readonly primaryButtonLabel: Signal<string> = computed(() => this.initPrimaryButtonLabel());
+  protected readonly checkedKeyMap: Signal<Record<string, boolean>> = computed(() => this.initCheckedKeyMap());
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
   protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+
+  // Hide the current contact's own email from the typeahead — reassigning Hideo to Hideo is a no-op.
+  private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
 
   public constructor() {
     if (this.orgUid) {
@@ -147,11 +98,6 @@ export class ReassignKeyContactRolesModalComponent {
     });
   }
 
-  protected isRoleChecked(key: ReassignKeyContactRolesRoleKey): boolean {
-    return this.selectedKeys().has(key);
-  }
-
-  // === Form handlers ===
   protected onEmailFocus(): void {
     this.suggestionsOpen.set(true);
   }
@@ -168,7 +114,6 @@ export class ReassignKeyContactRolesModalComponent {
   protected onEmailBlur(): void {
     // Mousedown on a suggestion preventDefaults so click fires before blur — safe to close on blur.
     this.suggestionsOpen.set(false);
-    this.emailTouched.set(true);
     this.duplicateError.set(null);
     const value = this.emailField().trim();
     if (value && !EMAIL_REGEX.test(value)) {
@@ -243,6 +188,50 @@ export class ReassignKeyContactRolesModalComponent {
   }
 
   // === Computed helpers ===
+  private initCheckedFoundationCount(): number {
+    const selected = this.selectedKeys();
+    const slugs = new Set<string>();
+    for (const r of this.roles) if (selected.has(r.key)) slugs.add(r.foundationSlug);
+    return slugs.size;
+  }
+
+  private initSubtitle(): string {
+    const n = this.checkedCount();
+    const m = this.checkedFoundationCount();
+    return `${n} ${n === 1 ? 'role' : 'roles'} across ${m} ${m === 1 ? 'foundation' : 'foundations'}`;
+  }
+
+  private initPrimaryButtonLabel(): string {
+    if (this.isSaving()) return 'Reassigning…';
+    const n = this.checkedCount();
+    return `Save Changes (${n} ${n === 1 ? 'role' : 'roles'})`;
+  }
+
+  // O(1) per-row template lookup — avoids `isRoleChecked(role.key)` method calls inside @for.
+  private initCheckedKeyMap(): Record<string, boolean> {
+    const selected = this.selectedKeys();
+    const map: Record<string, boolean> = {};
+    for (const r of this.roles) map[r.key] = selected.has(r.key);
+    return map;
+  }
+
+  private initExcludedEmails(): Set<string> {
+    const set = new Set<string>();
+    const currentEmail = this.person?.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  }
+
+  private initFilteredEmployees(): KeyContactEmployee[] {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  }
+
   private initSaveEnabled(): boolean {
     if (this.isSaving()) return false;
     if (this.noneChecked()) return false;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/components/reassign-key-contact-roles-modal.component.ts
@@ -1,0 +1,256 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectorRef, Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { OrgLensMembershipsService } from '@services/org-lens-memberships.service';
+import { EMAIL_REGEX } from '@lfx-one/shared/constants';
+import type {
+  KeyContactEmployee,
+  ReassignKeyContactRolesDialogData,
+  ReassignKeyContactRolesPersonRef,
+  ReassignKeyContactRolesRoleKey,
+  ReassignKeyContactRolesRoleOption,
+  ReassignKeyContactRolesSubmitEvent,
+} from '@lfx-one/shared/interfaces';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { take } from 'rxjs';
+
+/**
+ * LFXV2-2067 — main-row "Reassign Key Contact Roles" modal.
+ *
+ * Scoped to ONE PERSON across N (membership, role-TYPE) tuples. The parent owns the fan-out write
+ * (one PUT per selected role via `replaceKeyContactBySlug`) and reconciles the table on resolve;
+ * this modal stays open during the call and surfaces a retryable inline error if the parent rejects.
+ *
+ * Mirrors `ReassignBoardRolesModalComponent` (board seats) for layout/state parity, and the
+ * `EditKeyContactModalComponent` employee-search corpus for the "Assign to" typeahead. Uses the
+ * same transitional org-key-contacts-as-employees corpus until LFXV2-1677 lands the canonical
+ * employee feed.
+ */
+@Component({
+  selector: 'lfx-reassign-key-contact-roles-modal',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, CheckboxModule],
+  templateUrl: './reassign-key-contact-roles-modal.component.html',
+})
+export class ReassignKeyContactRolesModalComponent {
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly membershipsService = inject(OrgLensMembershipsService);
+  private readonly dialogConfig = inject<DynamicDialogConfig<ReassignKeyContactRolesDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  // === Dialog-injected data ===
+  protected readonly person: ReassignKeyContactRolesPersonRef | null = this.dialogConfig.data?.person ?? null;
+  protected readonly roles: readonly ReassignKeyContactRolesRoleOption[] = this.dialogConfig.data?.roles ?? [];
+  private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
+
+  // === Selection state ===
+  /** Per-(membership, role-TYPE) checkbox state. Default: all selected — matches the prototype's
+   *  "Select all preselected" intent so the most common workflow (full reassign) is one click. */
+  protected readonly selectedKeys = signal<Set<ReassignKeyContactRolesRoleKey>>(new Set(this.roles.map((r) => r.key)));
+
+  // === Form state ===
+  protected readonly emailField = signal('');
+  protected readonly firstNameField = signal('');
+  protected readonly lastNameField = signal('');
+  protected readonly emailTouched = signal(false);
+  protected readonly emailFormatError = signal<string | null>(null);
+  protected readonly duplicateError = signal<string | null>(null);
+
+  // === Save / typeahead state ===
+  protected readonly isSaving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly employees = signal<KeyContactEmployee[]>([]);
+  protected readonly employeeSearchUnavailable = signal(false);
+  protected readonly suggestionsOpen = signal(false);
+
+  // === Derived signals ===
+  protected readonly checkedCount: Signal<number> = computed(() => this.selectedKeys().size);
+
+  protected readonly checkedFoundationCount: Signal<number> = computed(() => {
+    const selected = this.selectedKeys();
+    const slugs = new Set<string>();
+    for (const r of this.roles) if (selected.has(r.key)) slugs.add(r.foundationSlug);
+    return slugs.size;
+  });
+
+  protected readonly allChecked: Signal<boolean> = computed(() => this.roles.length > 0 && this.selectedKeys().size === this.roles.length);
+
+  protected readonly noneChecked: Signal<boolean> = computed(() => this.selectedKeys().size === 0);
+
+  protected readonly subtitle: Signal<string> = computed(() => {
+    const n = this.checkedCount();
+    const m = this.checkedFoundationCount();
+    return `${n} ${n === 1 ? 'role' : 'roles'} across ${m} ${m === 1 ? 'foundation' : 'foundations'}`;
+  });
+
+  protected readonly primaryButtonLabel: Signal<string> = computed(() => {
+    if (this.isSaving()) return 'Reassigning…';
+    const n = this.checkedCount();
+    return `Save Changes (${n} ${n === 1 ? 'role' : 'roles'})`;
+  });
+
+  /** Hide the current contact's own email from the typeahead — reassigning Hideo to Hideo is a no-op. */
+  private readonly excludedEmails = computed(() => {
+    const set = new Set<string>();
+    const currentEmail = this.person?.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  });
+
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  });
+
+  protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+
+  public constructor() {
+    if (this.orgUid) {
+      this.membershipsService
+        .getKeyContactEmployees(this.orgUid)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (res) => this.employees.set(res.employees ?? []),
+          error: () => this.employeeSearchUnavailable.set(true),
+        });
+    }
+  }
+
+  // === Selection handlers ===
+  protected toggleSelectAll(): void {
+    if (this.isSaving()) return;
+    if (this.allChecked()) {
+      this.selectedKeys.set(new Set());
+    } else {
+      this.selectedKeys.set(new Set(this.roles.map((r) => r.key)));
+    }
+  }
+
+  protected toggleRole(key: ReassignKeyContactRolesRoleKey): void {
+    if (this.isSaving()) return;
+    this.selectedKeys.update((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  protected isRoleChecked(key: ReassignKeyContactRolesRoleKey): boolean {
+    return this.selectedKeys().has(key);
+  }
+
+  // === Form handlers ===
+  protected onEmailFocus(): void {
+    this.suggestionsOpen.set(true);
+  }
+
+  protected onEmailChange(value: string): void {
+    this.emailField.set(value);
+    this.suggestionsOpen.set(true);
+    if (this.duplicateError()) this.duplicateError.set(null);
+    if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onEmailBlur(): void {
+    // Mousedown on a suggestion preventDefaults so click fires before blur — safe to close on blur.
+    this.suggestionsOpen.set(false);
+    this.emailTouched.set(true);
+    this.duplicateError.set(null);
+    const value = this.emailField().trim();
+    if (value && !EMAIL_REGEX.test(value)) {
+      this.emailFormatError.set('Enter a valid email address');
+    } else {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onSelectEmployee(employee: KeyContactEmployee): void {
+    this.emailField.set(employee.email);
+    this.firstNameField.set(employee.firstName);
+    this.lastNameField.set(employee.lastName);
+    this.emailFormatError.set(null);
+    this.duplicateError.set(null);
+    this.suggestionsOpen.set(false);
+  }
+
+  protected onFormKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && this.saveEnabled()) {
+      event.preventDefault();
+      this.onSave();
+    }
+  }
+
+  // === Save / cancel ===
+  protected onSave(): void {
+    if (!this.saveEnabled()) return;
+
+    const enteredEmail = this.emailField().trim().toLowerCase();
+    const currentEmail = this.person?.email?.trim().toLowerCase() ?? '';
+    if (enteredEmail === currentEmail) {
+      this.duplicateError.set('This person already holds the selected role(s).');
+      return;
+    }
+
+    const selectedKeySet = this.selectedKeys();
+    const selected = this.roles.filter((r) => selectedKeySet.has(r.key));
+    if (selected.length === 0) return;
+
+    const intent: ReassignKeyContactRolesSubmitEvent = {
+      newPerson: {
+        email: this.emailField().trim(),
+        firstName: this.firstNameField().trim(),
+        lastName: this.lastNameField().trim(),
+        jobTitle: null,
+      },
+      selected,
+    };
+
+    const submit = this.dialogConfig.data?.submit;
+    if (!submit) {
+      // Defensive — production flows always inject submit; fall back to closing so the dialog isn't stuck.
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.isSaving.set(true);
+    this.saveError.set(null);
+    submit(intent)
+      .then(() => this.dialogRef.close(null))
+      .catch((e: unknown) => {
+        this.isSaving.set(false);
+        this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
+        this.cdr.markForCheck();
+      });
+  }
+
+  protected onCancel(): void {
+    if (this.isSaving()) return;
+    this.dialogRef.close(null);
+  }
+
+  // === Computed helpers ===
+  private initSaveEnabled(): boolean {
+    if (this.isSaving()) return false;
+    if (this.noneChecked()) return false;
+    const email = this.emailField().trim();
+    if (!email || !EMAIL_REGEX.test(email)) return false;
+    if (this.firstNameField().trim().length === 0) return false;
+    if (this.lastNameField().trim().length === 0) return false;
+    if (this.emailFormatError() || this.duplicateError()) return false;
+    return true;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -148,11 +148,14 @@
                 </button>
               </th>
               <!--
-                LFXV2-2067: per-assignment Edit pencil is on the expanded sub-table; main-row Actions
-                column stays empty until LFXV2-1677 lands canonical employee data and the bulk-reassign
-                modal becomes safe (spec FR-005). Until then, expanded-row pencils are the only writer
-                affordance.
+                LFXV2-2067: main-row Actions column carries the bulk-Reassign pencil — opens the
+                "Reassign Key Contact Roles" modal scoped to one PERSON across N (membership, role)
+                tuples. The expanded-row pencil scopes to ONE (membership, role-TYPE). Both gates
+                read `canEdit()`.
               -->
+              <th class="w-12 px-4 py-3 text-right">
+                <span class="sr-only">Actions</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -197,10 +200,23 @@
                     group.foundationCount
                   }}</span>
                 </td>
+                <td class="px-4 py-3 text-right">
+                  <button
+                    type="button"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                    [disabled]="!canEdit()"
+                    [attr.aria-label]="'Reassign key contact roles for ' + group.displayName"
+                    [attr.data-testid]="'org-people-key-contacts-reassign-' + group.email"
+                    [pTooltip]="canEdit() ? 'Reassign key contact roles' : editDisabledTooltip"
+                    tooltipPosition="top"
+                    (click)="onMainPencilClick(group, $event)">
+                    <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                  </button>
+                </td>
               </tr>
               @if (expanded) {
                 <tr class="bg-slate-50" [attr.data-testid]="'org-people-key-contacts-expanded-' + group.email">
-                  <td colspan="4" class="p-0 pl-11">
+                  <td colspan="5" class="p-0 pl-11">
                     <table class="w-full border-collapse">
                       <thead>
                         <!--

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -201,17 +201,17 @@
                   }}</span>
                 </td>
                 <td class="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
-                    [disabled]="!canEdit()"
-                    [attr.aria-label]="'Reassign key contact roles for ' + group.displayName"
-                    [attr.data-testid]="'org-people-key-contacts-reassign-' + group.email"
-                    [pTooltip]="canEdit() ? 'Reassign key contact roles' : editDisabledTooltip"
-                    tooltipPosition="left"
-                    (click)="onMainPencilClick(group, $event)">
-                    <i class="fa-light fa-pencil" aria-hidden="true"></i>
-                  </button>
+                  <span class="inline-flex" [pTooltip]="canEdit() ? 'Reassign key contact roles' : editDisabledTooltip" tooltipPosition="left">
+                    <button
+                      type="button"
+                      class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                      [disabled]="!canEdit()"
+                      [attr.aria-label]="'Reassign key contact roles for ' + group.displayName"
+                      [attr.data-testid]="'org-people-key-contacts-reassign-' + group.email"
+                      (click)="onMainPencilClick(group, $event)">
+                      <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                    </button>
+                  </span>
                 </td>
               </tr>
               @if (expanded) {
@@ -248,17 +248,17 @@
                               }}</span>
                             </td>
                             <td class="px-4 py-2.5 text-right">
-                              <button
-                                type="button"
-                                class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
-                                [disabled]="!canEdit()"
-                                [attr.aria-label]="'Edit ' + assignment.role + ' for ' + assignment.foundationLabel"
-                                [attr.data-testid]="'org-people-key-contacts-edit-' + assignment.contactUid"
-                                [pTooltip]="canEdit() ? 'Edit contact' : editDisabledTooltip"
-                                tooltipPosition="top"
-                                (click)="onPencilClick(assignment, $event)">
-                                <i class="fa-light fa-pencil" aria-hidden="true"></i>
-                              </button>
+                              <span class="inline-flex" [pTooltip]="canEdit() ? 'Edit contact' : editDisabledTooltip" tooltipPosition="top">
+                                <button
+                                  type="button"
+                                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                                  [disabled]="!canEdit()"
+                                  [attr.aria-label]="'Edit ' + assignment.role + ' for ' + assignment.foundationLabel"
+                                  [attr.data-testid]="'org-people-key-contacts-edit-' + assignment.contactUid"
+                                  (click)="onPencilClick(assignment, $event)">
+                                  <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                                </button>
+                              </span>
                             </td>
                           </tr>
                         }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -208,7 +208,7 @@
                     [attr.aria-label]="'Reassign key contact roles for ' + group.displayName"
                     [attr.data-testid]="'org-people-key-contacts-reassign-' + group.email"
                     [pTooltip]="canEdit() ? 'Reassign key contact roles' : editDisabledTooltip"
-                    tooltipPosition="top"
+                    tooltipPosition="left"
                     (click)="onMainPencilClick(group, $event)">
                     <i class="fa-light fa-pencil" aria-hidden="true"></i>
                   </button>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.html
@@ -1,6 +1,10 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<p-toast position="top-right" key="org-people-key-contact-toast-success" data-testid="org-people-key-contacts-toast-success" />
+<p-toast position="top-right" key="org-people-key-contact-toast-remove" data-testid="org-people-key-contacts-toast-remove" />
+<p-toast position="top-right" key="org-people-key-contact-toast-error" data-testid="org-people-key-contacts-toast-error" />
+
 <div class="flex flex-col gap-6" data-testid="org-people-key-contacts">
   <!-- Filter bar -->
   <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4" data-testid="org-people-key-contacts-filter-bar">
@@ -144,10 +148,10 @@
                 </button>
               </th>
               <!--
-                V1 is read-only: no Actions column on the main row and no per-assignment Edit on the
-                expanded sub-table. Spec FR-005's reassign pencil + FR-006's expanded-row Edit pencil
-                are both gated on LFXV2-1677 (broader employee-source typeahead) before they can ship.
-                See spec.md lines 167–199.
+                LFXV2-2067: per-assignment Edit pencil is on the expanded sub-table; main-row Actions
+                column stays empty until LFXV2-1677 lands canonical employee data and the bulk-reassign
+                modal becomes safe (spec FR-005). Until then, expanded-row pencils are the only writer
+                affordance.
               -->
             </tr>
           </thead>
@@ -200,14 +204,18 @@
                     <table class="w-full border-collapse">
                       <thead>
                         <!--
-                          Expanded sub-table: Foundation | Contact Role only. Per-assignment Edit pencil
-                          is intentionally omitted in V1 — see spec.md FR-006/FR-009 and V1 status footnote
-                          (lines 167–199): expanded-row add/replace/remove is post-V1, gated on T036 and
-                          LFXV2-1677. The main-row pencil (above) provides writer-gated bulk-reassign.
+                          LFXV2-2067: expanded sub-table now carries the per-(membership, role-TYPE) Edit
+                          pencil. Click opens the spec-024 4-state modal (chooser/single-add/replace/remove);
+                          writer entitlement is enforced both in the UX (`canEdit()`) and on the BFF write
+                          proxy. The Actions column always renders so column widths stay stable across
+                          reader/writer personas.
                         -->
                         <tr class="border-b border-gray-200 bg-slate-100 text-left text-xs font-semibold uppercase text-gray-400">
                           <th class="px-4 py-2.5">Foundation</th>
                           <th class="px-4 py-2.5">Contact Role</th>
+                          <th class="w-12 px-4 py-2.5 text-right">
+                            <span class="sr-only">Actions</span>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>
@@ -222,6 +230,19 @@
                               <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="assignment.pillClass">{{
                                 assignment.role
                               }}</span>
+                            </td>
+                            <td class="px-4 py-2.5 text-right">
+                              <button
+                                type="button"
+                                class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                                [disabled]="!canEdit()"
+                                [attr.aria-label]="'Edit ' + assignment.role + ' for ' + assignment.foundationLabel"
+                                [attr.data-testid]="'org-people-key-contacts-edit-' + assignment.contactUid"
+                                [pTooltip]="canEdit() ? 'Edit contact' : editDisabledTooltip"
+                                tooltipPosition="top"
+                                (click)="onPencilClick(assignment, $event)">
+                                <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                              </button>
                             </td>
                           </tr>
                         }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -5,7 +5,7 @@ import { DecimalPipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, firstValueFrom, map, of, skip, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, firstValueFrom, map, of, skip, Subject, switchMap, take, takeUntil, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -46,18 +46,7 @@ import { KeyContactsService } from '../../services/key-contacts.service';
 import { ReassignKeyContactRolesModalComponent } from './components/reassign-key-contact-roles-modal.component';
 import { rolePillClass } from './helpers/key-contacts.helper';
 
-/**
- * Org Lens — People → Key Contacts tab.
- *
- * V1 (LFXV2-1873) shipped pure-read. LFXV2-2067 lights up TWO writer affordances on top of that:
- *   - Expanded-row pencil → spec-024 4-state modal (chooser/single-add/replace/remove) scoped to ONE
- *     (membership, role-TYPE) tuple.
- *   - Main-row pencil → "Reassign Key Contact Roles" modal scoped to ONE PERSON across N (membership,
- *     role-TYPE) tuples; fan-out PUTs replace the current contactUid on each selected role with the new
- *     person.
- * Both gates read `canEdit()` (writer-FGA via OrgRoleGrantsService.writerSet()), and both reuse the
- * transitional org-key-contacts-as-employees corpus until LFXV2-1677 lands the canonical employee feed.
- */
+/** Org Lens — People → Key Contacts tab; LFXV2-2067 adds the per-role and bulk-reassign edit affordances. */
 @Component({
   selector: 'lfx-org-people-key-contacts',
   imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
@@ -119,21 +108,21 @@ export class KeyContactsComponent {
 
   protected readonly hasUnfilledRoles: Signal<boolean> = computed(() => this.stats().unfilledRequiredRoleCount > 0);
 
-  // LFXV2-2067 — writer-FGA gate (UX). When the uid is unknown we stay permissive; the BFF write
-  // proxy still enforces. Mirrors the membership-detail page's gate (spec 024 FR-027/028).
-  protected readonly canEdit: Signal<boolean> = computed(() => {
-    const uid = this.accountContext.selectedAccount()?.uid;
-    if (!uid) return true;
-    return this.roleGrants.writerSet().has(uid);
-  });
+  // Writer-FGA gate (UX); BFF still re-enforces on write.
+  protected readonly canEdit: Signal<boolean> = computed(() => this.initCanEdit());
   protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
 
   protected readonly ariaSortMap: Signal<Record<OrgKeyContactSortColumn, 'ascending' | 'descending' | 'none'>> = computed(() => this.initAriaSortMap());
   protected readonly sortIconMap: Signal<Record<OrgKeyContactSortColumn, string>> = computed(() => this.initSortIconMap());
 
+  // Cancels in-flight catalog GETs and closes any open edit/reassign dialog when the user switches account mid-flight.
+  private readonly accountCancel$ = new Subject<void>();
+
   public constructor() {
-    // Clear expansion/filter state only when the org uid actually changes (skip(1) drops the initial sync emission).
-    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => this.resetAllState());
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
+      this.accountCancel$.next();
+      this.resetAllState();
+    });
   }
 
   protected onSort(column: OrgKeyContactSortColumn): void {
@@ -170,9 +159,7 @@ export class KeyContactsComponent {
     this.retryTrigger.update((v) => v + 1);
   }
 
-  // LFXV2-2067 — expanded-row Edit pencil. Loads the (membership, role-TYPE) catalog row for the
-  // assignment then opens the spec-024 4-state modal scoped to that role; on success the table refetches
-  // via `retryTrigger`. Server still re-enforces writer-FGA on the write proxy (Constitution I).
+  // Expanded-row Edit pencil — opens the spec-024 4-state modal scoped to one (membership, role-TYPE).
   protected onPencilClick(assignment: OrgKeyContactAssignmentVm, event: Event): void {
     event.stopPropagation();
     if (!this.canEdit()) return;
@@ -183,7 +170,7 @@ export class KeyContactsComponent {
 
     this.membershipsService
       .getKeyContactCatalogBySlug(orgUid, assignment.foundationSlug)
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .pipe(take(1), takeUntil(this.accountCancel$), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
           const contact = response.contacts.find((c) => c.contactType === contactType);
@@ -211,9 +198,7 @@ export class KeyContactsComponent {
       });
   }
 
-  // LFXV2-2067 — main-row Reassign pencil. Stops propagation so the row's expansion toggle doesn't
-  // also fire. Builds the modal's role catalog from the person's current assignments (filtering out
-  // any non-canonical roles defensively — those wouldn't have a stable contactType for the PUT body).
+  // Main-row Reassign pencil — opens the bulk modal scoped to one person across N (membership, role-TYPE) tuples.
   protected onMainPencilClick(group: OrgKeyContactPersonGroupVm, event: Event): void {
     event.stopPropagation();
     if (!this.canEdit()) return;
@@ -243,7 +228,7 @@ export class KeyContactsComponent {
       } satisfies ReassignKeyContactRolesDialogData,
     }) as DynamicDialogRef;
 
-    ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => undefined);
+    this.wireDialogToAccountChange(ref);
   }
 
   private buildReassignRoleOptions(group: OrgKeyContactPersonGroupVm): ReassignKeyContactRolesRoleOption[] {
@@ -264,15 +249,12 @@ export class KeyContactsComponent {
     return options;
   }
 
-  // LFXV2-2067 — Reassign fan-out. Each selected role becomes one PUT (`replaceKeyContactBySlug`)
-  // against the existing contactUid; member-service finds-or-creates the new person on email match.
-  // Promise.allSettled lets every op run; we always refresh the table afterward so partial writes
-  // are reflected. On any failure we throw so the modal stays open with a retryable inline message.
-  // Caveat: re-saving on partial-success will 404 the already-replaced contactUids — the inline
-  // error nudges the user to close and reopen on fresh state rather than retry blindly.
+  // Fan-out: one PUT per selected role; refresh table afterward; throw on any failure so the modal can retry inline.
   private async performReassignWrite(intent: ReassignKeyContactRolesSubmitEvent, orgUid: string): Promise<void> {
     const ops = intent.selected.map((role) =>
-      firstValueFrom(this.membershipsService.replaceKeyContactBySlug(orgUid, role.foundationSlug, role.contactUid, this.toReassignBody(intent, role.contactType)))
+      firstValueFrom(
+        this.membershipsService.replaceKeyContactBySlug(orgUid, role.foundationSlug, role.contactUid, this.toReassignBody(intent, role.contactType))
+      )
     );
 
     const results = await Promise.allSettled(ops);
@@ -309,6 +291,11 @@ export class KeyContactsComponent {
     };
   }
 
+  // Closes the dialog if the user switches account before they confirm — prevents wrong-org writes.
+  private wireDialogToAccountChange(ref: DynamicDialogRef): void {
+    this.accountCancel$.pipe(takeUntil(ref.onClose), takeUntilDestroyed(this.destroyRef)).subscribe(() => ref.close(null));
+  }
+
   private deriveInitials(firstName: string, lastName: string): string {
     const f = (firstName ?? '').trim().charAt(0).toUpperCase();
     const l = (lastName ?? '').trim().charAt(0).toUpperCase();
@@ -335,12 +322,10 @@ export class KeyContactsComponent {
       } satisfies EditKeyContactDialogData,
     }) as DynamicDialogRef;
 
-    ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => undefined);
+    this.wireDialogToAccountChange(ref);
   }
 
-  // Pessimistic write — modal stays open during the call and re-throws Error(message) so the modal can
-  // surface it inline. On success the org-wide People → Key Contacts dataset is refetched (cheaper than
-  // partial reconciliation here because the response is a per-membership catalog row, not the org list).
+  // Pessimistic write — modal stays open during the call and re-throws so it can surface an inline retry.
   private performWrite(intent: Exclude<EditKeyContactDialogResult, null>, orgUid: string, foundationSlug: string): Promise<void> {
     if (intent.kind === 'replace') return this.handleReplaceSubmit(intent.event, orgUid, foundationSlug);
     if (intent.kind === 'add') return this.handleAddSubmit(intent.event, orgUid, foundationSlug);
@@ -411,6 +396,12 @@ export class KeyContactsComponent {
       ...(removedPerson ? { detail: `${removedPerson.fullName} is no longer a ${event.contactTypeLabel}.` } : {}),
       life: 4000,
     });
+  }
+
+  private initCanEdit(): boolean {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    if (!uid) return true;
+    return this.roleGrants.writerSet().has(uid);
   }
 
   private initFoundationOptions(): OrgKeyContactDropdownOption[] {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -64,6 +64,7 @@ export class KeyContactsComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly tableSkeletonRows: readonly number[] = [0, 1, 2, 3, 4, 5];
+  protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
 
   protected readonly filterForm = new FormGroup({
     search: new FormControl<string>('', { nonNullable: true }),
@@ -110,7 +111,6 @@ export class KeyContactsComponent {
 
   // Writer-FGA gate (UX); BFF still re-enforces on write.
   protected readonly canEdit: Signal<boolean> = computed(() => this.initCanEdit());
-  protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
 
   protected readonly ariaSortMap: Signal<Record<OrgKeyContactSortColumn, 'ascending' | 'descending' | 'none'>> = computed(() => this.initAriaSortMap());
   protected readonly sortIconMap: Signal<Record<OrgKeyContactSortColumn, string>> = computed(() => this.initSortIconMap());

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -2,18 +2,25 @@
 // SPDX-License-Identifier: MIT
 
 import { DecimalPipe } from '@angular/common';
-import { Component, computed, inject, signal, type Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, map, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, firstValueFrom, map, of, skip, switchMap, take, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { AccountContextService } from '@services/account-context.service';
+import { OrgLensMembershipsService } from '@services/org-lens-memberships.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonProfilePanelService } from '@services/person-profile-panel.service';
-import { EMPTY_ORG_KEY_CONTACTS_RESPONSE } from '@lfx-one/shared/constants';
+import { EMPTY_ORG_KEY_CONTACTS_RESPONSE, roleToContactType } from '@lfx-one/shared/constants';
 import type {
+  AddKeyContactRequest,
+  EditKeyContactDialogData,
+  EditKeyContactDialogResult,
+  EditKeyContactRemoveEvent,
+  EditKeyContactSubmitEvent,
   OrgKeyContactAssignment,
   OrgKeyContactAssignmentVm,
   OrgKeyContactDropdownOption,
@@ -21,22 +28,41 @@ import type {
   OrgKeyContactSortColumn,
   OrgKeyContactSortDirection,
   OrgKeyContactsResponse,
+  OrgMembershipKeyContact,
 } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
+import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
 
+import { EditKeyContactModalComponent } from '../../../org-membership-detail/components/edit-key-contact-modal.component';
 import { KeyContactsService } from '../../services/key-contacts.service';
 import { rolePillClass } from './helpers/key-contacts.helper';
 
-/** Org Lens — People → Key Contacts tab. V1 is pure-read (stat strip + grouped expandable table); both edit paths are gated on LFXV2-1677. */
+/**
+ * Org Lens — People → Key Contacts tab.
+ *
+ * V1 (LFXV2-1873) shipped pure-read. LFXV2-2067 lights up the expanded-row Edit pencil that opens the
+ * spec-024 4-state modal (chooser/single-add/replace/remove) using existing org key contacts as the
+ * transitional employee-search corpus, gated on the same writer-FGA `OrgRoleGrantsService.writerSet()`
+ * the membership-detail page uses.
+ */
 @Component({
   selector: 'lfx-org-people-key-contacts',
-  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent],
+  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
+  providers: [MessageService, DialogService],
   templateUrl: './key-contacts.component.html',
 })
 export class KeyContactsComponent {
   private readonly accountContext = inject(AccountContextService);
   private readonly dataService = inject(KeyContactsService);
+  private readonly membershipsService = inject(OrgLensMembershipsService);
+  private readonly roleGrants = inject(OrgRoleGrantsService);
   private readonly personPanel = inject(PersonProfilePanelService);
+  private readonly messageService = inject(MessageService);
+  private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly tableSkeletonRows: readonly number[] = [0, 1, 2, 3, 4, 5];
 
@@ -83,6 +109,15 @@ export class KeyContactsComponent {
 
   protected readonly hasUnfilledRoles: Signal<boolean> = computed(() => this.stats().unfilledRequiredRoleCount > 0);
 
+  // LFXV2-2067 — writer-FGA gate (UX). When the uid is unknown we stay permissive; the BFF write
+  // proxy still enforces. Mirrors the membership-detail page's gate (spec 024 FR-027/028).
+  protected readonly canEdit: Signal<boolean> = computed(() => {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    if (!uid) return true;
+    return this.roleGrants.writerSet().has(uid);
+  });
+  protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
+
   protected readonly ariaSortMap: Signal<Record<OrgKeyContactSortColumn, 'ascending' | 'descending' | 'none'>> = computed(() => this.initAriaSortMap());
   protected readonly sortIconMap: Signal<Record<OrgKeyContactSortColumn, string>> = computed(() => this.initSortIconMap());
 
@@ -123,6 +158,145 @@ export class KeyContactsComponent {
 
   protected retry(): void {
     this.retryTrigger.update((v) => v + 1);
+  }
+
+  // LFXV2-2067 — expanded-row Edit pencil. Loads the (membership, role-TYPE) catalog row for the
+  // assignment then opens the spec-024 4-state modal scoped to that role; on success the table refetches
+  // via `retryTrigger`. Server still re-enforces writer-FGA on the write proxy (Constitution I).
+  protected onPencilClick(assignment: OrgKeyContactAssignmentVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit()) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+    const contactType = roleToContactType(assignment.role);
+    if (!contactType) return; // non-canonical roles shouldn't render a pencil; defensive bail-out.
+
+    this.membershipsService
+      .getKeyContactCatalogBySlug(orgUid, assignment.foundationSlug)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          const contact = response.contacts.find((c) => c.contactType === contactType);
+          if (!contact) {
+            this.messageService.add({
+              key: 'org-people-key-contact-toast-error',
+              severity: 'error',
+              summary: 'Could not load this role',
+              detail: 'Please try again.',
+              life: 4000,
+            });
+            return;
+          }
+          this.openEditModal(contact, assignment, orgUid);
+        },
+        error: () => {
+          this.messageService.add({
+            key: 'org-people-key-contact-toast-error',
+            severity: 'error',
+            summary: 'Could not load this role',
+            detail: 'Please try again.',
+            life: 4000,
+          });
+        },
+      });
+  }
+
+  private openEditModal(contact: OrgMembershipKeyContact, assignment: OrgKeyContactAssignmentVm, orgUid: string): void {
+    // Single-slot roles seed the modal directly into replace-form on the existing holder; multi-slot roles
+    // pre-select the row the user clicked from so the chooser opens already focused on that contact.
+    const editingPersonId = contact.maxContacts === 1 && contact.people.length === 1 ? contact.people[0].personId : assignment.contactUid;
+    const ref = this.dialogService.open(EditKeyContactModalComponent, {
+      header: 'Edit Key Contact',
+      width: '560px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        contact,
+        foundationName: assignment.foundationName ?? assignment.foundationSlug,
+        editingPersonId,
+        orgUid,
+        submit: (intent) => this.performWrite(intent, orgUid, assignment.foundationSlug),
+      } satisfies EditKeyContactDialogData,
+    }) as DynamicDialogRef;
+
+    ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => undefined);
+  }
+
+  // Pessimistic write — modal stays open during the call and re-throws Error(message) so the modal can
+  // surface it inline. On success the org-wide People → Key Contacts dataset is refetched (cheaper than
+  // partial reconciliation here because the response is a per-membership catalog row, not the org list).
+  private performWrite(intent: Exclude<EditKeyContactDialogResult, null>, orgUid: string, foundationSlug: string): Promise<void> {
+    if (intent.kind === 'replace') return this.handleReplaceSubmit(intent.event, orgUid, foundationSlug);
+    if (intent.kind === 'add') return this.handleAddSubmit(intent.event, orgUid, foundationSlug);
+    return this.handleRemoveSubmit(intent.event, orgUid, foundationSlug);
+  }
+
+  private handleReplaceSubmit(event: EditKeyContactSubmitEvent, orgUid: string, foundationSlug: string): Promise<void> {
+    const contactUid = event.editingPersonId;
+    if (!contactUid) return Promise.reject(new Error('Could not save changes. Please try again.'));
+    return firstValueFrom(this.membershipsService.replaceKeyContactBySlug(orgUid, foundationSlug, contactUid, this.toWriteBody(event)))
+      .then(() => {
+        this.messageService.add({ key: 'org-people-key-contact-toast-success', severity: 'success', summary: 'Key contact updated', life: 3000 });
+        this.retry();
+      })
+      .catch((err) => {
+        throw new Error(this.cleanErrorMessage(err));
+      });
+  }
+
+  private handleAddSubmit(event: EditKeyContactSubmitEvent, orgUid: string, foundationSlug: string): Promise<void> {
+    return firstValueFrom(this.membershipsService.addKeyContactBySlug(orgUid, foundationSlug, this.toWriteBody(event)))
+      .then(() => {
+        this.messageService.add({ key: 'org-people-key-contact-toast-success', severity: 'success', summary: 'Key contact added', life: 3000 });
+        this.retry();
+      })
+      .catch((err) => {
+        throw new Error(this.cleanErrorMessage(err));
+      });
+  }
+
+  private handleRemoveSubmit(event: EditKeyContactRemoveEvent, orgUid: string, foundationSlug: string): Promise<void> {
+    const removedPerson = this.findAssignmentPerson(event.personId);
+    return firstValueFrom(this.membershipsService.removeKeyContactBySlug(orgUid, foundationSlug, event.personId))
+      .then(() => {
+        this.showRemoveToast(event, removedPerson);
+        this.retry();
+      })
+      .catch((err) => {
+        throw new Error(this.cleanErrorMessage(err));
+      });
+  }
+
+  private toWriteBody(event: EditKeyContactSubmitEvent): AddKeyContactRequest {
+    return {
+      contactType: event.contactType,
+      email: event.person.email,
+      firstName: event.person.firstName,
+      lastName: event.person.lastName,
+      jobTitle: event.person.jobTitle,
+    };
+  }
+
+  private cleanErrorMessage(err: unknown): string {
+    return (err as { error?: { error?: { message?: string } } })?.error?.error?.message ?? 'Could not save changes. Please try again.';
+  }
+
+  private findAssignmentPerson(personId: string): { fullName: string } | null {
+    const match = this.response().assignments.find((a) => a.contactUid === personId);
+    return match ? { fullName: match.displayName } : null;
+  }
+
+  private showRemoveToast(event: EditKeyContactRemoveEvent, removedPerson: { fullName: string } | null): void {
+    this.messageService.clear('org-people-key-contact-toast-remove');
+    this.messageService.add({
+      key: 'org-people-key-contact-toast-remove',
+      severity: 'success',
+      summary: 'Key contact removed',
+      ...(removedPerson ? { detail: `${removedPerson.fullName} is no longer a ${event.contactTypeLabel}.` } : {}),
+      life: 4000,
+    });
   }
 
   private initFoundationOptions(): OrgKeyContactDropdownOption[] {
@@ -172,7 +346,6 @@ export class KeyContactsComponent {
         roles,
         foundationCount: foundationSlugs.size,
         assignments,
-        canEditAny: assignments.some((a) => a.canEdit),
         rolePills: roles.map((role) => ({ role, pillClass: rolePillClass(role) })),
         sortedAssignments,
       };

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -278,7 +278,7 @@ export class KeyContactsComponent {
     if (succeeded === 0) {
       throw new Error(this.cleanErrorMessage(failures[0].reason));
     }
-    throw new Error(`${succeeded} of ${total} reassignments succeeded. Close this dialog and re-open it to update the remaining roles.`);
+    throw new Error(`${succeeded} of ${total} reassignments succeeded. Reopen this dialog to retry the remaining roles with fresh state.`);
   }
 
   private toReassignBody(intent: ReassignKeyContactRolesSubmitEvent, contactType: OrgMembershipKeyContactType): ReplaceKeyContactRequest {
@@ -303,9 +303,9 @@ export class KeyContactsComponent {
   }
 
   private openEditModal(contact: OrgMembershipKeyContact, assignment: OrgKeyContactAssignmentVm, orgUid: string): void {
-    // Single-slot roles seed the modal directly into replace-form on the existing holder; multi-slot roles
-    // pre-select the row the user clicked from so the chooser opens already focused on that contact.
-    const editingPersonId = contact.maxContacts === 1 && contact.people.length === 1 ? contact.people[0].personId : assignment.contactUid;
+    // Single-slot roles seed the modal directly into replace-form on the lone holder. Multi-slot roles
+    // open the chooser; the modal does not use editingPersonId in chooser state, so we pass null.
+    const editingPersonId = contact.maxContacts === 1 && contact.people.length === 1 ? contact.people[0].personId : null;
     const ref = this.dialogService.open(EditKeyContactModalComponent, {
       header: 'Edit Key Contact',
       width: '560px',
@@ -400,7 +400,7 @@ export class KeyContactsComponent {
 
   private initCanEdit(): boolean {
     const uid = this.accountContext.selectedAccount()?.uid;
-    if (!uid) return true;
+    if (!uid) return false; // No edit until the org uid resolves; placeholder bootstrap state.
     return this.roleGrants.writerSet().has(uid);
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/key-contacts/key-contacts.component.ts
@@ -29,6 +29,11 @@ import type {
   OrgKeyContactSortDirection,
   OrgKeyContactsResponse,
   OrgMembershipKeyContact,
+  OrgMembershipKeyContactType,
+  ReassignKeyContactRolesDialogData,
+  ReassignKeyContactRolesRoleOption,
+  ReassignKeyContactRolesSubmitEvent,
+  ReplaceKeyContactRequest,
 } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -38,15 +43,20 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { EditKeyContactModalComponent } from '../../../org-membership-detail/components/edit-key-contact-modal.component';
 import { KeyContactsService } from '../../services/key-contacts.service';
+import { ReassignKeyContactRolesModalComponent } from './components/reassign-key-contact-roles-modal.component';
 import { rolePillClass } from './helpers/key-contacts.helper';
 
 /**
  * Org Lens — People → Key Contacts tab.
  *
- * V1 (LFXV2-1873) shipped pure-read. LFXV2-2067 lights up the expanded-row Edit pencil that opens the
- * spec-024 4-state modal (chooser/single-add/replace/remove) using existing org key contacts as the
- * transitional employee-search corpus, gated on the same writer-FGA `OrgRoleGrantsService.writerSet()`
- * the membership-detail page uses.
+ * V1 (LFXV2-1873) shipped pure-read. LFXV2-2067 lights up TWO writer affordances on top of that:
+ *   - Expanded-row pencil → spec-024 4-state modal (chooser/single-add/replace/remove) scoped to ONE
+ *     (membership, role-TYPE) tuple.
+ *   - Main-row pencil → "Reassign Key Contact Roles" modal scoped to ONE PERSON across N (membership,
+ *     role-TYPE) tuples; fan-out PUTs replace the current contactUid on each selected role with the new
+ *     person.
+ * Both gates read `canEdit()` (writer-FGA via OrgRoleGrantsService.writerSet()), and both reuse the
+ * transitional org-key-contacts-as-employees corpus until LFXV2-1677 lands the canonical employee feed.
  */
 @Component({
   selector: 'lfx-org-people-key-contacts',
@@ -199,6 +209,110 @@ export class KeyContactsComponent {
           });
         },
       });
+  }
+
+  // LFXV2-2067 — main-row Reassign pencil. Stops propagation so the row's expansion toggle doesn't
+  // also fire. Builds the modal's role catalog from the person's current assignments (filtering out
+  // any non-canonical roles defensively — those wouldn't have a stable contactType for the PUT body).
+  protected onMainPencilClick(group: OrgKeyContactPersonGroupVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit()) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+
+    const roles = this.buildReassignRoleOptions(group);
+    if (roles.length === 0) return; // No editable roles; defensive — pencil shouldn't have rendered.
+
+    const first = group.assignments[0];
+    const ref = this.dialogService.open(ReassignKeyContactRolesModalComponent, {
+      header: 'Reassign Key Contact Roles',
+      width: '560px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        person: {
+          fullName: group.displayName,
+          email: group.email,
+          initials: this.deriveInitials(first.firstName, first.lastName),
+        },
+        roles,
+        orgUid,
+        submit: (intent) => this.performReassignWrite(intent, orgUid),
+      } satisfies ReassignKeyContactRolesDialogData,
+    }) as DynamicDialogRef;
+
+    ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => undefined);
+  }
+
+  private buildReassignRoleOptions(group: OrgKeyContactPersonGroupVm): ReassignKeyContactRolesRoleOption[] {
+    const options: ReassignKeyContactRolesRoleOption[] = [];
+    for (const a of group.assignments) {
+      const contactType = roleToContactType(a.role);
+      if (!contactType) continue; // Non-canonical role → can't safely PUT; skip silently.
+      options.push({
+        key: `${a.membershipUid}:${contactType}`,
+        contactUid: a.contactUid,
+        contactType,
+        role: a.role,
+        pillClass: rolePillClass(a.role),
+        foundationSlug: a.foundationSlug,
+        foundationName: a.foundationName ?? a.foundationSlug,
+      });
+    }
+    return options;
+  }
+
+  // LFXV2-2067 — Reassign fan-out. Each selected role becomes one PUT (`replaceKeyContactBySlug`)
+  // against the existing contactUid; member-service finds-or-creates the new person on email match.
+  // Promise.allSettled lets every op run; we always refresh the table afterward so partial writes
+  // are reflected. On any failure we throw so the modal stays open with a retryable inline message.
+  // Caveat: re-saving on partial-success will 404 the already-replaced contactUids — the inline
+  // error nudges the user to close and reopen on fresh state rather than retry blindly.
+  private async performReassignWrite(intent: ReassignKeyContactRolesSubmitEvent, orgUid: string): Promise<void> {
+    const ops = intent.selected.map((role) =>
+      firstValueFrom(this.membershipsService.replaceKeyContactBySlug(orgUid, role.foundationSlug, role.contactUid, this.toReassignBody(intent, role.contactType)))
+    );
+
+    const results = await Promise.allSettled(ops);
+    this.retry();
+
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failures.length === 0) {
+      const total = intent.selected.length;
+      this.messageService.add({
+        key: 'org-people-key-contact-toast-success',
+        severity: 'success',
+        summary: 'Roles reassigned',
+        detail: `${total} ${total === 1 ? 'role was' : 'roles were'} reassigned.`,
+        life: 3000,
+      });
+      return;
+    }
+
+    const total = intent.selected.length;
+    const succeeded = total - failures.length;
+    if (succeeded === 0) {
+      throw new Error(this.cleanErrorMessage(failures[0].reason));
+    }
+    throw new Error(`${succeeded} of ${total} reassignments succeeded. Close this dialog and re-open it to update the remaining roles.`);
+  }
+
+  private toReassignBody(intent: ReassignKeyContactRolesSubmitEvent, contactType: OrgMembershipKeyContactType): ReplaceKeyContactRequest {
+    return {
+      contactType,
+      email: intent.newPerson.email,
+      firstName: intent.newPerson.firstName,
+      lastName: intent.newPerson.lastName,
+      jobTitle: intent.newPerson.jobTitle,
+    };
+  }
+
+  private deriveInitials(firstName: string, lastName: string): string {
+    const f = (firstName ?? '').trim().charAt(0).toUpperCase();
+    const l = (lastName ?? '').trim().charAt(0).toUpperCase();
+    return `${f}${l}` || '?';
   }
 
   private openEditModal(contact: OrgMembershipKeyContact, assignment: OrgKeyContactAssignmentVm, orgUid: string): void {

--- a/apps/lfx-one/src/app/shared/services/org-lens-memberships.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-memberships.service.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import type {
   AddKeyContactRequest,
+  KeyContactCatalogResponse,
   KeyContactEmployeesResponse,
   KeyContactMutationResponse,
   OrgActiveMembershipsResponse,
@@ -73,6 +74,42 @@ export class OrgLensMembershipsService {
   public removeKeyContact(orgUid: string, foundationId: string, contactUid: string): Observable<KeyContactMutationResponse> {
     return this.http.delete<KeyContactMutationResponse>(
       `/api/orgs/${encodeURIComponent(orgUid)}/lens/memberships/${encodeURIComponent(foundationId)}/key-contacts/${encodeURIComponent(contactUid)}`
+    );
+  }
+
+  // LFXV2-2067 — slug-keyed catalog GET + write proxies, used by the People → Key Contacts tab.
+  // The id-keyed write methods above route through the org sfid → foundation_id bridge that the
+  // membership-detail page needs; the People tab already has the slug per assignment row, so these
+  // methods skip the bridge and let the BFF call member-service directly.
+
+  public getKeyContactCatalogBySlug(orgUid: string, foundationSlug: string): Observable<KeyContactCatalogResponse> {
+    return this.http.get<KeyContactCatalogResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/key-contacts/membership/${encodeURIComponent(foundationSlug)}`
+    );
+  }
+
+  public addKeyContactBySlug(orgUid: string, foundationSlug: string, body: AddKeyContactRequest): Observable<KeyContactMutationResponse> {
+    return this.http.post<KeyContactMutationResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/key-contacts/membership/${encodeURIComponent(foundationSlug)}`,
+      body
+    );
+  }
+
+  public replaceKeyContactBySlug(
+    orgUid: string,
+    foundationSlug: string,
+    contactUid: string,
+    body: ReplaceKeyContactRequest
+  ): Observable<KeyContactMutationResponse> {
+    return this.http.put<KeyContactMutationResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/key-contacts/membership/${encodeURIComponent(foundationSlug)}/${encodeURIComponent(contactUid)}`,
+      body
+    );
+  }
+
+  public removeKeyContactBySlug(orgUid: string, foundationSlug: string, contactUid: string): Observable<KeyContactMutationResponse> {
+    return this.http.delete<KeyContactMutationResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/key-contacts/membership/${encodeURIComponent(foundationSlug)}/${encodeURIComponent(contactUid)}`
     );
   }
 }

--- a/apps/lfx-one/src/server/controllers/org-lens-key-contacts.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-key-contacts.controller.ts
@@ -105,10 +105,7 @@ export class OrgLensKeyContactsController {
     }
   }
 
-  // LFXV2-2067 — slug-keyed catalog GET + write proxies, used by the People → Key Contacts tab.
-  // The id-keyed routes above route through the org sfid → foundation_id bridge that the membership-detail
-  // page needs; the People tab already has the foundation slug per assignment row, so these endpoints
-  // skip the round-trip and pass the slug straight through to the underlying service.
+  // LFXV2-2067 — slug-keyed proxies skip the sfid→foundation_id bridge that the membership-detail page needs.
 
   // GET /api/orgs/:orgUid/lens/key-contacts/membership/:foundationSlug
   public async getKeyContactCatalogBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/controllers/org-lens-key-contacts.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-key-contacts.controller.ts
@@ -105,6 +105,101 @@ export class OrgLensKeyContactsController {
     }
   }
 
+  // LFXV2-2067 — slug-keyed catalog GET + write proxies, used by the People → Key Contacts tab.
+  // The id-keyed routes above route through the org sfid → foundation_id bridge that the membership-detail
+  // page needs; the People tab already has the foundation slug per assignment row, so these endpoints
+  // skip the round-trip and pass the slug straight through to the underlying service.
+
+  // GET /api/orgs/:orgUid/lens/key-contacts/membership/:foundationSlug
+  public async getKeyContactCatalogBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const foundationSlug = req.params['foundationSlug'];
+    const startTime = logger.startOperation(req, 'get_org_key_contact_catalog_by_slug', { org_uid: orgUid, foundation_slug: foundationSlug });
+    try {
+      assertOrgUid(orgUid, 'get_org_key_contact_catalog_by_slug');
+      this.assertFoundationSlug(foundationSlug, 'get_org_key_contact_catalog_by_slug');
+
+      const contacts = await this.service.getKeyContacts(req, orgUid, foundationSlug);
+
+      logger.success(req, 'get_org_key_contact_catalog_by_slug', startTime, {
+        org_uid: orgUid,
+        foundation_slug: foundationSlug,
+        row_count: contacts.length,
+      });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({ contacts });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // POST /api/orgs/:orgUid/lens/key-contacts/membership/:foundationSlug
+  public async addKeyContactBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const foundationSlug = req.params['foundationSlug'];
+    const startTime = logger.startOperation(req, 'add_org_key_contact_by_slug', { org_uid: orgUid, foundation_slug: foundationSlug });
+    try {
+      assertOrgUid(orgUid, 'add_org_key_contact_by_slug');
+      this.assertFoundationSlug(foundationSlug, 'add_org_key_contact_by_slug');
+      const body = this.parseContactBody(req, 'add_org_key_contact_by_slug');
+
+      const contact = await this.service.addKeyContact(req, orgUid, foundationSlug, body);
+
+      logger.success(req, 'add_org_key_contact_by_slug', startTime, { org_uid: orgUid, foundation_slug: foundationSlug, contact_type: body.contactType });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({ contact });
+    } catch (error) {
+      this.handleWriteError(req, res, next, error, 'add_org_key_contact_by_slug');
+    }
+  }
+
+  // PUT /api/orgs/:orgUid/lens/key-contacts/membership/:foundationSlug/:contactUid
+  public async replaceKeyContactBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const foundationSlug = req.params['foundationSlug'];
+    const contactUid = req.params['contactUid'];
+    const startTime = logger.startOperation(req, 'replace_org_key_contact_by_slug', { org_uid: orgUid, foundation_slug: foundationSlug });
+    try {
+      assertOrgUid(orgUid, 'replace_org_key_contact_by_slug');
+      this.assertFoundationSlug(foundationSlug, 'replace_org_key_contact_by_slug');
+      this.assertContactUid(contactUid, 'replace_org_key_contact_by_slug');
+      const body = this.parseContactBody(req, 'replace_org_key_contact_by_slug') as ReplaceKeyContactRequest;
+
+      const contact = await this.service.replaceKeyContact(req, orgUid, foundationSlug, contactUid, body);
+
+      logger.success(req, 'replace_org_key_contact_by_slug', startTime, {
+        org_uid: orgUid,
+        foundation_slug: foundationSlug,
+        contact_type: body.contactType,
+      });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({ contact });
+    } catch (error) {
+      this.handleWriteError(req, res, next, error, 'replace_org_key_contact_by_slug');
+    }
+  }
+
+  // DELETE /api/orgs/:orgUid/lens/key-contacts/membership/:foundationSlug/:contactUid
+  public async removeKeyContactBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const foundationSlug = req.params['foundationSlug'];
+    const contactUid = req.params['contactUid'];
+    const startTime = logger.startOperation(req, 'remove_org_key_contact_by_slug', { org_uid: orgUid, foundation_slug: foundationSlug });
+    try {
+      assertOrgUid(orgUid, 'remove_org_key_contact_by_slug');
+      this.assertFoundationSlug(foundationSlug, 'remove_org_key_contact_by_slug');
+      this.assertContactUid(contactUid, 'remove_org_key_contact_by_slug');
+
+      const contact = await this.service.removeKeyContact(req, orgUid, foundationSlug, contactUid);
+
+      logger.success(req, 'remove_org_key_contact_by_slug', startTime, { org_uid: orgUid, foundation_slug: foundationSlug });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({ contact });
+    } catch (error) {
+      this.handleWriteError(req, res, next, error, 'remove_org_key_contact_by_slug');
+    }
+  }
+
   // ── helpers ────────────────────────────────────────────────────────────────
 
   // Resolves the foundation slug from the Snowflake-backed summaries. Spec 002: orgUid is the SFID.
@@ -157,6 +252,14 @@ export class OrgLensKeyContactsController {
   private assertFoundationId(foundationId: string | undefined, operation: string): asserts foundationId is string {
     if (!foundationId || !FOUNDATION_ID_PATTERN.test(foundationId)) {
       throw ServiceValidationError.forField('foundationId', 'Invalid foundationId format', { operation });
+    }
+  }
+
+  private assertFoundationSlug(foundationSlug: string | undefined, operation: string): asserts foundationSlug is string {
+    // Reuse FOUNDATION_ID_PATTERN — it permits the alphanumeric+hyphen surface that foundation slugs
+    // share with the legacy id strings (matches the precedent in `getMembershipDetail`).
+    if (!foundationSlug || !FOUNDATION_ID_PATTERN.test(foundationSlug)) {
+      throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', { operation });
     }
   }
 

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -56,6 +56,21 @@ function buildOrgsRouter(): Router {
   router.delete('/:orgUid/lens/memberships/:foundationId/key-contacts/:contactUid', (req, res, next) =>
     orgLensKeyContactsController.removeKeyContact(req, res, next)
   );
+  // LFXV2-2067 — slug-keyed catalog GET + write proxies for the People → Key Contacts tab. The id-keyed
+  // routes above route through the org sfid → foundation_id bridge that the membership-detail page uses;
+  // the People tab already has the slug per assignment row, so these endpoints skip the bridge.
+  router.get('/:orgUid/lens/key-contacts/membership/:foundationSlug', (req, res, next) =>
+    orgLensKeyContactsController.getKeyContactCatalogBySlug(req, res, next)
+  );
+  router.post('/:orgUid/lens/key-contacts/membership/:foundationSlug', (req, res, next) =>
+    orgLensKeyContactsController.addKeyContactBySlug(req, res, next)
+  );
+  router.put('/:orgUid/lens/key-contacts/membership/:foundationSlug/:contactUid', (req, res, next) =>
+    orgLensKeyContactsController.replaceKeyContactBySlug(req, res, next)
+  );
+  router.delete('/:orgUid/lens/key-contacts/membership/:foundationSlug/:contactUid', (req, res, next) =>
+    orgLensKeyContactsController.removeKeyContactBySlug(req, res, next)
+  );
   router.get('/:orgUid/lens/people/all', (req, res, next) => orgLensPeopleController.getAllEmployees(req, res, next));
   // Spec 005 (LFXV2-1873) — People → Key Contacts tab (org-wide, read-only). Membership-scoped reads + writes live above on orgLensKeyContactsController.
   router.get('/:orgUid/lens/people/key-contacts', (req, res, next) => orgLensPeopleController.getKeyContacts(req, res, next));

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -56,15 +56,11 @@ function buildOrgsRouter(): Router {
   router.delete('/:orgUid/lens/memberships/:foundationId/key-contacts/:contactUid', (req, res, next) =>
     orgLensKeyContactsController.removeKeyContact(req, res, next)
   );
-  // LFXV2-2067 — slug-keyed catalog GET + write proxies for the People → Key Contacts tab. The id-keyed
-  // routes above route through the org sfid → foundation_id bridge that the membership-detail page uses;
-  // the People tab already has the slug per assignment row, so these endpoints skip the bridge.
+  // LFXV2-2067 — slug-keyed proxies for the People → Key Contacts tab; skip the sfid→foundation_id bridge.
   router.get('/:orgUid/lens/key-contacts/membership/:foundationSlug', (req, res, next) =>
     orgLensKeyContactsController.getKeyContactCatalogBySlug(req, res, next)
   );
-  router.post('/:orgUid/lens/key-contacts/membership/:foundationSlug', (req, res, next) =>
-    orgLensKeyContactsController.addKeyContactBySlug(req, res, next)
-  );
+  router.post('/:orgUid/lens/key-contacts/membership/:foundationSlug', (req, res, next) => orgLensKeyContactsController.addKeyContactBySlug(req, res, next));
   router.put('/:orgUid/lens/key-contacts/membership/:foundationSlug/:contactUid', (req, res, next) =>
     orgLensKeyContactsController.replaceKeyContactBySlug(req, res, next)
   );

--- a/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
@@ -95,7 +95,6 @@ export class OrgPeopleKeyContactsService {
         role,
         foundationSlug,
         foundationName: this.resolveFoundationName(membership),
-        canEdit: false,
       });
     }
 
@@ -111,7 +110,9 @@ export class OrgPeopleKeyContactsService {
       }
     }
 
-    // T027 writer-FGA check is deferred until LFXV2-1677 lands the edit affordances; `canEdit` stays `false`.
+    // LFXV2-2067: writer-FGA gate is computed client-side via OrgRoleGrantsService.writerSet() (mirrors
+    // the membership-detail page in spec 024). Keeping the gate off the wire avoids a per-row server flag
+    // that would always equal a single org-level boolean; the BFF endpoints still re-enforce on write.
     return {
       assignments: rawAssignments,
       stats: this.computeStats(rawAssignments),

--- a/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-key-contacts.service.ts
@@ -110,9 +110,7 @@ export class OrgPeopleKeyContactsService {
       }
     }
 
-    // LFXV2-2067: writer-FGA gate is computed client-side via OrgRoleGrantsService.writerSet() (mirrors
-    // the membership-detail page in spec 024). Keeping the gate off the wire avoids a per-row server flag
-    // that would always equal a single org-level boolean; the BFF endpoints still re-enforce on write.
+    // LFXV2-2067: writer-FGA computed client-side via OrgRoleGrantsService.writerSet(); BFF re-enforces on write.
     return {
       assignments: rawAssignments,
       stats: this.computeStats(rawAssignments),

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -153,6 +153,16 @@ export interface KeyContactMutationResponse {
   contact: OrgMembershipKeyContact;
 }
 
+/**
+ * LFXV2-2067: response shape for the slug-keyed catalog GET used by the People → Key Contacts
+ * tab to populate the 4-state edit modal (chooser/single-add/replace/remove). The membership-detail
+ * page (spec 024) already gets the catalog inline as part of `OrgMembershipDetailResponse.keyContacts`,
+ * so it does not need this endpoint.
+ */
+export interface KeyContactCatalogResponse {
+  contacts: OrgMembershipKeyContact[];
+}
+
 export interface OrgMembershipKeyContact {
   contactType: OrgMembershipKeyContactType;
   contactTypeLabel: string;

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -153,12 +153,7 @@ export interface KeyContactMutationResponse {
   contact: OrgMembershipKeyContact;
 }
 
-/**
- * LFXV2-2067: response shape for the slug-keyed catalog GET used by the People → Key Contacts
- * tab to populate the 4-state edit modal (chooser/single-add/replace/remove). The membership-detail
- * page (spec 024) already gets the catalog inline as part of `OrgMembershipDetailResponse.keyContacts`,
- * so it does not need this endpoint.
- */
+/** LFXV2-2067: slug-keyed catalog response for the People → Key Contacts edit modal. */
 export interface KeyContactCatalogResponse {
   contacts: OrgMembershipKeyContact[];
 }

--- a/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
@@ -26,7 +26,6 @@ export interface OrgKeyContactAssignment {
   role: string;
   foundationSlug: string;
   foundationName: string | null;
-  canEdit: boolean;
 }
 
 /** Account-level stat strip (FR-004 — filter-independent). */
@@ -62,7 +61,6 @@ export interface OrgKeyContactPersonGroup {
   roles: string[];
   foundationCount: number;
   assignments: OrgKeyContactAssignment[];
-  canEditAny: boolean;
 }
 
 /** Pre-decorated assignment for the expanded sub-table — pillClass + foundation rowspan flags computed once. */

--- a/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { OrgMembershipKeyContactType } from './org-memberships.interface';
+
 /** Canonical member-service role strings — 9 values. */
 export type OrgKeyContactRole =
   | 'Billing Contact'
@@ -81,3 +83,63 @@ export interface OrgKeyContactPersonGroupVm extends OrgKeyContactPersonGroup {
   rolePills: OrgKeyContactRolePillVm[];
   sortedAssignments: OrgKeyContactAssignmentVm[];
 }
+
+// ============================================================
+// LFXV2-2067 — main-row "Reassign Key Contact Roles" modal
+// ============================================================
+// The expanded-row pencil opens the spec-024 4-state modal scoped to ONE (membership, role-TYPE).
+// The main-row pencil opens the Reassign Key Contact Roles modal below — scoped to ONE PERSON
+// across ALL their (membership, role) tuples — for swap-in-bulk flows where the legal admin
+// just changed and every role this person held should move to the new person.
+
+/** Stable identifier used by the modal's checkbox state map. `${membershipUid}:${contactType}`. */
+export type ReassignKeyContactRolesRoleKey = string;
+
+/** One checkbox row in the Reassign Key Contact Roles modal — represents the current person's
+ *  hold on a (membership, role-TYPE). The contactUid is the existing key_contact UID that gets
+ *  PUT-replaced when the user confirms. */
+export interface ReassignKeyContactRolesRoleOption {
+  key: ReassignKeyContactRolesRoleKey;
+  contactUid: string;
+  contactType: OrgMembershipKeyContactType;
+  /** Display role name (e.g. "Marketing Contact"). */
+  role: string;
+  /** Tailwind pill classes for the role badge — reused from the parent table's helper. */
+  pillClass: string;
+  foundationSlug: string;
+  foundationName: string;
+}
+
+/** Avatar/name/email summary for the orange "current contact" card in the modal header. */
+export interface ReassignKeyContactRolesPersonRef {
+  fullName: string;
+  email: string;
+  initials: string;
+}
+
+/** Dialog input — the parent supplies the person being replaced, the role catalog (one row per
+ *  current assignment), the org uuid for the employee-search corpus, and a pessimistic submit
+ *  callback that performs the fan-out write and resolves only when the affected rows are saved. */
+export interface ReassignKeyContactRolesDialogData {
+  person: ReassignKeyContactRolesPersonRef;
+  roles: ReassignKeyContactRolesRoleOption[];
+  orgUid: string;
+  submit: (intent: ReassignKeyContactRolesSubmitEvent) => Promise<void>;
+}
+
+/** Modal → parent submit payload. The parent fans out N PUTs (one per selected role) using the
+ *  slug-keyed write proxy and resolves the Promise on all-success; partial failure rejects with
+ *  Error(message) so the modal stays open with an inline error. */
+export interface ReassignKeyContactRolesSubmitEvent {
+  newPerson: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    jobTitle: string | null;
+  };
+  selected: ReassignKeyContactRolesRoleOption[];
+}
+
+/** Dialog returns null on cancel; on save the parent already drove the write through `submit`,
+ *  so the resolved value carries no payload. */
+export type ReassignKeyContactRolesDialogResult = null;

--- a/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
+++ b/packages/shared/src/interfaces/org-people-key-contacts.interface.ts
@@ -84,13 +84,7 @@ export interface OrgKeyContactPersonGroupVm extends OrgKeyContactPersonGroup {
   sortedAssignments: OrgKeyContactAssignmentVm[];
 }
 
-// ============================================================
-// LFXV2-2067 — main-row "Reassign Key Contact Roles" modal
-// ============================================================
-// The expanded-row pencil opens the spec-024 4-state modal scoped to ONE (membership, role-TYPE).
-// The main-row pencil opens the Reassign Key Contact Roles modal below — scoped to ONE PERSON
-// across ALL their (membership, role) tuples — for swap-in-bulk flows where the legal admin
-// just changed and every role this person held should move to the new person.
+// LFXV2-2067 — reassign-modal contracts.
 
 /** Stable identifier used by the modal's checkbox state map. `${membershipUid}:${contactType}`. */
 export type ReassignKeyContactRolesRoleKey = string;


### PR DESCRIPTION
## Summary

Two writer affordances, scoped differently, both gated client-side on `OrgRoleGrantsService.writerSet()` (BFF write proxies still re-enforce on every mutation):

- **Expanded-row Edit pencil** — opens the spec-024 4-state modal (chooser / single-add / replace / remove) scoped to ONE (active membership, role-TYPE) tuple. Reuses every server-side primitive from the Membership Detail tab: same write proxy, same min/max enforcement from `KEY_CONTACT_ROLE_CATALOG`, same employee typeahead, same optimistic-concurrency error mapping.
- **Main-row Reassign Key Contact Roles pencil** — opens a dedicated bulk-reassign modal scoped to ONE PERSON across N (membership, role-TYPE) tuples. Lists every role this person currently holds with checkboxes (Select-all preselected), live `X roles across Y foundations` subtitle, `Assign to` typeahead pre-excluding the current contact's email, fan-out save (one parallel PUT per checked role) with pessimistic UI — modal stays open during the call, surfaces a retryable inline error if any of the writes reject, refreshes the table on completion regardless.

New BFF surface: slug-keyed catalog GET + write proxies (POST / PUT / DELETE) on `OrgLensKeyContactsController`. The People tab carries the foundation slug per assignment row, so these endpoints skip the org `sfid → foundation_id` bridge that the membership-detail page needs.

Wire-level cleanup: the `canEdit` / `canEditAny` fields on `OrgKeyContactsResponse` always equalled a single org-level boolean and are dropped — the gate is now computed entirely client-side, mirroring the membership-detail page.

Mid-flight account switching: an `accountCancel$` subject piped off `orgUid$.pipe(skip(1))` cancels in-flight catalog fetches and closes any open edit / reassign dialog when the user changes account, so the user can't confirm a write against a previous org's scope.

Until LFXV2-1677 lands the canonical organisation-employees data source, the `Assign to` typeahead is populated from the same transitional corpus the spec-024 modal already uses (the org's existing `key_contact` records, deduped by email). When the canonical source ships, the BFF widens the corpus transparently — no UI change.

## Out of scope (intentionally)

- **LFXV2-1677** (canonical organisation-employees feed). This PR consumes whichever corpus is wired at runtime.
- **Read-path changes** to People → Key Contacts — already shipped under LFXV2-1873.
- **Voting-rep → dashboard-access downgrade** side effect — legacy org-dashboard behaviour, handled downstream by `fga-sync`.

## Test plan

### Manual QA

- [ ] Expanded-row pencil — single-slot role with one current contact: chooser does NOT open; modal seeds directly into Replace state on the existing holder.
- [ ] Expanded-row pencil — multi-slot role with multiple contacts: chooser opens with the clicked person preselected.
- [ ] Expanded-row pencil — Add: empty multi-slot role accepts a new contact; table refreshes with the new row.
- [ ] Expanded-row pencil — Replace: existing holder swapped for a new email; success toast confirms.
- [ ] Expanded-row pencil — Remove: existing holder removed when role count > minContacts; remove blocked when at minContacts.
- [ ] Main-row pencil — opens with `Select all` preselected; subtitle reads `X roles across Y foundations` matching the count.
- [ ] Main-row pencil — toggling individual checkboxes updates the subtitle and the `Save Changes (X roles)` label live.
- [ ] Main-row pencil — `Assign to` typeahead suggests existing org key contacts; current contact's email excluded; selecting prefills first / last name.
- [ ] Main-row pencil — happy path: full-success Save closes the modal, success toast fires, table reflects the new contact across all checked roles.
- [ ] Main-row pencil — partial failure: Save with some PUTs failing keeps the modal open with a retryable inline error and refreshes the table to show the partial state.
- [ ] Main-row pencil — full failure: Save with all PUTs failing keeps the modal open with the upstream error message inline.
- [ ] Read-only persona / impersonation: pencil affordances suppressed (both expanded-row and main-row).
- [ ] Account switch mid-flight: open the edit modal, then change account in the org selector; the modal closes and the in-flight catalog GET is cancelled.

### Automated

- [ ] `apps/lfx-one/e2e/org-people-key-contacts-reassign.spec.ts` — 5 tests cover the 18 user-perspective acceptance criteria for the main-row Reassign modal (anatomy + counts, reactive subtitle / save label, employee typeahead prefill, success lifecycle, error lifecycle).
- [ ] `yarn check-types`, `yarn lint:check`, `yarn format:check` — all pass locally.
- [ ] Full angular build passes (verified locally at ~53s).
