### PR TITLE
feat(committees): invite members by email with bulk add and pending invites

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -426,7 +426,13 @@
         }
         @case ('members') {
           @if (isMembersTabVisible()) {
-            <lfx-committee-members [committee]="committee()" [members]="members()" [membersLoading]="membersLoading()" (refresh)="onMembersRefreshed()" />
+            <lfx-committee-members
+              [committee]="committee()"
+              [members]="members()"
+              [membersLoading]="membersLoading()"
+              [invites]="invites()"
+              [invitesLoading]="invitesLoading()"
+              (refresh)="onMembersRefreshed()" />
           }
         }
         @case ('votes') {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@lfx-one/shared';
 import { GroupsIOMailingList, ProjectContext, TabConfigEntry } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_VALID_TABS } from '@lfx-one/shared/constants';
-import { getChatPlatformIcon, getChatPlatformLabel, getRepoPlatformIcon, getRepoPlatformLabel } from '@lfx-one/shared/utils';
+import { canManageCommitteeMembers, getChatPlatformIcon, getChatPlatformLabel, getRepoPlatformIcon, getRepoPlatformLabel } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
@@ -550,7 +550,9 @@ export class CommitteeViewComponent {
     return toSignal(
       combineLatest([toObservable(this.committee), toObservable(this.membersRefresh)]).pipe(
         switchMap(([committee]) => {
-          if (!committee?.uid) {
+          // Only managers can see pending invites — gate the fetch (not just the display) so
+          // non-managers never request invitee emails and we don't rely on upstream authz to reject.
+          if (!committee?.uid || !canManageCommitteeMembers(committee)) {
             this.invitesLoading.set(false);
             return of([] as CommitteeInvite[]);
           }

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -15,6 +15,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { RouteLoadingComponent } from '@components/loading/route-loading.component';
 import {
   Committee,
+  CommitteeInvite,
   CommitteeMember,
   CommitteeMemberVisibility,
   CommitteePermissionLevel,
@@ -109,11 +110,14 @@ export class CommitteeViewComponent {
   public refresh = signal(0);
   public membersRefresh = signal(0);
   public membersLoading = signal<boolean>(true);
+  public invitesLoading = signal<boolean>(true);
   public joiningOrLeaving = signal(false);
 
   // -- Computed / toSignal --
   public committee: Signal<Committee | null> = this.initializeCommittee();
   public members: Signal<CommitteeMember[]> = this.initializeMembers();
+  // Pending invites share the members refresh trigger so adding/revoking refreshes both.
+  public invites: Signal<CommitteeInvite[]> = this.initializeInvites();
 
   // Membership identity comes from server-enriched fields on the committee record,
   // resolved via the username-tagged membership query so visibility doesn't depend
@@ -539,6 +543,31 @@ export class CommitteeViewComponent {
         })
       ),
       { initialValue: [] }
+    );
+  }
+
+  private initializeInvites(): Signal<CommitteeInvite[]> {
+    return toSignal(
+      combineLatest([toObservable(this.committee), toObservable(this.membersRefresh)]).pipe(
+        switchMap(([committee]) => {
+          if (!committee?.uid) {
+            this.invitesLoading.set(false);
+            return of([] as CommitteeInvite[]);
+          }
+
+          this.invitesLoading.set(true);
+
+          return this.committeeService.getCommitteeInvites(committee.uid).pipe(
+            // Only pending invites belong on the roster — accepted ones are already members,
+            // and declined/revoked ones shouldn't block re-inviting. Status casing varies
+            // upstream, so compare case-insensitively.
+            map((invites) => invites.filter((invite) => (invite.status ?? '').toLowerCase() === 'pending')),
+            catchError(() => of([] as CommitteeInvite[])),
+            finalize(() => this.invitesLoading.set(false))
+          );
+        })
+      ),
+      { initialValue: [] as CommitteeInvite[] }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -3,8 +3,8 @@
 
 <div class="flex flex-col gap-5 px-1" data-testid="add-member-dialog">
   <p class="text-sm text-gray-500">
-    Invite people by email — one or many at once. Each person gets an invitation to join the group and completes their own profile, so you don't need to enter their
-    details. They appear as "Pending" until they accept.
+    Invite people by email — one or many at once. Each person gets an invitation to join the group and completes their own profile, so you don't need to enter
+    their details. They appear as "Pending" until they accept.
   </p>
 
   <!-- ── Find existing people (typeahead autofill, optional) ──────────────────── -->
@@ -100,7 +100,9 @@
 
     <div class="flex flex-col gap-1 text-xs" data-testid="add-member-preview">
       @if (categorized().toInvite.length > 0) {
-        <span class="text-emerald-600 font-medium"> <i class="fa-light fa-paper-plane" aria-hidden="true"></i> {{ categorized().toInvite.length }} to invite </span>
+        <span class="text-emerald-600 font-medium">
+          <i class="fa-light fa-paper-plane" aria-hidden="true"></i> {{ categorized().toInvite.length }} to invite
+        </span>
       }
       @if (categorized().alreadyMembers.length > 0) {
         <span class="text-gray-400">{{ categorized().alreadyMembers.length }} already in the group — will be skipped</span>
@@ -112,7 +114,9 @@
         <span class="text-gray-400">{{ parsed().duplicates.length }} duplicate(s) removed</span>
       }
       @if (parsed().invalid.length > 0) {
-        <span class="text-amber-600"> <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i> {{ parsed().invalid.length }} not valid: {{ parsed().invalid.join(', ') }} </span>
+        <span class="text-amber-600">
+          <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i> {{ parsed().invalid.length }} not valid: {{ parsed().invalid.join(', ') }}
+        </span>
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -117,7 +117,7 @@
       }
       @if (parsed().invalid.length > 0) {
         <span class="text-amber-600">
-          <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i> {{ parsed().invalid.length }} not valid: {{ parsed().invalid.join(', ') }}
+          <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i> {{ parsed().invalid.length }} not valid: {{ invalidSummary() }}
         </span>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -38,15 +38,15 @@
         @for (result of searchResults(); track result.email) {
           <li
             role="option"
-            [attr.aria-disabled]="result.alreadyMember || result.added"
+            [attr.aria-disabled]="result.alreadyMember || result.alreadyInvited || result.added"
             [attr.aria-selected]="result.added"
             (click)="addEmail(result)"
             (keydown.enter)="addEmail(result)"
             (keydown.space)="$event.preventDefault(); addEmail(result)"
-            [tabindex]="result.alreadyMember || result.added ? -1 : 0"
+            [tabindex]="result.alreadyMember || result.alreadyInvited || result.added ? -1 : 0"
             class="flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-colors"
             [ngClass]="
-              result.alreadyMember || result.added
+              result.alreadyMember || result.alreadyInvited || result.added
                 ? 'border-gray-100 bg-gray-50 opacity-60 cursor-not-allowed'
                 : 'border-gray-200 bg-white hover:bg-blue-50 hover:border-blue-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400'
             "
@@ -61,7 +61,7 @@
             <div class="flex flex-col gap-0.5 flex-1 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm font-medium text-gray-900 truncate">{{ result.first_name }} {{ result.last_name }}</span>
-                @if (result.username) {
+                @if (result.lfAccount) {
                   <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200 rounded px-1.5 py-0.5">
                     <i class="fa-light fa-shield-check text-[10px]" aria-hidden="true"></i> LF Account
                   </span>
@@ -74,6 +74,8 @@
               <span class="flex-none text-xs text-emerald-600 font-medium">Added</span>
             } @else if (result.alreadyMember) {
               <span class="flex-none text-xs text-gray-400 font-medium">Already member</span>
+            } @else if (result.alreadyInvited) {
+              <span class="flex-none text-xs text-gray-400 font-medium">Already invited</span>
             } @else {
               <i class="flex-none fa-light fa-plus text-gray-400" aria-hidden="true"></i>
             }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -1,237 +1,139 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-0" data-testid="add-member-dialog">
-  <!-- ── STEP 1: Search ───────────────────────────────────────────────────── -->
-  @if (mode() === 'search') {
-    <div class="flex flex-col gap-4 px-1">
-      <!-- Search input -->
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Search by name or email</label>
-        <lfx-input-text
-          [form]="searchForm"
-          control="query"
-          placeholder="Type at least 2 characters…"
-          icon="fa-light fa-search"
-          styleClass="w-full"
-          size="small"
-          dataTest="add-member-search-input"></lfx-input-text>
-      </div>
+<div class="flex flex-col gap-5 px-1" data-testid="add-member-dialog">
+  <p class="text-sm text-gray-500">
+    Invite people by email — one or many at once. Each person gets an invitation to join the group and completes their own profile, so you don't need to enter their
+    details. They appear as "Pending" until they accept.
+  </p>
 
-      <!-- Loading skeletons -->
-      @if (searchLoading()) {
-        <div class="flex flex-col gap-2" data-testid="add-member-search-loading">
-          @for (_ of [1, 2, 3]; track _) {
-            <div class="flex items-center gap-3 p-3 rounded-lg border border-gray-100">
-              <p-skeleton shape="circle" size="2.25rem" />
-              <div class="flex flex-col gap-1.5 flex-1">
-                <p-skeleton width="40%" height="0.875rem" />
-                <p-skeleton width="60%" height="0.75rem" />
-              </div>
-            </div>
-          }
-        </div>
-      }
+  <!-- ── Find existing people (typeahead autofill, optional) ──────────────────── -->
+  <div class="flex flex-col gap-2">
+    <label class="block text-sm font-medium text-gray-700">Find existing people <span class="text-gray-400 font-normal">(optional)</span></label>
+    <lfx-input-text
+      [form]="searchForm"
+      control="query"
+      placeholder="Search by name or email…"
+      icon="fa-light fa-search"
+      styleClass="w-full"
+      size="small"
+      dataTest="add-member-search-input"></lfx-input-text>
 
-      <!-- Results list -->
-      @if (!searchLoading() && searchResults().length > 0) {
-        <ul class="flex flex-col gap-1 max-h-72 overflow-y-auto" role="listbox" aria-label="Search results" data-testid="add-member-results">
-          @for (result of searchResults(); track result.email) {
-            <li
-              role="option"
-              [attr.aria-disabled]="result.alreadyMember"
-              [attr.aria-selected]="false"
-              (click)="!result.alreadyMember && selectUser(result)"
-              (keydown.enter)="!result.alreadyMember && selectUser(result)"
-              (keydown.space)="$event.preventDefault(); !result.alreadyMember && selectUser(result)"
-              [tabindex]="result.alreadyMember ? -1 : 0"
-              class="flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-colors"
-              [ngClass]="
-                result.alreadyMember
-                  ? 'border-gray-100 bg-gray-50 opacity-60 cursor-not-allowed'
-                  : 'border-gray-200 bg-white hover:bg-blue-50 hover:border-blue-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400'
-              "
-              [attr.data-testid]="'add-member-result-' + result.email">
-              <!-- Avatar initials -->
-              <div
-                class="flex-none w-9 h-9 rounded-full flex items-center justify-center text-white text-sm font-semibold select-none"
-                [ngClass]="result | userAvatarColor"
-                aria-hidden="true">
-                {{ result | userInitials }}
-              </div>
-
-              <!-- Name + email + org -->
-              <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
-                  <span class="text-sm font-medium text-gray-900 truncate">{{ result.first_name }} {{ result.last_name }}</span>
-                  <!-- LF Account badge -->
-                  @if (result.username) {
-                    <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200 rounded px-1.5 py-0.5">
-                      <i class="fa-light fa-shield-check text-[10px]" aria-hidden="true"></i> LF Account
-                    </span>
-                  }
-                  @if (result.alreadyMember) {
-                    <span class="text-xs text-gray-400 font-medium">Already member</span>
-                  }
-                </div>
-                <span class="text-sm text-gray-500 truncate">{{ result.email }}</span>
-                @if (result.organization?.name) {
-                  <span class="text-xs text-gray-400 truncate">{{ result.organization?.name }}</span>
-                }
-              </div>
-            </li>
-          }
-        </ul>
-      }
-
-      <!-- Empty state: query typed but no results -->
-      @if (!searchLoading() && searchResults().length === 0 && queryValue().length >= 2) {
-        <div class="flex flex-col items-center gap-3 py-8 text-center" data-testid="add-member-empty-state">
-          <i class="fa-light fa-user-magnifying-glass text-3xl text-gray-300" aria-hidden="true"></i>
-          <div>
-            <p class="text-sm font-medium text-gray-600">No LF accounts found</p>
-            <p class="text-xs text-gray-400 mt-0.5">No match for "{{ queryValue() }}"</p>
-          </div>
-          <button
-            type="button"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-700 underline-offset-2 hover:underline"
-            (click)="showManualForm()"
-            data-testid="add-member-manual-btn">
-            <i class="fa-light fa-user-pen" aria-hidden="true"></i> Add manually
-          </button>
-        </div>
-      }
-
-      <!-- Hint: before user types -->
-      @if (!searchLoading() && queryValue().length < 2) {
-        <p class="text-xs text-gray-400 text-center py-6">Start typing to search for LF accounts</p>
-      }
-    </div>
-  }
-
-  <!-- ── STEP 2: Configure ─────────────────────────────────────────────────── -->
-  @if (mode() === 'configure') {
-    <div class="flex flex-col gap-5 px-1" data-testid="add-member-configure">
-      <!-- Selected person card -->
-      @if (selectedUser(); as user) {
-        <div class="flex items-center gap-3 p-3 rounded-lg border border-blue-200 bg-blue-50" data-testid="add-member-selected-card">
-          <div
-            class="flex-none w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-semibold select-none"
-            [ngClass]="user | userAvatarColor"
-            aria-hidden="true">
-            {{ user | userInitials }}
-          </div>
-          <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-            <div class="flex items-center gap-2 flex-wrap">
-              <span class="text-sm font-semibold text-gray-900">{{ user.first_name }} {{ user.last_name }}</span>
-              @if (user.username) {
-                <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-100 text-blue-700 border border-blue-200 rounded px-1.5 py-0.5">
-                  <i class="fa-light fa-shield-check text-[10px]" aria-hidden="true"></i> LF Account
-                </span>
-              }
-            </div>
-            <span class="text-sm text-gray-500 truncate">{{ user.email }}</span>
-            @if (user.organization?.name) {
-              <span class="text-xs text-gray-400 truncate">{{ user.organization?.name }}</span>
-            }
-          </div>
-          <!-- Clear / back to search -->
-          <button
-            type="button"
-            class="flex-none p-1.5 text-gray-400 hover:text-gray-600 rounded transition-colors"
-            (click)="clearSelection()"
-            aria-label="Remove selection and go back to search"
-            data-testid="add-member-clear-selection">
-            <i class="fa-light fa-xmark text-sm" aria-hidden="true"></i>
-          </button>
-        </div>
-      }
-
-      <!-- Configuration fields -->
-      <div class="flex flex-col gap-4">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <!-- Role -->
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Role</label>
-            <lfx-select
-              [form]="configForm"
-              control="role"
-              [options]="roleOptions"
-              placeholder="Select role"
-              size="small"
-              [showClear]="true"
-              styleClass="w-full"
-              appendTo="body"
-              data-testid="add-member-role"></lfx-select>
-          </div>
-
-          <!-- Voting Status -->
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Voting Status</label>
-            <lfx-select
-              [form]="configForm"
-              control="voting_status"
-              [options]="votingStatusOptions"
-              placeholder="Select voting status"
-              size="small"
-              [showClear]="true"
-              styleClass="w-full"
-              appendTo="body"
-              data-testid="add-member-voting-status"></lfx-select>
-          </div>
-        </div>
-
-        <!-- Organization -->
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">
-            Organization
-            @if (requiresOrg()) {
-              <span class="text-red-500 ml-0.5">*</span>
-            }
-          </label>
-          <lfx-organization-search
-            [form]="configForm"
-            nameControl="org_name"
-            domainControl="org_domain"
-            placeholder="Search for organization…"
-            styleClass="w-full"
-            inputStyleClass="text-sm w-full"
-            panelStyleClass="text-sm w-full"
-            dataTestId="add-member-org-search"
-            (onOrganizationResolved)="onOrgResolved($event)">
-          </lfx-organization-search>
-        </div>
-
-        <!-- Permission -->
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Permission</label>
-          <lfx-select
-            [form]="configForm"
-            control="permission"
-            [options]="permissionOptions"
-            placeholder="Select permission"
-            size="small"
-            styleClass="w-full"
-            appendTo="body"
-            data-testid="add-member-permission"></lfx-select>
-        </div>
-
-        <!-- Mailing list subscription -->
-        @if (hasMailingList()) {
-          <div class="flex items-start gap-2 p-3 rounded-lg bg-gray-50 border border-gray-200">
-            <lfx-checkbox [form]="configForm" control="subscribe_mailing_list" data-testid="add-member-subscribe-ml"></lfx-checkbox>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-sm font-medium text-gray-700">Auto-subscribe to mailing list</span>
-              <span class="text-xs text-gray-400">The member will receive group announcements and discussions.</span>
+    @if (searchLoading()) {
+      <div class="flex flex-col gap-2" data-testid="add-member-search-loading">
+        @for (_ of [1, 2, 3]; track _) {
+          <div class="flex items-center gap-3 p-3 rounded-lg border border-gray-100">
+            <p-skeleton shape="circle" size="2.25rem" />
+            <div class="flex flex-col gap-1.5 flex-1">
+              <p-skeleton width="40%" height="0.875rem" />
+              <p-skeleton width="60%" height="0.75rem" />
             </div>
           </div>
         }
       </div>
-    </div>
-  }
+    }
 
-  <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
-  <div class="flex justify-end gap-3 pt-6 mt-4 border-t border-gray-100">
+    @if (!searchLoading() && searchResults().length > 0) {
+      <ul class="flex flex-col gap-1 max-h-60 overflow-y-auto" role="listbox" aria-label="Search results" data-testid="add-member-results">
+        @for (result of searchResults(); track result.email) {
+          <li
+            role="option"
+            [attr.aria-disabled]="result.alreadyMember || result.added"
+            [attr.aria-selected]="result.added"
+            (click)="addEmail(result)"
+            (keydown.enter)="addEmail(result)"
+            (keydown.space)="$event.preventDefault(); addEmail(result)"
+            [tabindex]="result.alreadyMember || result.added ? -1 : 0"
+            class="flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-colors"
+            [ngClass]="
+              result.alreadyMember || result.added
+                ? 'border-gray-100 bg-gray-50 opacity-60 cursor-not-allowed'
+                : 'border-gray-200 bg-white hover:bg-blue-50 hover:border-blue-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400'
+            "
+            [attr.data-testid]="'add-member-result-' + result.email">
+            <div
+              class="flex-none w-9 h-9 rounded-full flex items-center justify-center text-white text-sm font-semibold select-none"
+              [ngClass]="result | userAvatarColor"
+              aria-hidden="true">
+              {{ result | userInitials }}
+            </div>
+
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm font-medium text-gray-900 truncate">{{ result.first_name }} {{ result.last_name }}</span>
+                @if (result.username) {
+                  <span class="inline-flex items-center gap-1 text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200 rounded px-1.5 py-0.5">
+                    <i class="fa-light fa-shield-check text-[10px]" aria-hidden="true"></i> LF Account
+                  </span>
+                }
+              </div>
+              <span class="text-sm text-gray-500 truncate">{{ result.email }}</span>
+            </div>
+
+            @if (result.added) {
+              <span class="flex-none text-xs text-emerald-600 font-medium">Added</span>
+            } @else if (result.alreadyMember) {
+              <span class="flex-none text-xs text-gray-400 font-medium">Already member</span>
+            } @else {
+              <i class="flex-none fa-light fa-plus text-gray-400" aria-hidden="true"></i>
+            }
+          </li>
+        }
+      </ul>
+    }
+
+    @if (!searchLoading() && searchResults().length === 0 && queryValue().length >= 2) {
+      <p class="text-xs text-gray-400">No matches for "{{ queryValue() }}". You can still invite them by typing their email below.</p>
+    }
+  </div>
+
+  <!-- ── Email addresses ──────────────────────────────────────────────────────── -->
+  <div class="flex flex-col gap-2">
+    <label class="block text-sm font-medium text-gray-700">Email addresses</label>
+    <lfx-textarea
+      [form]="form"
+      control="emails"
+      [rows]="5"
+      placeholder="name@example.com, another@example.com — or one address per line"
+      styleClass="w-full"
+      dataTest="add-member-emails"></lfx-textarea>
+
+    <div class="flex flex-col gap-1 text-xs" data-testid="add-member-preview">
+      @if (categorized().toInvite.length > 0) {
+        <span class="text-emerald-600 font-medium"> <i class="fa-light fa-paper-plane" aria-hidden="true"></i> {{ categorized().toInvite.length }} to invite </span>
+      }
+      @if (categorized().alreadyMembers.length > 0) {
+        <span class="text-gray-400">{{ categorized().alreadyMembers.length }} already in the group — will be skipped</span>
+      }
+      @if (categorized().alreadyInvited.length > 0) {
+        <span class="text-gray-400">{{ categorized().alreadyInvited.length }} already invited — will be skipped</span>
+      }
+      @if (parsed().duplicates.length > 0) {
+        <span class="text-gray-400">{{ parsed().duplicates.length }} duplicate(s) removed</span>
+      }
+      @if (parsed().invalid.length > 0) {
+        <span class="text-amber-600"> <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i> {{ parsed().invalid.length }} not valid: {{ parsed().invalid.join(', ') }} </span>
+      }
+    </div>
+  </div>
+
+  <!-- ── Suggested role (applies to everyone in this batch) ───────────────────── -->
+  <div class="flex flex-col gap-1">
+    <label class="block text-sm font-medium text-gray-700">Suggested role <span class="text-gray-400 font-normal">(optional)</span></label>
+    <lfx-select
+      [form]="form"
+      control="role"
+      [options]="roleOptions"
+      placeholder="Select role"
+      size="small"
+      [showClear]="true"
+      styleClass="w-full"
+      appendTo="body"
+      data-testid="add-member-role"></lfx-select>
+  </div>
+
+  <!-- ── Footer ───────────────────────────────────────────────────────────────── -->
+  <div class="flex justify-end gap-3 pt-6 mt-1 border-t border-gray-100">
     <lfx-button
       label="Cancel"
       severity="secondary"
@@ -243,8 +145,8 @@
       data-testid="add-member-cancel"></lfx-button>
 
     <lfx-button
-      label="Add to Group"
-      icon="fa-light fa-user-plus"
+      label="Send Invites"
+      icon="fa-light fa-paper-plane"
       [loading]="submitting()"
       [disabled]="!canSubmit() || submitting()"
       (onClick)="onSubmit()"

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -3,8 +3,8 @@
 
 import { NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -12,7 +12,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
 import { MEMBER_ROLES } from '@lfx-one/shared/constants';
 import { Committee, CommitteeInvite, CommitteeInviteResult, CommitteeMember, EmailListParseResult, UserSearchResult } from '@lfx-one/shared/interfaces';
-import { parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
+import { hasLfAccount, parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
@@ -22,8 +22,8 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, Observable, of, startWith, switchMap, tap, toArray } from 'rxjs';
 
-/** A search hit decorated with whether its email is already added to the textarea or already a member. */
-type DecoratedResult = UserSearchResult & { added: boolean; alreadyMember: boolean };
+/** A search hit decorated for the typeahead: whether it's already added/member/invited and has an LF account. */
+type DecoratedResult = UserSearchResult & { added: boolean; alreadyMember: boolean; alreadyInvited: boolean; lfAccount: boolean };
 
 /** Parsed valid emails partitioned by what the submit action will do with each. */
 interface CategorizedEmails {
@@ -69,6 +69,7 @@ export class AddMemberDialogComponent {
   private readonly messageService = inject(MessageService);
   private readonly dialogRef = inject(DynamicDialogRef);
   private readonly config = inject(DynamicDialogConfig);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly committee: Committee | null = this.config.data?.committee ?? null;
   private readonly existingMemberEmails = new Set<string>(
@@ -118,7 +119,7 @@ export class AddMemberDialogComponent {
 
   /** Append a searched person's email to the textarea (autofill convenience). */
   public addEmail(user: DecoratedResult): void {
-    if (user.alreadyMember || user.added) {
+    if (user.alreadyMember || user.alreadyInvited || user.added) {
       return;
     }
     const email = (user.email ?? '').trim();
@@ -156,7 +157,8 @@ export class AddMemberDialogComponent {
             ),
           INVITE_CONCURRENCY
         ),
-        toArray()
+        toArray(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((results) => {
         this.submitting.set(false);
@@ -253,7 +255,13 @@ export class AddMemberDialogComponent {
         })
         .map((r) => {
           const email = (r.email ?? '').toLowerCase();
-          return { ...r, added: added.has(email), alreadyMember: this.existingMemberEmails.has(email) };
+          return {
+            ...r,
+            added: added.has(email),
+            alreadyMember: this.existingMemberEmails.has(email),
+            alreadyInvited: this.existingInviteEmails.has(email),
+            lfAccount: hasLfAccount(r),
+          };
         });
     });
   }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -49,7 +49,17 @@ const INVITE_CONCURRENCY = 5;
  */
 @Component({
   selector: 'lfx-add-member-dialog',
-  imports: [ReactiveFormsModule, NgClass, UserInitialsPipe, UserAvatarColorPipe, ButtonComponent, InputTextComponent, SelectComponent, TextareaComponent, SkeletonModule],
+  imports: [
+    ReactiveFormsModule,
+    NgClass,
+    UserInitialsPipe,
+    UserAvatarColorPipe,
+    ButtonComponent,
+    InputTextComponent,
+    SelectComponent,
+    TextareaComponent,
+    SkeletonModule,
+  ],
   templateUrl: './add-member-dialog.component.html',
   styleUrl: './add-member-dialog.component.scss',
 })
@@ -95,7 +105,13 @@ export class AddMemberDialogComponent {
   });
   public readonly canSubmit = computed(() => !this.submitting() && this.categorized().toInvite.length > 0);
 
-  public readonly queryValue = toSignal(this.searchForm.get('query')!.valueChanges.pipe(startWith(''), map((v) => (v ?? '').trim())), { initialValue: '' });
+  public readonly queryValue = toSignal(
+    this.searchForm.get('query')!.valueChanges.pipe(
+      startWith(''),
+      map((v) => (v ?? '').trim())
+    ),
+    { initialValue: '' }
+  );
   public searchResults: Signal<DecoratedResult[]> = this.initSearchResults();
 
   public readonly roleOptions = MEMBER_ROLES;
@@ -136,7 +152,9 @@ export class AddMemberDialogComponent {
           (email) =>
             this.committeeService.createCommitteeInvite(committeeId, { invitee_email: email, role }).pipe(
               map(() => ({ email, success: true }) as CommitteeInviteResult),
-              catchError((err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }) as ReturnType<typeof of<CommitteeInviteResult>>)
+              catchError(
+                (err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }) as ReturnType<typeof of<CommitteeInviteResult>>
+              )
             ),
           INVITE_CONCURRENCY
         ),
@@ -209,7 +227,12 @@ export class AddMemberDialogComponent {
             tap(() => this.searchLoading.set(false)),
             catchError(() => {
               this.searchLoading.set(false);
-              this.messageService.add({ severity: 'warn', summary: 'Search Unavailable', detail: 'Could not reach the user search service. Please try again.', life: 4000 });
+              this.messageService.add({
+                severity: 'warn',
+                summary: 'Search Unavailable',
+                detail: 'Could not reach the user search service. Please try again.',
+                life: 4000,
+              });
               return of([] as UserSearchResult[]);
             })
           );

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -20,7 +20,7 @@ import { SearchService } from '@services/search.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, of, startWith, switchMap, tap, toArray } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, Observable, of, startWith, switchMap, tap, toArray } from 'rxjs';
 
 /** A search hit decorated with whether its email is already added to the textarea or already a member. */
 type DecoratedResult = UserSearchResult & { added: boolean; alreadyMember: boolean };
@@ -149,12 +149,10 @@ export class AddMemberDialogComponent {
     from(emails)
       .pipe(
         mergeMap(
-          (email) =>
+          (email): Observable<CommitteeInviteResult> =>
             this.committeeService.createCommitteeInvite(committeeId, { invitee_email: email, role }).pipe(
-              map(() => ({ email, success: true }) as CommitteeInviteResult),
-              catchError(
-                (err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }) as ReturnType<typeof of<CommitteeInviteResult>>
-              )
+              map(() => ({ email, success: true })),
+              catchError((err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }))
             ),
           INVITE_CONCURRENCY
         ),

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -10,8 +10,17 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
-import { MEMBER_ROLES } from '@lfx-one/shared/constants';
-import { Committee, CommitteeInvite, CommitteeInviteResult, CommitteeMember, EmailListParseResult, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { COMMITTEE_INVITE_CONCURRENCY, MEMBER_ROLES } from '@lfx-one/shared/constants';
+import {
+  CategorizedCommitteeEmails,
+  Committee,
+  CommitteeInvite,
+  CommitteeInviteResult,
+  CommitteeMember,
+  DecoratedCommitteeSearchResult,
+  EmailListParseResult,
+  UserSearchResult,
+} from '@lfx-one/shared/interfaces';
 import { hasLfAccount, parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
@@ -21,22 +30,6 @@ import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, Observable, of, startWith, switchMap, tap, toArray } from 'rxjs';
-
-/** A search hit decorated for the typeahead: whether it's already added/member/invited and has an LF account. */
-type DecoratedResult = UserSearchResult & { added: boolean; alreadyMember: boolean; alreadyInvited: boolean; lfAccount: boolean };
-
-/** Parsed valid emails partitioned by what the submit action will do with each. */
-interface CategorizedEmails {
-  /** Emails that will be invited (not already a member or pending invite). */
-  toInvite: string[];
-  /** Emails skipped because the person is already a member. */
-  alreadyMembers: string[];
-  /** Emails skipped because a pending invite already exists. */
-  alreadyInvited: string[];
-}
-
-/** Max concurrent create-invite requests when fanning out a bulk invite. */
-const INVITE_CONCURRENCY = 5;
 
 /**
  * Invite people to a committee by email — single or bulk.
@@ -91,8 +84,8 @@ export class AddMemberDialogComponent {
   private readonly rawEmails = toSignal(this.form.get('emails')!.valueChanges.pipe(startWith(this.form.get('emails')!.value)), { initialValue: '' });
 
   public readonly parsed: Signal<EmailListParseResult> = computed(() => parseEmailList(this.rawEmails()));
-  public readonly categorized: Signal<CategorizedEmails> = computed(() => {
-    const result: CategorizedEmails = { toInvite: [], alreadyMembers: [], alreadyInvited: [] };
+  public readonly categorized: Signal<CategorizedCommitteeEmails> = computed(() => {
+    const result: CategorizedCommitteeEmails = { toInvite: [], alreadyMembers: [], alreadyInvited: [] };
     for (const email of this.parsed().valid) {
       if (this.existingMemberEmails.has(email)) {
         result.alreadyMembers.push(email);
@@ -105,6 +98,8 @@ export class AddMemberDialogComponent {
     return result;
   });
   public readonly canSubmit = computed(() => !this.submitting() && this.categorized().toInvite.length > 0);
+  /** Comma-joined invalid tokens for the preview — precomputed so the template reads a signal, not a function call. */
+  public readonly invalidSummary = computed(() => this.parsed().invalid.join(', '));
 
   public readonly queryValue = toSignal(
     this.searchForm.get('query')!.valueChanges.pipe(
@@ -113,12 +108,12 @@ export class AddMemberDialogComponent {
     ),
     { initialValue: '' }
   );
-  public searchResults: Signal<DecoratedResult[]> = this.initSearchResults();
+  public searchResults: Signal<DecoratedCommitteeSearchResult[]> = this.initSearchResults();
 
   public readonly roleOptions = MEMBER_ROLES;
 
   /** Append a searched person's email to the textarea (autofill convenience). */
-  public addEmail(user: DecoratedResult): void {
+  public addEmail(user: DecoratedCommitteeSearchResult): void {
     if (user.alreadyMember || user.alreadyInvited || user.added) {
       return;
     }
@@ -155,7 +150,7 @@ export class AddMemberDialogComponent {
               map(() => ({ email, success: true })),
               catchError((err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }))
             ),
-          INVITE_CONCURRENCY
+          COMMITTEE_INVITE_CONCURRENCY
         ),
         toArray(),
         takeUntilDestroyed(this.destroyRef)
@@ -208,7 +203,7 @@ export class AddMemberDialogComponent {
     return upstream ?? 'invite failed';
   }
 
-  private initSearchResults(): Signal<DecoratedResult[]> {
+  private initSearchResults(): Signal<DecoratedCommitteeSearchResult[]> {
     const rawResults = toSignal(
       this.searchForm.get('query')!.valueChanges.pipe(
         startWith(''),

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -3,153 +3,115 @@
 
 import { NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
-import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { SelectComponent } from '@components/select/select.component';
-import { COMMITTEE_PERMISSION_OPTIONS, MEMBER_ROLES, VOTING_STATUSES } from '@lfx-one/shared/constants';
-import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
-import {
-  Committee,
-  CommitteeMember,
-  CommitteePermissionLevel,
-  CommitteeUser,
-  CreateCommitteeMemberRequest,
-  DialogMode,
-  OrganizationResolveResult,
-  UserSearchResult,
-} from '@lfx-one/shared/interfaces';
-import { rankUserSearchResults } from '@lfx-one/shared/utils';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { MEMBER_ROLES } from '@lfx-one/shared/constants';
+import { Committee, CommitteeInvite, CommitteeInviteResult, CommitteeMember, EmailListParseResult, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
-import { MailingListService } from '@services/mailing-list.service';
 import { SearchService } from '@services/search.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, debounceTime, distinctUntilChanged, map, of, startWith, switchMap, take, tap } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, of, startWith, switchMap, tap, toArray } from 'rxjs';
 
+/** A search hit decorated with whether its email is already added to the textarea or already a member. */
+type DecoratedResult = UserSearchResult & { added: boolean; alreadyMember: boolean };
+
+/** Parsed valid emails partitioned by what the submit action will do with each. */
+interface CategorizedEmails {
+  /** Emails that will be invited (not already a member or pending invite). */
+  toInvite: string[];
+  /** Emails skipped because the person is already a member. */
+  alreadyMembers: string[];
+  /** Emails skipped because a pending invite already exists. */
+  alreadyInvited: string[];
+}
+
+/** Max concurrent create-invite requests when fanning out a bulk invite. */
+const INVITE_CONCURRENCY = 5;
+
+/**
+ * Invite people to a committee by email — single or bulk.
+ *
+ * The committee/registrant search corpus is not the LF identity directory, so this
+ * flow does not try to match every person to an existing account. Anyone is added by
+ * inviting their email (invite-and-forget); the invitee completes their own profile on
+ * accept, and an LFID is reconciled then. The typeahead is a convenience for finding
+ * people already known to v2 and appending their email — never a gate.
+ */
 @Component({
   selector: 'lfx-add-member-dialog',
-  imports: [
-    ReactiveFormsModule,
-    NgClass,
-    UserInitialsPipe,
-    UserAvatarColorPipe,
-    ButtonComponent,
-    InputTextComponent,
-    OrganizationSearchComponent,
-    SelectComponent,
-    CheckboxComponent,
-    SkeletonModule,
-  ],
+  imports: [ReactiveFormsModule, NgClass, UserInitialsPipe, UserAvatarColorPipe, ButtonComponent, InputTextComponent, SelectComponent, TextareaComponent, SkeletonModule],
   templateUrl: './add-member-dialog.component.html',
   styleUrl: './add-member-dialog.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AddMemberDialogComponent {
   private readonly committeeService = inject(CommitteeService);
-  private readonly mailingListService = inject(MailingListService);
   private readonly searchService = inject(SearchService);
   private readonly messageService = inject(MessageService);
   private readonly dialogRef = inject(DynamicDialogRef);
   private readonly config = inject(DynamicDialogConfig);
 
   public readonly committee: Committee | null = this.config.data?.committee ?? null;
-  private readonly existingEmails = new Set<string>(
-    ((this.config.data?.existingMembers as CommitteeMember[]) ?? []).map((m: CommitteeMember) => (m.email ?? '').toLowerCase())
+  private readonly existingMemberEmails = new Set<string>(
+    ((this.config.data?.existingMembers as CommitteeMember[]) ?? []).map((m) => (m.email ?? '').trim().toLowerCase()).filter(Boolean)
   );
-  public readonly searchForm = new FormGroup({ query: new FormControl('') });
-  public readonly configForm = new FormGroup({
-    role: new FormControl<string | null>(null, this.committee?.enable_voting ? [Validators.required] : []),
-    voting_status: new FormControl<string | null>(null, this.committee?.enable_voting ? [Validators.required] : []),
-    org_name: new FormControl<string>('', this.committee?.business_email_required || this.committee?.enable_voting ? [Validators.required] : []),
-    org_domain: new FormControl<string>(''),
-    org_id: new FormControl<string | null>(null),
-    subscribe_mailing_list: new FormControl<boolean>(true),
-    permission: new FormControl<CommitteePermissionLevel>('member'),
-  });
+  private readonly existingInviteEmails = new Set<string>(
+    ((this.config.data?.existingInvites as CommitteeInvite[]) ?? []).map((i) => (i.invitee_email ?? '').trim().toLowerCase()).filter(Boolean)
+  );
 
-  public mode = signal<DialogMode>('search');
+  public readonly form = new FormGroup({
+    emails: new FormControl<string>('', { nonNullable: true }),
+    role: new FormControl<string | null>(null),
+  });
+  public readonly searchForm = new FormGroup({ query: new FormControl('') });
+
   public submitting = signal(false);
   public searchLoading = signal(false);
-  public selectedUser = signal<UserSearchResult | null>(null);
-  public searchResults: Signal<(UserSearchResult & { alreadyMember: boolean })[]> = this.initSearchResults();
 
-  public readonly queryValue = toSignal(
-    this.searchForm.get('query')!.valueChanges.pipe(
-      startWith(''),
-      map((v) => (v ?? '').trim())
-    ),
-    { initialValue: '' }
-  );
+  private readonly rawEmails = toSignal(this.form.get('emails')!.valueChanges.pipe(startWith(this.form.get('emails')!.value)), { initialValue: '' });
 
-  /** Tracks form validity as a signal for use in computed() */
-  private readonly formValid = toSignal(
-    this.configForm.statusChanges.pipe(
-      startWith(this.configForm.status),
-      map((s) => s === 'VALID')
-    ),
-    {
-      initialValue: this.configForm.valid,
+  public readonly parsed: Signal<EmailListParseResult> = computed(() => parseEmailList(this.rawEmails()));
+  public readonly categorized: Signal<CategorizedEmails> = computed(() => {
+    const result: CategorizedEmails = { toInvite: [], alreadyMembers: [], alreadyInvited: [] };
+    for (const email of this.parsed().valid) {
+      if (this.existingMemberEmails.has(email)) {
+        result.alreadyMembers.push(email);
+      } else if (this.existingInviteEmails.has(email)) {
+        result.alreadyInvited.push(email);
+      } else {
+        result.toInvite.push(email);
+      }
     }
-  );
+    return result;
+  });
+  public readonly canSubmit = computed(() => !this.submitting() && this.categorized().toInvite.length > 0);
 
-  public readonly canSubmit = computed(() => this.mode() === 'configure' && !!this.selectedUser() && this.formValid());
-  public readonly hasMailingList = computed(() => !!this.committee?.mailing_list);
-
-  public readonly requiresOrg = computed(() => !!(this.committee?.business_email_required || this.committee?.enable_voting));
+  public readonly queryValue = toSignal(this.searchForm.get('query')!.valueChanges.pipe(startWith(''), map((v) => (v ?? '').trim())), { initialValue: '' });
+  public searchResults: Signal<DecoratedResult[]> = this.initSearchResults();
 
   public readonly roleOptions = MEMBER_ROLES;
-  public readonly votingStatusOptions = VOTING_STATUSES;
-  public readonly permissionOptions = [...COMMITTEE_PERMISSION_OPTIONS];
 
-  private resolvedOrgName: string | null = null;
-
-  public constructor() {
-    // Reset org_id whenever org name diverges from the last CDP-resolved name.
-    // Using the resolved name (not just empty check) prevents sending a stale
-    // org id when the user edits to a different non-empty value after resolution.
-    this.configForm
-      .get('org_name')!
-      .valueChanges.pipe(takeUntilDestroyed())
-      .subscribe((name) => {
-        const normalizedName = (name ?? '').trim();
-        if (!normalizedName || normalizedName !== this.resolvedOrgName) {
-          this.configForm.patchValue({ org_id: null }, { emitEvent: false });
-        }
-      });
-  }
-
-  public selectUser(user: UserSearchResult & { alreadyMember: boolean }): void {
-    if (user.alreadyMember) return;
-    this.selectedUser.set(user);
-    this.configForm.patchValue({
-      org_name: user.organization?.name ?? '',
-      org_domain: user.organization?.website ?? '',
-    });
-    this.mode.set('configure');
-  }
-
-  public clearSelection(): void {
-    this.selectedUser.set(null);
-    this.resolvedOrgName = null;
-    this.configForm.patchValue({ org_name: '', org_domain: '', org_id: null });
-    this.mode.set('search');
-  }
-
-  public onOrgResolved(result: OrganizationResolveResult): void {
-    this.resolvedOrgName = result.name;
-    this.configForm.patchValue({ org_id: result.id || null });
-  }
-
-  public showManualForm(): void {
-    this.dialogRef.close('manual');
+  /** Append a searched person's email to the textarea (autofill convenience). */
+  public addEmail(user: DecoratedResult): void {
+    if (user.alreadyMember || user.added) {
+      return;
+    }
+    const email = (user.email ?? '').trim();
+    if (!email) {
+      return;
+    }
+    const current = this.form.get('emails')!.value.trim();
+    this.form.get('emails')!.setValue(current ? `${current}\n${email}` : email);
+    this.searchForm.get('query')!.setValue('');
   }
 
   public onCancel(): void {
@@ -157,154 +119,97 @@ export class AddMemberDialogComponent {
   }
 
   public onSubmit(): void {
-    this.submitAddMember();
-  }
-
-  private submitAddMember(): void {
-    const user = this.selectedUser();
-    const committee = this.committee;
-    if (!user || !committee || !committee.uid) return;
+    const committeeId = this.committee?.uid;
+    const emails = this.categorized().toInvite;
+    if (!committeeId || emails.length === 0) {
+      return;
+    }
 
     this.submitting.set(true);
+    const role = this.form.get('role')!.value || null;
 
-    const formValue = this.configForm.getRawValue();
-    const memberData: CreateCommitteeMemberRequest = {
-      email: user.email,
-      username: user.username ?? null,
-      first_name: user.first_name ?? null,
-      last_name: user.last_name ?? null,
-      job_title: user.job_title ?? null,
-      organization:
-        formValue.org_name || formValue.org_domain || formValue.org_id
-          ? { id: formValue.org_id || null, name: formValue.org_name || null, website: formValue.org_domain || null }
-          : null,
-      role: formValue.role ? { name: formValue.role as CommitteeMemberRole, start_date: null, end_date: null } : null,
-      voting: formValue.voting_status ? { status: formValue.voting_status as CommitteeMemberVotingStatus, start_date: null, end_date: null } : null,
-    };
-
-    this.committeeService
-      .createCommitteeMember(committee.uid, memberData)
+    // No bulk endpoint upstream — fan out one create-invite per email with bounded
+    // concurrency, catching per-email so one failure never aborts the rest.
+    from(emails)
       .pipe(
-        take(1),
-        switchMap(() => {
-          const permission = formValue.permission;
-          const username = user.username;
-
-          if (username && permission !== 'member') {
-            const memberAsUser: CommitteeUser = {
-              username,
-              email: user.email,
-              name: `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || user.email,
-            };
-            const existingWriters = committee.writers ?? [];
-            const existingAuditors = committee.auditors ?? [];
-            const memberEmail = user.email?.toLowerCase();
-            const matchesMember = (u: CommitteeUser) => u.username === username || u.email?.toLowerCase() === memberEmail;
-            const writers = existingWriters.filter((w) => !matchesMember(w));
-            const auditors = existingAuditors.filter((a) => !matchesMember(a));
-
-            if (permission === 'manage') writers.push(memberAsUser);
-            else if (permission === 'review') auditors.push(memberAsUser);
-
-            return this.committeeService.updateCommitteePermissions(committee.uid, writers, auditors).pipe(
-              catchError(() => {
-                this.messageService.add({
-                  severity: 'warn',
-                  summary: 'Permission Update Failed',
-                  detail: 'Member added, but the permission could not be saved. Please try again from the member menu.',
-                  life: 6000,
-                });
-                return of(null);
-              })
-            );
-          }
-
-          if (permission !== 'member') {
-            this.messageService.add({
-              severity: 'warn',
-              summary: 'Permission Pending',
-              detail: 'Member added. Elevated permissions require a user account — grant this permission once the user signs in.',
-              life: 6000,
-            });
-          }
-
-          return of(null);
-        })
+        mergeMap(
+          (email) =>
+            this.committeeService.createCommitteeInvite(committeeId, { invitee_email: email, role }).pipe(
+              map(() => ({ email, success: true }) as CommitteeInviteResult),
+              catchError((err: HttpErrorResponse) => of({ email, success: false, reason: this.inviteFailureReason(err) }) as ReturnType<typeof of<CommitteeInviteResult>>)
+            ),
+          INVITE_CONCURRENCY
+        ),
+        toArray()
       )
-      .subscribe({
-        next: () => {
-          // Best-effort mailing list subscription (non-blocking — failure is silently swallowed)
-          const mailingListUid = committee.mailing_list;
-          if (formValue.subscribe_mailing_list && mailingListUid) {
-            this.mailingListService
-              .createMember(mailingListUid, {
-                email: user.email,
-                username: user.username ?? null,
-                first_name: user.first_name ?? null,
-                last_name: user.last_name ?? null,
-                organization: (formValue.org_name || user.organization?.name) ?? null,
-                job_title: user.job_title ?? null,
-              })
-              .pipe(
-                catchError(() => {
-                  this.messageService.add({
-                    severity: 'warn',
-                    summary: 'Mailing List',
-                    detail: 'Member added, but mailing list subscription failed. They can subscribe manually.',
-                    life: 5000,
-                  });
-                  return of(null);
-                })
-              )
-              .subscribe();
-          }
-
-          this.submitting.set(false);
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Member Added',
-            detail: `${`${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || user.email} has been added to the group.`,
-          });
+      .subscribe((results) => {
+        this.submitting.set(false);
+        this.summarize(results);
+        if (results.some((r) => r.success)) {
           this.dialogRef.close(true);
-        },
-        error: (err: HttpErrorResponse) => {
-          this.submitting.set(false);
-          const upstream = typeof err.error?.message === 'string' ? err.error.message : null;
-          const detail = err.status === 409 ? 'This person is already a member of this group.' : (upstream ?? 'Failed to add member. Please try again.');
-          this.messageService.add({ severity: 'error', summary: 'Unable to Add Member', detail });
-        },
+        }
       });
   }
 
-  private initSearchResults(): Signal<(UserSearchResult & { alreadyMember: boolean })[]> {
-    const queryControl = this.searchForm.get('query')!;
+  private summarize(results: CommitteeInviteResult[]): void {
+    const succeeded = results.filter((r) => r.success);
+    const failed = results.filter((r) => !r.success);
 
+    if (failed.length === 0) {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Invitations Sent',
+        detail: succeeded.length === 1 ? `Invited ${succeeded[0].email}.` : `Invited ${succeeded.length} people to the group.`,
+      });
+      return;
+    }
+
+    if (succeeded.length === 0) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Unable to Invite',
+        detail: failed.length === 1 ? `Could not invite ${failed[0].email}: ${failed[0].reason}.` : `None of the ${failed.length} invitations could be sent.`,
+        life: 6000,
+      });
+      return;
+    }
+
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Some Invitations Failed',
+      detail: `Invited ${succeeded.length} of ${results.length}. Could not invite: ${failed.map((f) => f.email).join(', ')}.`,
+      life: 8000,
+    });
+  }
+
+  private inviteFailureReason(err: HttpErrorResponse): string {
+    if (err.status === 409) {
+      return 'already invited or a member';
+    }
+    const upstream = typeof err.error?.message === 'string' ? err.error.message : null;
+    return upstream ?? 'invite failed';
+  }
+
+  private initSearchResults(): Signal<DecoratedResult[]> {
     const rawResults = toSignal(
-      queryControl.valueChanges.pipe(
+      this.searchForm.get('query')!.valueChanges.pipe(
         startWith(''),
         debounceTime(300),
         distinctUntilChanged(),
         switchMap((q) => {
-          // Clear results immediately when query drops below threshold
           if (typeof q !== 'string' || q.trim().length < 2) {
             this.searchLoading.set(false);
             return of([] as UserSearchResult[]);
           }
           this.searchLoading.set(true);
-          const trimmedQuery = q.trim();
-          return this.searchService.searchUsers(trimmedQuery, 'committee_member').pipe(
-            // Re-rank so name matches surface first and incidental email/alias
-            // matches (upstream over-match) are demoted below them.
-            map((users) => rankUserSearchResults(users, trimmedQuery)),
+          const trimmed = q.trim();
+          return this.searchService.searchUsers(trimmed, 'committee_member').pipe(
+            // Re-rank so name matches surface first and incidental email/alias matches are demoted (LFXV2-2058).
+            map((users) => rankUserSearchResults(users, trimmed)),
             tap(() => this.searchLoading.set(false)),
             catchError(() => {
               this.searchLoading.set(false);
-              this.messageService.add({
-                severity: 'warn',
-                summary: 'Search Unavailable',
-                detail: 'Could not reach the user search service. Please try again.',
-                life: 4000,
-              });
+              this.messageService.add({ severity: 'warn', summary: 'Search Unavailable', detail: 'Could not reach the user search service. Please try again.', life: 4000 });
               return of([] as UserSearchResult[]);
             })
           );
@@ -314,15 +219,21 @@ export class AddMemberDialogComponent {
     );
 
     return computed(() => {
+      const added = new Set(this.parsed().valid);
       const seen = new Set<string>();
       return rawResults()
         .filter((r) => {
           const key = (r.email ?? '').toLowerCase();
-          if (seen.has(key)) return false;
+          if (!key || seen.has(key)) {
+            return false;
+          }
           seen.add(key);
           return true;
         })
-        .map((r) => ({ ...r, alreadyMember: this.existingEmails.has((r.email ?? '').toLowerCase()) }));
+        .map((r) => {
+          const email = (r.email ?? '').toLowerCase();
+          return { ...r, added: added.has(email), alreadyMember: this.existingMemberEmails.has(email) };
+        });
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -215,4 +215,59 @@
       </lfx-table>
     }
   </lfx-card>
+
+  <!-- Pending Invitations Section (managers only) -->
+  @if (canManageMembers() && (invitesLoading() || invites().length > 0)) {
+    <lfx-card>
+      <div class="flex flex-col gap-3" data-testid="pending-invites">
+        <div class="flex items-center gap-2">
+          <i class="fa-light fa-envelope-open-text text-gray-500" aria-hidden="true"></i>
+          <h3 class="text-sm font-semibold text-gray-900">Pending Invitations</h3>
+          @if (!invitesLoading()) {
+            <span class="text-xs text-gray-400">({{ invites().length }})</span>
+          }
+        </div>
+
+        <p class="text-xs text-gray-400">Invited people appear here until they accept. They become members automatically on acceptance.</p>
+
+        @if (invitesLoading()) {
+          <div class="flex flex-col gap-2">
+            @for (_ of [1, 2]; track _) {
+              <div class="flex items-center gap-3">
+                <p-skeleton width="14rem" height="0.875rem" />
+                <p-skeleton width="6rem" height="0.875rem" />
+              </div>
+            }
+          </div>
+        } @else {
+          <ul class="flex flex-col gap-2" role="list">
+            @for (invite of invites(); track invite.uid) {
+              <li class="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 bg-white" [attr.data-testid]="'pending-invite-' + invite.invitee_email">
+                <i class="fa-light fa-clock text-amber-500" aria-hidden="true"></i>
+                <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+                  <span class="text-sm font-medium text-gray-900 truncate">{{ invite.invitee_email }}</span>
+                  @if (invite.role && invite.role !== 'None') {
+                    <span class="text-xs text-gray-400">Invited as {{ invite.role }}</span>
+                  }
+                </div>
+                <lfx-tag value="Pending" severity="warn"></lfx-tag>
+                <lfx-button
+                  icon="fa-light fa-xmark"
+                  [text]="true"
+                  [rounded]="true"
+                  size="small"
+                  severity="secondary"
+                  pTooltip="Revoke invitation"
+                  [loading]="revokingInviteUid() === invite.uid"
+                  [disabled]="!!revokingInviteUid()"
+                  (onClick)="revokeInvite(invite)"
+                  [attr.data-testid]="'revoke-invite-' + invite.invitee_email">
+                </lfx-button>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </lfx-card>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -248,7 +248,7 @@
                 <i class="fa-light fa-clock text-amber-500" aria-hidden="true"></i>
                 <div class="flex flex-col gap-0.5 flex-1 min-w-0">
                   <span class="text-sm font-medium text-gray-900 truncate">{{ invite.invitee_email }}</span>
-                  @if (invite.role && invite.role !== 'None') {
+                  @if (invite.role && invite.role !== noRoleSentinel) {
                     <span class="text-xs text-gray-400">Invited as {{ invite.role }}</span>
                   }
                 </div>
@@ -259,7 +259,8 @@
                   [rounded]="true"
                   size="small"
                   severity="secondary"
-                  pTooltip="Revoke invitation"
+                  tooltip="Revoke invitation"
+                  ariaLabel="Revoke invitation"
                   [loading]="revokingInviteUid() === invite.uid"
                   [disabled]="!!revokingInviteUid()"
                   (onClick)="revokeInvite(invite)"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -242,7 +242,9 @@
         } @else {
           <ul class="flex flex-col gap-2" role="list">
             @for (invite of invites(); track invite.uid) {
-              <li class="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 bg-white" [attr.data-testid]="'pending-invite-' + invite.invitee_email">
+              <li
+                class="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 bg-white"
+                [attr.data-testid]="'pending-invite-' + invite.invitee_email">
                 <i class="fa-light fa-clock text-amber-500" aria-hidden="true"></i>
                 <div class="flex flex-col gap-0.5 flex-1 min-w-0">
                   <span class="text-sm font-medium text-gray-900 truncate">{{ invite.invitee_email }}</span>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -83,6 +83,8 @@ export class CommitteeMembersComponent implements OnInit {
   public memberFilterChip = signal<CommitteeMemberFilterChip>('all');
   public memberActionMenuItems: MenuItem[] = [];
   public committeeLabel = COMMITTEE_LABEL;
+  // Upstream "no role" sentinel for committee invites — kept in one place rather than inline in the template.
+  public readonly noRoleSentinel = CommitteeMemberRole.NONE;
 
   // Computed signals — inline per component-organization.md
   // Driven by the API's effective `writer` flag, which already reflects access inherited

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -18,6 +18,7 @@ import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import {
   Committee,
+  CommitteeInvite,
   CommitteeMember,
   CommitteeMemberFilterChip,
   CommitteeMemberFilterChipConfig,
@@ -70,12 +71,15 @@ export class CommitteeMembersComponent implements OnInit {
   public committee = input.required<Committee | null>();
   public members = input.required<CommitteeMember[]>();
   public membersLoading = input<boolean>(true);
+  public invites = input<CommitteeInvite[]>([]);
+  public invitesLoading = input<boolean>(false);
 
   public readonly refresh = output<void>();
 
   // Simple writable signals
   public selectedMember = signal<CommitteeMember | null>(null);
   public isDeleting = signal<boolean>(false);
+  public revokingInviteUid = signal<string | null>(null);
   public memberFilterChip = signal<CommitteeMemberFilterChip>('all');
   public memberActionMenuItems: MenuItem[] = [];
   public committeeLabel = COMMITTEE_LABEL;
@@ -179,6 +183,7 @@ export class CommitteeMembersComponent implements OnInit {
       data: {
         committee: this.committee(),
         existingMembers: this.members(),
+        existingInvites: this.invites(),
       },
     });
 
@@ -186,6 +191,42 @@ export class CommitteeMembersComponent implements OnInit {
       if (result === true) {
         this.refreshMembers();
       }
+    });
+  }
+
+  public revokeInvite(invite: CommitteeInvite): void {
+    const committee = this.committee();
+    if (!committee?.uid || this.revokingInviteUid()) return;
+
+    this.confirmationService.confirm({
+      message: `Revoke the pending invitation for ${invite.invitee_email}?`,
+      header: 'Revoke Invitation',
+      acceptLabel: 'Revoke',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-outlined p-button-sm',
+      accept: () => {
+        this.revokingInviteUid.set(invite.uid);
+        this.committeeService.revokeCommitteeInvite(committee.uid, invite.uid).subscribe({
+          next: () => {
+            this.revokingInviteUid.set(null);
+            this.messageService.add({
+              severity: 'success',
+              summary: 'Invitation Revoked',
+              detail: `The invitation for ${invite.invitee_email} has been revoked.`,
+            });
+            this.refreshMembers();
+          },
+          error: (err: HttpErrorResponse) => {
+            this.revokingInviteUid.set(null);
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Unable to Revoke',
+              detail: getHttpErrorDetail(err, 'Failed to revoke the invitation. Please try again.'),
+            });
+          },
+        });
+      },
     });
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -182,29 +182,8 @@ export class CommitteeMembersComponent implements OnInit {
       },
     });
 
-    dialogRef?.onClose.pipe(take(1)).subscribe((result: boolean | string | undefined) => {
-      if (result === true) {
-        this.refreshMembers();
-      } else if (result === 'manual') {
-        this.openManualMemberForm();
-      }
-    });
-  }
-
-  private openManualMemberForm(): void {
-    const dialogRef = this.dialogService.open(MemberFormComponent, {
-      header: 'Add Member',
-      width: '700px',
-      modal: true,
-      closable: true,
-      data: {
-        isEditing: false,
-        committee: this.committee(),
-      },
-    });
-
     dialogRef?.onClose.pipe(take(1)).subscribe((result: boolean | undefined) => {
-      if (result) {
+      if (result === true) {
         this.refreshMembers();
       }
     });

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -110,9 +110,9 @@ export class CommitteeService {
   // have an LF account. Pending invites surface in the roster; on accept they
   // become committee members with their LFID reconciled.
 
-  /** Fetches all invites for a committee (caller filters to pending for display). */
+  /** Fetches all invites for a committee (caller filters to pending and handles errors). */
   public getCommitteeInvites(committeeId: string, params?: HttpParams): Observable<CommitteeInvite[]> {
-    return this.http.get<CommitteeInvite[]>(`/api/committees/${committeeId}/invites`, { params }).pipe(catchError(() => of([])));
+    return this.http.get<CommitteeInvite[]>(`/api/committees/${committeeId}/invites`, { params });
   }
 
   /** Creates a single committee invite. Bulk invite fans this out one call per email. */

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -7,10 +7,12 @@ import {
   Committee,
   CommitteeDocument,
   CommitteeDocumentType,
+  CommitteeInvite,
   CommitteeJoinApplication,
   CommitteeMember,
   CommitteeUser,
   CreateCommitteeDocumentRequest,
+  CreateCommitteeInviteRequest,
   CreateCommitteeJoinApplicationRequest,
   CreateCommitteeMemberRequest,
   MyCommittee,
@@ -101,6 +103,26 @@ export class CommitteeService {
 
   public deleteCommitteeMember(committeeId: string, memberId: string): Observable<void> {
     return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(take(1));
+  }
+
+  // ── Committee Invites ───────────────────────────────────────────────────────
+  // Invite-by-email add-member: lightweight invites for people who may not yet
+  // have an LF account. Pending invites surface in the roster; on accept they
+  // become committee members with their LFID reconciled.
+
+  /** Fetches all invites for a committee (caller filters to pending for display). */
+  public getCommitteeInvites(committeeId: string, params?: HttpParams): Observable<CommitteeInvite[]> {
+    return this.http.get<CommitteeInvite[]>(`/api/committees/${committeeId}/invites`, { params }).pipe(catchError(() => of([])));
+  }
+
+  /** Creates a single committee invite. Bulk invite fans this out one call per email. */
+  public createCommitteeInvite(committeeId: string, data: CreateCommitteeInviteRequest): Observable<CommitteeInvite> {
+    return this.http.post<CommitteeInvite>(`/api/committees/${committeeId}/invites`, data).pipe(take(1));
+  }
+
+  /** Revokes a pending committee invite. */
+  public revokeCommitteeInvite(committeeId: string, inviteId: string): Observable<void> {
+    return this.http.delete<void>(`/api/committees/${committeeId}/invites/${inviteId}`).pipe(take(1));
   }
 
   // ── Join / Leave Methods ──────────────────────────────────────────────────

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -112,7 +112,7 @@ export class CommitteeService {
 
   /** Fetches all invites for a committee (caller filters to pending and handles errors). */
   public getCommitteeInvites(committeeId: string, params?: HttpParams): Observable<CommitteeInvite[]> {
-    return this.http.get<CommitteeInvite[]>(`/api/committees/${committeeId}/invites`, { params });
+    return this.http.get<CommitteeInvite[]>(`/api/committees/${committeeId}/invites`, { params }).pipe(take(1));
   }
 
   /** Creates a single committee invite. Bulk invite fans this out one call per email. */

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -7,6 +7,7 @@ import {
   CommitteeCreateData,
   CommitteeUpdateData,
   CreateCommitteeDocumentRequest,
+  CreateCommitteeInviteRequest,
   CreateCommitteeMemberRequest,
   CreateCommitteeJoinApplicationRequest,
   UploadCommitteeDocumentRequest,
@@ -511,6 +512,122 @@ export class CommitteeController {
       res.status(204).send();
     } catch (error) {
       // Send the error to the next middleware
+      next(error);
+    }
+  }
+
+  // ── Invite Endpoints ──────────────────────────────────────────────────────
+
+  /**
+   * GET /committees/:id/invites
+   */
+  public async getCommitteeInvites(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id } = req.params;
+    const startTime = logger.startOperation(req, 'get_committee_invites', { committee_id: id });
+
+    try {
+      if (!id) {
+        next(
+          ServiceValidationError.forField('id', 'Committee ID is required', {
+            operation: 'get_committee_invites',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      const invites = await this.committeeService.getCommitteeInvites(req, id, req.query);
+
+      logger.success(req, 'get_committee_invites', startTime, { committee_id: id, invite_count: invites.length });
+      res.json(invites);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /committees/:id/invites
+   */
+  public async createCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id } = req.params;
+    const startTime = logger.startOperation(req, 'create_committee_invite', {
+      committee_id: id,
+      invite_data: logger.sanitize(req.body),
+    });
+
+    try {
+      if (!id) {
+        next(
+          ServiceValidationError.forField('id', 'Committee ID is required', {
+            operation: 'create_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      const inviteData: CreateCommitteeInviteRequest = req.body;
+
+      if (!inviteData?.invitee_email || typeof inviteData.invitee_email !== 'string') {
+        next(
+          ServiceValidationError.forField('invitee_email', 'Invitee email is required', {
+            operation: 'create_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      const invite = await this.committeeService.createCommitteeInvite(req, id, inviteData);
+
+      logger.success(req, 'create_committee_invite', startTime, { committee_id: id, invite_id: invite.uid });
+      res.status(201).json(invite);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * DELETE /committees/:id/invites/:inviteId
+   */
+  public async revokeCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id, inviteId } = req.params;
+    const startTime = logger.startOperation(req, 'revoke_committee_invite', {
+      committee_id: id,
+      invite_id: inviteId,
+    });
+
+    try {
+      if (!id) {
+        next(
+          ServiceValidationError.forField('id', 'Committee ID is required', {
+            operation: 'revoke_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      if (!inviteId) {
+        next(
+          ServiceValidationError.forField('inviteId', 'Invite ID is required', {
+            operation: 'revoke_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      await this.committeeService.revokeCommitteeInvite(req, id, inviteId);
+
+      logger.success(req, 'revoke_committee_invite', startTime, { committee_id: id, invite_id: inviteId });
+      res.status(204).send();
+    } catch (error) {
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -569,8 +569,9 @@ export class CommitteeController {
       }
 
       const inviteData: CreateCommitteeInviteRequest = req.body;
+      const trimmedEmail = typeof inviteData?.invitee_email === 'string' ? inviteData.invitee_email.trim() : '';
 
-      if (!inviteData?.invitee_email || typeof inviteData.invitee_email !== 'string') {
+      if (!trimmedEmail) {
         next(
           ServiceValidationError.forField('invitee_email', 'Invitee email is required', {
             operation: 'create_committee_invite',
@@ -581,7 +582,7 @@ export class CommitteeController {
         return;
       }
 
-      const invite = await this.committeeService.createCommitteeInvite(req, id, inviteData);
+      const invite = await this.committeeService.createCommitteeInvite(req, id, { ...inviteData, invitee_email: trimmedEmail });
 
       logger.success(req, 'create_committee_invite', startTime, { committee_id: id, invite_id: invite.uid });
       res.status(201).json(invite);

--- a/apps/lfx-one/src/server/routes/committees.route.ts
+++ b/apps/lfx-one/src/server/routes/committees.route.ts
@@ -25,6 +25,11 @@ router.post('/:id/members', (req, res, next) => committeeController.createCommit
 router.put('/:id/members/:memberId', (req, res, next) => committeeController.updateCommitteeMember(req, res, next));
 router.delete('/:id/members/:memberId', (req, res, next) => committeeController.deleteCommitteeMember(req, res, next));
 
+// ── Invite routes (invite-by-email add-member) ───────────────────────────────
+router.get('/:id/invites', (req, res, next) => committeeController.getCommitteeInvites(req, res, next));
+router.post('/:id/invites', (req, res, next) => committeeController.createCommitteeInvite(req, res, next));
+router.delete('/:id/invites/:inviteId', (req, res, next) => committeeController.revokeCommitteeInvite(req, res, next));
+
 // ── Sub-groups route ───────────────────────────────────────────────────────
 router.get('/:id/children', (req, res, next) => committeeController.getCommitteeChildren(req, res, next));
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -6,12 +6,14 @@ import {
   Committee,
   CommitteeCreateData,
   CommitteeDocument,
+  CommitteeInvite,
   CommitteeJoinApplication,
   CommitteeMember,
   CommitteeSettingsData,
   CommitteeUpdateData,
   CommitteeUser,
   CreateCommitteeDocumentRequest,
+  CreateCommitteeInviteRequest,
   CreateCommitteeJoinApplicationRequest,
   CreateCommitteeMemberRequest,
   MyCommittee,
@@ -560,6 +562,62 @@ export class CommitteeService {
     logger.debug(req, 'delete_committee_member', 'Committee member deleted successfully', {
       committee_uid: committeeId,
       member_uid: memberId,
+    });
+  }
+
+  // ── Committee Invites ───────────────────────────────────────────────────
+  // Invite-by-email is the add-member primitive for people who may not yet have
+  // an LF account. Pending/resolved invites are read from the query index
+  // (committee_invite resource); create/revoke go through the committee-service.
+
+  /**
+   * Fetches all invites for a committee from the query index. Callers filter by
+   * status (e.g. pending) client-side; the roster only surfaces pending ones.
+   */
+  public async getCommitteeInvites(req: Request, committeeId: string, query: Record<string, any> = {}): Promise<CommitteeInvite[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
+    const params = {
+      ...queryFilters,
+      type: 'committee_invite',
+      tags: `committee_uid:${committeeId}`,
+    };
+
+    return fetchAllQueryResources<CommitteeInvite>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeInvite>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+  }
+
+  /**
+   * Creates a single committee invite. The committee-service has no bulk endpoint,
+   * so bulk invite is the frontend fanning out one call per email.
+   */
+  public async createCommitteeInvite(req: Request, committeeId: string, data: CreateCommitteeInviteRequest): Promise<CommitteeInvite> {
+    const invite = await this.microserviceProxy.proxyRequest<CommitteeInvite>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/invites`, 'POST', {}, data);
+
+    logger.debug(req, 'create_committee_invite', 'Committee invite created successfully', {
+      committee_uid: committeeId,
+      invite_uid: invite.uid,
+    });
+
+    return invite;
+  }
+
+  /**
+   * Revokes a pending committee invite. The upstream revoke-invite endpoint is a
+   * plain DELETE (no ETag concurrency control).
+   */
+  public async revokeCommitteeInvite(req: Request, committeeId: string, inviteId: string): Promise<void> {
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/invites/${inviteId}`, 'DELETE');
+
+    logger.debug(req, 'revoke_committee_invite', 'Committee invite revoked successfully', {
+      committee_uid: committeeId,
+      invite_uid: inviteId,
     });
   }
 

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -591,3 +591,6 @@ export const BEHAVIORAL_CLASS_CONFIG: Record<GroupBehavioralClass, BehavioralCla
     bgColor: 'bg-gray-50',
   },
 };
+
+/** Max concurrent create-invite requests when fanning out a bulk committee invite. */
+export const COMMITTEE_INVITE_CONCURRENCY = 5;

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -5,6 +5,7 @@ import { CommitteeMemberVisibility } from '../enums/committee.enum';
 import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
 import { GroupsIOMailingList } from './mailing-list.interface';
 import { MeetingAttachment } from './meeting-attachment.interface';
+import { UserSearchResult } from './search.interface';
 
 // ── v2.0 Taxonomy Types ─────────────────────────────────────────────────────
 
@@ -119,6 +120,30 @@ export interface EmailListParseResult {
   invalid: string[];
   /** Normalized emails that appeared more than once (reported once each) */
   duplicates: string[];
+}
+
+/**
+ * A committee user-search hit decorated for the add-member typeahead: whether its
+ * email is already added to the input, already a member, already invited, and
+ * whether the person has an LF account (LFID).
+ */
+export type DecoratedCommitteeSearchResult = UserSearchResult & {
+  added: boolean;
+  alreadyMember: boolean;
+  alreadyInvited: boolean;
+  lfAccount: boolean;
+};
+
+/**
+ * Parsed valid invite emails partitioned by what the add-member submit will do with each.
+ */
+export interface CategorizedCommitteeEmails {
+  /** Emails that will be invited (not already a member or pending invite). */
+  toInvite: string[];
+  /** Emails skipped because the person is already a member. */
+  alreadyMembers: string[];
+  /** Emails skipped because a pending invite already exists. */
+  alreadyInvited: string[];
 }
 
 /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -49,49 +49,76 @@ export interface BehavioralClassDisplayConfig {
  */
 export type JoinMode = 'open' | 'invite_only' | 'application' | 'closed';
 
-/** Status of a member invite */
-export type InviteStatus = 'pending' | 'accepted' | 'declined' | 'expired';
+/**
+ * Status of a committee invite. Mirrors the committee-service `committee_invite`
+ * resource status enum (lfx-v2-committee-service): an invite is `pending` until the
+ * invitee accepts/declines, or an admin revokes it.
+ */
+export type CommitteeInviteStatus = 'pending' | 'accepted' | 'declined' | 'revoked';
 
 /**
- * A colleague-to-colleague or admin-to-user invitation to join a group.
+ * A pending/resolved invitation for a person (by email) to join a committee.
+ *
+ * Mirrors the committee-service `committee_invite` resource — the invite-and-forget
+ * primitive for adding people who may not yet have an LF account (LFID). The v2 query
+ * index has no identity/user resource type, so accounts can't be looked up directly;
+ * inviting by email is how anyone outside the existing committee/registrant corpus is
+ * added. On accept, the invite is reconciled into a `committee_member` with the
+ * person's LFID populated.
  */
-export interface GroupInvite {
-  /** Unique invite ID */
+export interface CommitteeInvite {
+  /** Invite UID */
   uid: string;
-  /** Committee this invite is for */
+  /** Committee this invite belongs to */
   committee_uid: string;
-  /** Email address of the invitee */
+  /** Email address the invite was delivered to */
   invitee_email: string;
-  /** Display name of the invitee (optional) */
-  invitee_name?: string;
-  /** UID of the user who sent the invite */
-  invited_by_uid: string;
-  /** Name of the person who sent the invite */
-  invited_by_name?: string;
-  /** Current status */
-  status: InviteStatus;
-  /** Optional personal message from inviter */
-  message?: string;
-  /** Role to assign on acceptance (default: 'Member') */
-  suggested_role?: string;
-  /** When the invite was created */
+  /** Suggested committee role for the invitee on acceptance (optional) */
+  role?: string | null;
+  /** Current invite status */
+  status: CommitteeInviteStatus;
+  /** Creation timestamp (RFC3339) */
   created_at: string;
-  /** When the invite expires (default: 14 days) */
-  expires_at: string;
-  /** When the invite was accepted / declined */
-  responded_at?: string;
 }
 
 /**
- * Payload to create one or more invites.
+ * Payload to create a single committee invite (committee-service create-invite).
+ * Only the invitee email is required; role is an optional suggestion.
  */
-export interface CreateGroupInviteRequest {
-  /** Email addresses to invite */
-  emails: string[];
-  /** Optional personal message included in the invite email */
-  message?: string;
-  /** Role to assign on acceptance */
-  suggested_role?: string;
+export interface CreateCommitteeInviteRequest {
+  /** Email of the person to invite (required) */
+  invitee_email: string;
+  /** Suggested role for the invitee (optional) */
+  role?: string | null;
+}
+
+/**
+ * Per-email outcome of one create-invite call within a bulk-invite batch.
+ *
+ * The committee-service exposes no bulk endpoint, so the client fans out one
+ * create-invite request per email and aggregates the individual outcomes here
+ * to drive a partial-success summary.
+ */
+export interface CommitteeInviteResult {
+  /** The normalized email this result is for */
+  email: string;
+  /** Whether the invite was created successfully */
+  success: boolean;
+  /** Human-readable failure reason when `success` is false */
+  reason?: string;
+}
+
+/**
+ * Result of parsing a free-text blob of email addresses (bulk invite input).
+ * Emails are normalized (trimmed + lowercased) and de-duplicated.
+ */
+export interface EmailListParseResult {
+  /** Unique, valid, normalized email addresses, in first-seen order */
+  valid: string[];
+  /** Non-empty tokens that failed email validation (original casing preserved) */
+  invalid: string[];
+  /** Normalized emails that appeared more than once (reported once each) */
+  duplicates: string[];
 }
 
 /**

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -10,6 +10,8 @@
 //
 // All fixtures use synthetic placeholder identities — never real user data.
 
+import { describe, expect, it } from 'vitest';
+
 import { Committee, CommitteeMember } from '../interfaces';
 import { canManageCommitteeMembers, resolveCommitteeMemberPermission } from './committee.utils';
 

--- a/packages/shared/src/utils/email.utils.spec.ts
+++ b/packages/shared/src/utils/email.utils.spec.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { isValidEmail, parseEmailList } from './email.utils';
+
+describe('isValidEmail', () => {
+  it('accepts a well-formed address', () => {
+    expect(isValidEmail('alice@example.com')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before testing', () => {
+    expect(isValidEmail('  alice@example.com  ')).toBe(true);
+  });
+
+  it.each([['no-at'], ['missing@tld'], ['@example.com'], ['alice@'], ['a b@example.com'], ['']])('rejects %p', (value) => {
+    expect(isValidEmail(value)).toBe(false);
+  });
+
+  it('rejects null and undefined', () => {
+    expect(isValidEmail(null)).toBe(false);
+    expect(isValidEmail(undefined)).toBe(false);
+  });
+});
+
+describe('parseEmailList', () => {
+  it('returns empty buckets for empty/nullish input', () => {
+    expect(parseEmailList('')).toEqual({ valid: [], invalid: [], duplicates: [] });
+    expect(parseEmailList(null)).toEqual({ valid: [], invalid: [], duplicates: [] });
+    expect(parseEmailList(undefined)).toEqual({ valid: [], invalid: [], duplicates: [] });
+  });
+
+  it('splits on commas, semicolons, whitespace, and newlines', () => {
+    const raw = 'a@example.com, b@example.com; c@example.com\nd@example.com\te@example.com';
+    expect(parseEmailList(raw).valid).toEqual(['a@example.com', 'b@example.com', 'c@example.com', 'd@example.com', 'e@example.com']);
+  });
+
+  it('normalizes to lowercase and trims each token', () => {
+    expect(parseEmailList('  Alice@Example.COM ').valid).toEqual(['alice@example.com']);
+  });
+
+  it('de-duplicates case-insensitively, preserving first-seen order, and reports each dup once', () => {
+    const result = parseEmailList('alice@example.com, ALICE@example.com, bob@example.com, alice@example.com');
+    expect(result.valid).toEqual(['alice@example.com', 'bob@example.com']);
+    expect(result.duplicates).toEqual(['alice@example.com']);
+  });
+
+  it('collects invalid tokens separately with original casing and keeps valid ones', () => {
+    const result = parseEmailList('Good@Example.com, not-an-email, also bad@, real@corp.io');
+    expect(result.valid).toEqual(['good@example.com', 'real@corp.io']);
+    expect(result.invalid).toEqual(['not-an-email', 'also', 'bad@']);
+  });
+
+  it('ignores empty tokens produced by trailing/duplicate separators', () => {
+    expect(parseEmailList(',,a@example.com,,\n\n').valid).toEqual(['a@example.com']);
+  });
+});

--- a/packages/shared/src/utils/email.utils.ts
+++ b/packages/shared/src/utils/email.utils.ts
@@ -1,0 +1,57 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { EMAIL_REGEX } from '../constants/regex.constants';
+import type { EmailListParseResult } from '../interfaces';
+
+/** True when `value` is a syntactically valid email address. Trims before testing. */
+export function isValidEmail(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return EMAIL_REGEX.test(value.trim());
+}
+
+/**
+ * Parse a free-text blob of email addresses (bulk-invite input) into normalized,
+ * de-duplicated buckets.
+ *
+ * Addresses may be separated by any mix of commas, semicolons, whitespace, or
+ * newlines — the formats people paste from spreadsheets, "To:" lines, and lists.
+ * Each token is trimmed and lowercased before validation and de-duplication, so
+ * casing and surrounding whitespace never produce a false duplicate or a false
+ * distinct address. Order is preserved (first-seen) so the preview matches input.
+ */
+export function parseEmailList(raw: string | null | undefined): EmailListParseResult {
+  const result: EmailListParseResult = { valid: [], invalid: [], duplicates: [] };
+  if (!raw) {
+    return result;
+  }
+
+  const seen = new Set<string>();
+
+  for (const token of raw.split(/[\s,;]+/)) {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const normalized = trimmed.toLowerCase();
+    if (!EMAIL_REGEX.test(normalized)) {
+      result.invalid.push(trimmed);
+      continue;
+    }
+
+    if (seen.has(normalized)) {
+      if (!result.duplicates.includes(normalized)) {
+        result.duplicates.push(normalized);
+      }
+      continue;
+    }
+
+    seen.add(normalized);
+    result.valid.push(normalized);
+  }
+
+  return result;
+}

--- a/packages/shared/src/utils/email.utils.ts
+++ b/packages/shared/src/utils/email.utils.ts
@@ -29,6 +29,7 @@ export function parseEmailList(raw: string | null | undefined): EmailListParseRe
   }
 
   const seen = new Set<string>();
+  const duplicatesSeen = new Set<string>();
 
   for (const token of raw.split(/[\s,;]+/)) {
     const trimmed = token.trim();
@@ -43,7 +44,10 @@ export function parseEmailList(raw: string | null | undefined): EmailListParseRe
     }
 
     if (seen.has(normalized)) {
-      if (!result.duplicates.includes(normalized)) {
+      // Report each duplicate once. Track reported dups in a Set rather than
+      // scanning result.duplicates (avoids O(n²) on large pastes).
+      if (!duplicatesSeen.has(normalized)) {
+        duplicatesSeen.add(normalized);
         result.duplicates.push(normalized);
       }
       continue;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -33,3 +33,4 @@ export * from './identity.utils';
 export * from './enrollment.utils';
 export * from './org-selector.utils';
 export * from './search.utils';
+export * from './email.utils';

--- a/packages/shared/src/utils/search.utils.spec.ts
+++ b/packages/shared/src/utils/search.utils.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import { UserSearchRelevance } from '../enums';
 import { UserSearchResult } from '../interfaces';
-import { rankUserSearchResults, scoreUserSearchResult } from './search.utils';
+import { hasLfAccount, rankUserSearchResults, scoreUserSearchResult } from './search.utils';
 
 /** Builds a UserSearchResult fixture, defaulting every field so tests set only what they assert on. */
 function user(partial: Partial<UserSearchResult>): UserSearchResult {
@@ -103,5 +103,23 @@ describe('rankUserSearchResults', () => {
   it('returns results unchanged for an empty query', () => {
     const input = [bob, ilona];
     expect(rankUserSearchResults(input, '   ')).toBe(input);
+  });
+});
+
+describe('hasLfAccount', () => {
+  it('is true when a non-empty username (LFID) is present', () => {
+    expect(hasLfAccount(user({ username: 'jdoe' }))).toBe(true);
+  });
+
+  it('is false when username is null (never reconciled to an LFID)', () => {
+    expect(hasLfAccount(user({ username: null }))).toBe(false);
+  });
+
+  it('is false when username is undefined', () => {
+    expect(hasLfAccount({ username: undefined })).toBe(false);
+  });
+
+  it('treats a whitespace-only username as no account (invite-by-email path)', () => {
+    expect(hasLfAccount(user({ username: '   ' }))).toBe(false);
   });
 });

--- a/packages/shared/src/utils/search.utils.ts
+++ b/packages/shared/src/utils/search.utils.ts
@@ -79,3 +79,17 @@ export function rankUserSearchResults<T extends RankableUser>(results: T[], quer
     .sort((a, b) => (a.score === b.score ? a.index - b.index : a.score - b.score))
     .map((entry) => entry.result);
 }
+
+/**
+ * Decides whether a search result corresponds to an existing LF account (LFID).
+ *
+ * "Has an LF account" is inferred solely from the presence of a non-empty, non-blank
+ * `username` (LFID) on the record. The v2 query index has no identity/user resource
+ * type — a person only carries a username once they appear in v2 with a reconciled
+ * LFID — so a blank/whitespace username means "no LFID yet" (use the invite-by-email
+ * path), NOT a definitive "this person has no account anywhere" claim. Treat it as a
+ * routing signal for the add-member flow, not an identity assertion.
+ */
+export function hasLfAccount(user: Pick<UserSearchResult, 'username'>): boolean {
+  return !!user.username && user.username.trim().length > 0;
+}


### PR DESCRIPTION
## Summary

Reworks the committee/group **Add Member** flow into **invite-by-email** (single + bulk) and surfaces **pending invitations** in the members roster. Resolves the LFXV2-2062 pain points: adding people one-by-one, unreliable type-ahead, and the flow forcing full manual entry when someone isn't already in the search corpus.

JIRA: https://linuxfoundation.atlassian.net/browse/LFXV2-2062

## Why

The member search corpus is `committee_member` / `meeting_registrant` only — there is **no LF identity directory** in the v2 query index — so a real account that had never been a registrant/committee member read as "no LF account" and dropped the admin into full manual entry (email, job title, LinkedIn, org, role, voting). The fix uses the committee-service **invite** primitive (`POST /committees/{uid}/invites`, email-only + optional role; `committee_invite` is a queryable resource), so anyone is added by inviting their email and completes their own profile on accept (invite-and-forget).

## What changed

**Shared** (`@lfx-one/shared`)
- Aligned the unused invite stubs to the real contract: `CommitteeInvite`, `CreateCommitteeInviteRequest`, `CommitteeInviteStatus`, plus result/parse types.
- `parseEmailList` / `isValidEmail` (bulk paste parsing, normalization, case-insensitive dedupe) and `hasLfAccount` — with unit tests.

**BFF** (Express)
- Three-file proxy for committee invites: `GET/POST /api/committees/:id/invites`, `DELETE …/:inviteId`.

**Frontend** (Angular)
- Add-member dialog → unified invite-by-email: paste one or many emails, live preview (to-invite / already-member / already-invited / duplicates / invalid), optional typeahead autofill (reuses LFXV2-2058 ranking), optional batch role, bounded-concurrency fan-out with a partial-success summary. Removes the full manual-entry gate.
- Members roster → **Pending Invitations** section with revoke; already-invited emails are skipped in the dialog.

## Behavior change (reviewers please note)

Inviting no longer sets org / voting status / permission / mailing-list subscription at add time — the invite endpoint carries only email + suggested role. Those move to post-accept member editing (existing flows). The per-person manual-entry fallback is removed from this dialog; the committee **manage** wizard keeps `MemberFormComponent` for full edits.

## Testing

- `yarn lint`, `yarn build` green; shared unit tests pass (incl. new `email.utils` + `hasLfAccount`).
- Manually validated end-to-end against the **dev** cluster: single + bulk invite, pending-invitations display, and revoke.

## Notes

- Invite emails are delivered by the platform pipeline (committee-service → `invite-service` → `email-service`/SES), not the UI.
- Drive-by: added a missing `vitest` import to `committee.utils.spec.ts` (it relied on bare globals and was breaking the shared test run).
- Follow-up: **LFXV2-2081** — CSV import for group members (intentionally not bundled here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
