### PR TITLE
feat(dashboards): hide irrelevant marketing impact tabs per focus area

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -50,7 +50,7 @@
 
     <!-- Section tabs -->
     <div class="flex gap-6 border-b border-gray-200" role="tablist" aria-label="Marketing impact sections" data-testid="marketing-impact-tabs">
-      @for (tab of tabs; track tab.id) {
+      @for (tab of visibleTabs(); track tab.id) {
         <button
           type="button"
           role="tab"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -7,7 +7,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MARKETING_IMPACT_FOCUS_OPTIONS, MARKETING_IMPACT_TABS } from '@lfx-one/shared/constants';
+import { FOCUS_VISIBLE_TABS, MARKETING_IMPACT_FOCUS_OPTIONS, MARKETING_IMPACT_TABS } from '@lfx-one/shared/constants';
 import { buildMarketingImpactMonthOptions, getDefaultMarketingImpactMonth } from '@lfx-one/shared/utils';
 import { ProjectContextService } from '@services/project-context.service';
 import { startWith } from 'rxjs';
@@ -71,11 +71,18 @@ export class MarketingImpactComponent {
   protected readonly foundationSlug = computed(() => this.projectContextService.selectedFoundation()?.slug);
   protected readonly selectedMonth: Signal<string> = this.initSelectedMonth();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
+  protected readonly visibleTabs: Signal<MarketingImpactTabOption[]> = this.initVisibleTabs();
 
   // === Protected Methods ===
   protected onFocusChange(focusId: string): void {
     if (this.focusOptions.some((o) => o.id === focusId)) {
-      this.selectedFocus.set(focusId as MarketingImpactFocusProgram);
+      const focus = focusId as MarketingImpactFocusProgram;
+      this.selectedFocus.set(focus);
+
+      const allowed = FOCUS_VISIBLE_TABS[focus];
+      if (!allowed.has(this.selectedTab())) {
+        this.selectedTab.set(this.tabs.find((t) => allowed.has(t.id))?.id ?? 'overview');
+      }
     }
   }
 
@@ -87,6 +94,13 @@ export class MarketingImpactComponent {
   private initSelectedMonth(): Signal<string> {
     return toSignal(this.headerForm.controls.month.valueChanges.pipe(startWith(this.defaultMonth)), {
       initialValue: this.defaultMonth,
+    });
+  }
+
+  private initVisibleTabs(): Signal<MarketingImpactTabOption[]> {
+    return computed(() => {
+      const allowed = FOCUS_VISIBLE_TABS[this.selectedFocus()];
+      return this.tabs.filter((t) => allowed.has(t.id));
     });
   }
 

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
-import type { AttributionModelOption, MarketingImpactFocusProgram, MarketingImpactTabOption } from '../interfaces/marketing-impact.interface';
+import type {
+  AttributionModelOption,
+  MarketingImpactFocusProgram,
+  MarketingImpactTab,
+  MarketingImpactTabOption,
+} from '../interfaces/marketing-impact.interface';
 
 /** Focus program filter options for the Marketing Impact FOCUS bar. Labels match Snowflake LF_SUB_DOMAIN_CLASSIFICATION values. */
 export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
@@ -42,6 +47,15 @@ export const FOCUS_TO_CLASSIFICATION: Record<MarketingImpactFocusProgram, string
 };
 
 export const VALID_CLASSIFICATIONS: ReadonlySet<string> = new Set(Object.values(FOCUS_TO_CLASSIFICATION).filter((v): v is string => v !== undefined));
+
+/** Which tabs are visible for each focus area. Tabs without classification-aware data are hidden when a non-"all" focus is selected. */
+export const FOCUS_VISIBLE_TABS: Record<MarketingImpactFocusProgram, ReadonlySet<MarketingImpactTab>> = {
+  all: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity', 'social-accounts', 'social-listening']),
+  lfCorporate: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  lfEvents: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  lfTraining: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  projectWebsites: new Set(['overview', 'attribution', 'performance-marketing', 'web-activity']),
+};
 
 /** Funnel stage filter options for the Performance Marketing tab. */
 export const FUNNEL_STAGE_OPTIONS: FilterPillOption[] = [

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -48,7 +48,7 @@ export const FOCUS_TO_CLASSIFICATION: Record<MarketingImpactFocusProgram, string
 
 export const VALID_CLASSIFICATIONS: ReadonlySet<string> = new Set(Object.values(FOCUS_TO_CLASSIFICATION).filter((v): v is string => v !== undefined));
 
-/** Which tabs are visible for each focus area. Tabs without classification-aware data are hidden when a non-"all" focus is selected. */
+/** Which tabs are visible for each focus area. Social tabs are hidden for non-"all" focuses (no classification filtering); Email is additionally hidden for projectWebsites (no email campaign data). */
 export const FOCUS_VISIBLE_TABS: Record<MarketingImpactFocusProgram, ReadonlySet<MarketingImpactTab>> = {
   all: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity', 'social-accounts', 'social-listening']),
   lfCorporate: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -50,11 +50,11 @@ export const VALID_CLASSIFICATIONS: ReadonlySet<string> = new Set(Object.values(
 
 /** Which tabs are visible for each focus area. Social tabs are hidden for non-"all" focuses (no classification filtering); Email is additionally hidden for projectWebsites (no email campaign data). */
 export const FOCUS_VISIBLE_TABS: Record<MarketingImpactFocusProgram, ReadonlySet<MarketingImpactTab>> = {
-  all: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity', 'social-accounts', 'social-listening']),
-  lfCorporate: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
-  lfEvents: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
-  lfTraining: new Set(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
-  projectWebsites: new Set(['overview', 'attribution', 'performance-marketing', 'web-activity']),
+  all: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity', 'social-accounts', 'social-listening']),
+  lfCorporate: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  lfEvents: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  lfTraining: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
+  projectWebsites: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'web-activity']),
 };
 
 /** Funnel stage filter options for the Performance Marketing tab. */


### PR DESCRIPTION
## Summary
- Add `FOCUS_VISIBLE_TABS` constant mapping each focus area to its set of data-supported tabs
- Hide Social Accounts and Social Listening tabs when any non-"all" focus area is selected (these tabs don't support classification filtering)
- Additionally hide the Email tab for "Project Websites" focus (no email campaign data for project websites)
- Auto-select first visible tab when the current tab becomes hidden on focus change

LFXV2-1644

🤖 Generated with [Claude Code](https://claude.ai/code)