### PR TITLE
fix(enrollment): use UTC midnight for end date status comparison (LFXV2-2084)

### DIFF
--- a/packages/shared/src/utils/enrollment.utils.ts
+++ b/packages/shared/src/utils/enrollment.utils.ts
@@ -3,7 +3,6 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { parseLocalDateString } from './date-time.utils';
 import { EnrollmentDisplayStatus, IndividualEnrollment } from '../interfaces/enrollment.interface';
 
 // Status derivation mirrors enrollment.plugin.js:197–226 from myprofile
@@ -16,11 +15,8 @@ export function deriveEnrollmentStatus(item: IndividualEnrollment): EnrollmentDi
   const endDateString = membership.EndDate.length >= 10 ? membership.EndDate.slice(0, 10) : membership.EndDate;
   let endDate: Date;
   if (/^\d{4}-\d{2}-\d{2}$/.test(endDateString)) {
-    try {
-      endDate = parseLocalDateString(endDateString);
-    } catch {
-      endDate = new Date(membership.EndDate);
-    }
+    const [y, m, d] = endDateString.split('-').map(Number);
+    endDate = new Date(Date.UTC(y, m - 1, d));
   } else {
     endDate = new Date(membership.EndDate);
   }


### PR DESCRIPTION
## Summary

- `deriveEnrollmentStatus` was parsing `EndDate` (a `YYYY-MM-DD` calendar day)
  as local midnight via `parseLocalDateString`, while the template renders the
  same field in UTC
- For users west of UTC (most US users), this caused the status chip and the
  displayed renewal date to disagree by one day at the boundary
- Fix: parse `EndDate` as `Date.UTC()` to align with the existing UTC display
  convention; drop the now-unused `parseLocalDateString` import

Fixes LFXV2-2084

## Test plan

- [ ] Open the individual enrollment view for an account whose membership
      `EndDate` is today or within the next few days; confirm the status chip
      (Active / Expiring Soon / Expired) and the displayed renewal date agree
- [ ] Confirm the 30-day "Expiring Soon" threshold still fires correctly for a
      membership expiring within 30 days

🤖 Generated with [Claude Code](https://claude.ai/code)