### PR TITLE
fix(campaigns): remove invalid gaql fields

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -140,6 +140,17 @@ export class ImplementationTabComponent {
 
     this.campaignService.createCampaign(request).subscribe({
       next: (response) => {
+        if (response.result) {
+          this.results.set(response.result.campaigns);
+          this.errors.set(response.result.errors);
+          this.step.set('results');
+          return;
+        }
+        if (response.error) {
+          this.errors.set([response.error]);
+          this.step.set('results');
+          return;
+        }
         if (!response.jobId) {
           this.errors.set(['Failed to start campaign creation.']);
           this.step.set('form');

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -35,8 +35,8 @@ export class CampaignService {
     });
   }
 
-  public createCampaign(request: CampaignCreateRequest): Observable<{ jobId: string }> {
-    return this.http.post<{ jobId: string }>('/api/campaigns/create', request);
+  public createCampaign(request: CampaignCreateRequest): Observable<{ jobId: string; result?: CampaignCreateResponse; error?: string }> {
+    return this.http.post<{ jobId: string; result?: CampaignCreateResponse; error?: string }>('/api/campaigns/create', request);
   }
 
   public getCreateResult(jobId: string): Observable<CampaignCreateResponse | null> {

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -31,7 +31,6 @@ export class CampaignMetricsService {
 
     const query = `
       SELECT campaign.name, campaign.status, campaign.id,
-             campaign.start_date, campaign.end_date,
              campaign_budget.amount_micros,
              metrics.impressions, metrics.clicks, metrics.cost_micros,
              metrics.conversions
@@ -145,16 +144,8 @@ function buildGoogleAdsUrl(campaignId: string): string {
   return campaignId ? `https://ads.google.com/aw/campaigns?campaignId=${campaignId}` : '';
 }
 
-function computeTotalBudget(budgetDay: number, startDate: string, endDate: string, fallbackDays: number): number {
-  if (startDate && endDate) {
-    const start = new Date(startDate);
-    const end = new Date(endDate);
-    if (!isNaN(start.getTime()) && !isNaN(end.getTime()) && end >= start) {
-      const flightDays = Math.round((end.getTime() - start.getTime()) / 86_400_000) + 1;
-      return budgetDay * flightDays;
-    }
-  }
-  return budgetDay * fallbackDays;
+function computeTotalBudget(budgetDay: number, days: number): number {
+  return budgetDay * days;
 }
 
 function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
@@ -172,9 +163,6 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
   const expectedSpend = budgetDay * days;
   const pacingPct = expectedSpend > 0 ? Math.round((spend / expectedSpend) * 100) : 0;
 
-  const startDate = (extractNested(r, 'campaign.start_date') as string) || '';
-  const endDate = (extractNested(r, 'campaign.end_date') as string) || '';
-
   let pacingLabel: PacingLabel = 'normal';
   if (pacingPct < 50) pacingLabel = 'underspending';
   else if (pacingPct > 100) pacingLabel = 'overspending';
@@ -187,10 +175,10 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
     adFormat: parsed.adFormat,
     targeting: parsed.targeting,
     status: normalizeCampaignStatus(extractNested(r, 'campaign.status')),
-    startDate,
-    endDate,
+    startDate: '',
+    endDate: '',
     budgetDay,
-    totalBudget: computeTotalBudget(budgetDay, startDate, endDate, days),
+    totalBudget: computeTotalBudget(budgetDay, days),
     spend,
     impressions,
     clicks,

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -148,6 +148,16 @@ function computeTotalBudget(budgetDay: number, days: number): number {
   return budgetDay * days;
 }
 
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function queryRangeStart(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - (days - 1));
+  return d.toISOString().slice(0, 10);
+}
+
 function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
   const r = row as Record<string, unknown>;
   const name = (extractNested(r, 'campaign.name') as string) || '';
@@ -175,8 +185,8 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
     adFormat: parsed.adFormat,
     targeting: parsed.targeting,
     status: normalizeCampaignStatus(extractNested(r, 'campaign.status')),
-    startDate: '',
-    endDate: '',
+    startDate: queryRangeStart(days),
+    endDate: todayIso(),
     budgetDay,
     totalBudget: computeTotalBudget(budgetDay, days),
     spend,

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -42,7 +42,9 @@ export class CampaignMetricsService {
       ORDER BY metrics.cost_micros DESC`;
 
     const rows = await gaqlSearch(query);
-    const campaigns = rows.map((row) => parseCampaignMetrics(row, effectiveDays)).filter((c) => !c.name.toLowerCase().startsWith('zz'));
+    const rangeStart = queryRangeStart(effectiveDays);
+    const rangeEnd = todayIso();
+    const campaigns = rows.map((row) => parseCampaignMetrics(row, effectiveDays, rangeStart, rangeEnd)).filter((c) => !c.name.toLowerCase().startsWith('zz'));
     const actionItems = generateActionItems(campaigns);
 
     return {
@@ -158,7 +160,7 @@ function queryRangeStart(days: number): string {
   return d.toISOString().slice(0, 10);
 }
 
-function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
+function parseCampaignMetrics(row: unknown, days: number, rangeStart: string, rangeEnd: string): CampaignMetrics {
   const r = row as Record<string, unknown>;
   const name = (extractNested(r, 'campaign.name') as string) || '';
   const parsed = parseCampaignName(name);
@@ -185,8 +187,8 @@ function parseCampaignMetrics(row: unknown, days: number): CampaignMetrics {
     adFormat: parsed.adFormat,
     targeting: parsed.targeting,
     status: normalizeCampaignStatus(extractNested(r, 'campaign.status')),
-    startDate: queryRangeStart(days),
-    endDate: todayIso(),
+    startDate: rangeStart,
+    endDate: rangeEnd,
     budgetDay,
     totalBudget: computeTotalBudget(budgetDay, days),
     spend,

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -156,7 +156,7 @@ function todayIso(): string {
 
 function queryRangeStart(days: number): string {
   const d = new Date();
-  d.setDate(d.getDate() - (days - 1));
+  d.setUTCDate(d.getUTCDate() - (days - 1));
   return d.toISOString().slice(0, 10);
 }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -676,13 +676,18 @@ export class CampaignProxyService {
 
   // === Campaign creation (async job) ===
 
-  public async createCampaign(_req: Request, body: CampaignCreateRequest): Promise<{ jobId: string }> {
+  public async createCampaign(_req: Request, body: CampaignCreateRequest): Promise<{ jobId: string; result?: CampaignCreateResponse; error?: string }> {
     const jobId = createJob();
 
-    this.executeCampaignCreation(jobId, body).catch((error) => {
+    try {
+      await this.executeCampaignCreation(jobId, body);
+    } catch (error) {
       failJob(jobId, error instanceof Error ? error.message : 'Campaign creation failed');
-    });
+    }
 
+    const job = jobs.get(jobId);
+    if (job?.status === 'done') return { jobId, result: job.result };
+    if (job?.status === 'error') return { jobId, error: job.error };
     return { jobId };
   }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -679,15 +679,19 @@ export class CampaignProxyService {
   public async createCampaign(_req: Request, body: CampaignCreateRequest): Promise<{ jobId: string; result?: CampaignCreateResponse; error?: string }> {
     const jobId = createJob();
 
-    try {
-      await this.executeCampaignCreation(jobId, body);
-    } catch (error) {
+    this.executeCampaignCreation(jobId, body).catch((error) => {
       failJob(jobId, error instanceof Error ? error.message : 'Campaign creation failed');
+    });
+
+    const POLL_INTERVAL_MS = 500;
+    const deadline = Date.now() + JOB_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      const job = jobs.get(jobId);
+      if (job?.status === 'done') return { jobId, result: job.result };
+      if (job?.status === 'error') return { jobId, error: job.error };
     }
 
-    const job = jobs.get(jobId);
-    if (job?.status === 'done') return { jobId, result: job.result };
-    if (job?.status === 'error') return { jobId, error: job.error };
     return { jobId };
   }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -684,7 +684,8 @@ export class CampaignProxyService {
     });
 
     const POLL_INTERVAL_MS = 500;
-    const deadline = Date.now() + JOB_TIMEOUT_MS;
+    const INLINE_WAIT_MS = 15_000;
+    const deadline = Date.now() + INLINE_WAIT_MS;
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
       const job = jobs.get(jobId);


### PR DESCRIPTION
## Summary
- Remove invalid GAQL fields (`campaign.start_date`, `campaign.end_date`) that fail on Google Ads API v23
- Populate campaign flight dates from the effective query range instead of empty strings
- Fix budget calculation to use `campaign_budget.amount_micros` (daily budget × days) instead of removed fields
- Change `createCampaign` response contract: inline result/error returned within a 15s poll window, otherwise falls back to `{ jobId }` for client-side polling via `/api/campaigns/jobs/:id`
- Use UTC date setters in `queryRangeStart` to avoid DST off-by-one

## Test plan
- [ ] Verify monitoring tab loads campaign metrics without GAQL errors
- [ ] Verify flight dates column shows the query date range (e.g., "2026-05-27 – 2026-06-03" for 7d)
- [ ] Verify budget/pacing uses daily budget × days instead of removed budget fields
- [ ] Verify campaign creation returns inline result for fast jobs (<15s) and jobId for slower ones

🤖 Generated with [Claude Code](https://claude.ai/code)