### PR TITLE
fix(meetings): remove None voting-status option from meeting form filter

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -6,7 +6,8 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
 import { Committee, CommitteeMember, MeetingCommittee } from '@lfx-one/shared';
-import { COMMITTEE_LABEL, VOTING_STATUSES } from '@lfx-one/shared/constants';
+import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
+import { COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared/constants';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { TooltipModule } from 'primeng/tooltip';
@@ -51,7 +52,7 @@ export class MeetingCommitteeManagerComponent {
   public filteredCommitteeMembers = this.initFilteredCommitteeMembers();
 
   // Voting status options for dropdown
-  public readonly votingStatusOptions = VOTING_STATUSES;
+  public readonly votingStatusOptions = MEETING_VOTING_STATUSES;
   public readonly committeeLabel = COMMITTEE_LABEL;
 
   // Computed signals
@@ -255,15 +256,17 @@ export class MeetingCommitteeManagerComponent {
         return members;
       }
 
-      // Filter members by selected voting statuses
-      // Members without voting status info are excluded from filtered results
+      // None is treated as Observer — normalize both sides so None-status members
+      // are included when Observer is selected.
+      const normalizeStatus = (s: string): string => (s === CommitteeMemberVotingStatus.NONE ? CommitteeMemberVotingStatus.OBSERVER : s);
+      const normalizedSelected = selectedVotingStatuses.map(normalizeStatus);
+
       return members.filter((member) => {
         const votingStatus = member.voting?.status;
-        // If member has no voting status, exclude them from filtered results
         if (!votingStatus) {
           return false;
         }
-        return selectedVotingStatuses.includes(votingStatus);
+        return normalizedSelected.includes(normalizeStatus(votingStatus));
       });
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
@@ -8,7 +8,8 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
 import { TableComponent } from '@components/table/table.component';
-import { COMMITTEE_LABEL, VOTING_STATUSES } from '@lfx-one/shared';
+import { COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared';
+import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import { Committee, CommitteeMember, Meeting } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -57,7 +58,7 @@ export class MeetingCommitteeModalComponent {
   private committeesMembersCache = new Map<string, CommitteeMemberDisplay[]>();
 
   // Voting status options for dropdown
-  public readonly votingStatusOptions = VOTING_STATUSES;
+  public readonly votingStatusOptions = MEETING_VOTING_STATUSES;
   public readonly committeeLabel = COMMITTEE_LABEL;
 
   // Load committees using toSignal
@@ -314,9 +315,17 @@ export class MeetingCommitteeModalComponent {
         return members;
       }
 
-      // Filter members by selected voting statuses
+      // None is treated as Observer — normalize both sides so None-status members
+      // are included when Observer is selected.
+      const normalizeStatus = (s: string): string => (s === CommitteeMemberVotingStatus.NONE ? CommitteeMemberVotingStatus.OBSERVER : s);
+      const normalizedSelected = selectedVotingStatuses.map(normalizeStatus);
+
       return members.filter((member) => {
-        return member.voting?.status && selectedVotingStatuses.includes(member.voting.status);
+        const votingStatus = member.voting?.status;
+        if (!votingStatus) {
+          return false;
+        }
+        return normalizedSelected.includes(normalizeStatus(votingStatus));
       });
     });
   }

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -255,6 +255,13 @@ export const VOTING_STATUSES = [
 ];
 
 /**
+ * Voting status options for meeting committee filters.
+ * Excludes None — it is not a selectable value in meeting forms but remains
+ * a valid member status. None is treated as Observer for filtering purposes.
+ */
+export const MEETING_VOTING_STATUSES = VOTING_STATUSES.filter(({ value }) => value !== CommitteeMemberVotingStatus.NONE);
+
+/**
  * Available appointment sources for committee members
  * @description Defines how a member was appointed to the committee
  * @readonly


### PR DESCRIPTION
## Summary

- Introduces \`MEETING_VOTING_STATUSES\`, a meeting-specific picker list derived from \`VOTING_STATUSES\` that excludes \`None\`
- Both meeting form pickers (committee manager and committee modal) now use this list, so \`None\` no longer appears as a selectable voting-status option
- \`None\` remains in \`VOTING_STATUSES\` as it is a valid backend-assigned member status (set when a committee has voting enabled and an existing member has no status yet)
- Members with a \`None\` voting status are treated as \`Observer\` when filtering the committee member preview

Closes LFXV2-2074