### PR TITLE
refactor(newsletter): drop edNameHeader (X-User-Name)

### DIFF
--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -62,9 +62,17 @@ export class NewsletterServiceClient {
     ifMatchVersion: number,
     payload: UpdateNewsletterRequest
   ): Promise<Newsletter> {
-    return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/${newsletterUid}`, 'PUT', undefined, payload, {
-      'If-Match': `"${ifMatchVersion}"`,
-    });
+    return this.microserviceProxy.proxyRequest<Newsletter>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletters/${newsletterUid}`,
+      'PUT',
+      undefined,
+      payload,
+      {
+        'If-Match': `"${ifMatchVersion}"`,
+      }
+    );
   }
 
   public async deleteNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<void> {
@@ -113,7 +121,14 @@ export class NewsletterServiceClient {
   }
 
   public async testSend(req: Request, projectUid: string, payload: NewsletterTestSendPayload): Promise<{ ok: boolean }> {
-    return this.microserviceProxy.proxyRequest<{ ok: boolean }>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/test-send`, 'POST', undefined, payload);
+    return this.microserviceProxy.proxyRequest<{ ok: boolean }>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletters/test-send`,
+      'POST',
+      undefined,
+      payload
+    );
   }
 
   public async getAnalytics(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterAnalytics> {
@@ -124,5 +139,4 @@ export class NewsletterServiceClient {
       'GET'
     );
   }
-
 }

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -31,15 +31,7 @@ export class NewsletterServiceClient {
   private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
 
   public async createNewsletter(req: Request, projectUid: string, payload: CreateNewsletterRequest): Promise<Newsletter> {
-    return this.microserviceProxy.proxyRequest<Newsletter>(
-      req,
-      'LFX_V2_SERVICE',
-      `/projects/${projectUid}/newsletters`,
-      'POST',
-      undefined,
-      payload,
-      this.edNameHeader(req)
-    );
+    return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters`, 'POST', undefined, payload);
   }
 
   public async getNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<Newsletter> {
@@ -70,18 +62,9 @@ export class NewsletterServiceClient {
     ifMatchVersion: number,
     payload: UpdateNewsletterRequest
   ): Promise<Newsletter> {
-    return this.microserviceProxy.proxyRequest<Newsletter>(
-      req,
-      'LFX_V2_SERVICE',
-      `/projects/${projectUid}/newsletters/${newsletterUid}`,
-      'PUT',
-      undefined,
-      payload,
-      {
-        ...this.edNameHeader(req),
-        'If-Match': `"${ifMatchVersion}"`,
-      }
-    );
+    return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/${newsletterUid}`, 'PUT', undefined, payload, {
+      'If-Match': `"${ifMatchVersion}"`,
+    });
   }
 
   public async deleteNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<void> {
@@ -91,8 +74,9 @@ export class NewsletterServiceClient {
   /**
    * Send a previously-saved newsletter draft. The Go service mints group_id,
    * resolves recipients, fans out to email-service, and persists the status
-   * transition — Express just forwards the user's identity (X-User-Name) so
-   * the Go service can stamp the sender attribution.
+   * transition. The sender's display name is resolved server-side from the
+   * signed JWT principal via the auth-service NATS lookup — Express forwards
+   * only the bearer token and the If-Match version.
    */
   public async sendNewsletter(req: Request, projectUid: string, newsletterUid: string, ifMatchVersion: number): Promise<NewsletterSendResult> {
     return this.microserviceProxy.proxyRequest<NewsletterSendResult>(
@@ -102,10 +86,7 @@ export class NewsletterServiceClient {
       'POST',
       undefined,
       {},
-      {
-        ...this.edNameHeader(req),
-        'If-Match': `"${ifMatchVersion}"`,
-      }
+      { 'If-Match': `"${ifMatchVersion}"` }
     );
   }
 
@@ -132,15 +113,7 @@ export class NewsletterServiceClient {
   }
 
   public async testSend(req: Request, projectUid: string, payload: NewsletterTestSendPayload): Promise<{ ok: boolean }> {
-    return this.microserviceProxy.proxyRequest<{ ok: boolean }>(
-      req,
-      'LFX_V2_SERVICE',
-      `/projects/${projectUid}/newsletters/test-send`,
-      'POST',
-      undefined,
-      payload,
-      this.edNameHeader(req)
-    );
+    return this.microserviceProxy.proxyRequest<{ ok: boolean }>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/test-send`, 'POST', undefined, payload);
   }
 
   public async getAnalytics(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterAnalytics> {
@@ -152,16 +125,4 @@ export class NewsletterServiceClient {
     );
   }
 
-  /**
-   * Forwards the ED display name from the inbound Auth0 session so the Go
-   * service can stamp emails without needing access to the LFX user store.
-   */
-  private edNameHeader(req: Request): Record<string, string> {
-    const user = req.oidc?.user;
-    const name = (user?.['name'] as string) || (user?.['nickname'] as string) || (user?.['email'] as string) || '';
-    if (!name) {
-      return {};
-    }
-    return { 'X-User-Name': String(name) };
-  }
 }


### PR DESCRIPTION
Newsletter-service now resolves the sender's display name server-side from the signed JWT principal via NATS `lfx.auth-service.user_metadata.read`. The Express-forwarded `X-User-Name` header is no longer read by the backend and was a spoofable channel — anyone with cluster-internal reach could set it.

Paired with [lfx-v2-newsletter-service#18](https://github.com/linuxfoundation/lfx-v2-newsletter-service/pull/18).

LFXV2-2111

## Test plan
- [x] `yarn lint` clean (sole warning is pre-existing in `docs-manifest.service.ts`)