### PR TITLE
docs(frontend): add persona x lens content matrix

### DIFF
--- a/docs/architecture/frontend/README.md
+++ b/docs/architecture/frontend/README.md
@@ -28,6 +28,10 @@ The LFX One frontend is built with Angular 20 using stable zoneless change detec
 
 ## 📋 Documentation Sections
 
+### [Persona × Lens Content Matrix](./persona-content-matrix.md)
+
+See which sidebar links and pages each persona can access in each lens, plus route guard wiring.
+
 ### [Angular Patterns](./angular-patterns.md)
 
 Learn about Angular 20 features, zoneless change detection, and SSR configuration.

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -152,11 +152,11 @@ Available to `contributor`, `maintainer`, and root writers.
 
 Guards enforce access at the router level — regardless of whether a sidebar link is visible.
 
-| Guard                    | Protected routes                                                                        | Access rule                                                        |
-| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`                        |
-| `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`                         |
-| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()`                   |
+| Guard                    | Protected routes                                                                        | Access rule                                                                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`                                                                                                             |
+| `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`                                                                                                              |
+| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()`                                                                                                        |
 | `orgLensEnabledGuard`    | `/org/*` (CanMatch — routes invisible when flag is off)                                 | Browser: `ORG_LENS_ENABLED_FLAG` must be `true`; redirects to `/` otherwise. SSR: always returns `true` — enforcement defers to browser after hydration |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -9,12 +9,12 @@ For background on how personas and lenses are resolved, see [Lens & Persona Syst
 
 ## Personas
 
-| Persona              | How acquired                                                    |
-| -------------------- | --------------------------------------------------------------- |
-| `contributor`        | Lowest-privilege; any authenticated user with no committee role |
-| `maintainer`         | Has a project-level maintainer committee membership             |
-| `board-member`       | Has a board committee membership on a foundation                |
-| `executive-director` | Has an ED committee membership, OR is a root writer (injected)  |
+| Persona              | How acquired                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| `contributor`        | Default project-scoped persona; assigned when no other project detection matches, or as a fallback |
+| `maintainer`         | Has a `cdp_roles` detection carrying a `maintainer` role for a project                             |
+| `board-member`       | Has a `board_member` detection on a foundation                                                     |
+| `executive-director` | Has an `executive_director` detection on a foundation, OR is a root writer (injected)              |
 
 A user can carry multiple personas simultaneously. When no explicit selection has been made, `PersonaService` defaults to the highest-priority persona (`executive-director` > `board-member` > `maintainer` > `contributor`). A user can explicitly **pin** a lower-priority persona (e.g., switch from ED to board-member view) — `PersonaService` preserves that choice across refreshes as long as the persona is still in the allowed set (`userSelected` flag). The active `currentPersona()` signal — not a static priority rule — drives which conditional sidebar sections are shown.
 
@@ -27,7 +27,7 @@ A user can carry multiple personas simultaneously. When no explicit selection ha
 | `project`    | Users with `hasProjectRole` (`maintainer` or `contributor`), or root writers        |
 | `org`        | All users (feature-flagged via `ORG_LENS_ENABLED_FLAG`)                             |
 
-A user can carry both board and project roles and see both the `foundation` and `project` lenses simultaneously.
+A user can carry both board and project roles simultaneously. In the sidebar lens switcher, hybrid users see a single merged **project** lens entry instead of separate `foundation` and `project` buttons — `LensService.displayLenses` filters the `foundation` option for hybrids so the `project` button serves as the unified entry point for both.
 
 ## Key conditions referenced in the matrix
 
@@ -129,7 +129,7 @@ Available to `contributor`, `maintainer`, and root writers.
 
 ## Org Lens
 
-**Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. Falls back to Me Lens items when the flag is off. Identical for all personas when enabled.
+**Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. When the flag is off, `orgLensEnabledGuard` (CanMatch) blocks all `/org/*` routes and redirects to `/` — the routes are invisible to the router. When enabled, the Org Lens is identical for all personas.
 
 | Section         | Item                     | Route                |
 | --------------- | ------------------------ | -------------------- |
@@ -152,11 +152,12 @@ Available to `contributor`, `maintainer`, and root writers.
 
 Guards enforce access at the router level — regardless of whether a sidebar link is visible.
 
-| Guard                    | Protected routes                                                                        | Access rule                                      |
-| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`      |
-| `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`       |
-| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()` |
+| Guard                    | Protected routes                                                                        | Access rule                                                        |
+| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`                        |
+| `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`                         |
+| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()`                   |
+| `orgLensEnabledGuard`    | `/org/*` (CanMatch — routes invisible when flag is off)                                 | `ORG_LENS_ENABLED_FLAG` must be `true`; redirects to `/` otherwise |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -155,7 +155,7 @@ Guards enforce access at the router level — regardless of whether a sidebar li
 | Guard                    | Protected routes                                                                        | Access rule                                      |
 | ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`      |
-| `newsletterAccessGuard`  | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes     | `canSeeNewsletters()` — ED or `canWrite()`       |
+| `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`       |
 | `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()` |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -9,33 +9,33 @@ For background on how personas and lenses are resolved, see [Lens & Persona Syst
 
 ## Personas
 
-| Persona              | How acquired                                                     |
-| -------------------- | ---------------------------------------------------------------- |
-| `contributor`        | Lowest-privilege; any authenticated user with no committee role  |
-| `maintainer`         | Has a project-level maintainer committee membership              |
-| `board-member`       | Has a board committee membership on a foundation                 |
-| `executive-director` | Has an ED committee membership, OR is a root writer (injected)   |
+| Persona              | How acquired                                                    |
+| -------------------- | --------------------------------------------------------------- |
+| `contributor`        | Lowest-privilege; any authenticated user with no committee role |
+| `maintainer`         | Has a project-level maintainer committee membership             |
+| `board-member`       | Has a board committee membership on a foundation                |
+| `executive-director` | Has an ED committee membership, OR is a root writer (injected)  |
 
 A user can carry multiple personas simultaneously. The **primary** persona is the highest-priority one (`executive-director` > `board-member` > `maintainer` > `contributor`) and drives conditional sidebar sections.
 
 ## Lenses and access rules
 
-| Lens         | Who can use it                                               |
-| ------------ | ------------------------------------------------------------ |
-| `me`         | All authenticated users                                      |
+| Lens         | Who can use it                                                                      |
+| ------------ | ----------------------------------------------------------------------------------- |
+| `me`         | All authenticated users                                                             |
 | `foundation` | Users with `hasBoardRole` (`board-member` or `executive-director`), or root writers |
-| `project`    | Users with `hasProjectRole` (`maintainer` or `contributor`), or root writers |
-| `org`        | All lenses users (feature-flagged via `ORG_LENS_ENABLED_FLAG`) |
+| `project`    | Users with `hasProjectRole` (`maintainer` or `contributor`), or root writers        |
+| `org`        | All lenses users (feature-flagged via `ORG_LENS_ENABLED_FLAG`)                      |
 
 A user can carry both board and project roles and see both the `foundation` and `project` lenses simultaneously.
 
 ## Key conditions referenced in the matrix
 
-| Condition              | Definition                                                                           | Source                         |
-| ---------------------- | ------------------------------------------------------------------------------------ | ------------------------------ |
-| `canWrite()`           | `ProjectContextService.canWrite` — reactive signal; true when the user has write/manage access to the active foundation or project | `project-context.service.ts`   |
-| `canSeeNewsletters()`  | `currentPersona() === 'executive-director' \|\| canWrite()`                           | `main-layout.component.ts:535` |
-| `foundationHasProjects()` | True when the selected foundation has ≥1 project row in Snowflake; cleared while fetching | `main-layout.component.ts:188` |
+| Condition                 | Definition                                                                                                                         | Source                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `canWrite()`              | `ProjectContextService.canWrite` — reactive signal; true when the user has write/manage access to the active foundation or project | `project-context.service.ts`   |
+| `canSeeNewsletters()`     | `currentPersona() === 'executive-director' \|\| canWrite()`                                                                        | `main-layout.component.ts:535` |
+| `foundationHasProjects()` | True when the selected foundation has ≥1 project row in Snowflake; cleared while fetching                                          | `main-layout.component.ts:188` |
 
 ---
 
@@ -43,23 +43,23 @@ A user can carry both board and project roles and see both the `foundation` and 
 
 **Identical for all personas.** Static items — no runtime persona conditions.
 
-| Section       | Item                     | Route                  |
-| ------------- | ------------------------ | ---------------------- |
-| *(top-level)* | My Dashboard             | `/`                    |
-| My Engagement | My Meetings              | `/meetings`            |
-|               | My Events                | `/events`              |
-|               | My Committees            | `/groups`              |
-|               | My Mailing Lists         | `/mailing-lists`       |
-|               | My Votes                 | `/votes`               |
-|               | My Surveys               | `/surveys`             |
-|               | My Documents             | `/documents`           |
-| My Growth     | Training & Certifications | `/me/training`        |
-|               | Mentorships              | *(external link)*      |
-|               | Crowdfunding             | *(external link)*      |
-|               | Badges                   | `/badges`              |
-| My Account    | Profile                  | `/profile`             |
-|               | Settings                 | `/settings`            |
-|               | Transactions             | `/me/transactions`     |
+| Section       | Item                      | Route              |
+| ------------- | ------------------------- | ------------------ |
+| _(top-level)_ | My Dashboard              | `/`                |
+| My Engagement | My Meetings               | `/meetings`        |
+|               | My Events                 | `/events`          |
+|               | My Committees             | `/groups`          |
+|               | My Mailing Lists          | `/mailing-lists`   |
+|               | My Votes                  | `/votes`           |
+|               | My Surveys                | `/surveys`         |
+|               | My Documents              | `/documents`       |
+| My Growth     | Training & Certifications | `/me/training`     |
+|               | Mentorships               | _(external link)_  |
+|               | Crowdfunding              | _(external link)_  |
+|               | Badges                    | `/badges`          |
+| My Account    | Profile                   | `/profile`         |
+|               | Settings                  | `/settings`        |
+|               | Transactions              | `/me/transactions` |
 
 ---
 
@@ -67,34 +67,34 @@ A user can carry both board and project roles and see both the `foundation` and 
 
 Available to `board-member`, `executive-director`, and root writers.
 
-| Sidebar item / section | Route                           | Visible to              |
-| ---------------------- | ------------------------------- | ----------------------- |
-| Dashboard              | `/foundation/overview`          | All foundation users    |
-| Projects               | `/foundation/projects`          | All — **only when** `foundationHasProjects()` is true |
-| Meetings               | `/foundation/meetings`          | All foundation users    |
-| Events                 | `/foundation/events`            | All foundation users    |
-| Mailing Lists          | `/foundation/mailing-lists`     | All foundation users    |
-| Committees             | `/foundation/groups`            | All foundation users    |
-| Documents              | `/foundation/documents`         | All foundation users    |
-| **Governance** section |                                 |                         |
-| → Votes                | `/foundation/votes`             | All foundation users    |
-| → Surveys              | `/foundation/surveys`           | All foundation users    |
-| → Permissions          | `/foundation/settings`          | All foundation users    |
-| **Communications** section |                             | `canSeeNewsletters()` — ED **or** `canWrite()` |
-| → Newsletters          | `/foundation/newsletters`       | `canSeeNewsletters()`   |
-| **Metrics** section    |                                 | `executive-director` only |
-| → Health Metrics       | `/foundation/health-metrics`    | `executive-director`    |
-| → Social Listening     | *(PCC external link)*           | `executive-director` — **only when** `selectedFoundationSfid()` is set |
-| **Marketing** section  |                                 | `executive-director` only |
-| → Marketing Impact     | `/foundation/marketing-impact`  | `executive-director`    |
-| → Campaigns            | `/foundation/campaigns`         | `executive-director`    |
+| Sidebar item / section     | Route                          | Visible to                                                             |
+| -------------------------- | ------------------------------ | ---------------------------------------------------------------------- |
+| Dashboard                  | `/foundation/overview`         | All foundation users                                                   |
+| Projects                   | `/foundation/projects`         | All — **only when** `foundationHasProjects()` is true                  |
+| Meetings                   | `/foundation/meetings`         | All foundation users                                                   |
+| Events                     | `/foundation/events`           | All foundation users                                                   |
+| Mailing Lists              | `/foundation/mailing-lists`    | All foundation users                                                   |
+| Committees                 | `/foundation/groups`           | All foundation users                                                   |
+| Documents                  | `/foundation/documents`        | All foundation users                                                   |
+| **Governance** section     |                                |                                                                        |
+| → Votes                    | `/foundation/votes`            | All foundation users                                                   |
+| → Surveys                  | `/foundation/surveys`          | All foundation users                                                   |
+| → Permissions              | `/foundation/settings`         | All foundation users                                                   |
+| **Communications** section |                                | `canSeeNewsletters()` — ED **or** `canWrite()`                         |
+| → Newsletters              | `/foundation/newsletters`      | `canSeeNewsletters()`                                                  |
+| **Metrics** section        |                                | `executive-director` only                                              |
+| → Health Metrics           | `/foundation/health-metrics`   | `executive-director`                                                   |
+| → Social Listening         | _(PCC external link)_          | `executive-director` — **only when** `selectedFoundationSfid()` is set |
+| **Marketing** section      |                                | `executive-director` only                                              |
+| → Marketing Impact         | `/foundation/marketing-impact` | `executive-director`                                                   |
+| → Campaigns                | `/foundation/campaigns`        | `executive-director`                                                   |
 
 ### Foundation lens by persona summary
 
 | Persona              | Sees Governance | Sees Newsletters (Communications) | Sees Metrics | Sees Marketing |
-| -------------------- | --------------- | ---------------------------------- | ------------ | -------------- |
-| `board-member`       | Yes             | Only if `canWrite()`               | No           | No             |
-| `executive-director` | Yes             | Yes (always)                       | Yes          | Yes            |
+| -------------------- | --------------- | --------------------------------- | ------------ | -------------- |
+| `board-member`       | Yes             | Only if `canWrite()`              | No           | No             |
+| `executive-director` | Yes             | Yes (always)                      | Yes          | Yes            |
 
 ---
 
@@ -102,26 +102,26 @@ Available to `board-member`, `executive-director`, and root writers.
 
 Available to `contributor`, `maintainer`, and root writers.
 
-| Sidebar item / section | Route                       | Visible to           |
-| ---------------------- | --------------------------- | -------------------- |
-| Dashboard              | `/project/overview`         | All project users    |
-| Meetings               | `/project/meetings`         | All project users    |
-| Mailing Lists          | `/project/mailing-lists`    | All project users    |
-| Committees             | `/project/groups`           | All project users    |
-| Documents              | `/project/documents`        | All project users    |
-| **Governance** section |                             |                      |
-| → Votes                | `/project/votes`            | All project users    |
-| → Surveys              | `/project/surveys`          | All project users    |
-| → Permissions          | `/project/settings`         | All project users    |
-| **Communications** section |                         | `canSeeNewsletters()` — ED **or** `canWrite()` |
-| → Newsletters          | `/project/newsletters`      | `canSeeNewsletters()` |
+| Sidebar item / section     | Route                    | Visible to                                     |
+| -------------------------- | ------------------------ | ---------------------------------------------- |
+| Dashboard                  | `/project/overview`      | All project users                              |
+| Meetings                   | `/project/meetings`      | All project users                              |
+| Mailing Lists              | `/project/mailing-lists` | All project users                              |
+| Committees                 | `/project/groups`        | All project users                              |
+| Documents                  | `/project/documents`     | All project users                              |
+| **Governance** section     |                          |                                                |
+| → Votes                    | `/project/votes`         | All project users                              |
+| → Surveys                  | `/project/surveys`       | All project users                              |
+| → Permissions              | `/project/settings`      | All project users                              |
+| **Communications** section |                          | `canSeeNewsletters()` — ED **or** `canWrite()` |
+| → Newsletters              | `/project/newsletters`   | `canSeeNewsletters()`                          |
 
 ### Project lens by persona summary
 
-| Persona              | Sees Governance | Sees Newsletters (Communications) |
-| -------------------- | --------------- | ---------------------------------- |
-| `contributor`        | Yes             | Only if `canWrite()`               |
-| `maintainer`         | Yes             | Only if `canWrite()`               |
+| Persona       | Sees Governance | Sees Newsletters (Communications) |
+| ------------- | --------------- | --------------------------------- |
+| `contributor` | Yes             | Only if `canWrite()`              |
+| `maintainer`  | Yes             | Only if `canWrite()`              |
 
 > **Note:** `canWrite()` is resolved from `ProjectContextService` and reflects the user's write access to the currently-selected project, not their persona level globally. A `contributor` who is a project manager (write access) will see Newsletters.
 
@@ -131,20 +131,20 @@ Available to `contributor`, `maintainer`, and root writers.
 
 **Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. Falls back to Me Lens items when the flag is off. Identical for all personas when enabled.
 
-| Section          | Item                    | Route                |
-| ---------------- | ----------------------- | -------------------- |
-| *(top-level)*    | Org Overview            | `/org/overview`      |
-| Org Foundations  | Memberships             | `/org/memberships`   |
-|                  | Projects                | `/org/projects`      |
-|                  | ROI                     | `/org/roi`           |
-|                  | Governance              | `/org/governance`    |
-| Org Engagement   | People                  | `/org/people`        |
-|                  | Code Contributions      | `/org/contributions` |
-|                  | Events                  | `/org/events`        |
-|                  | Training & Certification | `/org/training`     |
-|                  | Meetings                | `/org/meetings`      |
-|                  | Committees              | `/org/groups`        |
-| Org Admin        | Profile                 | `/org/profile`       |
+| Section         | Item                     | Route                |
+| --------------- | ------------------------ | -------------------- |
+| _(top-level)_   | Org Overview             | `/org/overview`      |
+| Org Foundations | Memberships              | `/org/memberships`   |
+|                 | Projects                 | `/org/projects`      |
+|                 | ROI                      | `/org/roi`           |
+|                 | Governance               | `/org/governance`    |
+| Org Engagement  | People                   | `/org/people`        |
+|                 | Code Contributions       | `/org/contributions` |
+|                 | Events                   | `/org/events`        |
+|                 | Training & Certification | `/org/training`      |
+|                 | Meetings                 | `/org/meetings`      |
+|                 | Committees               | `/org/groups`        |
+| Org Admin       | Profile                  | `/org/profile`       |
 
 ---
 
@@ -152,11 +152,11 @@ Available to `contributor`, `maintainer`, and root writers.
 
 Guards enforce access at the router level — regardless of whether a sidebar link is visible.
 
-| Guard                   | Protected routes                                                                 | Access rule                   |
-| ----------------------- | -------------------------------------------------------------------------------- | ----------------------------- |
-| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`                   | `currentPersona() === 'executive-director'` |
-| `newsletterAccessGuard` | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes | `canSeeNewsletters()` — ED or `canWrite()` |
-| `writerGuard`           | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `canWrite()` |
+| Guard                    | Protected routes                                                                        | Access rule                                 |
+| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`                            | `currentPersona() === 'executive-director'` |
+| `newsletterAccessGuard`  | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes     | `canSeeNewsletters()` — ED or `canWrite()`  |
+| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `canWrite()`                                |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 
@@ -166,14 +166,14 @@ Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 
 The `writerGuard` protects create and edit routes. Within read-only pages, UI elements (add/edit/delete buttons) are additionally gated by `canWrite()` in the component template.
 
-| Domain        | Create/edit route guard | In-page UI gating |
-| ------------- | ----------------------- | ----------------- |
-| Meetings      | `writerGuard`           | Yes               |
-| Committees    | `writerGuard`           | Yes               |
-| Mailing Lists | `writerGuard`           | Yes               |
-| Surveys       | `writerGuard`           | Yes               |
-| Votes         | `writerGuard`           | Yes               |
-| Settings / Permissions | —              | `canWrite()` — view-only banner shown to non-writers |
+| Domain                 | Create/edit route guard | In-page UI gating                                    |
+| ---------------------- | ----------------------- | ---------------------------------------------------- |
+| Meetings               | `writerGuard`           | Yes                                                  |
+| Committees             | `writerGuard`           | Yes                                                  |
+| Mailing Lists          | `writerGuard`           | Yes                                                  |
+| Surveys                | `writerGuard`           | Yes                                                  |
+| Votes                  | `writerGuard`           | Yes                                                  |
+| Settings / Permissions | —                       | `canWrite()` — view-only banner shown to non-writers |
 
 > Backend write enforcement (whether the upstream microservices independently reject unauthorized writes) is tracked separately in [LFXV2-1662](https://linuxfoundation.atlassian.net/browse/LFXV2-1662).
 

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -1,0 +1,193 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Persona × Lens Content Matrix
+
+Maps every persona to the sidebar links and key pages it can see in each lens. Use this as the source of truth when adding new nav items, writing persona regression tests, or auditing access gating.
+
+For background on how personas and lenses are resolved, see [Lens & Persona System](./lens-system.md).
+
+## Personas
+
+| Persona              | How acquired                                                     |
+| -------------------- | ---------------------------------------------------------------- |
+| `contributor`        | Lowest-privilege; any authenticated user with no committee role  |
+| `maintainer`         | Has a project-level maintainer committee membership              |
+| `board-member`       | Has a board committee membership on a foundation                 |
+| `executive-director` | Has an ED committee membership, OR is a root writer (injected)   |
+
+A user can carry multiple personas simultaneously. The **primary** persona is the highest-priority one (`executive-director` > `board-member` > `maintainer` > `contributor`) and drives conditional sidebar sections.
+
+## Lenses and access rules
+
+| Lens         | Who can use it                                               |
+| ------------ | ------------------------------------------------------------ |
+| `me`         | All authenticated users                                      |
+| `foundation` | Users with `hasBoardRole` (`board-member` or `executive-director`), or root writers |
+| `project`    | Users with `hasProjectRole` (`maintainer` or `contributor`), or root writers |
+| `org`        | All lenses users (feature-flagged via `ORG_LENS_ENABLED_FLAG`) |
+
+A user can carry both board and project roles and see both the `foundation` and `project` lenses simultaneously.
+
+## Key conditions referenced in the matrix
+
+| Condition              | Definition                                                                           | Source                         |
+| ---------------------- | ------------------------------------------------------------------------------------ | ------------------------------ |
+| `canWrite()`           | `ProjectContextService.canWrite` — reactive signal; true when the user has write/manage access to the active foundation or project | `project-context.service.ts`   |
+| `canSeeNewsletters()`  | `currentPersona() === 'executive-director' \|\| canWrite()`                           | `main-layout.component.ts:535` |
+| `foundationHasProjects()` | True when the selected foundation has ≥1 project row in Snowflake; cleared while fetching | `main-layout.component.ts:188` |
+
+---
+
+## Me Lens
+
+**Identical for all personas.** Static items — no runtime persona conditions.
+
+| Section       | Item                     | Route                  |
+| ------------- | ------------------------ | ---------------------- |
+| *(top-level)* | My Dashboard             | `/`                    |
+| My Engagement | My Meetings              | `/meetings`            |
+|               | My Events                | `/events`              |
+|               | My Committees            | `/groups`              |
+|               | My Mailing Lists         | `/mailing-lists`       |
+|               | My Votes                 | `/votes`               |
+|               | My Surveys               | `/surveys`             |
+|               | My Documents             | `/documents`           |
+| My Growth     | Training & Certifications | `/me/training`        |
+|               | Mentorships              | *(external link)*      |
+|               | Crowdfunding             | *(external link)*      |
+|               | Badges                   | `/badges`              |
+| My Account    | Profile                  | `/profile`             |
+|               | Settings                 | `/settings`            |
+|               | Transactions             | `/me/transactions`     |
+
+---
+
+## Foundation Lens
+
+Available to `board-member`, `executive-director`, and root writers.
+
+| Sidebar item / section | Route                           | Visible to              |
+| ---------------------- | ------------------------------- | ----------------------- |
+| Dashboard              | `/foundation/overview`          | All foundation users    |
+| Projects               | `/foundation/projects`          | All — **only when** `foundationHasProjects()` is true |
+| Meetings               | `/foundation/meetings`          | All foundation users    |
+| Events                 | `/foundation/events`            | All foundation users    |
+| Mailing Lists          | `/foundation/mailing-lists`     | All foundation users    |
+| Committees             | `/foundation/groups`            | All foundation users    |
+| Documents              | `/foundation/documents`         | All foundation users    |
+| **Governance** section |                                 |                         |
+| → Votes                | `/foundation/votes`             | All foundation users    |
+| → Surveys              | `/foundation/surveys`           | All foundation users    |
+| → Permissions          | `/foundation/settings`          | All foundation users    |
+| **Communications** section |                             | `canSeeNewsletters()` — ED **or** `canWrite()` |
+| → Newsletters          | `/foundation/newsletters`       | `canSeeNewsletters()`   |
+| **Metrics** section    |                                 | `executive-director` only |
+| → Health Metrics       | `/foundation/health-metrics`    | `executive-director`    |
+| → Social Listening     | *(PCC external link)*           | `executive-director` — **only when** `selectedFoundationSfid()` is set |
+| **Marketing** section  |                                 | `executive-director` only |
+| → Marketing Impact     | `/foundation/marketing-impact`  | `executive-director`    |
+| → Campaigns            | `/foundation/campaigns`         | `executive-director`    |
+
+### Foundation lens by persona summary
+
+| Persona              | Sees Governance | Sees Newsletters (Communications) | Sees Metrics | Sees Marketing |
+| -------------------- | --------------- | ---------------------------------- | ------------ | -------------- |
+| `board-member`       | Yes             | Only if `canWrite()`               | No           | No             |
+| `executive-director` | Yes             | Yes (always)                       | Yes          | Yes            |
+
+---
+
+## Project Lens
+
+Available to `contributor`, `maintainer`, and root writers.
+
+| Sidebar item / section | Route                       | Visible to           |
+| ---------------------- | --------------------------- | -------------------- |
+| Dashboard              | `/project/overview`         | All project users    |
+| Meetings               | `/project/meetings`         | All project users    |
+| Mailing Lists          | `/project/mailing-lists`    | All project users    |
+| Committees             | `/project/groups`           | All project users    |
+| Documents              | `/project/documents`        | All project users    |
+| **Governance** section |                             |                      |
+| → Votes                | `/project/votes`            | All project users    |
+| → Surveys              | `/project/surveys`          | All project users    |
+| → Permissions          | `/project/settings`         | All project users    |
+| **Communications** section |                         | `canSeeNewsletters()` — ED **or** `canWrite()` |
+| → Newsletters          | `/project/newsletters`      | `canSeeNewsletters()` |
+
+### Project lens by persona summary
+
+| Persona              | Sees Governance | Sees Newsletters (Communications) |
+| -------------------- | --------------- | ---------------------------------- |
+| `contributor`        | Yes             | Only if `canWrite()`               |
+| `maintainer`         | Yes             | Only if `canWrite()`               |
+
+> **Note:** `canWrite()` is resolved from `ProjectContextService` and reflects the user's write access to the currently-selected project, not their persona level globally. A `contributor` who is a project manager (write access) will see Newsletters.
+
+---
+
+## Org Lens
+
+**Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. Falls back to Me Lens items when the flag is off. Identical for all personas when enabled.
+
+| Section          | Item                    | Route                |
+| ---------------- | ----------------------- | -------------------- |
+| *(top-level)*    | Org Overview            | `/org/overview`      |
+| Org Foundations  | Memberships             | `/org/memberships`   |
+|                  | Projects                | `/org/projects`      |
+|                  | ROI                     | `/org/roi`           |
+|                  | Governance              | `/org/governance`    |
+| Org Engagement   | People                  | `/org/people`        |
+|                  | Code Contributions      | `/org/contributions` |
+|                  | Events                  | `/org/events`        |
+|                  | Training & Certification | `/org/training`     |
+|                  | Meetings                | `/org/meetings`      |
+|                  | Committees              | `/org/groups`        |
+| Org Admin        | Profile                 | `/org/profile`       |
+
+---
+
+## Route-level guards
+
+Guards enforce access at the router level — regardless of whether a sidebar link is visible.
+
+| Guard                   | Protected routes                                                                 | Access rule                   |
+| ----------------------- | -------------------------------------------------------------------------------- | ----------------------------- |
+| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`                   | `currentPersona() === 'executive-director'` |
+| `newsletterAccessGuard` | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes | `canSeeNewsletters()` — ED or `canWrite()` |
+| `writerGuard`           | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `canWrite()` |
+
+Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
+
+---
+
+## Write-action gating per feature domain
+
+The `writerGuard` protects create and edit routes. Within read-only pages, UI elements (add/edit/delete buttons) are additionally gated by `canWrite()` in the component template.
+
+| Domain        | Create/edit route guard | In-page UI gating |
+| ------------- | ----------------------- | ----------------- |
+| Meetings      | `writerGuard`           | Yes               |
+| Committees    | `writerGuard`           | Yes               |
+| Mailing Lists | `writerGuard`           | Yes               |
+| Surveys       | `writerGuard`           | Yes               |
+| Votes         | `writerGuard`           | Yes               |
+| Settings / Permissions | —              | `canWrite()` — view-only banner shown to non-writers |
+
+> Backend write enforcement (whether the upstream microservices independently reject unauthorized writes) is tracked separately in [LFXV2-1662](https://linuxfoundation.atlassian.net/browse/LFXV2-1662).
+
+---
+
+## Session eviction on access loss
+
+`evictOnWriteAccessLoss()` (`apps/lfx-one/src/app/shared/utils/`) subscribes to `canWrite` reactively. If write access is revoked mid-session (e.g., an admin removes the user's permission), the utility redirects to a safe page automatically.
+
+---
+
+## Related documents
+
+- [Lens & Persona System](./lens-system.md) — how lenses and personas are resolved and enforced
+- [Angular Patterns](./angular-patterns.md) — zoneless change detection and signals
+- [`main-layout.component.ts`](../../../apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts) — authoritative source for sidebar item definitions
+- [`app.routes.ts`](../../../apps/lfx-one/src/app/app.routes.ts) — route guard wiring

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -16,7 +16,7 @@ For background on how personas and lenses are resolved, see [Lens & Persona Syst
 | `board-member`       | Has a board committee membership on a foundation                |
 | `executive-director` | Has an ED committee membership, OR is a root writer (injected)  |
 
-A user can carry multiple personas simultaneously. The **primary** persona is the highest-priority one (`executive-director` > `board-member` > `maintainer` > `contributor`) and drives conditional sidebar sections.
+A user can carry multiple personas simultaneously. When no explicit selection has been made, `PersonaService` defaults to the highest-priority persona (`executive-director` > `board-member` > `maintainer` > `contributor`). A user can explicitly **pin** a lower-priority persona (e.g., switch from ED to board-member view) — `PersonaService` preserves that choice across refreshes as long as the persona is still in the allowed set (`userSelected` flag). The active `currentPersona()` signal — not a static priority rule — drives which conditional sidebar sections are shown.
 
 ## Lenses and access rules
 
@@ -25,17 +25,17 @@ A user can carry multiple personas simultaneously. The **primary** persona is th
 | `me`         | All authenticated users                                                             |
 | `foundation` | Users with `hasBoardRole` (`board-member` or `executive-director`), or root writers |
 | `project`    | Users with `hasProjectRole` (`maintainer` or `contributor`), or root writers        |
-| `org`        | All lenses users (feature-flagged via `ORG_LENS_ENABLED_FLAG`)                      |
+| `org`        | All users (feature-flagged via `ORG_LENS_ENABLED_FLAG`)                             |
 
 A user can carry both board and project roles and see both the `foundation` and `project` lenses simultaneously.
 
 ## Key conditions referenced in the matrix
 
-| Condition                 | Definition                                                                                                                         | Source                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `canWrite()`              | `ProjectContextService.canWrite` — reactive signal; true when the user has write/manage access to the active foundation or project | `project-context.service.ts`   |
-| `canSeeNewsletters()`     | `currentPersona() === 'executive-director' \|\| canWrite()`                                                                        | `main-layout.component.ts:535` |
-| `foundationHasProjects()` | True when the selected foundation has ≥1 project row in Snowflake; cleared while fetching                                          | `main-layout.component.ts:188` |
+| Condition                 | Definition                                                                                                                         | Source                       |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `canWrite()`              | `ProjectContextService.canWrite` — reactive signal; true when the user has write/manage access to the active foundation or project | `project-context.service.ts` |
+| `canSeeNewsletters()`     | `currentPersona() === 'executive-director' \|\| canWrite()`                                                                        | `main-layout.component.ts`   |
+| `foundationHasProjects()` | True when the selected foundation has ≥1 project row in Snowflake; cleared while fetching                                          | `main-layout.component.ts`   |
 
 ---
 
@@ -152,11 +152,11 @@ Available to `contributor`, `maintainer`, and root writers.
 
 Guards enforce access at the router level — regardless of whether a sidebar link is visible.
 
-| Guard                    | Protected routes                                                                        | Access rule                                 |
-| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`                            | `currentPersona() === 'executive-director'` |
-| `newsletterAccessGuard`  | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes     | `canSeeNewsletters()` — ED or `canWrite()`  |
-| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `canWrite()`                                |
+| Guard                    | Protected routes                                                                        | Access rule                                      |
+| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`      |
+| `newsletterAccessGuard`  | `/foundation/newsletters`, `/project/newsletters`, and all nested newsletter routes     | `canSeeNewsletters()` — ED or `canWrite()`       |
+| `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()` |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -129,7 +129,7 @@ Available to `contributor`, `maintainer`, and root writers.
 
 ## Org Lens
 
-**Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. When the flag is off, `orgLensEnabledGuard` (CanMatch) blocks all `/org/*` routes and redirects to `/` — the routes are invisible to the router. When enabled, the Org Lens is identical for all personas.
+**Feature-flagged** via `ORG_LENS_ENABLED_FLAG`. When the flag is off, `orgLensEnabledGuard` (CanMatch) blocks all `/org/*` routes in the browser and redirects to `/` — the routes are invisible to the router. On the server during SSR, LaunchDarkly is unavailable, so the guard returns `true` and defers the real enforcement to the browser after hydration. When the flag is enabled, the Org Lens is identical for all personas.
 
 | Section         | Item                     | Route                |
 | --------------- | ------------------------ | -------------------- |
@@ -157,7 +157,7 @@ Guards enforce access at the router level — regardless of whether a sidebar li
 | `executiveDirectorGuard` | `/foundation/health-metrics`, `/foundation/marketing-impact`, `/foundation/campaigns`   | `currentPersona() === 'executive-director'`                        |
 | `newsletterAccessGuard`  | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`                         |
 | `writerGuard`            | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or `canWrite()`                   |
-| `orgLensEnabledGuard`    | `/org/*` (CanMatch — routes invisible when flag is off)                                 | `ORG_LENS_ENABLED_FLAG` must be `true`; redirects to `/` otherwise |
+| `orgLensEnabledGuard`    | `/org/*` (CanMatch — routes invisible when flag is off)                                 | Browser: `ORG_LENS_ENABLED_FLAG` must be `true`; redirects to `/` otherwise. SSR: always returns `true` — enforcement defers to browser after hydration |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/frontend/persona-content-matrix.md` — a full reference matrix mapping every persona (`contributor`, `maintainer`, `board-member`, `executive-director`) × every lens (`me`, `foundation`, `project`, `org`) to the sidebar links they see
- Documents the two key runtime conditions: `canSeeNewsletters()` (ED or `canWrite()`) and the `foundationHasProjects()` data-driven gate
- Documents all route-level guards (`executiveDirectorGuard`, `newsletterAccessGuard`, `writerGuard`) and per-domain write-action gating
- Links `docs/architecture/frontend/README.md` to the new doc

## Context

Part of epic [LFXV2-1654](https://linuxfoundation.atlassian.net/browse/LFXV2-1654). Closes [LFXV2-1660](https://linuxfoundation.atlassian.net/browse/LFXV2-1660).

This doc serves as the source of truth for persona regression tests (LFXV2-1661) and the backend write-enforcement audit (LFXV2-1662).

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] Cross-links to `lens-system.md`, `app.routes.ts`, and `main-layout.component.ts` resolve

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1654]: https://linuxfoundation.atlassian.net/browse/LFXV2-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1660]: https://linuxfoundation.atlassian.net/browse/LFXV2-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ