### PR TITLE
fix(meetings): occurrence recurrence wins for cadence label

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -137,7 +137,7 @@
         @if (isRecurring()) {
           <span
             class="inline-flex items-center gap-1.5 text-xs text-gray-700 bg-white border border-gray-200 rounded-full px-2 py-0.5 leading-4"
-            [pTooltip]="meeting().recurrence | recurrenceSummary"
+            [pTooltip]="displayRecurrence() | recurrenceSummary"
             tooltipPosition="top"
             data-testid="dashboard-meeting-card-recurring-chip">
             <i class="fa-light fa-arrows-rotate text-[10px]"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -14,8 +14,10 @@ import {
   Meeting,
   MEETING_TYPE_CONFIGS,
   MeetingOccurrence,
+  MeetingRecurrence,
   MeetingTypeBadge,
   PastMeetingRecording,
+  resolveOccurrenceRecurrence,
   TagSeverity,
 } from '@lfx-one/shared';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
@@ -70,6 +72,9 @@ export class DashboardMeetingCardComponent {
   public readonly hasAiSummary: Signal<boolean> = this.initHasAiSummary();
   public readonly meetingTitle: Signal<string> = this.initMeetingTitle();
   public readonly isRecurring: Signal<boolean> = this.initIsRecurring();
+  // Recurrence rule for the cadence tooltip: the displayed occurrence's own override when
+  // present (cadence changed at/after it — LFXV2-2112), otherwise the series rule.
+  public readonly displayRecurrence: Signal<MeetingRecurrence | null> = computed(() => resolveOccurrenceRecurrence(this.meeting(), this.occurrence()));
   public readonly meetingDetailUrl: Signal<string> = this.initMeetingDetailUrl();
   public readonly meetingDetailQueryParams: Signal<Record<string, string>> = this.initMeetingDetailQueryParams();
   public readonly meetingDetailHref: Signal<string> = this.initMeetingDetailHref();

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -19,9 +19,9 @@
         }
 
         <!-- Recurring Badge -->
-        @if (meeting().recurrence) {
+        @if (displayRecurrence(); as recurrence) {
           <lfx-tag
-            [value]="meeting().recurrence | recurrenceSummary"
+            [value]="recurrence | recurrenceSummary"
             severity="secondary"
             icon="fa-light fa-repeat"
             styleClass="tag-recurring"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -49,12 +49,14 @@ import {
   MeetingAttachment,
   MeetingCancelOccurrenceResult,
   MeetingOccurrence,
+  MeetingRecurrence,
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
   PastMeetingRecording,
   PastMeetingSummary,
   PastMeetingTranscript,
+  resolveOccurrenceRecurrence,
   TagSeverity,
 } from '@lfx-one/shared';
 import { RecordingModalComponent } from '@components/recording-modal/recording-modal.component';
@@ -153,6 +155,9 @@ export class MeetingCardComponent implements OnInit {
   public readonly containerClass: Signal<string> = this.initContainerClass();
   public readonly rsvpToggleLabel: Signal<string> = this.initRsvpToggleLabel();
   public readonly currentOccurrence: Signal<MeetingOccurrence | null> = this.initCurrentOccurrence();
+  // Recurrence rule that drives the cadence badge: the displayed occurrence's own override
+  // when present (cadence changed at/after it — LFXV2-2112), otherwise the series rule.
+  public readonly displayRecurrence: Signal<MeetingRecurrence | null> = computed(() => resolveOccurrenceRecurrence(this.meeting(), this.currentOccurrence()));
   public readonly meetingStartTime: Signal<string | null> = this.initMeetingStartTime();
   public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
   public readonly joinUrl: Signal<string | null>;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -48,9 +48,9 @@
               }
 
               <!-- Recurring Badge -->
-              @if (meeting().recurrence) {
+              @if (displayRecurrence(); as recurrence) {
                 <lfx-tag
-                  [value]="meeting().recurrence | recurrenceSummary"
+                  [value]="recurrence | recurrenceSummary"
                   severity="secondary"
                   icon="fa-light fa-repeat"
                   styleClass="tag-recurring"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -30,8 +30,10 @@ import {
   getPastMeetingTranscriptUrl,
   MeetingAttachment,
   MeetingOccurrence,
+  MeetingRecurrence,
   MeetingRegistrant,
   MeetingRsvp,
+  resolveOccurrenceRecurrence,
   PastMeetingAttachment,
   PastMeetingParticipant,
   PastMeetingRecording,
@@ -131,6 +133,12 @@ export class MeetingJoinComponent implements OnInit {
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> | null }>;
   public currentOccurrence: Signal<MeetingOccurrence | null>;
+  // Recurrence rule that drives the cadence badge: the displayed occurrence's own override when
+  // present (cadence changed at/after it — LFXV2-2112), otherwise the series rule. NOTE: the
+  // detail/join view loads the meeting via the live ITX endpoint, which does not currently carry
+  // the per-occurrence override (occurrence.recurrence is null there), so this resolves to the
+  // top-level rule until that backend path stamps the effective recurrence. Forward-compatible.
+  public displayRecurrence: Signal<MeetingRecurrence | null>;
   private occurrenceContext: Signal<{ sorted: MeetingOccurrence[]; currentIdx: number }>;
   protected previousOccurrenceUrl: Signal<string | null>;
   protected nextOccurrenceUrl: Signal<string | null>;
@@ -264,6 +272,7 @@ export class MeetingJoinComponent implements OnInit {
     this.authenticated = this.userService.authenticated;
     this.meeting = this.initializeMeeting();
     this.currentOccurrence = this.initializeCurrentOccurrence();
+    this.displayRecurrence = computed(() => resolveOccurrenceRecurrence(this.meeting(), this.currentOccurrence()));
     this.occurrenceContext = this.initializeOccurrenceContext();
     this.previousOccurrenceUrl = this.initializePreviousOccurrenceUrl();
     this.nextOccurrenceUrl = this.initializeNextOccurrenceUrl();

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -78,6 +78,12 @@
           @if (meetingTypeBadge(); as badge) {
             <lfx-tag [value]="badge.text" [severity]="badge.severity" [icon]="badge.icon" [styleClass]="badge.styleClass" data-testid="badge-type"></lfx-tag>
           }
+          <!--
+            Intentionally uses the top-level series recurrence (LFXV2-2112). A past meeting is a
+            single occurrence snapshot and the past-meeting payload exposes no per-occurrence
+            recurrence override to resolve against (no occurrences[]/current-occurrence here),
+            so resolveOccurrenceRecurrence has nothing to prefer — the series rule is all we have.
+          -->
           @if (meeting.recurrence) {
             <lfx-tag
               [value]="meeting.recurrence | recurrenceSummary"

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -265,6 +265,17 @@ export interface MeetingOccurrence {
   status?: string;
   /** Total registrant count for this occurrence */
   registrant_count?: number;
+  /**
+   * Per-occurrence recurrence override. When a recurring meeting's cadence changes from a
+   * specific occurrence onwards, Zoom records it as an `all_following` update and the
+   * meeting-service's occurrence calculator stamps the new pattern (e.g. `repeat_interval: 3`
+   * for quarterly) onto the ANCHOR occurrence of that segment (LFXV2-2066). When present it
+   * supersedes the meeting's top-level `recurrence` for the cadence label — see
+   * `resolveOccurrenceRecurrence`. Only the query-service (list/index) payload populates this;
+   * it is null/absent on non-anchor occurrences and on the live ITX detail payload, which does
+   * not compute the effective recurrence.
+   */
+  recurrence?: MeetingRecurrence | null;
 }
 
 /**

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -8,8 +8,9 @@ import '@angular/compiler';
 
 import { describe, expect, it } from 'vitest';
 
-import { PastMeeting } from '../interfaces';
-import { sortPastMeetingsDescending } from './meeting.utils';
+import { RecurrenceType } from '../enums';
+import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting } from '../interfaces';
+import { buildRecurrenceSummary, resolveOccurrenceRecurrence, sortPastMeetingsDescending } from './meeting.utils';
 
 /**
  * Builds a minimal PastMeeting fixture. The sort only reads `scheduled_start_time`/`start_time`,
@@ -83,5 +84,54 @@ describe('sortPastMeetingsDescending', () => {
     const merged = sortPastMeetingsDescending([...page1, ...page2]);
 
     expect(uids(merged)).toEqual(['p2-may', 'p2-mar', 'p1-feb', 'p1-jan']);
+  });
+});
+
+describe('resolveOccurrenceRecurrence', () => {
+  // Top-level series rule: monthly on the 1st Thursday (the original, intentionally-stale cadence).
+  const monthly: MeetingRecurrence = { type: RecurrenceType.MONTHLY, repeat_interval: 1, monthly_week: 1, monthly_week_day: 5 };
+  // Per-occurrence override stamped after an all_following cadence change: quarterly on the 1st Thursday.
+  const quarterly: MeetingRecurrence = { type: RecurrenceType.MONTHLY, repeat_interval: 3, monthly_week: 1, monthly_week_day: 5 };
+
+  const occurrence = (recurrence?: MeetingRecurrence | null): MeetingOccurrence =>
+    ({ occurrence_id: '1786039200', start_time: '2026-08-06T18:00:00Z', duration: 60, recurrence }) as MeetingOccurrence;
+
+  const meeting = (recurrence: MeetingRecurrence | null): Pick<Meeting, 'recurrence'> => ({ recurrence });
+
+  it('prefers the occurrence-level recurrence override when present', () => {
+    expect(resolveOccurrenceRecurrence(meeting(monthly), occurrence(quarterly))).toBe(quarterly);
+  });
+
+  it('falls back to the top-level recurrence when the occurrence has none', () => {
+    expect(resolveOccurrenceRecurrence(meeting(monthly), occurrence(null))).toBe(monthly);
+    expect(resolveOccurrenceRecurrence(meeting(monthly), occurrence(undefined))).toBe(monthly);
+  });
+
+  it('falls back to the top-level recurrence when no occurrence is supplied', () => {
+    expect(resolveOccurrenceRecurrence(meeting(monthly), null)).toBe(monthly);
+    expect(resolveOccurrenceRecurrence(meeting(monthly))).toBe(monthly);
+  });
+
+  it('is null-safe when neither the occurrence nor the meeting carries a recurrence', () => {
+    expect(resolveOccurrenceRecurrence(meeting(null), occurrence(null))).toBeNull();
+    expect(resolveOccurrenceRecurrence(meeting(null), null)).toBeNull();
+  });
+
+  it('end-to-end label (meeting 92079944361): stale monthly top-level + quarterly occurrence override yields "Quarterly on the 1st Thursday"', () => {
+    // Mirrors the pipe: the resolved recurrence is fed to buildRecurrenceSummary after the
+    // monthly/day-of-week shape is applied. The override (repeat_interval=3) must win over the
+    // stale top-level monthly rule so the label reads "Quarterly", not "Monthly".
+    const resolved = resolveOccurrenceRecurrence(meeting(monthly), occurrence(quarterly));
+    const pattern = { ...resolved, patternType: 'monthly', monthlyType: 'dayOfWeek', endType: 'never' } as CustomRecurrencePattern;
+
+    expect(buildRecurrenceSummary(pattern).fullSummary).toBe('Quarterly on the 1st Thursday');
+  });
+
+  it('end-to-end label: with no occurrence override the same surfaces still render the stale top-level "Monthly on the 1st Thursday"', () => {
+    // Documents current behaviour: without an override the label falls back to the series rule.
+    const resolved = resolveOccurrenceRecurrence(meeting(monthly), occurrence(null));
+    const pattern = { ...resolved, patternType: 'monthly', monthlyType: 'dayOfWeek', endType: 'never' } as CustomRecurrencePattern;
+
+    expect(buildRecurrenceSummary(pattern).fullSummary).toBe('Monthly on the 1st Thursday');
   });
 });

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -8,6 +8,7 @@ import {
   CustomRecurrencePattern,
   Meeting,
   MeetingOccurrence,
+  MeetingRecurrence,
   PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
@@ -110,11 +111,13 @@ export function buildRecurrenceSummary(pattern: CustomRecurrencePattern): Recurr
       // (the meeting-service has no distinct QUARTERLY type), so surface that cadence
       // by name rather than the literal "Every 3 months".
       //
-      // NOTE (LFXV2-2057): the cadence label is derived from this recurrence RULE.
-      // A meeting switched to quarterly in PCC only renders as "Quarterly" once the
-      // PCC→V2 sync updates repeat_interval to 3. If a quarterly meeting still shows
-      // "Monthly", the rule is stale upstream (repeat_interval=1 with only the
-      // occurrences spaced quarterly) — that is an upstream sync fix, not a UI one.
+      // NOTE (LFXV2-2066/LFXV2-2112): the cadence label is derived from whichever recurrence
+      // RULE the caller feeds in. When a meeting's cadence changes from a given occurrence
+      // onwards, the meeting's top-level `recurrence` is intentionally left as the original
+      // rule and the new cadence (e.g. repeat_interval=3 for quarterly) is carried on the
+      // affected occurrence's own `recurrence`. Callers must therefore resolve the
+      // occurrence-level override first (see `resolveOccurrenceRecurrence`); a quarterly
+      // meeting still showing "Monthly" is a UI lookup bug, not an upstream sync problem.
       let monthText: string;
       if (interval === 1) {
         monthText = 'Monthly';
@@ -247,6 +250,26 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
     .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
 
   return futureOccurrences.length > 0 ? futureOccurrences[0] : null;
+}
+
+/**
+ * Returns the recurrence that should drive the displayed cadence label for a given occurrence:
+ * the occurrence's own recurrence override when present (the cadence changed at/after this
+ * occurrence — LFXV2-2112), otherwise the meeting's top-level recurrence.
+ *
+ * Background: when a recurring meeting's cadence changes from a specific occurrence onwards,
+ * Zoom records it as an `all_following` update and the meeting-service's occurrence calculator
+ * stamps the new pattern onto that occurrence's `recurrence` (LFXV2-2066). The meeting's
+ * top-level `recurrence` is intentionally left as the original rule, so the occurrence-level
+ * override — when present — is the source of truth for the cadence label. Centralised here so
+ * every surface that renders a recurrence label shares one priority rule.
+ *
+ * @param meeting The meeting (only its top-level `recurrence` is read)
+ * @param occurrence The occurrence being displayed (its `recurrence` override wins when set)
+ * @returns The recurrence to feed the label formatter, or null when neither is available
+ */
+export function resolveOccurrenceRecurrence(meeting: Pick<Meeting, 'recurrence'>, occurrence?: MeetingOccurrence | null): MeetingRecurrence | null {
+  return occurrence?.recurrence ?? meeting?.recurrence ?? null;
 }
 
 /**

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -269,7 +269,7 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
  * @returns The recurrence to feed the label formatter, or null when neither is available
  */
 export function resolveOccurrenceRecurrence(meeting: Pick<Meeting, 'recurrence'>, occurrence?: MeetingOccurrence | null): MeetingRecurrence | null {
-  return occurrence?.recurrence ?? meeting?.recurrence ?? null;
+  return occurrence?.recurrence ?? meeting.recurrence ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

A recurring meeting whose cadence changed from a specific occurrence onwards (e.g. monthly → quarterly) rendered the **stale** cadence label ("Monthly on the 1st Thursday" instead of "Quarterly on the 1st Thursday") on every UI surface, because each surface piped the top-level `meeting.recurrence`.

Zoom records a cadence change as an `all_following` update, and the meeting-service occurrence calculator (LFXV2-2066) stamps the new pattern onto that occurrence's own `recurrence`. The top-level `recurrence` is intentionally left as the original rule, so the **occurrence-level** recurrence is the source of truth for the label and the UI must do this lookup itself.

## Changes

- Add `MeetingOccurrence.recurrence?: MeetingRecurrence | null` to the shared interface.
- Add `resolveOccurrenceRecurrence(meeting, occurrence)` in `@lfx-one/shared` — one shared priority rule (`occurrence?.recurrence ?? meeting?.recurrence ?? null`) instead of each surface re-implementing `??`.
- Wire the displayed occurrence through the helper via a `displayRecurrence` computed on **meeting-card** (list card), **dashboard-meeting-card** (tooltip), and **meeting-join** (detail view).
- `past-meeting-details` intentionally keeps the top-level rule (a past meeting is a single-occurrence snapshot with no per-occurrence override to resolve — documented inline).
- Refresh the stale `buildRecurrenceSummary` note that previously misdiagnosed this (LFXV2-2057) as an upstream sync problem.
- Unit tests for `resolveOccurrenceRecurrence` (override wins / fallback / null-safe) plus an end-to-end label guard modeled on meeting `92079944361`.

## ⚠️ Known limitation (detail/join page)

The meeting **detail/join** view loads via the live ITX endpoint (`/itx/meetings/:uid`), whose occurrences currently return `recurrence: null`. So the fix there is **forward-compatible only** — it resolves to the top-level rule (no regression) and will start rendering the correct cadence once the ITX detail path also applies the effective/segment recurrence (mirroring LFXV2-2066's indexer fix) **or** the detail view switches to indexed data. The **list card / dashboard card are fixed today** (query-service index carries the override), which covers the primary repro surface.

Secondary: only the segment **anchor** occurrence carries the override in the index; later occurrences in the same segment fall back to the top-level rule until re-indexed.

## Upstream dependency

- meeting-service [PR #186 / LFXV2-2066](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/186) — added the per-occurrence effective-recurrence stamping consumed here (merged 2026-06-02, must be deployed).

## Testing

- 91/91 shared unit tests pass (6 new). `lint`, `check-types`, `format`, `build` (SSR bundle) all green.
- Verified against live prod for meeting `92079944361`: query-service path carries `occurrence.recurrence.repeat_interval: 3`; resolved label → "Quarterly on the 1st Thursday".

JIRA: [LFXV2-2112](https://linuxfoundation.atlassian.net/browse/LFXV2-2112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2112]: https://linuxfoundation.atlassian.net/browse/LFXV2-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ