### PR TITLE
feat(committees): surface group invites in dashboard and my groups

### DIFF
--- a/apps/lfx-one/public/assets/docs/search-index.json
+++ b/apps/lfx-one/public/assets/docs/search-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T23:38:05.884Z",
+  "generatedAt": "2026-05-30T04:01:59.530Z",
   "miniSearch": {
     "documentCount": 45,
     "nextId": 45,
@@ -4765,7 +4765,7 @@
             "35": 1,
             "37": 1,
             "41": 1,
-            "44": 3
+            "44": 4
           }
         }
       ],
@@ -10826,7 +10826,7 @@
             "34": 2,
             "41": 3,
             "42": 2,
-            "44": 3
+            "44": 2
           }
         }
       ],
@@ -13423,7 +13423,7 @@
       "id": "votes/manage-votes",
       "title": "Manage Votes",
       "headings": "View polls Cast your vote View results Edit a poll Close a poll Switch project context Related",
-      "body": "This article applies to users with maintainer, board-member, or executive-director personas. Use this guide to view, update, and manage polls in your project.\n\nView polls\n\nSign in to app.lfx.dev.\n\nSelect Votes from the left navigation sidebar.\n\nThe votes dashboard lists all polls for your active project context.\n\nSelect a poll to open its detail view.\n\nCast your vote\n\nOpen an active poll from the votes dashboard.\n\nSelect your preferred option or options from the poll.\n\nSubmit your vote.\n\nView results\nSelect a poll to view its current results and status.\n\nEdit a poll\n\nOpen the poll you want to update.\n\nSelect the edit option on the poll detail page.\n\nUpdate the poll details and save your changes.\n\nClose a poll\nUse the poll settings to edit details or close the poll before its end date.\n\nSwitch project context\nPolls are scoped to a project or foundation. Use the lens switcher to change your active context.\n\nRelated\n\nCreate a Vote — steps to create a new poll\n\nVotes overview — an overview of the Votes section",
+      "body": "This article applies to users with maintainer, board-member, or executive-director personas. Use this guide to view, update, and manage polls in your project.\n\nView polls\n\nSign in to app.lfx.dev.\n\nSelect Votes from the left navigation sidebar.\n\nThe votes dashboard lists all polls for your active project context.\n\nSelect a poll to open its detail view.\n\nCast your vote\n\nOpen an open poll from the votes dashboard.\n\nSelect your preferred option or options from the poll.\n\nSubmit your vote.\n\nView results\nSelect a poll to view its current results and status.\n\nEdit a poll\n\nOpen the poll you want to update.\n\nSelect the edit option on the poll detail page.\n\nUpdate the poll details and save your changes.\n\nClose a poll\nUse the poll settings to edit details or close the poll before its end date.\n\nSwitch project context\nPolls are scoped to a project or foundation. Use the lens switcher to change your active context.\n\nRelated\n\nCreate a Vote — steps to create a new poll\n\nVotes overview — an overview of the Votes section",
       "tags": "votes manage polls results",
       "url": "/docs/votes/manage-votes",
       "topic": "votes"

--- a/apps/lfx-one/public/assets/docs/search-index.json
+++ b/apps/lfx-one/public/assets/docs/search-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T04:01:59.530Z",
+  "generatedAt": "2026-06-03T23:38:05.884Z",
   "miniSearch": {
     "documentCount": 45,
     "nextId": 45,
@@ -4765,7 +4765,7 @@
             "35": 1,
             "37": 1,
             "41": 1,
-            "44": 4
+            "44": 3
           }
         }
       ],
@@ -10826,7 +10826,7 @@
             "34": 2,
             "41": 3,
             "42": 2,
-            "44": 2
+            "44": 3
           }
         }
       ],
@@ -13423,7 +13423,7 @@
       "id": "votes/manage-votes",
       "title": "Manage Votes",
       "headings": "View polls Cast your vote View results Edit a poll Close a poll Switch project context Related",
-      "body": "This article applies to users with maintainer, board-member, or executive-director personas. Use this guide to view, update, and manage polls in your project.\n\nView polls\n\nSign in to app.lfx.dev.\n\nSelect Votes from the left navigation sidebar.\n\nThe votes dashboard lists all polls for your active project context.\n\nSelect a poll to open its detail view.\n\nCast your vote\n\nOpen an open poll from the votes dashboard.\n\nSelect your preferred option or options from the poll.\n\nSubmit your vote.\n\nView results\nSelect a poll to view its current results and status.\n\nEdit a poll\n\nOpen the poll you want to update.\n\nSelect the edit option on the poll detail page.\n\nUpdate the poll details and save your changes.\n\nClose a poll\nUse the poll settings to edit details or close the poll before its end date.\n\nSwitch project context\nPolls are scoped to a project or foundation. Use the lens switcher to change your active context.\n\nRelated\n\nCreate a Vote — steps to create a new poll\n\nVotes overview — an overview of the Votes section",
+      "body": "This article applies to users with maintainer, board-member, or executive-director personas. Use this guide to view, update, and manage polls in your project.\n\nView polls\n\nSign in to app.lfx.dev.\n\nSelect Votes from the left navigation sidebar.\n\nThe votes dashboard lists all polls for your active project context.\n\nSelect a poll to open its detail view.\n\nCast your vote\n\nOpen an active poll from the votes dashboard.\n\nSelect your preferred option or options from the poll.\n\nSubmit your vote.\n\nView results\nSelect a poll to view its current results and status.\n\nEdit a poll\n\nOpen the poll you want to update.\n\nSelect the edit option on the poll detail page.\n\nUpdate the poll details and save your changes.\n\nClose a poll\nUse the poll settings to edit details or close the poll before its end date.\n\nSwitch project context\nPolls are scoped to a project or foundation. Use the lens switcher to change your active context.\n\nRelated\n\nCreate a Vote — steps to create a new poll\n\nVotes overview — an overview of the Votes section",
       "tags": "votes manage polls results",
       "url": "/docs/votes/manage-votes",
       "topic": "votes"

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -85,6 +85,9 @@
 
       <!-- My Groups Table (Me lens) -->
       @if (isMeLens()) {
+        <!-- Pending invitations — distinct section above the active groups table; renders nothing when empty -->
+        <lfx-committee-invitations (accepted)="reloadMyCommittees()" data-testid="committees-me-invitations" />
+
         @if (myCommitteesLoading()) {
           <lfx-card styleClass="[&_.p-card-body]:!px-5">
             <div class="flex flex-col gap-4 py-2">

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -1,8 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, DestroyRef, effect, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -11,6 +12,7 @@ import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL, getGroupBehavioralClass } from '@lfx-one/shared/constants';
 import { Committee, GroupBehavioralClass, MyCommittee, ProjectContext, StatCardItem } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
+import { InvitationService } from '@services/invitation.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -19,11 +21,12 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { CommitteeInvitationsComponent } from '../components/committee-invitations/committee-invitations.component';
 import { CommitteeTableComponent } from '../components/committee-table/committee-table.component';
 
 @Component({
   selector: 'lfx-committee-dashboard',
-  imports: [ButtonComponent, CardComponent, CommitteeTableComponent, SkeletonModule, EmptyStateComponent, StatCardGridComponent],
+  imports: [ButtonComponent, CardComponent, CommitteeInvitationsComponent, CommitteeTableComponent, SkeletonModule, EmptyStateComponent, StatCardGridComponent],
   templateUrl: './committee-dashboard.component.html',
   styleUrl: './committee-dashboard.component.scss',
 })
@@ -35,6 +38,12 @@ export class CommitteeDashboardComponent {
   private readonly router = inject(Router);
   private readonly lensService = inject(LensService);
   private readonly messageService = inject(MessageService);
+  private readonly invitationService = inject(InvitationService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Guards the one-time pending-invitations load when the Me lens first becomes active.
+  private invitationsLoaded = false;
 
   // Use the configurable label constants
   protected readonly committeeLabel = COMMITTEE_LABEL;
@@ -147,6 +156,25 @@ export class CommitteeDashboardComponent {
     ]);
 
     this.behavioralClassCounts = this.initializeBehavioralClassCounts();
+
+    // Load the user's pending invitations once when the Me lens is active in the browser, so the
+    // invitations section above the My Groups table populates. Guarded so it runs a single time and
+    // never on the server (the section is a browser-only, interactive surface).
+    effect(() => {
+      if (isPlatformBrowser(this.platformId) && this.isMeLens() && !this.invitationsLoaded) {
+        this.invitationsLoaded = true;
+        this.invitationService.loadPendingInvitations().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+      }
+    });
+  }
+
+  /**
+   * Re-triggers the My Committees fetch so an accepted invitation surfaces in the active list. Reuses
+   * the shared `refresh` trigger that already drives `initializeMyCommittees()`.
+   */
+  public reloadMyCommittees(): void {
+    this.myCommitteesLoading.set(true);
+    this.refresh.update((v) => v + 1);
   }
 
   public openCreateDialog(): void {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, DestroyRef, effect, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -18,7 +18,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, finalize, map, of, startWith, switchMap, take, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { CommitteeInvitationsComponent } from '../components/committee-invitations/committee-invitations.component';
@@ -41,9 +41,6 @@ export class CommitteeDashboardComponent {
   private readonly invitationService = inject(InvitationService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly destroyRef = inject(DestroyRef);
-
-  // Guards the one-time pending-invitations load when the Me lens first becomes active.
-  private invitationsLoaded = false;
 
   // Use the configurable label constants
   protected readonly committeeLabel = COMMITTEE_LABEL;
@@ -157,15 +154,20 @@ export class CommitteeDashboardComponent {
 
     this.behavioralClassCounts = this.initializeBehavioralClassCounts();
 
-    // Load the user's pending invitations once when the Me lens is active in the browser, so the
-    // invitations section above the My Groups table populates. Guarded so it runs a single time and
-    // never on the server (the section is a browser-only, interactive surface).
-    effect(() => {
-      if (isPlatformBrowser(this.platformId) && this.isMeLens() && !this.invitationsLoaded) {
-        this.invitationsLoaded = true;
-        this.invitationService.loadPendingInvitations().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
-      }
-    });
+    // Load the user's pending invitations the first time the Me lens becomes active in the browser,
+    // so the invitations section above the My Groups table populates. Driven by toObservable +
+    // switchMap (not effect(), per the frontend convention for data loads); take(1) makes it
+    // one-shot and the browser guard keeps it off the server (an interactive, browser-only surface).
+    if (isPlatformBrowser(this.platformId)) {
+      toObservable(this.isMeLens)
+        .pipe(
+          filter((isMe) => isMe),
+          take(1),
+          switchMap(() => this.invitationService.loadPendingInvitations()),
+          takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe();
+    }
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -2,6 +2,39 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto py-6 px-8">
+  <!-- Invitation decline toast — carries the Undo affordance for the deferred decline. -->
+  <p-toast [key]="inviteToastKey" position="top-right" styleClass="committee-view-invite-toast">
+    <ng-template let-message pTemplate="message">
+      <div class="flex items-start gap-3 w-full">
+        @switch (message.severity) {
+          @case ('error') {
+            <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+          @case ('info') {
+            <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+          @default {
+            <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+        }
+        <div class="flex flex-col gap-1 min-w-0 flex-1">
+          <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
+          @if (message.data?.uid) {
+            <button
+              type="button"
+              class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+              (click)="onUndoDecline(message.data.uid)"
+              aria-label="Undo declining the invitation"
+              data-testid="committee-view-invitation-undo">
+              <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+              <span>Undo</span>
+            </button>
+          }
+        </div>
+      </div>
+    </ng-template>
+  </p-toast>
+
   <!-- Loading State -->
   @if (loading()) {
     <lfx-route-loading />
@@ -32,6 +65,46 @@
   } @else if (committee()?.uid) {
     <!-- Committee Dashboard Content -->
     <div class="flex flex-col gap-6">
+      <!-- Pending-invitation banner — accept/decline right from the group page (in sync with the
+           dashboard + My Groups surfaces). Renders nothing unless the user is invited to this group. -->
+      @if (pendingInvitation(); as invite) {
+        <div
+          class="flex flex-col gap-3 rounded-xl border border-blue-200 bg-blue-50 px-5 py-4 sm:flex-row sm:items-center"
+          role="region"
+          aria-label="Group invitation"
+          data-testid="committee-view-invitation-banner">
+          <div class="flex flex-1 items-start gap-3">
+            <i class="fa-light fa-user-plus mt-0.5 text-lg text-blue-600" aria-hidden="true"></i>
+            <div class="flex flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-semibold text-gray-900">You've been invited to {{ committee()?.name }}</span>
+                <lfx-tag value="Invited" severity="info" />
+              </div>
+              @if (invite.inviter_name || invite.expires_at) {
+                <span class="text-xs text-gray-600">{{ invite | invitationSubtext }}</span>
+              }
+            </div>
+          </div>
+          <div class="flex items-center gap-2 sm:shrink-0">
+            <lfx-button
+              label="Accept"
+              icon="fa-light fa-check"
+              severity="info"
+              size="small"
+              [ariaLabel]="'Accept invite to ' + (committee()?.name || 'this group')"
+              (onClick)="onAcceptInvite(invite)"
+              data-testid="committee-view-invitation-accept" />
+            <lfx-button
+              label="Decline"
+              severity="secondary"
+              [text]="true"
+              size="small"
+              [ariaLabel]="'Decline invite to ' + (committee()?.name || 'this group')"
+              (onClick)="onDeclineInvite(invite)"
+              data-testid="committee-view-invitation-decline" />
+          </div>
+        </div>
+      }
       <!-- Header Section -->
       <lfx-card styleClass="[&_.p-card-body]:!p-0" data-testid="committee-view-header">
         <div class="px-6 pt-5 pb-4 flex flex-col gap-4">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -122,9 +122,11 @@
             @if (!committee()?.public) {
               <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
             }
-            <!-- Join / Request to Join / Contact Admin / Leave actions -->
+            <!-- Join / Request to Join / Contact Admin / Leave actions.
+                 Suppressed for an invited visitor — the Accept/Decline banner above is the action,
+                 so a "Request Access" CTA here would be redundant and contradictory. -->
             <div class="ml-auto flex items-center gap-2">
-              @if (isVisitor()) {
+              @if (isVisitor() && !pendingInvitation()) {
                 @if (committee()?.join_mode === 'open') {
                   <lfx-button
                     label="Join Group"
@@ -493,6 +495,7 @@
             [myRole]="myRole()"
             [myMemberUid]="myMemberUid()"
             [myRoleLoading]="myRoleLoading()"
+            [hasPendingInvite]="!!pendingInvitation()"
             (joinRequested)="handleJoinRequest()"
             (tabNavigated)="handleTabNavigation($event)"
             (committeeUpdated)="refreshMembers()" />

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -412,6 +412,7 @@ export class CommitteeViewComponent {
       .pipe(take(1))
       .subscribe({
         next: () => {
+          this.invitationService.forgetResolved(invite.uid);
           this.messageService.add({ severity: 'success', summary: 'Joined', detail: `You've joined "${committeeName}"` });
           // Refresh so my_role populates — the banner hides and member-only tabs/CTAs unlock.
           this.refreshCommittee();
@@ -515,6 +516,7 @@ export class CommitteeViewComponent {
       .declineInvitation(committeeUid, inviteUid)
       .pipe(take(1))
       .subscribe({
+        next: () => this.invitationService.forgetResolved(inviteUid),
         error: () => {
           this.invitationService.unmarkResolved(inviteUid);
           this.messageService.add({

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -1,14 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, linkedSignal, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, linkedSignal, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { DatePipe, NgClass } from '@angular/common';
+import { DatePipe, isPlatformBrowser, NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { PopoverModule } from 'primeng/popover';
 import { SkeletonModule } from 'primeng/skeleton';
+import { ToastModule } from 'primeng/toast';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -23,16 +24,25 @@ import {
   getCommitteeCategorySeverity,
   TagSeverity,
 } from '@lfx-one/shared';
-import { GroupsIOMailingList, ProjectContext, TabConfigEntry } from '@lfx-one/shared/interfaces';
+import { GroupsIOMailingList, PendingInvitation, ProjectContext, TabConfigEntry } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_VALID_TABS } from '@lfx-one/shared/constants';
-import { canManageCommitteeMembers, getChatPlatformIcon, getChatPlatformLabel, getRepoPlatformIcon, getRepoPlatformLabel } from '@lfx-one/shared/utils';
+import {
+  canManageCommitteeMembers,
+  findPendingInvitationForCommittee,
+  getChatPlatformIcon,
+  getChatPlatformLabel,
+  getRepoPlatformIcon,
+  getRepoPlatformLabel,
+} from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
+import { InvitationService } from '@services/invitation.service';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { CategoryAvatarColorPipe } from '@pipes/category-avatar-color.pipe';
 import { InitialsPipe } from '@pipes/initials.pipe';
+import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
 import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { SafeUrlPipe } from '@pipes/safe-url.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
@@ -51,6 +61,12 @@ import { CommitteeSettingsTabComponent } from '../components/committee-settings-
 import { CommitteeSurveysComponent } from '../components/committee-surveys/committee-surveys.component';
 import { CommitteeVotesComponent } from '../components/committee-votes/committee-votes.component';
 
+/** Window before a declined invite is actually sent upstream, during which the user can undo. */
+const INVITE_DECLINE_UNDO_MS = 5000;
+
+/** Dedicated toast key so the inline undo template renders only for this component's decline toast. */
+const INVITE_TOAST_KEY = 'committee-view-invite';
+
 @Component({
   selector: 'lfx-committee-view',
   imports: [
@@ -62,8 +78,10 @@ import { CommitteeVotesComponent } from '../components/committee-votes/committee
     NgClass,
     PopoverModule,
     SkeletonModule,
+    ToastModule,
     CategoryAvatarColorPipe,
     InitialsPipe,
+    InvitationSubtextPipe,
     JoinModeLabelPipe,
     MailingListEmailPipe,
     SafeUrlPipe,
@@ -91,6 +109,9 @@ export class CommitteeViewComponent {
   private readonly userService = inject(UserService);
   private readonly lensService = inject(LensService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly invitationService = inject(InvitationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
 
   private readonly navBackLabel: string | null = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
 
@@ -129,6 +150,22 @@ export class CommitteeViewComponent {
   // committee response carrying the new my_role.
   public myRoleLoading: Signal<boolean> = computed(() => this.loading() || this.committeeRefreshing());
   public isVisitor: Signal<boolean> = computed(() => this.myRole() === null && !this.myRoleLoading());
+
+  // Pending invitation for THIS committee, surfaced from the shared cross-surface cache so a user
+  // landing on a group they were invited to can accept/decline right here. Excludes invites already
+  // resolved this session, and is suppressed once the user is a member (my_role populated).
+  public readonly inviteToastKey = INVITE_TOAST_KEY;
+  public pendingInvitation: Signal<PendingInvitation | null> = computed(() => {
+    const committee = this.committee();
+    if (!committee?.uid || !this.isVisitor()) {
+      return null;
+    }
+    return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), committee.uid);
+  });
+
+  // Deferred-decline timers keyed by invite UID (committee UID stored alongside since the invite is
+  // out of the cache by the time the timer/destroy flush fires). Mirrors the dashboard/My Groups UX.
+  private readonly pendingDeclines = new Map<string, { committeeUid: string; timerId: ReturnType<typeof setTimeout> }>();
 
   public categorySeverity: Signal<TagSeverity> = computed(() => {
     const category = this.committee()?.category;
@@ -218,6 +255,20 @@ export class CommitteeViewComponent {
 
   public constructor() {
     this.initAutoSelectInitialTab();
+
+    // Populate the shared invitation cache once in the browser so a direct landing on an invited
+    // group (e.g. via the email link) can surface the Accept/Decline banner. Browser-only: the
+    // banner is an interactive surface and the list is per-user.
+    if (isPlatformBrowser(this.platformId)) {
+      this.invitationService.loadPendingInvitations().pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe();
+    }
+
+    // Flush any deferred decline on destroy so navigating away still commits it.
+    this.destroyRef.onDestroy(() => {
+      for (const inviteUid of [...this.pendingDeclines.keys()]) {
+        this.flushDecline(inviteUid);
+      }
+    });
   }
 
   // -- Public methods --
@@ -352,6 +403,65 @@ export class CommitteeViewComponent {
       });
   }
 
+  public onAcceptInvite(invite: PendingInvitation): void {
+    const committeeName = this.committee()?.name ?? 'this group';
+    // Optimistic: hide the banner everywhere immediately, then commit upstream.
+    this.invitationService.markResolved(invite.uid);
+    this.invitationService
+      .acceptInvitation(invite.committee_uid, invite.uid)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.messageService.add({ severity: 'success', summary: 'Joined', detail: `You've joined "${committeeName}"` });
+          // Refresh so my_role populates — the banner hides and member-only tabs/CTAs unlock.
+          this.refreshCommittee();
+          this.membersRefresh.update((v) => v + 1);
+        },
+        error: () => {
+          this.invitationService.unmarkResolved(invite.uid);
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Unable to Accept',
+            detail: `Couldn't accept the invitation to "${committeeName}". Please try again.`,
+            life: 6000,
+          });
+        },
+      });
+  }
+
+  public onDeclineInvite(invite: PendingInvitation): void {
+    // Optimistic + deferred-undo: hide the banner now, only send the decline after the undo window.
+    this.invitationService.markResolved(invite.uid);
+
+    const timerId = setTimeout(() => {
+      this.pendingDeclines.delete(invite.uid);
+      this.sendDecline(invite.committee_uid, invite.uid);
+    }, INVITE_DECLINE_UNDO_MS);
+    this.pendingDeclines.set(invite.uid, { committeeUid: invite.committee_uid, timerId });
+
+    this.messageService.add({
+      key: INVITE_TOAST_KEY,
+      severity: 'info',
+      summary: 'Invitation declined',
+      data: { uid: invite.uid },
+      life: INVITE_DECLINE_UNDO_MS,
+      closable: true,
+    });
+  }
+
+  public onUndoDecline(inviteUid: string): void {
+    const pending = this.pendingDeclines.get(inviteUid);
+    // Timer already fired -> the decline is committed upstream; restoring would lie to the user.
+    if (!pending) {
+      this.messageService.clear(INVITE_TOAST_KEY);
+      return;
+    }
+    clearTimeout(pending.timerId);
+    this.pendingDeclines.delete(inviteUid);
+    this.invitationService.unmarkResolved(inviteUid);
+    this.messageService.clear(INVITE_TOAST_KEY);
+  }
+
   public navigateToParentGroup(): void {
     const parent = this.parentGroup();
     if (parent?.uid) {
@@ -389,6 +499,34 @@ export class CommitteeViewComponent {
   }
 
   // -- Private methods --
+  /** Cancels the deferred timer and fires the upstream decline immediately (destroy flush). */
+  private flushDecline(inviteUid: string): void {
+    const pending = this.pendingDeclines.get(inviteUid);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timerId);
+    this.pendingDeclines.delete(inviteUid);
+    this.sendDecline(pending.committeeUid, inviteUid);
+  }
+
+  private sendDecline(committeeUid: string, inviteUid: string): void {
+    this.invitationService
+      .declineInvitation(committeeUid, inviteUid)
+      .pipe(take(1))
+      .subscribe({
+        error: () => {
+          this.invitationService.unmarkResolved(inviteUid);
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Unable to Decline',
+            detail: `Couldn't decline the invitation. Please try again.`,
+            life: 6000,
+          });
+        },
+      });
+  }
+
   private openApplicationDialog(committeeUid: string, committeeName: string, mode: 'application' | 'invite_only'): void {
     const isApplication = mode === 'application';
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -52,9 +52,15 @@
           <div class="flex items-center gap-3 min-w-0 flex-1">
             <lfx-tag value="Invited" severity="info" icon="fa-light fa-envelope" styleClass="whitespace-nowrap shrink-0" />
             <div class="flex flex-col gap-0.5 min-w-0">
-              <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="invitation.committee_name" data-testid="committee-invitations-name">
+              <a
+                [routerLink]="['/groups', invitation.committee_uid]"
+                [state]="{ backLabel: 'My Groups' }"
+                class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline truncate"
+                [attr.title]="invitation.committee_name"
+                [attr.aria-label]="'Open group ' + invitation.committee_name"
+                data-testid="committee-invitations-name">
                 {{ invitation.committee_name }}
-              </span>
+              </a>
               <span class="text-xs text-gray-500 truncate" data-testid="committee-invitations-subtext">
                 {{ invitation | invitationSubtext }}
               </span>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -1,0 +1,84 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-toast [key]="toastKey" position="top-right" styleClass="committee-invitations-toast">
+  <ng-template let-message pTemplate="message">
+    <div class="flex items-start gap-3 w-full">
+      @switch (message.severity) {
+        @case ('error') {
+          <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+        }
+        @case ('info') {
+          <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+        }
+        @default {
+          <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+        }
+      }
+      <div class="flex flex-col gap-1 min-w-0 flex-1">
+        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
+        @if (message.data?.uid) {
+          <button
+            type="button"
+            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            (click)="onUndoDecline({ uid: message.data.uid, committeeUid: message.data.committeeUid })"
+            aria-label="Undo declining the invitation"
+            data-testid="committee-invitations-toast-undo">
+            <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+            <span>Undo</span>
+          </button>
+        }
+      </div>
+    </div>
+  </ng-template>
+</p-toast>
+
+@if (invitations().length > 0) {
+  <section class="flex flex-col gap-4" data-testid="committee-invitations-section">
+    <div class="flex items-center gap-3">
+      <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
+        <i class="fa-light fa-envelope-open-text text-lg" aria-hidden="true"></i>
+        <span>Invitations ({{ invitations().length }})</span>
+      </h2>
+      <div class="flex-1 border-t border-gray-200 self-center"></div>
+    </div>
+
+    <ul class="flex flex-col gap-3 list-none p-0 m-0" role="list" aria-label="Pending invitations" data-testid="committee-invitations-list">
+      @for (invitation of invitations(); track invitation.uid) {
+        <li
+          role="listitem"
+          class="flex flex-col sm:flex-row sm:items-center gap-3 bg-white rounded-2xl border border-gray-200 shadow-sm px-4 py-3"
+          data-testid="committee-invitations-item">
+          <div class="flex items-center gap-3 min-w-0 flex-1">
+            <lfx-tag value="Invited" severity="info" icon="fa-light fa-envelope" styleClass="whitespace-nowrap shrink-0" />
+            <div class="flex flex-col gap-0.5 min-w-0">
+              <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="invitation.committee_name" data-testid="committee-invitations-name">
+                {{ invitation.committee_name }}
+              </span>
+              <span class="text-xs text-gray-500 truncate" data-testid="committee-invitations-subtext">
+                {{ invitation | invitationSubtext }}
+              </span>
+            </div>
+          </div>
+          <div class="flex items-center gap-2 self-start sm:self-auto sm:shrink-0">
+            <lfx-button
+              size="small"
+              severity="primary"
+              label="Accept"
+              [ariaLabel]="'Accept invite to ' + invitation.committee_name"
+              (onClick)="onAccept(invitation)"
+              data-testid="committee-invitations-accept" />
+            <lfx-button
+              size="small"
+              severity="secondary"
+              [text]="true"
+              label="Decline"
+              [ariaLabel]="'Decline invite to ' + invitation.committee_name"
+              (onClick)="onDecline(invitation)"
+              data-testid="committee-invitations-decline" />
+          </div>
+        </li>
+      }
+    </ul>
+  </section>
+}

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.scss
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
 import { computed, Component, DestroyRef, inject, output, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -30,7 +29,6 @@ const TOAST_KEY = 'committee-invitations';
 @Component({
   selector: 'lfx-committee-invitations',
   imports: [ButtonComponent, TagComponent, ToastModule, InvitationSubtextPipe],
-  providers: [DatePipe],
   templateUrl: './committee-invitations.component.html',
   styleUrl: './committee-invitations.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -1,0 +1,155 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { computed, Component, DestroyRef, inject, output, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { PendingInvitation } from '@lfx-one/shared/interfaces';
+import { InvitationService } from '@services/invitation.service';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+import { take } from 'rxjs';
+
+import { InvitationSubtextPipe } from '../../../../shared/pipes/invitation-subtext.pipe';
+
+/** Window before a declined invite is actually sent upstream, during which the user can undo. */
+const DECLINE_UNDO_MS = 5000;
+
+/** Dedicated toast key so the inline undo template renders only for this component's toasts. */
+const TOAST_KEY = 'committee-invitations';
+
+/**
+ * "Invitations" section shown above the My Groups table (Me lens only).
+ *
+ * Sources pending committee invitations from {@link InvitationService} (the shared cross-surface
+ * cache) and renders nothing when there are none. Accept is optimistic + emits {@link accepted} so
+ * the parent can refresh the active list. Decline uses a deferred-undo pattern: the row is removed
+ * immediately, the upstream decline is fired after a short window, and an Undo toast cancels it.
+ */
+@Component({
+  selector: 'lfx-committee-invitations',
+  imports: [ButtonComponent, TagComponent, ToastModule, InvitationSubtextPipe],
+  providers: [DatePipe],
+  templateUrl: './committee-invitations.component.html',
+  styleUrl: './committee-invitations.component.scss',
+})
+export class CommitteeInvitationsComponent {
+  // ── Injections ──────────────────────────────────────────────────────────────
+  private readonly invitationService = inject(InvitationService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // ── Outputs ───────────────────────────────────────────────────────────────
+  /** Emitted after an invite is accepted so the parent can refresh My Committees. */
+  public readonly accepted = output<void>();
+
+  // Dedicated toast key exposed to the template.
+  protected readonly toastKey = TOAST_KEY;
+
+  // ── Computed / Read-only Signals ──────────────────────────────────────────
+  /** Pending invitations not yet resolved (accepted/declined) this session. */
+  public readonly invitations: Signal<PendingInvitation[]> = computed(() =>
+    this.invitationService.pendingInvitations().filter((invitation) => !this.invitationService.resolvedInviteUids().has(invitation.uid))
+  );
+
+  /**
+   * Pending decline timers keyed by invite UID, carrying the committee UID and timer handle so
+   * undo can cancel and destroy can flush (the invite is already out of the cache by then, so the
+   * committee UID can't be re-derived from the service).
+   */
+  private readonly pendingDeclines = new Map<string, { committeeUid: string; timerId: ReturnType<typeof setTimeout> }>();
+
+  public constructor() {
+    // On destroy, flush any deferred declines immediately so they are not silently dropped.
+    this.destroyRef.onDestroy(() => {
+      for (const inviteUid of [...this.pendingDeclines.keys()]) {
+        this.flushDecline(inviteUid);
+      }
+    });
+  }
+
+  public onAccept(invitation: PendingInvitation): void {
+    this.invitationService.markResolved(invitation.uid);
+    this.invitationService
+      .acceptInvitation(invitation.committee_uid, invitation.uid)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            key: TOAST_KEY,
+            severity: 'success',
+            summary: `You've joined ${invitation.committee_name}`,
+            life: 3000,
+          });
+          this.accepted.emit();
+        },
+        error: () => {
+          this.invitationService.unmarkResolved(invitation.uid);
+          this.messageService.add({
+            key: TOAST_KEY,
+            severity: 'error',
+            summary: `Couldn't accept — try again.`,
+            life: 4000,
+          });
+        },
+      });
+  }
+
+  public onDecline(invitation: PendingInvitation): void {
+    this.invitationService.markResolved(invitation.uid);
+
+    const timerId = setTimeout(() => {
+      this.pendingDeclines.delete(invitation.uid);
+      this.sendDecline(invitation.committee_uid, invitation.uid);
+    }, DECLINE_UNDO_MS);
+    this.pendingDeclines.set(invitation.uid, { committeeUid: invitation.committee_uid, timerId });
+
+    this.messageService.add({
+      key: TOAST_KEY,
+      severity: 'info',
+      summary: 'Invite declined',
+      data: { uid: invitation.uid, committeeUid: invitation.committee_uid },
+      sticky: true,
+      closable: true,
+    });
+  }
+
+  public onUndoDecline(invitation: { uid: string; committeeUid: string }): void {
+    const pending = this.pendingDeclines.get(invitation.uid);
+    if (pending) {
+      clearTimeout(pending.timerId);
+      this.pendingDeclines.delete(invitation.uid);
+    }
+    this.invitationService.unmarkResolved(invitation.uid);
+    this.messageService.clear(TOAST_KEY);
+  }
+
+  /** Cancels the deferred timer and fires the upstream decline immediately (destroy flush). */
+  private flushDecline(inviteUid: string): void {
+    const pending = this.pendingDeclines.get(inviteUid);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timerId);
+    this.pendingDeclines.delete(inviteUid);
+    this.sendDecline(pending.committeeUid, inviteUid);
+  }
+
+  private sendDecline(committeeUid: string, inviteUid: string): void {
+    this.invitationService
+      .declineInvitation(committeeUid, inviteUid)
+      .pipe(take(1))
+      .subscribe({
+        error: () => {
+          this.invitationService.unmarkResolved(inviteUid);
+          this.messageService.add({
+            key: TOAST_KEY,
+            severity: 'error',
+            summary: `Couldn't decline — try again.`,
+            life: 4000,
+          });
+        },
+      });
+  }
+}

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -75,6 +75,7 @@ export class CommitteeInvitationsComponent {
       .pipe(take(1))
       .subscribe({
         next: () => {
+          this.invitationService.forgetResolved(invitation.uid);
           this.messageService.add({
             key: TOAST_KEY,
             severity: 'success',
@@ -146,6 +147,7 @@ export class CommitteeInvitationsComponent {
       .declineInvitation(committeeUid, inviteUid)
       .pipe(take(1))
       .subscribe({
+        next: () => this.invitationService.forgetResolved(inviteUid),
         error: () => {
           this.invitationService.unmarkResolved(inviteUid);
           this.messageService.add({

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -105,22 +105,28 @@ export class CommitteeInvitationsComponent {
     }, DECLINE_UNDO_MS);
     this.pendingDeclines.set(invitation.uid, { committeeUid: invitation.committee_uid, timerId });
 
+    // life matches the undo window so the Undo affordance disappears exactly when the decline
+    // commits — never leaving a stale Undo that would falsely "restore" an already-declined invite.
     this.messageService.add({
       key: TOAST_KEY,
       severity: 'info',
       summary: 'Invite declined',
       data: { uid: invitation.uid, committeeUid: invitation.committee_uid },
-      sticky: true,
+      life: DECLINE_UNDO_MS,
       closable: true,
     });
   }
 
   public onUndoDecline(invitation: { uid: string; committeeUid: string }): void {
     const pending = this.pendingDeclines.get(invitation.uid);
-    if (pending) {
-      clearTimeout(pending.timerId);
-      this.pendingDeclines.delete(invitation.uid);
+    // If the timer already fired, the decline is committed upstream — there's nothing to undo.
+    // Restoring the row here would lie to the user (it would reappear, then vanish on next load).
+    if (!pending) {
+      this.messageService.clear(TOAST_KEY);
+      return;
     }
+    clearTimeout(pending.timerId);
+    this.pendingDeclines.delete(invitation.uid);
     this.invitationService.unmarkResolved(invitation.uid);
     this.messageService.clear(TOAST_KEY);
   }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -6,12 +6,11 @@ import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PendingInvitation } from '@lfx-one/shared/interfaces';
 import { RouterLink } from '@angular/router';
+import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
 import { InvitationService } from '@services/invitation.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 import { take } from 'rxjs';
-
-import { InvitationSubtextPipe } from '../../../../shared/pipes/invitation-subtext.pipe';
 
 /** Window before a declined invite is actually sent upstream, during which the user can undo. */
 const DECLINE_UNDO_MS = 5000;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -5,6 +5,7 @@ import { computed, Component, DestroyRef, inject, output, Signal } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PendingInvitation } from '@lfx-one/shared/interfaces';
+import { RouterLink } from '@angular/router';
 import { InvitationService } from '@services/invitation.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
@@ -28,7 +29,7 @@ const TOAST_KEY = 'committee-invitations';
  */
 @Component({
   selector: 'lfx-committee-invitations',
-  imports: [ButtonComponent, TagComponent, ToastModule, InvitationSubtextPipe],
+  imports: [ButtonComponent, TagComponent, ToastModule, InvitationSubtextPipe, RouterLink],
   templateUrl: './committee-invitations.component.html',
   styleUrl: './committee-invitations.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -51,6 +51,9 @@ export class CommitteeOverviewComponent {
   public myRole = input<string | null>(null);
   public myMemberUid = input<string | null>(null);
   public myRoleLoading = input<boolean>(true);
+  // True when the viewer has a pending invitation to this group — suppresses the visitor join CTA
+  // (the Accept/Decline banner on the group page is the action; a "Request Access" CTA would be redundant).
+  public hasPendingInvite = input<boolean>(false);
 
   // Outputs
   public readonly committeeUpdated = output<void>();
@@ -115,7 +118,7 @@ export class CommitteeOverviewComponent {
     return 'member';
   });
 
-  public canJoin: Signal<boolean> = computed(() => this.isVisitor() && this.committee().join_mode !== 'closed');
+  public canJoin: Signal<boolean> = computed(() => this.isVisitor() && this.committee().join_mode !== 'closed' && !this.hasPendingInvite());
 
   public joinButtonLabel: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
@@ -51,6 +51,15 @@
                   <span class="truncate group-hover:underline">{{ item.text }}</span>
                   <i class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 shrink-0 no-underline" aria-hidden="true"></i>
                 </a>
+              } @else if (item.isInvitation) {
+                <div class="flex flex-col gap-0.5 min-w-0">
+                  <span class="text-sm font-medium text-gray-900 truncate block" [attr.title]="item.text" data-testid="pending-actions-drawer-title">
+                    {{ item.text }}
+                  </span>
+                  @if (item.date) {
+                    <span class="text-xs text-gray-500" data-testid="pending-actions-drawer-invitation-expiry"> Expires {{ item.date }} </span>
+                  }
+                </div>
               } @else {
                 <span class="text-sm font-medium text-gray-900 truncate block" [attr.title]="item.text" data-testid="pending-actions-drawer-title">
                   {{ item.text }}
@@ -87,6 +96,24 @@
                   [label]="item.buttonText"
                   [icon]="buttonIcons[item.type]"
                   data-testid="pending-actions-drawer-vote-button" />
+              } @else if (item.isInvitation) {
+                <div class="flex items-center gap-2">
+                  <lfx-button
+                    size="small"
+                    severity="primary"
+                    [label]="item.buttonText"
+                    [ariaLabel]="item.acceptAriaLabel"
+                    (onClick)="onAcceptInvitation(item)"
+                    data-testid="pending-actions-drawer-invitation-accept" />
+                  <lfx-button
+                    size="small"
+                    severity="secondary"
+                    [text]="true"
+                    label="Decline"
+                    [ariaLabel]="item.declineAriaLabel"
+                    (onClick)="onDeclineInvitation(item)"
+                    data-testid="pending-actions-drawer-invitation-decline" />
+                </div>
               } @else if (item.buttonLink) {
                 <lfx-button
                   size="small"
@@ -109,18 +136,21 @@
                   [icon]="buttonIcons[item.type]" />
               }
             </div>
-            <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready -->
-            @if (item.isRsvpInline && (item.isMeetingLoading || !item.meeting)) {
-              <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0" />
-            } @else {
-              <button
-                type="button"
-                class="shrink-0 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
-                (click)="handleDismiss(item)"
-                [attr.aria-label]="'Dismiss: ' + item.text"
-                [attr.data-testid]="'pending-actions-drawer-dismiss-' + item.type">
-                Dismiss
-              </button>
+            <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready. Invitations are resolved
+                 server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. -->
+            @if (!item.isInvitation) {
+              @if (item.isRsvpInline && (item.isMeetingLoading || !item.meeting)) {
+                <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0" />
+              } @else {
+                <button
+                  type="button"
+                  class="shrink-0 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
+                  (click)="handleDismiss(item)"
+                  [attr.aria-label]="'Dismiss: ' + item.text"
+                  [attr.data-testid]="'pending-actions-drawer-dismiss-' + item.type">
+                  Dismiss
+                </button>
+              }
             }
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -11,6 +11,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL } from '@lfx-one/shared/constants';
 import { MeetingService } from '@services/meeting.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
+import { InvitationService } from '@shared/services/invitation.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -27,6 +28,7 @@ import type { DrawerActionRow, Meeting, MeetingRsvp, PendingActionItem, RsvpResp
 export class PendingActionsDrawerComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
   private readonly meetingService = inject(MeetingService);
+  private readonly invitationService = inject(InvitationService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
@@ -40,6 +42,10 @@ export class PendingActionsDrawerComponent {
   public readonly actionCompleted = output<PendingActionItem>();
   // Emits voteUid when a Vote row's CTA is clicked so the parent dashboard can open the cast drawer inline.
   public readonly castVoteRequested = output<string>();
+  // Invitation Accept/Decline are delegated to the parent so the optimistic markResolved, the success/error toasts, and the
+  // deferred-undo decline (whose Undo affordance lives in the parent's shared p-toast) are all owned in one place.
+  public readonly acceptInvitationRequested = output<PendingActionItem>();
+  public readonly declineInvitationRequested = output<PendingActionItem>();
 
   private readonly hiddenActionsVersion = signal(0);
   // Rows currently in the fade-out + collapse transition; keeps them rendered through the animation.
@@ -90,6 +96,17 @@ export class PendingActionsDrawerComponent {
     this.hiddenActionsService.dismissAction(item);
     // skipHide: the permanent dismiss cookie already hides the row; a 24h hideAction cookie would be redundant.
     this.startCompletion(item, true);
+  }
+
+  // Delegate invitation Accept/Decline to the parent (it owns the optimistic markResolved, toasts, and deferred undo).
+  // The shared resolvedInviteUids signal drives this drawer's filter too, so the row disappears here the moment the
+  // parent resolves it — no local completion animation needed.
+  protected onAcceptInvitation(item: DrawerActionRow): void {
+    this.acceptInvitationRequested.emit(item);
+  }
+
+  protected onDeclineInvitation(item: DrawerActionRow): void {
+    this.declineInvitationRequested.emit(item);
   }
 
   protected handleRsvpSubmit(item: DrawerActionRow, rsvp: MeetingRsvp): void {
@@ -193,18 +210,28 @@ export class PendingActionsDrawerComponent {
   private initVisibleRows(): Signal<DrawerActionRow[]> {
     return computed(() => {
       this.hiddenActionsVersion();
+      // Invitations are resolved server-side, not cookie-hidden: drop any invite resolved this session (shared signal) so
+      // the row disappears in lockstep with the inline list. Reading the signal makes this computed re-run on accept/decline/undo.
+      const resolvedInvites = this.invitationService.resolvedInviteUids();
       const completing = this.completingRowKeys();
       const cache = this.meetingCache();
       const loading = this.loadingMeetingUids();
       const failed = this.failedMeetingUids();
       return this.pendingActions()
-        .filter((item) => completing.has(this.getRowKey(item)) || !this.hiddenActionsService.isActionHidden(item))
+        .filter((item) => {
+          if (item.type === 'Invitation' && !!item.inviteUid && resolvedInvites.has(item.inviteUid)) {
+            return false;
+          }
+          return completing.has(this.getRowKey(item)) || !this.hiddenActionsService.isActionHidden(item);
+        })
         .map((item) => {
           const rowKey = this.getRowKey(item);
           // When the meeting fetch fails, fall back to the regular buttonLink/CTA branch so users still have a working action.
           const meetingLoadFailed = !!item.meetingUid && failed.has(item.meetingUid);
           const isRsvpInline = item.type === 'RSVP' && !!item.meetingUid && !meetingLoadFailed;
           const isVoteInline = item.type === 'Vote' && !!item.voteUid;
+          const isInvitation = item.type === 'Invitation' && !!item.inviteUid;
+          const inviteGroupName = item.inviteGroupName ?? item.badge;
           return {
             ...item,
             rowKey,
@@ -213,6 +240,9 @@ export class PendingActionsDrawerComponent {
             meeting: item.meetingUid ? (cache[item.meetingUid] ?? null) : null,
             isMeetingLoading: !!item.meetingUid && loading.has(item.meetingUid),
             meetingLoadFailed,
+            isInvitation,
+            acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
+            declineAriaLabel: `Decline invite to ${inviteGroupName}`,
           };
         });
     });

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -230,7 +230,8 @@ export class PendingActionsDrawerComponent {
           const meetingLoadFailed = !!item.meetingUid && failed.has(item.meetingUid);
           const isRsvpInline = item.type === 'RSVP' && !!item.meetingUid && !meetingLoadFailed;
           const isVoteInline = item.type === 'Vote' && !!item.voteUid;
-          const isInvitation = item.type === 'Invitation' && !!item.inviteUid;
+          // Require committeeUid too — Accept/Decline delegate to the parent which calls the API with it.
+          const isInvitation = item.type === 'Invitation' && !!item.inviteUid && !!item.committeeUid;
           const inviteGroupName = item.inviteGroupName ?? item.badge;
           return {
             ...item,

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -32,6 +32,17 @@
             <span>View meeting details</span>
           </a>
         }
+        @if (message.data?.undoInviteUid) {
+          <button
+            type="button"
+            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            (click)="onUndoDecline()"
+            aria-label="Undo declining the invitation"
+            data-testid="dashboard-pending-actions-toast-undo">
+            <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+            <span>Undo</span>
+          </button>
+        }
       </div>
     </div>
   </ng-template>
@@ -101,6 +112,15 @@
                       <span class="sm:truncate group-hover:underline">{{ item.text }}</span>
                       <i class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 shrink-0 no-underline" aria-hidden="true"></i>
                     </a>
+                  } @else if (item.isInvitation) {
+                    <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
+                      <p class="text-sm font-medium text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
+                        {{ item.text }}
+                      </p>
+                      @if (item.date) {
+                        <span class="text-xs text-gray-500" data-testid="dashboard-pending-actions-invitation-expiry"> Expires {{ item.date }} </span>
+                      }
+                    </div>
                   } @else {
                     <p
                       class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
@@ -162,6 +182,24 @@
                         }
                         <!-- else: inline ballot is rendering below (action column intentionally empty); drawer-bound votes collapse expandedVoteKey synchronously in dispatchLoadedVote so no branch is needed here -->
                       </div>
+                    } @else if (item.isInvitation) {
+                      <div class="flex items-center gap-2">
+                        <lfx-button
+                          size="small"
+                          severity="primary"
+                          [label]="item.buttonText"
+                          [ariaLabel]="item.acceptAriaLabel"
+                          (onClick)="onAcceptInvitation(item)"
+                          data-testid="dashboard-pending-actions-invitation-accept" />
+                        <lfx-button
+                          size="small"
+                          severity="secondary"
+                          [text]="true"
+                          label="Decline"
+                          [ariaLabel]="item.declineAriaLabel"
+                          (onClick)="onDeclineInvitation(item)"
+                          data-testid="dashboard-pending-actions-invitation-decline" />
+                      </div>
                     } @else if (item.buttonLink) {
                       <lfx-button
                         size="small"
@@ -184,18 +222,21 @@
                         [icon]="buttonIcons[item.type]" />
                     }
                   </div>
-                  <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready -->
-                  @if (item.isRsvpInline && (!item.meeting || item.isLoading)) {
-                    <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0 self-start sm:self-auto sm:ml-4" />
-                  } @else {
-                    <button
-                      type="button"
-                      class="shrink-0 self-start sm:self-auto sm:ml-4 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
-                      (click)="handleDismiss(item)"
-                      [attr.aria-label]="'Dismiss: ' + item.text"
-                      [attr.data-testid]="'dashboard-pending-actions-dismiss-' + item.type">
-                      Dismiss
-                    </button>
+                  <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready. Invitations are resolved
+                       server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. -->
+                  @if (!item.isInvitation) {
+                    @if (item.isRsvpInline && (!item.meeting || item.isLoading)) {
+                      <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0 self-start sm:self-auto sm:ml-4" />
+                    } @else {
+                      <button
+                        type="button"
+                        class="shrink-0 self-start sm:self-auto sm:ml-4 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
+                        (click)="handleDismiss(item)"
+                        [attr.aria-label]="'Dismiss: ' + item.text"
+                        [attr.data-testid]="'dashboard-pending-actions-dismiss-' + item.type">
+                        Dismiss
+                      </button>
+                    }
                   }
                 </div>
                 @if (item.isVoteInlineExpanded && item.vote && !item.voteUsesDrawer) {
@@ -212,7 +253,9 @@
       [pendingActions]="pendingActions()"
       [(visible)]="drawerVisible"
       (actionCompleted)="onDrawerActionCompleted()"
-      (castVoteRequested)="castVoteRequested.emit($event)" />
+      (castVoteRequested)="castVoteRequested.emit($event)"
+      (acceptInvitationRequested)="onAcceptInvitation($event)"
+      (declineInvitationRequested)="onDeclineInvitation($event)" />
   } @else {
     <div class="bg-gray-50 rounded-2xl border border-gray-200 flex items-center justify-center gap-4 px-5 py-10" data-testid="dashboard-pending-actions-empty">
       <i class="fa-light fa-box-check text-4xl text-gray-400 shrink-0"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -114,10 +114,10 @@
                     </a>
                   } @else if (item.isInvitation) {
                     <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
-                      <!-- Inviter copy isn't in the committee-service contract today, so the prefix is
-                           fixed and the group name is the link into the group (project-lens detail page). -->
+                      <!-- Title comes from the backend-built item.text (same copy as the drawer); the
+                           group name is split off as a link into the group (project-lens detail page). -->
                       <p class="text-sm text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
-                        You've been invited to
+                        {{ item.inviteTitlePrefix }}
                         <a
                           [routerLink]="['/groups', item.committeeUid]"
                           [state]="{ backLabel: 'My Dashboard' }"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -32,6 +32,19 @@
             <span>View meeting details</span>
           </a>
         }
+      </div>
+    </div>
+  </ng-template>
+</p-toast>
+
+<!-- Dedicated toast for the deferred-decline Undo, on its own key so clearing it on Undo can't dismiss
+     unrelated RSVP/vote/meeting toasts that share the 'pending-actions-toast' key. -->
+<p-toast [key]="undoToastKey" position="top-right" styleClass="pending-actions-toast">
+  <ng-template let-message pTemplate="message">
+    <div class="flex items-start gap-3 w-full">
+      <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+      <div class="flex flex-col gap-1 min-w-0 flex-1">
+        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
         @if (message.data?.undoInviteUid) {
           <button
             type="button"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -114,8 +114,19 @@
                     </a>
                   } @else if (item.isInvitation) {
                     <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
-                      <p class="text-sm font-medium text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
-                        {{ item.text }}
+                      <!-- Inviter copy isn't in the committee-service contract today, so the prefix is
+                           fixed and the group name is the link into the group (project-lens detail page). -->
+                      <p class="text-sm text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
+                        You've been invited to
+                        <a
+                          [routerLink]="['/groups', item.committeeUid]"
+                          [state]="{ backLabel: 'My Dashboard' }"
+                          (click)="$event.stopPropagation()"
+                          class="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                          [attr.aria-label]="'Open group ' + item.inviteGroupName"
+                          data-testid="dashboard-pending-actions-invitation-link"
+                          >{{ item.inviteGroupName }}</a
+                        >
                       </p>
                       @if (item.date) {
                         <span class="text-xs text-gray-500" data-testid="dashboard-pending-actions-invitation-expiry"> Expires {{ item.date }} </span>

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -14,12 +14,16 @@ import { PollType } from '@lfx-one/shared/enums';
 import { MeetingService } from '@services/meeting.service';
 import { VoteService } from '@services/vote.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
+import { InvitationService } from '@shared/services/invitation.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { ToastModule } from 'primeng/toast';
 import { timer } from 'rxjs';
 
-import type { DecoratedPendingAction, Meeting, MeetingRsvp, PendingActionItem, RsvpResponse, Vote } from '@lfx-one/shared/interfaces';
+import type { DecoratedPendingAction, Meeting, MeetingRsvp, PendingActionItem, PendingDecline, RsvpResponse, Vote } from '@lfx-one/shared/interfaces';
+
+/** Deferred-undo window (ms) before an optimistic decline is committed upstream. */
+const INVITE_DECLINE_UNDO_MS = 5000;
 
 @Component({
   selector: 'lfx-pending-actions',
@@ -40,6 +44,7 @@ export class PendingActionsComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
   private readonly meetingService = inject(MeetingService);
   private readonly voteService = inject(VoteService);
+  private readonly invitationService = inject(InvitationService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
@@ -69,6 +74,11 @@ export class PendingActionsComponent {
   private readonly loadingVoteUids = signal<ReadonlySet<string>>(new Set());
   private readonly failedMeetingUids = signal<ReadonlySet<string>>(new Set());
 
+  // The decline currently inside its deferred-undo window — drives the Undo affordance in the toast. Null when no decline is pending.
+  protected readonly pendingDecline = signal<PendingDecline | null>(null);
+  // setTimeout handle for the in-flight deferred decline; cleared on undo or when the timer fires.
+  private declineTimerId: ReturnType<typeof setTimeout> | null = null;
+
   // Clamped display limit shared by slicing, hasMore, and skeleton-swap arrival logic — rejects NaN/Infinity, floors fractional values, default 2.
   protected readonly safeDisplayLimit: Signal<number> = this.initSafeDisplayLimit();
   protected readonly visibleActionsUnlimited: Signal<PendingActionItem[]> = this.initVisibleActionsUnlimited();
@@ -88,6 +98,15 @@ export class PendingActionsComponent {
           }
         }
       });
+
+    // If the user navigates away while a decline is still in its undo window, commit it immediately so
+    // leaving the page doesn't silently drop the decline (clear the timer first so it can't double-fire).
+    this.destroyRef.onDestroy(() => {
+      const pending = this.pendingDecline();
+      if (!pending) return;
+      this.clearDeclineTimer();
+      this.invitationService.declineInvitation(pending.committeeUid, pending.inviteUid).subscribe();
+    });
   }
 
   protected handleAgendaOrOtherClick(item: DecoratedPendingAction): void {
@@ -128,6 +147,73 @@ export class PendingActionsComponent {
     if (this.expandedVoteKey() === this.getRowKey(item)) {
       this.expandedVoteKey.set(null);
     }
+  }
+
+  // Accept a committee invitation. Optimistically removes the row (markResolved → resolvedInviteUids filter), then commits
+  // upstream; on failure the row is restored (unmarkResolved) and an error toast is shown.
+  protected onAcceptInvitation(item: PendingActionItem): void {
+    const inviteUid = item.inviteUid;
+    const committeeUid = item.committeeUid;
+    if (!inviteUid || !committeeUid) return;
+
+    const groupName = item.inviteGroupName ?? item.badge;
+    this.invitationService.markResolved(inviteUid);
+    this.invitationService
+      .acceptInvitation(committeeUid, inviteUid)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            key: 'pending-actions-toast',
+            severity: 'success',
+            summary: `You've joined ${groupName}`,
+            life: 5000,
+          });
+        },
+        error: () => {
+          this.invitationService.unmarkResolved(inviteUid);
+          this.messageService.add({
+            key: 'pending-actions-toast',
+            severity: 'error',
+            summary: "Couldn't accept — try again.",
+            life: 5000,
+          });
+        },
+      });
+  }
+
+  // Decline a committee invitation with a true (deferred) undo: optimistically remove the row, schedule the real decline
+  // ~5s out, and surface an Undo toast. Undo (or destroy) cancels the timer; only one decline can be pending at a time, so
+  // a new decline first commits any in-flight one.
+  protected onDeclineInvitation(item: PendingActionItem): void {
+    const inviteUid = item.inviteUid;
+    const committeeUid = item.committeeUid;
+    if (!inviteUid || !committeeUid) return;
+
+    // If a previous decline is still mid-window, commit it now before starting a new one.
+    this.commitPendingDecline();
+
+    this.invitationService.markResolved(inviteUid);
+    this.pendingDecline.set({ inviteUid, committeeUid });
+    this.declineTimerId = setTimeout(() => this.fireDecline(inviteUid, committeeUid), INVITE_DECLINE_UNDO_MS);
+
+    this.messageService.add({
+      key: 'pending-actions-toast',
+      severity: 'info',
+      summary: 'Invite declined',
+      data: { undoInviteUid: inviteUid },
+      life: INVITE_DECLINE_UNDO_MS,
+    });
+  }
+
+  // Undo a still-pending decline: cancel the timer, restore the row, and clear the toast.
+  protected onUndoDecline(): void {
+    const pending = this.pendingDecline();
+    if (!pending) return;
+    this.clearDeclineTimer();
+    this.invitationService.unmarkResolved(pending.inviteUid);
+    this.pendingDecline.set(null);
+    this.messageService.clear('pending-actions-toast');
   }
 
   protected openDrawer(): void {
@@ -279,6 +365,45 @@ export class PendingActionsComponent {
       });
   }
 
+  // Commit the deferred decline upstream once its undo window elapses. The row is already optimistically removed; on
+  // failure restore it and surface an inline error toast. Only acts while this UID is still the pending decline.
+  private fireDecline(inviteUid: string, committeeUid: string): void {
+    const pending = this.pendingDecline();
+    if (!pending || pending.inviteUid !== inviteUid) return;
+    this.declineTimerId = null;
+    this.pendingDecline.set(null);
+    this.invitationService
+      .declineInvitation(committeeUid, inviteUid)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        error: () => {
+          this.invitationService.unmarkResolved(inviteUid);
+          this.messageService.add({
+            key: 'pending-actions-toast',
+            severity: 'error',
+            summary: "Couldn't decline — try again.",
+            life: 5000,
+          });
+        },
+      });
+  }
+
+  // Flush a still-pending decline synchronously (e.g. a new decline supersedes it): clear the timer and fire the API now.
+  private commitPendingDecline(): void {
+    const pending = this.pendingDecline();
+    if (!pending) return;
+    this.clearDeclineTimer();
+    this.pendingDecline.set(null);
+    this.invitationService.declineInvitation(pending.committeeUid, pending.inviteUid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+  }
+
+  private clearDeclineTimer(): void {
+    if (this.declineTimerId !== null) {
+      clearTimeout(this.declineTimerId);
+      this.declineTimerId = null;
+    }
+  }
+
   private removeFromSet(keys: ReadonlySet<string>, rowKey: string): ReadonlySet<string> {
     if (!keys.has(rowKey)) return keys;
     const next = new Set(keys);
@@ -329,10 +454,19 @@ export class PendingActionsComponent {
   private initVisibleActionsUnlimited(): Signal<PendingActionItem[]> {
     return computed(() => {
       this.hiddenActionsVersion();
+      // Invitations are resolved server-side, not cookie-hidden: drop any invite the user accepted/declined this session
+      // (tracked in the shared resolvedInviteUids signal) so the row disappears across every surface. Reading the signal
+      // here makes this computed re-run automatically on accept/decline/undo.
+      const resolvedInvites = this.invitationService.resolvedInviteUids();
       const pinned = new Set<string>();
       this.completingRowKeys().forEach((k) => pinned.add(k));
       this.swappingRowKeys().forEach((k) => pinned.add(k));
-      return this.pendingActions().filter((item) => pinned.has(this.getRowKey(item)) || !this.hiddenActionsService.isActionHidden(item));
+      return this.pendingActions().filter((item) => {
+        if (item.type === 'Invitation' && !!item.inviteUid && resolvedInvites.has(item.inviteUid)) {
+          return false;
+        }
+        return pinned.has(this.getRowKey(item)) || !this.hiddenActionsService.isActionHidden(item);
+      });
     });
   }
 
@@ -359,6 +493,8 @@ export class PendingActionsComponent {
         const isVoteLoading = !!item.voteUid && loadingVoteUids.has(item.voteUid);
         const isVoteInlineExpanded = isVoteInline && expandedVoteKey === rowKey;
         const voteUsesDrawerVal = !!vote && this.voteUsesDrawer(vote);
+        const isInvitation = item.type === 'Invitation' && !!item.inviteUid;
+        const inviteGroupName = item.inviteGroupName ?? item.badge;
         return {
           ...item,
           rowKey,
@@ -373,6 +509,9 @@ export class PendingActionsComponent {
           isVoteLoading,
           isVoteInlineExpanded,
           voteUsesDrawer: voteUsesDrawerVal,
+          isInvitation,
+          acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
+          declineAriaLabel: `Decline invite to ${inviteGroupName}`,
         };
       });
     });

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -105,7 +105,12 @@ export class PendingActionsComponent {
       const pending = this.pendingDecline();
       if (!pending) return;
       this.clearDeclineTimer();
-      this.invitationService.declineInvitation(pending.committeeUid, pending.inviteUid).subscribe();
+      // Component is tearing down (no toast), but still roll back the optimistic hide on failure so the
+      // invite reappears on the next load / on the other surfaces rather than being lost for the session.
+      this.invitationService.declineInvitation(pending.committeeUid, pending.inviteUid).subscribe({
+        next: () => this.invitationService.forgetResolved(pending.inviteUid),
+        error: () => this.invitationService.unmarkResolved(pending.inviteUid),
+      });
     });
   }
 
@@ -163,6 +168,7 @@ export class PendingActionsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
+          this.invitationService.forgetResolved(inviteUid);
           this.messageService.add({
             key: 'pending-actions-toast',
             severity: 'success',
@@ -376,6 +382,7 @@ export class PendingActionsComponent {
       .declineInvitation(committeeUid, inviteUid)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
+        next: () => this.invitationService.forgetResolved(inviteUid),
         error: () => {
           this.invitationService.unmarkResolved(inviteUid);
           this.messageService.add({
@@ -394,7 +401,14 @@ export class PendingActionsComponent {
     if (!pending) return;
     this.clearDeclineTimer();
     this.pendingDecline.set(null);
-    this.invitationService.declineInvitation(pending.committeeUid, pending.inviteUid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+    this.invitationService
+      .declineInvitation(pending.committeeUid, pending.inviteUid)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.invitationService.forgetResolved(pending.inviteUid),
+        // Roll back so a failed decline doesn't leave the invite hidden across the app for the session.
+        error: () => this.invitationService.unmarkResolved(pending.inviteUid),
+      });
   }
 
   private clearDeclineTimer(): void {
@@ -495,6 +509,11 @@ export class PendingActionsComponent {
         const voteUsesDrawerVal = !!vote && this.voteUsesDrawer(vote);
         const isInvitation = item.type === 'Invitation' && !!item.inviteUid;
         const inviteGroupName = item.inviteGroupName ?? item.badge;
+        // Render the title from the backend-built `text` (e.g. "You've been invited to {Group}") with
+        // the group name split off as a link — keeps the inline list and the drawer copy in sync and
+        // surfaces inviter context automatically if upstream ever provides it.
+        const nameIdx = item.text.lastIndexOf(inviteGroupName);
+        const inviteTitlePrefix = nameIdx >= 0 ? item.text.slice(0, nameIdx) : item.text;
         return {
           ...item,
           rowKey,
@@ -510,6 +529,7 @@ export class PendingActionsComponent {
           isVoteInlineExpanded,
           voteUsesDrawer: voteUsesDrawerVal,
           isInvitation,
+          inviteTitlePrefix,
           acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
           declineAriaLabel: `Decline invite to ${inviteGroupName}`,
         };

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -25,6 +25,10 @@ import type { DecoratedPendingAction, Meeting, MeetingRsvp, PendingActionItem, P
 /** Deferred-undo window (ms) before an optimistic decline is committed upstream. */
 const INVITE_DECLINE_UNDO_MS = 5000;
 
+/** Dedicated toast key for the decline Undo, isolated from the shared 'pending-actions-toast' so
+ *  clearing it on Undo can't dismiss unrelated RSVP/vote/meeting toasts. */
+const INVITE_UNDO_TOAST_KEY = 'pending-actions-undo';
+
 @Component({
   selector: 'lfx-pending-actions',
   imports: [
@@ -78,6 +82,8 @@ export class PendingActionsComponent {
   protected readonly pendingDecline = signal<PendingDecline | null>(null);
   // setTimeout handle for the in-flight deferred decline; cleared on undo or when the timer fires.
   private declineTimerId: ReturnType<typeof setTimeout> | null = null;
+  // Dedicated toast key for the decline Undo, exposed to the template's keyed <p-toast>.
+  protected readonly undoToastKey = INVITE_UNDO_TOAST_KEY;
 
   // Clamped display limit shared by slicing, hasMore, and skeleton-swap arrival logic — rejects NaN/Infinity, floors fractional values, default 2.
   protected readonly safeDisplayLimit: Signal<number> = this.initSafeDisplayLimit();
@@ -204,7 +210,7 @@ export class PendingActionsComponent {
     this.declineTimerId = setTimeout(() => this.fireDecline(inviteUid, committeeUid), INVITE_DECLINE_UNDO_MS);
 
     this.messageService.add({
-      key: 'pending-actions-toast',
+      key: INVITE_UNDO_TOAST_KEY,
       severity: 'info',
       summary: 'Invite declined',
       data: { undoInviteUid: inviteUid },
@@ -212,14 +218,14 @@ export class PendingActionsComponent {
     });
   }
 
-  // Undo a still-pending decline: cancel the timer, restore the row, and clear the toast.
+  // Undo a still-pending decline: cancel the timer, restore the row, and clear only the undo toast.
   protected onUndoDecline(): void {
     const pending = this.pendingDecline();
     if (!pending) return;
     this.clearDeclineTimer();
     this.invitationService.unmarkResolved(pending.inviteUid);
     this.pendingDecline.set(null);
-    this.messageService.clear('pending-actions-toast');
+    this.messageService.clear(INVITE_UNDO_TOAST_KEY);
   }
 
   protected openDrawer(): void {
@@ -507,13 +513,10 @@ export class PendingActionsComponent {
         const isVoteLoading = !!item.voteUid && loadingVoteUids.has(item.voteUid);
         const isVoteInlineExpanded = isVoteInline && expandedVoteKey === rowKey;
         const voteUsesDrawerVal = !!vote && this.voteUsesDrawer(vote);
-        const isInvitation = item.type === 'Invitation' && !!item.inviteUid;
+        // Require committeeUid too — the invitation branch builds a routerLink to /groups/:committeeUid
+        // and calls accept/decline with it, so a row missing it would render /groups/undefined.
+        const isInvitation = item.type === 'Invitation' && !!item.inviteUid && !!item.committeeUid;
         const inviteGroupName = item.inviteGroupName ?? item.badge;
-        // Render the title from the backend-built `text` (e.g. "You've been invited to {Group}") with
-        // the group name split off as a link — keeps the inline list and the drawer copy in sync and
-        // surfaces inviter context automatically if upstream ever provides it.
-        const nameIdx = item.text.lastIndexOf(inviteGroupName);
-        const inviteTitlePrefix = nameIdx >= 0 ? item.text.slice(0, nameIdx) : item.text;
         return {
           ...item,
           rowKey,
@@ -529,7 +532,6 @@ export class PendingActionsComponent {
           isVoteInlineExpanded,
           voteUsesDrawer: voteUsesDrawerVal,
           isInvitation,
-          inviteTitlePrefix,
           acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
           declineAriaLabel: `Decline invite to ${inviteGroupName}`,
         };

--- a/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { inject, Pipe, PipeTransform } from '@angular/core';
+import { PendingInvitation } from '@lfx-one/shared/interfaces';
+import { buildInvitationSubtext } from '@lfx-one/shared/utils';
+
+/**
+ * Builds the secondary line for a pending committee invitation row.
+ *
+ * Base text is "{inviter_name} invited you" when an inviter name is present (it usually isn't in the
+ * current committee-service contract), otherwise "You've been invited". When the invite carries an
+ * expiry (also usually absent), " · expires {date}" is appended. The string assembly lives in the
+ * framework-free, unit-tested `buildInvitationSubtext`; the pipe only formats the date for it.
+ * Keeping this in a pipe avoids a template method and keeps the row template declarative.
+ */
+@Pipe({
+  name: 'invitationSubtext',
+})
+export class InvitationSubtextPipe implements PipeTransform {
+  private readonly datePipe = inject(DatePipe);
+
+  public transform(invitation: PendingInvitation): string {
+    const formattedExpiry = invitation.expires_at ? this.datePipe.transform(invitation.expires_at, 'mediumDate') : null;
+    return buildInvitationSubtext(invitation, formattedExpiry);
+  }
+}

--- a/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
@@ -1,8 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
-import { inject, Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform } from '@angular/core';
 import { PendingInvitation } from '@lfx-one/shared/interfaces';
 import { buildInvitationSubtext } from '@lfx-one/shared/utils';
 
@@ -13,16 +12,19 @@ import { buildInvitationSubtext } from '@lfx-one/shared/utils';
  * current committee-service contract), otherwise "You've been invited". When the invite carries an
  * expiry (also usually absent), " · expires {date}" is appended. The string assembly lives in the
  * framework-free, unit-tested `buildInvitationSubtext`; the pipe only formats the date for it.
- * Keeping this in a pipe avoids a template method and keeps the row template declarative.
+ *
+ * Formats the date with `toLocaleDateString` (no `DatePipe` injection) so the pipe is self-sufficient
+ * in any component — injecting `DatePipe` would NullInjector-crash any host that uses the pipe without
+ * adding `DatePipe` to its `providers`.
  */
 @Pipe({
   name: 'invitationSubtext',
 })
 export class InvitationSubtextPipe implements PipeTransform {
-  private readonly datePipe = inject(DatePipe);
-
   public transform(invitation: PendingInvitation): string {
-    const formattedExpiry = invitation.expires_at ? this.datePipe.transform(invitation.expires_at, 'mediumDate') : null;
+    const formattedExpiry = invitation.expires_at
+      ? new Date(invitation.expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+      : null;
     return buildInvitationSubtext(invitation, formattedExpiry);
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
@@ -19,6 +19,7 @@ import { buildInvitationSubtext, formatInviteExpiry } from '@lfx-one/shared/util
  */
 @Pipe({
   name: 'invitationSubtext',
+  standalone: true,
 })
 export class InvitationSubtextPipe implements PipeTransform {
   public transform(invitation: PendingInvitation): string {

--- a/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/invitation-subtext.pipe.ts
@@ -3,7 +3,7 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 import { PendingInvitation } from '@lfx-one/shared/interfaces';
-import { buildInvitationSubtext } from '@lfx-one/shared/utils';
+import { buildInvitationSubtext, formatInviteExpiry } from '@lfx-one/shared/utils';
 
 /**
  * Builds the secondary line for a pending committee invitation row.
@@ -22,9 +22,8 @@ import { buildInvitationSubtext } from '@lfx-one/shared/utils';
 })
 export class InvitationSubtextPipe implements PipeTransform {
   public transform(invitation: PendingInvitation): string {
-    const formattedExpiry = invitation.expires_at
-      ? new Date(invitation.expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-      : null;
-    return buildInvitationSubtext(invitation, formattedExpiry);
+    // formatInviteExpiry guards malformed timestamps (returns null), so the subtext falls back to the
+    // base copy instead of rendering "Invalid Date".
+    return buildInvitationSubtext(invitation, formatInviteExpiry(invitation.expires_at));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -53,12 +53,12 @@ export class InvitationService {
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
   public acceptInvitation(committeeUid: string, inviteUid: string): Observable<void> {
-    return this.http.post<void>(`/api/committees/${committeeUid}/invites/${inviteUid}/accept`, {}).pipe(take(1));
+    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, {}).pipe(take(1));
   }
 
   /** Declines an invitation. Upstream is invitee-authenticated; returns 204. */
   public declineInvitation(committeeUid: string, inviteUid: string): Observable<void> {
-    return this.http.post<void>(`/api/committees/${committeeUid}/invites/${inviteUid}/decline`, {}).pipe(take(1));
+    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/decline`, {}).pipe(take(1));
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { PendingInvitation } from '@lfx-one/shared/interfaces';
+import { catchError, Observable, of, take, tap } from 'rxjs';
+
+/**
+ * Shared client for the current user's pending committee invitations.
+ *
+ * Holds a single source-of-truth signal so both surfaces that show invitations — the dashboard
+ * pending-actions list and My Groups — stay in sync. Accept/decline optimistically remove a row
+ * from the signal (both surfaces react instantly); `restoreToCache` supports undo / failure
+ * rollback.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class InvitationService {
+  /** Shared cache of the user's pending invitations; both surfaces bind to this. */
+  public pendingInvitations: WritableSignal<PendingInvitation[]> = signal<PendingInvitation[]>([]);
+
+  /**
+   * Invite UIDs the user has accepted/declined this session. The cross-surface sync primitive:
+   * the dashboard sources its invitation rows from the `/api/user/pending-actions` aggregator (a
+   * separate fetch from {@link pendingInvitations}), so removing from the cache alone wouldn't hide
+   * a dashboard row. Both surfaces additionally filter out any invite whose UID is in this set, so
+   * resolving an invite in one surface hides it in the other regardless of which fetch sourced it.
+   * Undo clears the UID again (`unmarkResolved`), re-surfacing the row in both places.
+   */
+  public resolvedInviteUids: WritableSignal<Set<string>> = signal<Set<string>>(new Set());
+
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Stash of invitations removed by {@link markResolved}, keyed by UID, so undo can restore the
+   * full object from a UID alone. The dashboard holds only a `PendingActionItem` (UID + committee
+   * UID), not the full `PendingInvitation`, so uid-keyed restore lets either surface undo.
+   */
+  private readonly resolvedStash = new Map<string, PendingInvitation>();
+
+  /**
+   * Loads the user's pending invitations and tees the result into {@link pendingInvitations}.
+   * Degrades to an empty list on error so neither surface breaks.
+   */
+  public loadPendingInvitations(): Observable<PendingInvitation[]> {
+    return this.http.get<PendingInvitation[]>('/api/user/pending-invitations').pipe(
+      tap((invitations) => this.pendingInvitations.set(invitations)),
+      catchError(() => of([]))
+    );
+  }
+
+  /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
+  public acceptInvitation(committeeUid: string, inviteUid: string): Observable<void> {
+    return this.http.post<void>(`/api/committees/${committeeUid}/invites/${inviteUid}/accept`, {}).pipe(take(1));
+  }
+
+  /** Declines an invitation. Upstream is invitee-authenticated; returns 204. */
+  public declineInvitation(committeeUid: string, inviteUid: string): Observable<void> {
+    return this.http.post<void>(`/api/committees/${committeeUid}/invites/${inviteUid}/decline`, {}).pipe(take(1));
+  }
+
+  /**
+   * Marks an invite resolved (accepted/declined) — the optimistic primitive both surfaces call.
+   * Adds the UID to {@link resolvedInviteUids} (hides it on the dashboard, whose rows come from the
+   * aggregator) and removes it from {@link pendingInvitations} (hides it in My Groups). Idempotent.
+   */
+  public markResolved(inviteUid: string): void {
+    const stashable = this.pendingInvitations().find((invitation) => invitation.uid === inviteUid);
+    if (stashable) {
+      this.resolvedStash.set(inviteUid, stashable);
+    }
+    this.resolvedInviteUids.update((resolved) => {
+      if (resolved.has(inviteUid)) {
+        return resolved;
+      }
+      const next = new Set(resolved);
+      next.add(inviteUid);
+      return next;
+    });
+    this.pendingInvitations.update((invitations) => invitations.filter((invitation) => invitation.uid !== inviteUid));
+  }
+
+  /**
+   * Reverses {@link markResolved} for undo / failure rollback, by UID alone: clears the resolved
+   * UID (re-surfaces the row on the dashboard, whose source still holds it) and restores the stashed
+   * invitation to {@link pendingInvitations} (re-surfaces it in My Groups). Restoring is a no-op when
+   * nothing was stashed or the entry is already present.
+   */
+  public unmarkResolved(inviteUid: string): void {
+    this.resolvedInviteUids.update((resolved) => {
+      if (!resolved.has(inviteUid)) {
+        return resolved;
+      }
+      const next = new Set(resolved);
+      next.delete(inviteUid);
+      return next;
+    });
+    const stashed = this.resolvedStash.get(inviteUid);
+    if (stashed) {
+      this.resolvedStash.delete(inviteUid);
+      this.pendingInvitations.update((invitations) => (invitations.some((existing) => existing.uid === stashed.uid) ? invitations : [...invitations, stashed]));
+    }
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { PendingInvitation } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, of, take, tap } from 'rxjs';
+import { catchError, finalize, Observable, of, shareReplay, tap } from 'rxjs';
 
 /**
  * Shared client for the current user's pending committee invitations.
@@ -40,30 +40,42 @@ export class InvitationService {
    */
   private readonly resolvedStash = new Map<string, PendingInvitation>();
 
+  /** In-flight load shared across concurrent callers (dashboard Me-lens + group-page) to dedupe the GET. */
+  private inFlightLoad: Observable<PendingInvitation[]> | null = null;
+
   /**
    * Loads the user's pending invitations and tees the result into {@link pendingInvitations}.
-   * Degrades to an empty list on error so neither surface breaks.
+   * Degrades to an empty list on error so neither surface breaks. Concurrent callers (the Me-lens
+   * dashboard and a direct group navigation can both trigger a load) share one in-flight request.
    */
   public loadPendingInvitations(): Observable<PendingInvitation[]> {
-    return this.http.get<PendingInvitation[]>('/api/user/pending-invitations').pipe(
+    if (this.inFlightLoad) {
+      return this.inFlightLoad;
+    }
+    this.inFlightLoad = this.http.get<PendingInvitation[]>('/api/user/pending-invitations').pipe(
       tap((invitations) => this.pendingInvitations.set(invitations)),
       catchError(() => {
         // Clear the cache so a failed refresh can't leave stale invitations rendered on either
         // surface (matches the "degrades to an empty list on error" contract above).
         this.pendingInvitations.set([]);
-        return of([]);
-      })
+        return of([] as PendingInvitation[]);
+      }),
+      finalize(() => {
+        this.inFlightLoad = null;
+      }),
+      shareReplay(1)
     );
+    return this.inFlightLoad;
   }
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
   public acceptInvitation(committeeUid: string, inviteUid: string): Observable<void> {
-    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, {}).pipe(take(1));
+    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, {});
   }
 
   /** Declines an invitation. Upstream is invitee-authenticated; returns 204. */
   public declineInvitation(committeeUid: string, inviteUid: string): Observable<void> {
-    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/decline`, {}).pipe(take(1));
+    return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/decline`, {});
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -11,8 +11,8 @@ import { catchError, Observable, of, take, tap } from 'rxjs';
  *
  * Holds a single source-of-truth signal so both surfaces that show invitations — the dashboard
  * pending-actions list and My Groups — stay in sync. Accept/decline optimistically remove a row
- * from the signal (both surfaces react instantly); `restoreToCache` supports undo / failure
- * rollback.
+ * from the signal (both surfaces react instantly); `unmarkResolved` supports undo / failure
+ * rollback, and `forgetResolved` drops the undo stash on terminal success.
  */
 @Injectable({
   providedIn: 'root',
@@ -47,7 +47,12 @@ export class InvitationService {
   public loadPendingInvitations(): Observable<PendingInvitation[]> {
     return this.http.get<PendingInvitation[]>('/api/user/pending-invitations').pipe(
       tap((invitations) => this.pendingInvitations.set(invitations)),
-      catchError(() => of([]))
+      catchError(() => {
+        // Clear the cache so a failed refresh can't leave stale invitations rendered on either
+        // surface (matches the "degrades to an empty list on error" contract above).
+        this.pendingInvitations.set([]);
+        return of([]);
+      })
     );
   }
 
@@ -102,5 +107,14 @@ export class InvitationService {
       this.resolvedStash.delete(inviteUid);
       this.pendingInvitations.update((invitations) => (invitations.some((existing) => existing.uid === stashed.uid) ? invitations : [...invitations, stashed]));
     }
+  }
+
+  /**
+   * Drops the undo stash entry for an invite whose accept/decline has terminally succeeded (no undo
+   * possible anymore), so the stash doesn't accumulate resolved invitations over a long session. The
+   * UID stays in {@link resolvedInviteUids}, so the row remains hidden.
+   */
+  public forgetResolved(inviteUid: string): void {
+    this.resolvedStash.delete(inviteUid);
   }
 }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -666,6 +666,19 @@ export class CommitteeController {
         return;
       }
 
+      // Validate UUID format (path params are decoded before routing) — consistent with the rest of
+      // this controller and avoids forwarding a malformed UID pair upstream.
+      if (!FOLDER_UID_PATTERN.test(id) || !FOLDER_UID_PATTERN.test(inviteId)) {
+        next(
+          ServiceValidationError.forField('inviteId', 'Committee ID and Invite ID must be valid UUIDs', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
       await this.committeeService.acceptCommitteeInvite(req, id, inviteId);
 
       logger.success(req, 'accept_committee_invite', startTime, { committee_id: id, invite_id: inviteId });
@@ -700,6 +713,19 @@ export class CommitteeController {
       if (!inviteId) {
         next(
           ServiceValidationError.forField('inviteId', 'Invite ID is required', {
+            operation: 'decline_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      // Validate UUID format (path params are decoded before routing) — consistent with the rest of
+      // this controller and avoids forwarding a malformed UID pair upstream.
+      if (!FOLDER_UID_PATTERN.test(id) || !FOLDER_UID_PATTERN.test(inviteId)) {
+        next(
+          ServiceValidationError.forField('inviteId', 'Committee ID and Invite ID must be valid UUIDs', {
             operation: 'decline_committee_invite',
             service: 'committee_controller',
             path: req.path,

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -633,6 +633,90 @@ export class CommitteeController {
     }
   }
 
+  /**
+   * POST /committees/:id/invites/:inviteId/accept
+   */
+  public async acceptCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id, inviteId } = req.params;
+    const startTime = logger.startOperation(req, 'accept_committee_invite', {
+      committee_id: id,
+      invite_id: inviteId,
+    });
+
+    try {
+      if (!id) {
+        next(
+          ServiceValidationError.forField('id', 'Committee ID is required', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      if (!inviteId) {
+        next(
+          ServiceValidationError.forField('inviteId', 'Invite ID is required', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      await this.committeeService.acceptCommitteeInvite(req, id, inviteId);
+
+      logger.success(req, 'accept_committee_invite', startTime, { committee_id: id, invite_id: inviteId });
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /committees/:id/invites/:inviteId/decline
+   */
+  public async declineCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id, inviteId } = req.params;
+    const startTime = logger.startOperation(req, 'decline_committee_invite', {
+      committee_id: id,
+      invite_id: inviteId,
+    });
+
+    try {
+      if (!id) {
+        next(
+          ServiceValidationError.forField('id', 'Committee ID is required', {
+            operation: 'decline_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      if (!inviteId) {
+        next(
+          ServiceValidationError.forField('inviteId', 'Invite ID is required', {
+            operation: 'decline_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      await this.committeeService.declineCommitteeInvite(req, id, inviteId);
+
+      logger.success(req, 'decline_committee_invite', startTime, { committee_id: id, invite_id: inviteId });
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+
   // ── Document Endpoints ──────────────────────────────────────────────────
 
   /**

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -634,7 +634,7 @@ export class CommitteeController {
   }
 
   /**
-   * POST /committees/:id/invites/:inviteId/accept
+   * POST /api/committees/:id/invites/:inviteId/accept
    */
   public async acceptCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id, inviteId } = req.params;
@@ -676,7 +676,7 @@ export class CommitteeController {
   }
 
   /**
-   * POST /committees/:id/invites/:inviteId/decline
+   * POST /api/committees/:id/invites/:inviteId/decline
    */
   public async declineCommitteeInvite(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id, inviteId } = req.params;

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -113,6 +113,39 @@ export class UserController {
   }
 
   /**
+   * GET /api/user/pending-invitations - Get the authenticated user's pending committee invitations
+   */
+  public async getPendingInvitations(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_pending_invitations');
+
+    try {
+      // Extract user email from auth context (impersonation-aware)
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
+          operation: 'get_pending_invitations',
+          service: 'user_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      const invitations = await this.userService.getMyPendingInvitations(req, userEmail);
+
+      logger.success(req, 'get_pending_invitations', startTime, { invitation_count: invitations.length });
+
+      // Private, revalidate-every-time — server recomputes for the real authenticated identity on
+      // every hit, mirroring getPendingActions.
+      res.set('Cache-Control', 'private, no-cache');
+      res.json(invitations);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/user/meetings - Get meetings for the authenticated user
    * Returns meetings the user has direct FGA access to (host, participant, organizer), optionally filtered by project
    * @query projectUid - Optional project UID to filter meetings

--- a/apps/lfx-one/src/server/routes/committees.route.ts
+++ b/apps/lfx-one/src/server/routes/committees.route.ts
@@ -29,6 +29,8 @@ router.delete('/:id/members/:memberId', (req, res, next) => committeeController.
 router.get('/:id/invites', (req, res, next) => committeeController.getCommitteeInvites(req, res, next));
 router.post('/:id/invites', (req, res, next) => committeeController.createCommitteeInvite(req, res, next));
 router.delete('/:id/invites/:inviteId', (req, res, next) => committeeController.revokeCommitteeInvite(req, res, next));
+router.post('/:id/invites/:inviteId/accept', (req, res, next) => committeeController.acceptCommitteeInvite(req, res, next));
+router.post('/:id/invites/:inviteId/decline', (req, res, next) => committeeController.declineCommitteeInvite(req, res, next));
 
 // ── Sub-groups route ───────────────────────────────────────────────────────
 router.get('/:id/children', (req, res, next) => committeeController.getCommitteeChildren(req, res, next));

--- a/apps/lfx-one/src/server/routes/user.route.ts
+++ b/apps/lfx-one/src/server/routes/user.route.ts
@@ -11,6 +11,9 @@ const userController = new UserController();
 // GET /api/user/pending-actions - Get all pending actions for the authenticated user
 router.get('/pending-actions', (req, res, next) => userController.getPendingActions(req, res, next));
 
+// GET /api/user/pending-invitations - Get the authenticated user's pending committee invitations
+router.get('/pending-invitations', (req, res, next) => userController.getPendingInvitations(req, res, next));
+
 // GET /api/user/meetings - Get all meetings for the authenticated user
 router.get('/meetings', (req, res, next) => userController.getUserMeetings(req, res, next));
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -647,7 +647,9 @@ export class CommitteeService {
       return [];
     }
 
-    logger.debug(req, 'get_my_pending_invitations', 'Fetching committee invitations for user', { invitee_email: normalizedEmail });
+    // Don't log the invitee email — it's PII and the request is already correlated by req.id and
+    // the authenticated session. The upstream query is still scoped to normalizedEmail.
+    logger.debug(req, 'get_my_pending_invitations', 'Fetching committee invitations for user');
 
     const invites = await fetchAllQueryResources<CommitteeInvite>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeInvite>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
@@ -662,7 +664,7 @@ export class CommitteeService {
       return [];
     }
 
-    logger.debug(req, 'get_my_pending_invitations', 'Found pending invitations, enriching with committee data', {
+    logger.info(req, 'get_my_pending_invitations', 'Found pending invitations, enriching with committee data', {
       pending_count: pendingInvites.length,
     });
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -707,9 +707,9 @@ export class CommitteeService {
         invitee_email: invite.invitee_email,
         status: invite.status,
         created_at: invite.created_at,
-        // Not provided by the committee-service contract today — left undefined.
-        inviter_name: null,
-        expires_at: null,
+        // inviter_name / expires_at are intentionally omitted (left undefined) — they're reserved
+        // optional fields not in the committee-service contract yet, so JSON drops them rather than
+        // sending an explicit null that consumers would have to disambiguate from "set".
       } satisfies PendingInvitation;
     });
   }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -17,6 +17,7 @@ import {
   CreateCommitteeJoinApplicationRequest,
   CreateCommitteeMemberRequest,
   MyCommittee,
+  PendingInvitation,
   Project,
   ProjectSettings,
   QueryServiceCountResponse,
@@ -616,6 +617,122 @@ export class CommitteeService {
     await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/invites/${inviteId}`, 'DELETE');
 
     logger.debug(req, 'revoke_committee_invite', 'Committee invite revoked successfully', {
+      committee_uid: committeeId,
+      invite_uid: inviteId,
+    });
+  }
+
+  // ── My Pending Invitations (invitee-facing) ───────────────────────────────
+  // The invitee side of invite-by-email: surface the committee_invite resources
+  // addressed to the current user's email, enriched with committee/project display
+  // context for the dashboard and My Groups. Accept/decline are invitee-authenticated
+  // committee-service calls (upstream enforces principal == invitee_email).
+
+  /**
+   * Returns the current user's pending committee invitations, enriched for display.
+   *
+   * Reads `committee_invite` resources tagged with the user's email from the query
+   * index, filters to `status === 'pending'` client-side, then batch-enriches the
+   * distinct committees (name, category) and their projects (project_name) so each
+   * row can render without further round-trips. Enrichment is best-effort: if a
+   * committee/project lookup fails, the row is still returned with `committee_name`
+   * falling back to the committee UID — the list is never dropped wholesale.
+   *
+   * `inviter_name` / `expires_at` are left undefined — the committee-service contract
+   * does not provide them today.
+   */
+  public async getMyPendingInvitations(req: Request, email: string): Promise<PendingInvitation[]> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      return [];
+    }
+
+    logger.debug(req, 'get_my_pending_invitations', 'Fetching committee invitations for user', { invitee_email: normalizedEmail });
+
+    const invites = await fetchAllQueryResources<CommitteeInvite>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeInvite>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'committee_invite',
+        tags: `invitee_email:${normalizedEmail}`,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    const pendingInvites = invites.filter((invite) => invite.status === 'pending');
+    if (pendingInvites.length === 0) {
+      return [];
+    }
+
+    logger.debug(req, 'get_my_pending_invitations', 'Found pending invitations, enriching with committee data', {
+      pending_count: pendingInvites.length,
+    });
+
+    // Enrich committee context (name, category, project) for the distinct committees once.
+    // Best-effort: a failed lookup degrades to a UID fallback rather than dropping the list.
+    const committeeUids = Array.from(new Set(pendingInvites.map((invite) => invite.committee_uid).filter(Boolean)));
+    const committeeContext = new Map<string, { committee_name: string; category?: string | null; project_name?: string | null }>();
+
+    try {
+      const committees = await this.getCommitteesByIds(req, committeeUids);
+      const enriched = await this.projectService.enrichWithProjectData(req, Array.from(committees.values()));
+      const projectNameByCommittee = new Map(enriched.map((committee) => [committee.uid, committee.project_name]));
+
+      for (const uid of committeeUids) {
+        const committee = committees.get(uid);
+        if (committee) {
+          committeeContext.set(uid, {
+            committee_name: committee.name || uid,
+            category: committee.category ?? null,
+            project_name: projectNameByCommittee.get(uid) || null,
+          });
+        }
+      }
+    } catch (error) {
+      logger.warning(req, 'get_my_pending_invitations', 'Committee enrichment failed, returning invitations with UID fallback', {
+        committee_count: committeeUids.length,
+        err: error,
+      });
+    }
+
+    return pendingInvites.map((invite) => {
+      const context = committeeContext.get(invite.committee_uid);
+      return {
+        uid: invite.uid,
+        committee_uid: invite.committee_uid,
+        committee_name: context?.committee_name || invite.committee_uid,
+        project_name: context?.project_name ?? null,
+        category: context?.category ?? null,
+        role: invite.role ?? null,
+        invitee_email: invite.invitee_email,
+        status: invite.status,
+        created_at: invite.created_at,
+        // Not provided by the committee-service contract today — left undefined.
+        inviter_name: null,
+        expires_at: null,
+      } satisfies PendingInvitation;
+    });
+  }
+
+  /**
+   * Accepts a committee invitation on behalf of the invitee. The upstream endpoint is
+   * invitee-authenticated (committee-service enforces principal == invitee_email).
+   */
+  public async acceptCommitteeInvite(req: Request, committeeId: string, inviteId: string): Promise<void> {
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/invites/${inviteId}/accept`, 'POST');
+
+    logger.debug(req, 'accept_committee_invite', 'Committee invite accepted successfully', {
+      committee_uid: committeeId,
+      invite_uid: inviteId,
+    });
+  }
+
+  /**
+   * Declines a committee invitation on behalf of the invitee. The upstream endpoint is
+   * invitee-authenticated (committee-service enforces principal == invitee_email).
+   */
+  public async declineCommitteeInvite(req: Request, committeeId: string, inviteId: string): Promise<void> {
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/invites/${inviteId}/decline`, 'POST');
+
+    logger.debug(req, 'decline_committee_invite', 'Committee invite declined successfully', {
       committee_uid: committeeId,
       invite_uid: inviteId,
     });

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1327,11 +1327,6 @@ export class UserService {
   }
 
   /**
-   * Build a "Cast Vote" pending action per active vote. Links to the My Votes page (me-lens of
-   * /votes) — there's no standalone vote-detail route, so the user lands on the list and picks
-   * the vote to cast.
-   */
-  /**
    * Transform pending committee invitations into pending action rows. Invitations carry no
    * closing window in the current committee-service contract, so the `date` field is only set
    * when `expires_at` is (reserved for a future upstream that emits it). The badge prefers the
@@ -1342,6 +1337,11 @@ export class UserService {
     return buildInvitationActions(invitations);
   }
 
+  /**
+   * Build a "Cast Vote" pending action per active vote. Links to the My Votes page (me-lens of
+   * /votes) — there's no standalone vote-detail route, so the user lands on the list and picks
+   * the vote to cast.
+   */
   private transformVotesToActions(votes: Vote[]): PendingActionItem[] {
     return votes.map((vote) => {
       const endDate = new Date(vote.end_time);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -23,6 +23,7 @@ import {
   PastMeeting,
   PastMeetingParticipant,
   PendingActionItem,
+  PendingInvitation,
   QueryServiceResponse,
   UserCodeCommitsResponse,
   UserCodeCommitsRow,
@@ -33,13 +34,14 @@ import {
   UserPullRequestsRow,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { getCurrentOrNextOccurrence, hasMeetingEnded, parseToInt } from '@lfx-one/shared/utils';
+import { buildInvitationActions, getCurrentOrNextOccurrence, hasMeetingEnded, parseToInt } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { MicroserviceError, ResourceNotFoundError } from '../errors';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
+import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -60,6 +62,7 @@ export class UserService {
   private projectService: ProjectService;
   private microserviceProxy: MicroserviceProxyService;
   private accessCheckService: AccessCheckService;
+  private committeeService: CommitteeService;
 
   private readonly twoWeeksMs = 14 * 24 * 60 * 60 * 1000;
   private readonly bufferMinutes = 40;
@@ -71,6 +74,7 @@ export class UserService {
     this.projectService = new ProjectService();
     this.microserviceProxy = new MicroserviceProxyService();
     this.accessCheckService = new AccessCheckService();
+    this.committeeService = new CommitteeService();
   }
 
   /**
@@ -391,6 +395,18 @@ export class UserService {
   ): Promise<PendingActionItem[]> {
     const actions = await this.getUserPendingActions(req, email, projectSlug, projectUid);
     return limit && limit > 0 && actions.length > limit ? actions.slice(0, limit) : actions;
+  }
+
+  /**
+   * Returns the current user's pending committee invitations (enriched), for the dashboard
+   * and My Groups surfaces. Thin passthrough to the committee service so both surfaces share a
+   * single BFF endpoint and the frontend can keep one shared signal in sync.
+   * @param req - Express request object
+   * @param email - User email (impersonation-aware, resolved by the controller)
+   * @returns Array of enriched pending invitations
+   */
+  public async getMyPendingInvitations(req: Request, email: string): Promise<PendingInvitation[]> {
+    return this.committeeService.getMyPendingInvitations(req, email);
   }
 
   /**
@@ -1018,8 +1034,15 @@ export class UserService {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
 
-    // Phase 1: surveys, meetings, and pending votes are independent — issue them in parallel.
-    const [surveys, meetings, pendingVotes] = await Promise.all([
+    // Pending committee invitations only belong on the unscoped Me-lens path — they're personal
+    // to the user (by email) and not tied to a project lens. On a project/foundation lens, skip
+    // the lookup entirely.
+    const isMeLens = !projectUid && !projectSlug;
+
+    // Phase 1: surveys, meetings, pending votes, and (Me-lens only) invitations are independent —
+    // issue them in parallel. Each source has its own `.catch` returning [] so one flaky source
+    // can't wipe the whole list.
+    const [surveys, meetings, pendingVotes, pendingInvitations] = await Promise.all([
       this.projectService.getPendingActionSurveys(email, projectSlug).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch surveys for pending actions', { err: error });
         return [];
@@ -1034,11 +1057,19 @@ export class UserService {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending votes', { err: error });
         return [] as Vote[];
       }),
+
+      isMeLens
+        ? this.committeeService.getMyPendingInvitations(req, email).catch((error) => {
+            logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending invitations', { err: error });
+            return [] as PendingInvitation[];
+          })
+        : Promise.resolve([] as PendingInvitation[]),
     ]);
 
     const inWindowMeetings = this.filterMeetingsInWindow(meetings);
     const meetingActions = this.transformMeetingsToActions(inWindowMeetings);
     const voteActions = this.transformVotesToActions(pendingVotes);
+    const invitationActions = this.transformInvitationsToActions(pendingInvitations);
 
     // Phase 2: RSVP + registrant lookups are only meaningful when there are in-window meetings
     // to evaluate. Skip them otherwise — avoids two full paginated per-user scans per request
@@ -1060,11 +1091,12 @@ export class UserService {
       }
     }
 
-    // Order by actionability: someone is waiting on RSVPs and votes have closing windows, so
-    // those go first. Surveys are time-bounded by their cutoff. Review Agenda is informational
-    // (read-before-meeting) and goes last — with the 5-item display cap, plentiful meetings
-    // shouldn't crowd out the rows the user actually has to respond to.
-    return [...rsvpActions, ...voteActions, ...surveys, ...meetingActions];
+    // Order by actionability: pending invitations are the most actionable (someone is waiting on
+    // the user to join) and only ever appear on the Me lens, so they lead. RSVPs and votes have
+    // closing windows next. Surveys are time-bounded by their cutoff. Review Agenda is
+    // informational (read-before-meeting) and goes last — with the 5-item display cap, plentiful
+    // meetings shouldn't crowd out the rows the user actually has to respond to.
+    return [...invitationActions, ...rsvpActions, ...voteActions, ...surveys, ...meetingActions];
   }
 
   /**
@@ -1299,6 +1331,17 @@ export class UserService {
    * /votes) — there's no standalone vote-detail route, so the user lands on the list and picks
    * the vote to cast.
    */
+  /**
+   * Transform pending committee invitations into pending action rows. Invitations carry no
+   * closing window in the current committee-service contract, so the `date` field is only set
+   * when `expires_at` is (reserved for a future upstream that emits it). The badge prefers the
+   * project name and falls back to the committee name. `inviteUid` / `committeeUid` are carried
+   * through so the dashboard can call accept/decline inline.
+   */
+  private transformInvitationsToActions(invitations: PendingInvitation[]): PendingActionItem[] {
+    return buildInvitationActions(invitations);
+  }
+
   private transformVotesToActions(votes: Vote[]): PendingActionItem[] {
     return votes.map((vote) => {
       const endDate = new Date(vote.end_time);

--- a/packages/shared/src/constants/pending-action.constants.ts
+++ b/packages/shared/src/constants/pending-action.constants.ts
@@ -14,6 +14,7 @@ export const PENDING_ACTION_SEVERITY: Record<PendingActionType, TagSeverity> = {
   Survey: 'warn', // amber — pending survey, action needed
   Agenda: 'secondary', // gray — informational read-before-meeting cue
   Submitted: 'success', // green — completed survey/feedback acknowledgement, distinguishes from pending Survey
+  Invitation: 'success', // green — matches the design's green invite pill
 };
 
 /** Per-type CTA button icon — conveys the action rather than the category. */
@@ -23,6 +24,7 @@ export const PENDING_ACTION_BUTTON_ICON: Record<PendingActionType, string> = {
   Survey: 'fa-light fa-clipboard-list',
   Agenda: 'fa-light fa-list',
   Submitted: 'fa-light fa-circle-check',
+  Invitation: 'fa-light fa-user-plus',
 };
 
 /** Human-friendly display labels for the pending-action category tag. */
@@ -32,6 +34,7 @@ export const PENDING_ACTION_LABEL: Record<PendingActionType, string> = {
   Survey: 'Survey',
   Agenda: 'Agenda',
   Submitted: 'Submitted',
+  Invitation: 'Invitation',
 };
 
 /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -83,6 +83,61 @@ export interface CommitteeInvite {
 }
 
 /**
+ * Enriched, person-facing view model for a committee invitation surfaced to the
+ * invitee (dashboard pending-actions + My Groups). Built server-side by joining a
+ * committee-service `committee_invite` resource with its `committee` resource for
+ * display context (committee name, project name, category).
+ *
+ * The underlying `committee_invite` resource carries ONLY: uid, committee_uid,
+ * invitee_email, role, status, created_at. There is NO inviter name and NO expiry in
+ * the current committee-service contract — so {@link inviter_name} and
+ * {@link expires_at} are reserved, optional fields that stay `undefined` until/unless
+ * the committee-service starts emitting them. Do NOT fabricate either on the BFF.
+ */
+export interface PendingInvitation {
+  /** committee_invite UID — used for accept/decline */
+  uid: string;
+  /** Committee this invitation is for */
+  committee_uid: string;
+  /** Committee display name — enriched from the committee resource */
+  committee_name: string;
+  /** Project display name — enriched (optional) */
+  project_name?: string | null;
+  /** Committee category, for the My Groups class badge (optional) */
+  category?: string | null;
+  /** Suggested role on acceptance (from the invite) */
+  role?: string | null;
+  /** Email address the invitation was delivered to */
+  invitee_email: string;
+  /** Current invite status (surfaced rows are `pending`) */
+  status: CommitteeInviteStatus;
+  /** Creation timestamp (RFC3339) */
+  created_at: string;
+  /**
+   * Name of the person who sent the invitation. NOT in the current committee-service
+   * contract — populated only if upstream adds it. Stays `undefined` otherwise.
+   */
+  inviter_name?: string | null;
+  /**
+   * Expiration timestamp (RFC3339). NOT in the current committee-service contract —
+   * populated only if upstream adds it. Stays `undefined` otherwise.
+   */
+  expires_at?: string | null;
+}
+
+/**
+ * A decline that has been optimistically applied but not yet committed upstream — held while the
+ * deferred-undo timer runs so the dashboard can either fire the real decline when the timer elapses
+ * (or on component destroy) or roll it back if the user hits Undo.
+ */
+export interface PendingDecline {
+  /** committee_invite UID being declined */
+  inviteUid: string;
+  /** committee_uid the invite belongs to */
+  committeeUid: string;
+}
+
+/**
  * Payload to create a single committee invite (committee-service create-invite).
  * Only the invitee email is required; role is an optional suggestion.
  */

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -544,6 +544,8 @@ export interface DecoratedPendingAction extends PendingActionItem {
   voteUsesDrawer: boolean;
   /** True when the action is an Invitation (committee invite) that renders Accept/Decline controls inline. */
   isInvitation: boolean;
+  /** Invitation title text up to (and excluding) the group name — derived from `text` so the inline list renders the same copy as the drawer while linking just the group name. */
+  inviteTitlePrefix: string;
   /** Precomputed `aria-label` for the Accept control ("Accept invite to {inviteGroupName}") — built in TS so the template never calls a method. */
   acceptAriaLabel: string;
   /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -476,7 +476,7 @@ export interface ProgressItemWithChart extends ProgressItem {
  * Pending-action row discriminator. String union (not enum) so it round-trips through JSON
  * without value-vs-key reverse-mapping footguns.
  */
-export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda' | 'Submitted';
+export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda' | 'Submitted' | 'Invitation';
 
 /**
  * Pending action item for task list
@@ -505,6 +505,12 @@ export interface PendingActionItem {
   occurrenceId?: string;
   /** Vote UID (set on Vote action types so the dashboard can lazy-open the cast drawer inline without leaving the page). Populated by user.service.ts transformVotesToActions. */
   voteUid?: string;
+  /** committee_invite UID (set on Invitation action types). Used by the dashboard to call accept/decline on the invitation. */
+  inviteUid?: string;
+  /** committee_uid the invitation is for (set on Invitation action types). Paired with `inviteUid` to call accept/decline. */
+  committeeUid?: string;
+  /** Committee/group display name (set on Invitation action types). Used for the "You've joined {Group}" toast and the accept/decline `aria-label`, so the copy doesn't have to be parsed back out of `text`. */
+  inviteGroupName?: string;
 }
 
 /**
@@ -536,6 +542,12 @@ export interface DecoratedPendingAction extends PendingActionItem {
   isVoteInlineExpanded: boolean;
   /** True when this Vote row should use the drawer instead of inline (multi-question or ranked poll). */
   voteUsesDrawer: boolean;
+  /** True when the action is an Invitation (committee invite) that renders Accept/Decline controls inline. */
+  isInvitation: boolean;
+  /** Precomputed `aria-label` for the Accept control ("Accept invite to {inviteGroupName}") — built in TS so the template never calls a method. */
+  acceptAriaLabel: string;
+  /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */
+  declineAriaLabel: string;
 }
 
 /** Pending action row for the right-side drawer — adds inline-RSVP flags and per-row meeting-fetch state. */
@@ -552,6 +564,12 @@ export interface DrawerActionRow extends PendingActionItem {
   isMeetingLoading: boolean;
   /** True when the Meeting fetch failed; the row falls back to the regular buttonLink CTA so the user has a working action */
   meetingLoadFailed: boolean;
+  /** True when the action is an Invitation (committee invite) that renders Accept/Decline controls inline. */
+  isInvitation: boolean;
+  /** Precomputed `aria-label` for the Accept control ("Accept invite to {inviteGroupName}") — built in TS so the template never calls a method. */
+  acceptAriaLabel: string;
+  /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */
+  declineAriaLabel: string;
 }
 
 /** Lighter pending-action row used by committee-overview's static list — adds a stable `@for ... track` key. */

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -511,6 +511,8 @@ export interface PendingActionItem {
   committeeUid?: string;
   /** Committee/group display name (set on Invitation action types). Used for the "You've joined {Group}" toast and the accept/decline `aria-label`, so the copy doesn't have to be parsed back out of `text`. */
   inviteGroupName?: string;
+  /** Invitation title text up to (and excluding) the group name (set on Invitation action types), e.g. "You've been invited to " — built alongside `text` so the UI can link just the group name without runtime string-splitting. */
+  inviteTitlePrefix?: string;
 }
 
 /**
@@ -544,8 +546,6 @@ export interface DecoratedPendingAction extends PendingActionItem {
   voteUsesDrawer: boolean;
   /** True when the action is an Invitation (committee invite) that renders Accept/Decline controls inline. */
   isInvitation: boolean;
-  /** Invitation title text up to (and excluding) the group name — derived from `text` so the inline list renders the same copy as the drawer while linking just the group name. */
-  inviteTitlePrefix: string;
   /** Precomputed `aria-label` for the Accept control ("Accept invite to {inviteGroupName}") — built in TS so the template never calls a method. */
   acceptAriaLabel: string;
   /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -34,3 +34,4 @@ export * from './enrollment.utils';
 export * from './org-selector.utils';
 export * from './search.utils';
 export * from './email.utils';
+export * from './invitation.utils';

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for the pending-invitation pure helpers (LFXV2-2118).
+//
+// NOTE: this repo has no Angular unit-test runner wired (`ng test` has no target; component testing
+// is Playwright E2E only). The accept/decline interaction logic lives in components and is covered
+// by E2E; the framework-free row/copy logic is extracted here so it executes under the existing
+// Vitest suite (`yarn test` → packages/shared). All fixtures use synthetic placeholder data.
+
+import { describe, expect, it } from 'vitest';
+
+import { PendingInvitation } from '../interfaces/committee.interface';
+import { buildInvitationActions, buildInvitationSubtext } from './invitation.utils';
+
+/** Minimal invitation builder — only the fields the helpers read. */
+function invitation(overrides: Partial<PendingInvitation> = {}): PendingInvitation {
+  return {
+    uid: 'inv-1',
+    committee_uid: 'cmte-1',
+    committee_name: 'PyTorch TSC',
+    invitee_email: 'invitee@example.com',
+    status: 'pending',
+    created_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildInvitationActions', () => {
+  it('maps an invitation to an Invitation pending-action with accept/decline identifiers', () => {
+    const [action] = buildInvitationActions([invitation({ project_name: 'PyTorch' })]);
+
+    expect(action.type).toBe('Invitation');
+    expect(action.buttonText).toBe('Accept');
+    expect(action.inviteUid).toBe('inv-1');
+    expect(action.committeeUid).toBe('cmte-1');
+    expect(action.inviteGroupName).toBe('PyTorch TSC');
+  });
+
+  it('uses the project name as the badge, falling back to the committee name', () => {
+    expect(buildInvitationActions([invitation({ project_name: 'PyTorch' })])[0].badge).toBe('PyTorch');
+    expect(buildInvitationActions([invitation({ project_name: null })])[0].badge).toBe('PyTorch TSC');
+  });
+
+  it('degrades the title to "You\'ve been invited to {Group}" when no inviter is known', () => {
+    expect(buildInvitationActions([invitation()])[0].text).toBe("You've been invited to PyTorch TSC");
+  });
+
+  it('names the inviter in the title when present', () => {
+    const [action] = buildInvitationActions([invitation({ inviter_name: 'Nirav Patel' })]);
+    expect(action.text).toBe('Nirav Patel invited you to PyTorch TSC');
+  });
+
+  it('omits the date when the invite carries no expiry, and sets it when present', () => {
+    expect(buildInvitationActions([invitation()])[0].date).toBeUndefined();
+    expect(buildInvitationActions([invitation({ expires_at: '2026-06-20T00:00:00Z' })])[0].date).toBe('2026-06-20T00:00:00Z');
+  });
+
+  it('maps each invitation in order', () => {
+    const actions = buildInvitationActions([invitation({ uid: 'a' }), invitation({ uid: 'b' })]);
+    expect(actions.map((a) => a.inviteUid)).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildInvitationSubtext', () => {
+  it('returns "You\'ve been invited" with no inviter and no expiry', () => {
+    expect(buildInvitationSubtext(invitation())).toBe("You've been invited");
+  });
+
+  it('names the inviter when present', () => {
+    expect(buildInvitationSubtext(invitation({ inviter_name: 'Nirav Patel' }))).toBe('Nirav Patel invited you');
+  });
+
+  it('appends the formatted expiry only when both the expiry and a formatted string are supplied', () => {
+    expect(buildInvitationSubtext(invitation({ expires_at: '2026-06-20T00:00:00Z' }), 'Jun 20, 2026')).toBe("You've been invited · expires Jun 20, 2026");
+  });
+
+  it('does not append an expiry when the invite has no expires_at, even if a date string is passed', () => {
+    expect(buildInvitationSubtext(invitation(), 'Jun 20, 2026')).toBe("You've been invited");
+  });
+
+  it('falls back to base copy when the expiry is set but formatting produced nothing', () => {
+    expect(buildInvitationSubtext(invitation({ expires_at: '2026-06-20T00:00:00Z' }), null)).toBe("You've been invited");
+  });
+});

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -51,6 +51,14 @@ describe('buildInvitationActions', () => {
     expect(action.text).toBe('Nirav Patel invited you to PyTorch TSC');
   });
 
+  it('sets inviteTitlePrefix to the title minus the group name (so the UI links just the name without parsing)', () => {
+    expect(buildInvitationActions([invitation()])[0].inviteTitlePrefix).toBe("You've been invited to ");
+    expect(buildInvitationActions([invitation({ inviter_name: 'Nirav Patel' })])[0].inviteTitlePrefix).toBe('Nirav Patel invited you to ');
+    // text === prefix + committee_name
+    const [a] = buildInvitationActions([invitation()]);
+    expect(a.text).toBe(`${a.inviteTitlePrefix}PyTorch TSC`);
+  });
+
   it('omits the date when the invite carries no expiry', () => {
     expect(buildInvitationActions([invitation()])[0].date).toBeUndefined();
   });

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { PendingInvitation } from '../interfaces/committee.interface';
-import { buildInvitationActions, buildInvitationSubtext } from './invitation.utils';
+import { buildInvitationActions, buildInvitationSubtext, findPendingInvitationForCommittee } from './invitation.utils';
 
 /** Minimal invitation builder — only the fields the helpers read. */
 function invitation(overrides: Partial<PendingInvitation> = {}): PendingInvitation {
@@ -81,5 +81,26 @@ describe('buildInvitationSubtext', () => {
 
   it('falls back to base copy when the expiry is set but formatting produced nothing', () => {
     expect(buildInvitationSubtext(invitation({ expires_at: '2026-06-20T00:00:00Z' }), null)).toBe("You've been invited");
+  });
+});
+
+describe('findPendingInvitationForCommittee', () => {
+  const invites = [invitation({ uid: 'i1', committee_uid: 'c1' }), invitation({ uid: 'i2', committee_uid: 'c2' })];
+
+  it('returns the unresolved invite matching the committee UID', () => {
+    expect(findPendingInvitationForCommittee(invites, new Set(), 'c2')?.uid).toBe('i2');
+  });
+
+  it('returns null when no invite matches the committee', () => {
+    expect(findPendingInvitationForCommittee(invites, new Set(), 'c3')).toBeNull();
+  });
+
+  it('returns null when the committee UID is missing', () => {
+    expect(findPendingInvitationForCommittee(invites, new Set(), null)).toBeNull();
+    expect(findPendingInvitationForCommittee(invites, new Set(), undefined)).toBeNull();
+  });
+
+  it('excludes an invite already resolved this session', () => {
+    expect(findPendingInvitationForCommittee(invites, new Set(['i1']), 'c1')).toBeNull();
   });
 });

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { PendingInvitation } from '../interfaces/committee.interface';
-import { buildInvitationActions, buildInvitationSubtext, findPendingInvitationForCommittee } from './invitation.utils';
+import { buildInvitationActions, buildInvitationSubtext, findPendingInvitationForCommittee, formatInviteExpiry } from './invitation.utils';
 
 /** Minimal invitation builder — only the fields the helpers read. */
 function invitation(overrides: Partial<PendingInvitation> = {}): PendingInvitation {
@@ -51,9 +51,19 @@ describe('buildInvitationActions', () => {
     expect(action.text).toBe('Nirav Patel invited you to PyTorch TSC');
   });
 
-  it('omits the date when the invite carries no expiry, and sets it when present', () => {
+  it('omits the date when the invite carries no expiry', () => {
     expect(buildInvitationActions([invitation()])[0].date).toBeUndefined();
-    expect(buildInvitationActions([invitation({ expires_at: '2026-06-20T00:00:00Z' })])[0].date).toBe('2026-06-20T00:00:00Z');
+  });
+
+  it('sets a formatted (not raw ISO) display date when an expiry is present', () => {
+    const { date } = buildInvitationActions([invitation({ expires_at: '2026-06-20T12:00:00Z' })])[0];
+    expect(date).toBeDefined();
+    expect(date).not.toContain('T'); // not the raw ISO timestamp
+    expect(date).toMatch(/2026/); // human-readable, includes the year
+  });
+
+  it('omits the date when the expiry is an unparseable timestamp', () => {
+    expect(buildInvitationActions([invitation({ expires_at: 'not-a-date' })])[0].date).toBeUndefined();
   });
 
   it('maps each invitation in order', () => {
@@ -102,5 +112,25 @@ describe('findPendingInvitationForCommittee', () => {
 
   it('excludes an invite already resolved this session', () => {
     expect(findPendingInvitationForCommittee(invites, new Set(['i1']), 'c1')).toBeNull();
+  });
+});
+
+describe('formatInviteExpiry', () => {
+  it('returns null for missing values', () => {
+    expect(formatInviteExpiry(null)).toBeNull();
+    expect(formatInviteExpiry(undefined)).toBeNull();
+    expect(formatInviteExpiry('')).toBeNull();
+  });
+
+  it('returns null for an unparseable timestamp (no "Invalid Date")', () => {
+    expect(formatInviteExpiry('not-a-date')).toBeNull();
+  });
+
+  it('formats a valid RFC3339 timestamp as a human-readable date', () => {
+    const formatted = formatInviteExpiry('2026-06-20T12:00:00Z');
+    expect(formatted).not.toBeNull();
+    expect(formatted).not.toContain('T');
+    expect(formatted).not.toContain('Invalid');
+    expect(formatted).toMatch(/2026/);
   });
 });

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -35,12 +35,14 @@ export function formatInviteExpiry(expiresAt: string | null | undefined): string
 export function buildInvitationActions(invitations: PendingInvitation[]): PendingActionItem[] {
   return invitations.map((invitation) => {
     const expiry = formatInviteExpiry(invitation.expires_at);
+    // Build the title and its prefix from the same inputs so the UI can link just the group name
+    // without runtime string-splitting (`text` = `${prefix}${committee_name}`).
+    const titlePrefix = invitation.inviter_name ? `${invitation.inviter_name} invited you to ` : `You've been invited to `;
     return {
       type: 'Invitation',
       badge: invitation.project_name || invitation.committee_name,
-      text: invitation.inviter_name
-        ? `${invitation.inviter_name} invited you to ${invitation.committee_name}`
-        : `You've been invited to ${invitation.committee_name}`,
+      text: `${titlePrefix}${invitation.committee_name}`,
+      inviteTitlePrefix: titlePrefix,
       icon: PENDING_ACTION_BUTTON_ICON.Invitation,
       severity: PENDING_ACTION_SEVERITY.Invitation,
       buttonText: 'Accept',

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_SEVERITY } from '../constants/pending-action.constants';
+import { PendingActionItem } from '../interfaces/components.interface';
+import { PendingInvitation } from '../interfaces/committee.interface';
+
+/**
+ * Pure mapping from enriched pending committee invitations to dashboard pending-action rows.
+ *
+ * Extracted from the server aggregator so the row shape — the copy fallback, the accept/decline
+ * identifiers, and the per-type tag tone — is unit-testable without standing up the Express stack.
+ * Both the inviter name and the expiry are usually absent in the current committee-service contract;
+ * the title degrades to "You've been invited to {Group}" and no `date` is set when `expires_at` is
+ * missing, so the row never depends on email dispatch (the LFXV2-2117 fallback requirement).
+ */
+export function buildInvitationActions(invitations: PendingInvitation[]): PendingActionItem[] {
+  return invitations.map((invitation) => ({
+    type: 'Invitation',
+    badge: invitation.project_name || invitation.committee_name,
+    text: invitation.inviter_name
+      ? `${invitation.inviter_name} invited you to ${invitation.committee_name}`
+      : `You've been invited to ${invitation.committee_name}`,
+    icon: PENDING_ACTION_BUTTON_ICON.Invitation,
+    severity: PENDING_ACTION_SEVERITY.Invitation,
+    buttonText: 'Accept',
+    inviteUid: invitation.uid,
+    committeeUid: invitation.committee_uid,
+    inviteGroupName: invitation.committee_name,
+    ...(invitation.expires_at ? { date: invitation.expires_at } : {}),
+  }));
+}
+
+/**
+ * Pure builder for the secondary line on a pending-invitation row.
+ *
+ * Base copy is "{inviter_name} invited you" when an inviter is known (usually it isn't), otherwise
+ * "You've been invited". When the invite carries an expiry, " · expires {formattedExpiry}" is
+ * appended — the caller passes the already-formatted date string (e.g. via Angular's `DatePipe`) so
+ * this stays framework-free and testable.
+ */
+export function buildInvitationSubtext(invitation: PendingInvitation, formattedExpiry?: string | null): string {
+  const base = invitation.inviter_name ? `${invitation.inviter_name} invited you` : `You've been invited`;
+  if (!invitation.expires_at || !formattedExpiry) {
+    return base;
+  }
+  return `${base} · expires ${formattedExpiry}`;
+}

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -32,6 +32,25 @@ export function buildInvitationActions(invitations: PendingInvitation[]): Pendin
 }
 
 /**
+ * Finds the current user's unresolved pending invitation for a specific committee, or null.
+ *
+ * Shared by the group-detail invite banner: it matches the shared invitation cache against the
+ * committee being viewed, excluding any invite already accepted/declined this session (so the banner
+ * disappears the moment the user acts, in sync with the other surfaces). Returns null when there is
+ * no committee UID or no matching pending invite.
+ */
+export function findPendingInvitationForCommittee(
+  invitations: PendingInvitation[],
+  resolvedUids: ReadonlySet<string>,
+  committeeUid: string | null | undefined
+): PendingInvitation | null {
+  if (!committeeUid) {
+    return null;
+  }
+  return invitations.find((invite) => invite.committee_uid === committeeUid && !resolvedUids.has(invite.uid)) ?? null;
+}
+
+/**
  * Pure builder for the secondary line on a pending-invitation row.
  *
  * Base copy is "{inviter_name} invited you" when an inviter is known (usually it isn't), otherwise

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -6,29 +6,50 @@ import { PendingActionItem } from '../interfaces/components.interface';
 import { PendingInvitation } from '../interfaces/committee.interface';
 
 /**
+ * Formats an invite expiry (RFC3339) into a short display string (e.g. "Jun 20, 2026"), or null when
+ * the value is missing or not a parseable date. Guarding the parse keeps a malformed upstream
+ * timestamp from surfacing "Invalid Date" in the UI — callers fall back to no-expiry copy on null.
+ */
+export function formatInviteExpiry(expiresAt: string | null | undefined): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/**
  * Pure mapping from enriched pending committee invitations to dashboard pending-action rows.
  *
  * Extracted from the server aggregator so the row shape — the copy fallback, the accept/decline
  * identifiers, and the per-type tag tone — is unit-testable without standing up the Express stack.
  * Both the inviter name and the expiry are usually absent in the current committee-service contract;
  * the title degrades to "You've been invited to {Group}" and no `date` is set when `expires_at` is
- * missing, so the row never depends on email dispatch (the LFXV2-2117 fallback requirement).
+ * missing, so the row never depends on email dispatch (the LFXV2-2117 fallback requirement). When an
+ * expiry IS present it's formatted for display (`PendingActionItem.date` is a human-readable string,
+ * not a raw ISO timestamp).
  */
 export function buildInvitationActions(invitations: PendingInvitation[]): PendingActionItem[] {
-  return invitations.map((invitation) => ({
-    type: 'Invitation',
-    badge: invitation.project_name || invitation.committee_name,
-    text: invitation.inviter_name
-      ? `${invitation.inviter_name} invited you to ${invitation.committee_name}`
-      : `You've been invited to ${invitation.committee_name}`,
-    icon: PENDING_ACTION_BUTTON_ICON.Invitation,
-    severity: PENDING_ACTION_SEVERITY.Invitation,
-    buttonText: 'Accept',
-    inviteUid: invitation.uid,
-    committeeUid: invitation.committee_uid,
-    inviteGroupName: invitation.committee_name,
-    ...(invitation.expires_at ? { date: invitation.expires_at } : {}),
-  }));
+  return invitations.map((invitation) => {
+    const expiry = formatInviteExpiry(invitation.expires_at);
+    return {
+      type: 'Invitation',
+      badge: invitation.project_name || invitation.committee_name,
+      text: invitation.inviter_name
+        ? `${invitation.inviter_name} invited you to ${invitation.committee_name}`
+        : `You've been invited to ${invitation.committee_name}`,
+      icon: PENDING_ACTION_BUTTON_ICON.Invitation,
+      severity: PENDING_ACTION_SEVERITY.Invitation,
+      buttonText: 'Accept',
+      inviteUid: invitation.uid,
+      committeeUid: invitation.committee_uid,
+      inviteGroupName: invitation.committee_name,
+      ...(expiry ? { date: expiry } : {}),
+    };
+  });
 }
 
 /**
@@ -55,8 +76,8 @@ export function findPendingInvitationForCommittee(
  *
  * Base copy is "{inviter_name} invited you" when an inviter is known (usually it isn't), otherwise
  * "You've been invited". When the invite carries an expiry, " · expires {formattedExpiry}" is
- * appended — the caller passes the already-formatted date string (e.g. via Angular's `DatePipe`) so
- * this stays framework-free and testable.
+ * appended — the caller passes the already-formatted date string (e.g. via {@link formatInviteExpiry})
+ * so this stays framework-free and testable.
  */
 export function buildInvitationSubtext(invitation: PendingInvitation, formattedExpiry?: string | null): string {
   const base = invitation.inviter_name ? `${invitation.inviter_name} invited you` : `You've been invited`;


### PR DESCRIPTION
## What

Surfaces pending committee/group invitations **in-app** so an invite is visible and actionable without depending on email delivery — the reliable fallback for [LFXV2-2117](https://linuxfoundation.atlassian.net/browse/LFXV2-2117) (invite emails never sent). Two surfaces, one shared source of truth:

- **Dashboard "My Pending Actions"** — a new `Invitation` pending-action row (`{Inviter} invited you to {Group}` / "You've been invited to {Group}"), **Accept** (primary) + **Decline**. Accept is optimistic with a "You've joined {Group}" toast; Decline uses a deferred-undo toast (the upstream decline only fires after the undo window).
- **My Groups** — a distinct **Invitations** section above the active-groups table (Me lens), each row badged **Invited** with inline Accept/Decline.

Acting in one surface reflects in the other via a shared `InvitationService` cache + a `resolvedInviteUids` set (cross-surface sync, with undo).

Resolves [LFXV2-2118](https://linuxfoundation.atlassian.net/browse/LFXV2-2118).

## How it's wired (no upstream changes)

The committee-service already supports the full invitee flow — this PR is **thin BFF passthroughs** to endpoints that already exist:

| Capability | BFF route (new) | Upstream (existing) |
|---|---|---|
| List my pending invites | `GET /api/user/pending-invitations` | query-service `type=committee_invite&tags=invitee_email:{email}` |
| Accept | `POST /api/committees/:id/invites/:inviteId/accept` | `POST /committees/{uid}/invites/{invite_uid}/accept` |
| Decline | `POST /api/committees/:id/invites/:inviteId/decline` | `POST /committees/{uid}/invites/{invite_uid}/decline` |

Invitations are folded into the existing `/api/user/pending-actions` aggregator (Me lens only). Accept/decline use the **user bearer token** (upstream enforces `principal == invitee_email`) — no M2M.

## Accessibility

Real `<button>`s with `aria-label` including the group name; status conveyed by the "Invited" text, not color alone; toasts via PrimeNG `p-toast` (aria-live polite); `data-testid` on every interactive control.

## Tests

Pure row/copy logic is extracted to `packages/shared/src/utils/invitation.utils.ts` and covered by `invitation.utils.spec.ts` — **runnable** under the existing Vitest suite (`yarn test`, +11 tests).

⚠️ **The app has no Angular unit-test runner** (`ng test` has no target; component testing is Playwright E2E only — see the note atop `packages/shared/src/utils/committee.utils.spec.ts`). Accept/decline **interaction** logic lives in components and is not unit-tested here; an E2E spec against a seeded invitation fixture is the right follow-up.

## Known limitations / follow-ups

- **No inviter name or expiry** in the `committee_invite` contract — those fields are modeled as optional and the copy degrades to "You've been invited to {Group}". The mocks show inviter/expiry; surfacing them needs an upstream change.
- **Runtime check for the committee-service team:** confirm the query-service scopes `committee_invite` reads to the invitee (the BFF derives the email server-side from the authenticated session, so it isn't a client-exposed surface).
- Scope is **committees/groups** only (per the spec's v1 phasing).

## Notes for review

- Diff is ~1.2k lines — above the 1000 target, but it's a single cohesive vertical slice (shared types → BFF → two front-end surfaces) intentionally kept together.
- Pre-PR review: ran the post-commit reviewer pair + the full-branch sweep. All findings addressed (PII-in-logs, log level, JSDoc, decline-toast race, `encodeURIComponent`, `effect()`→`toObservable`) except the documented no-unit-runner spec gap above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2117]: https://linuxfoundation.atlassian.net/browse/LFXV2-2117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2118]: https://linuxfoundation.atlassian.net/browse/LFXV2-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ