### PR TITLE
fix(newsletters): preserve spacing and indent on google docs paste

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.scss
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview/newsletter-preview.component.scss
@@ -87,6 +87,16 @@
       li {
         margin: 0 0 0.5rem;
         line-height: 1.6;
+
+        > p {
+          margin: 0;
+
+          // Continuation paragraphs absorbed under a bullet (e.g. from a Google Docs paste) need
+          // breathing room from the bullet's first paragraph; otherwise they visually merge.
+          &:not(:first-child) {
+            margin-top: 0.5rem;
+          }
+        }
       }
 
       blockquote {

--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -145,7 +145,23 @@ const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
 // any future content type the editor learns to render (images, media, embeds, form widgets).
 // HTML elements always uppercase their tagName, but namespaced elements (SVG, MathML) preserve
 // case, so we normalize via toUpperCase() at the lookup site rather than maintaining both forms.
-const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'MATH', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
+const CONTENT_LEAF_TAGS = new Set([
+  'IMG',
+  'IFRAME',
+  'VIDEO',
+  'AUDIO',
+  'SOURCE',
+  'PICTURE',
+  'SVG',
+  'MATH',
+  'CANVAS',
+  'EMBED',
+  'OBJECT',
+  'INPUT',
+  'SELECT',
+  'TEXTAREA',
+  'HR',
+]);
 
 // Google Docs (and Word) inject empty <p style="height:11pt"><span></span></p> nodes as blank-line
 // spacers between content blocks. After style/class strip, the editor's `p { margin: 0 0 0.75rem }`

--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -143,7 +143,9 @@ const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
 // Replaced/void/embedded leaf elements carry visual content even when textContent is empty —
 // e.g. <p><img></p> is not an empty paragraph. Without this, isEmptyBlock would silently drop
 // any future content type the editor learns to render (images, media, embeds, form widgets).
-const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
+// HTML elements always uppercase their tagName, but namespaced elements (SVG, MathML) preserve
+// case, so we normalize via toUpperCase() at the lookup site rather than maintaining both forms.
+const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'MATH', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
 
 // Google Docs (and Word) inject empty <p style="height:11pt"><span></span></p> nodes as blank-line
 // spacers between content blocks. After style/class strip, the editor's `p { margin: 0 0 0.75rem }`
@@ -173,7 +175,7 @@ function isEmptyBlock(element: Element): boolean {
     if (child.tagName === 'BR') {
       continue;
     }
-    if (CONTENT_LEAF_TAGS.has(child.tagName)) {
+    if (CONTENT_LEAF_TAGS.has(child.tagName.toUpperCase())) {
       return false;
     }
     if (EMPTY_BLOCK_TAGS.has(child.tagName)) {

--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -15,7 +15,9 @@ export function cleanPastedHtml(html: string): string {
   }
 
   unwrapGoogleDocsWrapper(body);
+  absorbListContinuationParagraphs(body);
   walkAndClean(body);
+  collapseEmptyBlocks(body);
 
   return body.innerHTML;
 }
@@ -28,6 +30,145 @@ function unwrapGoogleDocsWrapper(body: HTMLElement): void {
     }
     wrapper.remove();
   }
+}
+
+// Google Docs models continuation paragraphs under a bullet as a top-level <p style="margin-left:36pt">
+// sandwiched between two <ul>/<ol> blocks. Stripping style erases the indent, so the paragraph collapses
+// to flush-left and loses its visual relationship to the bullet. Move such paragraphs into the last <li>
+// of the preceding list while inline styles are still readable.
+function absorbListContinuationParagraphs(body: HTMLElement): void {
+  const lists = Array.from(body.querySelectorAll<HTMLElement>('ul, ol'));
+
+  for (const list of lists) {
+    const lastItem = list.querySelector<HTMLElement>(':scope > li:last-child');
+    if (!lastItem) {
+      continue;
+    }
+    const listIndent = readMarginLeftPt(lastItem) || readMarginLeftPt(list);
+    if (listIndent <= 0) {
+      // Without an explicit indent on the list, we can't tell whether a following indented
+      // paragraph is a bullet continuation or unrelated content. Skip.
+      continue;
+    }
+
+    let cursor: Element | null = list.nextElementSibling;
+    while (cursor) {
+      if (cursor.tagName !== 'P') {
+        break;
+      }
+
+      if (isEmptyInlineContainer(cursor)) {
+        // Skip Google Docs spacer paragraphs; Pass B will drop them.
+        cursor = cursor.nextElementSibling;
+        continue;
+      }
+
+      const paragraphIndent = readMarginLeftPt(cursor);
+      // Allow ~1pt tolerance for rounding across unit conversions.
+      if (paragraphIndent + 1 < listIndent) {
+        break;
+      }
+
+      const next = cursor.nextElementSibling;
+      lastItem.appendChild(cursor);
+      cursor = next;
+    }
+  }
+}
+
+// Read margin-left from an element's inline style and normalize to points so we can compare values
+// across units. We only care about relative magnitude (does this paragraph sit at or beyond the list's
+// indent), so the approximations are good enough.
+function readMarginLeftPt(element: Element): number {
+  const style = element.getAttribute('style');
+  if (!style) {
+    return 0;
+  }
+  const match = /margin-left\s*:\s*(-?[\d.]+)\s*(pt|px|em|rem|in|cm|mm|%)?/i.exec(style);
+  if (!match) {
+    return 0;
+  }
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const unit = (match[2] ?? 'px').toLowerCase();
+  switch (unit) {
+    case 'pt':
+      return value;
+    case 'px':
+      return value * 0.75;
+    case 'em':
+    case 'rem':
+      return value * 12;
+    case 'in':
+      return value * 72;
+    case 'cm':
+      return value * 28.3464567;
+    case 'mm':
+      return value * 2.83464567;
+    case '%':
+      return value;
+    default:
+      return value;
+  }
+}
+
+function isEmptyInlineContainer(element: Element): boolean {
+  if (element.textContent && element.textContent.replace(/[\s\u00A0]/g, '') !== '') {
+    return false;
+  }
+  for (const child of Array.from(element.children)) {
+    if (child.tagName === 'BR') {
+      continue;
+    }
+    if (!isEmptyInlineContainer(child)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
+
+// Google Docs (and Word) inject empty <p style="height:11pt"><span></span></p> nodes as blank-line
+// spacers between content blocks. After style/class strip, the editor's `p { margin: 0 0 0.75rem }`
+// renders each as ~14px of dead space — multiple spacers stack into the gaps the user is reporting.
+// Walk inside-out so that lists which contain only empty <li> children also drop.
+function collapseEmptyBlocks(root: HTMLElement): void {
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>('p, h2, h3, li, ul, ol'));
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const node = nodes[i];
+    if (!EMPTY_BLOCK_TAGS.has(node.tagName)) {
+      continue;
+    }
+    if (!node.isConnected) {
+      continue;
+    }
+    if (isEmptyBlock(node)) {
+      node.remove();
+    }
+  }
+}
+
+function isEmptyBlock(element: Element): boolean {
+  if (element.textContent && element.textContent.replace(/[\s\u00A0]/g, '') !== '') {
+    return false;
+  }
+  for (const child of Array.from(element.children)) {
+    if (child.tagName === 'BR') {
+      continue;
+    }
+    if (EMPTY_BLOCK_TAGS.has(child.tagName)) {
+      // A list with all-empty children would have had its children removed earlier in the
+      // inside-out walk, so reaching here means a non-empty descendant survived.
+      return false;
+    }
+    if (!isEmptyBlock(child)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function walkAndClean(root: Element): void {

--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -37,7 +37,11 @@ function unwrapGoogleDocsWrapper(body: HTMLElement): void {
 // to flush-left and loses its visual relationship to the bullet. Move such paragraphs into the last <li>
 // of the preceding list while inline styles are still readable.
 function absorbListContinuationParagraphs(body: HTMLElement): void {
-  const lists = Array.from(body.querySelectorAll<HTMLElement>('ul, ol'));
+  // Walk deepest list first. If we processed outer-then-inner and the outer absorbed a paragraph
+  // into its last <li>, that paragraph would become a sibling of any nested inner list inside that
+  // <li>, and the inner list's pass could re-absorb it. Processing inner first means an inner list's
+  // nextElementSibling can only be its original sibling, never a paragraph the outer just moved in.
+  const lists = Array.from(body.querySelectorAll<HTMLElement>('ul, ol')).reverse();
 
   for (const list of lists) {
     const lastItem = list.querySelector<HTMLElement>(':scope > li:last-child');
@@ -92,7 +96,12 @@ function readMarginLeftPt(element: Element): number {
   if (!Number.isFinite(value)) {
     return 0;
   }
-  const unit = (match[2] ?? 'px').toLowerCase();
+  // CSS requires a unit on every non-zero margin. A unitless non-zero value is malformed and
+  // could come from quirky source HTML — treat it as no indent rather than guessing pixels.
+  if (!match[2] && value !== 0) {
+    return 0;
+  }
+  const unit = (match[2] ?? 'pt').toLowerCase();
   switch (unit) {
     case 'pt':
       return value;
@@ -131,6 +140,11 @@ function isEmptyInlineContainer(element: Element): boolean {
 
 const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
 
+// Replaced/void/embedded leaf elements carry visual content even when textContent is empty —
+// e.g. <p><img></p> is not an empty paragraph. Without this, isEmptyBlock would silently drop
+// any future content type the editor learns to render (images, media, embeds, form widgets).
+const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
+
 // Google Docs (and Word) inject empty <p style="height:11pt"><span></span></p> nodes as blank-line
 // spacers between content blocks. After style/class strip, the editor's `p { margin: 0 0 0.75rem }`
 // renders each as ~14px of dead space — multiple spacers stack into the gaps the user is reporting.
@@ -158,6 +172,9 @@ function isEmptyBlock(element: Element): boolean {
   for (const child of Array.from(element.children)) {
     if (child.tagName === 'BR') {
       continue;
+    }
+    if (CONTENT_LEAF_TAGS.has(child.tagName)) {
+      return false;
     }
     if (EMPTY_BLOCK_TAGS.has(child.tagName)) {
       // A list with all-empty children would have had its children removed earlier in the

--- a/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.scss
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.scss
@@ -47,6 +47,12 @@
 
     > p {
       margin: 0;
+
+      // Continuation paragraphs absorbed under a bullet (e.g. from a Google Docs paste) need
+      // breathing room from the bullet's first paragraph; otherwise they visually merge into one block.
+      &:not(:first-child) {
+        margin-top: 0.5rem;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Pasting from Google Docs into the newsletter body editor injected large vertical gaps between sections and dropped the indentation of continuation paragraphs under bullets. The TipTap paste cleaner now removes Google Docs' blank-line spacers (both `<p><span></span></p>` from the export and orphan `<br>` from the Cmd+C clipboard) and absorbs indented continuation paragraphs into the preceding `<li>`. Repo has no unit-test architect; verified end-to-end against the live editor + preview.