### PR TITLE
fix(rich-editor): close remaining google docs paste spacing gaps

### DIFF
--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -1,7 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DROP_TAGS, STRIPPED_ATTRS, UNWRAP_TAGS } from '@lfx-one/shared/constants';
+import { CONTENT_LEAF_TAGS, DROP_TAGS, EMPTY_BLOCK_TAGS, PARAGRAPH_LIKE_TAGS, STRIPPED_ATTRS, UNWRAP_TAGS } from '@lfx-one/shared/constants';
+
+// CSS selector derived from PARAGRAPH_LIKE_TAGS for closest() lookups. closest() needs
+// lowercase tag names in a comma-separated string; the Set is the source of truth.
+const PARAGRAPH_LIKE_SELECTOR = Array.from(PARAGRAPH_LIKE_TAGS)
+  .map((tag) => tag.toLowerCase())
+  .join(',');
 
 export function cleanPastedHtml(html: string): string {
   if (!html || typeof DOMParser === 'undefined') {
@@ -37,17 +43,12 @@ function unwrapGoogleDocsWrapper(body: HTMLElement): void {
 // at the block-flow level (siblings of <p>), not with empty <p> spacers. ProseMirror's schema
 // doesn't allow <br> at block level, so it wraps each orphan <br> in a paragraph — producing
 // <p><br></p> empty paragraphs in the final document. Remove these orphan breaks before
-// ProseMirror parses; a <br> nested inside a paragraph-like element stays (legitimate hard break).
-const PARAGRAPH_LIKE_TAGS = new Set(['P', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'TD', 'TH', 'BLOCKQUOTE', 'FIGCAPTION', 'CAPTION', 'PRE']);
-
+// ProseMirror parses; a <br> with any paragraph-like ancestor stays (legitimate hard break,
+// including breaks inside inline wrappers like <p><span>line 1<br>line 2</span></p>).
 function removeBlockLevelBreaks(root: HTMLElement): void {
   const breaks = Array.from(root.querySelectorAll<HTMLBRElement>('br'));
   for (const br of breaks) {
-    const parent = br.parentElement;
-    if (!parent) {
-      continue;
-    }
-    if (PARAGRAPH_LIKE_TAGS.has(parent.tagName)) {
+    if (br.closest(PARAGRAPH_LIKE_SELECTOR)) {
       continue;
     }
     br.remove();
@@ -159,31 +160,6 @@ function isEmptyInlineContainer(element: Element): boolean {
   }
   return true;
 }
-
-const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
-
-// Replaced/void/embedded leaf elements carry visual content even when textContent is empty —
-// e.g. <p><img></p> is not an empty paragraph. Without this, isEmptyBlock would silently drop
-// any future content type the editor learns to render (images, media, embeds, form widgets).
-// HTML elements always uppercase their tagName, but namespaced elements (SVG, MathML) preserve
-// case, so we normalize via toUpperCase() at the lookup site rather than maintaining both forms.
-const CONTENT_LEAF_TAGS = new Set([
-  'IMG',
-  'IFRAME',
-  'VIDEO',
-  'AUDIO',
-  'SOURCE',
-  'PICTURE',
-  'SVG',
-  'MATH',
-  'CANVAS',
-  'EMBED',
-  'OBJECT',
-  'INPUT',
-  'SELECT',
-  'TEXTAREA',
-  'HR',
-]);
 
 // Google Docs (and Word) inject empty <p style="height:11pt"><span></span></p> nodes as blank-line
 // spacers between content blocks. After style/class strip, the editor's `p { margin: 0 0 0.75rem }`

--- a/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/clean-pasted-html.util.ts
@@ -15,6 +15,7 @@ export function cleanPastedHtml(html: string): string {
   }
 
   unwrapGoogleDocsWrapper(body);
+  removeBlockLevelBreaks(body);
   absorbListContinuationParagraphs(body);
   walkAndClean(body);
   collapseEmptyBlocks(body);
@@ -29,6 +30,27 @@ function unwrapGoogleDocsWrapper(body: HTMLElement): void {
       body.insertBefore(wrapper.firstChild, wrapper);
     }
     wrapper.remove();
+  }
+}
+
+// Google Docs' Cmd+C clipboard format separates paragraphs with standalone <br /> elements
+// at the block-flow level (siblings of <p>), not with empty <p> spacers. ProseMirror's schema
+// doesn't allow <br> at block level, so it wraps each orphan <br> in a paragraph — producing
+// <p><br></p> empty paragraphs in the final document. Remove these orphan breaks before
+// ProseMirror parses; a <br> nested inside a paragraph-like element stays (legitimate hard break).
+const PARAGRAPH_LIKE_TAGS = new Set(['P', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'TD', 'TH', 'BLOCKQUOTE', 'FIGCAPTION', 'CAPTION', 'PRE']);
+
+function removeBlockLevelBreaks(root: HTMLElement): void {
+  const breaks = Array.from(root.querySelectorAll<HTMLBRElement>('br'));
+  for (const br of breaks) {
+    const parent = br.parentElement;
+    if (!parent) {
+      continue;
+    }
+    if (PARAGRAPH_LIKE_TAGS.has(parent.tagName)) {
+      continue;
+    }
+    br.remove();
   }
 }
 

--- a/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.ts
@@ -133,7 +133,7 @@ export class RichEditorComponent {
       editable: !this.readonly(),
       editorProps: {
         attributes: {
-          class: 'lfx-rich-editor__content prose prose-sm max-w-none focus:outline-none',
+          class: 'lfx-rich-editor__content max-w-none focus:outline-none',
           'data-testid': this.dataTest() ?? '',
         },
         transformPastedHTML: (html: string) => cleanPastedHtml(html),

--- a/packages/shared/src/constants/rich-editor.constants.ts
+++ b/packages/shared/src/constants/rich-editor.constants.ts
@@ -13,7 +13,23 @@ export const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
 
 // Replaced/void/embedded leaf elements that carry visual content even when textContent
 // is empty — keep paragraphs/list-items that hold these even if no text is present.
-export const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'MATH', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
+export const CONTENT_LEAF_TAGS = new Set([
+  'IMG',
+  'IFRAME',
+  'VIDEO',
+  'AUDIO',
+  'SOURCE',
+  'PICTURE',
+  'SVG',
+  'MATH',
+  'CANVAS',
+  'EMBED',
+  'OBJECT',
+  'INPUT',
+  'SELECT',
+  'TEXTAREA',
+  'HR',
+]);
 
 // Paragraph-like containers where a <br> child is a legitimate hard break (not a
 // block-flow spacer). Used to decide whether a pasted <br> should be preserved.

--- a/packages/shared/src/constants/rich-editor.constants.ts
+++ b/packages/shared/src/constants/rich-editor.constants.ts
@@ -7,6 +7,18 @@ export const STRIPPED_ATTRS = ['style', 'class', 'id', 'dir', 'lang', 'align', '
 export const UNWRAP_TAGS = new Set(['SPAN', 'FONT', 'O:P']);
 export const DROP_TAGS = new Set(['META', 'STYLE', 'SCRIPT', 'LINK', 'TITLE']);
 
+// Block-level structural tags the editor renders with margin; treated as removable
+// when empty so Google Docs blank-line spacers don't survive a paste cleanup.
+export const EMPTY_BLOCK_TAGS = new Set(['P', 'H2', 'H3', 'LI', 'UL', 'OL']);
+
+// Replaced/void/embedded leaf elements that carry visual content even when textContent
+// is empty — keep paragraphs/list-items that hold these even if no text is present.
+export const CONTENT_LEAF_TAGS = new Set(['IMG', 'IFRAME', 'VIDEO', 'AUDIO', 'SOURCE', 'PICTURE', 'SVG', 'MATH', 'CANVAS', 'EMBED', 'OBJECT', 'INPUT', 'SELECT', 'TEXTAREA', 'HR']);
+
+// Paragraph-like containers where a <br> child is a legitimate hard break (not a
+// block-flow spacer). Used to decide whether a pasted <br> should be preserved.
+export const PARAGRAPH_LIKE_TAGS = new Set(['P', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'TD', 'TH', 'BLOCKQUOTE', 'FIGCAPTION', 'CAPTION', 'PRE']);
+
 export const RICH_EDITOR_TOOLBAR_BUTTONS: readonly RichEditorToolbarButton[] = [
   { id: 'h2', icon: 'fa-light fa-h2', label: 'Heading 2', command: 'h2', activeKey: 'heading', activeAttrs: { level: 2 } },
   { id: 'h3', icon: 'fa-light fa-h3', label: 'Heading 3', command: 'h3', activeKey: 'heading', activeAttrs: { level: 3 } },


### PR DESCRIPTION
## Summary

Follow-up to #886. Two issues surfaced when testing the live editor against a real Google Docs Cmd+C paste (not the API export the first PR was tested against):

- The Cmd+C clipboard separates paragraphs with standalone `<br />` siblings of `<p>`, which ProseMirror wraps in its own paragraph — producing visible empty `<p><br></p>` blocks between every section. The cleaner now strips `<br>` whose parent is a block-flow container (siblings of `<p>`/`<ul>`/etc.); `<br>` inside a paragraph stays as a legitimate hard break.
- `prose prose-sm` Tailwind typography classes on the editor element were layering em-based paragraph margins on top of the component's own SCSS, making sections appear with more space than the source document. Removed; the component SCSS already covers every element the toolbar can emit.