### PR TITLE
feat(votes): color due-date labels by urgency

### DIFF
--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -159,7 +159,7 @@
                   <div class="flex flex-col gap-0.5">
                     <span class="text-sm text-gray-700">{{ survey.survey_cutoff_date | date: 'MMM d, y' }}</span>
                     @if (dueDateLabelValue) {
-                      <span class="text-xs text-gray-500">{{ dueDateLabelValue }}</span>
+                      <span class="text-xs {{ dueDateLabelValue | dueDateLabelColor }}">{{ dueDateLabelValue }}</span>
                     }
                   </div>
                 } @else {

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -16,6 +16,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
 import { FilterPillOption, Survey } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { SurveyStatusLabelPipe } from '@pipes/survey-status-label.pipe';
 import { SurveyStatusSeverityPipe } from '@pipes/survey-status-severity.pipe';
@@ -39,6 +40,7 @@ import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
     SurveyStatusLabelPipe,
     SurveyStatusSeverityPipe,
     DueDateLabelPipe,
+    DueDateLabelColorPipe,
     TooltipModule,
     ConfirmDialogModule,
     EmptyStateComponent,

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -140,7 +140,7 @@
                   <div class="flex flex-col gap-0.5">
                     <span class="text-sm text-gray-700">{{ vote.end_time | date: 'MMM d, y' }}</span>
                     @if (dueDateLabelValue) {
-                      <span class="text-xs text-gray-500">{{ dueDateLabelValue }}</span>
+                      <span class="text-xs {{ dueDateLabelValue | dueDateLabelColor }}">{{ dueDateLabelValue }}</span>
                     }
                   </div>
                 } @else {

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -16,6 +16,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
 import { FilterPillOption, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
+import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
@@ -41,6 +42,7 @@ import { combineLatest, debounceTime, distinctUntilChanged, map, startWith, take
     PollStatusLabelPipe,
     PollStatusSeverityPipe,
     DueDateLabelPipe,
+    DueDateLabelColorPipe,
     TooltipModule,
     ConfirmDialogModule,
     EmptyStateComponent,

--- a/apps/lfx-one/src/app/shared/pipes/due-date-label-color.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/due-date-label-color.pipe.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+// Keyed off the labels emitted by DueDateLabelPipe; defaults to neutral gray.
+const DUE_DATE_LABEL_COLORS: Record<string, string> = {
+  'Closes today': 'text-red-600',
+  'Closes tomorrow': 'text-amber-600',
+};
+
+const DEFAULT_DUE_DATE_LABEL_COLOR = 'text-gray-500';
+
+@Pipe({
+  name: 'dueDateLabelColor',
+})
+export class DueDateLabelColorPipe implements PipeTransform {
+  public transform(dueDateLabel: string): string {
+    return DUE_DATE_LABEL_COLORS[dueDateLabel] || DEFAULT_DUE_DATE_LABEL_COLOR;
+  }
+}

--- a/apps/lfx-one/src/app/shared/pipes/due-date-label-color.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/due-date-label-color.pipe.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { DUE_DATE_LABELS } from '@lfx-one/shared';
 
 // Keyed off the labels emitted by DueDateLabelPipe; defaults to neutral gray.
 const DUE_DATE_LABEL_COLORS: Record<string, string> = {
-  'Closes today': 'text-red-600',
-  'Closes tomorrow': 'text-amber-600',
+  [DUE_DATE_LABELS.CLOSES_TODAY]: 'text-red-600',
+  [DUE_DATE_LABELS.CLOSES_TOMORROW]: 'text-amber-600',
 };
 
 const DEFAULT_DUE_DATE_LABEL_COLOR = 'text-gray-500';

--- a/apps/lfx-one/src/app/shared/pipes/due-date-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/due-date-label.pipe.ts
@@ -16,18 +16,22 @@ export class DueDateLabelPipe implements PipeTransform {
     const diffTime = dueDay.getTime() - today.getTime();
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
-    if (diffDays <= 0) return '';
+    // Past due: the row already shows the absolute date, so emit no countdown (mirrors the drawer once daysLeft < 0).
+    if (diffDays < 0) return '';
+
+    if (diffDays === 0) return 'Closes today';
+    if (diffDays === 1) return 'Closes tomorrow';
 
     if (diffDays < 14) {
-      return `Due in ${diffDays} ${diffDays === 1 ? 'day' : 'days'}`;
+      return `Closes in ${diffDays} days`;
     }
 
     if (diffDays <= 41) {
       const weeks = Math.round(diffDays / 7);
-      return `Due in ${weeks} ${weeks === 1 ? 'week' : 'weeks'}`;
+      return `Closes in ${weeks} ${weeks === 1 ? 'week' : 'weeks'}`;
     }
 
     const months = Math.round(diffDays / 30);
-    return `Due in ${months} ${months === 1 ? 'month' : 'months'}`;
+    return `Closes in ${months} ${months === 1 ? 'month' : 'months'}`;
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/due-date-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/due-date-label.pipe.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { DUE_DATE_LABELS } from '@lfx-one/shared';
 
 @Pipe({
   name: 'dueDateLabel',
@@ -19,8 +20,8 @@ export class DueDateLabelPipe implements PipeTransform {
     // Past due: the row already shows the absolute date, so emit no countdown (mirrors the drawer once daysLeft < 0).
     if (diffDays < 0) return '';
 
-    if (diffDays === 0) return 'Closes today';
-    if (diffDays === 1) return 'Closes tomorrow';
+    if (diffDays === 0) return DUE_DATE_LABELS.CLOSES_TODAY;
+    if (diffDays === 1) return DUE_DATE_LABELS.CLOSES_TOMORROW;
 
     if (diffDays < 14) {
       return `Closes in ${diffDays} days`;

--- a/packages/shared/src/constants/due-date.constants.ts
+++ b/packages/shared/src/constants/due-date.constants.ts
@@ -1,0 +1,8 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Shared so DueDateLabelPipe wording and DueDateLabelColorPipe lookups can't desync.
+export const DUE_DATE_LABELS = {
+  CLOSES_TODAY: 'Closes today',
+  CLOSES_TOMORROW: 'Closes tomorrow',
+} as const;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -67,3 +67,4 @@ export * from './vote.constants';
 export * from './docs.constant';
 export * from './linux-email.constants';
 export * from './rich-editor.constants';
+export * from './due-date.constants';


### PR DESCRIPTION
# Summary

The votes and surveys tables now signal closing urgency through color: due-date labels render red for "Closes today" and amber for "Closes tomorrow", with everything further out staying neutral gray. This makes time-sensitive polls and surveys stand out at a glance in the list views.

The branch also includes the underlying label fix that surfaces "Closes today" / "Closes tomorrow" wording (previously same-day items were swallowed). Coloring is driven by a small pure `DueDateLabelColorPipe` that maps the label text to a Tailwind color scale, keeping the three class bindings out of the templates and shared cleanly across both tables.