### PR TITLE
fix(org-lens): synthetic test data for Board & Committee (PII remediation)

### DIFF
--- a/apps/lfx-one/e2e/org-membership-board-committee.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-board-committee.spec.ts
@@ -21,7 +21,7 @@
  * Prerequisites:
  * - Dev server running on localhost:4200 (auto via Playwright webServer)
  * - User authenticated via Auth0 (auto via global-setup, .env credentials)
- * - `org-lens-enabled` LaunchDarkly flag on (handled by org-lens-flag-toggle skill defaults)
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
  * - Organization context selected (existing AccountContextService default applies)
  *
  * Mock semantics (v1): every foundationId returns the same shared payload (FR-009c),
@@ -32,7 +32,7 @@
 import { expect, test } from '@playwright/test';
 
 const DETAIL_URL_FOUNDATION = '/org/memberships/sample-foundation';
-const DETAIL_URL_BOARD = '/org/memberships/sample-foundation#board';
+const DETAIL_URL_BOARD = `${DETAIL_URL_FOUNDATION}#board`;
 const DATA_LOAD_TIMEOUT = 30_000;
 
 test.setTimeout(90_000);

--- a/apps/lfx-one/e2e/org-membership-board-committee.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-board-committee.spec.ts
@@ -5,7 +5,7 @@
  * Board & Committee Tab E2E Tests (spec 016)
  *
  * Covers spec 016-board-committee-tab success criteria:
- * - SC-007: row counts match the AGL mock (1 board / 8 committee / 3 voting) on first visit
+ * - SC-007: row counts match the sample mock (1 board / 8 committee / 3 voting) on first visit
  * - SC-006: search by name OR email (case-insensitive) filters Board+Committee, NOT Voting History
  * - SC-002: pencil click opens Reassign modal with correct surface
  * - SC-003: "Why can't I edit?" link opens explainer modal
@@ -25,26 +25,26 @@
  * - Organization context selected (existing AccountContextService default applies)
  *
  * Mock semantics (v1): every foundationId returns the same shared payload (FR-009c),
- * so the AGL fixture data is what every test below asserts against — Masanori Itoh,
- * Kensuke Hanaoka × 3, Yasushi Ando, Masaki Isetani × 2, Mitsuo Date.
+ * so the sample fixture data is what every test below asserts against — Alex Rivera,
+ * Jordan Kim × 3, Taylor Morgan, Sam Chen × 2, Riley Brooks.
  */
 
 import { expect, test } from '@playwright/test';
 
-const DETAIL_URL_AGL = '/org/memberships/agl-001';
-const DETAIL_URL_AGL_BOARD = '/org/memberships/agl-001#board';
+const DETAIL_URL_FOUNDATION = '/org/memberships/sample-foundation';
+const DETAIL_URL_BOARD = '/org/memberships/sample-foundation#board';
 const DATA_LOAD_TIMEOUT = 30_000;
 
 test.setTimeout(90_000);
 
 /**
- * Helper: navigate directly to the AGL detail page with the `#board` URL fragment
+ * Helper: navigate directly to the sample detail page with the `#board` URL fragment
  * (FR-001b — tab state synced with URL fragment for e2e simplicity, spec 016
  * round 7). Returns once the card is fully rendered (initial loading skeleton
  * gone). One round-trip — no tab-button click required.
  */
 async function openBoardCommitteeTab(page: import('@playwright/test').Page): Promise<void> {
-  await page.goto(DETAIL_URL_AGL_BOARD, { waitUntil: 'domcontentloaded' });
+  await page.goto(DETAIL_URL_BOARD, { waitUntil: 'domcontentloaded' });
   await expect(page).not.toHaveURL(/auth0\.com/);
   await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   await expect(page.getByTestId('board-committee-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
@@ -77,7 +77,7 @@ test.describe('US1 — Board & Committee tab view (FR-002 through FR-007)', () =
     await expect(committeeHeader).toBeVisible();
     await expect(votingHeader).toBeVisible();
 
-    // Counts from AGL mock fixture (spec FR-010b)
+    // Counts from sample mock fixture (spec FR-010b)
     await expect(boardHeader).toContainText('Board Seats (1)');
     await expect(committeeHeader).toContainText('Committee Seats (8)');
     await expect(votingHeader).toContainText('Voting History (3)');
@@ -88,17 +88,17 @@ test.describe('US1 — Board & Committee tab view (FR-002 through FR-007)', () =
     await expect(page.getByTestId('board-committee-section-voting-body')).not.toBeVisible();
   });
 
-  test('Board Seats table renders Masanori Itoh / Governing Board / 92% with pencil (FR-004, FR-004b, SC-007)', async ({ page }) => {
+  test('Board Seats table renders Alex Rivera / Governing Board / 92% with pencil (FR-004, FR-004b, SC-007)', async ({ page }) => {
     await expect(page.getByTestId('board-committee-board-table')).toBeVisible();
-    const row = page.getByTestId('board-committee-board-row-agl-board-1');
+    const row = page.getByTestId('board-committee-board-row-board-1');
     await expect(row).toBeVisible();
-    await expect(row).toContainText('Masanori Itoh');
+    await expect(row).toContainText('Alex Rivera');
     await expect(row).toContainText('Principal Engineer');
     await expect(row).toContainText('Governing Board');
     await expect(row).toContainText('92%');
     // isOrgEditable: true → pencil affordance (NOT "Why can't I edit?" link)
-    await expect(page.getByTestId('board-committee-board-edit-agl-board-1')).toBeVisible();
-    await expect(page.getByTestId('board-committee-board-why-agl-board-1')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-board-edit-board-1')).toBeVisible();
+    await expect(page.getByTestId('board-committee-board-why-board-1')).toHaveCount(0);
   });
 
   test('Committee Seats — Role-before-Committee column order + 2 foundation-controlled rows (FR-005, FR-004b)', async ({ page }) => {
@@ -106,37 +106,37 @@ test.describe('US1 — Board & Committee tab view (FR-002 through FR-007)', () =
     await expect(page.getByTestId('board-committee-committee-table')).toBeVisible();
 
     // Verify all 8 fixture rows are present
-    for (const seatId of ['agl-com-1', 'agl-com-2', 'agl-com-3', 'agl-com-4', 'agl-com-5', 'agl-com-6', 'agl-com-7', 'agl-com-8']) {
+    for (const seatId of ['com-1', 'com-2', 'com-3', 'com-4', 'com-5', 'com-6', 'com-7', 'com-8']) {
       await expect(page.getByTestId(`board-committee-committee-row-${seatId}`)).toBeVisible();
     }
 
     // Foundation-controlled seats render the "Why can't I edit?" link, NOT a pencil
-    await expect(page.getByTestId('board-committee-committee-why-agl-com-1')).toBeVisible(); // Masanori / TSC Chair
-    await expect(page.getByTestId('board-committee-committee-edit-agl-com-1')).toHaveCount(0);
-    await expect(page.getByTestId('board-committee-committee-why-agl-com-3')).toBeVisible(); // Kensuke / Budget & Finance Observer
-    await expect(page.getByTestId('board-committee-committee-edit-agl-com-3')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-committee-why-com-1')).toBeVisible(); // Alex / TSC Chair
+    await expect(page.getByTestId('board-committee-committee-edit-com-1')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-committee-why-com-3')).toBeVisible(); // Jordan / Budget & Finance Observer
+    await expect(page.getByTestId('board-committee-committee-edit-com-3')).toHaveCount(0);
 
     // Org-editable seats render the pencil, NOT the link
-    await expect(page.getByTestId('board-committee-committee-edit-agl-com-2')).toBeVisible(); // Kensuke / Marketing Member
-    await expect(page.getByTestId('board-committee-committee-why-agl-com-2')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-committee-edit-com-2')).toBeVisible(); // Jordan / Marketing Member
+    await expect(page.getByTestId('board-committee-committee-why-com-2')).toHaveCount(0);
   });
 
   test('Voting History renders 3 rows in reverse-chronological order with vote chips (FR-006, FR-013b)', async ({ page }) => {
     await page.getByTestId('board-committee-section-voting-header').click();
     await expect(page.getByTestId('board-committee-voting-table')).toBeVisible();
 
-    for (const voteId of ['agl-vote-1', 'agl-vote-2', 'agl-vote-3']) {
+    for (const voteId of ['vote-1', 'vote-2', 'vote-3']) {
       await expect(page.getByTestId(`board-committee-voting-row-${voteId}`)).toBeVisible();
     }
 
     // Verify vote content + chip classes for each
-    const v1 = page.getByTestId('board-committee-voting-row-agl-vote-1');
+    const v1 = page.getByTestId('board-committee-voting-row-vote-1');
     await expect(v1).toContainText('Apr 14, 2026');
     await expect(v1).toContainText('Approve 2026 budget allocation');
     await expect(v1).toContainText('Yes');
     await expect(v1).toContainText('Passed (8-1)');
 
-    const v3 = page.getByTestId('board-committee-voting-row-agl-vote-3');
+    const v3 = page.getByTestId('board-committee-voting-row-vote-3');
     await expect(v3).toContainText('No');
     await expect(v3).toContainText('Passed (6-3)');
   });
@@ -154,7 +154,7 @@ test.describe('US1 — Board & Committee tab view (FR-002 through FR-007)', () =
     await expect(page).toHaveURL(/#board$/);
 
     // Direct goto with an UNKNOWN fragment falls back to the default tab (key-contacts)
-    await page.goto('/org/memberships/agl-001#totally-bogus-tab', { waitUntil: 'domcontentloaded' });
+    await page.goto('/org/memberships/sample-foundation#totally-bogus-tab', { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('membership-detail-key-contacts-card')).toBeVisible();
   });
@@ -164,38 +164,38 @@ test.describe('US1 — Board & Committee tab view (FR-002 through FR-007)', () =
     await page.getByTestId('board-committee-section-committee-header').click();
     await page.getByTestId('board-committee-section-voting-header').click();
 
-    // Search by partial name "kensuke" → 0 board / 3 committee / 3 voting (unchanged)
-    await page.getByTestId('board-committee-search-input').fill('kensuke');
+    // Search by partial name "jordan" → 0 board / 3 committee / 3 voting (unchanged)
+    await page.getByTestId('board-committee-search-input').fill('jordan');
     // Wait past the 200ms debounce
     await page.waitForTimeout(300);
 
-    await expect(page.getByTestId('board-committee-board-row-agl-board-1')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-board-row-board-1')).toHaveCount(0);
     await expect(page.getByTestId('board-committee-empty-board')).toBeVisible();
 
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-2')).toBeVisible();
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-3')).toBeVisible();
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-4')).toBeVisible();
+    await expect(page.getByTestId('board-committee-committee-row-com-2')).toBeVisible();
+    await expect(page.getByTestId('board-committee-committee-row-com-3')).toBeVisible();
+    await expect(page.getByTestId('board-committee-committee-row-com-4')).toBeVisible();
     // Other committee rows hidden
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-1')).toHaveCount(0);
+    await expect(page.getByTestId('board-committee-committee-row-com-1')).toHaveCount(0);
 
     // Voting History is untouched (FR-006a)
-    await expect(page.getByTestId('board-committee-voting-row-agl-vote-1')).toBeVisible();
-    await expect(page.getByTestId('board-committee-voting-row-agl-vote-2')).toBeVisible();
-    await expect(page.getByTestId('board-committee-voting-row-agl-vote-3')).toBeVisible();
+    await expect(page.getByTestId('board-committee-voting-row-vote-1')).toBeVisible();
+    await expect(page.getByTestId('board-committee-voting-row-vote-2')).toBeVisible();
+    await expect(page.getByTestId('board-committee-voting-row-vote-3')).toBeVisible();
 
     // Count badges show UNFILTERED totals (FR-007b)
     await expect(page.getByTestId('board-committee-section-committee-header')).toContainText('Committee Seats (8)');
 
-    // Now search by full email — should still match the same 3 Kensuke rows (FR-007 email match)
-    await page.getByTestId('board-committee-search-input').fill('kensuke.hanaoka@example.com');
+    // Now search by full email — should still match the same 3 Jordan rows (FR-007 email match)
+    await page.getByTestId('board-committee-search-input').fill('jordan.kim@example.com');
     await page.waitForTimeout(300);
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-2')).toBeVisible();
+    await expect(page.getByTestId('board-committee-committee-row-com-2')).toBeVisible();
 
     // Clear search via the (×) button — all rows return
     await page.getByTestId('board-committee-search-clear').click();
     await page.waitForTimeout(300);
-    await expect(page.getByTestId('board-committee-board-row-agl-board-1')).toBeVisible();
-    await expect(page.getByTestId('board-committee-committee-row-agl-com-1')).toBeVisible();
+    await expect(page.getByTestId('board-committee-board-row-board-1')).toBeVisible();
+    await expect(page.getByTestId('board-committee-committee-row-com-1')).toBeVisible();
   });
 });
 
@@ -208,16 +208,16 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
   });
 
   test('renders the Reassign modal testid surface on pencil click (SC-012, FR-016)', async ({ page }) => {
-    await page.getByTestId('board-committee-board-edit-agl-board-1').click();
+    await page.getByTestId('board-committee-board-edit-board-1').click();
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible({ timeout: 5_000 });
 
     await expect(page.getByTestId('reassign-board-title')).toHaveText('Reassign Board Roles');
     await expect(page.getByTestId('reassign-board-subtitle')).toContainText('1 role across 1 foundation');
-    await expect(page.getByTestId('reassign-board-current-member')).toContainText('Masanori Itoh');
-    await expect(page.getByTestId('reassign-board-current-member')).toContainText('masanori.itoh@example.com');
+    await expect(page.getByTestId('reassign-board-current-member')).toContainText('Alex Rivera');
+    await expect(page.getByTestId('reassign-board-current-member')).toContainText('alex.rivera@example.com');
     await expect(page.getByTestId('reassign-board-select-all')).toBeVisible();
-    await expect(page.getByTestId('reassign-board-role-row-agl-board-1')).toBeVisible();
-    await expect(page.getByTestId('reassign-board-role-checkbox-agl-board-1')).toBeVisible();
+    await expect(page.getByTestId('reassign-board-role-row-board-1')).toBeVisible();
+    await expect(page.getByTestId('reassign-board-role-checkbox-board-1')).toBeVisible();
     await expect(page.getByTestId('reassign-board-info-banner')).toBeVisible();
     await expect(page.getByTestId('reassign-board-assign-form')).toBeVisible();
     await expect(page.getByTestId('reassign-board-email-input')).toBeVisible();
@@ -228,7 +228,7 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
   });
 
   test('Save Changes flow: optimistic update + Board roles reassigned toast (FR-008h, SC-004)', async ({ page }) => {
-    await page.getByTestId('board-committee-board-edit-agl-board-1').click();
+    await page.getByTestId('board-committee-board-edit-board-1').click();
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible();
 
     await page.getByTestId('reassign-board-email-input').fill('jane.doe@example.com');
@@ -249,20 +249,20 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
     await expect(page.getByText('Board roles reassigned')).toBeVisible({ timeout: 3_000 });
 
     // Optimistic update is briefly visible then refetch overwrites it. By the time the
-    // assertion runs the refetch has likely already resolved, restoring Masanori Itoh.
+    // assertion runs the refetch has likely already resolved, restoring Alex Rivera.
     // SC-004 documents this as explicit accepted v1 behavior. We just assert the row
     // still exists with SOME person — exact identity isn't deterministic post-refetch.
-    await expect(page.getByTestId('board-committee-board-row-agl-board-1')).toBeVisible();
+    await expect(page.getByTestId('board-committee-board-row-board-1')).toBeVisible();
   });
 
   test('self-reassign duplicate check intercepts Save Changes (FR-008e)', async ({ page }) => {
-    await page.getByTestId('board-committee-board-edit-agl-board-1').click();
+    await page.getByTestId('board-committee-board-edit-board-1').click();
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible();
 
     // Type the CURRENT member's email — should trigger the duplicate-check intercept
-    await page.getByTestId('reassign-board-email-input').fill('masanori.itoh@example.com');
-    await page.getByTestId('reassign-board-first-name-input').fill('Masanori');
-    await page.getByTestId('reassign-board-last-name-input').fill('Itoh');
+    await page.getByTestId('reassign-board-email-input').fill('alex.rivera@example.com');
+    await page.getByTestId('reassign-board-first-name-input').fill('Alex');
+    await page.getByTestId('reassign-board-last-name-input').fill('Rivera');
 
     await page.getByTestId('reassign-board-primary-button').click();
 
@@ -274,7 +274,7 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
   });
 
   test('email validation shows inline error on blur with invalid format (FR-008f)', async ({ page }) => {
-    await page.getByTestId('board-committee-board-edit-agl-board-1').click();
+    await page.getByTestId('board-committee-board-edit-board-1').click();
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible();
 
     const emailInput = page.getByTestId('reassign-board-email-input');
@@ -291,7 +291,7 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
   });
 
   test('Cancel button closes modal with no toast or table mutation (FR-008i, SC-005)', async ({ page }) => {
-    await page.getByTestId('board-committee-board-edit-agl-board-1').click();
+    await page.getByTestId('board-committee-board-edit-board-1').click();
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible();
 
     await page.getByTestId('reassign-board-email-input').fill('some.person@example.com');
@@ -301,12 +301,12 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
     // The toast outlet (testid) is always in the DOM; assert on toast TEXT instead.
     await expect(page.getByText('Board roles reassigned')).toHaveCount(0);
     // Board table row still shows the original person (no mutation)
-    await expect(page.getByTestId('board-committee-board-row-agl-board-1')).toContainText('Masanori Itoh');
+    await expect(page.getByTestId('board-committee-board-row-board-1')).toContainText('Alex Rivera');
   });
 
   test('keyboard-only Reassign flow (SC-015, FR-017a, FR-017b)', async ({ page }) => {
     // Focus the pencil and activate via Enter (NOT click)
-    await page.getByTestId('board-committee-board-edit-agl-board-1').focus();
+    await page.getByTestId('board-committee-board-edit-board-1').focus();
     await page.keyboard.press('Enter');
 
     await expect(page.getByTestId('reassign-board-modal')).toBeVisible({ timeout: 5_000 });
@@ -334,12 +334,12 @@ test.describe('US2 — Reassign Board Roles modal (FR-008)', () => {
 test.describe("US3 — Why-can't-I-edit explainer modal (FR-012)", () => {
   test.beforeEach(async ({ page }) => {
     await openBoardCommitteeTab(page);
-    // Expand Committee section — both foundation-controlled seats (agl-com-1, agl-com-3) live there
+    // Expand Committee section — both foundation-controlled seats (com-1, com-3) live there
     await page.getByTestId('board-committee-section-committee-header').click();
   });
 
   test('opens with the per-seat reason and full testid surface (FR-012a, SC-003, SC-012)', async ({ page }) => {
-    await page.getByTestId('board-committee-committee-why-agl-com-1').click();
+    await page.getByTestId('board-committee-committee-why-com-1').click();
 
     await expect(page.getByTestId('why-cant-edit-modal')).toBeVisible({ timeout: 3_000 });
     await expect(page.getByTestId('why-cant-edit-icon')).toBeVisible();
@@ -354,7 +354,7 @@ test.describe("US3 — Why-can't-I-edit explainer modal (FR-012)", () => {
 
   test('Contact Foundation is a no-op (FR-012c) — emits console event, no navigation', async ({ page }) => {
     const urlBefore = page.url();
-    await page.getByTestId('board-committee-committee-why-agl-com-1').click();
+    await page.getByTestId('board-committee-committee-why-com-1').click();
     await expect(page.getByTestId('why-cant-edit-modal')).toBeVisible();
 
     const consolePromise = page.waitForEvent('console', {
@@ -369,7 +369,7 @@ test.describe("US3 — Why-can't-I-edit explainer modal (FR-012)", () => {
     // Modal stays open
     await expect(page.getByTestId('why-cant-edit-modal')).toBeVisible();
     // Console event fired with the expected seatId payload
-    expect(consoleMsg.text()).toContain('agl-com-1');
+    expect(consoleMsg.text()).toContain('com-1');
 
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('why-cant-edit-modal')).not.toBeVisible({ timeout: 3_000 });

--- a/apps/lfx-one/e2e/org-membership-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-detail.spec.ts
@@ -17,7 +17,7 @@
  * - Organization context has at least one membership (the existing /org/memberships list has rows)
  *
  * Mock semantics (v1): every foundationId returns the same `sharedKeyContacts` payload, so
- * the sample foundation data (Alex Rivera as Representative, two-person Billing row, etc.)
+ * the sample foundation data (Sam Chen as Representative, two-person Billing row, etc.)
  * is what every detail-page test below asserts against.
  */
 
@@ -276,8 +276,8 @@ test.describe('Org Membership Detail — SSR rendered HTML (SC-006, post-analyze
     // so the test runs against the SSR-rendered detail page only when the request fixture inherits
     // the storage state. If the test runs pre-auth (unusual), the response body will be a redirect
     // or login shell — in that case we skip the content assertion and only verify the route exists.
-    if (status === 200 && /Alex Rivera|Key Contacts/.test(body)) {
-      expect(body).toContain('Alex Rivera');
+    if (status === 200 && /Sam Chen|Key Contacts/.test(body)) {
+      expect(body).toContain('Sam Chen');
       expect(body).toContain('membership-detail-key-contacts-table');
     } else {
       test.skip(

--- a/apps/lfx-one/e2e/org-membership-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-detail.spec.ts
@@ -17,14 +17,14 @@
  * - Organization context has at least one membership (the existing /org/memberships list has rows)
  *
  * Mock semantics (v1): every foundationId returns the same `sharedKeyContacts` payload, so
- * the AGL fixture data (Masaki Isetani as Representative, two-person Billing row, etc.)
+ * the sample foundation data (Alex Rivera as Representative, two-person Billing row, etc.)
  * is what every detail-page test below asserts against.
  */
 
 import { expect, test } from '@playwright/test';
 
 const MEMBERSHIPS_URL = '/org/memberships';
-const DETAIL_URL_AGL = '/org/memberships/agl-001';
+const DETAIL_URL_FOUNDATION = '/org/memberships/sample-foundation';
 const DETAIL_URL_BOGUS = '/org/memberships/totally-bogus-foundation';
 const DATA_LOAD_TIMEOUT = 30_000;
 
@@ -32,7 +32,7 @@ test.setTimeout(90_000);
 
 test.describe('Org Membership Detail — testid resolution (SC-014, FR-034)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
@@ -57,10 +57,10 @@ test.describe('Org Membership Detail — testid resolution (SC-014, FR-034)', ()
     }
   });
 
-  test('renders the AGL Billing row with TWO people stacked under one pencil', async ({ page }) => {
+  test('renders the Billing row with TWO people stacked under one pencil', async ({ page }) => {
     const billingRow = page.getByTestId('membership-detail-key-contacts-row-billing');
-    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-agl-kc-bill-1')).toBeVisible();
-    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-agl-kc-bill-2')).toBeVisible();
+    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-sample-kc-bill-1')).toBeVisible();
+    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-sample-kc-bill-2')).toBeVisible();
     // Only one pencil per row (FR-010)
     await expect(billingRow.getByTestId('membership-detail-key-contacts-edit-billing')).toHaveCount(1);
   });
@@ -81,12 +81,12 @@ test.describe('Org Membership Detail — testid resolution (SC-014, FR-034)', ()
 
   test('URL fragment ↔ tab sync — direct goto activates correct tab (spec 016 round 7)', async ({ page }) => {
     // Direct goto with #docs activates the Documentation tab without a click
-    await page.goto('/org/memberships/agl-001#docs', { waitUntil: 'domcontentloaded' });
+    await page.goto('/org/memberships/sample-foundation#docs', { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     // Direct goto with #governance activates Governance
-    await page.goto('/org/memberships/agl-001#governance', { waitUntil: 'domcontentloaded' });
+    await page.goto('/org/memberships/sample-foundation#governance', { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByTestId('membership-detail-governance-empty-state')).toBeVisible();
   });
@@ -121,7 +121,7 @@ test.describe('Org Membership Detail — testid resolution (SC-014, FR-034)', ()
 
 test.describe('Org Membership Detail — modal save flows + toasts', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
@@ -150,7 +150,7 @@ test.describe('Org Membership Detail — modal save flows + toasts', () => {
   test('Remove flow shows the removed toast and drops the row (no undo)', async ({ page }) => {
     await page.getByTestId('membership-detail-key-contacts-edit-billing').click();
     await page.getByTestId('edit-key-contact-chooser-remove').click();
-    await page.getByTestId('edit-key-contact-remove-candidate-agl-kc-bill-1').click();
+    await page.getByTestId('edit-key-contact-remove-candidate-sample-kc-bill-1').click();
     await page.getByTestId('edit-key-contact-primary-button').click();
     await expect(page.getByTestId('edit-key-contact-modal')).not.toBeVisible({ timeout: 5_000 });
 
@@ -159,15 +159,15 @@ test.describe('Org Membership Detail — modal save flows + toasts', () => {
     await expect(page.getByTestId('key-contact-toast-undo')).toHaveCount(0);
     // Row should now have only 1 person, and the removal is not reversible from the toast.
     const billingRow = page.getByTestId('membership-detail-key-contacts-row-billing');
-    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-agl-kc-bill-1')).not.toBeVisible();
-    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-agl-kc-bill-2')).toBeVisible();
+    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-sample-kc-bill-1')).not.toBeVisible();
+    await expect(billingRow.getByTestId('membership-detail-key-contacts-person-sample-kc-bill-2')).toBeVisible();
   });
 
   test('in-row duplicate Email blocks Save with inline error (FR-016f)', async ({ page }) => {
     await page.getByTestId('membership-detail-key-contacts-edit-billing').click();
     await page.getByTestId('edit-key-contact-chooser-add').click();
-    // Type an email that already exists in Billing (Tomoya Suzuki — fixture uses @example.com)
-    await page.getByTestId('edit-key-contact-email-input').fill('tomoya_suzuki@example.com');
+    // Type an email that already exists in Billing (Jordan Kim — fixture uses @example.com)
+    await page.getByTestId('edit-key-contact-email-input').fill('jordan.kim@example.com');
     await page.getByTestId('edit-key-contact-first-name-input').fill('Dup');
     await page.getByTestId('edit-key-contact-last-name-input').fill('Person');
     await page.getByTestId('edit-key-contact-primary-button').click();
@@ -179,7 +179,7 @@ test.describe('Org Membership Detail — modal save flows + toasts', () => {
 
 test.describe('Org Membership Detail — keyboard-only journey (SC-015, FR-035)', () => {
   test('opens modal, fills form, submits — zero page.click() calls', async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     // Programmatically focus the Representative pencil, then drive everything with the keyboard
@@ -203,7 +203,7 @@ test.describe('Org Membership Detail — keyboard-only journey (SC-015, FR-035)'
   });
 
   test('Esc dismisses the modal and restores focus to the pencil', async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     const pencil = page.getByTestId('membership-detail-key-contacts-edit-marketing');
@@ -229,7 +229,7 @@ test.describe('Org Membership Detail — performance timing (SC-001/002/003, pos
 
   test('page load → table visible (SC-001 — production budget 2 s)', async ({ page }) => {
     const start = Date.now();
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-key-contacts-row-representative')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     const elapsed = Date.now() - start;
     console.log(`[SC-001] page load → first row visible: ${elapsed} ms (prod budget 2000 ms; dev allowance ${2000 * PERF_DEV_MULTIPLIER} ms)`);
@@ -237,7 +237,7 @@ test.describe('Org Membership Detail — performance timing (SC-001/002/003, pos
   });
 
   test('pencil click → modal visible (SC-002 — production budget 200 ms)', async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     const start = Date.now();
@@ -250,7 +250,7 @@ test.describe('Org Membership Detail — performance timing (SC-001/002/003, pos
   });
 
   test('Save click → toast visible (SC-003 — production budget 500 ms inc. 400 ms mock latency)', async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await page.getByTestId('membership-detail-key-contacts-edit-representative').click();
     await page.getByTestId('edit-key-contact-email-input').fill('perf.test@example.com');
@@ -268,16 +268,16 @@ test.describe('Org Membership Detail — performance timing (SC-001/002/003, pos
 
 test.describe('Org Membership Detail — SSR rendered HTML (SC-006, post-analyze C2)', () => {
   test('initial HTML contains the populated Key Contacts table before client hydration', async ({ request }) => {
-    const response = await request.get(DETAIL_URL_AGL);
+    const response = await request.get(DETAIL_URL_FOUNDATION);
     const status = response.status();
     const body = await response.text();
-    // These strings come from the AGL fixture — must be in the initial HTML if SSR is active.
+    // These strings come from the seeded key-contacts data — must be in the initial HTML if SSR is active.
     // `ng serve` runs SSR per angular.json, but pre-auth requests get bounced to the Auth0 login,
     // so the test runs against the SSR-rendered detail page only when the request fixture inherits
     // the storage state. If the test runs pre-auth (unusual), the response body will be a redirect
     // or login shell — in that case we skip the content assertion and only verify the route exists.
-    if (status === 200 && /Masaki Isetani|Key Contacts/.test(body)) {
-      expect(body).toContain('Masaki Isetani');
+    if (status === 200 && /Alex Rivera|Key Contacts/.test(body)) {
+      expect(body).toContain('Alex Rivera');
       expect(body).toContain('membership-detail-key-contacts-table');
     } else {
       test.skip(
@@ -291,7 +291,7 @@ test.describe('Org Membership Detail — SSR rendered HTML (SC-006, post-analyze
 test.describe('Org Membership Detail — viewport resilience (SC-008, post-analyze C3)', () => {
   test('modal usable at 320×600 viewport — header + footer visible, no internal modal overflow', async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 600 });
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await page.getByTestId('membership-detail-key-contacts-edit-billing').click();

--- a/apps/lfx-one/e2e/org-membership-documentation.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-documentation.spec.ts
@@ -26,18 +26,18 @@
  * - Dev server running on localhost:4200
  * - User authenticated with org-lens-enabled flag
  * - Organization context has at least one membership
- *   is seeded (see spec 018 quickstart §7 — the seed includes AGL/Toyota data).
+ *   is seeded (see spec 018 quickstart §7 — the seed includes sample foundation data).
  */
 
 import { expect, test } from '@playwright/test';
 
-const DETAIL_URL_AGL = '/org/memberships/agl-001';
-const DOCS_URL_AGL = '/org/memberships/agl-001#docs';
+const DETAIL_URL_FOUNDATION = '/org/memberships/sample-foundation';
+const DOCS_URL_FOUNDATION = '/org/memberships/sample-foundation#docs';
 // SC-014 needs a foundation with zero agreements to exercise the disabled
 // download-all branch. Until a guaranteed-empty foundation is seeded in dev,
-// this aliases AGL — the test will `skip()` when the list is non-empty.
+// this aliases the sample foundation — the test will `skip()` when the list is non-empty.
 // TODO(LFXV2-1866): retarget this to a known-empty foundation slug once one is seeded.
-const DOCS_URL_EMPTY_FOUNDATION = DOCS_URL_AGL;
+const DOCS_URL_EMPTY_FOUNDATION = DOCS_URL_FOUNDATION;
 const DATA_LOAD_TIMEOUT = 30_000;
 
 test.setTimeout(90_000);
@@ -70,7 +70,7 @@ function countRfc4180Columns(line: string): number {
 
 test.describe('Documentation Tab — testid resolution (SC-008, FR-028)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
@@ -197,7 +197,7 @@ test.describe('Documentation Tab — testid resolution (SC-008, FR-028)', () => 
 //     if explicit coverage is desired, add a single test below.
 test.describe('Documentation Tab — View link live behavior (SC-011, SC-012, FR-028)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('membership-detail-docs-agreements-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
@@ -250,7 +250,7 @@ test.describe('Documentation Tab — View link live behavior (SC-011, SC-012, FR
 
 test.describe('Documentation Tab — CSV download (SC-013, SC-014, FR-032)', () => {
   test('SC-013: download-all icon downloads a 9-column CSV with the correct filename pattern', async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('membership-detail-docs-agreements-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
@@ -308,7 +308,7 @@ test.describe('Documentation Tab — CSV download (SC-013, SC-014, FR-032)', () 
 // is non-null and a disabled <button> otherwise; the card itself is conditional.
 test.describe('Documentation Tab — Certificate Download live behavior (Spec 019 FR-018)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
@@ -331,7 +331,7 @@ test.describe('Documentation Tab — Certificate Download live behavior (Spec 01
 
 test.describe('Documentation Tab — tab navigation (SC-001, SC-010)', () => {
   test('clicking Documentation tab from Key Contacts renders content within budget (SC-001)', async ({ page }) => {
-    await page.goto(DETAIL_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DETAIL_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     const start = Date.now();
@@ -345,7 +345,7 @@ test.describe('Documentation Tab — tab navigation (SC-001, SC-010)', () => {
   });
 
   test('navigating away and back does not trigger redundant fetch (SC-010)', async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-docs-agreements-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     let fetchCount = 0;
@@ -367,7 +367,7 @@ test.describe('Documentation Tab — tab navigation (SC-001, SC-010)', () => {
   });
 
   test('direct navigation to #docs URL shows Documentation tab active', async ({ page }) => {
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('membership-detail-docs-content')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
@@ -384,7 +384,7 @@ test.describe('Documentation Tab — loading and error states (SC-009)', () => {
       await route.continue();
     });
 
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     // The loading skeleton should be visible while the response is delayed
@@ -399,7 +399,7 @@ test.describe('Documentation Tab — loading and error states (SC-009)', () => {
     // Intercept and abort the documents request
     await page.route('**/lens/memberships/*/documents', (route) => route.abort());
 
-    await page.goto(DOCS_URL_AGL, { waitUntil: 'domcontentloaded' });
+    await page.goto(DOCS_URL_FOUNDATION, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('membership-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await expect(page.getByTestId('membership-detail-docs-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });

--- a/apps/lfx-one/e2e/org-membership-documentation.spec.ts
+++ b/apps/lfx-one/e2e/org-membership-documentation.spec.ts
@@ -228,7 +228,7 @@ test.describe('Documentation Tab — View link live behavior (SC-011, SC-012, FR
     const count = await disabledViewSpans.count();
 
     if (count === 0) {
-      // Skip: dev data has 100% coverage of download URLs at this foundation (e.g., Toyota).
+      // Skip: dev data has 100% coverage of download URLs at this foundation.
       test.skip();
       return;
     }

--- a/apps/lfx-one/src/server/services/fixtures/org-membership-board-committee.mock.json
+++ b/apps/lfx-one/src/server/services/fixtures/org-membership-board-committee.mock.json
@@ -168,7 +168,7 @@
     {
       "voteId": "vote-2",
       "date": "2026-03-21",
-      "resolution": "New project admission: ELISA Safety Toolkit",
+      "resolution": "New project admission: Sample Project Toolkit",
       "vote": "Yes",
       "outcome": "Passed (unanimous)"
     },

--- a/apps/lfx-one/src/server/services/fixtures/org-membership-board-committee.mock.json
+++ b/apps/lfx-one/src/server/services/fixtures/org-membership-board-committee.mock.json
@@ -1,16 +1,16 @@
 {
-  "_comment": "Copyright The Linux Foundation and each contributor to LFX. SPDX-License-Identifier: MIT. Shared mock fixture for the three Board & Committee SSR endpoints (spec 016). Same payload returned for every requested foundationId in v1 mock per FR-009c. Data pinned from spec FR-010b mirroring the V3 wireframe AGL data.",
+  "_comment": "Copyright The Linux Foundation and each contributor to LFX. SPDX-License-Identifier: MIT. Shared mock fixture for the three Board & Committee SSR endpoints (spec 016). Same payload returned for every requested foundationId in v1 mock per FR-009c. Synthetic sample data only — no real member information.",
   "sharedBoardSeats": [
     {
-      "seatId": "agl-board-1",
+      "seatId": "board-1",
       "person": {
-        "personId": "agl-person-itoh",
-        "firstName": "Masanori",
-        "lastName": "Itoh",
-        "fullName": "Masanori Itoh",
-        "email": "masanori.itoh@example.com",
+        "personId": "person-1",
+        "firstName": "Alex",
+        "lastName": "Rivera",
+        "fullName": "Alex Rivera",
+        "email": "alex.rivera@example.com",
         "jobTitle": "Principal Engineer",
-        "initials": "MI"
+        "initials": "AR"
       },
       "seatName": "Governing Board",
       "tagLabel": "Voting Rep",
@@ -21,15 +21,15 @@
   ],
   "sharedCommitteeSeats": [
     {
-      "seatId": "agl-com-1",
+      "seatId": "com-1",
       "person": {
-        "personId": "agl-person-itoh",
-        "firstName": "Masanori",
-        "lastName": "Itoh",
-        "fullName": "Masanori Itoh",
-        "email": "masanori.itoh@example.com",
+        "personId": "person-1",
+        "firstName": "Alex",
+        "lastName": "Rivera",
+        "fullName": "Alex Rivera",
+        "email": "alex.rivera@example.com",
         "jobTitle": "Principal Engineer",
-        "initials": "MI"
+        "initials": "AR"
       },
       "committeeName": "Technical Steering Committee",
       "role": "Chair",
@@ -38,15 +38,15 @@
       "reason": "This seat is held by foundation election or appointment, not by your organization's membership entitlement."
     },
     {
-      "seatId": "agl-com-2",
+      "seatId": "com-2",
       "person": {
-        "personId": "agl-person-hanaoka",
-        "firstName": "Kensuke",
-        "lastName": "Hanaoka",
-        "fullName": "Kensuke Hanaoka",
-        "email": "kensuke.hanaoka@example.com",
+        "personId": "person-2",
+        "firstName": "Jordan",
+        "lastName": "Kim",
+        "fullName": "Jordan Kim",
+        "email": "jordan.kim@example.com",
         "jobTitle": "Engineer",
-        "initials": "KH"
+        "initials": "JK"
       },
       "committeeName": "Marketing Committee",
       "role": "Member",
@@ -55,15 +55,15 @@
       "reason": null
     },
     {
-      "seatId": "agl-com-3",
+      "seatId": "com-3",
       "person": {
-        "personId": "agl-person-hanaoka",
-        "firstName": "Kensuke",
-        "lastName": "Hanaoka",
-        "fullName": "Kensuke Hanaoka",
-        "email": "kensuke.hanaoka@example.com",
+        "personId": "person-2",
+        "firstName": "Jordan",
+        "lastName": "Kim",
+        "fullName": "Jordan Kim",
+        "email": "jordan.kim@example.com",
         "jobTitle": "Engineer",
-        "initials": "KH"
+        "initials": "JK"
       },
       "committeeName": "Budget & Finance",
       "role": "Observer",
@@ -72,15 +72,15 @@
       "reason": "This seat is held by foundation election or appointment, not by your organization's membership entitlement."
     },
     {
-      "seatId": "agl-com-4",
+      "seatId": "com-4",
       "person": {
-        "personId": "agl-person-hanaoka",
-        "firstName": "Kensuke",
-        "lastName": "Hanaoka",
-        "fullName": "Kensuke Hanaoka",
-        "email": "kensuke.hanaoka@example.com",
+        "personId": "person-2",
+        "firstName": "Jordan",
+        "lastName": "Kim",
+        "fullName": "Jordan Kim",
+        "email": "jordan.kim@example.com",
         "jobTitle": "Engineer",
-        "initials": "KH"
+        "initials": "JK"
       },
       "committeeName": "Steering Committee",
       "role": "Non-voting Representative",
@@ -89,15 +89,15 @@
       "reason": null
     },
     {
-      "seatId": "agl-com-5",
+      "seatId": "com-5",
       "person": {
-        "personId": "agl-person-ando",
-        "firstName": "Yasushi",
-        "lastName": "Ando",
-        "fullName": "Yasushi Ando",
-        "email": "yasushi.ando@example.com",
+        "personId": "person-3",
+        "firstName": "Taylor",
+        "lastName": "Morgan",
+        "fullName": "Taylor Morgan",
+        "email": "taylor.morgan@example.com",
         "jobTitle": "Distinguished Engineer",
-        "initials": "YA"
+        "initials": "TM"
       },
       "committeeName": "Steering Committee",
       "role": "Non-voting Representative",
@@ -106,15 +106,15 @@
       "reason": null
     },
     {
-      "seatId": "agl-com-6",
+      "seatId": "com-6",
       "person": {
-        "personId": "agl-person-isetani",
-        "firstName": "Masaki",
-        "lastName": "Isetani",
-        "fullName": "Masaki Isetani",
-        "email": "masaki.isetani@example.com",
+        "personId": "person-4",
+        "firstName": "Sam",
+        "lastName": "Chen",
+        "fullName": "Sam Chen",
+        "email": "sam.chen@example.com",
         "jobTitle": "Senior Manager, Open Source Strategy",
-        "initials": "MI"
+        "initials": "SC"
       },
       "committeeName": "Steering Committee",
       "role": "Non-voting Representative",
@@ -123,34 +123,34 @@
       "reason": null
     },
     {
-      "seatId": "agl-com-7",
+      "seatId": "com-7",
       "person": {
-        "personId": "agl-person-date",
-        "firstName": "Mitsuo",
-        "lastName": "Date",
-        "fullName": "Mitsuo Date",
-        "email": "mitsuo.date@example.com",
+        "personId": "person-5",
+        "firstName": "Riley",
+        "lastName": "Brooks",
+        "fullName": "Riley Brooks",
+        "email": "riley.brooks@example.com",
         "jobTitle": null,
-        "initials": "MD"
+        "initials": "RB"
       },
-      "committeeName": "Japan Core Member (Platinum+Gold+OEMs)",
+      "committeeName": "Regional Member Committee",
       "role": "Non-voting",
       "votingPercentage": 85,
       "isOrgEditable": true,
       "reason": null
     },
     {
-      "seatId": "agl-com-8",
+      "seatId": "com-8",
       "person": {
-        "personId": "agl-person-isetani",
-        "firstName": "Masaki",
-        "lastName": "Isetani",
-        "fullName": "Masaki Isetani",
-        "email": "masaki.isetani@example.com",
+        "personId": "person-4",
+        "firstName": "Sam",
+        "lastName": "Chen",
+        "fullName": "Sam Chen",
+        "email": "sam.chen@example.com",
         "jobTitle": "Senior Manager, Open Source Strategy",
-        "initials": "MI"
+        "initials": "SC"
       },
-      "committeeName": "Japan Core Member (Platinum+Gold+OEMs)",
+      "committeeName": "Regional Member Committee",
       "role": "Non-voting",
       "votingPercentage": 91,
       "isOrgEditable": true,
@@ -159,21 +159,21 @@
   ],
   "sharedVotingHistory": [
     {
-      "voteId": "agl-vote-1",
+      "voteId": "vote-1",
       "date": "2026-04-14",
       "resolution": "Approve 2026 budget allocation",
       "vote": "Yes",
       "outcome": "Passed (8-1)"
     },
     {
-      "voteId": "agl-vote-2",
+      "voteId": "vote-2",
       "date": "2026-03-21",
       "resolution": "New project admission: ELISA Safety Toolkit",
       "vote": "Yes",
       "outcome": "Passed (unanimous)"
     },
     {
-      "voteId": "agl-vote-3",
+      "voteId": "vote-3",
       "date": "2026-02-09",
       "resolution": "Revise membership fee structure",
       "vote": "No",

--- a/packages/shared/src/constants/regex.constants.ts
+++ b/packages/shared/src/constants/regex.constants.ts
@@ -24,7 +24,7 @@ export const ORG_ACCOUNT_ID_PATTERN = /^001[A-Za-z0-9]{15}$/;
  * Allowed values intentionally span three legitimate id shapes the SSR layer sees:
  *   1. Salesforce 18-char custom-object IDs (e.g. "a0941000002wBz2AAE") — the
  *      PRODUCTION foundationId shape, mixed case base32+checksum
- *   2. Synthetic v1 mock IDs (e.g. "agl-001", "agl-board-1") — kebab-case lowercase
+ *   2. Synthetic v1 mock IDs (e.g. "sample-foundation", "board-1") — kebab-case lowercase
  *   3. Future UUID v8 shape from `lfx-v2-member-service` (hex + hyphens, 36 chars)
  *
  * Defense-in-depth at the SSR boundary; caps payload size to 64 chars (DoS guard)

--- a/packages/shared/src/constants/regex.constants.ts
+++ b/packages/shared/src/constants/regex.constants.ts
@@ -24,7 +24,7 @@ export const ORG_ACCOUNT_ID_PATTERN = /^001[A-Za-z0-9]{15}$/;
  * Allowed values intentionally span three legitimate id shapes the SSR layer sees:
  *   1. Salesforce 18-char custom-object IDs (e.g. "a0941000002wBz2AAE") — the
  *      PRODUCTION foundationId shape, mixed case base32+checksum
- *   2. Synthetic v1 mock IDs (e.g. "sample-foundation", "board-1") — kebab-case lowercase
+ *   2. Synthetic v1 mock IDs (e.g. "sample-foundation") — kebab-case lowercase foundation slug
  *   3. Future UUID v8 shape from `lfx-v2-member-service` (hex + hyphens, 36 chars)
  *
  * Defense-in-depth at the SSR boundary; caps payload size to 64 chars (DoS guard)


### PR DESCRIPTION
## Summary
Security / PII remediation. The Board & Committee **spec-016 mock fixture** and its **e2e spec** on `main` carried lightly-obscured **real member data** (names + job titles) and the **AGL** project reference, flagged in code review. This replaces all person data with **synthetic** values and removes the AGL references.

- `apps/lfx-one/src/server/services/fixtures/org-membership-board-committee.mock.json` — 5 synthetic people, neutral fixture ids, comment updated (no "AGL" / "wireframe AGL data").
- `apps/lfx-one/e2e/org-membership-board-committee.spec.ts` — assertions, search term, and fixture ids updated to the synthetic data.

No runtime/behavior change — the mock returns the same shape; only the data values changed.

## Scope note
This stops the **live** exposure in `main`'s current tree. The data entered `main` via merged PR #757 ("org memberships page"), so it is also present in `main`'s **git history** — purging that (org-wide history rewrite / GitHub Support) is a separate **incident** decision, not part of this PR.

Refs LFXV2-1865 (security review)

Made with [Cursor](https://cursor.com)