### PR TITLE
feat(campaigns): add AI-driven brief refinement with feedback

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -817,7 +817,7 @@
       @if (isRefining()) {
         <div class="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4" data-testid="planning-refine-panel">
           <div class="mb-2 flex items-center gap-2">
-            <i class="fa-light fa-wand-magic-sparkles text-blue-600"></i>
+            <i class="fa-light fa-wand-magic-sparkles text-blue-600" aria-hidden="true"></i>
             <span class="text-sm font-semibold text-blue-800">Refine with AI</span>
           </div>
           <p class="mb-3 text-xs text-blue-700">Describe what you'd like to change — tone, audience focus, specific headlines, keyword direction, etc.</p>
@@ -834,7 +834,7 @@
           @if (refineStatusMessages().length > 0) {
             <div class="mt-2 flex flex-col gap-1">
               @for (msg of refineStatusMessages(); track $index) {
-                <span class="text-xs text-blue-600"><i class="fa-light fa-circle-info mr-1"></i>{{ msg }}</span>
+                <span class="text-xs text-blue-600"><i class="fa-light fa-circle-info mr-1" aria-hidden="true"></i>{{ msg }}</span>
               }
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -272,7 +272,7 @@
     <!-- Success / Refined Banner -->
     <div
       class="rounded-lg border p-4"
-      [class]="lastAppliedFeedback() ? 'border-violet-200 bg-violet-50' : 'border-green-200 bg-green-50'"
+      [ngClass]="lastAppliedFeedback() ? 'border-violet-200 bg-violet-50' : 'border-green-200 bg-green-50'"
       data-testid="planning-success-banner">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
@@ -832,7 +832,7 @@
 
           @if (refineStatusMessages().length > 0) {
             <div class="mt-2 flex flex-col gap-1">
-              @for (msg of refineStatusMessages(); track msg) {
+              @for (msg of refineStatusMessages(); track $index) {
                 <span class="text-xs text-blue-600"><i class="fa-light fa-circle-info mr-1"></i>{{ msg }}</span>
               }
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -825,6 +825,7 @@
             class="w-full rounded-md border border-blue-300 bg-white p-3 text-sm text-gray-800 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             rows="3"
             placeholder="e.g. Make headlines more action-oriented, focus on cloud-native developers, add urgency for early-bird pricing..."
+            maxlength="2000"
             [value]="refineFeedback()"
             (input)="refineFeedback.set($any($event.target).value)"
             [disabled]="isRefineStreaming()"

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -269,12 +269,20 @@
 <!-- Review Step -->
 @if (step() === 'review') {
   <div class="flex flex-col gap-4" data-testid="planning-review-step">
-    <!-- Success Banner -->
-    <div class="rounded-lg border border-green-200 bg-green-50 p-4" data-testid="planning-success-banner">
+    <!-- Success / Refined Banner -->
+    <div
+      class="rounded-lg border p-4"
+      [class]="lastAppliedFeedback() ? 'border-violet-200 bg-violet-50' : 'border-green-200 bg-green-50'"
+      data-testid="planning-success-banner">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
-          <i class="fa-light fa-circle-check text-lg text-green-600" aria-hidden="true"></i>
-          <span class="text-sm font-semibold text-green-800">Brief generated successfully</span>
+          @if (lastAppliedFeedback()) {
+            <i class="fa-light fa-wand-magic-sparkles text-lg text-violet-600" aria-hidden="true"></i>
+            <span class="text-sm font-semibold text-violet-800">Brief refined (iteration {{ refineCount() }})</span>
+          } @else {
+            <i class="fa-light fa-circle-check text-lg text-green-600" aria-hidden="true"></i>
+            <span class="text-sm font-semibold text-green-800">Brief generated successfully</span>
+          }
         </div>
         @if (!isEditing()) {
           <button
@@ -298,6 +306,12 @@
             <i class="fa-light fa-location-dot" aria-hidden="true"></i>
             {{ details.city }}
           </span>
+        </div>
+      }
+      @if (lastAppliedFeedback()) {
+        <div class="mt-2 flex items-start gap-2 pl-7">
+          <i class="fa-light fa-quote-left mt-0.5 text-xs text-violet-400" aria-hidden="true"></i>
+          <span class="text-xs italic text-violet-700">{{ lastAppliedFeedback() }}</span>
         </div>
       }
     </div>
@@ -766,6 +780,14 @@
           ariaLabel="Proceed to implementation with this brief"
           data-testid="planning-proceed-btn" />
         <lfx-button
+          label="Refine Brief"
+          icon="fa-light fa-wand-magic-sparkles"
+          severity="secondary"
+          [outlined]="true"
+          (onClick)="enterRefineMode()"
+          ariaLabel="Provide feedback to regenerate the brief"
+          data-testid="planning-refine-brief-btn" />
+        <lfx-button
           label="Edit Brief"
           icon="fa-light fa-pen-to-square"
           severity="secondary"
@@ -790,6 +812,55 @@
           ariaLabel="Start a new brief"
           data-testid="planning-new-brief-btn" />
       </div>
+
+      <!-- Refine Feedback Panel -->
+      @if (isRefining()) {
+        <div class="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4" data-testid="planning-refine-panel">
+          <div class="mb-2 flex items-center gap-2">
+            <i class="fa-light fa-wand-magic-sparkles text-blue-600"></i>
+            <span class="text-sm font-semibold text-blue-800">Refine with AI</span>
+          </div>
+          <p class="mb-3 text-xs text-blue-700">Describe what you'd like to change — tone, audience focus, specific headlines, keyword direction, etc.</p>
+          <textarea
+            class="w-full rounded-md border border-blue-300 bg-white p-3 text-sm text-gray-800 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            rows="3"
+            placeholder="e.g. Make headlines more action-oriented, focus on cloud-native developers, add urgency for early-bird pricing..."
+            [value]="refineFeedback()"
+            (input)="refineFeedback.set($any($event.target).value)"
+            [disabled]="isRefineStreaming()"
+            data-testid="planning-refine-textarea"></textarea>
+
+          @if (refineStatusMessages().length > 0) {
+            <div class="mt-2 flex flex-col gap-1">
+              @for (msg of refineStatusMessages(); track msg) {
+                <span class="text-xs text-blue-600"><i class="fa-light fa-circle-info mr-1"></i>{{ msg }}</span>
+              }
+            </div>
+          }
+
+          <div class="mt-3 flex items-center gap-2">
+            <lfx-button
+              label="Regenerate"
+              icon="fa-light fa-sparkles"
+              severity="primary"
+              size="small"
+              [disabled]="!refineFeedback().trim() || isRefineStreaming()"
+              [loading]="isRefineStreaming()"
+              (onClick)="submitRefine()"
+              ariaLabel="Submit feedback and regenerate brief"
+              data-testid="planning-refine-submit-btn" />
+            <lfx-button
+              label="Cancel"
+              severity="secondary"
+              size="small"
+              [outlined]="true"
+              [disabled]="isRefineStreaming()"
+              (onClick)="cancelRefine()"
+              ariaLabel="Cancel refine"
+              data-testid="planning-refine-cancel-btn" />
+          </div>
+        </div>
+      }
     }
   </div>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, NgClass } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
@@ -28,7 +28,7 @@ type PlanningStep = 'input' | 'generating' | 'review';
 
 @Component({
   selector: 'lfx-planning-tab',
-  imports: [ReactiveFormsModule, ButtonComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, NgClass],
   templateUrl: './planning-tab.component.html',
   styleUrl: './planning-tab.component.scss',
 })
@@ -211,6 +211,9 @@ export class PlanningTabComponent implements OnInit {
     this.errorMessage.set(null);
     this.isEditing.set(false);
     this.isRefining.set(false);
+    this.isRefineStreaming.set(false);
+    this.refineFeedback.set('');
+    this.refineStatusMessages.set([]);
     this.lastAppliedFeedback.set(null);
     this.refineCount.set(0);
   }
@@ -403,8 +406,6 @@ export class PlanningTabComponent implements OnInit {
         },
         complete: () => {
           this.isRefineStreaming.set(false);
-          this.isRefining.set(false);
-          this.refineFeedback.set('');
         },
       });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -12,6 +12,7 @@ import { debounceTime, Subject, Subscription } from 'rxjs';
 
 import type {
   CampaignBriefOutput,
+  CampaignBriefRefineRequest,
   CampaignEventDetails,
   CampaignGoal,
   CampaignGoalOption,
@@ -82,6 +83,14 @@ export class PlanningTabComponent implements OnInit {
   protected readonly editDisplayCta = signal('');
   protected readonly editKeywords = signal<CampaignKeyword[]>([]);
   protected readonly isEditing = signal(false);
+
+  // === Refine Mode Signals ===
+  protected readonly isRefining = signal(false);
+  protected readonly refineFeedback = signal('');
+  protected readonly refineStatusMessages = signal<string[]>([]);
+  protected readonly isRefineStreaming = signal(false);
+  protected readonly lastAppliedFeedback = signal<string | null>(null);
+  protected readonly refineCount = signal(0);
 
   // === Computed Signals ===
   private readonly formValid = toSignal(this.briefForm.statusChanges, { initialValue: this.briefForm.status });
@@ -201,6 +210,9 @@ export class PlanningTabComponent implements OnInit {
     this.keywords.set([]);
     this.errorMessage.set(null);
     this.isEditing.set(false);
+    this.isRefining.set(false);
+    this.lastAppliedFeedback.set(null);
+    this.refineCount.set(0);
   }
 
   protected onProceedToImplementation(): void {
@@ -344,6 +356,96 @@ export class PlanningTabComponent implements OnInit {
 
   protected removeKeyword(index: number): void {
     this.editKeywords.update((kws) => kws.filter((_, i) => i !== index));
+  }
+
+  protected enterRefineMode(): void {
+    this.isRefining.set(true);
+    this.refineFeedback.set('');
+    this.refineStatusMessages.set([]);
+  }
+
+  protected cancelRefine(): void {
+    this.isRefining.set(false);
+    this.refineFeedback.set('');
+    this.refineStatusMessages.set([]);
+  }
+
+  protected submitRefine(): void {
+    const feedback = this.refineFeedback().trim();
+    if (!feedback) return;
+
+    const currentCopy = this.structuredCopy();
+    if (!currentCopy) return;
+
+    this.isRefineStreaming.set(true);
+    this.refineStatusMessages.set([]);
+    this.copyBuffer.set('');
+
+    const capturedFeedback = feedback;
+
+    const request: CampaignBriefRefineRequest = {
+      currentCopy,
+      currentKeywords: this.keywords(),
+      feedback: capturedFeedback,
+      eventDetails: this.eventDetails(),
+      platforms: [...this.selectedPlatforms()],
+    };
+
+    this.briefSubscription?.unsubscribe();
+    this.briefSubscription = this.campaignService
+      .refineBrief(request)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (event: SSEEvent<CampaignSSEEventType>) => this.handleRefineSSEEvent(event, capturedFeedback),
+        error: () => {
+          this.refineStatusMessages.update((msgs) => [...msgs, 'Connection lost. Please try again.']);
+          this.isRefineStreaming.set(false);
+        },
+        complete: () => {
+          this.isRefineStreaming.set(false);
+          this.isRefining.set(false);
+          this.refineFeedback.set('');
+        },
+      });
+  }
+
+  private handleRefineSSEEvent(event: SSEEvent<CampaignSSEEventType>, feedback: string): void {
+    switch (event.type) {
+      case 'status':
+        this.refineStatusMessages.update((msgs) => [...msgs, event.data as string]);
+        break;
+      case 'copy_token':
+        this.copyBuffer.update((buf) => buf + (event.data as string));
+        break;
+      case 'copy_structured': {
+        const raw = event.data as Record<string, unknown>;
+        const nested = raw['platforms'] as Record<string, unknown> | undefined;
+        if (nested) {
+          for (const [key, value] of Object.entries(nested)) {
+            if (!(key in raw)) raw[key] = value;
+          }
+          delete raw['platforms'];
+        }
+        this.structuredCopy.set(raw);
+        break;
+      }
+      case 'copy_done':
+        break;
+      case 'keywords':
+        this.keywords.set(event.data as CampaignKeyword[]);
+        break;
+      case 'error':
+        this.refineStatusMessages.update((msgs) => [...msgs, event.data as string]);
+        this.isRefineStreaming.set(false);
+        break;
+      case 'done':
+        this.lastAppliedFeedback.set(feedback);
+        this.refineCount.update((n) => n + 1);
+        this.isRefineStreaming.set(false);
+        this.isRefining.set(false);
+        this.refineFeedback.set('');
+        break;
+    }
   }
 
   // === Private Methods ===

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -8,6 +8,7 @@ import {
   AudienceDemographics,
   BulkKeywordActionRequest,
   BulkKeywordActionResponse,
+  CampaignBriefRefineRequest,
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
@@ -30,6 +31,13 @@ export class CampaignService {
 
   public generateBrief(request: CampaignBriefRequest): Observable<SSEEvent<CampaignSSEEventType>> {
     return this.sse.connect<CampaignSSEEventType>('/api/campaigns/brief/generate', {
+      method: 'POST',
+      body: request,
+    });
+  }
+
+  public refineBrief(request: CampaignBriefRefineRequest): Observable<SSEEvent<CampaignSSEEventType>> {
+    return this.sse.connect<CampaignSSEEventType>('/api/campaigns/brief/refine', {
       method: 'POST',
       body: request,
     });

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -119,6 +119,18 @@ export class CampaignController {
       return;
     }
 
+    const MAX_FEEDBACK_LENGTH = 2000;
+    if (body.feedback.trim().length > MAX_FEEDBACK_LENGTH) {
+      _next(
+        ServiceValidationError.forField('feedback', `feedback must be ${MAX_FEEDBACK_LENGTH} characters or fewer`, {
+          operation: 'campaign_refine_brief',
+          service: 'campaign_controller',
+          path: req.path,
+        })
+      );
+      return;
+    }
+
     if (!body.currentCopy || typeof body.currentCopy !== 'object') {
       const validationError = ServiceValidationError.forField('currentCopy', 'currentCopy is required', {
         operation: 'campaign_refine_brief',
@@ -126,6 +138,18 @@ export class CampaignController {
         path: req.path,
       });
       _next(validationError);
+      return;
+    }
+
+    const MAX_COPY_JSON_LENGTH = 50_000;
+    if (JSON.stringify(body.currentCopy).length > MAX_COPY_JSON_LENGTH) {
+      _next(
+        ServiceValidationError.forField('currentCopy', 'currentCopy payload too large', {
+          operation: 'campaign_refine_brief',
+          service: 'campaign_controller',
+          path: req.path,
+        })
+      );
       return;
     }
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -131,7 +131,7 @@ export class CampaignController {
       return;
     }
 
-    if (!body.currentCopy || typeof body.currentCopy !== 'object') {
+    if (!body.currentCopy || typeof body.currentCopy !== 'object' || Array.isArray(body.currentCopy)) {
       const validationError = ServiceValidationError.forField('currentCopy', 'currentCopy is required', {
         operation: 'campaign_refine_brief',
         service: 'campaign_controller',
@@ -153,8 +153,8 @@ export class CampaignController {
       return;
     }
 
-    if (body.currentKeywords && !Array.isArray(body.currentKeywords)) {
-      const validationError = ServiceValidationError.forField('currentKeywords', 'currentKeywords must be an array', {
+    if (!body.currentKeywords || !Array.isArray(body.currentKeywords)) {
+      const validationError = ServiceValidationError.forField('currentKeywords', 'currentKeywords must be a non-empty array', {
         operation: 'campaign_refine_brief',
         service: 'campaign_controller',
         path: req.path,

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -129,6 +129,16 @@ export class CampaignController {
       return;
     }
 
+    if (body.currentKeywords && !Array.isArray(body.currentKeywords)) {
+      const validationError = ServiceValidationError.forField('currentKeywords', 'currentKeywords must be an array', {
+        operation: 'campaign_refine_brief',
+        service: 'campaign_controller',
+        path: req.path,
+      });
+      _next(validationError);
+      return;
+    }
+
     const startTime = logger.startOperation(req, 'campaign_refine_brief', {});
 
     res.setHeader('Content-Type', 'text/event-stream');
@@ -156,12 +166,18 @@ export class CampaignController {
     };
 
     try {
+      let hadError = false;
       for await (const event of this.proxyService.streamRefinedBrief(req, body, abortController.signal)) {
         if (clientDisconnected) return;
+        if (event.type === 'error') hadError = true;
         sendEvent(event.type, event.data);
       }
 
-      logger.success(req, 'campaign_refine_brief', startTime, {});
+      if (hadError) {
+        logger.warning(req, 'campaign_refine_brief', 'Refine stream completed with error event', {});
+      } else {
+        logger.success(req, 'campaign_refine_brief', startTime, {});
+      }
     } catch (error) {
       if (clientDisconnected) return;
       logger.error(req, 'campaign_refine_brief', startTime, error, {});

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -3,7 +3,13 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import type { BulkKeywordActionRequest, CampaignBriefRequest, CampaignSSEEventType, FlushableResponse } from '@lfx-one/shared/interfaces';
+import type {
+  BulkKeywordActionRequest,
+  CampaignBriefRefineRequest,
+  CampaignBriefRequest,
+  CampaignSSEEventType,
+  FlushableResponse,
+} from '@lfx-one/shared/interfaces';
 
 import { ServiceValidationError } from '../errors';
 import { CampaignMetricsService } from '../services/campaign-metrics.service';
@@ -87,6 +93,79 @@ export class CampaignController {
       if (clientDisconnected) return;
       logger.error(req, 'campaign_generate_brief', startTime, error, {});
       sendEvent('error', 'Brief generation failed. Please try again.');
+    } finally {
+      this.activeStreams.delete(res);
+      if (!clientDisconnected) {
+        res.end();
+      }
+    }
+  }
+
+  public async refineBrief(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    if (isShuttingDown()) {
+      res.status(503).json({ status: 'shutting_down' });
+      return;
+    }
+
+    const body = req.body as CampaignBriefRefineRequest;
+
+    if (!body.feedback || typeof body.feedback !== 'string' || !body.feedback.trim()) {
+      const validationError = ServiceValidationError.forField('feedback', 'feedback is required', {
+        operation: 'campaign_refine_brief',
+        service: 'campaign_controller',
+        path: req.path,
+      });
+      _next(validationError);
+      return;
+    }
+
+    if (!body.currentCopy || typeof body.currentCopy !== 'object') {
+      const validationError = ServiceValidationError.forField('currentCopy', 'currentCopy is required', {
+        operation: 'campaign_refine_brief',
+        service: 'campaign_controller',
+        path: req.path,
+      });
+      _next(validationError);
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'campaign_refine_brief', {});
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('Content-Encoding', 'identity');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+    res.socket?.setNoDelay(true);
+
+    const abortController = new AbortController();
+    let clientDisconnected = false;
+
+    this.activeStreams.add(res);
+    res.on('close', () => {
+      clientDisconnected = true;
+      this.activeStreams.delete(res);
+      abortController.abort();
+    });
+
+    const sendEvent = (type: CampaignSSEEventType, data: unknown): void => {
+      if (clientDisconnected || isShuttingDown()) return;
+      res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
+      (res as FlushableResponse).flush?.();
+    };
+
+    try {
+      for await (const event of this.proxyService.streamRefinedBrief(req, body, abortController.signal)) {
+        if (clientDisconnected) return;
+        sendEvent(event.type, event.data);
+      }
+
+      logger.success(req, 'campaign_refine_brief', startTime, {});
+    } catch (error) {
+      if (clientDisconnected) return;
+      logger.error(req, 'campaign_refine_brief', startTime, error, {});
+      sendEvent('error', 'Brief refinement failed. Please try again.');
     } finally {
       this.activeStreams.delete(res);
       if (!clientDisconnected) {

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -9,6 +9,7 @@ const router = Router();
 const campaignController = new CampaignController();
 
 router.post('/brief/generate', (req, res, next) => campaignController.generateBrief(req, res, next));
+router.post('/brief/refine', (req, res, next) => campaignController.refineBrief(req, res, next));
 router.post('/create', (req, res, next) => campaignController.createCampaign(req, res, next));
 router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(req, res, next));
 router.get('/hubspot/utm', (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -673,6 +673,12 @@ export class CampaignProxyService {
   ): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
+    const unsupported = (body.platforms ?? []).filter((p) => p !== 'google-ads');
+    if (unsupported.length > 0) {
+      yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Only google-ads is currently supported.` };
+      return;
+    }
+
     yield { type: 'status', data: 'Refining brief based on your feedback...' };
 
     const userPrompt = buildRefinePrompt(body);
@@ -1228,7 +1234,7 @@ Respect all character limits from the system prompt. Return the same JSON format
 }
 
 function buildRefineKeywordPrompt(body: CampaignBriefRefineRequest): string {
-  const currentKws = body.currentKeywords.map((kw) => kw.term).join(', ');
+  const currentKws = (body.currentKeywords ?? []).map((kw) => kw.term).join(', ');
   const eventName = body.eventDetails?.name || '';
 
   return `Regenerate keywords for this event based on user feedback.

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -289,10 +289,12 @@ async function resolveHubSpotUtm(eventName: string): Promise<string | null> {
 // AI service helpers (LiteLLM proxy — same pattern as ai.service.ts)
 // ---------------------------------------------------------------------------
 
-async function aiChat(systemPrompt: string, userPrompt: string, maxTokens = 4096): Promise<string> {
+async function aiChat(systemPrompt: string, userPrompt: string, externalSignal?: AbortSignal, maxTokens = 4096): Promise<string> {
   const aiProxyUrl = getEnv('AI_PROXY_URL');
   const aiApiKey = getEnv('AI_API_KEY');
   if (!aiProxyUrl || !aiApiKey) throw new Error('AI_PROXY_URL and AI_API_KEY required');
+
+  const signal = externalSignal ? AbortSignal.any([externalSignal, AbortSignal.timeout(30_000)]) : AbortSignal.timeout(30_000);
 
   const response = await fetch(aiProxyUrl, {
     method: 'POST',
@@ -309,7 +311,7 @@ async function aiChat(systemPrompt: string, userPrompt: string, maxTokens = 4096
       max_tokens: maxTokens,
       temperature: 0.7,
     }),
-    signal: AbortSignal.timeout(30_000),
+    signal,
   });
 
   if (!response.ok) {
@@ -718,32 +720,36 @@ export class CampaignProxyService {
       return;
     }
 
-    yield { type: 'status', data: 'Regenerating keywords...' };
+    const platforms = body.platforms || ['google-ads'];
+    if (platforms.includes('google-ads')) {
+      yield { type: 'status', data: 'Regenerating keywords...' };
 
-    try {
-      const kwPrompt = buildRefineKeywordPrompt(body);
-      let kwText = (await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt)).trim();
-      if (kwText.startsWith('```')) {
-        const firstNl = kwText.indexOf('\n');
-        if (firstNl !== -1) kwText = kwText.slice(firstNl + 1);
-        const lastFence = kwText.lastIndexOf('```');
-        if (lastFence !== -1) kwText = kwText.slice(0, lastFence);
-        kwText = kwText.trim();
+      try {
+        const kwPrompt = buildRefineKeywordPrompt(body);
+        let kwText = (await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt, signal)).trim();
+        if (kwText.startsWith('```')) {
+          const firstNl = kwText.indexOf('\n');
+          if (firstNl !== -1) kwText = kwText.slice(firstNl + 1);
+          const lastFence = kwText.lastIndexOf('```');
+          if (lastFence !== -1) kwText = kwText.slice(0, lastFence);
+          kwText = kwText.trim();
+        }
+        let kwList = JSON.parse(kwText);
+        if (kwList && typeof kwList === 'object' && !Array.isArray(kwList) && Array.isArray(kwList.keywords)) {
+          kwList = kwList.keywords;
+        }
+        const keywords = (kwList as Record<string, string>[]).map((k) => ({
+          term: k['term'] || k['keyword'] || '',
+          matchType: k['match_type'] || k['matchType'] || 'Broad',
+          intentLevel: k['intent_level'] || k['intentLevel'] || 'Medium',
+          notes: k['notes'] || '',
+        }));
+        yield { type: 'keywords', data: keywords };
+      } catch (error) {
+        if (signal.aborted) return;
+        logger.warning(req, 'campaign_refine_keywords', 'Keyword regeneration failed', { err: error });
+        yield { type: 'status', data: 'Keyword regeneration failed, keeping existing keywords...' };
       }
-      let kwList = JSON.parse(kwText);
-      if (kwList && typeof kwList === 'object' && !Array.isArray(kwList) && Array.isArray(kwList.keywords)) {
-        kwList = kwList.keywords;
-      }
-      const keywords = (kwList as Record<string, string>[]).map((k) => ({
-        term: k['term'] || k['keyword'] || '',
-        matchType: k['match_type'] || k['matchType'] || 'Broad',
-        intentLevel: k['intent_level'] || k['intentLevel'] || 'Medium',
-        notes: k['notes'] || '',
-      }));
-      yield { type: 'keywords', data: keywords };
-    } catch (error) {
-      logger.warning(req, 'campaign_refine_keywords', 'Keyword regeneration failed', { err: error });
-      yield { type: 'status', data: 'Keyword regeneration failed, keeping existing keywords...' };
     }
 
     yield { type: 'done', data: null };

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -624,14 +624,7 @@ export class CampaignProxyService {
       yield { type: 'copy_done', data: null };
 
       try {
-        let text = fullCopy.trim();
-        if (text.startsWith('```')) {
-          const firstNewline = text.indexOf('\n');
-          if (firstNewline !== -1) text = text.slice(firstNewline + 1);
-          const lastFence = text.lastIndexOf('```');
-          if (lastFence !== -1) text = text.slice(0, lastFence);
-          text = text.trim();
-        }
+        const text = stripJsonFences(fullCopy);
         const structured = JSON.parse(text) as Record<string, unknown>;
 
         truncateAdCopy(structured);
@@ -650,14 +643,7 @@ export class CampaignProxyService {
 
       try {
         const kwPrompt = buildKeywordPrompt(body, eventDetails);
-        let kwText = (await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt)).trim();
-        if (kwText.startsWith('```')) {
-          const firstNl = kwText.indexOf('\n');
-          if (firstNl !== -1) kwText = kwText.slice(firstNl + 1);
-          const lastFence = kwText.lastIndexOf('```');
-          if (lastFence !== -1) kwText = kwText.slice(0, lastFence);
-          kwText = kwText.trim();
-        }
+        const kwText = stripJsonFences(await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt));
         let kwList = JSON.parse(kwText);
         if (kwList && typeof kwList === 'object' && !Array.isArray(kwList) && Array.isArray(kwList.keywords)) {
           kwList = kwList.keywords;
@@ -700,14 +686,7 @@ export class CampaignProxyService {
       yield { type: 'copy_done', data: null };
 
       try {
-        let text = fullCopy.trim();
-        if (text.startsWith('```')) {
-          const firstNewline = text.indexOf('\n');
-          if (firstNewline !== -1) text = text.slice(firstNewline + 1);
-          const lastFence = text.lastIndexOf('```');
-          if (lastFence !== -1) text = text.slice(0, lastFence);
-          text = text.trim();
-        }
+        const text = stripJsonFences(fullCopy);
         const structured = JSON.parse(text) as Record<string, unknown>;
         truncateAdCopy(structured);
         yield { type: 'copy_structured', data: structured };
@@ -726,14 +705,7 @@ export class CampaignProxyService {
 
       try {
         const kwPrompt = buildRefineKeywordPrompt(body);
-        let kwText = (await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt, signal)).trim();
-        if (kwText.startsWith('```')) {
-          const firstNl = kwText.indexOf('\n');
-          if (firstNl !== -1) kwText = kwText.slice(firstNl + 1);
-          const lastFence = kwText.lastIndexOf('```');
-          if (lastFence !== -1) kwText = kwText.slice(0, lastFence);
-          kwText = kwText.trim();
-        }
+        const kwText = stripJsonFences(await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt, signal));
         let kwList = JSON.parse(kwText);
         if (kwList && typeof kwList === 'object' && !Array.isArray(kwList) && Array.isArray(kwList.keywords)) {
           kwList = kwList.keywords;
@@ -1097,6 +1069,15 @@ export class CampaignProxyService {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function stripJsonFences(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('```')) return trimmed;
+  const firstNewline = trimmed.indexOf('\n');
+  const inner = firstNewline !== -1 ? trimmed.slice(firstNewline + 1) : trimmed;
+  const lastFence = inner.lastIndexOf('```');
+  return (lastFence !== -1 ? inner.slice(0, lastFence) : inner).trim();
+}
 
 function resolveMatchType(matchType: string): number {
   const normalized = matchType.toLowerCase();

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -6,6 +6,7 @@ import { AI_MODEL } from '@lfx-one/shared/constants';
 import type {
   BulkKeywordActionRequest,
   BulkKeywordActionResponse,
+  CampaignBriefRefineRequest,
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
@@ -675,6 +676,79 @@ export class CampaignProxyService {
     yield { type: 'done', data: null };
   }
 
+  // === Brief refinement (SSE stream) ===
+
+  public async *streamRefinedBrief(
+    req: Request,
+    body: CampaignBriefRefineRequest,
+    signal: AbortSignal
+  ): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
+    checkRequiredEnv(req);
+
+    yield { type: 'status', data: 'Refining brief based on your feedback...' };
+
+    const userPrompt = buildRefinePrompt(body);
+    let fullCopy = '';
+
+    try {
+      for await (const token of aiChatStream(COPY_SYSTEM_PROMPT, userPrompt, signal)) {
+        yield { type: 'copy_token', data: token };
+        fullCopy += token;
+      }
+      yield { type: 'copy_done', data: null };
+
+      try {
+        let text = fullCopy.trim();
+        if (text.startsWith('```')) {
+          const firstNewline = text.indexOf('\n');
+          if (firstNewline !== -1) text = text.slice(firstNewline + 1);
+          const lastFence = text.lastIndexOf('```');
+          if (lastFence !== -1) text = text.slice(0, lastFence);
+          text = text.trim();
+        }
+        const structured = JSON.parse(text) as Record<string, unknown>;
+        truncateAdCopy(structured);
+        yield { type: 'copy_structured', data: structured };
+      } catch {
+        yield { type: 'copy_structured', data: { raw: fullCopy } };
+      }
+    } catch (error) {
+      if (signal.aborted) return;
+      yield { type: 'error', data: `Brief refinement failed: ${error instanceof Error ? error.message : 'Unknown error'}` };
+      return;
+    }
+
+    yield { type: 'status', data: 'Regenerating keywords...' };
+
+    try {
+      const kwPrompt = buildRefineKeywordPrompt(body);
+      let kwText = (await aiChat(KEYWORD_SYSTEM_PROMPT, kwPrompt)).trim();
+      if (kwText.startsWith('```')) {
+        const firstNl = kwText.indexOf('\n');
+        if (firstNl !== -1) kwText = kwText.slice(firstNl + 1);
+        const lastFence = kwText.lastIndexOf('```');
+        if (lastFence !== -1) kwText = kwText.slice(0, lastFence);
+        kwText = kwText.trim();
+      }
+      let kwList = JSON.parse(kwText);
+      if (kwList && typeof kwList === 'object' && !Array.isArray(kwList) && Array.isArray(kwList.keywords)) {
+        kwList = kwList.keywords;
+      }
+      const keywords = (kwList as Record<string, string>[]).map((k) => ({
+        term: k['term'] || k['keyword'] || '',
+        matchType: k['match_type'] || k['matchType'] || 'Broad',
+        intentLevel: k['intent_level'] || k['intentLevel'] || 'Medium',
+        notes: k['notes'] || '',
+      }));
+      yield { type: 'keywords', data: keywords };
+    } catch (error) {
+      logger.warning(req, 'campaign_refine_keywords', 'Keyword regeneration failed', { err: error });
+      yield { type: 'status', data: 'Keyword regeneration failed, keeping existing keywords...' };
+    }
+
+    yield { type: 'done', data: null };
+  }
+
   // === Campaign creation (async job) ===
 
   public async createCampaign(_req: Request, body: CampaignCreateRequest): Promise<{ jobId: string; result?: CampaignCreateResponse; error?: string }> {
@@ -1149,6 +1223,43 @@ CRITICAL RULES:
 - The event year is ${eventYear}. NEVER use any other year in keywords.
 - Prefer HIGH INTENT — keywords that indicate someone actively searching for this event.
 - Avoid generic broad terms that waste budget (e.g. "conference" alone).`;
+}
+
+function buildRefinePrompt(body: CampaignBriefRefineRequest): string {
+  const eventBlock = body.eventDetails ? `\nEVENT: ${body.eventDetails.name}\nDates: ${body.eventDetails.dates}\nCity: ${body.eventDetails.city}\n` : '';
+
+  return `I have existing Google Ads copy that needs refinement based on user feedback.
+
+CURRENT AD COPY:
+${JSON.stringify(body.currentCopy, null, 2)}
+${eventBlock}
+USER FEEDBACK:
+${body.feedback}
+
+Please regenerate the ad copy incorporating the user's feedback while maintaining the same JSON structure.
+Respect all character limits from the system prompt. Return the same JSON format with keys "google_search" and "google_display".`;
+}
+
+function buildRefineKeywordPrompt(body: CampaignBriefRefineRequest): string {
+  const currentKws = body.currentKeywords.map((kw) => kw.term).join(', ');
+  const eventName = body.eventDetails?.name || '';
+
+  return `Regenerate keywords for this event based on user feedback.
+
+EVENT: ${eventName}
+CURRENT KEYWORDS: ${currentKws}
+
+USER FEEDBACK: ${body.feedback}
+
+Based on the feedback, generate 25-40 refined Google Search keywords.
+
+Return a JSON array where each object has EXACTLY these keys:
+- "term": the keyword string
+- "match_type": "Exact", "Phrase", or "Broad"
+- "intent_level": "High" (direct event search), "Medium" (related topic), "Low" (broad)
+- "notes": any flag (e.g. "added per user feedback")
+
+Prefer HIGH INTENT keywords. Incorporate the user's feedback to improve the keyword list.`;
 }
 
 const REGION_MAP: Record<string, string> = {

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -109,6 +109,14 @@ export interface CampaignBriefOutput {
   campaignGoal: CampaignGoal | null;
 }
 
+export interface CampaignBriefRefineRequest {
+  currentCopy: Record<string, unknown>;
+  currentKeywords: CampaignKeyword[];
+  feedback: string;
+  eventDetails?: CampaignEventDetails | null;
+  platforms?: CampaignPlatform[];
+}
+
 // ---------------------------------------------------------------------------
 // Campaign Creation (Implementation Phase)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds an inline "Refine Brief" feedback panel to the campaign planning tab, allowing users to describe changes and have the AI regenerate the brief based on their feedback
- Introduces a new `/api/campaigns/brief/refine` SSE endpoint that skips scraping/extraction and sends existing copy + feedback directly to the AI for refinement
- Shows a distinct violet "Brief refined (iteration N)" banner with quoted feedback after successful refinement

## Changes
- `packages/shared/src/interfaces/campaign.interface.ts` — new `CampaignBriefRefineRequest` interface
- `apps/lfx-one/src/server/routes/campaigns.route.ts` — new POST route for `/brief/refine`
- `apps/lfx-one/src/server/controllers/campaign.controller.ts` — new `refineBrief()` controller method with SSE streaming
- `apps/lfx-one/src/server/services/campaign-proxy.service.ts` — new `streamRefinedBrief()` async generator + refine prompt builders
- `apps/lfx-one/src/app/shared/services/campaign.service.ts` — new `refineBrief()` Angular service method
- `apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts` — refine mode state signals and handlers
- `apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html` — inline feedback textarea UI, refine button, iteration banner

LFXV2-2023

🤖 Generated with [Claude Code](https://claude.ai/code)