### PR TITLE
feat(campaigns): add linkedin ads shared types and constants

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -226,18 +226,31 @@
               <div class="flex items-center justify-between">
                 <div>
                   <p class="text-sm font-medium text-gray-900">{{ campaign.campaignName }}</p>
-                  <p class="text-xs text-gray-500">
-                    {{ campaign.type }} · {{ campaign.adGroupCount }} ad groups · {{ campaign.keywordCount }} keywords · {{ campaign.adCount }} ads
-                  </p>
+                  @if (campaign.platform === 'google-ads') {
+                    <p class="text-xs text-gray-500">
+                      {{ campaign.type }} · {{ campaign.adGroupCount }} ad groups · {{ campaign.keywordCount }} keywords · {{ campaign.adCount }} ads
+                    </p>
+                  }
                 </div>
-                <a
-                  [href]="campaign.googleAdsUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
-                  Open in Google Ads
-                  <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
-                </a>
+                @if (campaign.platform === 'google-ads') {
+                  <a
+                    [href]="campaign.googleAdsUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
+                    Open in Google Ads
+                    <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+                  </a>
+                } @else {
+                  <a
+                    [href]="campaign.linkedInUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
+                    Open in LinkedIn
+                    <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+                  </a>
+                }
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -10,7 +10,7 @@ import { CampaignService } from '@services/campaign.service';
 import { map, startWith, Subscription, take } from 'rxjs';
 
 import type { Signal } from '@angular/core';
-import type { CampaignBriefOutput, CampaignCreateResponse, CampaignCreateResult, CampaignKeyword, CampaignType } from '@lfx-one/shared/interfaces';
+import type { CampaignBriefOutput, CampaignCreateResponse, CampaignResult, CampaignKeyword, CampaignType } from '@lfx-one/shared/interfaces';
 
 type ImplementationStep = 'form' | 'creating' | 'results';
 
@@ -53,7 +53,7 @@ export class ImplementationTabComponent {
   // === WritableSignals ===
   protected readonly step = signal<ImplementationStep>('form');
   protected readonly creationProgress = signal<string[]>([]);
-  protected readonly results = signal<CampaignCreateResult[]>([]);
+  protected readonly results = signal<CampaignResult[]>([]);
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
   protected readonly briefHsToken = signal<string | null>(null);

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -11,6 +11,7 @@ import type {
   CampaignCreateRequest,
   CampaignCreateResponse,
   CampaignCreateResult,
+  CampaignResult,
   CampaignJobStatus,
   CampaignKeyword,
   CampaignSSEEventType,
@@ -833,7 +834,7 @@ export class CampaignProxyService {
       }
     }
 
-    const results: CampaignCreateResult[] = [];
+    const results: CampaignResult[] = [];
     const errors: string[] = [];
 
     for (const campaignType of effectiveBody.campaignTypes) {
@@ -982,6 +983,7 @@ export class CampaignProxyService {
     steps.push(`Created RSA ad with ${headlines.length} headlines, ${descriptions.length} descriptions`);
 
     return {
+      platform: 'google-ads' as const,
       type: 'search',
       campaignName,
       campaignId,
@@ -1060,6 +1062,7 @@ export class CampaignProxyService {
     steps.push('Demand Gen campaign created — upload images and publish in Google Ads UI');
 
     return {
+      platform: 'google-ads' as const,
       type: 'demand-gen',
       campaignName,
       campaignId,

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1,7 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CampaignGoalOption, CampaignPlatformOption, CampaignStatus, CampaignTabOption, ParsedCampaignName } from '../interfaces/campaign.interface';
+import type {
+  CampaignGoalOption,
+  CampaignPlatformOption,
+  CampaignStatus,
+  CampaignTabOption,
+  LinkedInGeoTarget,
+  LinkedInTargetingProfile,
+  ParsedCampaignName,
+} from '../interfaces/campaign.interface';
 
 /** Tab definitions for the Campaigns page tab navigation. */
 export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
@@ -14,7 +22,7 @@ export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
 export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'google-ads', label: 'Google Ads', icon: 'fa-brands fa-google' },
   { id: 'microsoft-ads', label: 'Microsoft Ads', icon: 'fa-brands fa-microsoft', disabled: true },
-  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin', disabled: true },
+  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin' },
   { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta', disabled: true },
   { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit', disabled: true },
   { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield', disabled: true },
@@ -95,3 +103,101 @@ export function parseCampaignName(raw: string): ParsedCampaignName {
     raw,
   };
 }
+
+// ---------------------------------------------------------------------------
+// LinkedIn Ads Constants
+// ---------------------------------------------------------------------------
+
+export const LINKEDIN_API_VERSION = '202602';
+
+export const LINKEDIN_CHAR_LIMITS = {
+  introText: 600,
+  headline: 200,
+} as const;
+
+export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; orgId: string }[] = [
+  { accountId: '538170226', label: 'The Linux Foundation', orgId: '208777' },
+  { accountId: '509430019', label: 'LF Events', orgId: '208777' },
+] as const;
+
+export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
+
+export interface LinkedInTargetingProfileConfig {
+  id: LinkedInTargetingProfile;
+  label: string;
+  skills: readonly string[];
+  groups: readonly string[];
+}
+
+export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [
+  {
+    id: 'cloud-native',
+    label: 'Cloud Native / CNCF',
+    skills: [
+      'urn:li:skill:55158',
+      'urn:li:skill:56347',
+      'urn:li:skill:56319',
+      'urn:li:skill:18442',
+      'urn:li:skill:1500290',
+      'urn:li:skill:55734',
+      'urn:li:skill:55383',
+      'urn:li:skill:1500358',
+      'urn:li:skill:56908',
+      'urn:li:skill:58498',
+      'urn:li:skill:55644',
+      'urn:li:skill:55102',
+      'urn:li:skill:56912',
+      'urn:li:skill:18443',
+      'urn:li:skill:25168',
+      'urn:li:skill:56320',
+      'urn:li:skill:25154',
+      'urn:li:skill:56580',
+      'urn:li:skill:56581',
+      'urn:li:skill:55385',
+    ],
+    groups: [
+      'urn:li:group:6821178',
+      'urn:li:group:9375272',
+      'urn:li:group:12405624',
+      'urn:li:group:12391549',
+      'urn:li:group:8553150',
+      'urn:li:group:13681295',
+      'urn:li:group:4490628',
+      'urn:li:group:2602008',
+      'urn:li:group:50985',
+      'urn:li:group:6585490',
+      'urn:li:group:3779791',
+      'urn:li:group:13799412',
+    ],
+  },
+  {
+    id: 'mcp',
+    label: 'MCP / Agentic AI',
+    skills: [
+      'urn:li:skill:59695',
+      'urn:li:skill:59040',
+      'urn:li:skill:61790',
+      'urn:li:skill:2407',
+      'urn:li:skill:3289',
+      'urn:li:skill:56912',
+      'urn:li:skill:61642',
+      'urn:li:skill:59698',
+      'urn:li:skill:5835',
+    ],
+    groups: ['urn:li:group:6672014', 'urn:li:group:6608681', 'urn:li:group:6773450', 'urn:li:group:10321152', 'urn:li:group:6731624', 'urn:li:group:961087'],
+  },
+] as const;
+
+export const LINKEDIN_GEO_RESOLVE_MAP: Readonly<Record<string, LinkedInGeoTarget>> = {
+  japan: { label: 'Japan', urn: 'urn:li:geo:101355337' },
+  india: { label: 'India', urn: 'urn:li:geo:102713980' },
+  singapore: { label: 'Singapore', urn: 'urn:li:geo:102454443' },
+  'south korea': { label: 'South Korea', urn: 'urn:li:geo:101452733' },
+  australia: { label: 'Australia', urn: 'urn:li:geo:101452733' },
+  taiwan: { label: 'Taiwan', urn: 'urn:li:geo:104441761' },
+  'hong kong': { label: 'Hong Kong', urn: 'urn:li:geo:103291313' },
+  'united states': { label: 'United States', urn: 'urn:li:geo:103644278' },
+  usa: { label: 'United States', urn: 'urn:li:geo:103644278' },
+  germany: { label: 'Germany', urn: 'urn:li:geo:101165590' },
+  'united kingdom': { label: 'United Kingdom', urn: 'urn:li:geo:106693272' },
+} as const;

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -192,7 +192,7 @@ export const LINKEDIN_GEO_RESOLVE_MAP: Readonly<Record<string, LinkedInGeoTarget
   japan: { label: 'Japan', urn: 'urn:li:geo:101355337' },
   india: { label: 'India', urn: 'urn:li:geo:102713980' },
   singapore: { label: 'Singapore', urn: 'urn:li:geo:102454443' },
-  'south korea': { label: 'South Korea', urn: 'urn:li:geo:101452733' },
+  'south korea': { label: 'South Korea', urn: 'urn:li:geo:105149562' },
   australia: { label: 'Australia', urn: 'urn:li:geo:101452733' },
   taiwan: { label: 'Taiwan', urn: 'urn:li:geo:104441761' },
   'hong kong': { label: 'Hong Kong', urn: 'urn:li:geo:103291313' },

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -7,7 +7,6 @@ import type {
   CampaignStatus,
   CampaignTabOption,
   LinkedInGeoTarget,
-  LinkedInTargetingProfile,
   LinkedInTargetingProfileConfig,
   ParsedCampaignName,
 } from '../interfaces/campaign.interface';

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -8,6 +8,7 @@ import type {
   CampaignTabOption,
   LinkedInGeoTarget,
   LinkedInTargetingProfile,
+  LinkedInTargetingProfileConfig,
   ParsedCampaignName,
 } from '../interfaces/campaign.interface';
 
@@ -22,7 +23,7 @@ export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
 export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'google-ads', label: 'Google Ads', icon: 'fa-brands fa-google' },
   { id: 'microsoft-ads', label: 'Microsoft Ads', icon: 'fa-brands fa-microsoft', disabled: true },
-  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin' },
+  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin', disabled: true },
   { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta', disabled: true },
   { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit', disabled: true },
   { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield', disabled: true },
@@ -121,13 +122,6 @@ export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; org
 ] as const;
 
 export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
-
-export interface LinkedInTargetingProfileConfig {
-  id: LinkedInTargetingProfile;
-  label: string;
-  skills: readonly string[];
-  groups: readonly string[];
-}
 
 export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [
   {

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -22,7 +22,7 @@ export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
 export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'google-ads', label: 'Google Ads', icon: 'fa-brands fa-google' },
   { id: 'microsoft-ads', label: 'Microsoft Ads', icon: 'fa-brands fa-microsoft', disabled: true },
-  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin', disabled: true },
+  { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin' },
   { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta', disabled: true },
   { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit', disabled: true },
   { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield', disabled: true },

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -198,7 +198,7 @@ export interface CampaignCreateRequest extends CampaignCreateBase {
   displayCallToAction?: string;
   geoTargets: string[];
   platforms?: CampaignPlatform[];
-  linkedInConfig?: LinkedInCampaignCreateRequest;
+  linkedInConfig?: Omit<LinkedInCampaignCreateRequest, keyof CampaignCreateBase>;
 }
 
 export interface CampaignCreateResult {

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -134,21 +134,36 @@ export interface LinkedInBriefCopy {
   recommendedTargetingProfile: LinkedInTargetingProfile;
 }
 
-export interface LinkedInCampaignCreateRequest {
+export interface LinkedInTargetingProfileConfig {
+  id: LinkedInTargetingProfile;
+  label: string;
+  skills: readonly string[];
+  groups: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Campaign Creation (Implementation Phase)
+// ---------------------------------------------------------------------------
+
+/** Fields shared between CampaignCreateRequest and LinkedInCampaignCreateRequest. */
+export interface CampaignCreateBase {
   eventName: string;
   eventSlug: string;
-  dates: string;
   registrationUrl: string;
   hsToken?: string;
   budgetUsd: number;
-  lifetimeBudget: boolean;
   startDate: string;
   endDate: string;
+  project?: string;
+  driveFolderUrl?: string;
+}
+
+export interface LinkedInCampaignCreateRequest extends CampaignCreateBase {
+  dates: string;
+  lifetimeBudget: boolean;
   geoTargets: LinkedInGeoTarget[];
   targetingProfile: LinkedInTargetingProfile;
   variants: LinkedInCreativeVariant[];
-  project?: string;
-  driveFolderUrl?: string;
 }
 
 export interface LinkedInCampaignCreateResult {
@@ -170,21 +185,10 @@ export interface CampaignBriefRefineRequest {
   platforms?: CampaignPlatform[];
 }
 
-// ---------------------------------------------------------------------------
-// Campaign Creation (Implementation Phase)
-// ---------------------------------------------------------------------------
-
-export interface CampaignCreateRequest {
-  eventName: string;
-  eventSlug: string;
+export interface CampaignCreateRequest extends CampaignCreateBase {
   countryCode: string;
-  registrationUrl: string;
-  hsToken?: string;
   campaignTypes: CampaignType[];
-  budgetUsd: number;
   searchBudgetPct: number;
-  startDate: string;
-  endDate: string;
   keywords: CampaignKeyword[];
   headlines: string[];
   descriptions: string[];
@@ -193,14 +197,12 @@ export interface CampaignCreateRequest {
   displayBusinessName?: string;
   displayCallToAction?: string;
   geoTargets: string[];
-  project?: string;
-  driveFolderUrl?: string;
   platforms?: CampaignPlatform[];
   linkedInConfig?: LinkedInCampaignCreateRequest;
 }
 
 export interface CampaignCreateResult {
-  platform?: CampaignPlatform;
+  platform: 'google-ads';
   type: CampaignType;
   campaignName: string;
   campaignId: string;
@@ -211,9 +213,12 @@ export interface CampaignCreateResult {
   steps: string[];
 }
 
+/** Discriminated union of per-platform create results. */
+export type CampaignResult = CampaignCreateResult | LinkedInCampaignCreateResult;
+
 export interface CampaignCreateResponse {
   success: boolean;
-  campaigns: CampaignCreateResult[];
+  campaigns: CampaignResult[];
   errors: string[];
 }
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -9,6 +9,8 @@ export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' |
 
 export type CampaignPhase = 'planning' | 'implementation' | 'insights' | 'optimization';
 
+export type LinkedInTargetingProfile = 'cloud-native' | 'mcp' | 'custom';
+
 export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited' | 'unknown';
 
 export type CampaignType = 'search' | 'demand-gen';
@@ -107,6 +109,57 @@ export interface CampaignBriefOutput {
   totalBudget: number | null;
   driveFolderUrl: string;
   campaignGoal: CampaignGoal | null;
+  selectedPlatforms?: CampaignPlatform[];
+  linkedInCopy?: LinkedInBriefCopy;
+}
+
+// ---------------------------------------------------------------------------
+// LinkedIn Ads
+// ---------------------------------------------------------------------------
+
+export interface LinkedInGeoTarget {
+  label: string;
+  urn: string;
+}
+
+export interface LinkedInCreativeVariant {
+  introText: string;
+  headline: string;
+  imageUrl?: string;
+}
+
+export interface LinkedInBriefCopy {
+  variants: LinkedInCreativeVariant[];
+  recommendedGeoTargets: LinkedInGeoTarget[];
+  recommendedTargetingProfile: LinkedInTargetingProfile;
+}
+
+export interface LinkedInCampaignCreateRequest {
+  eventName: string;
+  eventSlug: string;
+  dates: string;
+  registrationUrl: string;
+  hsToken?: string;
+  budgetUsd: number;
+  lifetimeBudget: boolean;
+  startDate: string;
+  endDate: string;
+  geoTargets: LinkedInGeoTarget[];
+  targetingProfile: LinkedInTargetingProfile;
+  variants: LinkedInCreativeVariant[];
+  project?: string;
+  driveFolderUrl?: string;
+}
+
+export interface LinkedInCampaignCreateResult {
+  platform: 'linkedin-ads';
+  campaignGroupName: string;
+  campaignGroupId: string;
+  campaignName: string;
+  campaignId: string;
+  creativeCount: number;
+  linkedInUrl: string;
+  steps: string[];
 }
 
 export interface CampaignBriefRefineRequest {
@@ -142,9 +195,12 @@ export interface CampaignCreateRequest {
   geoTargets: string[];
   project?: string;
   driveFolderUrl?: string;
+  platforms?: CampaignPlatform[];
+  linkedInConfig?: LinkedInCampaignCreateRequest;
 }
 
 export interface CampaignCreateResult {
+  platform?: CampaignPlatform;
   type: CampaignType;
   campaignName: string;
   campaignId: string;


### PR DESCRIPTION
## Summary
- Add LinkedIn-specific interfaces: `LinkedInGeoTarget`, `LinkedInCreativeVariant`, `LinkedInBriefCopy`, `LinkedInCampaignCreateRequest`, `LinkedInCampaignCreateResult`
- Add LinkedIn constants: targeting profiles (cloud-native + mcp with skill/group URNs), geo resolve map, char limits, account config, employer exclusions
- Enable LinkedIn in the platform selector (`disabled: true` removed)
- Extend `CampaignBriefOutput` with `selectedPlatforms` and `linkedInCopy` fields
- Add `platforms` and `linkedInConfig` to `CampaignCreateRequest` for multi-platform dispatch

## Test plan
- [ ] `yarn check-types` passes
- [ ] `yarn lint` passes
- [ ] `yarn build` passes
- [ ] Platform selector at `/foundation/campaigns?project=tlf` shows LinkedIn as enabled (clickable)

LFXV2-2154

🤖 Generated with [Claude Code](https://claude.ai/code)