### PR TITLE
feat(campaigns): add multi-platform dispatch for LinkedIn Ads

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -232,25 +232,14 @@
                     </p>
                   }
                 </div>
-                @if (campaign.platform === 'google-ads') {
-                  <a
-                    [href]="campaign.googleAdsUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
-                    Open in Google Ads
-                    <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
-                  </a>
-                } @else {
-                  <a
-                    [href]="campaign.linkedInUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
-                    Open in LinkedIn
-                    <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
-                  </a>
-                }
+                <a
+                  [href]="campaign.campaignUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
+                  {{ campaign.platform === 'linkedin-ads' ? 'Open in LinkedIn' : 'Open in Google Ads' }}
+                  <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+                </a>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -200,7 +200,7 @@ function parseCampaignMetrics(row: unknown, days: number, rangeStart: string, ra
     pacingPct,
     pacingLabel,
     campaignId,
-    googleAdsUrl: buildGoogleAdsUrl(campaignId),
+    campaignUrl: buildGoogleAdsUrl(campaignId),
   };
 }
 
@@ -232,7 +232,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'HIGH',
         issue: `Campaign limited by Google — only ${c.impressions.toLocaleString()} impressions on $${c.budgetDay.toFixed(2)}/day budget`,
         action: 'Switch bid strategy to Maximize Clicks, or expand keyword match types to increase eligible auctions',
@@ -243,7 +243,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'HIGH',
         issue: `Budget is $${c.budgetDay.toFixed(2)}/day — this is a placeholder and won't generate meaningful traffic`,
         action: 'Set a real daily budget (typically $10–50/day for events) before expecting results',
@@ -254,7 +254,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Campaign is paused — spent $${c.spend.toFixed(2)} before pause`,
         action: 'Check if this was intentionally paused or if the event is still upcoming and needs reactivation',
@@ -265,7 +265,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Only spending ${c.pacingPct}% of $${c.budgetDay.toFixed(2)}/day budget — $${c.spend.toFixed(2)} spent vs $${(c.budgetDay * 30).toFixed(2)} expected`,
         action: 'Broaden targeting (locations, audiences), add broad match keywords, or increase bids to win more auctions',
@@ -276,7 +276,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Spending ${c.pacingPct}% of budget — demand exceeds $${c.budgetDay.toFixed(2)}/day cap, ads stop showing mid-day`,
         action: 'Increase daily budget to capture missed impressions, or narrow targeting to focus spend on highest-value audiences',
@@ -287,7 +287,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Search CTR is ${c.ctr.toFixed(2)}% (benchmark: 2%+) — ${c.clicks} clicks from ${c.impressions.toLocaleString()} impressions`,
         action: 'Improve headline relevance to search intent, add negative keywords to filter irrelevant queries',
@@ -298,7 +298,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Display CTR is ${c.ctr.toFixed(2)}% (benchmark: 0.3%+) — ${c.clicks} clicks from ${c.impressions.toLocaleString()} impressions`,
         action: 'Refresh creative assets, check for audience overlap across campaigns, or narrow placement targeting',
@@ -309,7 +309,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `${c.clicks} clicks ($${c.spend.toFixed(2)} spent) but 0 conversions — traffic is not converting`,
         action: 'Verify conversion tracking is firing correctly, check landing page load speed, and review if the CTA matches the ad promise',
@@ -320,7 +320,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Avg CPC is $${c.avgCpc.toFixed(2)} — spending $${c.spend.toFixed(2)} for only ${c.clicks} clicks`,
         action: 'Switch to a Target CPA or Maximize Clicks bid strategy, add long-tail keywords with lower competition',
@@ -331,7 +331,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `${c.impressions.toLocaleString()} impressions but 0 clicks — ads are showing but no one is clicking`,
         action: 'Rewrite ad copy to be more compelling, ensure headlines match search intent, test different CTAs',
@@ -342,7 +342,7 @@ function generateActionItems(campaigns: CampaignMetrics[]): CampaignActionItem[]
       items.push({
         eventName: c.eventName,
         campaigns: [c.shortName],
-        campaignUrls: { [c.shortName]: c.googleAdsUrl },
+        campaignUrls: { [c.shortName]: c.campaignUrl },
         priority: 'MED',
         issue: `Campaign is still in draft — $${c.budgetDay.toFixed(2)}/day budget allocated but not running`,
         action: 'Upload creative assets, review ad groups, publish the campaign (then pause if not ready to go live)',
@@ -371,7 +371,7 @@ function parseKeywordRow(row: unknown): KeywordMetrics {
     criterionId: String(extractNested(r, 'ad_group_criterion.criterion_id') || ''),
     campaign: (extractNested(r, 'campaign.name') as string) || '',
     campaignId,
-    googleAdsUrl: buildGoogleAdsUrl(campaignId),
+    campaignUrl: buildGoogleAdsUrl(campaignId),
     impressions: Number(extractNested(r, 'metrics.impressions') || 0),
     clicks,
     ctr: Number(extractNested(r, 'metrics.ctr') || 0) * 100,

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -20,7 +20,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
-import { executeLinkedInCampaignCreation } from './linkedin-ads.service';
+import { executeLinkedInCampaignCreation, resolveGeoTargets } from './linkedin-ads.service';
 import { logger } from './logger.service';
 
 // ---------------------------------------------------------------------------
@@ -390,11 +390,10 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
 // AI prompts
 // ---------------------------------------------------------------------------
 
-const COPY_SYSTEM_PROMPT = `You are an expert digital marketer specialising in developer events and open-source conferences.
-Generate high-quality, conversion-focused ad copy for the Linux Foundation's LFX events.
+const COPY_SYSTEM_PROMPT_BASE = `You are an expert digital marketer specialising in developer events and open-source conferences.
+Generate high-quality, conversion-focused ad copy for the Linux Foundation's LFX events.`;
 
-PLATFORM SPECIFICATIONS (hard limits — never exceed):
-
+const COPY_GOOGLE_SECTION = `
 GOOGLE SEARCH (RSA):
 - Headlines: 15 total, each ≤ 30 characters (STRICT — Google rejects longer)
 - Descriptions: 4 total, each ≤ 90 characters (STRICT)
@@ -404,16 +403,48 @@ GOOGLE DEMAND GEN (key: "google_display" — runs on YouTube, Discover, Gmail, D
 - headlines: 5 variations, each ≤ 40 characters (STRICT — Demand Gen limit is 40, not 30)
 - descriptions: 5 variations, each ≤ 90 characters (STRICT)
 - business_name: ≤ 25 chars — use the event's parent organization (e.g. "CNCF" for KubeCon). Default to "Linux Foundation" only if no specific foundation is identifiable.
-- call_to_action: one of "Learn More", "Register", "Sign Up", "Book Now", "Apply Now"
+- call_to_action: one of "Learn More", "Register", "Sign Up", "Book Now", "Apply Now"`;
 
+const COPY_LINKEDIN_SECTION = `
+LINKEDIN SPONSORED CONTENT (key: "linkedin_sponsored"):
+- variants: array of 2-4 ad variations, each containing:
+  - intro_text: ≤ 600 characters (the post body — compelling, professional, conversational)
+  - headline: ≤ 200 characters (appears below the link card — clear CTA)
+- recommended_geos: array of 3-8 location names (e.g. "United States", "India", "Germany") — select based on event location, audience, and topic relevance. Use full country/region names.
+- recommended_targeting_profile: one of "cloud-native" or "mcp" — select "cloud-native" for Kubernetes, CNCF, DevOps, infrastructure, containers, or cloud events; select "mcp" for AI, GenAI, LLM, agents, or machine learning events.
+
+LINKEDIN COPY RULES:
+- Intro text tone: professional but engaging, speak to the developer community, highlight learning opportunities and networking
+- Use line breaks in intro text for readability (\\n between paragraphs)
+- NEVER use em-dashes (—) or en-dashes (–) — use commas or periods
+- Include event dates and location naturally in at least one variant
+- Headline should drive action: "Register Now", "Secure Your Spot", "Join Us in [City]"`;
+
+const COPY_RULES_SECTION = `
 IMPORTANT RULES:
 1. Dates must come ONLY from the event data provided — never use training-data memory
-2. CHARACTER LIMITS ARE HARD — Google Ads REJECTS copy that exceeds them. Verify EVERY line.
+2. CHARACTER LIMITS ARE HARD — platforms REJECT copy that exceeds them. Verify EVERY line.
 3. NEVER abbreviate month names, city names, or event names unless required to fit character limits
 4. NEVER use em-dashes (—) or en-dashes (–) in ad copy. Use commas, periods, or colons instead.
-5. Demand Gen headlines are 40 chars max (not 30) — use the extra space for better copy.
+5. Demand Gen headlines are 40 chars max (not 30) — use the extra space for better copy.`;
 
-Respond with a JSON object (no markdown fences). Keys: "google_search" and "google_display".`;
+function buildCopySystemPrompt(platforms: string[]): string {
+  const includeGoogle = platforms.includes('google-ads');
+  const includeLinkedIn = platforms.includes('linkedin-ads');
+
+  let prompt = COPY_SYSTEM_PROMPT_BASE + '\n\nPLATFORM SPECIFICATIONS (hard limits — never exceed):\n';
+
+  if (includeGoogle) prompt += COPY_GOOGLE_SECTION;
+  if (includeLinkedIn) prompt += COPY_LINKEDIN_SECTION;
+  prompt += COPY_RULES_SECTION;
+
+  const keys: string[] = [];
+  if (includeGoogle) keys.push('"google_search"', '"google_display"');
+  if (includeLinkedIn) keys.push('"linkedin_sponsored"');
+  prompt += `\n\nRespond with a JSON object (no markdown fences). Keys: ${keys.join(' and ')}.`;
+
+  return prompt;
+}
 
 const KEYWORD_SYSTEM_PROMPT = `You are a Google Ads keyword strategist. Return only a valid JSON array. No markdown fences, no explanation.`;
 
@@ -614,14 +645,16 @@ export class CampaignProxyService {
       }
     }
 
-    const platformList = (body.platforms || ['google-ads']).join(', ');
+    const selectedPlatforms = body.platforms || ['google-ads'];
+    const platformList = selectedPlatforms.join(', ');
     yield { type: 'status', data: `Generating copy for ${platformList}...` };
 
+    const copySystemPrompt = buildCopySystemPrompt(selectedPlatforms);
     const userPrompt = buildCopyPrompt(body, eventDetails);
     let fullCopy = '';
 
     try {
-      for await (const token of aiChatStream(COPY_SYSTEM_PROMPT, userPrompt, signal)) {
+      for await (const token of aiChatStream(copySystemPrompt, userPrompt, signal)) {
         yield { type: 'copy_token', data: token };
         fullCopy += token;
       }
@@ -632,6 +665,22 @@ export class CampaignProxyService {
         const structured = JSON.parse(text) as Record<string, unknown>;
 
         truncateAdCopy(structured);
+
+        if (selectedPlatforms.includes('linkedin-ads')) {
+          const liData = structured['linkedin_sponsored'] as Record<string, unknown> | undefined;
+          if (liData) {
+            const recommendedGeos = liData['recommended_geos'] as string[] | undefined;
+            if (Array.isArray(recommendedGeos) && recommendedGeos.length > 0) {
+              try {
+                const resolved = await resolveGeoTargets(recommendedGeos);
+                liData['resolved_geo_targets'] = resolved;
+              } catch (geoError) {
+                logger.warning(req, 'campaign_brief_geo_resolve', 'Failed to resolve LinkedIn geo targets', { err: geoError });
+              }
+            }
+          }
+        }
+
         yield { type: 'copy_structured', data: structured };
       } catch {
         yield { type: 'copy_structured', data: { raw: fullCopy } };
@@ -1183,6 +1232,17 @@ function truncateAdCopy(obj: Record<string, unknown>): void {
     if (typeof gd['business_name'] === 'string') gd['business_name'] = (gd['business_name'] as string).slice(0, 25);
   }
 
+  const li = obj['linkedin_sponsored'] as Record<string, unknown> | undefined;
+  if (li) {
+    const variants = li['variants'] as Record<string, unknown>[] | undefined;
+    if (Array.isArray(variants)) {
+      for (const v of variants) {
+        if (typeof v['intro_text'] === 'string') v['intro_text'] = (v['intro_text'] as string).slice(0, 600);
+        if (typeof v['headline'] === 'string') v['headline'] = (v['headline'] as string).slice(0, 200);
+      }
+    }
+  }
+
   const platforms = obj['platforms'] as Record<string, unknown> | undefined;
   if (platforms) {
     if (platforms['google_search']) truncateAdCopy({ google_search: platforms['google_search'] } as Record<string, unknown>);
@@ -1190,6 +1250,7 @@ function truncateAdCopy(obj: Record<string, unknown>): void {
       const key = platforms['google_display'] ? 'google_display' : 'demand_gen';
       truncateAdCopy({ google_display: platforms[key] } as Record<string, unknown>);
     }
+    if (platforms['linkedin_sponsored']) truncateAdCopy({ linkedin_sponsored: platforms['linkedin_sponsored'] } as Record<string, unknown>);
   }
 }
 
@@ -1204,12 +1265,22 @@ function extractEventNameFromUrl(url: string): string {
 }
 
 function buildCopyPrompt(body: CampaignBriefRequest, eventDetails: Record<string, unknown> | null): string {
+  const platforms = body.platforms || ['google-ads'];
+  const includeGoogle = platforms.includes('google-ads');
+  const includeLinkedIn = platforms.includes('linkedin-ads');
+
+  const requestedKeys: string[] = [];
+  if (includeGoogle) requestedKeys.push('google_search', 'google_display');
+  if (includeLinkedIn) requestedKeys.push('linkedin_sponsored');
+
   const extraParts: string[] = [];
   if (body.campaignGoal) extraParts.push(`Campaign Goal: ${body.campaignGoal}`);
   if (body.targetAudience) extraParts.push(`Target Audience: ${body.targetAudience}`);
   if (body.valueProp) extraParts.push(`Key Value Prop / Offer: ${body.valueProp}`);
   if (body.totalBudget) extraParts.push(`Total Campaign Budget: $${body.totalBudget}`);
   const extraBlock = extraParts.length > 0 ? `\n\nADDITIONAL CAMPAIGN CONTEXT:\n${extraParts.join('\n')}` : '';
+
+  const platformInstruction = `REQUESTED PLATFORMS: ${requestedKeys.join(', ')}\n\nReturn a JSON object with keys ${requestedKeys.map((k) => `"${k}"`).join(' and ')} following the schema in the system prompt.`;
 
   if (eventDetails) {
     const e = eventDetails;
@@ -1228,16 +1299,12 @@ Registration URL: ${e['registration_url'] || body.url}
 Speakers: ${speakers}
 Format: ${e['format_notes'] || ''}${extraBlock}
 
-REQUESTED PLATFORMS: google_search, google_display
-
-Return a JSON object with keys "google_search" and "google_display" following the schema in the system prompt.`;
+${platformInstruction}`;
   }
 
   return `Generate ad copy for: ${body.url}${extraBlock}
 
-REQUESTED PLATFORMS: google_search, google_display
-
-Return a JSON object with keys "google_search" and "google_display" following the schema in the system prompt.`;
+${platformInstruction}`;
 }
 
 function buildKeywordPrompt(body: CampaignBriefRequest, eventDetails: Record<string, unknown> | null): string {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -1000,7 +1000,7 @@ export class CampaignProxyService {
       });
       results.push(result);
     } catch (error: unknown) {
-      logger.error(undefined, 'linkedin_dispatch', startTime, error as Error, { eventName: config.eventName });
+      logger.error(undefined, 'linkedin_dispatch', startTime, error as Error, { eventName: config.eventName ?? body.eventName ?? 'unknown' });
       errors.push('linkedin-ads: Campaign creation failed. Check server logs for details.');
     }
   }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -16,9 +16,11 @@ import type {
   CampaignKeyword,
   CampaignSSEEventType,
   KeywordActionResponse,
+  LinkedInCampaignCreateResult,
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
+import { executeLinkedInCampaignCreation } from './linkedin-ads.service';
 import { logger } from './logger.service';
 
 // ---------------------------------------------------------------------------
@@ -534,9 +536,10 @@ export class CampaignProxyService {
   public async *streamBrief(req: Request, body: CampaignBriefRequest, signal: AbortSignal): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
-    const unsupported = (body.platforms ?? []).filter((p) => p !== 'google-ads');
+    const supportedPlatforms = new Set(['google-ads', 'linkedin-ads']);
+    const unsupported = (body.platforms ?? []).filter((p) => !supportedPlatforms.has(p));
     if (unsupported.length > 0) {
-      yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Only google-ads is currently supported.` };
+      yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Supported: google-ads, linkedin-ads.` };
       return;
     }
 
@@ -823,7 +826,7 @@ export class CampaignProxyService {
   // === Private: campaign creation orchestration ===
 
   private async executeCampaignCreation(jobId: string, body: CampaignCreateRequest): Promise<void> {
-    const startTime = logger.startOperation(undefined, 'campaign_create', { jobId, types: body.campaignTypes });
+    const startTime = logger.startOperation(undefined, 'campaign_create', { jobId, types: body.campaignTypes, platforms: body.platforms });
     const effectiveBody = { ...body };
     if (!effectiveBody.hsToken) {
       try {
@@ -834,9 +837,56 @@ export class CampaignProxyService {
       }
     }
 
-    const results: CampaignResult[] = [];
+    const platforms = effectiveBody.platforms || ['google-ads'];
+    const includeGoogle = platforms.includes('google-ads');
+    const includeLinkedIn = platforms.includes('linkedin-ads');
+
+    const results: CampaignCreateResult[] = [];
+    const linkedInResults: LinkedInCampaignCreateResult[] = [];
     const errors: string[] = [];
 
+    const promises: Promise<void>[] = [];
+
+    if (includeGoogle) {
+      promises.push(this.executeGoogleCampaignCreation(effectiveBody, results, errors));
+    }
+
+    if (includeLinkedIn && effectiveBody.linkedInConfig) {
+      promises.push(this.executeLinkedInDispatch(effectiveBody, linkedInResults, errors));
+    }
+
+    await Promise.allSettled(promises);
+
+    const allCampaigns = [
+      ...results,
+      ...linkedInResults.map((li) => ({
+        platform: 'linkedin-ads' as const,
+        type: 'search' as const,
+        campaignName: li.campaignName,
+        campaignId: li.campaignId,
+        adGroupCount: 1,
+        keywordCount: 0,
+        adCount: li.creativeCount,
+        googleAdsUrl: li.linkedInUrl,
+        steps: li.steps,
+      })),
+    ];
+
+    const response: CampaignCreateResponse = { success: errors.length === 0, campaigns: allCampaigns, errors };
+    completeJob(jobId, response);
+    if (errors.length > 0) {
+      logger.warning(undefined, 'campaign_create', `Campaign creation completed with ${errors.length} error(s)`, {
+        jobId,
+        campaignCount: allCampaigns.length,
+        errorCount: errors.length,
+        duration_ms: Date.now() - startTime,
+      });
+    } else {
+      logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: allCampaigns.length });
+    }
+  }
+
+  private async executeGoogleCampaignCreation(effectiveBody: CampaignCreateRequest, results: CampaignCreateResult[], errors: string[]): Promise<void> {
     for (const campaignType of effectiveBody.campaignTypes) {
       const typeStartTime = Date.now();
       try {
@@ -852,27 +902,38 @@ export class CampaignProxyService {
           } catch (retryError: unknown) {
             const detail = extractGadsErrorMessage(retryError);
             logger.error(undefined, 'campaign_create_type', typeStartTime, retryError as Error, { campaignType, detail });
-            errors.push(`${campaignType}: ${detail}`);
+            errors.push(`google-ads/${campaignType}: ${detail}`);
             continue;
           }
         }
         const detail = extractGadsErrorMessage(error);
         logger.error(undefined, 'campaign_create_type', typeStartTime, error as Error, { campaignType, detail });
-        errors.push(`${campaignType}: ${detail}`);
+        errors.push(`google-ads/${campaignType}: ${detail}`);
       }
     }
+  }
 
-    const response = { success: errors.length === 0, campaigns: results, errors };
-    completeJob(jobId, response);
-    if (errors.length > 0) {
-      logger.warning(undefined, 'campaign_create', `Campaign creation completed with ${errors.length} error(s)`, {
-        jobId,
-        campaignCount: results.length,
-        errorCount: errors.length,
-        duration_ms: Date.now() - startTime,
+  private async executeLinkedInDispatch(body: CampaignCreateRequest, results: LinkedInCampaignCreateResult[], errors: string[]): Promise<void> {
+    const config = body.linkedInConfig!;
+    try {
+      const result = await executeLinkedInCampaignCreation(undefined, {
+        eventName: config.eventName || body.eventName,
+        eventSlug: config.eventSlug || body.eventSlug,
+        registrationUrl: config.registrationUrl || body.registrationUrl,
+        hsToken: config.hsToken || body.hsToken,
+        budgetUsd: config.budgetUsd,
+        lifetimeBudget: config.lifetimeBudget,
+        startDate: config.startDate || body.startDate,
+        endDate: config.endDate || body.endDate,
+        geoTargets: config.geoTargets,
+        targetingProfile: config.targetingProfile,
+        variants: config.variants,
+        project: config.project || body.project,
       });
-    } else {
-      logger.success(undefined, 'campaign_create', startTime, { jobId, campaignCount: results.length });
+      results.push(result);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown LinkedIn error';
+      errors.push(`linkedin-ads: ${msg}`);
     }
   }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -644,7 +644,7 @@ export class CampaignProxyService {
       }
     }
 
-    const selectedPlatforms = body.platforms || ['google-ads'];
+    const selectedPlatforms = body.platforms?.length ? body.platforms : ['google-ads'];
     const platformList = selectedPlatforms.join(', ');
     yield { type: 'status', data: `Generating copy for ${platformList}...` };
 
@@ -725,7 +725,9 @@ export class CampaignProxyService {
   ): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
-    const supportedPlatforms = (body.platforms ?? ['google-ads']).filter((p) => p === 'google-ads' || p === 'linkedin-ads');
+    const supportedPlatforms = (body.platforms?.length ? body.platforms : ['google-ads']).filter(
+      (p): p is 'google-ads' | 'linkedin-ads' => p === 'google-ads' || p === 'linkedin-ads'
+    );
     if (supportedPlatforms.length === 0) {
       yield { type: 'error', data: 'No supported platforms specified. Supported: google-ads, linkedin-ads.' };
       return;
@@ -758,7 +760,7 @@ export class CampaignProxyService {
       return;
     }
 
-    const platforms = body.platforms || ['google-ads'];
+    const platforms = body.platforms?.length ? body.platforms : ['google-ads'];
     if (platforms.includes('google-ads')) {
       yield { type: 'status', data: 'Regenerating keywords...' };
 
@@ -1272,7 +1274,7 @@ function extractEventNameFromUrl(url: string): string {
 }
 
 function buildCopyPrompt(body: CampaignBriefRequest, eventDetails: Record<string, unknown> | null): string {
-  const platforms = body.platforms || ['google-ads'];
+  const platforms = body.platforms?.length ? body.platforms : ['google-ads'];
   const includeGoogle = platforms.includes('google-ads');
   const includeLinkedIn = platforms.includes('linkedin-ads');
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -672,7 +672,7 @@ export class CampaignProxyService {
             const recommendedGeos = liData['recommended_geos'] as string[] | undefined;
             if (Array.isArray(recommendedGeos) && recommendedGeos.length > 0) {
               try {
-                const resolved = await resolveGeoTargets(recommendedGeos);
+                const resolved = await resolveGeoTargets(recommendedGeos, req);
                 liData['resolved_geo_targets'] = resolved;
               } catch (geoError) {
                 logger.warning(req, 'campaign_brief_geo_resolve', 'Failed to resolve LinkedIn geo targets', { err: geoError });
@@ -886,9 +886,19 @@ export class CampaignProxyService {
       }
     }
 
-    const platforms = effectiveBody.platforms || ['google-ads'];
+    const platforms = effectiveBody.platforms?.length ? effectiveBody.platforms : ['google-ads'];
     const includeGoogle = platforms.includes('google-ads');
     const includeLinkedIn = platforms.includes('linkedin-ads');
+
+    if (!includeGoogle && !includeLinkedIn) {
+      const response: CampaignCreateResponse = {
+        success: false,
+        campaigns: [],
+        errors: ['No supported platforms selected. Supported: google-ads, linkedin-ads.'],
+      };
+      completeJob(jobId, response);
+      return;
+    }
 
     const results: CampaignCreateResult[] = [];
     const linkedInResults: LinkedInCampaignCreateResult[] = [];
@@ -900,14 +910,22 @@ export class CampaignProxyService {
       promises.push(this.executeGoogleCampaignCreation(effectiveBody, results, errors));
     }
 
-    if (includeLinkedIn && effectiveBody.linkedInConfig) {
-      promises.push(this.executeLinkedInDispatch(effectiveBody, linkedInResults, errors));
+    if (includeLinkedIn) {
+      if (effectiveBody.linkedInConfig) {
+        promises.push(this.executeLinkedInDispatch(effectiveBody, linkedInResults, errors));
+      } else {
+        errors.push('linkedin-ads: No LinkedIn configuration was provided.');
+      }
     }
 
     await Promise.allSettled(promises);
 
+    if (promises.length === 0 && errors.length === 0) {
+      errors.push('No campaign creation tasks were dispatched.');
+    }
+
     const allCampaigns = [
-      ...results,
+      ...results.map((r) => ({ ...r, platform: 'google-ads' as const })),
       ...linkedInResults.map((li) => ({
         platform: 'linkedin-ads' as const,
         type: 'search' as const,
@@ -981,8 +999,8 @@ export class CampaignProxyService {
       });
       results.push(result);
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : 'Unknown LinkedIn error';
-      errors.push(`linkedin-ads: ${msg}`);
+      logger.error(undefined, 'linkedin_dispatch', 0, error as Error, { eventName: config.eventName });
+      errors.push('linkedin-ads: Campaign creation failed. Check server logs for details.');
     }
   }
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -934,7 +934,7 @@ export class CampaignProxyService {
         adGroupCount: 1,
         keywordCount: 0,
         adCount: li.creativeCount,
-        googleAdsUrl: li.linkedInUrl,
+        campaignUrl: li.linkedInUrl,
         steps: li.steps,
       })),
     ];
@@ -1119,7 +1119,7 @@ export class CampaignProxyService {
       adGroupCount: 1,
       keywordCount: keywordOps.length,
       adCount: 1,
-      googleAdsUrl: `https://ads.google.com/aw/campaigns?campaignId=${campaignId}`,
+      campaignUrl: `https://ads.google.com/aw/campaigns?campaignId=${campaignId}`,
       steps,
     };
   }
@@ -1198,7 +1198,7 @@ export class CampaignProxyService {
       adGroupCount: 1,
       keywordCount: 0,
       adCount: 0,
-      googleAdsUrl: `https://ads.google.com/aw/campaigns?campaignId=${campaignId}`,
+      campaignUrl: `https://ads.google.com/aw/campaigns?campaignId=${campaignId}`,
       steps,
     };
   }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -982,6 +982,7 @@ export class CampaignProxyService {
 
   private async executeLinkedInDispatch(body: CampaignCreateRequest, results: LinkedInCampaignCreateResult[], errors: string[]): Promise<void> {
     const config = body.linkedInConfig!;
+    const startTime = Date.now();
     try {
       const result = await executeLinkedInCampaignCreation(undefined, {
         eventName: config.eventName || body.eventName,
@@ -999,7 +1000,7 @@ export class CampaignProxyService {
       });
       results.push(result);
     } catch (error: unknown) {
-      logger.error(undefined, 'linkedin_dispatch', 0, error as Error, { eventName: config.eventName });
+      logger.error(undefined, 'linkedin_dispatch', startTime, error as Error, { eventName: config.eventName });
       errors.push('linkedin-ads: Campaign creation failed. Check server logs for details.');
     }
   }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -726,19 +726,20 @@ export class CampaignProxyService {
   ): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
-    const unsupported = (body.platforms ?? []).filter((p) => p !== 'google-ads');
-    if (unsupported.length > 0) {
-      yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Only google-ads is currently supported.` };
+    const supportedPlatforms = (body.platforms ?? ['google-ads']).filter((p) => p === 'google-ads' || p === 'linkedin-ads');
+    if (supportedPlatforms.length === 0) {
+      yield { type: 'error', data: 'No supported platforms specified. Supported: google-ads, linkedin-ads.' };
       return;
     }
 
     yield { type: 'status', data: 'Refining brief based on your feedback...' };
 
+    const copySystemPrompt = buildCopySystemPrompt(supportedPlatforms);
     const userPrompt = buildRefinePrompt(body);
     let fullCopy = '';
 
     try {
-      for await (const token of aiChatStream(COPY_SYSTEM_PROMPT, userPrompt, signal)) {
+      for await (const token of aiChatStream(copySystemPrompt, userPrompt, signal)) {
         yield { type: 'copy_token', data: token };
         fullCopy += token;
       }
@@ -926,17 +927,7 @@ export class CampaignProxyService {
 
     const allCampaigns = [
       ...results.map((r) => ({ ...r, platform: 'google-ads' as const })),
-      ...linkedInResults.map((li) => ({
-        platform: 'linkedin-ads' as const,
-        type: 'search' as const,
-        campaignName: li.campaignName,
-        campaignId: li.campaignId,
-        adGroupCount: 1,
-        keywordCount: 0,
-        adCount: li.creativeCount,
-        campaignUrl: li.linkedInUrl,
-        steps: li.steps,
-      })),
+      ...linkedInResults,
     ];
 
     const response: CampaignCreateResponse = { success: errors.length === 0, campaigns: allCampaigns, errors };
@@ -985,22 +976,23 @@ export class CampaignProxyService {
     const startTime = Date.now();
     try {
       const result = await executeLinkedInCampaignCreation(undefined, {
-        eventName: config.eventName || body.eventName,
-        eventSlug: config.eventSlug || body.eventSlug,
-        registrationUrl: config.registrationUrl || body.registrationUrl,
-        hsToken: config.hsToken || body.hsToken,
-        budgetUsd: config.budgetUsd,
+        eventName: body.eventName,
+        eventSlug: body.eventSlug,
+        registrationUrl: body.registrationUrl,
+        hsToken: body.hsToken,
+        budgetUsd: body.budgetUsd,
+        startDate: body.startDate,
+        endDate: body.endDate,
+        project: body.project,
+        dates: `${body.startDate} – ${body.endDate}`,
         lifetimeBudget: config.lifetimeBudget,
-        startDate: config.startDate || body.startDate,
-        endDate: config.endDate || body.endDate,
         geoTargets: config.geoTargets,
         targetingProfile: config.targetingProfile,
         variants: config.variants,
-        project: config.project || body.project,
       });
       results.push(result);
     } catch (error: unknown) {
-      logger.error(undefined, 'linkedin_dispatch', startTime, error as Error, { eventName: config.eventName ?? body.eventName ?? 'unknown' });
+      logger.error(undefined, 'linkedin_dispatch', startTime, error as Error, { eventName: body.eventName ?? 'unknown' });
       errors.push('linkedin-ads: Campaign creation failed. Check server logs for details.');
     }
   }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -11,7 +11,6 @@ import type {
   CampaignCreateRequest,
   CampaignCreateResponse,
   CampaignCreateResult,
-  CampaignResult,
   CampaignJobStatus,
   CampaignKeyword,
   CampaignSSEEventType,
@@ -925,10 +924,7 @@ export class CampaignProxyService {
       errors.push('No campaign creation tasks were dispatched.');
     }
 
-    const allCampaigns = [
-      ...results.map((r) => ({ ...r, platform: 'google-ads' as const })),
-      ...linkedInResults,
-    ];
+    const allCampaigns = [...results.map((r) => ({ ...r, platform: 'google-ads' as const })), ...linkedInResults];
 
     const response: CampaignCreateResponse = { success: errors.length === 0, campaigns: allCampaigns, errors };
     completeJob(jobId, response);

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -196,7 +196,7 @@ export async function resolveGeoTargets(locationNames: string[], req?: Request):
         }
       }
     } catch (error: unknown) {
-      logger.warning(req ?? undefined, 'linkedin_resolve_geo', `Failed to resolve geo: ${name}`, { name, err: error });
+      logger.warning(req, 'linkedin_resolve_geo', `Failed to resolve geo: ${name}`, { name, err: error });
     }
   }
 
@@ -374,6 +374,12 @@ export async function executeLinkedInCampaignCreation(req: Request | undefined, 
   const steps: string[] = [];
   const startTime = logger.startOperation(req, 'linkedin_campaign_create', { event: params.eventName });
 
+  if (params.endDate <= params.startDate) {
+    const err = new Error(`Invalid date range: endDate (${params.endDate}) must be after startDate (${params.startDate})`);
+    logger.error(req, 'linkedin_campaign_create', startTime, err, { startDate: params.startDate, endDate: params.endDate });
+    throw err;
+  }
+
   try {
     const account = await verifyAccount();
     steps.push(`Verified account: ${account.name} (${account.status})`);
@@ -422,7 +428,7 @@ export async function executeLinkedInCampaignCreation(req: Request | undefined, 
 
     logger.success(req, 'linkedin_campaign_create', startTime, { campaignId, creativeCount });
     return result;
-  } catch (error) {
+  } catch (error: unknown) {
     logger.error(req, 'linkedin_campaign_create', startTime, error, { event: params.eventName });
     throw error;
   }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -422,7 +422,7 @@ export async function executeLinkedInCampaignCreation(req: Request | undefined, 
       campaignName,
       campaignId,
       creativeCount,
-      linkedInUrl: `https://www.linkedin.com/campaignmanager/accounts/${getAccountId()}/campaigns/${campaignId}`,
+      campaignUrl: `https://www.linkedin.com/campaignmanager/accounts/${getAccountId()}/campaigns/${campaignId}`,
       steps,
     };
 

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -134,10 +134,8 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
       if (elements.length < pageSize) break;
       start += pageSize;
     }
-  } catch (err) {
-    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}"`, {
-      error: err instanceof Error ? err.message : String(err),
-    });
+  } catch (error: unknown) {
+    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for ${nestedPath}`, { name, err: error });
   }
   return null;
 }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -143,6 +143,9 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
 }
 
 function toMs(dateStr: string, eod = false): number {
+  if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    throw new Error(`Invalid date format: expected YYYY-MM-DD, got "${dateStr}"`);
+  }
   const [y, m, d] = dateStr.split('-').map(Number);
   if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
     throw new Error(`Invalid date string: "${dateStr}" — expected YYYY-MM-DD`);
@@ -170,7 +173,7 @@ export async function verifyAccount(): Promise<{ name: string; status: string }>
   return { name: data.name || getAccountId(), status: data.status || 'UNKNOWN' };
 }
 
-export async function resolveGeoTargets(locationNames: string[]): Promise<LinkedInGeoTarget[]> {
+export async function resolveGeoTargets(locationNames: string[], req?: Request): Promise<LinkedInGeoTarget[]> {
   const resolved: LinkedInGeoTarget[] = [];
 
   for (const name of locationNames) {
@@ -194,8 +197,8 @@ export async function resolveGeoTargets(locationNames: string[]): Promise<Linked
           });
         }
       }
-    } catch {
-      logger.warning(undefined, 'linkedin_resolve_geo', `Failed to resolve geo: ${name}`, { name });
+    } catch (error: unknown) {
+      logger.warning(req ?? undefined, 'linkedin_resolve_geo', `Failed to resolve geo: ${name}`, { name, err: error });
     }
   }
 
@@ -296,9 +299,8 @@ export async function createDarkPost(introText: string, headline: string, destUr
   };
 
   const data = await linkedInRequest('POST', 'posts', body);
-  const id = data.id || '';
-  if (!id) throw new Error('LinkedIn API returned no ID for dark post');
-  return id;
+  if (!data.id) throw new Error('LinkedIn dark post creation succeeded but returned no ID');
+  return data.id;
 }
 
 export async function createCreative(campaignId: string, shareUrn: string, adName: string): Promise<string> {
@@ -310,9 +312,8 @@ export async function createCreative(campaignId: string, shareUrn: string, adNam
   };
 
   const data = await linkedInRequest('POST', `adAccounts/${getAccountId()}/creatives`, body);
-  const id = data.id || '';
-  if (!id) throw new Error('LinkedIn API returned no ID for creative');
-  return id;
+  if (!data.id) throw new Error('LinkedIn creative creation succeeded but returned no ID');
+  return data.id;
 }
 
 export function buildTargetingCriteria(profile: LinkedInTargetingProfile, geoUrns: string[]): Record<string, unknown> {

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -115,11 +115,6 @@ export const LINKEDIN_CHAR_LIMITS = {
   headline: 200,
 } as const;
 
-export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; orgId: string }[] = [
-  { accountId: '538170226', label: 'The Linux Foundation', orgId: '208777' },
-  { accountId: '509430019', label: 'LF Events', orgId: '208777' },
-] as const;
-
 export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
 
 export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -173,7 +173,7 @@ export interface LinkedInCampaignCreateResult {
   campaignName: string;
   campaignId: string;
   creativeCount: number;
-  linkedInUrl: string;
+  campaignUrl: string;
   steps: string[];
 }
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -209,7 +209,7 @@ export interface CampaignCreateResult {
   adGroupCount: number;
   keywordCount: number;
   adCount: number;
-  googleAdsUrl: string;
+  campaignUrl: string;
   steps: string[];
 }
 
@@ -256,7 +256,7 @@ export interface CampaignMetrics {
   pacingPct: number;
   pacingLabel: PacingLabel;
   campaignId: string;
-  googleAdsUrl: string;
+  campaignUrl: string;
 }
 
 export interface CampaignActionItem {
@@ -307,7 +307,7 @@ export interface KeywordMetrics {
   criterionId: string;
   campaign: string;
   campaignId: string;
-  googleAdsUrl: string;
+  campaignUrl: string;
   impressions: number;
   clicks: number;
   ctr: number;
@@ -362,7 +362,7 @@ export interface ImpressionShareMetrics {
   campaignName: string;
   eventName: string;
   campaignId: string;
-  googleAdsUrl: string;
+  campaignUrl: string;
   impressionShare: number | null;
   budgetLostShare: number | null;
   rankLostShare: number | null;
@@ -408,7 +408,7 @@ export interface SearchTermMetrics {
   campaignName: string;
   eventName: string;
   campaignId: string;
-  googleAdsUrl: string;
+  campaignUrl: string;
   impressions: number;
   clicks: number;
   ctr: number;
@@ -427,7 +427,7 @@ export interface QualityScoreInsight {
   campaignName: string;
   eventName: string;
   campaignId: string;
-  googleAdsUrl: string;
+  campaignUrl: string;
   impressions: number;
   clicks: number;
   spend: number;


### PR DESCRIPTION
## Summary
- Wire LinkedIn Ads into the campaign creation orchestrator alongside Google Ads
- Both platforms execute in parallel via `Promise.allSettled()`
- Update `streamBrief()` to accept `linkedin-ads` as a supported platform
- Refactor `executeCampaignCreation()` into multi-platform dispatch with extracted `executeGoogleCampaignCreation()` and `executeLinkedInDispatch()` methods
- Map LinkedIn results into unified `CampaignCreateResponse` format
- Prefix error messages with platform name for disambiguation

## Dependencies
- #895 — LinkedIn shared types and constants
- #896 — LinkedIn Ads API client service

## Test plan
- [ ] `yarn check-types` passes
- [ ] `yarn lint` passes
- [ ] `yarn build` passes
- [ ] Existing Google Ads campaign creation flow unaffected (no LinkedIn config = Google-only path)
- [ ] With `linkedInConfig` in request body, both platforms dispatch in parallel

LFXV2-2156

🤖 Generated with [Claude Code](https://claude.ai/code)