### PR TITLE
feat(campaigns): multi-platform brief generation with LinkedIn copy

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -231,7 +231,7 @@
           <!-- LinkedIn Budget -->
           <div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
             <div class="flex flex-col gap-1">
-              <label class="text-xs font-medium text-gray-700">LinkedIn Budget (USD)</label>
+              <label class="text-xs font-medium text-gray-700">{{ linkedInLifetimeBudget() ? 'Lifetime Budget (USD)' : 'Daily Budget (USD)' }}</label>
               <input
                 #linkedInBudgetInput
                 type="number"

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -233,9 +233,10 @@
             <div class="flex flex-col gap-1">
               <label class="text-xs font-medium text-gray-700">LinkedIn Budget (USD)</label>
               <input
+                #linkedInBudgetInput
                 type="number"
                 [value]="linkedInBudgetUsd()"
-                (input)="setLinkedInBudget($any($event.target).valueAsNumber || 0)"
+                (input)="setLinkedInBudget(linkedInBudgetInput.valueAsNumber || 0)"
                 min="1"
                 class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 data-testid="implementation-linkedin-budget" />
@@ -243,9 +244,10 @@
             <div class="flex items-end gap-2 pb-1">
               <label class="flex items-center gap-2 text-sm text-gray-700">
                 <input
+                  #lifetimeCheckbox
                   type="checkbox"
                   [checked]="linkedInLifetimeBudget()"
-                  (change)="setLinkedInLifetimeBudget($any($event.target).checked)"
+                  (change)="setLinkedInLifetimeBudget(lifetimeCheckbox.checked)"
                   class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
                 Lifetime budget
               </label>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -212,6 +212,7 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('cloud-native')"
+                [attr.aria-pressed]="linkedInTargetingProfile() === 'cloud-native'"
                 [class]="
                   linkedInTargetingProfile() === 'cloud-native'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'
@@ -223,6 +224,7 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('mcp')"
+                [attr.aria-pressed]="linkedInTargetingProfile() === 'mcp'"
                 [class]="
                   linkedInTargetingProfile() === 'mcp'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -78,96 +78,197 @@
           </div>
         </div>
 
-        <!-- Budget Split -->
-        <div class="mt-4 flex flex-col gap-2">
-          <label class="text-xs font-medium text-gray-700">Budget Split: Search {{ 100 - displayBudgetPct() }}% / Display {{ displayBudgetPct() }}%</label>
-          <input type="range" formControlName="searchBudgetPct" min="0" max="100" class="w-full accent-blue-600" data-testid="implementation-budget-split" />
-        </div>
+        @if (showGoogleSection()) {
+          <!-- Budget Split -->
+          <div class="mt-4 flex flex-col gap-2">
+            <label class="text-xs font-medium text-gray-700">Budget Split: Search {{ 100 - displayBudgetPct() }}% / Display {{ displayBudgetPct() }}%</label>
+            <input type="range" formControlName="searchBudgetPct" min="0" max="100" class="w-full accent-blue-600" data-testid="implementation-budget-split" />
+          </div>
 
-        <!-- Campaign Types -->
-        <div class="mt-4 flex items-center gap-4">
-          <label class="flex items-center gap-2 text-sm text-gray-700">
-            <input type="checkbox" formControlName="includeSearch" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
-            Search Campaign
-          </label>
-          <label class="flex items-center gap-2 text-sm text-gray-700">
-            <input type="checkbox" formControlName="includeDemandGen" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
-            Demand Gen Campaign
-          </label>
-        </div>
+          <!-- Campaign Types -->
+          <div class="mt-4 flex items-center gap-4">
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+              <input type="checkbox" formControlName="includeSearch" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+              Search Campaign
+            </label>
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+              <input type="checkbox" formControlName="includeDemandGen" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+              Demand Gen Campaign
+            </label>
+          </div>
+        }
       </div>
 
-      <!-- Headlines -->
-      <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="implementation-headlines-section">
-        <div class="mb-3 flex items-center justify-between">
-          <h3 class="text-sm font-semibold text-gray-900">Headlines</h3>
-          <lfx-button
-            label="Add"
-            icon="fa-light fa-plus"
-            severity="secondary"
-            [outlined]="true"
-            (onClick)="addHeadline()"
-            ariaLabel="Add headline"
-            data-testid="implementation-add-headline" />
+      <!-- Google Ads: Headlines -->
+      @if (showGoogleSection()) {
+        <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="implementation-headlines-section">
+          <div class="mb-3 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-gray-900">Headlines</h3>
+            <lfx-button
+              label="Add"
+              icon="fa-light fa-plus"
+              severity="secondary"
+              [outlined]="true"
+              (onClick)="addHeadline()"
+              ariaLabel="Add headline"
+              data-testid="implementation-add-headline" />
+          </div>
+          <div class="flex flex-col gap-2" formArrayName="headlines">
+            @for (control of headlinesArray.controls; track $index; let i = $index) {
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  [formControlName]="i"
+                  [maxlength]="charLimits.searchHeadline"
+                  placeholder="Headline (max {{ charLimits.searchHeadline }} chars)"
+                  class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  [attr.data-testid]="'implementation-headline-' + i" />
+                <span class="text-xs text-gray-400">{{ control.value?.length || 0 }}/{{ charLimits.searchHeadline }}</span>
+                @if (headlinesArray.length > 1) {
+                  <button type="button" (click)="removeHeadline(i)" class="text-gray-400 hover:text-red-500" [attr.aria-label]="'Remove headline ' + (i + 1)">
+                    <i class="fa-light fa-xmark" aria-hidden="true"></i>
+                  </button>
+                }
+              </div>
+            }
+          </div>
         </div>
-        <div class="flex flex-col gap-2" formArrayName="headlines">
-          @for (control of headlinesArray.controls; track $index; let i = $index) {
-            <div class="flex items-center gap-2">
+
+        <!-- Google Ads: Descriptions -->
+        <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="implementation-descriptions-section">
+          <div class="mb-3 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-gray-900">Descriptions</h3>
+            <lfx-button
+              label="Add"
+              icon="fa-light fa-plus"
+              severity="secondary"
+              [outlined]="true"
+              (onClick)="addDescription()"
+              ariaLabel="Add description"
+              data-testid="implementation-add-description" />
+          </div>
+          <div class="flex flex-col gap-2" formArrayName="descriptions">
+            @for (control of descriptionsArray.controls; track $index; let i = $index) {
+              <div class="flex items-center gap-2">
+                <textarea
+                  [formControlName]="i"
+                  [maxlength]="charLimits.searchDescription"
+                  placeholder="Description (max {{ charLimits.searchDescription }} chars)"
+                  rows="2"
+                  class="flex-1 resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  [attr.data-testid]="'implementation-description-' + i"></textarea>
+                <span class="text-xs text-gray-400">{{ control.value?.length || 0 }}/{{ charLimits.searchDescription }}</span>
+                @if (descriptionsArray.length > 1) {
+                  <button
+                    type="button"
+                    (click)="removeDescription(i)"
+                    class="text-gray-400 hover:text-red-500"
+                    [attr.aria-label]="'Remove description ' + (i + 1)">
+                    <i class="fa-light fa-xmark" aria-hidden="true"></i>
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- LinkedIn Ads Section -->
+      @if (showLinkedInSection()) {
+        <div class="rounded-lg border border-blue-200 bg-white p-5" data-testid="implementation-linkedin-section">
+          <div class="mb-4 flex items-center gap-2">
+            <i class="fa-brands fa-linkedin text-blue-600" aria-hidden="true"></i>
+            <h3 class="text-sm font-semibold text-gray-900">LinkedIn Sponsored Content</h3>
+          </div>
+
+          <!-- Geo Targets -->
+          <div class="mb-4">
+            <label class="mb-2 block text-xs font-medium text-gray-700">Geo Targets (AI-recommended)</label>
+            <div class="flex flex-wrap gap-2">
+              @for (geo of linkedInGeoTargets(); track geo.urn; let i = $index) {
+                <span class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+                  {{ geo.label }}
+                  <button type="button" (click)="removeGeoTarget(i)" class="ml-0.5 text-blue-400 hover:text-blue-600" [attr.aria-label]="'Remove ' + geo.label">
+                    <i class="fa-light fa-xmark text-[10px]" aria-hidden="true"></i>
+                  </button>
+                </span>
+              }
+              @if (linkedInGeoTargets().length === 0) {
+                <span class="text-xs text-gray-400">No geo targets selected</span>
+              }
+            </div>
+          </div>
+
+          <!-- Targeting Profile -->
+          <div class="mb-4">
+            <label class="mb-2 block text-xs font-medium text-gray-700">Targeting Profile</label>
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                (click)="setLinkedInTargetingProfile('cloud-native')"
+                [class]="
+                  linkedInTargetingProfile() === 'cloud-native'
+                    ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'
+                    : 'rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300'
+                "
+                data-testid="implementation-linkedin-profile-cloud-native">
+                Cloud Native / CNCF
+              </button>
+              <button
+                type="button"
+                (click)="setLinkedInTargetingProfile('mcp')"
+                [class]="
+                  linkedInTargetingProfile() === 'mcp'
+                    ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'
+                    : 'rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300'
+                "
+                data-testid="implementation-linkedin-profile-mcp">
+                AI / MCP
+              </button>
+            </div>
+          </div>
+
+          <!-- LinkedIn Budget -->
+          <div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-gray-700">LinkedIn Budget (USD)</label>
               <input
-                type="text"
-                [formControlName]="i"
-                [maxlength]="charLimits.searchHeadline"
-                placeholder="Headline (max {{ charLimits.searchHeadline }} chars)"
-                class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                [attr.data-testid]="'implementation-headline-' + i" />
-              <span class="text-xs text-gray-400">{{ control.value?.length || 0 }}/{{ charLimits.searchHeadline }}</span>
-              @if (headlinesArray.length > 1) {
-                <button type="button" (click)="removeHeadline(i)" class="text-gray-400 hover:text-red-500" [attr.aria-label]="'Remove headline ' + (i + 1)">
-                  <i class="fa-light fa-xmark" aria-hidden="true"></i>
-                </button>
-              }
+                type="number"
+                [value]="linkedInBudgetUsd()"
+                (input)="setLinkedInBudget($any($event.target).valueAsNumber || 0)"
+                min="1"
+                class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                data-testid="implementation-linkedin-budget" />
             </div>
-          }
-        </div>
-      </div>
+            <div class="flex items-end gap-2 pb-1">
+              <label class="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  [checked]="linkedInLifetimeBudget()"
+                  (change)="setLinkedInLifetimeBudget($any($event.target).checked)"
+                  class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                Lifetime budget
+              </label>
+            </div>
+          </div>
 
-      <!-- Descriptions -->
-      <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="implementation-descriptions-section">
-        <div class="mb-3 flex items-center justify-between">
-          <h3 class="text-sm font-semibold text-gray-900">Descriptions</h3>
-          <lfx-button
-            label="Add"
-            icon="fa-light fa-plus"
-            severity="secondary"
-            [outlined]="true"
-            (onClick)="addDescription()"
-            ariaLabel="Add description"
-            data-testid="implementation-add-description" />
-        </div>
-        <div class="flex flex-col gap-2" formArrayName="descriptions">
-          @for (control of descriptionsArray.controls; track $index; let i = $index) {
-            <div class="flex items-center gap-2">
-              <textarea
-                [formControlName]="i"
-                [maxlength]="charLimits.searchDescription"
-                placeholder="Description (max {{ charLimits.searchDescription }} chars)"
-                rows="2"
-                class="flex-1 resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                [attr.data-testid]="'implementation-description-' + i"></textarea>
-              <span class="text-xs text-gray-400">{{ control.value?.length || 0 }}/{{ charLimits.searchDescription }}</span>
-              @if (descriptionsArray.length > 1) {
-                <button
-                  type="button"
-                  (click)="removeDescription(i)"
-                  class="text-gray-400 hover:text-red-500"
-                  [attr.aria-label]="'Remove description ' + (i + 1)">
-                  <i class="fa-light fa-xmark" aria-hidden="true"></i>
-                </button>
-              }
+          <!-- Variant Preview -->
+          @if (linkedInVariants().length > 0) {
+            <div>
+              <label class="mb-2 block text-xs font-medium text-gray-700">Ad Variants ({{ linkedInVariants().length }})</label>
+              <div class="flex flex-col gap-2">
+                @for (variant of linkedInVariants(); track $index; let i = $index) {
+                  <div class="rounded-md border border-gray-200 bg-gray-50 p-3" [attr.data-testid]="'implementation-linkedin-variant-' + i">
+                    <p class="mb-1 text-xs font-medium text-gray-500">Variant {{ i + 1 }}</p>
+                    <p class="text-sm text-gray-800">{{ variant.introText | slice: 0 : 120 }}{{ variant.introText.length > 120 ? '...' : '' }}</p>
+                    <p class="mt-1 text-xs font-medium text-gray-600">{{ variant.headline }}</p>
+                  </div>
+                }
+              </div>
             </div>
           }
         </div>
-      </div>
+      }
 
       <!-- Submit -->
       <div class="flex items-center gap-3">
@@ -204,7 +305,7 @@
         }
         <div class="flex items-center gap-2 text-sm text-gray-400">
           <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
-          Waiting for Google Ads API...
+          Waiting for campaign APIs...
         </div>
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -188,9 +188,15 @@
               @for (geo of linkedInGeoTargets(); track geo.urn; let i = $index) {
                 <span class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
                   {{ geo.label }}
-                  <button type="button" (click)="removeGeoTarget(i)" class="ml-0.5 text-blue-400 hover:text-blue-600" [attr.aria-label]="'Remove ' + geo.label">
-                    <i class="fa-light fa-xmark text-[10px]" aria-hidden="true"></i>
-                  </button>
+                  @if (linkedInGeoTargets().length > 1) {
+                    <button
+                      type="button"
+                      (click)="removeGeoTarget(i)"
+                      class="ml-0.5 text-blue-400 hover:text-blue-600"
+                      [attr.aria-label]="'Remove ' + geo.label">
+                      <i class="fa-light fa-xmark text-[10px]" aria-hidden="true"></i>
+                    </button>
+                  }
                 </span>
               }
               @if (linkedInGeoTargets().length === 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -276,9 +276,9 @@
           label="Create Campaign"
           icon="fa-light fa-rocket"
           severity="primary"
-          [disabled]="campaignForm.invalid"
+          [disabled]="!canSubmit()"
           (onClick)="submit()"
-          ariaLabel="Create campaign in Google Ads"
+          ariaLabel="Create campaign"
           data-testid="implementation-submit-btn" />
         @if (errors().length > 0) {
           <p class="text-sm text-red-600">{{ errors()[0] }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -80,6 +80,15 @@ export class ImplementationTabComponent {
   // === Computed Signals ===
   protected readonly showGoogleSection = computed(() => this.selectedPlatforms().includes('google-ads'));
   protected readonly showLinkedInSection = computed(() => this.selectedPlatforms().includes('linkedin-ads'));
+  protected readonly canSubmit = computed(() => {
+    const platforms = this.selectedPlatforms();
+    const googleSelected = platforms.includes('google-ads');
+    const linkedInSelected = platforms.includes('linkedin-ads');
+    if (!googleSelected && !linkedInSelected) return false;
+    if (googleSelected && this.campaignForm.invalid) return false;
+    if (linkedInSelected && this.linkedInBudgetUsd() < 1) return false;
+    return true;
+  });
 
   // === Reactive Signals (from form valueChanges) ===
   protected readonly displayBudgetPct: Signal<number> = this.initDisplayBudgetPct();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -146,7 +146,12 @@ export class ImplementationTabComponent {
   }
 
   protected submit(): void {
-    if (this.campaignForm.invalid) return;
+    const platforms = this.selectedPlatforms();
+    const googleSelected = platforms.includes('google-ads');
+    const linkedInSelected = platforms.includes('linkedin-ads');
+    if (googleSelected && this.campaignForm.invalid) return;
+    if (!googleSelected && !linkedInSelected) return;
+    if (linkedInSelected && this.linkedInBudgetUsd() < 1) return;
 
     this.step.set('creating');
     this.creationProgress.set(['Submitting campaign...']);
@@ -158,7 +163,6 @@ export class ImplementationTabComponent {
     if (form.includeSearch) campaignTypes.push('search');
     if (form.includeDemandGen) campaignTypes.push('demand-gen');
 
-    const platforms = this.selectedPlatforms();
     const slug = form.eventSlug || form.eventName.toLowerCase().replace(/\s+/g, '-');
 
     const request = {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -87,6 +87,8 @@ export class ImplementationTabComponent {
     if (!googleSelected && !linkedInSelected) return false;
     if (googleSelected && this.campaignForm.invalid) return false;
     if (linkedInSelected && this.linkedInBudgetUsd() < 1) return false;
+    if (linkedInSelected && this.linkedInGeoTargets().length === 0) return false;
+    if (linkedInSelected && this.linkedInVariants().length === 0) return false;
     return true;
   });
 
@@ -161,6 +163,8 @@ export class ImplementationTabComponent {
     if (googleSelected && this.campaignForm.invalid) return;
     if (!googleSelected && !linkedInSelected) return;
     if (linkedInSelected && this.linkedInBudgetUsd() < 1) return;
+    if (linkedInSelected && this.linkedInGeoTargets().length === 0) return;
+    if (linkedInSelected && this.linkedInVariants().length === 0) return;
 
     this.step.set('creating');
     this.creationProgress.set(['Submitting campaign...']);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -1,22 +1,33 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, DestroyRef, effect, inject, input, signal } from '@angular/core';
+import { SlicePipe } from '@angular/common';
+import { Component, computed, DestroyRef, effect, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { CAMPAIGN_BUDGET_DEFAULTS, CAMPAIGN_CHAR_LIMITS, CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
+import { CAMPAIGN_BUDGET_DEFAULTS, CAMPAIGN_CHAR_LIMITS, CAMPAIGN_JOB_POLL_INTERVAL_MS, LINKEDIN_CHAR_LIMITS } from '@lfx-one/shared/constants';
 import { CampaignService } from '@services/campaign.service';
 import { map, startWith, Subscription, take } from 'rxjs';
 
 import type { Signal } from '@angular/core';
-import type { CampaignBriefOutput, CampaignCreateResponse, CampaignResult, CampaignKeyword, CampaignType } from '@lfx-one/shared/interfaces';
+import type {
+  CampaignBriefOutput,
+  CampaignCreateResponse,
+  CampaignKeyword,
+  CampaignPlatform,
+  CampaignResult,
+  CampaignType,
+  LinkedInCreativeVariant,
+  LinkedInGeoTarget,
+  LinkedInTargetingProfile,
+} from '@lfx-one/shared/interfaces';
 
 type ImplementationStep = 'form' | 'creating' | 'results';
 
 @Component({
   selector: 'lfx-implementation-tab',
-  imports: [ReactiveFormsModule, ButtonComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, SlicePipe],
   templateUrl: './implementation-tab.component.html',
   styleUrl: './implementation-tab.component.scss',
 })
@@ -31,6 +42,7 @@ export class ImplementationTabComponent {
 
   // === Constants ===
   protected readonly charLimits = CAMPAIGN_CHAR_LIMITS;
+  protected readonly linkedInCharLimits = LINKEDIN_CHAR_LIMITS;
   protected readonly todayDate = new Date().toISOString().split('T')[0];
   protected readonly defaultEndDate = new Date(Date.now() + 30 * 86_400_000).toISOString().split('T')[0];
 
@@ -58,6 +70,16 @@ export class ImplementationTabComponent {
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
   protected readonly briefHsToken = signal<string | null>(null);
   protected readonly briefDriveFolderUrl = signal('');
+  protected readonly selectedPlatforms = signal<CampaignPlatform[]>(['google-ads']);
+  protected readonly linkedInGeoTargets = signal<LinkedInGeoTarget[]>([]);
+  protected readonly linkedInTargetingProfile = signal<LinkedInTargetingProfile>('cloud-native');
+  protected readonly linkedInVariants = signal<LinkedInCreativeVariant[]>([]);
+  protected readonly linkedInBudgetUsd = signal(500);
+  protected readonly linkedInLifetimeBudget = signal(false);
+
+  // === Computed Signals ===
+  protected readonly showGoogleSection = computed(() => this.selectedPlatforms().includes('google-ads'));
+  protected readonly showLinkedInSection = computed(() => this.selectedPlatforms().includes('linkedin-ads'));
 
   // === Reactive Signals (from form valueChanges) ===
   protected readonly displayBudgetPct: Signal<number> = this.initDisplayBudgetPct();
@@ -107,6 +129,22 @@ export class ImplementationTabComponent {
     if (arr.length > 1) arr.removeAt(index);
   }
 
+  protected removeGeoTarget(index: number): void {
+    this.linkedInGeoTargets.update((targets) => targets.filter((_, i) => i !== index));
+  }
+
+  protected setLinkedInTargetingProfile(profile: LinkedInTargetingProfile): void {
+    this.linkedInTargetingProfile.set(profile);
+  }
+
+  protected setLinkedInLifetimeBudget(value: boolean): void {
+    this.linkedInLifetimeBudget.set(value);
+  }
+
+  protected setLinkedInBudget(value: number): void {
+    this.linkedInBudgetUsd.set(value);
+  }
+
   protected submit(): void {
     if (this.campaignForm.invalid) return;
 
@@ -120,9 +158,12 @@ export class ImplementationTabComponent {
     if (form.includeSearch) campaignTypes.push('search');
     if (form.includeDemandGen) campaignTypes.push('demand-gen');
 
+    const platforms = this.selectedPlatforms();
+    const slug = form.eventSlug || form.eventName.toLowerCase().replace(/\s+/g, '-');
+
     const request = {
       eventName: form.eventName,
-      eventSlug: form.eventSlug || form.eventName.toLowerCase().replace(/\s+/g, '-'),
+      eventSlug: slug,
       countryCode: form.countryCode,
       registrationUrl: form.registrationUrl,
       hsToken: this.briefHsToken() ?? undefined,
@@ -136,6 +177,25 @@ export class ImplementationTabComponent {
       descriptions: (form.descriptions as string[]).filter((d) => d.trim()),
       geoTargets: [form.countryCode],
       driveFolderUrl: this.briefDriveFolderUrl() || undefined,
+      platforms,
+      ...(platforms.includes('linkedin-ads')
+        ? {
+            linkedInConfig: {
+              eventName: form.eventName,
+              eventSlug: slug,
+              dates: `${form.startDate} - ${form.endDate}`,
+              registrationUrl: form.registrationUrl,
+              hsToken: this.briefHsToken() ?? undefined,
+              budgetUsd: this.linkedInBudgetUsd(),
+              lifetimeBudget: this.linkedInLifetimeBudget(),
+              startDate: form.startDate,
+              endDate: form.endDate,
+              geoTargets: this.linkedInGeoTargets(),
+              targetingProfile: this.linkedInTargetingProfile(),
+              variants: this.linkedInVariants(),
+            },
+          }
+        : {}),
     };
 
     this.campaignService.createCampaign(request).subscribe({
@@ -188,6 +248,10 @@ export class ImplementationTabComponent {
       endDate: this.defaultEndDate,
     });
 
+    if (brief.selectedPlatforms?.length) {
+      this.selectedPlatforms.set(brief.selectedPlatforms);
+    }
+
     const searchCopy = brief.structuredCopy?.['google_search'] as Record<string, unknown> | undefined;
     if (searchCopy) {
       const headlines = (searchCopy['headlines'] as string[]) ?? [];
@@ -204,6 +268,12 @@ export class ImplementationTabComponent {
       for (const d of descriptions) {
         descriptionsArr.push(this.fb.control(d, [Validators.required, Validators.maxLength(CAMPAIGN_CHAR_LIMITS.searchDescription)]));
       }
+    }
+
+    if (brief.linkedInCopy) {
+      this.linkedInVariants.set(brief.linkedInCopy.variants);
+      this.linkedInGeoTargets.set(brief.linkedInCopy.recommendedGeoTargets);
+      this.linkedInTargetingProfile.set(brief.linkedInCopy.recommendedTargetingProfile);
     }
 
     this.briefKeywords.set(brief.keywords);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -245,7 +245,7 @@ export class PlanningTabComponent implements OnInit {
     const liData = (this.structuredCopy()?.['linkedin_sponsored'] ?? null) as Record<string, unknown> | null;
     const linkedInCopy: LinkedInBriefCopy | undefined = liData
       ? {
-          variants: ((liData['variants'] as Record<string, unknown>[]) ?? []).map((v) => ({
+          variants: (Array.isArray(liData['variants']) ? (liData['variants'] as Record<string, unknown>[]) : []).map((v) => ({
             introText: (v['intro_text'] as string) ?? (v['introText'] as string) ?? '',
             headline: (v['headline'] as string) ?? '',
           })),

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -249,8 +249,10 @@ export class PlanningTabComponent implements OnInit {
             introText: (v['intro_text'] as string) ?? (v['introText'] as string) ?? '',
             headline: (v['headline'] as string) ?? '',
           })),
-          recommendedGeoTargets: (liData['resolved_geo_targets'] as LinkedInGeoTarget[]) ?? [],
-          recommendedTargetingProfile: (liData['recommended_targeting_profile'] as LinkedInTargetingProfile) ?? 'cloud-native',
+          recommendedGeoTargets: Array.isArray(liData['resolved_geo_targets']) ? (liData['resolved_geo_targets'] as LinkedInGeoTarget[]) : [],
+          recommendedTargetingProfile: ['cloud-native', 'mcp', 'custom'].includes(liData['recommended_targeting_profile'] as string)
+            ? (liData['recommended_targeting_profile'] as LinkedInTargetingProfile)
+            : 'cloud-native',
         }
       : undefined;
     this.proceedToImplementation.emit({

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -22,7 +22,6 @@ import type {
   CampaignSSEEventType,
   HubSpotUtmLookupResult,
   LinkedInBriefCopy,
-  LinkedInCreativeVariant,
   LinkedInGeoTarget,
   LinkedInTargetingProfile,
   SSEEvent,
@@ -246,7 +245,10 @@ export class PlanningTabComponent implements OnInit {
     const liData = (this.structuredCopy()?.['linkedin_sponsored'] ?? null) as Record<string, unknown> | null;
     const linkedInCopy: LinkedInBriefCopy | undefined = liData
       ? {
-          variants: (liData['variants'] as LinkedInCreativeVariant[]) ?? [],
+          variants: ((liData['variants'] as Record<string, unknown>[]) ?? []).map((v) => ({
+            introText: (v['intro_text'] as string) ?? (v['introText'] as string) ?? '',
+            headline: (v['headline'] as string) ?? '',
+          })),
           recommendedGeoTargets: (liData['resolved_geo_targets'] as LinkedInGeoTarget[]) ?? [],
           recommendedTargetingProfile: (liData['recommended_targeting_profile'] as LinkedInTargetingProfile) ?? 'cloud-native',
         }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -21,6 +21,10 @@ import type {
   CampaignPlatformOption,
   CampaignSSEEventType,
   HubSpotUtmLookupResult,
+  LinkedInBriefCopy,
+  LinkedInCreativeVariant,
+  LinkedInGeoTarget,
+  LinkedInTargetingProfile,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
 
@@ -239,6 +243,14 @@ export class PlanningTabComponent implements OnInit {
     };
     const budgetRaw2 = this.briefForm.controls.totalBudget.value;
     const budgetStr = typeof budgetRaw2 === 'string' ? budgetRaw2.trim() : String(budgetRaw2 ?? '');
+    const liData = (this.structuredCopy()?.['linkedin_sponsored'] ?? null) as Record<string, unknown> | null;
+    const linkedInCopy: LinkedInBriefCopy | undefined = liData
+      ? {
+          variants: (liData['variants'] as LinkedInCreativeVariant[]) ?? [],
+          recommendedGeoTargets: (liData['resolved_geo_targets'] as LinkedInGeoTarget[]) ?? [],
+          recommendedTargetingProfile: (liData['recommended_targeting_profile'] as LinkedInTargetingProfile) ?? 'cloud-native',
+        }
+      : undefined;
     this.proceedToImplementation.emit({
       eventDetails: details,
       structuredCopy: this.structuredCopy(),
@@ -247,6 +259,8 @@ export class PlanningTabComponent implements OnInit {
       totalBudget: budgetStr ? Number(budgetStr) : null,
       driveFolderUrl: this.briefForm.controls.driveFolderUrl.value.trim(),
       campaignGoal: (this.briefForm.controls.campaignGoal.value as CampaignGoal) || null,
+      selectedPlatforms: [...this.selectedPlatforms()] as CampaignPlatform[],
+      linkedInCopy,
     });
   }
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -154,7 +154,7 @@ export class CampaignController {
     }
 
     if (!body.currentKeywords || !Array.isArray(body.currentKeywords)) {
-      const validationError = ServiceValidationError.forField('currentKeywords', 'currentKeywords must be a non-empty array', {
+      const validationError = ServiceValidationError.forField('currentKeywords', 'currentKeywords is required and must be an array', {
         operation: 'campaign_refine_brief',
         service: 'campaign_controller',
         path: req.path,

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -666,8 +666,11 @@ export class CampaignProxyService {
         truncateAdCopy(structured);
 
         if (selectedPlatforms.includes('linkedin-ads')) {
-          const liData = structured['linkedin_sponsored'] as Record<string, unknown> | undefined;
+          const liData =
+            (structured['linkedin_sponsored'] as Record<string, unknown> | undefined) ??
+            ((structured['platforms'] as Record<string, unknown> | undefined)?.['linkedin_sponsored'] as Record<string, unknown> | undefined);
           if (liData) {
+            if (!structured['linkedin_sponsored']) structured['linkedin_sponsored'] = liData;
             const recommendedGeos = liData['recommended_geos'] as string[] | undefined;
             if (Array.isArray(recommendedGeos) && recommendedGeos.length > 0) {
               try {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -754,7 +754,7 @@ export class CampaignProxyService {
         const structured = JSON.parse(text) as Record<string, unknown>;
         truncateAdCopy(structured);
 
-        if (platforms.includes('linkedin-ads')) {
+        if (supportedPlatforms.includes('linkedin-ads')) {
           const liData =
             (structured['linkedin_sponsored'] as Record<string, unknown> | undefined) ??
             ((structured['platforms'] as Record<string, unknown> | undefined)?.['linkedin_sponsored'] as Record<string, unknown> | undefined);

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -739,7 +739,7 @@ export class CampaignProxyService {
     yield { type: 'status', data: 'Refining brief based on your feedback...' };
 
     const copySystemPrompt = buildCopySystemPrompt(supportedPlatforms);
-    const userPrompt = buildRefinePrompt(body);
+    const userPrompt = buildRefinePrompt(body, supportedPlatforms);
     let fullCopy = '';
 
     try {
@@ -763,8 +763,7 @@ export class CampaignProxyService {
       return;
     }
 
-    const platforms = body.platforms?.length ? body.platforms : ['google-ads'];
-    if (platforms.includes('google-ads')) {
+    if (supportedPlatforms.includes('google-ads')) {
       yield { type: 'status', data: 'Regenerating keywords...' };
 
       try {
@@ -1361,10 +1360,21 @@ CRITICAL RULES:
 - Avoid generic broad terms that waste budget (e.g. "conference" alone).`;
 }
 
-function buildRefinePrompt(body: CampaignBriefRefineRequest): string {
+function buildRefinePrompt(body: CampaignBriefRefineRequest, platforms: string[]): string {
   const eventBlock = body.eventDetails ? `\nEVENT: ${body.eventDetails.name}\nDates: ${body.eventDetails.dates}\nCity: ${body.eventDetails.city}\n` : '';
 
-  return `I have existing Google Ads copy that needs refinement based on user feedback.
+  const keys: string[] = [];
+  const labels: string[] = [];
+  if (platforms.includes('google-ads')) {
+    keys.push('"google_search"', '"google_display"');
+    labels.push('Google Ads');
+  }
+  if (platforms.includes('linkedin-ads')) {
+    keys.push('"linkedin_sponsored"');
+    labels.push('LinkedIn Sponsored Content');
+  }
+
+  return `I have existing ${labels.join(' and ')} copy that needs refinement based on user feedback.
 
 CURRENT AD COPY:
 ${JSON.stringify(body.currentCopy, null, 2)}
@@ -1373,7 +1383,7 @@ USER FEEDBACK:
 ${body.feedback}
 
 Please regenerate the ad copy incorporating the user's feedback while maintaining the same JSON structure.
-Respect all character limits from the system prompt. Return the same JSON format with keys "google_search" and "google_display".`;
+Respect all character limits from the system prompt. Return the same JSON format with keys ${keys.join(' and ')}.`;
 }
 
 function buildRefineKeywordPrompt(body: CampaignBriefRefineRequest): string {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -763,7 +763,7 @@ export class CampaignProxyService {
             const recommendedGeos = liData['recommended_geos'] as string[] | undefined;
             if (Array.isArray(recommendedGeos) && recommendedGeos.length > 0) {
               try {
-                const resolved = await resolveGeoTargets(recommendedGeos);
+                const resolved = await resolveGeoTargets(recommendedGeos, req);
                 liData['resolved_geo_targets'] = resolved;
               } catch (geoError) {
                 logger.warning(req, 'campaign_refine_geo_resolve', 'Failed to resolve LinkedIn geo targets during refinement', { err: geoError });

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -753,6 +753,25 @@ export class CampaignProxyService {
         const text = stripJsonFences(fullCopy);
         const structured = JSON.parse(text) as Record<string, unknown>;
         truncateAdCopy(structured);
+
+        if (platforms.includes('linkedin-ads')) {
+          const liData =
+            (structured['linkedin_sponsored'] as Record<string, unknown> | undefined) ??
+            ((structured['platforms'] as Record<string, unknown> | undefined)?.['linkedin_sponsored'] as Record<string, unknown> | undefined);
+          if (liData) {
+            if (!structured['linkedin_sponsored']) structured['linkedin_sponsored'] = liData;
+            const recommendedGeos = liData['recommended_geos'] as string[] | undefined;
+            if (Array.isArray(recommendedGeos) && recommendedGeos.length > 0) {
+              try {
+                const resolved = await resolveGeoTargets(recommendedGeos);
+                liData['resolved_geo_targets'] = resolved;
+              } catch (geoError) {
+                logger.warning(req, 'campaign_refine_geo_resolve', 'Failed to resolve LinkedIn geo targets during refinement', { err: geoError });
+              }
+            }
+          }
+        }
+
         yield { type: 'copy_structured', data: structured };
       } catch {
         yield { type: 'copy_structured', data: { raw: fullCopy } };

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -137,7 +137,7 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
       start += pageSize;
     }
   } catch (error: unknown) {
-    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}"`, { name, err: error });
+    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}" on ${nestedPath}`, { name, nestedPath, err: error });
   }
   return null;
 }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -21,6 +21,8 @@ const SENIORITY_EXCLUSIONS = ['urn:li:seniority:1', 'urn:li:seniority:3'];
 
 const SKIP_STATUSES = new Set(['ARCHIVED', 'CANCELED', 'COMPLETED', 'DRAFT', 'REMOVED', 'DELETED']);
 
+const LINKEDIN_REQUEST_TIMEOUT_MS = 30_000;
+
 // ---------------------------------------------------------------------------
 // Environment
 // ---------------------------------------------------------------------------
@@ -89,7 +91,7 @@ async function linkedInRequest(
   const response = await fetch(url.toString(), {
     method,
     headers,
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
     ...(body ? { body: JSON.stringify(body) } : {}),
   });
 

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -440,7 +440,7 @@ export async function executeLinkedInCampaignCreation(req: Request | undefined, 
 
 function stripEmDashes(text: string): string {
   return text
-    .replace(/ — /g, ', ')
-    .replace(/—/g, ', ')
+    .replace(/ [—–] /g, ', ')
+    .replace(/[—–]/g, ', ')
     .replace(/^, |, $/g, '');
 }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -137,7 +137,7 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
       start += pageSize;
     }
   } catch (error: unknown) {
-    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for ${nestedPath}`, { name, err: error });
+    logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}"`, { name, err: error });
   }
   return null;
 }

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -13,7 +13,7 @@ export type LinkedInTargetingProfile = 'cloud-native' | 'mcp' | 'custom';
 
 export type CampaignStatus = 'draft' | 'paused' | 'enabled' | 'removed' | 'limited' | 'unknown';
 
-export type CampaignType = 'search' | 'demand-gen';
+export type CampaignType = 'search' | 'demand-gen' | 'sponsored';
 
 export type DateRangeOption = 7 | 14 | 30;
 


### PR DESCRIPTION
## Summary
- Extend the AI brief pipeline to generate copy for all selected platforms in one SSE stream
- When LinkedIn is selected, AI generates intro text + headline variants, recommends geo targets and targeting profile based on event context
- Convert static `COPY_SYSTEM_PROMPT` into dynamic `buildCopySystemPrompt()` that includes only specs for selected platforms
- Add LinkedIn Sponsored Content specs: intro text (600ch), headline (200ch), geo/targeting recommendations
- After AI response, resolve recommended geo names to LinkedIn URNs via `resolveGeoTargets()`
- Extend `truncateAdCopy()` to enforce LinkedIn character limits
- Keywords are skipped when only LinkedIn is selected (LinkedIn doesn't use keywords)

## Dependencies
- #895 — LinkedIn shared types and constants
- #896 — LinkedIn Ads API client service (provides `resolveGeoTargets`)
- #897 — Multi-platform dispatch

## Test plan
- [ ] `yarn check-types` passes
- [ ] `yarn lint` passes
- [ ] `yarn build` passes
- [ ] Google-only brief generation unchanged (backward compatible)
- [ ] With `platforms: ["linkedin-ads"]`, AI generates `linkedin_sponsored` key with variants + geo recommendations

LFXV2-2157

🤖 Generated with [Claude Code](https://claude.ai/code)