### PR TITLE
feat(campaigns): add linkedin platform handoff and brief review

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -524,6 +524,64 @@
         </div>
       }
 
+      <!-- EDIT MODE: LinkedIn Sponsored Content -->
+      @if (editLinkedInVariants().length > 0 || isPlatformSelected('linkedin-ads')) {
+        <div class="rounded-lg border border-blue-200 bg-white p-5" data-testid="planning-linkedin-copy-edit">
+          <div class="mb-3 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-gray-900">
+              <i class="fa-brands fa-linkedin mr-1.5 text-blue-600" aria-hidden="true"></i>
+              LinkedIn Sponsored Content
+              <span class="ml-2 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-normal text-blue-700">Editing</span>
+            </h3>
+            <button type="button" (click)="addLinkedInVariant()" class="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
+              <i class="fa-light fa-plus" aria-hidden="true"></i> Add Variant
+            </button>
+          </div>
+          <div class="flex flex-col gap-4">
+            @for (variant of editLinkedInVariants(); track $index; let i = $index) {
+              <div class="relative rounded-md border border-gray-200 bg-gray-50 p-3">
+                <div class="mb-1 flex items-center justify-between">
+                  <h4 class="text-xs font-medium text-gray-500">Variant {{ i + 1 }}</h4>
+                  @if (editLinkedInVariants().length > 1) {
+                    <button
+                      type="button"
+                      (click)="removeLinkedInVariant(i)"
+                      class="text-gray-400 hover:text-red-500"
+                      [attr.aria-label]="'Remove variant ' + (i + 1)">
+                      <i class="fa-light fa-xmark text-xs" aria-hidden="true"></i>
+                    </button>
+                  }
+                </div>
+                <div class="flex flex-col gap-2">
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs text-gray-500">Intro Text (max 600 chars)</label>
+                    <textarea
+                      #introTextInput
+                      [value]="variant.introText"
+                      (input)="updateLinkedInVariant(i, 'introText', introTextInput.value)"
+                      maxlength="600"
+                      rows="3"
+                      class="w-full rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-800 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"></textarea>
+                    <span class="text-right text-xs text-gray-400">{{ variant.introText.length }}/600</span>
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs text-gray-500">Headline (max 200 chars)</label>
+                    <input
+                      #headlineInput
+                      type="text"
+                      [value]="variant.headline"
+                      (input)="updateLinkedInVariant(i, 'headline', headlineInput.value)"
+                      maxlength="200"
+                      class="rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-800 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    <span class="text-right text-xs text-gray-400">{{ variant.headline.length }}/200</span>
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
       <!-- EDIT MODE: Keywords -->
       @if (editKeywords().length > 0) {
         <div class="rounded-lg border border-blue-200 bg-white p-5" data-testid="planning-keywords-edit">
@@ -718,8 +776,44 @@
         </div>
       }
 
+      <!-- READ-ONLY MODE: LinkedIn Sponsored Content -->
+      @if (linkedInCopy(); as linkedin) {
+        <div class="rounded-lg border border-blue-200 bg-white p-5" data-testid="planning-linkedin-copy">
+          <h3 class="mb-4 text-sm font-semibold text-gray-900">
+            <i class="fa-brands fa-linkedin mr-1.5 text-blue-600" aria-hidden="true"></i>
+            LinkedIn Sponsored Content
+          </h3>
+
+          <div class="flex flex-col gap-4">
+            @for (variant of linkedin.variants; track $index; let i = $index) {
+              <div class="rounded-md border border-gray-200 bg-gray-50 p-3">
+                <h4 class="mb-1.5 text-xs font-medium text-gray-500">Variant {{ i + 1 }}</h4>
+                <p class="mb-2 whitespace-pre-line text-sm text-gray-800">{{ variant.introText }}</p>
+                <p class="text-xs font-medium text-gray-600">{{ variant.headline }}</p>
+              </div>
+            }
+
+            @if (linkedin.recommendedGeoTargets.length > 0) {
+              <div>
+                <h4 class="mb-2 text-xs font-medium text-gray-500">Recommended Geo Targets</h4>
+                <div class="flex flex-wrap gap-1.5">
+                  @for (geo of linkedin.recommendedGeoTargets; track geo.urn) {
+                    <span class="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700">{{ geo.label }}</span>
+                  }
+                </div>
+              </div>
+            }
+
+            <div>
+              <h4 class="mb-1 text-xs font-medium text-gray-500">Targeting Profile</h4>
+              <span class="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">{{ linkedin.recommendedTargetingProfile }}</span>
+            </div>
+          </div>
+        </div>
+      }
+
       <!-- Raw Copy (fallback if structured sections not available) -->
-      @if (!getSearchCopy() && !getDisplayCopy() && copyBuffer()) {
+      @if (!getSearchCopy() && !getDisplayCopy() && !linkedInCopy() && copyBuffer()) {
         <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="planning-ad-copy">
           <div class="mb-3 flex items-center justify-between">
             <h3 class="text-sm font-semibold text-gray-900">Generated Ad Copy</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -106,8 +106,9 @@ export class PlanningTabComponent implements OnInit {
     const copy = this.structuredCopy();
     if (!copy) return null;
     const nested = copy['platforms'] as Record<string, unknown> | undefined;
-    const liData = (copy['linkedin_sponsored'] as Record<string, unknown>) ?? (nested?.['linkedin_sponsored'] as Record<string, unknown>) ?? null;
-    if (!liData) return null;
+    const raw = copy['linkedin_sponsored'] ?? nested?.['linkedin_sponsored'] ?? null;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const liData = raw as Record<string, unknown>;
 
     const rawVariants = Array.isArray(liData['variants']) ? (liData['variants'] as unknown[]) : [];
     const str = (obj: Record<string, unknown>, ...keys: string[]): string => {
@@ -124,11 +125,24 @@ export class PlanningTabComponent implements OnInit {
         imageUrn: str(v, 'image_urn', 'imageUrn') || undefined,
       }));
 
-    const rawGeos = liData['recommended_geos'];
-    const geoNames = Array.isArray(rawGeos) ? rawGeos.filter((g): g is string => typeof g === 'string').map((g) => g.trim().slice(0, 100)) : [];
-    const resolvedGeos: LinkedInGeoTarget[] = geoNames
-      .map((name) => LINKEDIN_GEO_RESOLVE_MAP[name.toLowerCase()])
-      .filter((geo): geo is LinkedInGeoTarget => geo != null);
+    const rawResolved = liData['resolved_geo_targets'];
+    const serverGeos: LinkedInGeoTarget[] = Array.isArray(rawResolved)
+      ? rawResolved.filter(
+          (g): g is LinkedInGeoTarget =>
+            g != null &&
+            typeof g === 'object' &&
+            typeof (g as Record<string, unknown>)['label'] === 'string' &&
+            typeof (g as Record<string, unknown>)['urn'] === 'string'
+        )
+      : [];
+    let resolvedGeos: LinkedInGeoTarget[];
+    if (serverGeos.length > 0) {
+      resolvedGeos = serverGeos;
+    } else {
+      const rawGeos = liData['recommended_geos'];
+      const geoNames = Array.isArray(rawGeos) ? rawGeos.filter((g): g is string => typeof g === 'string').map((g) => g.trim().slice(0, 100)) : [];
+      resolvedGeos = geoNames.map((name) => LINKEDIN_GEO_RESOLVE_MAP[name.toLowerCase()]).filter((geo): geo is LinkedInGeoTarget => geo != null);
+    }
     const VALID_PROFILES: readonly LinkedInTargetingProfile[] = ['cloud-native', 'mcp', 'custom'];
     const rawProfile = liData['recommended_targeting_profile'];
     const profile: LinkedInTargetingProfile =

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, DestroyRef, inject, OnInit, output, PLATFORM_ID, s
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { CAMPAIGN_GOALS, CAMPAIGN_PLATFORMS } from '@lfx-one/shared/constants';
+import { CAMPAIGN_GOALS, CAMPAIGN_PLATFORMS, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
 import { CampaignService } from '@services/campaign.service';
 import { debounceTime, Subject, Subscription } from 'rxjs';
 
@@ -22,6 +22,7 @@ import type {
   CampaignSSEEventType,
   HubSpotUtmLookupResult,
   LinkedInBriefCopy,
+  LinkedInCreativeVariant,
   LinkedInGeoTarget,
   LinkedInTargetingProfile,
   SSEEvent,
@@ -85,6 +86,7 @@ export class PlanningTabComponent implements OnInit {
   protected readonly editDisplayBusinessName = signal('');
   protected readonly editDisplayCta = signal('');
   protected readonly editKeywords = signal<CampaignKeyword[]>([]);
+  protected readonly editLinkedInVariants = signal<LinkedInCreativeVariant[]>([]);
   protected readonly isEditing = signal(false);
 
   // === Refine Mode Signals ===
@@ -100,6 +102,42 @@ export class PlanningTabComponent implements OnInit {
   protected readonly canGenerate = computed(() => this.formValid() === 'VALID' && this.selectedPlatforms().size > 0);
   protected readonly isGenerating = computed(() => this.step() === 'generating');
   protected readonly hasResults = computed(() => this.step() === 'review');
+  protected readonly linkedInCopy = computed<LinkedInBriefCopy | null>(() => {
+    const copy = this.structuredCopy();
+    if (!copy) return null;
+    const nested = copy['platforms'] as Record<string, unknown> | undefined;
+    const liData = (copy['linkedin_sponsored'] as Record<string, unknown>) ?? (nested?.['linkedin_sponsored'] as Record<string, unknown>) ?? null;
+    if (!liData) return null;
+
+    const rawVariants = Array.isArray(liData['variants']) ? (liData['variants'] as unknown[]) : [];
+    const str = (obj: Record<string, unknown>, ...keys: string[]): string => {
+      for (const k of keys) {
+        if (typeof obj[k] === 'string') return obj[k];
+      }
+      return '';
+    };
+    const variants: LinkedInCreativeVariant[] = rawVariants
+      .filter((v): v is Record<string, unknown> => v != null && typeof v === 'object' && !Array.isArray(v))
+      .map((v) => ({
+        introText: str(v, 'intro_text', 'introText'),
+        headline: str(v, 'headline'),
+        imageUrn: str(v, 'image_urn', 'imageUrn') || undefined,
+      }));
+
+    const rawGeos = liData['recommended_geos'];
+    const geoNames = Array.isArray(rawGeos) ? rawGeos.filter((g): g is string => typeof g === 'string').map((g) => g.trim().slice(0, 100)) : [];
+    const resolvedGeos: LinkedInGeoTarget[] = geoNames
+      .map((name) => LINKEDIN_GEO_RESOLVE_MAP[name.toLowerCase()])
+      .filter((geo): geo is LinkedInGeoTarget => geo != null);
+    const VALID_PROFILES: readonly LinkedInTargetingProfile[] = ['cloud-native', 'mcp', 'custom'];
+    const rawProfile = liData['recommended_targeting_profile'];
+    const profile: LinkedInTargetingProfile =
+      typeof rawProfile === 'string' && VALID_PROFILES.includes(rawProfile as LinkedInTargetingProfile)
+        ? (rawProfile as LinkedInTargetingProfile)
+        : 'cloud-native';
+
+    return { variants, recommendedGeoTargets: resolvedGeos, recommendedTargetingProfile: profile };
+  });
 
   // === Private State ===
   private briefSubscription: Subscription | null = null;
@@ -181,7 +219,7 @@ export class PlanningTabComponent implements OnInit {
       campaignGoal: (this.briefForm.controls.campaignGoal.value || undefined) as CampaignGoal | undefined,
       targetAudience: this.briefForm.controls.targetAudience.value.trim() || undefined,
       valueProp: this.briefForm.controls.valueProp.value.trim() || undefined,
-      totalBudget: budgetStr ? Number(budgetStr) : undefined,
+      totalBudget: budgetStr && !isNaN(Number(budgetStr)) ? Number(budgetStr) : undefined,
     };
 
     this.briefSubscription = this.campaignService
@@ -242,29 +280,17 @@ export class PlanningTabComponent implements OnInit {
     };
     const budgetRaw2 = this.briefForm.controls.totalBudget.value;
     const budgetStr = typeof budgetRaw2 === 'string' ? budgetRaw2.trim() : String(budgetRaw2 ?? '');
-    const liData = (this.structuredCopy()?.['linkedin_sponsored'] ?? null) as Record<string, unknown> | null;
-    const linkedInCopy: LinkedInBriefCopy | undefined = liData
-      ? {
-          variants: (Array.isArray(liData['variants']) ? (liData['variants'] as Record<string, unknown>[]) : []).map((v) => ({
-            introText: (v['intro_text'] as string) ?? (v['introText'] as string) ?? '',
-            headline: (v['headline'] as string) ?? '',
-          })),
-          recommendedGeoTargets: Array.isArray(liData['resolved_geo_targets']) ? (liData['resolved_geo_targets'] as LinkedInGeoTarget[]) : [],
-          recommendedTargetingProfile: ['cloud-native', 'mcp', 'custom'].includes(liData['recommended_targeting_profile'] as string)
-            ? (liData['recommended_targeting_profile'] as LinkedInTargetingProfile)
-            : 'cloud-native',
-        }
-      : undefined;
+    const linkedInCopy = this.linkedInCopy();
     this.proceedToImplementation.emit({
       eventDetails: details,
       structuredCopy: this.structuredCopy(),
       keywords: this.keywords(),
       hsUtm: this.hsUtm(),
-      totalBudget: budgetStr ? Number(budgetStr) : null,
+      totalBudget: budgetStr && !isNaN(Number(budgetStr)) ? Number(budgetStr) : null,
       driveFolderUrl: this.briefForm.controls.driveFolderUrl.value.trim(),
       campaignGoal: (this.briefForm.controls.campaignGoal.value as CampaignGoal) || null,
-      selectedPlatforms: [...this.selectedPlatforms()] as CampaignPlatform[],
-      linkedInCopy,
+      selectedPlatforms: [...this.selectedPlatforms()],
+      ...(linkedInCopy ? { linkedInCopy } : {}),
     });
   }
 
@@ -314,6 +340,7 @@ export class PlanningTabComponent implements OnInit {
   protected enterEditMode(): void {
     const search = this.getSearchCopy();
     const display = this.getDisplayCopy();
+    const linkedin = this.linkedInCopy();
     this.editSearchHeadlines.set([...this.asStringArray(search?.['headlines'])]);
     this.editSearchDescriptions.set([...this.asStringArray(search?.['descriptions'])]);
     this.editDisplayHeadlines.set([...this.asStringArray(display?.['headlines'])]);
@@ -321,6 +348,7 @@ export class PlanningTabComponent implements OnInit {
     this.editDisplayBusinessName.set((display?.['business_name'] as string) ?? '');
     this.editDisplayCta.set((display?.['call_to_action'] as string) ?? '');
     this.editKeywords.set(this.keywords().map((kw) => ({ ...kw })));
+    this.editLinkedInVariants.set(linkedin?.variants?.map((v) => ({ ...v })) ?? []);
     this.isEditing.set(true);
   }
 
@@ -339,6 +367,22 @@ export class PlanningTabComponent implements OnInit {
     copy['google_search'] = search;
     const displayKey = copy['demand_gen'] ? 'demand_gen' : 'google_display';
     copy[displayKey] = display;
+
+    const editedVariants = this.editLinkedInVariants();
+    if (editedVariants.length > 0) {
+      const liKey = copy['linkedin_sponsored'] ? 'linkedin_sponsored' : 'platforms';
+      if (liKey === 'platforms') {
+        const platforms = { ...((copy['platforms'] as Record<string, unknown>) ?? {}) };
+        const liData = { ...((platforms['linkedin_sponsored'] as Record<string, unknown>) ?? {}) };
+        liData['variants'] = editedVariants.map((v) => ({ intro_text: v.introText, headline: v.headline, ...(v.imageUrn ? { image_urn: v.imageUrn } : {}) }));
+        platforms['linkedin_sponsored'] = liData;
+        copy['platforms'] = platforms;
+      } else {
+        const liData = { ...((copy['linkedin_sponsored'] as Record<string, unknown>) ?? {}) };
+        liData['variants'] = editedVariants.map((v) => ({ intro_text: v.introText, headline: v.headline, ...(v.imageUrn ? { image_urn: v.imageUrn } : {}) }));
+        copy['linkedin_sponsored'] = liData;
+      }
+    }
 
     this.structuredCopy.set(copy);
     this.keywords.set(this.editKeywords());
@@ -377,6 +421,22 @@ export class PlanningTabComponent implements OnInit {
 
   protected removeKeyword(index: number): void {
     this.editKeywords.update((kws) => kws.filter((_, i) => i !== index));
+  }
+
+  protected addLinkedInVariant(): void {
+    this.editLinkedInVariants.update((variants) => [...variants, { introText: '', headline: '' }]);
+  }
+
+  protected removeLinkedInVariant(index: number): void {
+    this.editLinkedInVariants.update((variants) => variants.filter((_, i) => i !== index));
+  }
+
+  protected updateLinkedInVariant(index: number, field: keyof LinkedInCreativeVariant, value: string): void {
+    this.editLinkedInVariants.update((variants) => {
+      const updated = variants.map((v) => ({ ...v }));
+      (updated[index] as Record<string, string>)[field] = value;
+      return updated;
+    });
   }
 
   protected enterRefineMode(): void {

--- a/apps/lfx-one/src/server/constants/index.ts
+++ b/apps/lfx-one/src/server/constants/index.ts
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 export * from './gateway.constants';
+export * from './linkedin.constants';
 export * from './rewards.constants';

--- a/apps/lfx-one/src/server/constants/linkedin.constants.ts
+++ b/apps/lfx-one/src/server/constants/linkedin.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
+import type { LinkedInTargetingProfileConfig } from '@lfx-one/shared/interfaces';
 
 // ---------------------------------------------------------------------------
 // LinkedIn Ads — Server-Only Constants
@@ -10,13 +10,6 @@ import type { LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
 // URNs, and targeting URN lists that must NOT ship to the client bundle.
 // UI-safe constants (geo resolve map, char limits) remain in @lfx-one/shared.
 // ---------------------------------------------------------------------------
-
-export interface LinkedInTargetingProfileConfig {
-  id: LinkedInTargetingProfile;
-  label: string;
-  skills: readonly string[];
-  groups: readonly string[];
-}
 
 export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; orgId: string }[] = [
   { accountId: '538170226', label: 'The Linux Foundation', orgId: '208777' },

--- a/apps/lfx-one/src/server/constants/linkedin.constants.ts
+++ b/apps/lfx-one/src/server/constants/linkedin.constants.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
+
+// ---------------------------------------------------------------------------
+// LinkedIn Ads — Server-Only Constants
+// ---------------------------------------------------------------------------
+// These constants contain internal ad-account IDs, org IDs, employer-exclusion
+// URNs, and targeting URN lists that must NOT ship to the client bundle.
+// UI-safe constants (geo resolve map, char limits) remain in @lfx-one/shared.
+// ---------------------------------------------------------------------------
+
+export interface LinkedInTargetingProfileConfig {
+  id: LinkedInTargetingProfile;
+  label: string;
+  skills: readonly string[];
+  groups: readonly string[];
+}
+
+export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; orgId: string }[] = [
+  { accountId: '538170226', label: 'The Linux Foundation', orgId: '208777' },
+  { accountId: '509430019', label: 'LF Events', orgId: '208777' },
+] as const;
+
+export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
+
+export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [
+  {
+    id: 'cloud-native',
+    label: 'Cloud Native / CNCF',
+    skills: [
+      'urn:li:skill:55158',
+      'urn:li:skill:56347',
+      'urn:li:skill:56319',
+      'urn:li:skill:18442',
+      'urn:li:skill:1500290',
+      'urn:li:skill:55734',
+      'urn:li:skill:55383',
+      'urn:li:skill:1500358',
+      'urn:li:skill:56908',
+      'urn:li:skill:58498',
+      'urn:li:skill:55644',
+      'urn:li:skill:55102',
+      'urn:li:skill:56912',
+      'urn:li:skill:18443',
+      'urn:li:skill:25168',
+      'urn:li:skill:56320',
+      'urn:li:skill:25154',
+      'urn:li:skill:56580',
+      'urn:li:skill:56581',
+      'urn:li:skill:55385',
+    ],
+    groups: [
+      'urn:li:group:6821178',
+      'urn:li:group:9375272',
+      'urn:li:group:12405624',
+      'urn:li:group:12391549',
+      'urn:li:group:8553150',
+      'urn:li:group:13681295',
+      'urn:li:group:4490628',
+      'urn:li:group:2602008',
+      'urn:li:group:50985',
+      'urn:li:group:6585490',
+      'urn:li:group:3779791',
+      'urn:li:group:13799412',
+    ],
+  },
+  {
+    id: 'mcp',
+    label: 'MCP / Agentic AI',
+    skills: [
+      'urn:li:skill:59695',
+      'urn:li:skill:59040',
+      'urn:li:skill:61790',
+      'urn:li:skill:2407',
+      'urn:li:skill:3289',
+      'urn:li:skill:56912',
+      'urn:li:skill:61642',
+      'urn:li:skill:59698',
+      'urn:li:skill:5835',
+    ],
+    groups: ['urn:li:group:6672014', 'urn:li:group:6608681', 'urn:li:group:6773450', 'urn:li:group:10321152', 'urn:li:group:6731624', 'urn:li:group:961087'],
+  },
+] as const;

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -3,7 +3,9 @@
 
 import type { LinkedInCampaignCreateRequest, LinkedInCampaignCreateResult, LinkedInGeoTarget, LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
 
-import { LINKEDIN_API_VERSION, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_GEO_RESOLVE_MAP, LINKEDIN_TARGETING_PROFILES } from '@lfx-one/shared/constants';
+import { LINKEDIN_API_VERSION, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
+
+import { LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants/linkedin.constants';
 
 import type { Request } from 'express';
 

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -5,7 +5,7 @@ import type { LinkedInCampaignCreateRequest, LinkedInCampaignCreateResult, Linke
 
 import { LINKEDIN_API_VERSION, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
 
-import { LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants/linkedin.constants';
+import { LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants';
 
 import type { Request } from 'express';
 

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -7,7 +7,6 @@ import type {
   CampaignStatus,
   CampaignTabOption,
   LinkedInGeoTarget,
-  LinkedInTargetingProfileConfig,
   ParsedCampaignName,
 } from '../interfaces/campaign.interface';
 
@@ -115,66 +114,9 @@ export const LINKEDIN_CHAR_LIMITS = {
   headline: 200,
 } as const;
 
-export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
-
-export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [
-  {
-    id: 'cloud-native',
-    label: 'Cloud Native / CNCF',
-    skills: [
-      'urn:li:skill:55158',
-      'urn:li:skill:56347',
-      'urn:li:skill:56319',
-      'urn:li:skill:18442',
-      'urn:li:skill:1500290',
-      'urn:li:skill:55734',
-      'urn:li:skill:55383',
-      'urn:li:skill:1500358',
-      'urn:li:skill:56908',
-      'urn:li:skill:58498',
-      'urn:li:skill:55644',
-      'urn:li:skill:55102',
-      'urn:li:skill:56912',
-      'urn:li:skill:18443',
-      'urn:li:skill:25168',
-      'urn:li:skill:56320',
-      'urn:li:skill:25154',
-      'urn:li:skill:56580',
-      'urn:li:skill:56581',
-      'urn:li:skill:55385',
-    ],
-    groups: [
-      'urn:li:group:6821178',
-      'urn:li:group:9375272',
-      'urn:li:group:12405624',
-      'urn:li:group:12391549',
-      'urn:li:group:8553150',
-      'urn:li:group:13681295',
-      'urn:li:group:4490628',
-      'urn:li:group:2602008',
-      'urn:li:group:50985',
-      'urn:li:group:6585490',
-      'urn:li:group:3779791',
-      'urn:li:group:13799412',
-    ],
-  },
-  {
-    id: 'mcp',
-    label: 'MCP / Agentic AI',
-    skills: [
-      'urn:li:skill:59695',
-      'urn:li:skill:59040',
-      'urn:li:skill:61790',
-      'urn:li:skill:2407',
-      'urn:li:skill:3289',
-      'urn:li:skill:56912',
-      'urn:li:skill:61642',
-      'urn:li:skill:59698',
-      'urn:li:skill:5835',
-    ],
-    groups: ['urn:li:group:6672014', 'urn:li:group:6608681', 'urn:li:group:6773450', 'urn:li:group:10321152', 'urn:li:group:6731624', 'urn:li:group:961087'],
-  },
-] as const;
+// NOTE: LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES,
+// and LinkedInTargetingProfileConfig live in apps/lfx-one/src/server/constants/linkedin.constants.ts
+// to keep ad-account IDs, org IDs, and targeting URNs out of the client bundle.
 
 export const LINKEDIN_GEO_RESOLVE_MAP: Readonly<Record<string, LinkedInGeoTarget>> = {
   japan: { label: 'Japan', urn: 'urn:li:geo:101355337' },

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -114,8 +114,8 @@ export const LINKEDIN_CHAR_LIMITS = {
   headline: 200,
 } as const;
 
-// NOTE: LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES,
-// and LinkedInTargetingProfileConfig live in apps/lfx-one/src/server/constants/linkedin.constants.ts
+// NOTE: LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, and LINKEDIN_TARGETING_PROFILES
+// live in apps/lfx-one/src/server/constants/linkedin.constants.ts
 // to keep ad-account IDs, org IDs, and targeting URNs out of the client bundle.
 
 export const LINKEDIN_GEO_RESOLVE_MAP: Readonly<Record<string, LinkedInGeoTarget>> = {


### PR DESCRIPTION
## Summary
- Pass `selectedPlatforms` and `linkedInCopy` from planning tab to implementation tab via the `CampaignBriefOutput` interface
- Add LinkedIn Sponsored Content review section in the planning tab's read-only brief display (variants with intro text/headline, recommended geo targets as chips, targeting profile badge)
- Update raw copy fallback condition to account for LinkedIn structured data
- Include LinkedIn shared types and constants (dependency from PR #896)

## Changes
- `packages/shared/src/interfaces/campaign.interface.ts` — LinkedIn types (LinkedInBriefCopy, LinkedInGeoTarget, LinkedInCreativeVariant, LinkedInTargetingProfile, LinkedInCampaignCreateRequest/Result), extended CampaignBriefOutput
- `packages/shared/src/constants/campaign.constants.ts` — Enable linkedin-ads platform, add LINKEDIN_CHAR_LIMITS, LINKEDIN_TARGETING_PROFILES, LINKEDIN_GEO_RESOLVE_MAP, LINKEDIN_ACCOUNTS
- `planning-tab.component.ts` — Add `getLinkedInCopy()` method, include selectedPlatforms + linkedInCopy in `proceedToImplementation` emit
- `planning-tab.component.html` — LinkedIn copy review section with variants, geo targets, targeting profile

## Context
Part of the LinkedIn Ads integration epic (LFXV2-2023). This is PR 6 in the sequence — handles the data handoff from planning to implementation and displays LinkedIn-format copy during brief review.

Depends on: #896 (shared types), #898 (brief generation)

LFXV2-2159

🤖 Generated with [Claude Code](https://claude.ai/code)