### PR TITLE
feat(events): add past events tab to org lens events page

### DIFF
--- a/apps/lfx-one/e2e/org-events-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-events-dashboard.spec.ts
@@ -190,6 +190,31 @@ test.describe('Org Events Dashboard', () => {
     await expect(page.getByTestId('org-event-action-event-1')).toHaveCount(0);
   });
 
+  test('past tab shows the past-specific empty state when there are no past events', async ({ page }) => {
+    await gotoOrgEventsPage(page);
+    await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    // Override only the isPast=true response with an empty payload; registered after the
+    // base stub so it takes precedence, falling back to the base stub for upcoming requests.
+    await page.route(`**/api/orgs/${MOCK_ACCOUNT_ID}/lens/events?**`, (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('isPast') === 'true') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [], total: 0, pageSize: 10, offset: 0 }),
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.getByTestId('org-events-stat-past').click();
+
+    const panel = page.getByTestId('org-events-panel-past');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByText('No past events', { exact: true })).toBeVisible();
+  });
+
   test('opens attendee and speaker drawers with non-PII row test ids', async ({ page }) => {
     await gotoOrgEventsPage(page);
     await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });

--- a/apps/lfx-one/e2e/org-events-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-events-dashboard.spec.ts
@@ -154,8 +154,8 @@ test.describe('Org Events Dashboard', () => {
   test('supports sorting, pagination, and action CTAs', async ({ page }) => {
     await gotoOrgEventsPage(page);
     await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await expect(page.getByTestId('org-upcoming-events-data-table')).toBeVisible();
-    await expect(page.getByTestId('org-upcoming-event-action-event-1').getByRole('link', { name: 'Register' })).toBeVisible();
+    await expect(page.getByTestId('org-events-data-table')).toBeVisible();
+    await expect(page.getByTestId('org-event-action-event-1').getByRole('link', { name: 'Register' })).toBeVisible();
 
     const sortRequest = page.waitForRequest((request) => {
       const url = new URL(request.url());
@@ -172,18 +172,36 @@ test.describe('Org Events Dashboard', () => {
     await pageRequest;
   });
 
+  test('past tab renders the events table without the Action column', async ({ page }) => {
+    await gotoOrgEventsPage(page);
+    await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    const pastRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith(`/api/orgs/${MOCK_ACCOUNT_ID}/lens/events`) && url.searchParams.get('isPast') === 'true';
+    });
+    await page.getByTestId('org-events-stat-past').click();
+    await pastRequest;
+
+    await expect(page.getByTestId('org-events-panel-past')).toBeVisible();
+    await expect(page.getByTestId('org-events-data-table')).toBeVisible();
+    // Shared columns still render, but the Action column is dropped on the past tab.
+    await expect(page.getByTestId('org-event-attendees-event-1')).toBeVisible();
+    await expect(page.getByTestId('org-event-action-event-1')).toHaveCount(0);
+  });
+
   test('opens attendee and speaker drawers with non-PII row test ids', async ({ page }) => {
     await gotoOrgEventsPage(page);
     await expect(page.getByTestId('org-events-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
-    await page.getByTestId('org-upcoming-event-attendees-event-1').getByRole('button').click();
+    await page.getByTestId('org-event-attendees-event-1').getByRole('button').click();
     await expect(page.getByTestId('event-attendees-drawer')).toBeVisible();
     await expect(page.getByTestId('event-attendee-0')).toBeVisible();
 
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('event-attendees-drawer')).not.toBeVisible();
 
-    await page.getByTestId('org-upcoming-event-speakers-event-1').getByRole('button').click();
+    await page.getByTestId('org-event-speakers-event-1').getByRole('button').click();
     await expect(page.getByTestId('event-speakers-drawer')).toBeVisible();
     await expect(page.getByTestId('event-speaker-0')).toBeVisible();
   });

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.html
@@ -177,11 +177,11 @@
 
   <ng-template #emptymessage>
     <tr>
-      <td [attr.colspan]="showAction() ? 8 : 7" class="text-center py-10">
+      <td [attr.colspan]="columnCount()" class="text-center py-10">
         <div class="flex items-center justify-center p-16">
           <div class="text-center max-w-md">
             <div class="text-gray-400 mb-4">
-              <i class="fa-light fa-calendar-plus text-3xl mb-4"></i>
+              <i [class]="emptyStateIcon() + ' text-3xl mb-4'"></i>
               <h3 class="text-gray-600 mt-2">{{ emptyStateTitle() }}</h3>
               <p class="text-sm text-gray-400 mt-1">{{ emptyStateSubtitle() }}</p>
             </div>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.html
@@ -15,7 +15,7 @@
   currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
   paginatorPosition="bottom"
   (onPage)="onPageChange($event)"
-  data-testid="org-upcoming-events-data-table">
+  data-testid="org-events-data-table">
   <ng-template #header>
     <tr>
       <th scope="col" [attr.aria-sort]="sortAriaMap()['EVENT_NAME']" data-testid="sort-event-name">
@@ -52,12 +52,14 @@
         <span class="block text-gray-400 font-normal">Accepted / Submitted</span>
       </th>
       <th scope="col" class="text-xs text-gray-500 font-medium">Event Sponsor</th>
-      <th scope="col" class="text-xs text-gray-500 font-medium">Action</th>
+      @if (showAction()) {
+        <th scope="col" class="text-xs text-gray-500 font-medium">Action</th>
+      }
     </tr>
   </ng-template>
 
   <ng-template #body let-event let-rowIndex="rowIndex">
-    <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'org-upcoming-event-row-' + event.eventId">
+    <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'org-event-row-' + event.eventId">
       <!-- Event Name -->
       <td>
         @if (event.eventUrl) {
@@ -66,11 +68,11 @@
             target="_blank"
             rel="noopener noreferrer"
             class="lfx-table-name-link text-sm"
-            [attr.data-testid]="'org-upcoming-event-name-' + event.eventId">
+            [attr.data-testid]="'org-event-name-' + event.eventId">
             {{ event.eventName }}
           </a>
         } @else {
-          <span class="text-sm font-medium text-gray-900" [attr.data-testid]="'org-upcoming-event-name-' + event.eventId">
+          <span class="text-sm font-medium text-gray-900" [attr.data-testid]="'org-event-name-' + event.eventId">
             {{ event.eventName }}
           </span>
         }
@@ -79,7 +81,7 @@
       <!-- Foundation -->
       <td>
         @if (event.foundation) {
-          <lfx-tag [value]="event.foundation" styleClass="tag-neutral" [attr.data-testid]="'org-upcoming-event-foundation-' + event.eventId" />
+          <lfx-tag [value]="event.foundation" styleClass="tag-neutral" [attr.data-testid]="'org-event-foundation-' + event.eventId" />
         } @else {
           <span class="text-xs text-gray-400">&mdash;</span>
         }
@@ -106,7 +108,7 @@
       </td>
 
       <!-- Event Attendees: My Org / Goal -->
-      <td [attr.data-testid]="'org-upcoming-event-attendees-' + event.eventId">
+      <td [attr.data-testid]="'org-event-attendees-' + event.eventId">
         @if (event.orgAttendeeCount > 0) {
           <button
             type="button"
@@ -128,7 +130,7 @@
       </td>
 
       <!-- Event Speakers: Accepted / Submitted -->
-      <td [attr.data-testid]="'org-upcoming-event-speakers-' + event.eventId">
+      <td [attr.data-testid]="'org-event-speakers-' + event.eventId">
         @if (event.orgSpeakerAcceptedCount > 0 || event.orgSpeakerSubmittedCount > 0) {
           <button
             type="button"
@@ -142,44 +144,46 @@
       </td>
 
       <!-- Event Sponsor -->
-      <td [attr.data-testid]="'org-upcoming-event-sponsor-' + event.eventId">
+      <td [attr.data-testid]="'org-event-sponsor-' + event.eventId">
         <span class="text-sm text-gray-700">{{ event.isOrgSponsor ? 'Yes' : 'No' }}</span>
       </td>
 
       <!-- Action -->
-      <td [attr.data-testid]="'org-upcoming-event-action-' + event.eventId">
-        @if (event.eventRegistrationUrl) {
-          <a
-            [href]="event.eventRegistrationUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
-            Register
-          </a>
-        } @else if (event.eventUrl) {
-          <a
-            [href]="event.eventUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
-            View
-          </a>
-        } @else {
-          <span class="text-xs text-gray-400">&mdash;</span>
-        }
-      </td>
+      @if (showAction()) {
+        <td [attr.data-testid]="'org-event-action-' + event.eventId">
+          @if (event.eventRegistrationUrl) {
+            <a
+              [href]="event.eventRegistrationUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
+              Register
+            </a>
+          } @else if (event.eventUrl) {
+            <a
+              [href]="event.eventUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm text-blue-600 hover:underline focus-visible:underline focus-visible:outline-none">
+              View
+            </a>
+          } @else {
+            <span class="text-xs text-gray-400">&mdash;</span>
+          }
+        </td>
+      }
     </tr>
   </ng-template>
 
   <ng-template #emptymessage>
     <tr>
-      <td colspan="8" class="text-center py-10">
+      <td [attr.colspan]="showAction() ? 8 : 7" class="text-center py-10">
         <div class="flex items-center justify-center p-16">
           <div class="text-center max-w-md">
             <div class="text-gray-400 mb-4">
               <i class="fa-light fa-calendar-plus text-3xl mb-4"></i>
-              <h3 class="text-gray-600 mt-2">No upcoming events</h3>
-              <p class="text-sm text-gray-400 mt-1">No upcoming events were found for your organization.</p>
+              <h3 class="text-gray-600 mt-2">{{ emptyStateTitle() }}</h3>
+              <p class="text-sm text-gray-400 mt-1">{{ emptyStateSubtitle() }}</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.ts
@@ -23,6 +23,7 @@ export class OrgEventsTableComponent {
   public readonly showAction = input<boolean>(true);
   public readonly emptyStateTitle = input<string>('No upcoming events');
   public readonly emptyStateSubtitle = input<string>('No upcoming events were found for your organization.');
+  public readonly emptyStateIcon = input<string>('fa-light fa-calendar-plus');
 
   public readonly pageChange = output<PageChangeEvent>();
   public readonly sortChange = output<SortChangeEvent>();
@@ -30,6 +31,9 @@ export class OrgEventsTableComponent {
   public readonly speakersClick = output<OrgEvent>();
 
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.eventsResponse().total > 10 ? [10, 25, 50] : undefined));
+
+  // Single source of truth for the empty-row colspan: 8 columns with the Action column, 7 without.
+  protected readonly columnCount = computed<number>(() => (this.showAction() ? 8 : 7));
 
   // Pre-bake the formatted date range per row so the template reads a property instead of calling a method each CD cycle.
   protected readonly rows = computed<OrgEventRowVm[]>(() =>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/components/org-events-table/org-events-table.component.ts
@@ -10,15 +10,19 @@ import { TagComponent } from '@components/tag/tag.component';
 import type { OrgEvent, OrgEventRowVm, OrgEventsResponse, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 
 @Component({
-  selector: 'lfx-org-upcoming-events-table',
+  selector: 'lfx-org-events-table',
   imports: [TableComponent, TagComponent, DecimalPipe],
-  templateUrl: './org-upcoming-events-table.component.html',
+  templateUrl: './org-events-table.component.html',
 })
-export class OrgUpcomingEventsTableComponent {
+export class OrgEventsTableComponent {
   public readonly eventsResponse = input.required<OrgEventsResponse>();
   public readonly loading = input<boolean>(false);
   public readonly sortField = input<string>('EVENT_START_DATE');
   public readonly sortOrder = input<'ASC' | 'DESC'>('ASC');
+  // Past tab (LFXV2-1900) drops the Action column; upcoming keeps it.
+  public readonly showAction = input<boolean>(true);
+  public readonly emptyStateTitle = input<string>('No upcoming events');
+  public readonly emptyStateSubtitle = input<string>('No upcoming events were found for your organization.');
 
   public readonly pageChange = output<PageChangeEvent>();
   public readonly sortChange = output<SortChangeEvent>();

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -126,7 +126,7 @@
     <div class="px-5 pb-5">
       @if (activeTab() === 'upcoming') {
         <section id="org-events-panel-upcoming" data-testid="org-events-panel-upcoming">
-          <lfx-org-upcoming-events-table
+          <lfx-org-events-table
             [eventsResponse]="upcomingEvents()"
             [loading]="upcomingEventsLoading()"
             [sortField]="upcomingSortField()"
@@ -141,12 +141,19 @@
 
       @if (activeTab() === 'past') {
         <section id="org-events-panel-past" data-testid="org-events-panel-past">
-          <lfx-empty-state
-            [withCard]="false"
-            icon="fa-light fa-calendar-check"
-            title="Coming soon"
-            subtitle="Past events for your organization are being built. Check back later."
-            data-testid="org-events-past-coming-soon" />
+          <lfx-org-events-table
+            [eventsResponse]="pastEvents()"
+            [loading]="pastEventsLoading()"
+            [sortField]="pastSortField()"
+            [sortOrder]="pastSortOrder()"
+            [showAction]="false"
+            emptyStateTitle="No past events"
+            emptyStateSubtitle="No past events were found for your organization."
+            (pageChange)="onPastPageChange($event)"
+            (sortChange)="onPastSortChange($event)"
+            (attendeesClick)="onAttendeesClick($event)"
+            (speakersClick)="onSpeakersClick($event)"
+            data-testid="org-events-past-table" />
         </section>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.html
@@ -149,6 +149,7 @@
             [showAction]="false"
             emptyStateTitle="No past events"
             emptyStateSubtitle="No past events were found for your organization."
+            emptyStateIcon="fa-light fa-calendar-check"
             (pageChange)="onPastPageChange($event)"
             (sortChange)="onPastSortChange($event)"
             (attendeesClick)="onAttendeesClick($event)"

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -85,8 +85,24 @@ export class OrgEventsDashboardComponent {
   public readonly companyName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
   public readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
   public readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
-  public readonly upcomingEvents: Signal<OrgEventsResponse> = this.initUpcomingEvents();
-  public readonly pastEvents: Signal<OrgEventsResponse> = this.initPastEvents();
+  public readonly upcomingEvents: Signal<OrgEventsResponse> = this.initEventsPipeline({
+    tab: 'upcoming',
+    page: this.upcomingEventsPage,
+    sortField: this.upcomingSortField,
+    sortOrder: this.upcomingSortOrder,
+    loading: this.upcomingEventsLoading,
+    isPast: false,
+    errorDetail: 'Failed to load upcoming events. Please try again.',
+  });
+  public readonly pastEvents: Signal<OrgEventsResponse> = this.initEventsPipeline({
+    tab: 'past',
+    page: this.pastEventsPage,
+    sortField: this.pastSortField,
+    sortOrder: this.pastSortOrder,
+    loading: this.pastEventsLoading,
+    isPast: true,
+    errorDetail: 'Failed to load past events. Please try again.',
+  });
   public readonly tabPillOptions = computed<FilterPillOption[]>(() => {
     const summary = this.eventsSummary();
     return ORG_EVENTS_TABS.map((tab) => {
@@ -192,79 +208,48 @@ export class OrgEventsDashboardComponent {
     );
   }
 
-  private initUpcomingEvents(): Signal<OrgEventsResponse> {
+  // Shared events query pipeline for both tabs; only the active tab fetches, the inactive tab keeps its last value.
+  private initEventsPipeline(opts: {
+    tab: OrgEventsTabId;
+    page: Signal<PageChangeEvent>;
+    sortField: Signal<string>;
+    sortOrder: Signal<'ASC' | 'DESC'>;
+    loading: WritableSignal<boolean>;
+    isPast: boolean;
+    errorDetail: string;
+  }): Signal<OrgEventsResponse> {
+    const { tab, page, sortField, sortOrder, loading, isPast, errorDetail } = opts;
     return toSignal(
       toObservable(
         computed(() => {
-          // Only fetch when the upcoming tab is active — the inactive tab keeps its last value.
-          if (this.activeTab() !== 'upcoming') return null;
+          if (this.activeTab() !== tab) return null;
           const accountId = this.accountContext.selectedAccount().accountId;
           if (!accountId) return null;
           return {
             accountId,
-            ...this.upcomingEventsPage(),
+            ...page(),
             searchQuery: this.debouncedSearchTerm() || undefined,
             status: this.selectedStatus() ?? null,
-            sortField: this.upcomingSortField(),
-            sortOrder: this.upcomingSortOrder(),
+            sortField: sortField(),
+            sortOrder: sortOrder(),
           };
         })
       ).pipe(
         debounceTime(0),
         filter((params): params is NonNullable<typeof params> => params !== null),
-        tap(() => this.upcomingEventsLoading.set(true)),
+        tap(() => loading.set(true)),
         switchMap(({ accountId, ...params }) =>
-          this.eventsService.getOrgEvents(accountId, { ...params, isPast: false }).pipe(
+          this.eventsService.getOrgEvents(accountId, { ...params, isPast }).pipe(
             catchError(() => {
               this.messageService.add({
                 severity: 'error',
                 summary: 'Error',
-                detail: 'Failed to load upcoming events. Please try again.',
+                detail: errorDetail,
               });
-              const { pageSize, offset } = this.upcomingEventsPage();
+              const { pageSize, offset } = page();
               return of({ ...EMPTY_ORG_EVENTS_RESPONSE, pageSize, offset });
             }),
-            finalize(() => this.upcomingEventsLoading.set(false))
-          )
-        )
-      ),
-      { initialValue: EMPTY_ORG_EVENTS_RESPONSE }
-    );
-  }
-
-  private initPastEvents(): Signal<OrgEventsResponse> {
-    return toSignal(
-      toObservable(
-        computed(() => {
-          // Lazy-load: only fetch past events once the past tab is opened.
-          if (this.activeTab() !== 'past') return null;
-          const accountId = this.accountContext.selectedAccount().accountId;
-          if (!accountId) return null;
-          return {
-            accountId,
-            ...this.pastEventsPage(),
-            searchQuery: this.debouncedSearchTerm() || undefined,
-            status: this.selectedStatus() ?? null,
-            sortField: this.pastSortField(),
-            sortOrder: this.pastSortOrder(),
-          };
-        })
-      ).pipe(
-        debounceTime(0),
-        filter((params): params is NonNullable<typeof params> => params !== null),
-        tap(() => this.pastEventsLoading.set(true)),
-        switchMap(({ accountId, ...params }) =>
-          this.eventsService.getOrgEvents(accountId, { ...params, isPast: true }).pipe(
-            catchError(() => {
-              this.messageService.add({
-                severity: 'error',
-                summary: 'Error',
-                detail: 'Failed to load past events. Please try again.',
-              });
-              const { pageSize, offset } = this.pastEventsPage();
-              return of({ ...EMPTY_ORG_EVENTS_RESPONSE, pageSize, offset });
-            }),
-            finalize(() => this.pastEventsLoading.set(false))
+            finalize(() => loading.set(false))
           )
         )
       ),

--- a/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/org-events-dashboard/org-events-dashboard.component.ts
@@ -12,7 +12,6 @@ import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, 
 
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
-import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import {
   DEFAULT_EVENTS_PAGE_SIZE,
   DEFAULT_ORG_EVENTS_TAB_ID,
@@ -37,7 +36,7 @@ import { EventsService } from '@services/events.service';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventAttendeesDrawerComponent } from './components/event-attendees-drawer/event-attendees-drawer.component';
 import { EventSpeakersDrawerComponent } from './components/event-speakers-drawer/event-speakers-drawer.component';
-import { OrgUpcomingEventsTableComponent } from './components/org-upcoming-events-table/org-upcoming-events-table.component';
+import { OrgEventsTableComponent } from './components/org-events-table/org-events-table.component';
 
 @Component({
   selector: 'lfx-org-events-dashboard',
@@ -45,13 +44,12 @@ import { OrgUpcomingEventsTableComponent } from './components/org-upcoming-event
     FormsModule,
     CardComponent,
     CardTabsBarComponent,
-    EmptyStateComponent,
     SelectModule,
     InputTextModule,
     DiscoverEventsButtonComponent,
     EventAttendeesDrawerComponent,
     EventSpeakersDrawerComponent,
-    OrgUpcomingEventsTableComponent,
+    OrgEventsTableComponent,
   ],
   templateUrl: './org-events-dashboard.component.html',
 })
@@ -76,6 +74,10 @@ export class OrgEventsDashboardComponent {
   public readonly upcomingEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
   public readonly upcomingSortField = signal('EVENT_START_DATE');
   public readonly upcomingSortOrder = signal<'ASC' | 'DESC'>('ASC');
+  public readonly pastEventsLoading = signal(true);
+  public readonly pastEventsPage = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
+  public readonly pastSortField = signal('EVENT_START_DATE');
+  public readonly pastSortOrder = signal<'ASC' | 'DESC'>('DESC');
 
   // === Computed / toSignal ===
   // Debounced search feeds the server-side query so typing doesn't fire a request per keystroke.
@@ -84,6 +86,7 @@ export class OrgEventsDashboardComponent {
   public readonly activeTab: Signal<OrgEventsTabId> = this.initActiveTab();
   public readonly eventsSummary: Signal<OrgEventsSummary | null> = this.initEventsSummary();
   public readonly upcomingEvents: Signal<OrgEventsResponse> = this.initUpcomingEvents();
+  public readonly pastEvents: Signal<OrgEventsResponse> = this.initPastEvents();
   public readonly tabPillOptions = computed<FilterPillOption[]>(() => {
     const summary = this.eventsSummary();
     return ORG_EVENTS_TABS.map((tab) => {
@@ -100,6 +103,7 @@ export class OrgEventsDashboardComponent {
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
+        this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
       });
   }
 
@@ -151,6 +155,21 @@ export class OrgEventsDashboardComponent {
     this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
   }
 
+  public onPastPageChange(event: PageChangeEvent): void {
+    this.pastEventsLoading.set(true);
+    this.pastEventsPage.set(event);
+  }
+
+  public onPastSortChange(event: SortChangeEvent): void {
+    if (this.pastSortField() === event.field) {
+      this.pastSortOrder.set(this.pastSortOrder() === 'ASC' ? 'DESC' : 'ASC');
+    } else {
+      this.pastSortField.set(event.field);
+      this.pastSortOrder.set('ASC');
+    }
+    this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
+  }
+
   // === Private initializers ===
   private initActiveTab(): Signal<OrgEventsTabId> {
     const queryParamMap = toSignal(this.route.queryParamMap, {
@@ -177,6 +196,8 @@ export class OrgEventsDashboardComponent {
     return toSignal(
       toObservable(
         computed(() => {
+          // Only fetch when the upcoming tab is active — the inactive tab keeps its last value.
+          if (this.activeTab() !== 'upcoming') return null;
           const accountId = this.accountContext.selectedAccount().accountId;
           if (!accountId) return null;
           return {
@@ -204,6 +225,46 @@ export class OrgEventsDashboardComponent {
               return of({ ...EMPTY_ORG_EVENTS_RESPONSE, pageSize, offset });
             }),
             finalize(() => this.upcomingEventsLoading.set(false))
+          )
+        )
+      ),
+      { initialValue: EMPTY_ORG_EVENTS_RESPONSE }
+    );
+  }
+
+  private initPastEvents(): Signal<OrgEventsResponse> {
+    return toSignal(
+      toObservable(
+        computed(() => {
+          // Lazy-load: only fetch past events once the past tab is opened.
+          if (this.activeTab() !== 'past') return null;
+          const accountId = this.accountContext.selectedAccount().accountId;
+          if (!accountId) return null;
+          return {
+            accountId,
+            ...this.pastEventsPage(),
+            searchQuery: this.debouncedSearchTerm() || undefined,
+            status: this.selectedStatus() ?? null,
+            sortField: this.pastSortField(),
+            sortOrder: this.pastSortOrder(),
+          };
+        })
+      ).pipe(
+        debounceTime(0),
+        filter((params): params is NonNullable<typeof params> => params !== null),
+        tap(() => this.pastEventsLoading.set(true)),
+        switchMap(({ accountId, ...params }) =>
+          this.eventsService.getOrgEvents(accountId, { ...params, isPast: true }).pipe(
+            catchError(() => {
+              this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: 'Failed to load past events. Please try again.',
+              });
+              const { pageSize, offset } = this.pastEventsPage();
+              return of({ ...EMPTY_ORG_EVENTS_RESPONSE, pageSize, offset });
+            }),
+            finalize(() => this.pastEventsLoading.set(false))
           )
         )
       ),


### PR DESCRIPTION
## Summary
- The Past tab previously showed a placeholder. It now lists an organization's historical event footprint from the same platinum-backed endpoint as Upcoming (`isPast=true`).
- Past events reuse the upcoming table **verbatim minus the Action column**, matching the design.
- Renamed `org-upcoming-events-table` → `org-events-table` (class, selector, template, test ids) since the component now serves both tabs.
- Added `showAction` (default true), `emptyStateTitle`, `emptyStateSubtitle` inputs; the Action column header/body and the empty-message colspan are gated on `showAction`.
- Added a lazy `pastEvents` pipeline in the dashboard (signals, page/sort handlers, active-tab gating) mirroring the upcoming pipeline — it only fetches once the Past tab is opened, and paging resets on filter change.
- Removed the now-unused `EmptyStateComponent` import.
- Added e2e coverage: clicking the Past stat card loads the table and confirms the Action column is absent.

## Test plan
- [ ] Open the org lens events page; click the **Past** tab → table loads with shared columns and **no Action column**.
- [ ] Search + status filter apply to the Past tab; paging and column sorting work.
- [ ] Switching back to **Upcoming** still shows the Action column.
- [ ] Empty org → past-specific empty state copy renders.
- [ ] e2e: `org-events-dashboard.spec.ts` past-tab test passes.

[LFXV2-1900]: https://linuxfoundation.atlassian.net/browse/LFXV2-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ