### PR TITLE
feat(dashboards): hide empty pending actions section across lenses and groups

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -184,7 +184,7 @@
           Hide the whole section when there are no pending actions (and nothing loading) so it doesn't steal page space.
           Stay mounted through the fade (isSectionFading) so the collapse animation can play before removal.
         -->
-        @if (votesLoading() || surveysLoading() || (!isSectionHidden() && (pendingActionItems().length > 0 || isSectionFading()))) {
+        @if (votesLoading() || surveysLoading() || (!isSectionHidden() && (pendingActionItems().length > 0 || isSectionGracePending() || isSectionFading()))) {
           <section class="pending-actions-section" [class.is-fading]="isSectionFading()" data-testid="committee-overview-pending-actions-section">
             <div class="flex items-center gap-3 mb-6">
               <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -180,67 +180,63 @@
         </div>
 
         <!-- My Pending Actions -->
-        <section data-testid="committee-overview-pending-actions-section">
-          <div class="flex items-center gap-3 mb-6">
-            <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
-              <i class="fa-light fa-list-check text-lg"></i>
-              <span>My Pending Actions</span>
-            </h2>
-            <div class="flex-1 border-t border-gray-200 self-center"></div>
-            @if (pendingActionItems().length) {
-              <lfx-button
-                [text]="true"
-                severity="primary"
-                label="View All"
-                (onClick)="navigateToTab(pendingActionsViewAllTab())"
-                data-testid="committee-overview-pending-actions-view-all" />
-            }
-          </div>
-          @if (votesLoading() || surveysLoading()) {
-            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200">
-              @for (i of [1, 2]; track i) {
-                <div class="flex items-center gap-4 px-4 py-3">
-                  <p-skeleton width="15%" height="1.5rem" borderRadius="1rem" />
-                  <p-skeleton width="55%" height="1rem" />
-                  <p-skeleton width="20%" height="1.75rem" borderRadius="0.375rem" styleClass="ml-auto" />
-                </div>
+        <!--
+          Hide the whole section when there are no pending actions (and nothing loading) so it doesn't steal page space.
+          Stay mounted through the fade (isSectionFading) so the collapse animation can play before removal.
+        -->
+        @if (votesLoading() || surveysLoading() || (!isSectionHidden() && (pendingActionItems().length > 0 || isSectionFading()))) {
+          <section class="pending-actions-section" [class.is-fading]="isSectionFading()" data-testid="committee-overview-pending-actions-section">
+            <div class="flex items-center gap-3 mb-6">
+              <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
+                <i class="fa-light fa-list-check text-lg"></i>
+                <span>My Pending Actions</span>
+              </h2>
+              <div class="flex-1 border-t border-gray-200 self-center"></div>
+              @if (pendingActionItems().length) {
+                <lfx-button
+                  [text]="true"
+                  severity="primary"
+                  label="View All"
+                  (onClick)="navigateToTab(pendingActionsViewAllTab())"
+                  data-testid="committee-overview-pending-actions-view-all" />
               }
             </div>
-          } @else if (pendingActionItems().length) {
-            <div
-              class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
-              data-testid="committee-overview-pending-actions-list">
-              @for (item of pendingActionItems(); track item.rowKey; let idx = $index) {
-                <div [attr.data-testid]="'committee-overview-pending-action-' + item.type + '-' + idx">
-                  <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-white">
-                    <div class="shrink-0 sm:w-40">
-                      <lfx-tag [value]="typeLabels[item.type]" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
-                    </div>
-                    <p
-                      class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
-                      [attr.title]="item.text"
-                      data-testid="committee-overview-pending-action-title">
-                      {{ item.text }}
-                    </p>
-                    <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">
-                      <lfx-button size="small" severity="secondary" [outlined]="true" (onClick)="handlePendingActionClick(item)" [label]="item.buttonText" />
+            @if (votesLoading() || surveysLoading()) {
+              <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200">
+                @for (i of [1, 2]; track i) {
+                  <div class="flex items-center gap-4 px-4 py-3">
+                    <p-skeleton width="15%" height="1.5rem" borderRadius="1rem" />
+                    <p-skeleton width="55%" height="1rem" />
+                    <p-skeleton width="20%" height="1.75rem" borderRadius="0.375rem" styleClass="ml-auto" />
+                  </div>
+                }
+              </div>
+            } @else if (pendingActionItems().length) {
+              <div
+                class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
+                data-testid="committee-overview-pending-actions-list">
+                @for (item of pendingActionItems(); track item.rowKey; let idx = $index) {
+                  <div [attr.data-testid]="'committee-overview-pending-action-' + item.type + '-' + idx">
+                    <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-white">
+                      <div class="shrink-0 sm:w-40">
+                        <lfx-tag [value]="typeLabels[item.type]" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
+                      </div>
+                      <p
+                        class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
+                        [attr.title]="item.text"
+                        data-testid="committee-overview-pending-action-title">
+                        {{ item.text }}
+                      </p>
+                      <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">
+                        <lfx-button size="small" severity="secondary" [outlined]="true" (onClick)="handlePendingActionClick(item)" [label]="item.buttonText" />
+                      </div>
                     </div>
                   </div>
-                </div>
-              }
-            </div>
-          } @else {
-            <div
-              class="bg-gray-50 rounded-2xl border border-gray-200 flex items-center justify-center gap-4 px-5 py-10"
-              data-testid="committee-overview-pending-actions-empty">
-              <i class="fa-light fa-box-check text-4xl text-gray-400 shrink-0"></i>
-              <div>
-                <p class="text-sm font-medium text-gray-700">Your desk is clear</p>
-                <p class="text-xs text-gray-400 mt-0.5">No pending actions assigned to you</p>
+                }
               </div>
-            </div>
-          }
-        </section>
+            }
+          </section>
+        }
       } @else if (canJoin()) {
         <!-- Visitor CTA -->
         <div class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center" data-testid="committee-overview-visitor-cta">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.scss
@@ -1,13 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Section-level fade-out for "My Pending Actions" when all actions are resolved. max-height is slightly
-// longer than opacity so the collapse completes smoothly after the content has already faded.
-// overflow: hidden is scoped to .is-fading only so normal content is never clipped.
+// Section-level fade-out for "My Pending Actions" when all actions are resolved. Both opacity and
+// max-height run for 300ms to match PENDING_ACTION_FADE_OUT_MS, so the JS hide timer (fade + 50ms buffer)
+// fires only after the collapse animation completes. overflow: hidden is scoped to .is-fading so resting
+// content is never clipped.
 .pending-actions-section {
   transition:
     opacity 300ms ease-out,
-    max-height 400ms ease-out;
+    max-height 300ms ease-out;
+
   // Generous ceiling; only constrains during animation, never clips at rest (overflow is visible by default).
   max-height: 2000px;
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.scss
@@ -1,2 +1,19 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
+
+// Section-level fade-out for "My Pending Actions" when all actions are resolved. max-height is slightly
+// longer than opacity so the collapse completes smoothly after the content has already faded.
+// overflow: hidden is scoped to .is-fading only so normal content is never clipped.
+.pending-actions-section {
+  transition:
+    opacity 300ms ease-out,
+    max-height 400ms ease-out;
+  // Generous ceiling; only constrains during animation, never clips at rest (overflow is visible by default).
+  max-height: 2000px;
+
+  &.is-fading {
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+  }
+}

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, input, output, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, output, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PENDING_ACTION_LABEL, PENDING_ACTION_SEVERITY } from '@lfx-one/shared/constants';
+import { PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL, PENDING_ACTION_SEVERITY } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import { Committee, CommitteeMember, CommitteePendingActionRow, Meeting, PastMeeting, PendingActionItem, Survey, Vote } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
@@ -42,6 +42,7 @@ export class CommitteeOverviewComponent {
   private readonly surveyService = inject(SurveyService);
   private readonly messageService = inject(MessageService);
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Inputs
   public committee = input.required<Committee>();
@@ -73,6 +74,14 @@ export class CommitteeOverviewComponent {
   // Loading states for meeting sections
   public upcomingMeetingsLoading = signal(true);
   public pastMeetingsLoading = signal(true);
+
+  // Section-level fade-out for "My Pending Actions": true while the CSS collapse animation is in flight;
+  // isSectionHidden removes the section from the DOM once the last vote/survey is resolved.
+  public isSectionFading = signal(false);
+  public isSectionHidden = signal(false);
+  private sectionEverShown = false;
+  // setTimeout handle for the in-flight section-fade; cleared when actions repopulate or on destroy to prevent stale hides.
+  private sectionFadeTimerId: ReturnType<typeof setTimeout> | null = null;
 
   // Computed: chairs derived from members
   public chairs: Signal<CommitteeMember[]> = this.initChairs();
@@ -184,6 +193,31 @@ export class CommitteeOverviewComponent {
     return past[0] ?? null;
   });
 
+  public constructor() {
+    // When the last pending vote/survey is resolved, fade the section out then remove it from the DOM.
+    // sectionEverShown prevents the fade from triggering on initial load with zero actions.
+    toObservable(this.pendingActionItems)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((items) => {
+        if (items.length > 0) {
+          this.sectionEverShown = true;
+          // Cancel any in-flight section-hide so a repopulated section stays visible.
+          this.clearSectionFadeTimer();
+          this.isSectionHidden.set(false);
+          this.isSectionFading.set(false);
+        } else if (this.sectionEverShown && !this.isSectionHidden()) {
+          this.isSectionFading.set(true);
+          this.sectionFadeTimerId = setTimeout(() => {
+            this.sectionFadeTimerId = null;
+            this.isSectionHidden.set(true);
+          }, PENDING_ACTION_FADE_OUT_MS + 50);
+        }
+      });
+
+    // Cancel pending section-hide so it can't fire on a destroyed component.
+    this.destroyRef.onDestroy(() => this.clearSectionFadeTimer());
+  }
+
   // Action methods
   public onJoinClick(): void {
     this.joinRequested.emit();
@@ -280,6 +314,13 @@ export class CommitteeOverviewComponent {
         });
       },
     });
+  }
+
+  private clearSectionFadeTimer(): void {
+    if (this.sectionFadeTimerId !== null) {
+      clearTimeout(this.sectionFadeTimerId);
+      this.sectionFadeTimerId = null;
+    }
   }
 
   // Private initializer functions

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL, PENDING_ACTION_SEVERITY } from '@lfx-one/shared/constants';
+import { PENDING_ACTION_EMPTY_GRACE_MS, PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL, PENDING_ACTION_SEVERITY } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import { Committee, CommitteeMember, CommitteePendingActionRow, Meeting, PastMeeting, PendingActionItem, Survey, Vote } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
@@ -77,10 +77,14 @@ export class CommitteeOverviewComponent {
 
   // Section-level fade-out for "My Pending Actions": true while the CSS collapse animation is in flight;
   // isSectionHidden removes the section from the DOM once the last vote/survey is resolved.
-  public isSectionFading = signal(false);
-  public isSectionHidden = signal(false);
+  // isSectionGracePending keeps the section mounted (not yet fading) during the post-empty grace window so a
+  // context switch that briefly empties the list doesn't trigger a spurious fade before the new data arrives.
+  // Template-only state — protected, matching pending-actions.component.ts.
+  protected readonly isSectionFading = signal(false);
+  protected readonly isSectionHidden = signal(false);
+  protected readonly isSectionGracePending = signal(false);
   private sectionEverShown = false;
-  // setTimeout handle for the in-flight section-fade; cleared when actions repopulate or on destroy to prevent stale hides.
+  // setTimeout handle for the in-flight grace/section-fade; cleared when actions repopulate or on destroy to prevent stale hides.
   private sectionFadeTimerId: ReturnType<typeof setTimeout> | null = null;
 
   // Computed: chairs derived from members
@@ -201,18 +205,27 @@ export class CommitteeOverviewComponent {
       .subscribe((items) => {
         if (items.length > 0) {
           this.sectionEverShown = true;
-          // Cancel any in-flight section-hide so a repopulated section stays visible.
+          // Cancel any in-flight grace/fade so a repopulated section stays visible.
           this.clearSectionFadeTimer();
+          this.isSectionGracePending.set(false);
           this.isSectionHidden.set(false);
           this.isSectionFading.set(false);
         } else if (this.sectionEverShown && !this.isSectionHidden() && this.sectionFadeTimerId === null) {
-          // Guard on sectionFadeTimerId so repeated empty emissions can't schedule overlapping timers
-          // (an orphaned earlier timer would survive clearSectionFadeTimer and wrongly hide a repopulated section).
-          this.isSectionFading.set(true);
+          // Wait a grace period before fading: a context switch (changing group) can briefly empty the list
+          // before new data arrives — if it repopulates within the grace, the items>0 branch cancels this timer
+          // and nothing fades. The sectionFadeTimerId guard also prevents overlapping timers on repeated empty
+          // emissions. isSectionGracePending keeps the section mounted (stable, not collapsing) during the grace.
+          this.isSectionGracePending.set(true);
           this.sectionFadeTimerId = setTimeout(() => {
+            // Still empty after the grace — commit to the fade.
             this.sectionFadeTimerId = null;
-            this.isSectionHidden.set(true);
-          }, PENDING_ACTION_FADE_OUT_MS + 50);
+            this.isSectionGracePending.set(false);
+            this.isSectionFading.set(true);
+            this.sectionFadeTimerId = setTimeout(() => {
+              this.sectionFadeTimerId = null;
+              this.isSectionHidden.set(true);
+            }, PENDING_ACTION_FADE_OUT_MS + 50);
+          }, PENDING_ACTION_EMPTY_GRACE_MS);
         }
       });
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -205,7 +205,9 @@ export class CommitteeOverviewComponent {
           this.clearSectionFadeTimer();
           this.isSectionHidden.set(false);
           this.isSectionFading.set(false);
-        } else if (this.sectionEverShown && !this.isSectionHidden()) {
+        } else if (this.sectionEverShown && !this.isSectionHidden() && this.sectionFadeTimerId === null) {
+          // Guard on sectionFadeTimerId so repeated empty emissions can't schedule overlapping timers
+          // (an orphaned earlier timer would survive clearSectionFadeTimer and wrongly hide a repopulated section).
           this.isSectionFading.set(true);
           this.sectionFadeTimerId = setTimeout(() => {
             this.sectionFadeTimerId = null;

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -61,7 +61,7 @@
   </ng-template>
 </p-toast>
 
-@if (!isSectionHidden() && (totalVisible() > 0 || isSectionFading())) {
+@if (!isSectionHidden() && (totalVisible() > 0 || isSectionGracePending() || isSectionFading())) {
   <section class="pending-actions-section" [class.is-fading]="isSectionFading()" data-testid="dashboard-pending-actions-section">
     <!-- Section header with inline divider -->
     <div class="flex items-center gap-3 mb-6">

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -61,232 +61,228 @@
   </ng-template>
 </p-toast>
 
-<section data-testid="dashboard-pending-actions-section">
-  <!-- Section header with inline divider -->
-  <div class="flex items-center gap-3 mb-6">
-    <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
-      <i class="fa-light fa-list-check text-lg"></i>
-      <span>My Pending Actions</span>
-    </h2>
-    <div class="flex-1 border-t border-gray-200 self-center"></div>
-    @if (hasMore()) {
-      <lfx-button
-        [text]="true"
-        severity="primary"
-        [label]="'View all (' + totalVisible() + ')'"
-        (onClick)="openDrawer()"
-        data-testid="dashboard-pending-actions-view-all" />
-    }
-  </div>
+@if (!isSectionHidden() && (totalVisible() > 0 || isSectionFading())) {
+  <section class="pending-actions-section" [class.is-fading]="isSectionFading()" data-testid="dashboard-pending-actions-section">
+    <!-- Section header with inline divider -->
+    <div class="flex items-center gap-3 mb-6">
+      <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
+        <i class="fa-light fa-list-check text-lg"></i>
+        <span>My Pending Actions</span>
+      </h2>
+      <div class="flex-1 border-t border-gray-200 self-center"></div>
+      @if (hasMore()) {
+        <lfx-button
+          [text]="true"
+          severity="primary"
+          [label]="'View all (' + totalVisible() + ')'"
+          (onClick)="openDrawer()"
+          data-testid="dashboard-pending-actions-view-all" />
+      }
+    </div>
 
-  <!--
+    <!--
     Use totalVisible() (unwindowed count) to choose between the populated branch and the empty state so the drawer stays
     reachable even when displayLimit clamps decoratedActions() to zero. Inside the populated branch, the inline list only
     renders when decoratedActions() actually has rows.
   -->
-  @if (totalVisible() > 0) {
-    @if (decoratedActions().length > 0) {
-      <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200" data-testid="dashboard-pending-actions-list">
-        @for (item of decoratedActions(); track item.rowKey) {
-          <div
-            class="pending-action-row"
-            [class.is-completing]="completingRowKeys().has(item.rowKey)"
-            [attr.data-testid]="'dashboard-pending-actions-item-' + item.type">
-            @if (swappingRowKeys().has(item.rowKey)) {
-              <!-- Skeleton placeholder occupying the row slot while the next action takes over -->
-              <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3" [class]="item.rowClass">
-                <div class="shrink-0 sm:w-40">
-                  <p-skeleton width="5rem" height="1.5rem" />
-                </div>
-                <div class="sm:flex-1 sm:min-w-0 sm:px-4">
-                  <p-skeleton width="80%" height="1rem" />
-                </div>
-                <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">
-                  <p-skeleton width="6rem" height="2rem" />
-                </div>
-              </div>
-            } @else {
-              <div class="flex flex-col gap-2 px-4 py-3" [class]="item.rowClass">
-                <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0">
-                  <!-- Label — fixed-content width, no longer 20% -->
+    @if (totalVisible() > 0) {
+      @if (decoratedActions().length > 0) {
+        <div
+          class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
+          data-testid="dashboard-pending-actions-list">
+          @for (item of decoratedActions(); track item.rowKey) {
+            <div
+              class="pending-action-row"
+              [class.is-completing]="completingRowKeys().has(item.rowKey)"
+              [attr.data-testid]="'dashboard-pending-actions-item-' + item.type">
+              @if (swappingRowKeys().has(item.rowKey)) {
+                <!-- Skeleton placeholder occupying the row slot while the next action takes over -->
+                <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3" [class]="item.rowClass">
                   <div class="shrink-0 sm:w-40">
-                    <lfx-tag [value]="typeLabels[item.type]" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
+                    <p-skeleton width="5rem" height="1.5rem" />
                   </div>
-                  <!-- Description — flexes to fill; RSVP titles with a `buttonLink` link to the meeting page in a new tab, all other titles render as plain text. -->
-                  @if (item.isRsvpInlineLink) {
-                    <a
-                      [href]="item.buttonLink"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="group text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:px-4 hover:text-blue-600 inline-flex items-center gap-1.5"
-                      [attr.title]="item.text"
-                      [attr.aria-label]="'Open meeting in new tab: ' + item.text"
-                      data-testid="dashboard-pending-actions-title">
-                      <span class="sm:truncate group-hover:underline">{{ item.text }}</span>
-                      <i class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 shrink-0 no-underline" aria-hidden="true"></i>
-                    </a>
-                  } @else if (item.isInvitation) {
-                    <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
-                      <!-- Title comes from the backend-built item.text (same copy as the drawer); the
-                           group name is split off as a link into the group (project-lens detail page). -->
-                      <p class="text-sm text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
-                        {{ item.inviteTitlePrefix }}
-                        <a
-                          [routerLink]="['/groups', item.committeeUid]"
-                          [state]="{ backLabel: 'My Dashboard' }"
-                          (click)="$event.stopPropagation()"
-                          class="font-medium text-blue-600 hover:text-blue-700 hover:underline"
-                          [attr.aria-label]="'Open group ' + item.inviteGroupName"
-                          data-testid="dashboard-pending-actions-invitation-link"
-                          >{{ item.inviteGroupName }}</a
-                        >
-                      </p>
-                      @if (item.date) {
-                        <span class="text-xs text-gray-500" data-testid="dashboard-pending-actions-invitation-expiry"> Expires {{ item.date }} </span>
-                      }
-                    </div>
-                  } @else {
-                    <p
-                      class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
-                      [attr.title]="item.text"
-                      data-testid="dashboard-pending-actions-title">
-                      {{ item.text }}
-                    </p>
-                  }
-                  <!-- Action button — right-aligned, fixed by content -->
+                  <div class="sm:flex-1 sm:min-w-0 sm:px-4">
+                    <p-skeleton width="80%" height="1rem" />
+                  </div>
                   <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">
-                    @if (item.isRsvpInline) {
-                      @if (!item.meeting || item.isLoading) {
-                        <div class="flex items-center gap-2" data-testid="dashboard-pending-actions-rsvp-loading">
-                          <p-skeleton width="4rem" height="2rem" />
-                          <p-skeleton width="4rem" height="2rem" />
-                          <p-skeleton width="4rem" height="2rem" />
-                        </div>
-                      } @else {
-                        <div data-testid="dashboard-pending-actions-rsvp-buttons">
-                          <lfx-rsvp-button-group
-                            [meeting]="item.meeting"
-                            [showHeader]="false"
-                            [compact]="true"
-                            [suppressToast]="true"
-                            [occurrenceId]="item.occurrenceId"
-                            (rsvpChanged)="handleRsvpSubmit(item, $event)" />
-                        </div>
-                      }
-                    } @else if (item.isVoteInline) {
-                      <div class="flex flex-col items-end gap-1">
-                        @if (!item.isVoteInlineExpanded) {
-                          <lfx-button
-                            size="small"
-                            severity="secondary"
-                            [outlined]="true"
-                            (onClick)="handleAgendaOrOtherClick(item)"
-                            [label]="item.buttonText"
-                            [icon]="buttonIcons[item.type]"
-                            data-testid="dashboard-pending-actions-vote-button" />
-                          @if (item.buttonLink) {
-                            <a
-                              [href]="item.buttonLink"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              class="text-xs text-gray-500 hover:text-blue-600"
-                              data-testid="dashboard-pending-actions-vote-pcc-link">
-                              Open in My Votes →
-                            </a>
-                          }
-                        } @else if (item.isVoteLoading || !item.vote) {
-                          <lfx-button
-                            size="small"
-                            severity="secondary"
-                            [outlined]="true"
-                            [disabled]="true"
-                            [label]="item.buttonText"
-                            icon="fa-light fa-spinner-third fa-spin"
-                            data-testid="dashboard-pending-actions-vote-loading" />
-                        }
-                        <!-- else: inline ballot is rendering below (action column intentionally empty); drawer-bound votes collapse expandedVoteKey synchronously in dispatchLoadedVote so no branch is needed here -->
-                      </div>
+                    <p-skeleton width="6rem" height="2rem" />
+                  </div>
+                </div>
+              } @else {
+                <div class="flex flex-col gap-2 px-4 py-3" [class]="item.rowClass">
+                  <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0">
+                    <!-- Label — fixed-content width, no longer 20% -->
+                    <div class="shrink-0 sm:w-40">
+                      <lfx-tag [value]="typeLabels[item.type]" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
+                    </div>
+                    <!-- Description — flexes to fill; RSVP titles with a `buttonLink` link to the meeting page in a new tab, all other titles render as plain text. -->
+                    @if (item.isRsvpInlineLink) {
+                      <a
+                        [href]="item.buttonLink"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="group text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:px-4 hover:text-blue-600 inline-flex items-center gap-1.5"
+                        [attr.title]="item.text"
+                        [attr.aria-label]="'Open meeting in new tab: ' + item.text"
+                        data-testid="dashboard-pending-actions-title">
+                        <span class="sm:truncate group-hover:underline">{{ item.text }}</span>
+                        <i class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 shrink-0 no-underline" aria-hidden="true"></i>
+                      </a>
                     } @else if (item.isInvitation) {
-                      <div class="flex items-center gap-2">
-                        <lfx-button
-                          size="small"
-                          severity="primary"
-                          [label]="item.buttonText"
-                          [ariaLabel]="item.acceptAriaLabel"
-                          (onClick)="onAcceptInvitation(item)"
-                          data-testid="dashboard-pending-actions-invitation-accept" />
+                      <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
+                        <!-- Title comes from the backend-built item.text (same copy as the drawer); the
+                           group name is split off as a link into the group (project-lens detail page). -->
+                        <p class="text-sm text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
+                          {{ item.inviteTitlePrefix }}
+                          <a
+                            [routerLink]="['/groups', item.committeeUid]"
+                            [state]="{ backLabel: 'My Dashboard' }"
+                            (click)="$event.stopPropagation()"
+                            class="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                            [attr.aria-label]="'Open group ' + item.inviteGroupName"
+                            data-testid="dashboard-pending-actions-invitation-link"
+                            >{{ item.inviteGroupName }}</a
+                          >
+                        </p>
+                        @if (item.date) {
+                          <span class="text-xs text-gray-500" data-testid="dashboard-pending-actions-invitation-expiry"> Expires {{ item.date }} </span>
+                        }
+                      </div>
+                    } @else {
+                      <p
+                        class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
+                        [attr.title]="item.text"
+                        data-testid="dashboard-pending-actions-title">
+                        {{ item.text }}
+                      </p>
+                    }
+                    <!-- Action button — right-aligned, fixed by content -->
+                    <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">
+                      @if (item.isRsvpInline) {
+                        @if (!item.meeting || item.isLoading) {
+                          <div class="flex items-center gap-2" data-testid="dashboard-pending-actions-rsvp-loading">
+                            <p-skeleton width="4rem" height="2rem" />
+                            <p-skeleton width="4rem" height="2rem" />
+                            <p-skeleton width="4rem" height="2rem" />
+                          </div>
+                        } @else {
+                          <div data-testid="dashboard-pending-actions-rsvp-buttons">
+                            <lfx-rsvp-button-group
+                              [meeting]="item.meeting"
+                              [showHeader]="false"
+                              [compact]="true"
+                              [suppressToast]="true"
+                              [occurrenceId]="item.occurrenceId"
+                              (rsvpChanged)="handleRsvpSubmit(item, $event)" />
+                          </div>
+                        }
+                      } @else if (item.isVoteInline) {
+                        <div class="flex flex-col items-end gap-1">
+                          @if (!item.isVoteInlineExpanded) {
+                            <lfx-button
+                              size="small"
+                              severity="secondary"
+                              [outlined]="true"
+                              (onClick)="handleAgendaOrOtherClick(item)"
+                              [label]="item.buttonText"
+                              [icon]="buttonIcons[item.type]"
+                              data-testid="dashboard-pending-actions-vote-button" />
+                            @if (item.buttonLink) {
+                              <a
+                                [href]="item.buttonLink"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-xs text-gray-500 hover:text-blue-600"
+                                data-testid="dashboard-pending-actions-vote-pcc-link">
+                                Open in My Votes →
+                              </a>
+                            }
+                          } @else if (item.isVoteLoading || !item.vote) {
+                            <lfx-button
+                              size="small"
+                              severity="secondary"
+                              [outlined]="true"
+                              [disabled]="true"
+                              [label]="item.buttonText"
+                              icon="fa-light fa-spinner-third fa-spin"
+                              data-testid="dashboard-pending-actions-vote-loading" />
+                          }
+                          <!-- else: inline ballot is rendering below (action column intentionally empty); drawer-bound votes collapse expandedVoteKey synchronously in dispatchLoadedVote so no branch is needed here -->
+                        </div>
+                      } @else if (item.isInvitation) {
+                        <div class="flex items-center gap-2">
+                          <lfx-button
+                            size="small"
+                            severity="primary"
+                            [label]="item.buttonText"
+                            [ariaLabel]="item.acceptAriaLabel"
+                            (onClick)="onAcceptInvitation(item)"
+                            data-testid="dashboard-pending-actions-invitation-accept" />
+                          <lfx-button
+                            size="small"
+                            severity="secondary"
+                            [text]="true"
+                            label="Decline"
+                            [ariaLabel]="item.declineAriaLabel"
+                            (onClick)="onDeclineInvitation(item)"
+                            data-testid="dashboard-pending-actions-invitation-decline" />
+                        </div>
+                      } @else if (item.buttonLink) {
                         <lfx-button
                           size="small"
                           severity="secondary"
-                          [text]="true"
-                          label="Decline"
-                          [ariaLabel]="item.declineAriaLabel"
-                          (onClick)="onDeclineInvitation(item)"
-                          data-testid="dashboard-pending-actions-invitation-decline" />
-                      </div>
-                    } @else if (item.buttonLink) {
-                      <lfx-button
-                        size="small"
-                        severity="secondary"
-                        [outlined]="true"
-                        rel="noopener noreferrer"
-                        [link]="true"
-                        [href]="item.buttonLink"
-                        target="_blank"
-                        (onClick)="handleAgendaOrOtherClick(item)"
-                        [label]="item.buttonText"
-                        [icon]="buttonIcons[item.type]" />
-                    } @else {
-                      <lfx-button
-                        size="small"
-                        severity="secondary"
-                        [outlined]="true"
-                        (onClick)="handleAgendaOrOtherClick(item)"
-                        [label]="item.buttonText"
-                        [icon]="buttonIcons[item.type]" />
+                          [outlined]="true"
+                          rel="noopener noreferrer"
+                          [link]="true"
+                          [href]="item.buttonLink"
+                          target="_blank"
+                          (onClick)="handleAgendaOrOtherClick(item)"
+                          [label]="item.buttonText"
+                          [icon]="buttonIcons[item.type]" />
+                      } @else {
+                        <lfx-button
+                          size="small"
+                          severity="secondary"
+                          [outlined]="true"
+                          (onClick)="handleAgendaOrOtherClick(item)"
+                          [label]="item.buttonText"
+                          [icon]="buttonIcons[item.type]" />
+                      }
+                    </div>
+                    <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready. Invitations are resolved
+                       server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. -->
+                    @if (!item.isInvitation) {
+                      @if (item.isRsvpInline && (!item.meeting || item.isLoading)) {
+                        <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0 self-start sm:self-auto sm:ml-4" />
+                      } @else {
+                        <button
+                          type="button"
+                          class="shrink-0 self-start sm:self-auto sm:ml-4 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
+                          (click)="handleDismiss(item)"
+                          [attr.aria-label]="'Dismiss: ' + item.text"
+                          [attr.data-testid]="'dashboard-pending-actions-dismiss-' + item.type">
+                          Dismiss
+                        </button>
+                      }
                     }
                   </div>
-                  <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready. Invitations are resolved
-                       server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. -->
-                  @if (!item.isInvitation) {
-                    @if (item.isRsvpInline && (!item.meeting || item.isLoading)) {
-                      <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0 self-start sm:self-auto sm:ml-4" />
-                    } @else {
-                      <button
-                        type="button"
-                        class="shrink-0 self-start sm:self-auto sm:ml-4 text-[10px] text-gray-400 hover:text-gray-500 hover:underline transition-colors whitespace-nowrap"
-                        (click)="handleDismiss(item)"
-                        [attr.aria-label]="'Dismiss: ' + item.text"
-                        [attr.data-testid]="'dashboard-pending-actions-dismiss-' + item.type">
-                        Dismiss
-                      </button>
-                    }
+                  @if (item.isVoteInlineExpanded && item.vote && !item.voteUsesDrawer) {
+                    <lfx-vote-ballot-inline [vote]="item.vote" (voteSubmitted)="handleVoteSubmitted(item)" (cancelled)="handleVoteCancelled(item)" />
                   }
                 </div>
-                @if (item.isVoteInlineExpanded && item.vote && !item.voteUsesDrawer) {
-                  <lfx-vote-ballot-inline [vote]="item.vote" (voteSubmitted)="handleVoteSubmitted(item)" (cancelled)="handleVoteCancelled(item)" />
-                }
-              </div>
-            }
-          </div>
-        }
-      </div>
-    }
+              }
+            </div>
+          }
+        </div>
+      }
 
-    <lfx-pending-actions-drawer
-      [pendingActions]="pendingActions()"
-      [(visible)]="drawerVisible"
-      (actionCompleted)="onDrawerActionCompleted()"
-      (castVoteRequested)="castVoteRequested.emit($event)"
-      (acceptInvitationRequested)="onAcceptInvitation($event)"
-      (declineInvitationRequested)="onDeclineInvitation($event)" />
-  } @else {
-    <div class="bg-gray-50 rounded-2xl border border-gray-200 flex items-center justify-center gap-4 px-5 py-10" data-testid="dashboard-pending-actions-empty">
-      <i class="fa-light fa-box-check text-4xl text-gray-400 shrink-0"></i>
-      <div>
-        <p class="text-sm font-medium text-gray-700">Your desk is clear</p>
-        <p class="text-xs text-gray-400 mt-0.5">No pending actions assigned to you</p>
-      </div>
-    </div>
-  }
-</section>
+      <lfx-pending-actions-drawer
+        [pendingActions]="pendingActions()"
+        [(visible)]="drawerVisible"
+        (actionCompleted)="onDrawerActionCompleted()"
+        (castVoteRequested)="castVoteRequested.emit($event)"
+        (acceptInvitationRequested)="onAcceptInvitation($event)"
+        (declineInvitationRequested)="onDeclineInvitation($event)" />
+    }
+  </section>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -81,9 +81,10 @@
     </div>
 
     <!--
-    Use totalVisible() (unwindowed count) to choose between the populated branch and the empty state so the drawer stays
-    reachable even when displayLimit clamps decoratedActions() to zero. Inside the populated branch, the inline list only
-    renders when decoratedActions() actually has rows.
+    Gate the list/drawer on totalVisible() (the unwindowed count) so the drawer's "View all (N)" stays reachable
+    even when displayLimit clamps decoratedActions() to zero. When it's 0 the section is either mid-fade (the outer
+    @if keeps it mounted to play the collapse) or already removed; nothing renders inside in that window. Within the
+    populated branch the inline list only renders when decoratedActions() actually has rows.
   -->
     @if (totalVisible() > 0) {
       @if (decoratedActions().length > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
@@ -6,16 +6,18 @@
 
 // Section-level fade-out when all actions are resolved. max-height is slightly longer than opacity
 // so the collapse completes smoothly after the content has already faded.
+// overflow: hidden is scoped to .is-fading only so normal content is never clipped.
 .pending-actions-section {
   transition:
     opacity 300ms ease-out,
     max-height 400ms ease-out;
-  max-height: 800px;
-  overflow: hidden;
+  // Generous ceiling; only constrains during animation, never clips at rest (overflow is visible by default).
+  max-height: 2000px;
 
   &.is-fading {
     opacity: 0;
     max-height: 0;
+    overflow: hidden;
   }
 }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
@@ -3,6 +3,22 @@
 
 // Both transitions run for 300ms so the longest CSS animation matches PENDING_ACTION_FADE_OUT_MS in
 // @lfx-one/shared/constants and the JS doesn't drop the row before the fade has finished playing.
+
+// Section-level fade-out when all actions are resolved. max-height is slightly longer than opacity
+// so the collapse completes smoothly after the content has already faded.
+.pending-actions-section {
+  transition:
+    opacity 300ms ease-out,
+    max-height 400ms ease-out;
+  max-height: 800px;
+  overflow: hidden;
+
+  &.is-fading {
+    opacity: 0;
+    max-height: 0;
+  }
+}
+
 .pending-action-row {
   transition:
     opacity 300ms ease-out,

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.scss
@@ -4,13 +4,14 @@
 // Both transitions run for 300ms so the longest CSS animation matches PENDING_ACTION_FADE_OUT_MS in
 // @lfx-one/shared/constants and the JS doesn't drop the row before the fade has finished playing.
 
-// Section-level fade-out when all actions are resolved. max-height is slightly longer than opacity
-// so the collapse completes smoothly after the content has already faded.
-// overflow: hidden is scoped to .is-fading only so normal content is never clipped.
+// Section-level fade-out when all actions are resolved. Both opacity and max-height run for 300ms to
+// match PENDING_ACTION_FADE_OUT_MS, so the JS hide timer (fade + 50ms buffer) fires only after the
+// collapse animation completes. overflow: hidden is scoped to .is-fading so resting content is never clipped.
 .pending-actions-section {
   transition:
     opacity 300ms ease-out,
-    max-height 400ms ease-out;
+    max-height 300ms ease-out;
+
   // Generous ceiling; only constrains during animation, never clips at rest (overflow is visible by default).
   max-height: 2000px;
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -86,6 +86,8 @@ export class PendingActionsComponent {
   protected readonly isSectionFading = signal(false);
   protected readonly isSectionHidden = signal(false);
   private sectionEverShown = false;
+  // setTimeout handle for the in-flight section-fade; cleared when actions repopulate or on destroy to prevent stale hides.
+  private sectionFadeTimerId: ReturnType<typeof setTimeout> | null = null;
   // Dedicated toast key for the decline Undo, exposed to the template's keyed <p-toast>.
   protected readonly undoToastKey = INVITE_UNDO_TOAST_KEY;
 
@@ -105,11 +107,16 @@ export class PendingActionsComponent {
       .subscribe((count) => {
         if (count > 0) {
           this.sectionEverShown = true;
+          // Cancel any in-flight section-hide so a repopulated section stays visible.
+          this.clearSectionFadeTimer();
           this.isSectionHidden.set(false);
           this.isSectionFading.set(false);
         } else if (this.sectionEverShown && !this.isSectionHidden()) {
           this.isSectionFading.set(true);
-          setTimeout(() => this.isSectionHidden.set(true), PENDING_ACTION_FADE_OUT_MS + 50);
+          this.sectionFadeTimerId = setTimeout(() => {
+            this.sectionFadeTimerId = null;
+            this.isSectionHidden.set(true);
+          }, PENDING_ACTION_FADE_OUT_MS + 50);
         }
       });
 
@@ -127,6 +134,9 @@ export class PendingActionsComponent {
     // If the user navigates away while a decline is still in its undo window, commit it immediately so
     // leaving the page doesn't silently drop the decline (clear the timer first so it can't double-fire).
     this.destroyRef.onDestroy(() => {
+      // Cancel pending section-hide so it can't fire on a destroyed component.
+      this.clearSectionFadeTimer();
+
       const pending = this.pendingDecline();
       if (!pending) return;
       this.clearDeclineTimer();
@@ -440,6 +450,13 @@ export class PendingActionsComponent {
     if (this.declineTimerId !== null) {
       clearTimeout(this.declineTimerId);
       this.declineTimerId = null;
+    }
+  }
+
+  private clearSectionFadeTimer(): void {
+    if (this.sectionFadeTimerId !== null) {
+      clearTimeout(this.sectionFadeTimerId);
+      this.sectionFadeTimerId = null;
     }
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -82,6 +82,10 @@ export class PendingActionsComponent {
   protected readonly pendingDecline = signal<PendingDecline | null>(null);
   // setTimeout handle for the in-flight deferred decline; cleared on undo or when the timer fires.
   private declineTimerId: ReturnType<typeof setTimeout> | null = null;
+  // Section-level fade-out: true while the CSS collapse animation is in flight; isSectionHidden removes the section from the DOM.
+  protected readonly isSectionFading = signal(false);
+  protected readonly isSectionHidden = signal(false);
+  private sectionEverShown = false;
   // Dedicated toast key for the decline Undo, exposed to the template's keyed <p-toast>.
   protected readonly undoToastKey = INVITE_UNDO_TOAST_KEY;
 
@@ -94,6 +98,21 @@ export class PendingActionsComponent {
   protected readonly decoratedActions: Signal<DecoratedPendingAction[]> = this.initDecoratedActions();
 
   public constructor() {
+    // When the last action is resolved, fade the section out then remove it from the DOM.
+    // sectionEverShown prevents the fade from triggering on initial load with zero actions.
+    toObservable(this.totalVisible)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((count) => {
+        if (count > 0) {
+          this.sectionEverShown = true;
+          this.isSectionHidden.set(false);
+          this.isSectionFading.set(false);
+        } else if (this.sectionEverShown && !this.isSectionHidden()) {
+          this.isSectionFading.set(true);
+          setTimeout(() => this.isSectionHidden.set(true), PENDING_ACTION_FADE_OUT_MS + 50);
+        }
+      });
+
     // Eagerly load Meeting payloads for every inline RSVP row so its buttons render immediately.
     toObservable(this.decoratedActions)
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -111,7 +111,11 @@ export class PendingActionsComponent {
           this.clearSectionFadeTimer();
           this.isSectionHidden.set(false);
           this.isSectionFading.set(false);
-        } else if (this.sectionEverShown && !this.isSectionHidden()) {
+        } else if (this.sectionEverShown && !this.isSectionHidden() && this.sectionFadeTimerId === null) {
+          // Guard on sectionFadeTimerId so repeated empty emissions can't schedule overlapping timers
+          // (an orphaned earlier timer would survive clearSectionFadeTimer and wrongly hide a repopulated section).
+          // Close the drawer too, so a repopulated section doesn't reopen it with stale state.
+          this.drawerVisible.set(false);
           this.isSectionFading.set(true);
           this.sectionFadeTimerId = setTimeout(() => {
             this.sectionFadeTimerId = null;

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -9,7 +9,13 @@ import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-
 import { VoteBallotInlineComponent } from '@app/modules/votes/components/vote-ballot-inline/vote-ballot-inline.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL, PENDING_ACTION_SKELETON_HOLD_MS } from '@lfx-one/shared/constants';
+import {
+  PENDING_ACTION_BUTTON_ICON,
+  PENDING_ACTION_EMPTY_GRACE_MS,
+  PENDING_ACTION_FADE_OUT_MS,
+  PENDING_ACTION_LABEL,
+  PENDING_ACTION_SKELETON_HOLD_MS,
+} from '@lfx-one/shared/constants';
 import { PollType } from '@lfx-one/shared/enums';
 import { MeetingService } from '@services/meeting.service';
 import { VoteService } from '@services/vote.service';
@@ -83,8 +89,11 @@ export class PendingActionsComponent {
   // setTimeout handle for the in-flight deferred decline; cleared on undo or when the timer fires.
   private declineTimerId: ReturnType<typeof setTimeout> | null = null;
   // Section-level fade-out: true while the CSS collapse animation is in flight; isSectionHidden removes the section from the DOM.
+  // isSectionGracePending keeps the section mounted (not yet fading) during the post-empty grace window so a context
+  // switch that briefly empties the list doesn't trigger a spurious fade before the new data arrives.
   protected readonly isSectionFading = signal(false);
   protected readonly isSectionHidden = signal(false);
+  protected readonly isSectionGracePending = signal(false);
   private sectionEverShown = false;
   // setTimeout handle for the in-flight section-fade; cleared when actions repopulate or on destroy to prevent stale hides.
   private sectionFadeTimerId: ReturnType<typeof setTimeout> | null = null;
@@ -107,20 +116,30 @@ export class PendingActionsComponent {
       .subscribe((count) => {
         if (count > 0) {
           this.sectionEverShown = true;
-          // Cancel any in-flight section-hide so a repopulated section stays visible.
+          // Cancel any in-flight grace/fade so a repopulated section stays visible.
           this.clearSectionFadeTimer();
+          this.isSectionGracePending.set(false);
           this.isSectionHidden.set(false);
           this.isSectionFading.set(false);
         } else if (this.sectionEverShown && !this.isSectionHidden() && this.sectionFadeTimerId === null) {
-          // Guard on sectionFadeTimerId so repeated empty emissions can't schedule overlapping timers
-          // (an orphaned earlier timer would survive clearSectionFadeTimer and wrongly hide a repopulated section).
-          // Close the drawer too, so a repopulated section doesn't reopen it with stale state.
-          this.drawerVisible.set(false);
-          this.isSectionFading.set(true);
+          // Wait a grace period before fading: a context switch (org/project change) can briefly empty the
+          // list before new data arrives — if it repopulates within the grace, the count>0 branch cancels
+          // this timer and nothing fades. The sectionFadeTimerId guard also prevents overlapping timers on
+          // repeated empty emissions (an orphan would survive clearSectionFadeTimer and hide a repopulated section).
+          // isSectionGracePending keeps the section mounted (stable, not collapsing) during the grace.
+          this.isSectionGracePending.set(true);
           this.sectionFadeTimerId = setTimeout(() => {
+            // Still empty after the grace — commit to the fade.
             this.sectionFadeTimerId = null;
-            this.isSectionHidden.set(true);
-          }, PENDING_ACTION_FADE_OUT_MS + 50);
+            this.isSectionGracePending.set(false);
+            // Close the drawer so a later repopulation can't reopen it with stale state.
+            this.drawerVisible.set(false);
+            this.isSectionFading.set(true);
+            this.sectionFadeTimerId = setTimeout(() => {
+              this.sectionFadeTimerId = null;
+              this.isSectionHidden.set(true);
+            }, PENDING_ACTION_FADE_OUT_MS + 50);
+          }, PENDING_ACTION_EMPTY_GRACE_MS);
         }
       });
 

--- a/packages/shared/src/constants/pending-action.constants.ts
+++ b/packages/shared/src/constants/pending-action.constants.ts
@@ -48,3 +48,12 @@ export const PENDING_ACTION_FADE_OUT_MS = 300;
  * action takes over, in milliseconds.
  */
 export const PENDING_ACTION_SKELETON_HOLD_MS = 500;
+
+/**
+ * Grace period (ms) the "My Pending Actions" section waits after the action count drops to zero
+ * before starting its fade-out. A context switch (e.g. changing org/project) can briefly empty the
+ * list before the new context's data arrives; waiting this long lets the data repopulate without a
+ * spurious fade-then-reappear. A genuine dismissal of the last action stays empty past the grace,
+ * so it still collapses — just ~this many ms later.
+ */
+export const PENDING_ACTION_EMPTY_GRACE_MS = 250;


### PR DESCRIPTION
## What
Hide the entire "My Pending Actions" section when there are no pending actions, instead of showing a static "Your desk is clear" card that occupied page space. Applies to both the lens dashboards (Me / Foundation / Project / Org) and the group/committee Overview page.

## How
- Replaced the empty-state card with section-level visibility: when the last action is resolved or dismissed, the section fades out (opacity + max-height collapse) and is then removed from the DOM.
- On initial load with zero actions, the section never appears (no flash).
- The section-fade timer is tracked and cleared on repopulation and on destroy; `overflow: hidden` is scoped to the fading state so normal content is never clipped.
- The committee-overview visibility guard preserves the loading skeleton.

## Testing
- Me dashboard: dismissing all pending actions fades each row, then the section collapses and is removed from the DOM (verified `querySelector` returns null).
- Technical Advisory Committee group page: section renders correctly with votes/surveys present.
- `yarn build` and `yarn check-types` pass.

## Notes
- No JIRA ticket (intentional — untracked work).
- No automated e2e coverage for the hide-when-empty behavior; verified manually. Candidate for a follow-up.

## Checklist
- [x] License headers on changed files
- [x] Conventional commits, DCO + GPG signed
- [x] Under 1000 lines of diff
- [ ] Tests — N/A (verified manually; no pending-actions e2e harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)