### PR TITLE
feat(profile): embed linux.com email panel in identities tab

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
@@ -91,7 +91,12 @@
                     <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
                   </div>
                   <div class="flex items-center gap-3">
-                    <lfx-button severity="primary" [outlined]="true" size="small" (onClick)="onVerify(identity)" [attr.data-testid]="'verify-btn-' + identity.id">
+                    <lfx-button
+                      severity="primary"
+                      [outlined]="true"
+                      size="small"
+                      (onClick)="onVerify(identity)"
+                      [attr.data-testid]="'verify-btn-' + identity.id">
                       Verify
                     </lfx-button>
                     <lfx-button severity="secondary" [outlined]="true" size="small" (onClick)="onRemove(identity)" data-testid="reject-identity-btn">

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
@@ -80,7 +80,7 @@
             You have unverified identities connected to your profile. Please verify them to validate your project affiliations and work history.
           </p>
           <!-- Unverified card -->
-          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="unverified-identities-list">
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="unverified-identities-section">
             <div class="flex flex-col gap-0 divide-y divide-slate-100">
               @for (identity of unverifiedIdentities(); track identity.id) {
                 <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
@@ -91,7 +91,7 @@
                     <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
                   </div>
                   <div class="flex items-center gap-3">
-                    <lfx-button severity="primary" [outlined]="true" size="small" (onClick)="onVerify(identity)" data-testid="verify-identity-btn">
+                    <lfx-button severity="primary" [outlined]="true" size="small" (onClick)="onVerify(identity)" [attr.data-testid]="'verify-btn-' + identity.id">
                       Verify
                     </lfx-button>
                     <lfx-button severity="secondary" [outlined]="true" size="small" (onClick)="onRemove(identity)" data-testid="reject-identity-btn">
@@ -115,7 +115,7 @@
             <div class="h-px flex-1 bg-slate-200"></div>
           </div>
           <!-- Verified card -->
-          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="verified-identities-list">
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="verified-identities-section">
             <div class="flex flex-col gap-0 divide-y divide-slate-100">
               @for (identity of verifiedIdentities(); track identity.id) {
                 <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
@@ -152,7 +152,7 @@
     <!-- Linux.com Email -->
     <div class="flex flex-col gap-5">
       <h2>Linux.com email</h2>
-      <lfx-profile-linux-email />
+      <lfx-profile-linux-email [identities]="enrichedIdentities()" />
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
@@ -23,127 +23,136 @@
     </lfx-message>
   }
 
-  <!-- Left Column: Identities -->
-  <div class="flex flex-col gap-5">
-    <!-- Header with Add Button -->
-    <div class="flex items-start justify-between">
-      <div class="flex flex-col gap-1">
-        <h2>Identities</h2>
-        <p class="text-sm text-slate-500">Manage the accounts used to identify you and attribute contributions.</p>
+  <!-- Two-column layout: Identities (left) + Linux.com Email (right) -->
+  <div class="grid grid-cols-1 gap-8 items-start lg:grid-cols-[minmax(0,1fr)_360px]">
+    <!-- Identities -->
+    <div class="flex flex-col gap-5">
+      <!-- Header with Add Button -->
+      <div class="flex items-start justify-between">
+        <div class="flex flex-col gap-1">
+          <h2>Identities</h2>
+          <p class="text-sm text-slate-500">Manage the accounts used to identify you and attribute contributions.</p>
+        </div>
+        <lfx-button severity="primary" [text]="true" size="small" (onClick)="onAdd()" data-testid="add-identity-btn">
+          <i class="fa-light fa-plus mr-1.5"></i>
+          Add identity
+        </lfx-button>
       </div>
-      <lfx-button severity="primary" [text]="true" size="small" (onClick)="onAdd()" data-testid="add-identity-btn">
-        <i class="fa-light fa-plus mr-1.5"></i>
-        Add identity
-      </lfx-button>
-    </div>
 
-    @if (loading()) {
-      <!-- Loading Skeleton -->
-      <lfx-card data-testid="identities-loading">
-        <div class="flex flex-col gap-0 divide-y divide-slate-100">
-          @for (i of [1, 2, 3]; track i) {
-            <div class="flex items-center gap-3 px-4 py-3">
-              <div class="h-5 w-5 animate-pulse rounded bg-slate-200"></div>
-              <div class="h-4 w-48 animate-pulse rounded bg-slate-200"></div>
-            </div>
-          }
-        </div>
-      </lfx-card>
-    } @else if (isEmpty()) {
-      <!-- Empty State -->
-      <lfx-card>
-        <div class="flex flex-col items-center gap-4 py-12" data-testid="identities-empty">
-          <div class="flex h-14 w-14 items-center justify-center rounded-full bg-slate-100">
-            <i class="fa-light fa-id-badge text-2xl text-slate-400"></i>
-          </div>
-          <div class="flex flex-col items-center gap-1 text-center">
-            <p class="text-base font-medium text-slate-700">No identities found</p>
-            <p class="max-w-sm text-sm text-slate-500">No connected accounts were found for your profile.</p>
-          </div>
-        </div>
-      </lfx-card>
-    } @else {
-      <!-- Unverified Section -->
-      @if (hasUnverified()) {
-        <!-- Orange section header -->
-        <div class="flex items-center gap-2">
-          <div class="flex items-center gap-1">
-            <i class="fa-light fa-circle-exclamation text-[15px] text-orange-500"></i>
-            <span class="text-xs font-semibold text-orange-500">Unverified identities</span>
-          </div>
-          <div class="h-px flex-1 bg-slate-200"></div>
-        </div>
-        <!-- Warning text -->
-        <p class="text-xs text-slate-500">
-          You have unverified identities connected to your profile. Please verify them to validate your project affiliations and work history.
-        </p>
-        <!-- Unverified card -->
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="unverified-identities-list">
+      @if (loading()) {
+        <!-- Loading Skeleton -->
+        <lfx-card data-testid="identities-loading">
           <div class="flex flex-col gap-0 divide-y divide-slate-100">
-            @for (identity of unverifiedIdentities(); track identity.id) {
-              <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
-                <div class="flex items-center gap-3">
-                  <div class="flex h-5 w-5 shrink-0 items-center justify-center">
-                    <i [class]="identity.icon + ' text-sm text-slate-600'"></i>
-                  </div>
-                  <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
-                </div>
-                <div class="flex items-center gap-3">
-                  <lfx-button severity="primary" [outlined]="true" size="small" (onClick)="onVerify(identity)" data-testid="verify-identity-btn">
-                    Verify
-                  </lfx-button>
-                  <lfx-button severity="secondary" [outlined]="true" size="small" (onClick)="onRemove(identity)" data-testid="reject-identity-btn">
-                    This is not me
-                  </lfx-button>
-                </div>
+            @for (i of [1, 2, 3]; track i) {
+              <div class="flex items-center gap-3 px-4 py-3">
+                <div class="h-5 w-5 animate-pulse rounded bg-slate-200"></div>
+                <div class="h-4 w-48 animate-pulse rounded bg-slate-200"></div>
               </div>
             }
           </div>
         </lfx-card>
-      }
-
-      <!-- Verified Section -->
-      @if (verifiedIdentities().length > 0) {
-        <!-- Grey section header -->
-        <div class="flex items-center gap-2">
-          <div class="flex items-center gap-1">
-            <i class="fa-light fa-circle-check text-[15px] text-slate-600"></i>
-            <span class="text-xs font-semibold text-slate-500">Verified identities</span>
+      } @else if (isEmpty()) {
+        <!-- Empty State -->
+        <lfx-card>
+          <div class="flex flex-col items-center gap-4 py-12" data-testid="identities-empty">
+            <div class="flex h-14 w-14 items-center justify-center rounded-full bg-slate-100">
+              <i class="fa-light fa-id-badge text-2xl text-slate-400"></i>
+            </div>
+            <div class="flex flex-col items-center gap-1 text-center">
+              <p class="text-base font-medium text-slate-700">No identities found</p>
+              <p class="max-w-sm text-sm text-slate-500">No connected accounts were found for your profile.</p>
+            </div>
           </div>
-          <div class="h-px flex-1 bg-slate-200"></div>
-        </div>
-        <!-- Verified card -->
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="verified-identities-list">
-          <div class="flex flex-col gap-0 divide-y divide-slate-100">
-            @for (identity of verifiedIdentities(); track identity.id) {
-              <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
-                <div class="flex items-center gap-3">
-                  <div class="flex h-5 w-5 shrink-0 items-center justify-center">
-                    <i [class]="identity.icon + ' text-sm text-slate-600'"></i>
+        </lfx-card>
+      } @else {
+        <!-- Unverified Section -->
+        @if (hasUnverified()) {
+          <!-- Orange section header -->
+          <div class="flex items-center gap-2">
+            <div class="flex items-center gap-1">
+              <i class="fa-light fa-circle-exclamation text-[15px] text-orange-500"></i>
+              <span class="text-xs font-semibold text-orange-500">Unverified identities</span>
+            </div>
+            <div class="h-px flex-1 bg-slate-200"></div>
+          </div>
+          <!-- Warning text -->
+          <p class="text-xs text-slate-500">
+            You have unverified identities connected to your profile. Please verify them to validate your project affiliations and work history.
+          </p>
+          <!-- Unverified card -->
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="unverified-identities-list">
+            <div class="flex flex-col gap-0 divide-y divide-slate-100">
+              @for (identity of unverifiedIdentities(); track identity.id) {
+                <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-5 w-5 shrink-0 items-center justify-center">
+                      <i [class]="identity.icon + ' text-sm text-slate-600'"></i>
+                    </div>
+                    <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
                   </div>
-                  <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
-                  @if (identity.isPrimary) {
-                    <span class="rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-700">Primary</span>
+                  <div class="flex items-center gap-3">
+                    <lfx-button severity="primary" [outlined]="true" size="small" (onClick)="onVerify(identity)" data-testid="verify-identity-btn">
+                      Verify
+                    </lfx-button>
+                    <lfx-button severity="secondary" [outlined]="true" size="small" (onClick)="onRemove(identity)" data-testid="reject-identity-btn">
+                      This is not me
+                    </lfx-button>
+                  </div>
+                </div>
+              }
+            </div>
+          </lfx-card>
+        }
+
+        <!-- Verified Section -->
+        @if (verifiedIdentities().length > 0) {
+          <!-- Grey section header -->
+          <div class="flex items-center gap-2">
+            <div class="flex items-center gap-1">
+              <i class="fa-light fa-circle-check text-[15px] text-slate-600"></i>
+              <span class="text-xs font-semibold text-slate-500">Verified identities</span>
+            </div>
+            <div class="h-px flex-1 bg-slate-200"></div>
+          </div>
+          <!-- Verified card -->
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="verified-identities-list">
+            <div class="flex flex-col gap-0 divide-y divide-slate-100">
+              @for (identity of verifiedIdentities(); track identity.id) {
+                <div class="flex items-center justify-between px-4 py-3" [attr.data-testid]="'identity-row-' + identity.id">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-5 w-5 shrink-0 items-center justify-center">
+                      <i [class]="identity.icon + ' text-sm text-slate-600'"></i>
+                    </div>
+                    <span class="text-sm font-medium text-slate-900">{{ identity.identifier }}</span>
+                    @if (identity.isPrimary) {
+                      <span class="rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-700">Primary</span>
+                    }
+                  </div>
+                  @if (!identity.isPrimary) {
+                    <div class="relative inline-block">
+                      <lfx-button
+                        icon="fa-solid fa-ellipsis-vertical"
+                        [text]="true"
+                        [rounded]="true"
+                        size="small"
+                        styleClass="!text-slate-400 hover:!text-slate-600 hover:!bg-slate-100"
+                        (onClick)="actionMenu.toggle($event)"
+                        [attr.data-testid]="'identity-menu-' + identity.id" />
+                      <lfx-menu #actionMenu [model]="menuItemsMap().get(identity.id) ?? []" [popup]="true" appendTo="body" />
+                    </div>
                   }
                 </div>
-                @if (!identity.isPrimary) {
-                  <div class="relative inline-block">
-                    <lfx-button
-                      icon="fa-solid fa-ellipsis-vertical"
-                      [text]="true"
-                      [rounded]="true"
-                      size="small"
-                      styleClass="!text-slate-400 hover:!text-slate-600 hover:!bg-slate-100"
-                      (onClick)="actionMenu.toggle($event)"
-                      [attr.data-testid]="'identity-menu-' + identity.id" />
-                    <lfx-menu #actionMenu [model]="menuItemsMap().get(identity.id) ?? []" [popup]="true" appendTo="body" />
-                  </div>
-                }
-              </div>
-            }
-          </div>
-        </lfx-card>
+              }
+            </div>
+          </lfx-card>
+        }
       }
-    }
+    </div>
+
+    <!-- Linux.com Email -->
+    <div class="flex flex-col gap-5">
+      <h2>Linux.com email</h2>
+      <lfx-profile-linux-email />
+    </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -68,6 +68,10 @@ export class ProfileIdentitiesComponent implements OnInit {
     () => !this.identitiesLoadError() && this.identitiesState().loaded && this.identitiesState().identities.length === 0
   );
 
+  // Raw EnrichedIdentity[] passed to ProfileLinuxEmailComponent to avoid a duplicate
+  // getIdentities() fetch when both panels render on the Identities tab.
+  public readonly enrichedIdentities: Signal<EnrichedIdentity[]> = computed(() => this.identitiesState().identities);
+
   public readonly unverifiedIdentities: Signal<ConnectedIdentityFull[]> = computed(() => this.identities().filter((i) => i.state === 'unverified'));
   public readonly verifiedIdentities: Signal<ConnectedIdentityFull[]> = computed(() => this.identities().filter((i) => i.state === 'verified'));
   public readonly hasUnverified: Signal<boolean> = computed(() => this.unverifiedIdentities().length > 0);

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -25,6 +25,7 @@ import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { catchError, map, of, startWith, Subject, switchMap, take } from 'rxjs';
 
 import { AddAccountDialogComponent } from '../components/add-account-dialog/add-account-dialog.component';
+import { ProfileLinuxEmailComponent } from '../linux-email/profile-linux-email.component';
 import { RemoveIdentityDialogComponent } from '../components/remove-identity-dialog/remove-identity-dialog.component';
 import { VerifyIdentityDialogComponent } from '../components/verify-identity-dialog/verify-identity-dialog.component';
 
@@ -35,7 +36,7 @@ interface IdentitiesState {
 
 @Component({
   selector: 'lfx-profile-identities',
-  imports: [CardComponent, ButtonComponent, MenuComponent, MessageComponent, OpenIntercomDirective],
+  imports: [CardComponent, ButtonComponent, MenuComponent, MessageComponent, OpenIntercomDirective, ProfileLinuxEmailComponent],
   providers: [DialogService],
   templateUrl: './profile-identities.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -147,11 +147,7 @@
             <div class="border-t border-gray-100"></div>
 
             <!-- Forward to form -->
-            <form
-              [formGroup]="editForm"
-              (ngSubmit)="updateForward()"
-              class="flex flex-col gap-3 pt-5"
-              data-testid="linux-email-forward-form">
+            <form [formGroup]="editForm" (ngSubmit)="updateForward()" class="flex flex-col gap-3 pt-5" data-testid="linux-email-forward-form">
               <div class="flex flex-col gap-0.5">
                 <span class="text-sm font-medium text-gray-700">Forward to</span>
                 <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -11,10 +11,14 @@
     @switch (state()) {
       <!-- Service unavailable -->
       @case ('service_unavailable') {
-        <lfx-message severity="warn" icon="fa-light fa-triangle-exclamation" styleClass="mb-6" title="Service temporarily unavailable">
+        <lfx-message severity="warn" styleClass="mb-6 !p-3">
           <ng-template #content>
             <div class="flex flex-col gap-3 items-start">
-              <p class="text-sm">We couldn't reach the Linux.com email service right now. Please try again in a moment.</p>
+              <div class="flex items-center gap-2">
+                <i class="fa-light fa-triangle-exclamation shrink-0"></i>
+                <span class="text-sm font-semibold">Service temporarily unavailable</span>
+              </div>
+              <p class="text-sm font-normal text-gray-900">We couldn't reach the Linux.com email service right now. Please try again in a moment.</p>
               <lfx-button
                 size="small"
                 label="Retry"
@@ -55,73 +59,78 @@
 
       <!-- Purchased but not yet claimed -->
       @case ('purchased_unclaimed') {
-        <lfx-message severity="info" icon="fa-light fa-info-circle" styleClass="mb-6" title="Claim your Linux.com email address">
-          <ng-template #content>
-            <p class="text-sm">
-              Choose an alias and the address you'd like your &#64;{{ domain() }} email forwarded to. Your alias can't be changed after claiming.
-            </p>
-          </ng-template>
-        </lfx-message>
-
-        <lfx-card>
-          <form [formGroup]="claimForm" (ngSubmit)="claim()" class="flex flex-col gap-4" data-testid="linux-email-claim-form">
-            <div class="flex flex-col gap-1">
-              <label class="block text-sm font-medium text-gray-700">Alias</label>
-              <div class="flex items-center gap-2">
-                <div class="flex-1">
-                  <lfx-input-text
-                    control="alias"
-                    [form]="claimForm"
-                    placeholder="your-alias"
-                    type="text"
-                    size="small"
-                    styleClass="w-full"
-                    data-testid="linux-email-alias-input"></lfx-input-text>
-                </div>
-                <span class="text-sm text-gray-600 shrink-0">&#64;{{ domain() }}</span>
+        <lfx-card styleClass="[&_.p-card-body]:p-0 overflow-hidden">
+          <div class="flex flex-col" data-testid="linux-email-claim-panel">
+            <!-- Info banner: full-width, clipped by card's overflow-hidden -->
+            <div class="flex items-start gap-3 border-b border-blue-200 bg-blue-50 p-5">
+              <i class="fa-light fa-info-circle mt-0.5 shrink-0 text-blue-500"></i>
+              <div class="flex flex-col gap-1">
+                <span class="text-sm font-semibold text-blue-600">Claim your Linux.com email address</span>
+                <p class="text-sm font-normal text-gray-900">
+                  Choose an alias and the address you'd like your &#64;{{ domain() }} email forwarded to. Your alias can't be changed after claiming.
+                </p>
               </div>
-              @if (claimForm.controls.alias.touched && claimForm.controls.alias.invalid) {
-                <div class="text-red-600 text-xs" data-testid="linux-email-alias-error">
-                  @if (claimForm.controls.alias.errors?.['required']) {
-                    An alias is required.
-                  } @else if (claimForm.controls.alias.errors?.['aliasReserved']) {
-                    That alias is reserved. Please choose another.
-                  } @else if (claimForm.controls.alias.errors?.['aliasMaxLength']) {
-                    Aliases can be at most 64 characters.
-                  } @else {
-                    Use letters, numbers, dots, and hyphens only.
-                  }
+            </div>
+
+            <form [formGroup]="claimForm" (ngSubmit)="claim()" class="flex flex-col gap-4 p-6" data-testid="linux-email-claim-form">
+              <div class="flex flex-col gap-1">
+                <label class="block text-sm font-medium text-gray-700">Your alias</label>
+                <div class="flex items-center gap-2">
+                  <div class="flex-1">
+                    <lfx-input-text
+                      control="alias"
+                      [form]="claimForm"
+                      placeholder="your-alias"
+                      type="text"
+                      size="small"
+                      styleClass="w-full"
+                      data-testid="linux-email-alias-input"></lfx-input-text>
+                  </div>
+                  <span class="text-sm text-gray-600 shrink-0">&#64;{{ domain() }}</span>
                 </div>
-              }
-            </div>
+                @if (claimForm.controls.alias.touched && claimForm.controls.alias.invalid) {
+                  <div class="text-red-600 text-xs" data-testid="linux-email-alias-error">
+                    @if (claimForm.controls.alias.errors?.['required']) {
+                      An alias is required.
+                    } @else if (claimForm.controls.alias.errors?.['aliasReserved']) {
+                      That alias is reserved. Please choose another.
+                    } @else if (claimForm.controls.alias.errors?.['aliasMaxLength']) {
+                      Aliases can be at most 64 characters.
+                    } @else {
+                      Use letters, numbers, dots, and hyphens only.
+                    }
+                  </div>
+                }
+              </div>
 
-            <div class="flex flex-col gap-1">
-              <label class="block text-sm font-medium text-gray-700">Forward to</label>
-              <lfx-select
-                [form]="claimForm"
-                control="forwardTo"
-                [options]="forwardOptions()"
-                placeholder="Select a verified email"
+              <div class="flex flex-col gap-1">
+                <label class="block text-sm font-medium text-gray-700">Forward to</label>
+                <lfx-select
+                  [form]="claimForm"
+                  control="forwardTo"
+                  [options]="forwardOptions()"
+                  placeholder="Select a verified email"
+                  size="small"
+                  styleClass="w-full"
+                  appendTo="body"
+                  data-testid="linux-email-claim-forward-select"></lfx-select>
+                <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
+                @if (claimForm.controls.forwardTo.touched && claimForm.controls.forwardTo.invalid) {
+                  <div class="text-red-600 text-xs" data-testid="linux-email-claim-forward-error">Please choose a forwarding address.</div>
+                }
+              </div>
+
+              <lfx-button
+                type="submit"
+                label="Claim alias"
+                icon="fa-light fa-check"
+                severity="info"
                 size="small"
-                styleClass="w-full"
-                appendTo="body"
-                data-testid="linux-email-claim-forward-select"></lfx-select>
-              <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
-              @if (claimForm.controls.forwardTo.touched && claimForm.controls.forwardTo.invalid) {
-                <div class="text-red-600 text-xs" data-testid="linux-email-claim-forward-error">Please choose a forwarding address.</div>
-              }
-            </div>
-
-            <lfx-button
-              type="submit"
-              label="Claim alias"
-              icon="fa-light fa-check"
-              severity="info"
-              class="self-start"
-              [disabled]="claimForm.invalid || claiming()"
-              [loading]="claiming()"
-              data-testid="linux-email-claim-button"></lfx-button>
-          </form>
+                [disabled]="claimForm.invalid || claiming()"
+                [loading]="claiming()"
+                data-testid="linux-email-claim-button"></lfx-button>
+            </form>
+          </div>
         </lfx-card>
       }
 

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -30,25 +30,23 @@
 
       <!-- Not purchased -->
       @case ('not_purchased') {
-        <lfx-message severity="info" icon="fa-light fa-info-circle" styleClass="mb-6" title="Get a Linux.com email address">
-          <ng-template #content>
-            <p class="text-sm">
-              A personal <strong>&#64;{{ domain() }}</strong> address forwards email to any inbox you choose. The Lifetime Linux.com Email Alias is a one-time
-              add-on for Individual Supporters.
-            </p>
-          </ng-template>
-        </lfx-message>
-
-        <lfx-card>
-          <div class="flex flex-col gap-4 items-start" data-testid="linux-email-purchase-panel">
-            <div>
-              <h3 class="text-base font-medium text-gray-900">You haven't purchased a Linux.com email alias add-on</h3>
-              <p class="text-sm text-gray-500 mt-1">Purchase the add-on to claim your personal &#64;{{ domain() }} address.</p>
+        <lfx-card styleClass="[&_.p-card-body]:p-6">
+          <div class="flex flex-col gap-4" data-testid="linux-email-purchase-panel">
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100">
+                <i class="fa-light fa-at text-lg text-blue-500"></i>
+              </div>
+              <h3 class="text-sm font-semibold text-gray-900">Get your personal &#64;{{ domain() }} email address</h3>
             </div>
+            <p class="text-sm text-gray-500">
+              A personal &#64;{{ domain() }} address forwards email to any inbox you choose. The Lifetime Linux.com Email Alias is a one-time add-on for
+              Individual Supporters.
+            </p>
             <lfx-button
               label="Purchase Email"
               icon="fa-light fa-cart-shopping"
               severity="info"
+              size="small"
               (onClick)="purchase()"
               data-testid="linux-email-purchase-button"></lfx-button>
           </div>
@@ -129,49 +127,57 @@
 
       <!-- Claimed -->
       @case ('claimed') {
-        <lfx-message severity="success" icon="fa-light fa-circle-check" styleClass="mb-6" title="Your Linux.com email is active">
-          <ng-template #content>
-            <p class="text-sm">Email sent to your alias is forwarded to the address below.</p>
-          </ng-template>
-        </lfx-message>
-
-        <lfx-card>
-          <div class="flex flex-col gap-6">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm font-medium text-gray-700">Your alias</span>
-              <span class="text-base font-medium text-gray-900" data-testid="linux-email-claimed-address">{{ email() }}</span>
+        <lfx-card styleClass="[&_.p-card-body]:p-6">
+          <div class="flex flex-col gap-0" data-testid="linux-email-claimed-panel">
+            <!-- Alias row -->
+            <div class="flex items-center justify-between pb-5">
+              <div class="flex items-center gap-3">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100">
+                  <i class="fa-light fa-envelope text-lg text-blue-500"></i>
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <span class="text-xs text-gray-500">Your alias</span>
+                  <span class="text-sm font-semibold text-gray-900" data-testid="linux-email-claimed-address">{{ email() }}</span>
+                </div>
+              </div>
+              <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Active</span>
             </div>
 
+            <!-- Divider -->
+            <div class="border-t border-gray-100"></div>
+
+            <!-- Forward to form -->
             <form
               [formGroup]="editForm"
               (ngSubmit)="updateForward()"
-              class="flex flex-col gap-1 border-t border-gray-200 pt-4"
+              class="flex flex-col gap-3 pt-5"
               data-testid="linux-email-forward-form">
-              <label class="block text-sm font-medium text-gray-700">Forward to</label>
-              <div class="flex gap-3">
-                <div class="flex-1">
-                  <lfx-select
-                    [form]="editForm"
-                    control="forwardTo"
-                    [options]="forwardOptions()"
-                    placeholder="Select a verified email"
-                    size="small"
-                    styleClass="w-full"
-                    appendTo="body"
-                    data-testid="linux-email-forward-select"></lfx-select>
-                </div>
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm font-medium text-gray-700">Forward to</span>
+                <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
+              </div>
+              <lfx-select
+                [form]="editForm"
+                control="forwardTo"
+                [options]="forwardOptions()"
+                placeholder="Select a verified email"
+                size="small"
+                styleClass="w-full"
+                appendTo="body"
+                data-testid="linux-email-forward-select"></lfx-select>
+              @if (editForm.controls.forwardTo.touched && editForm.controls.forwardTo.invalid) {
+                <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
+              }
+              @if (forwardDirty()) {
                 <lfx-button
                   type="submit"
                   label="Save"
                   icon="fa-light fa-check"
                   severity="info"
+                  size="small"
                   [disabled]="editForm.invalid || savingForward()"
                   [loading]="savingForward()"
                   data-testid="linux-email-forward-save-button"></lfx-button>
-              </div>
-              <p class="text-xs text-gray-500">Choose one of your verified email addresses.</p>
-              @if (editForm.controls.forwardTo.touched && editForm.controls.forwardTo.invalid) {
-                <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
               }
             </form>
           </div>

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -18,7 +18,7 @@ import { linuxAliasValidator } from '@lfx-one/shared/validators';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
-import { BehaviorSubject, catchError, finalize, forkJoin, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, finalize, forkJoin, map, of, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-profile-linux-email',
@@ -51,6 +51,9 @@ export class ProfileLinuxEmailComponent {
   public claiming = signal(false);
   public savingForward = signal(false);
 
+  // Tracks the last loaded/saved forward-to value so we can detect unsaved changes.
+  private readonly savedForwardTo = signal<string>('');
+
   // Data signals
   public data: Signal<LinuxEmailData> = this.initData();
 
@@ -58,6 +61,9 @@ export class ProfileLinuxEmailComponent {
   public state = computed(() => this.data().alias?.state ?? null);
   public domain = computed(() => this.data().alias?.domain ?? '');
   public email = computed(() => this.data().alias?.email ?? null);
+
+  // True only when the user has changed the forward-to selection from its saved value.
+  public forwardDirty: Signal<boolean> = this.initForwardDirty();
 
   // Verified emails the user can forward to (primary first, default selection).
   // Sourced from the same verified identities shown in the Identities tab —
@@ -170,6 +176,15 @@ export class ProfileLinuxEmailComponent {
     this.messageService.add({ severity: 'error', summary: 'Error', detail: err.error?.message || fallback });
   }
 
+  private initForwardDirty(): Signal<boolean> {
+    return toSignal(
+      this.editForm.controls.forwardTo.valueChanges.pipe(
+        map((value) => (value ?? '').toLowerCase().trim() !== this.savedForwardTo())
+      ),
+      { initialValue: false }
+    );
+  }
+
   private initData(): Signal<LinuxEmailData> {
     return toSignal(
       this.refresh.pipe(
@@ -226,6 +241,8 @@ export class ProfileLinuxEmailComponent {
       // primary email — a guessed value could overwrite the real forward on Save. Normalize so
       // the default matches a (normalized) forwardOptions value.
       const forwardTo = (alias.forwardTo ?? '').toLowerCase().trim();
+      // Set savedForwardTo BEFORE patching so the valueChanges emission sees the correct baseline.
+      this.savedForwardTo.set(forwardTo);
       this.editForm.patchValue({ forwardTo });
     } else if (alias?.state === 'purchased_unclaimed' && primary) {
       this.claimForm.patchValue({ forwardTo: primary });

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -182,6 +182,11 @@ export class ProfileLinuxEmailComponent {
   }
 
   private initForwardDirty(): Signal<boolean> {
+    // Reset coupling: after a successful save, updateForward() → refresh.next() →
+    // applyFormDefaults() → patchValue({ forwardTo }, { emitEvent: true }) fires a
+    // fresh valueChanges emission that re-runs this map against the now-updated
+    // savedForwardTo, hiding the Save button. If patchValue is ever called with
+    // { emitEvent: false }, the Save button will stay visible after a successful save.
     return toSignal(this.editForm.controls.forwardTo.valueChanges.pipe(map((value) => (value ?? '').toLowerCase().trim() !== this.savedForwardTo())), {
       initialValue: false,
     });

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -177,12 +177,9 @@ export class ProfileLinuxEmailComponent {
   }
 
   private initForwardDirty(): Signal<boolean> {
-    return toSignal(
-      this.editForm.controls.forwardTo.valueChanges.pipe(
-        map((value) => (value ?? '').toLowerCase().trim() !== this.savedForwardTo())
-      ),
-      { initialValue: false }
-    );
+    return toSignal(this.editForm.controls.forwardTo.valueChanges.pipe(map((value) => (value ?? '').toLowerCase().trim() !== this.savedForwardTo())), {
+      initialValue: false,
+    });
   }
 
   private initData(): Signal<LinuxEmailData> {

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -4,7 +4,7 @@
 // Generated with [Claude Code](https://claude.ai/code)
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { Component, computed, inject, input, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -29,6 +29,10 @@ export class ProfileLinuxEmailComponent {
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
+
+  // Identities passed in from the parent (ProfileIdentitiesComponent) to avoid
+  // a duplicate getIdentities() fetch when both panels render on the same page.
+  public readonly identities = input<EnrichedIdentity[]>([]);
 
   // One-shot guard (sessionStorage key) so a tokenless re-auth round-trip can't loop.
   private readonly reauthFlagKey = 'linux-email:forward-reauth-attempted';
@@ -71,7 +75,8 @@ export class ProfileLinuxEmailComponent {
   // GitHub) are excluded since you can't forward email to them, and the claimed
   // alias is excluded since you can't forward an address to itself.
   public forwardOptions = computed((): LinuxForwardOption[] => {
-    const { alias, emails, identities } = this.data();
+    const { alias, emails } = this.data();
+    const identities = this.identities();
 
     const aliasEmail = alias?.email?.toLowerCase().trim();
     const seen = new Set<string>();
@@ -192,7 +197,6 @@ export class ProfileLinuxEmailComponent {
               .getLinuxAlias()
               .pipe(catchError(() => of<LinuxAliasData | null>({ state: 'service_unavailable', domain: '', alias: null, email: null, forwardTo: null }))),
             emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
-            identities: this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))),
           }).pipe(
             tap(({ alias, emails }) => {
               this.applyFormDefaults(alias, emails);
@@ -202,7 +206,7 @@ export class ProfileLinuxEmailComponent {
           );
         })
       ),
-      { initialValue: { alias: null, emails: null, identities: [] } }
+      { initialValue: { alias: null, emails: null } }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -29,11 +29,8 @@ export const PROFILE_ROUTES: Routes = [
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
       },
 
-      // Linux.com Email tab
-      {
-        path: 'linux-email',
-        loadComponent: () => import('./linux-email/profile-linux-email.component').then((m) => m.ProfileLinuxEmailComponent),
-      },
+      // linux-email is now embedded in the Identities tab — redirect for backward compat
+      { path: 'linux-email', redirectTo: 'identities' },
 
       // Direct-URL-only routes (no tab, but still accessible)
       {

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -10,7 +10,6 @@ export const PROFILE_TABS: ProfileTab[] = [
   { id: 'attribution', label: 'Work history & Affiliations', route: 'attribution' },
   { id: 'identities', label: 'Identities', route: 'identities' },
   { id: 'individual-enrollment', label: 'Individual Enrollment', route: 'individual-enrollment' },
-  { id: 'linux-email', label: 'Linux.com Email', route: 'linux-email' },
 ];
 
 /**

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -27,7 +27,6 @@ export type LinuxAliasState = 'not_purchased' | 'purchased_unclaimed' | 'claimed
 export interface LinuxEmailData {
   alias: LinuxAliasData | null;
   emails: EmailManagementData | null;
-  identities: EnrichedIdentity[];
 }
 
 /** Aggregate state returned by `GET /api/profile/linux-email`. */

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -3,7 +3,6 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import type { EnrichedIdentity } from './profile.interface';
 import type { EmailManagementData } from './user-profile.interface';
 
 /**


### PR DESCRIPTION
## Summary

- Moves the Linux.com Email section from its own profile tab into the right-hand panel of the **Identities** tab, restoring an earlier two-column design
- `/profile/linux-email` redirects to `/profile/identities` for backward compatibility; the standalone tab is removed from `PROFILE_TABS`
- Redesigns the `not_purchased` state: single card with `@` icon circle, heading, body copy, and a Purchase Email CTA (removes the separate info banner)
- Redesigns the `claimed` state: envelope icon + Active badge, divider, Forward to selector — Save button only appears when the user's selection differs from the last saved value (`forwardDirty` signal)

## Changes

| File | Change |
|---|---|
| `profile-identities.component.html` | Two-column responsive grid (`lg:grid-cols-[minmax(0,1fr)_360px]`); `<lfx-profile-linux-email />` added to right column |
| `profile-identities.component.ts` | Added `ProfileLinuxEmailComponent` import |
| `profile-linux-email.component.html` | Redesigned `not_purchased` and `claimed` cases; conditional Save button via `forwardDirty()` |
| `profile-linux-email.component.ts` | Added `savedForwardTo` signal and `initForwardDirty()` — tracks unsaved changes to the Forward to selector |
| `profile.routes.ts` | `linux-email` route changed to `redirectTo: 'identities'` |
| `profile.constants.ts` | Removed `linux-email` from `PROFILE_TABS` |

## Test plan

- [ ] Navigate to `/profile/identities` — identities list on left, Linux.com Email panel on right (two-column on lg+, stacks on mobile)
- [ ] Navigate to `/profile/linux-email` — redirects to `/profile/identities`
- [ ] Profile tab bar shows 3 tabs (no Linux.com Email tab)
- [ ] `not_purchased` state: card with `@` icon, heading, body copy, Purchase Email button
- [ ] `claimed` state: envelope icon + Active badge, divider, Forward to selector
- [ ] Save button hidden on load; appears when a different option is selected; hides again after save succeeds
- [ ] `service_unavailable` and `purchased_unclaimed` states render correctly in the panel

🤖 Generated with [Claude Code](https://claude.ai/claude-code)