### PR TITLE
fix(votes): enforce vote close date is after today (LFXV2-2165)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
@@ -128,7 +128,7 @@
             @if (form().get('close_date')?.touched && !form().get('close_date')?.value) {
               <p class="text-red-500 text-xs">Close date is required.</p>
             }
-            <p class="text-xs text-gray-400">The date when this {{ voteLabel.singular | lowercase }} will close and no longer accept responses.</p>
+            <p class="text-xs text-gray-400">Select a date after today when this {{ voteLabel.singular | lowercase }} will close and no longer accept responses.</p>
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
@@ -128,7 +128,9 @@
             @if (form().get('close_date')?.touched && !form().get('close_date')?.value) {
               <p class="text-red-500 text-xs">Close date is required.</p>
             }
-            <p class="text-xs text-gray-400">Select a date after today when this {{ voteLabel.singular | lowercase }} will close and no longer accept responses.</p>
+            <p class="text-xs text-gray-400">
+              Select a date after today when this {{ voteLabel.singular | lowercase }} will close and no longer accept responses.
+            </p>
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
@@ -28,5 +28,10 @@ export class VoteBasicsComponent {
   public readonly committeeLabel = COMMITTEE_LABEL;
   public readonly voteLabel = VOTE_LABEL;
   public readonly eligibleParticipantsOptions = [...VOTE_ELIGIBLE_PARTICIPANTS];
-  public readonly minDate = new Date();
+  public readonly minDate = (() => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    return tomorrow;
+  })();
 }


### PR DESCRIPTION
# Summary

Vote close dates must be set to a day after today. This prevents EDs and admins from accidentally scheduling votes that are already closed or close the same day they are created.