### PR TITLE
fix(meetings): show join cta as disabled+loading on first paint

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -312,20 +312,7 @@
 
               <!-- Right Column: Join Button (immediate meetings) or RSVP (future meetings) -->
               @if (canJoinMeeting() && authenticated()) {
-                @if (isLoadingJoinUrl() && !showGuestForm()) {
-                  <div class="w-full md:w-[296px]">
-                    <lfx-button
-                      styleClass="w-full h-[40px]"
-                      label="Join Meeting"
-                      icon="fa-light fa-video"
-                      severity="success"
-                      size="large"
-                      [loading]="true"
-                      [disabled]="true"
-                      [attr.data-testid]="'join-meeting-button-loading'">
-                    </lfx-button>
-                  </div>
-                } @else if (fetchedJoinUrl() && !showGuestForm()) {
+                @if (fetchedJoinUrl() && !showGuestForm()) {
                   <div class="w-full md:w-[296px]">
                     <lfx-button
                       styleClass="w-full h-[40px]"
@@ -359,6 +346,22 @@
                         >
                       }
                     </div>
+                  </div>
+                } @else if (!showGuestForm()) {
+                  <!-- Disabled+loading is the default while the join URL is resolving.
+                       Placed last so it renders at SSR first paint (no join URL or error yet)
+                       rather than depending on the client-only isLoadingJoinUrl signal. -->
+                  <div class="w-full md:w-[296px]">
+                    <lfx-button
+                      styleClass="w-full h-[40px]"
+                      label="Join Meeting"
+                      icon="fa-light fa-video"
+                      severity="success"
+                      size="large"
+                      [loading]="true"
+                      [disabled]="true"
+                      [attr.data-testid]="'join-meeting-button-loading'">
+                    </lfx-button>
                   </div>
                 }
               } @else if (authenticated() && !isPastMeeting() && meeting().organizer) {


### PR DESCRIPTION
## Summary

- The Join Meeting CTA was invisible on SSR first paint for authenticated users of joinable meetings — the right column painted empty and the button only appeared after client hydration
- Root cause: the loading button was gated on `isLoadingJoinUrl()`, a client-only signal forced to `false` on the server; since `fetchedJoinUrl()` and `joinUrlError()` are also empty at SSR time, none of the three branches rendered
- Fix: reorder the three CTA branches so the disabled+loading button is the `@else` fallback — it now renders in the SSR HTML on first paint, stays visible through hydration, then is replaced by the enabled link once the join URL resolves

## Test plan

- [ ] Open a joinable meeting join page as an authenticated user — Join Meeting button visible immediately on first paint, disabled with spinner, then becomes enabled link once join URL loads
- [ ] `view-source` / curl the page and confirm `data-testid="join-meeting-button-loading"` is present in the SSR HTML before JS runs
- [ ] Unauthenticated viewer → sign-in CTA + guest form render as before (no loading button)
- [ ] Past / non-joinable meeting → Join button absent (column hidden by `canJoinMeeting()` gate)
- [ ] Join-URL fetch error → error button + message renders correctly
- [ ] `showGuestForm()` flow → right-column button suppressed, guest submit button behaves as before

Fixes [LFXV2-2178](https://linuxfoundation.atlassian.net/browse/LFXV2-2178)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2178]: https://linuxfoundation.atlassian.net/browse/LFXV2-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ