### PR TITLE
fix(committees): mount confirm dialog host for member actions

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -2,6 +2,9 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-4 pt-2">
+  <!-- Confirm dialog host for revoke-invite and remove-member actions -->
+  <p-confirmDialog></p-confirmDialog>
+
   <!-- Committee Members Section -->
   <lfx-card>
     @if (!isMembersVisible()) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -56,7 +56,7 @@ import { MemberFormComponent } from '../member-form/member-form.component';
     DynamicDialogModule,
     Skeleton,
   ],
-  providers: [DialogService],
+  providers: [ConfirmationService, DialogService],
   templateUrl: './committee-members.component.html',
   styleUrl: './committee-members.component.scss',
 })


### PR DESCRIPTION
## What
The committee-members component injected `ConfirmationService` and called `confirmationService.confirm()` for the **revoke-invite** and **remove-member** actions, but never provided `ConfirmationService` nor hosted a `<p-confirmDialog>`. Used standalone in `committee-view` (the project Members tab), no ancestor supplied a host either — so `confirm()` rendered nothing and the `accept` callback never fired. **Clicking revoke (or remove) did nothing.**

## Fix
- Add component-scoped `ConfirmationService` to `providers`
- Mount a local `<p-confirmDialog>` host in the template

Matches the established `votes-table` / `surveys-table` convention (`ConfirmDialogModule` was already imported). One unkeyed host covers both confirm actions; the global `<p-toast />` at app root surfaces the success/error toasts.

## Test plan
- Build / lint / type-check pass.
- Verified on prod-backed localhost: clicking the X on a pending invitation now opens the **Revoke Invitation** dialog; Cancel and the confirm flow both work.

## Notes
- **No JIRA ticket** — intentional; descriptive branch name (`fix/revoke-pending-invitation`). The branch-name / JIRA "should-fix" readiness items are this documented trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)