### PR TITLE
feat(campaigns): add linkedin monitoring + optimization

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -2,314 +2,495 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="monitoring-tab">
-  <!-- Controls -->
-  <div class="flex items-center justify-between">
-    <div class="flex items-center gap-2" data-testid="monitoring-date-range">
-      @for (days of dateRangeOptions; track days) {
-        <button
-          type="button"
-          (click)="setDateRange(days)"
-          [class]="
-            selectedDays() === days
-              ? 'rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white'
-              : 'rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200'
-          "
-          [attr.data-testid]="'monitoring-range-' + days">
-          {{ days }}d
-        </button>
-      }
-    </div>
-    <div class="flex items-center gap-3">
-      @if (pulledAt()) {
-        <span class="text-xs text-gray-400" data-testid="monitoring-pulled-at">Last pulled: {{ pulledAt() }}</span>
-      }
-      <button
-        type="button"
-        (click)="refresh()"
-        [disabled]="loading()"
-        class="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-        data-testid="monitoring-refresh"
-        aria-label="Refresh metrics">
-        <i class="fa-light fa-arrows-rotate" [class.fa-spin]="loading()" aria-hidden="true"></i>
-        Refresh
-      </button>
-    </div>
+  <!-- Platform switcher -->
+  <div class="flex items-center gap-2" data-testid="platform-switcher">
+    <button
+      type="button"
+      (click)="setPlatform('google')"
+      [class]="
+        selectedPlatform() === 'google'
+          ? 'flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white'
+          : 'flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200'
+      "
+      data-testid="platform-google">
+      <i class="fa-brands fa-google" aria-hidden="true"></i>
+      Google Ads
+    </button>
+    <button
+      type="button"
+      (click)="setPlatform('linkedin')"
+      [class]="
+        selectedPlatform() === 'linkedin'
+          ? 'flex items-center gap-1.5 rounded-md bg-[#0077B5] px-3 py-1.5 text-xs font-medium text-white'
+          : 'flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200'
+      "
+      data-testid="platform-linkedin">
+      <i class="fa-brands fa-linkedin" aria-hidden="true"></i>
+      LinkedIn Ads
+    </button>
   </div>
 
-  @if (loading() && !monitorData()) {
-    <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-12" data-testid="monitoring-loading">
-      <div class="flex items-center gap-2 text-sm text-gray-500">
-        <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
-        Loading campaign data...
+  @if (selectedPlatform() === 'google') {
+    <!-- Controls -->
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2" data-testid="monitoring-date-range">
+        @for (days of dateRangeOptions; track days) {
+          <button
+            type="button"
+            (click)="setDateRange(days)"
+            [class]="
+              selectedDays() === days
+                ? 'rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white'
+                : 'rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200'
+            "
+            [attr.data-testid]="'monitoring-range-' + days">
+            {{ days }}d
+          </button>
+        }
       </div>
-    </div>
-  } @else if (error()) {
-    <div class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-red-300 bg-red-50 p-12" data-testid="monitoring-error">
-      <i class="fa-light fa-triangle-exclamation text-3xl text-red-400" aria-hidden="true"></i>
-      <p class="text-sm font-medium text-red-700">Failed to load campaign data</p>
-      <p class="max-w-md text-center text-xs text-red-500">{{ error() }}</p>
-      <button
-        type="button"
-        (click)="fetchData()"
-        class="mt-2 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
-        data-testid="monitoring-retry">
-        Retry
-      </button>
-    </div>
-  } @else if (!hasCampaigns()) {
-    <div class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-12" data-testid="monitoring-empty">
-      <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
-      <p class="text-sm text-gray-500">No active campaigns found for the selected date range.</p>
-    </div>
-  } @else {
-    <!-- KPI Strip -->
-    <div class="grid grid-cols-2 gap-4 md:grid-cols-5" data-testid="monitoring-kpis">
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <p class="text-xs font-medium text-gray-500">Impressions</p>
-        <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-impressions">{{ formatNumber(accountTotals()!.impressions) }}</p>
-      </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <p class="text-xs font-medium text-gray-500">Clicks</p>
-        <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-clicks">{{ formatNumber(accountTotals()!.clicks) }}</p>
-      </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <p class="text-xs font-medium text-gray-500">CTR</p>
-        <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-ctr">{{ formatPct(totalCtr()) }}</p>
-      </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <p class="text-xs font-medium text-gray-500">Spend</p>
-        <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-spend">{{ formatCurrency(accountTotals()!.spend) }}</p>
-      </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <p class="text-xs font-medium text-gray-500">Conversions</p>
-        <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-conversions">{{ formatNumber(accountTotals()!.conversions) }}</p>
+      <div class="flex items-center gap-3">
+        @if (pulledAt()) {
+          <span class="text-xs text-gray-400" data-testid="monitoring-pulled-at">Last pulled: {{ pulledAt() }}</span>
+        }
+        <button
+          type="button"
+          (click)="refresh()"
+          [disabled]="loading()"
+          class="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          data-testid="monitoring-refresh"
+          aria-label="Refresh metrics">
+          <i class="fa-light fa-arrows-rotate" [class.fa-spin]="loading()" aria-hidden="true"></i>
+          Refresh
+        </button>
       </div>
     </div>
 
-    <!-- Campaign Table -->
-    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="monitoring-campaign-table">
-      <div class="overflow-x-auto">
-        <table class="w-full text-left text-sm">
-          <thead>
-            <tr class="border-b border-gray-200 bg-gray-50">
-              <th class="px-4 py-3 text-xs font-medium text-gray-500">Campaign</th>
-              <th class="px-4 py-3 text-xs font-medium text-gray-500">Flight Dates</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Total Budget</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Spend</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Impr.</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Clicks</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">CTR</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Avg CPC</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Conv.</th>
-              <th class="px-4 py-3 text-xs font-medium text-gray-500">Pacing</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (campaign of campaigns(); track campaign.campaignId) {
-              <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'monitoring-campaign-row-' + $index">
-                <td class="px-4 py-3">
-                  <div class="flex items-center gap-1.5">
-                    <span class="font-medium text-gray-900">{{ campaign.eventName || campaign.name }}</span>
+    @if (loading() && !monitorData()) {
+      <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-12" data-testid="monitoring-loading">
+        <div class="flex items-center gap-2 text-sm text-gray-500">
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          Loading campaign data...
+        </div>
+      </div>
+    } @else if (error()) {
+      <div class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-red-300 bg-red-50 p-12" data-testid="monitoring-error">
+        <i class="fa-light fa-triangle-exclamation text-3xl text-red-400" aria-hidden="true"></i>
+        <p class="text-sm font-medium text-red-700">Failed to load campaign data</p>
+        <p class="max-w-md text-center text-xs text-red-500">{{ error() }}</p>
+        <button
+          type="button"
+          (click)="fetchData()"
+          class="mt-2 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
+          data-testid="monitoring-retry">
+          Retry
+        </button>
+      </div>
+    } @else if (!hasCampaigns()) {
+      <div
+        class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-12"
+        data-testid="monitoring-empty">
+        <i class="fa-light fa-chart-mixed text-3xl text-gray-400" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">No active campaigns found for the selected date range.</p>
+      </div>
+    } @else {
+      <!-- KPI Strip -->
+      <div class="grid grid-cols-2 gap-4 md:grid-cols-5" data-testid="monitoring-kpis">
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <p class="text-xs font-medium text-gray-500">Impressions</p>
+          <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-impressions">{{ formatNumber(accountTotals()!.impressions) }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <p class="text-xs font-medium text-gray-500">Clicks</p>
+          <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-clicks">{{ formatNumber(accountTotals()!.clicks) }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <p class="text-xs font-medium text-gray-500">CTR</p>
+          <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-ctr">{{ formatPct(totalCtr()) }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <p class="text-xs font-medium text-gray-500">Spend</p>
+          <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-spend">{{ formatCurrency(accountTotals()!.spend) }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <p class="text-xs font-medium text-gray-500">Conversions</p>
+          <p class="text-lg font-semibold text-gray-900" data-testid="monitoring-kpi-conversions">{{ formatNumber(accountTotals()!.conversions) }}</p>
+        </div>
+      </div>
+
+      <!-- Campaign Table -->
+      <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="monitoring-campaign-table">
+        <div class="overflow-x-auto">
+          <table class="w-full text-left text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 bg-gray-50">
+                <th class="px-4 py-3 text-xs font-medium text-gray-500">Campaign</th>
+                <th class="px-4 py-3 text-xs font-medium text-gray-500">Flight Dates</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Total Budget</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Spend</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Impr.</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Clicks</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">CTR</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Avg CPC</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Conv.</th>
+                <th class="px-4 py-3 text-xs font-medium text-gray-500">Pacing</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (campaign of campaigns(); track campaign.campaignId) {
+                <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'monitoring-campaign-row-' + $index">
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-1.5">
+                      <span class="font-medium text-gray-900">{{ campaign.eventName || campaign.name }}</span>
+                      <button
+                        type="button"
+                        (click)="copyName(campaign.name)"
+                        class="text-gray-400 hover:text-blue-600"
+                        [attr.title]="'Copy: ' + campaign.name"
+                        aria-label="Copy campaign name to find in Google Ads">
+                        <i
+                          [class]="copiedName() === campaign.name ? 'fa-light fa-check text-xs text-green-500' : 'fa-light fa-copy text-xs'"
+                          aria-hidden="true"></i>
+                      </button>
+                    </div>
+                    <p class="text-xs text-gray-400">{{ campaign.shortName }}</p>
+                  </td>
+                  <td class="px-4 py-3">
+                    <p class="text-xs text-gray-700">{{ formatDate(campaign.startDate) }}</p>
+                    <p class="text-xs text-gray-400">{{ formatDate(campaign.endDate) }}</p>
+                  </td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.totalBudget) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.spend) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.impressions) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.clicks) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatPct(campaign.ctr) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.avgCpc) }}</td>
+                  <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.conversions) }}</td>
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-2">
+                      <div class="h-2 w-16 overflow-hidden rounded-full bg-gray-200">
+                        <div class="h-full rounded-full" [class]="pacingClass(campaign)" [style.width.%]="Math.min(campaign.pacingPct, 100)"></div>
+                      </div>
+                      <span class="text-xs text-gray-500">{{ campaign.pacingPct }}%</span>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ===== Keyword Performance ===== -->
+      <div class="flex flex-col gap-4" data-testid="keyword-performance">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <h4 class="text-sm font-semibold text-gray-900">Keyword Performance</h4>
+            @if (hasKeywords()) {
+              <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">{{ keywords().length }} keywords</span>
+            }
+          </div>
+        </div>
+
+        @if (keywordsLoading() && !keywordsData()) {
+          <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-8" data-testid="keyword-loading">
+            <div class="flex items-center gap-2 text-sm text-gray-500">
+              <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+              Loading keywords...
+            </div>
+          </div>
+        } @else if (keywordsError()) {
+          <div class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-red-300 bg-red-50 p-8" data-testid="keyword-error">
+            <i class="fa-light fa-circle-exclamation text-2xl text-red-400" aria-hidden="true"></i>
+            <p class="text-sm text-red-600">{{ keywordsError() }}</p>
+          </div>
+        } @else if (!hasKeywords()) {
+          <div
+            class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8"
+            data-testid="keyword-empty">
+            <i class="fa-light fa-key text-2xl text-gray-400" aria-hidden="true"></i>
+            <p class="text-sm text-gray-500">No keyword data available for the selected date range.</p>
+          </div>
+        } @else {
+          <!-- Keyword Totals Strip -->
+          @if (keywordTotals()) {
+            <div class="grid grid-cols-2 gap-3 md:grid-cols-5" data-testid="keyword-totals">
+              <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
+                <p class="text-xs text-gray-500">Impressions</p>
+                <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.impressions) }}</p>
+              </div>
+              <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
+                <p class="text-xs text-gray-500">Clicks</p>
+                <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.clicks) }}</p>
+              </div>
+              <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
+                <p class="text-xs text-gray-500">Avg CTR</p>
+                <p class="text-sm font-semibold text-gray-900">{{ formatPct(keywordTotals()!.avgCtr) }}</p>
+              </div>
+              <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
+                <p class="text-xs text-gray-500">Spend</p>
+                <p class="text-sm font-semibold text-gray-900">{{ formatCurrency(keywordTotals()!.spend) }}</p>
+              </div>
+              <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
+                <p class="text-xs text-gray-500">Conversions</p>
+                <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.conversions) }}</p>
+              </div>
+            </div>
+          }
+
+          <!-- Keyword Table -->
+          <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="keyword-table">
+            <div class="overflow-x-auto">
+              <table class="w-full text-left text-sm">
+                <thead>
+                  <tr class="border-b border-gray-200 bg-gray-50">
+                    <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Keyword</th>
+                    <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Match</th>
+                    <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">QS</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Impr.</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Clicks</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">CTR</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Avg CPC</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Spend</th>
+                    <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Conv.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (kw of visibleKeywords(); track kw.keyword + '-' + kw.campaignId) {
+                    <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'keyword-row-' + $index">
+                      <td class="px-4 py-2.5">
+                        <p class="font-medium text-gray-900">{{ kw.keyword }}</p>
+                        <div class="flex items-center gap-1">
+                          <span class="text-xs text-gray-400">{{ eventLabel(kw.campaign) }}</span>
+                          <button
+                            type="button"
+                            (click)="copyName(kw.campaign)"
+                            class="text-gray-400 hover:text-blue-600"
+                            [attr.title]="'Copy: ' + kw.campaign"
+                            aria-label="Copy campaign name">
+                            <i
+                              [class]="copiedName() === kw.campaign ? 'fa-light fa-check text-xs text-green-500' : 'fa-light fa-copy text-xs'"
+                              aria-hidden="true"></i>
+                          </button>
+                        </div>
+                      </td>
+                      <td class="px-4 py-2.5">
+                        <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" [class]="matchTypeClass(kw.matchType)">
+                          {{ kw.matchType }}
+                        </span>
+                      </td>
+                      <td class="px-4 py-2.5 text-center">
+                        <span class="text-sm font-medium" [class]="qualityScoreClass(kw.qualityScore)">
+                          {{ kw.qualityScore ?? '–' }}
+                        </span>
+                      </td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.impressions) }}</td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatPct(kw.ctr) }}</td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.avgCpc) }}</td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.spend) }}</td>
+                      <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.conversions) }}</td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+            @if (keywordTotalPages() > 1) {
+              <div class="flex items-center justify-between border-t border-gray-200 px-4 py-2.5" data-testid="keyword-pagination">
+                <span class="text-xs text-gray-500">
+                  Showing {{ (keywordPage() - 1) * keywordPageSize + 1 }}–{{
+                    keywordPage() === keywordTotalPages() ? keywords().length : keywordPage() * keywordPageSize
+                  }}
+                  of
+                  {{ keywords().length }}
+                </span>
+                <div class="flex items-center gap-1">
+                  <button
+                    type="button"
+                    (click)="goToKeywordPage(keywordPage() - 1)"
+                    [disabled]="!hasKeywordPrevPage()"
+                    class="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-300"
+                    data-testid="keyword-page-prev"
+                    aria-label="Previous page">
+                    <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
+                  </button>
+                  @for (page of keywordPageNumbers(); track page) {
                     <button
                       type="button"
-                      (click)="copyName(campaign.name)"
-                      class="text-gray-400 hover:text-blue-600"
-                      [attr.title]="'Copy: ' + campaign.name"
-                      aria-label="Copy campaign name to find in Google Ads">
-                      <i
-                        [class]="copiedName() === campaign.name ? 'fa-light fa-check text-xs text-green-500' : 'fa-light fa-copy text-xs'"
-                        aria-hidden="true"></i>
+                      (click)="goToKeywordPage(page)"
+                      [class]="
+                        keywordPage() === page
+                          ? 'rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white'
+                          : 'rounded-md px-2.5 py-1 text-xs text-gray-600 hover:bg-gray-100'
+                      "
+                      [attr.data-testid]="'keyword-page-' + page">
+                      {{ page }}
                     </button>
-                  </div>
-                  <p class="text-xs text-gray-400">{{ campaign.shortName }}</p>
-                </td>
-                <td class="px-4 py-3">
-                  <p class="text-xs text-gray-700">{{ formatDate(campaign.startDate) }}</p>
-                  <p class="text-xs text-gray-400">{{ formatDate(campaign.endDate) }}</p>
-                </td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.totalBudget) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.spend) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.impressions) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.clicks) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatPct(campaign.ctr) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatCurrency(campaign.avgCpc) }}</td>
-                <td class="px-4 py-3 text-right text-gray-700">{{ formatNumber(campaign.conversions) }}</td>
-                <td class="px-4 py-3">
-                  <div class="flex items-center gap-2">
-                    <div class="h-2 w-16 overflow-hidden rounded-full bg-gray-200">
-                      <div class="h-full rounded-full" [class]="pacingClass(campaign)" [style.width.%]="Math.min(campaign.pacingPct, 100)"></div>
-                    </div>
-                    <span class="text-xs text-gray-500">{{ campaign.pacingPct }}%</span>
-                  </div>
-                </td>
-              </tr>
+                  }
+                  <button
+                    type="button"
+                    (click)="goToKeywordPage(keywordPage() + 1)"
+                    [disabled]="!hasKeywordNextPage()"
+                    class="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-300"
+                    data-testid="keyword-page-next"
+                    aria-label="Next page">
+                    <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
+                  </button>
+                </div>
+              </div>
             }
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- ===== Keyword Performance ===== -->
-    <div class="flex flex-col gap-4" data-testid="keyword-performance">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <h4 class="text-sm font-semibold text-gray-900">Keyword Performance</h4>
-          @if (hasKeywords()) {
-            <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">{{ keywords().length }} keywords</span>
-          }
-        </div>
-      </div>
-
-      @if (keywordsLoading() && !keywordsData()) {
-        <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-8" data-testid="keyword-loading">
-          <div class="flex items-center gap-2 text-sm text-gray-500">
-            <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
-            Loading keywords...
-          </div>
-        </div>
-      } @else if (keywordsError()) {
-        <div class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-red-300 bg-red-50 p-8" data-testid="keyword-error">
-          <i class="fa-light fa-circle-exclamation text-2xl text-red-400" aria-hidden="true"></i>
-          <p class="text-sm text-red-600">{{ keywordsError() }}</p>
-        </div>
-      } @else if (!hasKeywords()) {
-        <div class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="keyword-empty">
-          <i class="fa-light fa-key text-2xl text-gray-400" aria-hidden="true"></i>
-          <p class="text-sm text-gray-500">No keyword data available for the selected date range.</p>
-        </div>
-      } @else {
-        <!-- Keyword Totals Strip -->
-        @if (keywordTotals()) {
-          <div class="grid grid-cols-2 gap-3 md:grid-cols-5" data-testid="keyword-totals">
-            <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
-              <p class="text-xs text-gray-500">Impressions</p>
-              <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.impressions) }}</p>
-            </div>
-            <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
-              <p class="text-xs text-gray-500">Clicks</p>
-              <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.clicks) }}</p>
-            </div>
-            <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
-              <p class="text-xs text-gray-500">Avg CTR</p>
-              <p class="text-sm font-semibold text-gray-900">{{ formatPct(keywordTotals()!.avgCtr) }}</p>
-            </div>
-            <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
-              <p class="text-xs text-gray-500">Spend</p>
-              <p class="text-sm font-semibold text-gray-900">{{ formatCurrency(keywordTotals()!.spend) }}</p>
-            </div>
-            <div class="rounded-md border border-gray-200 bg-white px-3 py-2">
-              <p class="text-xs text-gray-500">Conversions</p>
-              <p class="text-sm font-semibold text-gray-900">{{ formatNumber(keywordTotals()!.conversions) }}</p>
-            </div>
           </div>
         }
+      </div>
 
-        <!-- Keyword Table -->
-        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="keyword-table">
+      <!-- Audience Demographics -->
+      <lfx-audience-demographics [days]="selectedDays()" data-testid="monitoring-audience" />
+    }
+  } @else {
+    <!-- LinkedIn Ads Panel -->
+    <div class="flex flex-col gap-4" data-testid="linkedin-monitor-panel">
+      <!-- Account selector + controls -->
+      <div class="flex items-center justify-between">
+        <select
+          [value]="selectedLinkedInAccountId()"
+          (change)="setLinkedInAccount($any($event.target).value)"
+          class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          data-testid="linkedin-account-select">
+          @for (acct of linkedInAccountOptions; track acct.accountId) {
+            <option [value]="acct.accountId">{{ acct.label }}</option>
+          }
+        </select>
+        <div class="flex items-center gap-3">
+          @if (linkedInPulledAt()) {
+            <span class="text-xs text-gray-400">Last pulled: {{ linkedInPulledAt() }}</span>
+          }
+          <button
+            type="button"
+            (click)="fetchLinkedInData()"
+            [disabled]="linkedInLoading()"
+            class="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            data-testid="linkedin-refresh">
+            <i class="fa-light fa-arrows-rotate" [class.fa-spin]="linkedInLoading()" aria-hidden="true"></i>
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      @if (linkedInLoading() && !linkedInData()) {
+        <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-white p-12" data-testid="linkedin-loading">
+          <div class="flex items-center gap-2 text-sm text-gray-500">
+            <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+            Loading LinkedIn campaigns...
+          </div>
+        </div>
+      } @else if (linkedInError()) {
+        <div class="flex flex-col items-center gap-3 rounded-lg border border-dashed border-red-300 bg-red-50 p-12" data-testid="linkedin-error">
+          <i class="fa-light fa-triangle-exclamation text-3xl text-red-400" aria-hidden="true"></i>
+          <p class="text-sm font-medium text-red-700">Failed to load LinkedIn data</p>
+          <p class="text-xs text-red-500">{{ linkedInError() }}</p>
+          <button type="button" (click)="fetchLinkedInData()" class="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700">
+            Retry
+          </button>
+        </div>
+      } @else if (linkedInData() && linkedInCampaigns().length === 0) {
+        <div class="flex flex-col items-center gap-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-12" data-testid="linkedin-empty">
+          <i class="fa-brands fa-linkedin text-3xl text-gray-400" aria-hidden="true"></i>
+          <p class="text-sm text-gray-500">No active LinkedIn campaigns found for this account.</p>
+        </div>
+      } @else if (linkedInData()) {
+        <!-- KPI Strip -->
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-5" data-testid="linkedin-kpi-strip">
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium text-gray-500">Impressions</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatNumber(linkedInTotals()!.impressions) }}</p>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium text-gray-500">Clicks</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatNumber(linkedInTotals()!.clicks) }}</p>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium text-gray-500">CTR</p>
+            <p class="text-lg font-semibold text-gray-900">
+              @if (linkedInTotals()!.impressions > 0) {
+                {{ formatLinkedInPct(linkedInTotals()!.clicks / linkedInTotals()!.impressions) }}
+              } @else {
+                —
+              }
+            </p>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium text-gray-500">Spend</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatLinkedInCurrency(linkedInTotals()!.spend) }}</p>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium text-gray-500">Conversions</p>
+            <p class="text-lg font-semibold text-gray-900">{{ formatNumber(linkedInTotals()!.conversions) }}</p>
+          </div>
+        </div>
+
+        <!-- Campaign Table -->
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="linkedin-campaign-table">
           <div class="overflow-x-auto">
             <table class="w-full text-left text-sm">
               <thead>
                 <tr class="border-b border-gray-200 bg-gray-50">
-                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Keyword</th>
-                  <th class="px-4 py-2.5 text-xs font-medium text-gray-500">Match</th>
-                  <th class="px-4 py-2.5 text-center text-xs font-medium text-gray-500">QS</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Impr.</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Clicks</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">CTR</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Avg CPC</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Spend</th>
-                  <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500">Conv.</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Campaign</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Status</th>
+                  <th class="px-4 py-3 text-xs font-medium text-gray-500">Flight</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Budget</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Spend</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Pacing</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Impr.</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Clicks</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">CTR</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Conv.</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500">Creatives</th>
                 </tr>
               </thead>
-              <tbody>
-                @for (kw of visibleKeywords(); track kw.keyword + '-' + kw.campaignId) {
-                  <tr class="border-b border-gray-100 last:border-0" [attr.data-testid]="'keyword-row-' + $index">
-                    <td class="px-4 py-2.5">
-                      <p class="font-medium text-gray-900">{{ kw.keyword }}</p>
-                      <div class="flex items-center gap-1">
-                        <span class="text-xs text-gray-400">{{ eventLabel(kw.campaign) }}</span>
-                        <button
-                          type="button"
-                          (click)="copyName(kw.campaign)"
-                          class="text-gray-400 hover:text-blue-600"
-                          [attr.title]="'Copy: ' + kw.campaign"
-                          aria-label="Copy campaign name">
-                          <i
-                            [class]="copiedName() === kw.campaign ? 'fa-light fa-check text-xs text-green-500' : 'fa-light fa-copy text-xs'"
-                            aria-hidden="true"></i>
-                        </button>
-                      </div>
+              <tbody class="divide-y divide-gray-100">
+                @for (camp of linkedInCampaigns(); track camp.campaignId) {
+                  <tr class="hover:bg-gray-50" data-testid="linkedin-campaign-row">
+                    <td class="px-4 py-3">
+                      <p class="max-w-xs truncate font-medium text-gray-900" [title]="camp.campaignName">{{ camp.eventName }}</p>
+                      <p class="max-w-xs truncate text-xs text-gray-400" [title]="camp.campaignName">{{ camp.campaignName }}</p>
                     </td>
-                    <td class="px-4 py-2.5">
-                      <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" [class]="matchTypeClass(kw.matchType)">
-                        {{ kw.matchType }}
+                    <td class="px-4 py-3">
+                      <span
+                        [class]="
+                          camp.status === 'ACTIVE'
+                            ? 'inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700'
+                            : 'inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600'
+                        ">
+                        {{ camp.status }}
                       </span>
                     </td>
-                    <td class="px-4 py-2.5 text-center">
-                      <span class="text-sm font-medium" [class]="qualityScoreClass(kw.qualityScore)">
-                        {{ kw.qualityScore ?? '–' }}
+                    <td class="px-4 py-3 text-xs text-gray-500">
+                      @if (camp.startDate) {
+                        {{ camp.startDate }} → {{ camp.endDate }}
+                      } @else {
+                        —
+                      }
+                    </td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">
+                      {{ formatLinkedInCurrency(camp.totalBudget || camp.dailyBudget) }}
+                    </td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ formatLinkedInCurrency(camp.spend) }}</td>
+                    <td class="px-4 py-3 text-right">
+                      <span [class]="'text-xs font-medium ' + linkedInPacingClass(camp.pacingLabel)">
+                        {{ camp.pacingPct.toFixed(0) }}% {{ camp.pacingLabel }}
                       </span>
                     </td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.impressions) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.clicks) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatPct(kw.ctr) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.avgCpc) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatCurrency(kw.spend) }}</td>
-                    <td class="px-4 py-2.5 text-right text-gray-700">{{ formatNumber(kw.conversions) }}</td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ formatNumber(camp.impressions) }}</td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ formatNumber(camp.clicks) }}</td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ formatLinkedInPct(camp.ctr) }}</td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ camp.conversions }}</td>
+                    <td class="px-4 py-3 text-right text-xs text-gray-700">{{ camp.creatives.length }}</td>
                   </tr>
                 }
               </tbody>
             </table>
           </div>
-          @if (keywordTotalPages() > 1) {
-            <div class="flex items-center justify-between border-t border-gray-200 px-4 py-2.5" data-testid="keyword-pagination">
-              <span class="text-xs text-gray-500">
-                Showing {{ (keywordPage() - 1) * keywordPageSize + 1 }}–{{
-                  keywordPage() === keywordTotalPages() ? keywords().length : keywordPage() * keywordPageSize
-                }}
-                of
-                {{ keywords().length }}
-              </span>
-              <div class="flex items-center gap-1">
-                <button
-                  type="button"
-                  (click)="goToKeywordPage(keywordPage() - 1)"
-                  [disabled]="!hasKeywordPrevPage()"
-                  class="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-300"
-                  data-testid="keyword-page-prev"
-                  aria-label="Previous page">
-                  <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
-                </button>
-                @for (page of keywordPageNumbers(); track page) {
-                  <button
-                    type="button"
-                    (click)="goToKeywordPage(page)"
-                    [class]="
-                      keywordPage() === page
-                        ? 'rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white'
-                        : 'rounded-md px-2.5 py-1 text-xs text-gray-600 hover:bg-gray-100'
-                    "
-                    [attr.data-testid]="'keyword-page-' + page">
-                    {{ page }}
-                  </button>
-                }
-                <button
-                  type="button"
-                  (click)="goToKeywordPage(keywordPage() + 1)"
-                  [disabled]="!hasKeywordNextPage()"
-                  class="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-300"
-                  data-testid="keyword-page-next"
-                  aria-label="Next page">
-                  <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
-                </button>
-              </div>
-            </div>
-          }
         </div>
       }
     </div>
-
-    <!-- Audience Demographics -->
-    <lfx-audience-demographics [days]="selectedDays()" data-testid="monitoring-audience" />
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -451,7 +451,7 @@
               </thead>
               <tbody class="divide-y divide-gray-100">
                 @for (camp of linkedInCampaigns(); track camp.campaignId) {
-                  <tr class="hover:bg-gray-50" data-testid="linkedin-campaign-row">
+                  <tr class="hover:bg-gray-50" [attr.data-testid]="'linkedin-campaign-row-' + $index">
                     <td class="px-4 py-3">
                       <p class="max-w-xs truncate font-medium text-gray-900" [title]="camp.campaignName">{{ camp.eventName }}</p>
                       <p class="max-w-xs truncate text-xs text-gray-400" [title]="camp.campaignName">{{ camp.campaignName }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -353,13 +353,13 @@
       <!-- Account selector + controls -->
       <div class="flex items-center justify-between">
         <select
-          [value]="selectedLinkedInAccountId()"
+          [value]="selectedLinkedInAccountKey()"
           (change)="onLinkedInAccountChange($event)"
           aria-label="LinkedIn ad account"
           class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           data-testid="linkedin-account-select">
-          @for (acct of linkedInAccountOptions(); track acct.accountId) {
-            <option [value]="acct.accountId">{{ acct.label }}</option>
+          @for (acct of linkedInAccountOptions(); track acct.key) {
+            <option [value]="acct.key">{{ acct.label }}</option>
           }
         </select>
         <div class="flex items-center gap-3">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -354,7 +354,7 @@
       <div class="flex items-center justify-between">
         <select
           [value]="selectedLinkedInAccountId()"
-          (change)="setLinkedInAccount($any($event.target).value)"
+          (change)="onLinkedInAccountChange($event)"
           aria-label="LinkedIn ad account"
           class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           data-testid="linkedin-account-select">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -355,6 +355,7 @@
         <select
           [value]="selectedLinkedInAccountId()"
           (change)="setLinkedInAccount($any($event.target).value)"
+          aria-label="LinkedIn ad account"
           class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           data-testid="linkedin-account-select">
           @for (acct of linkedInAccountOptions(); track acct.accountId) {
@@ -413,7 +414,7 @@
             <p class="text-xs font-medium text-gray-500">CTR</p>
             <p class="text-lg font-semibold text-gray-900">
               @if (linkedInTotals()!.impressions > 0) {
-                {{ formatLinkedInPct(linkedInTotals()!.clicks / linkedInTotals()!.impressions) }}
+                {{ formatLinkedInPct((linkedInTotals()!.clicks / linkedInTotals()!.impressions) * 100) }}
               } @else {
                 —
               }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -355,7 +355,7 @@
           (change)="setLinkedInAccount($any($event.target).value)"
           class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           data-testid="linkedin-account-select">
-          @for (acct of linkedInAccountOptions; track acct.accountId) {
+          @for (acct of linkedInAccountOptions(); track acct.accountId) {
             <option [value]="acct.accountId">{{ acct.label }}</option>
           }
         </select>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.html
@@ -3,10 +3,11 @@
 
 <div class="flex flex-col gap-6" data-testid="monitoring-tab">
   <!-- Platform switcher -->
-  <div class="flex items-center gap-2" data-testid="platform-switcher">
+  <div class="flex items-center gap-2" role="group" aria-label="Platform" data-testid="platform-switcher">
     <button
       type="button"
       (click)="setPlatform('google')"
+      [attr.aria-pressed]="selectedPlatform() === 'google'"
       [class]="
         selectedPlatform() === 'google'
           ? 'flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white'
@@ -19,6 +20,7 @@
     <button
       type="button"
       (click)="setPlatform('linkedin')"
+      [attr.aria-pressed]="selectedPlatform() === 'linkedin'"
       [class]="
         selectedPlatform() === 'linkedin'
           ? 'flex items-center gap-1.5 rounded-md bg-[#0077B5] px-3 py-1.5 text-xs font-medium text-white'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -8,13 +8,25 @@ import type { Subscription } from 'rxjs';
 import { CAMPAIGN_PACING_THRESHOLDS, parseCampaignName } from '@lfx-one/shared/constants';
 import { CampaignService } from '@services/campaign.service';
 
-import type { CampaignMetrics, CampaignMonitorResponse, KeywordMetrics, KeywordMetricsResponse } from '@lfx-one/shared/interfaces';
+import type { CampaignMetrics, CampaignMonitorResponse, KeywordMetrics, KeywordMetricsResponse, LinkedInMonitorResponse } from '@lfx-one/shared/interfaces';
 
 import { AudienceDemographicsComponent } from '../audience-demographics/audience-demographics.component';
 
 type DateRangeOption = 7 | 14 | 30;
+type PlatformType = 'google' | 'linkedin';
 
 const KEYWORD_PAGE_SIZE = 10;
+
+const LINKEDIN_ACCOUNT_OPTIONS = [
+  { accountId: '509430019', label: 'LF Events' },
+  { accountId: '538170226', label: 'The Linux Foundation' },
+  { accountId: '500928401', label: 'CNCF' },
+  { accountId: '508209098', label: 'LF Education' },
+  { accountId: '537341179', label: 'Agentic AI Foundation' },
+  { accountId: '515244770', label: 'OpenJS Foundation' },
+  { accountId: '514596831', label: 'OpenSSF' },
+  { accountId: '514553720', label: 'OpenSearch Project' },
+] as const;
 
 @Component({
   selector: 'lfx-monitoring-tab',
@@ -38,6 +50,17 @@ export class MonitoringTabComponent implements OnInit {
   protected readonly loading = signal(false);
   protected readonly monitorData = signal<CampaignMonitorResponse | null>(null);
   protected readonly error = signal<string | null>(null);
+
+  // Platform switcher
+  protected readonly selectedPlatform = signal<PlatformType>('google');
+  protected readonly linkedInAccountOptions = LINKEDIN_ACCOUNT_OPTIONS;
+  protected readonly selectedLinkedInAccountId = signal<string>('509430019');
+  protected readonly linkedInLoading = signal(false);
+  protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
+  protected readonly linkedInError = signal<string | null>(null);
+  protected readonly linkedInCampaigns = computed(() => this.linkedInData()?.campaigns ?? []);
+  protected readonly linkedInTotals = computed(() => this.linkedInData()?.accountTotals ?? null);
+  protected readonly linkedInPulledAt = computed(() => (this.linkedInData()?.pulledAt ? new Date(this.linkedInData()!.pulledAt).toLocaleString() : null));
 
   protected readonly keywordsLoading = signal(false);
   protected readonly keywordsData = signal<KeywordMetricsResponse | null>(null);
@@ -142,6 +165,51 @@ export class MonitoringTabComponent implements OnInit {
         })
         .catch(() => undefined);
     }
+  }
+
+  protected setPlatform(p: PlatformType): void {
+    this.selectedPlatform.set(p);
+    if (p === 'linkedin' && !this.linkedInData()) {
+      this.fetchLinkedInData();
+    }
+  }
+
+  protected setLinkedInAccount(accountId: string): void {
+    this.selectedLinkedInAccountId.set(accountId);
+    this.fetchLinkedInData();
+  }
+
+  protected fetchLinkedInData(): void {
+    this.linkedInLoading.set(true);
+    this.linkedInError.set(null);
+    this.campaignService
+      .getLinkedInMonitorData(this.selectedLinkedInAccountId(), this.selectedDays())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.linkedInData.set(data);
+          this.linkedInLoading.set(false);
+        },
+        error: (err: unknown) => {
+          const httpErr = err as { error?: { message?: string }; message?: string };
+          this.linkedInError.set(httpErr?.error?.message || httpErr?.message || 'Failed to load LinkedIn data');
+          this.linkedInLoading.set(false);
+        },
+      });
+  }
+
+  protected linkedInPacingClass(label: string): string {
+    if (label === 'underspending') return 'text-red-600';
+    if (label === 'constrained' || label === 'overspending') return 'text-amber-600';
+    return 'text-green-600';
+  }
+
+  protected formatLinkedInCurrency(n: number): string {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+  }
+
+  protected formatLinkedInPct(n: number): string {
+    return `${(n * 100).toFixed(2)}%`;
   }
 
   protected eventLabel(campaignName: string): string {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -57,7 +57,10 @@ export class MonitoringTabComponent implements OnInit {
   protected readonly linkedInError = signal<string | null>(null);
   protected readonly linkedInCampaigns = computed(() => this.linkedInData()?.campaigns ?? []);
   protected readonly linkedInTotals = computed(() => this.linkedInData()?.accountTotals ?? null);
-  protected readonly linkedInPulledAt = computed(() => (this.linkedInData()?.pulledAt ? new Date(this.linkedInData()!.pulledAt).toLocaleString() : null));
+  protected readonly linkedInPulledAt = computed(() => {
+    const pulledAt = this.linkedInData()?.pulledAt;
+    return pulledAt ? new Date(pulledAt).toLocaleString() : null;
+  });
 
   protected readonly keywordsLoading = signal(false);
   protected readonly keywordsData = signal<KeywordMetricsResponse | null>(null);
@@ -121,6 +124,9 @@ export class MonitoringTabComponent implements OnInit {
 
   protected refresh(): void {
     this.fetchData();
+    if (this.selectedPlatform() === 'linkedin') {
+      this.fetchLinkedInData();
+    }
   }
 
   protected fetchData(): void {
@@ -194,6 +200,10 @@ export class MonitoringTabComponent implements OnInit {
   protected setLinkedInAccount(accountId: string): void {
     this.selectedLinkedInAccountId.set(accountId);
     this.fetchLinkedInData();
+  }
+
+  protected onLinkedInAccountChange(event: Event): void {
+    this.setLinkedInAccount((event.target as HTMLSelectElement).value);
   }
 
   protected fetchLinkedInData(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -102,7 +102,10 @@ export class MonitoringTabComponent implements OnInit {
             this.selectedLinkedInAccountId.set(accounts[0].accountId);
           }
         },
-        error: () => undefined,
+        error: (err: unknown) => {
+          const httpErr = err as { error?: { message?: string }; message?: string };
+          this.linkedInError.set(httpErr?.error?.message || httpErr?.message || 'Failed to load LinkedIn accounts');
+        },
       });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -15,6 +15,7 @@ import type {
   KeywordMetricsResponse,
   LinkedInAccountOption,
   LinkedInMonitorResponse,
+  LinkedInPacingLabel,
 } from '@lfx-one/shared/interfaces';
 
 import { AudienceDemographicsComponent } from '../audience-demographics/audience-demographics.component';
@@ -232,7 +233,7 @@ export class MonitoringTabComponent implements OnInit {
       });
   }
 
-  protected linkedInPacingClass(label: string): string {
+  protected linkedInPacingClass(label: LinkedInPacingLabel): string {
     if (label === 'underspending') return 'text-red-600';
     if (label === 'constrained' || label === 'overspending') return 'text-amber-600';
     return 'text-green-600';

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -51,7 +51,7 @@ export class MonitoringTabComponent implements OnInit {
   // Platform switcher
   protected readonly selectedPlatform = signal<PlatformType>('google');
   protected readonly linkedInAccountOptions = signal<LinkedInAccountOption[]>([]);
-  protected readonly selectedLinkedInAccountId = signal<string>('');
+  protected readonly selectedLinkedInAccountKey = signal<string>('');
   protected readonly linkedInLoading = signal(false);
   protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
   protected readonly linkedInError = signal<string | null>(null);
@@ -101,8 +101,8 @@ export class MonitoringTabComponent implements OnInit {
       .subscribe({
         next: (accounts) => {
           this.linkedInAccountOptions.set(accounts);
-          if (accounts.length > 0 && !this.selectedLinkedInAccountId()) {
-            this.selectedLinkedInAccountId.set(accounts[0].accountId);
+          if (accounts.length > 0 && !this.selectedLinkedInAccountKey()) {
+            this.selectedLinkedInAccountKey.set(accounts[0].key);
             if (this.selectedPlatform() === 'linkedin') {
               this.fetchLinkedInData();
             }
@@ -200,8 +200,8 @@ export class MonitoringTabComponent implements OnInit {
     }
   }
 
-  protected setLinkedInAccount(accountId: string): void {
-    this.selectedLinkedInAccountId.set(accountId);
+  protected setLinkedInAccount(key: string): void {
+    this.selectedLinkedInAccountKey.set(key);
     this.fetchLinkedInData();
   }
 
@@ -210,13 +210,13 @@ export class MonitoringTabComponent implements OnInit {
   }
 
   protected fetchLinkedInData(): void {
-    const accountId = this.selectedLinkedInAccountId();
-    if (!accountId) return;
+    const accountKey = this.selectedLinkedInAccountKey();
+    if (!accountKey) return;
     this.linkedInSub?.unsubscribe();
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
     this.linkedInSub = this.campaignService
-      .getLinkedInMonitorData(accountId, this.selectedDays())
+      .getLinkedInMonitorData(accountKey, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -229,7 +229,7 @@ export class MonitoringTabComponent implements OnInit {
   }
 
   protected formatLinkedInPct(n: number): string {
-    return `${(n * 100).toFixed(2)}%`;
+    return `${n.toFixed(2)}%`;
   }
 
   protected eventLabel(campaignName: string): string {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -37,6 +37,7 @@ export class MonitoringTabComponent implements OnInit {
   private monitorSub: Subscription | null = null;
   private keywordsSub: Subscription | null = null;
   private linkedInSub: Subscription | null = null;
+  private readonly currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
 
   protected readonly Math = Math;
   protected readonly dateRangeOptions: DateRangeOption[] = [7, 14, 30];
@@ -238,7 +239,7 @@ export class MonitoringTabComponent implements OnInit {
   }
 
   protected formatLinkedInCurrency(n: number): string {
-    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+    return this.currencyFormatter.format(n);
   }
 
   protected formatLinkedInPct(n: number): string {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -36,6 +36,7 @@ export class MonitoringTabComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private monitorSub: Subscription | null = null;
   private keywordsSub: Subscription | null = null;
+  private linkedInSub: Subscription | null = null;
 
   protected readonly Math = Math;
   protected readonly dateRangeOptions: DateRangeOption[] = [7, 14, 30];
@@ -195,9 +196,10 @@ export class MonitoringTabComponent implements OnInit {
   protected fetchLinkedInData(): void {
     const accountId = this.selectedLinkedInAccountId();
     if (!accountId) return;
+    this.linkedInSub?.unsubscribe();
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
-    this.campaignService
+    this.linkedInSub = this.campaignService
       .getLinkedInMonitorData(accountId, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -103,6 +103,9 @@ export class MonitoringTabComponent implements OnInit {
           this.linkedInAccountOptions.set(accounts);
           if (accounts.length > 0 && !this.selectedLinkedInAccountId()) {
             this.selectedLinkedInAccountId.set(accounts[0].accountId);
+            if (this.selectedPlatform() === 'linkedin') {
+              this.fetchLinkedInData();
+            }
           }
         },
         error: (err: unknown) => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/monitoring-tab/monitoring-tab.component.ts
@@ -8,7 +8,14 @@ import type { Subscription } from 'rxjs';
 import { CAMPAIGN_PACING_THRESHOLDS, parseCampaignName } from '@lfx-one/shared/constants';
 import { CampaignService } from '@services/campaign.service';
 
-import type { CampaignMetrics, CampaignMonitorResponse, KeywordMetrics, KeywordMetricsResponse, LinkedInMonitorResponse } from '@lfx-one/shared/interfaces';
+import type {
+  CampaignMetrics,
+  CampaignMonitorResponse,
+  KeywordMetrics,
+  KeywordMetricsResponse,
+  LinkedInAccountOption,
+  LinkedInMonitorResponse,
+} from '@lfx-one/shared/interfaces';
 
 import { AudienceDemographicsComponent } from '../audience-demographics/audience-demographics.component';
 
@@ -16,17 +23,6 @@ type DateRangeOption = 7 | 14 | 30;
 type PlatformType = 'google' | 'linkedin';
 
 const KEYWORD_PAGE_SIZE = 10;
-
-const LINKEDIN_ACCOUNT_OPTIONS = [
-  { accountId: '509430019', label: 'LF Events' },
-  { accountId: '538170226', label: 'The Linux Foundation' },
-  { accountId: '500928401', label: 'CNCF' },
-  { accountId: '508209098', label: 'LF Education' },
-  { accountId: '537341179', label: 'Agentic AI Foundation' },
-  { accountId: '515244770', label: 'OpenJS Foundation' },
-  { accountId: '514596831', label: 'OpenSSF' },
-  { accountId: '514553720', label: 'OpenSearch Project' },
-] as const;
 
 @Component({
   selector: 'lfx-monitoring-tab',
@@ -53,8 +49,8 @@ export class MonitoringTabComponent implements OnInit {
 
   // Platform switcher
   protected readonly selectedPlatform = signal<PlatformType>('google');
-  protected readonly linkedInAccountOptions = LINKEDIN_ACCOUNT_OPTIONS;
-  protected readonly selectedLinkedInAccountId = signal<string>('509430019');
+  protected readonly linkedInAccountOptions = signal<LinkedInAccountOption[]>([]);
+  protected readonly selectedLinkedInAccountId = signal<string>('');
   protected readonly linkedInLoading = signal(false);
   protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
   protected readonly linkedInError = signal<string | null>(null);
@@ -95,11 +91,28 @@ export class MonitoringTabComponent implements OnInit {
 
   public ngOnInit(): void {
     this.fetchData();
+    this.campaignService
+      .getLinkedInAccounts()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (accounts) => {
+          this.linkedInAccountOptions.set(accounts);
+          if (accounts.length > 0 && !this.selectedLinkedInAccountId()) {
+            this.selectedLinkedInAccountId.set(accounts[0].accountId);
+          }
+        },
+        error: () => undefined,
+      });
   }
 
   protected setDateRange(days: DateRangeOption): void {
     this.selectedDays.set(days);
     this.fetchData();
+    if (this.selectedPlatform() === 'linkedin') {
+      this.fetchLinkedInData();
+    } else {
+      this.linkedInData.set(null);
+    }
   }
 
   protected refresh(): void {
@@ -169,7 +182,7 @@ export class MonitoringTabComponent implements OnInit {
 
   protected setPlatform(p: PlatformType): void {
     this.selectedPlatform.set(p);
-    if (p === 'linkedin' && !this.linkedInData()) {
+    if (p === 'linkedin') {
       this.fetchLinkedInData();
     }
   }
@@ -180,10 +193,12 @@ export class MonitoringTabComponent implements OnInit {
   }
 
   protected fetchLinkedInData(): void {
+    const accountId = this.selectedLinkedInAccountId();
+    if (!accountId) return;
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
     this.campaignService
-      .getLinkedInMonitorData(this.selectedLinkedInAccountId(), this.selectedDays())
+      .getLinkedInMonitorData(accountId, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -398,53 +398,55 @@
   }
 
   <!-- LinkedIn Optimization -->
-  <div class="mt-2 flex flex-col gap-3" data-testid="linkedin-optimization">
-    <div class="flex items-center justify-between">
-      <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-800">
-        <i class="fa-brands fa-linkedin text-[#0077B5]" aria-hidden="true"></i>
-        LinkedIn Optimization
-      </h3>
-      <select
-        [value]="selectedLinkedInAccountId()"
-        (change)="setLinkedInAccount($any($event.target).value)"
-        aria-label="LinkedIn ad account"
-        class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        data-testid="linkedin-account-select-opt">
-        @for (acct of linkedInAccountOptions(); track acct.accountId) {
-          <option [value]="acct.accountId">{{ acct.label }}</option>
-        }
-      </select>
-    </div>
+  @if (linkedInAccountOptions().length > 0) {
+    <div class="mt-2 flex flex-col gap-3" data-testid="linkedin-optimization">
+      <div class="flex items-center justify-between">
+        <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-800">
+          <i class="fa-brands fa-linkedin text-[#0077B5]" aria-hidden="true"></i>
+          LinkedIn Optimization
+        </h3>
+        <select
+          [value]="selectedLinkedInAccountId()"
+          (change)="onLinkedInAccountChange($event)"
+          aria-label="LinkedIn ad account"
+          class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          data-testid="linkedin-account-select-opt">
+          @for (acct of linkedInAccountOptions(); track acct.accountId) {
+            <option [value]="acct.accountId">{{ acct.label }}</option>
+          }
+        </select>
+      </div>
 
-    @if (linkedInLoading()) {
-      <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-500" data-testid="linkedin-opt-loading">
-        <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
-        Loading LinkedIn optimization data...
-      </div>
-    } @else if (linkedInError()) {
-      <div class="rounded-lg border border-dashed border-red-300 bg-red-50 p-4 text-xs text-red-600" data-testid="linkedin-opt-error">
-        {{ linkedInError() }}
-      </div>
-    } @else if (linkedInActionItems().length === 0) {
-      <div class="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6 text-center" data-testid="linkedin-opt-empty">
-        <i class="fa-light fa-circle-check mb-2 text-2xl text-green-400" aria-hidden="true"></i>
-        <p class="text-sm text-gray-500">No LinkedIn optimization actions needed.</p>
-      </div>
-    } @else {
-      <div class="flex flex-col gap-2" data-testid="linkedin-action-items">
-        @for (item of linkedInActionItems(); track item.campaignName + item.issue) {
-          <div class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3" data-testid="linkedin-action-item">
-            <span [class]="'mt-0.5 rounded-full px-2 py-0.5 text-xs font-semibold ' + linkedInPriorityClass(item.priority)">
-              {{ item.priority }}
-            </span>
-            <div class="min-w-0 flex-1">
-              <p class="truncate text-xs font-medium text-gray-800" [title]="item.campaignName">{{ item.campaignName }}</p>
-              <p class="text-xs text-gray-500">{{ item.issue }}</p>
-              <p class="mt-1 text-xs text-blue-600">→ {{ item.action }}</p>
+      @if (linkedInLoading()) {
+        <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-500" data-testid="linkedin-opt-loading">
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          Loading LinkedIn optimization data...
+        </div>
+      } @else if (linkedInError()) {
+        <div class="rounded-lg border border-dashed border-red-300 bg-red-50 p-4 text-xs text-red-600" data-testid="linkedin-opt-error">
+          {{ linkedInError() }}
+        </div>
+      } @else if (linkedInActionItems().length === 0) {
+        <div class="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6 text-center" data-testid="linkedin-opt-empty">
+          <i class="fa-light fa-circle-check mb-2 text-2xl text-green-400" aria-hidden="true"></i>
+          <p class="text-sm text-gray-500">No LinkedIn optimization actions needed.</p>
+        </div>
+      } @else {
+        <div class="flex flex-col gap-2" data-testid="linkedin-action-items">
+          @for (item of linkedInActionItems(); track item.campaignName + item.issue) {
+            <div class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3" data-testid="linkedin-action-item">
+              <span [class]="'mt-0.5 rounded-full px-2 py-0.5 text-xs font-semibold ' + linkedInPriorityClass(item.priority)">
+                {{ item.priority }}
+              </span>
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-xs font-medium text-gray-800" [title]="item.campaignName">{{ item.campaignName }}</p>
+                <p class="text-xs text-gray-500">{{ item.issue }}</p>
+                <p class="mt-1 text-xs text-blue-600">→ {{ item.action }}</p>
+              </div>
             </div>
-          </div>
-        }
-      </div>
-    }
-  </div>
+          }
+        </div>
+      }
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -409,7 +409,7 @@
         (change)="setLinkedInAccount($any($event.target).value)"
         class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
         data-testid="linkedin-account-select-opt">
-        @for (acct of linkedInAccountOptions; track acct.accountId) {
+        @for (acct of linkedInAccountOptions(); track acct.accountId) {
           <option [value]="acct.accountId">{{ acct.label }}</option>
         }
       </select>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -396,4 +396,54 @@
       </div>
     }
   }
+
+  <!-- LinkedIn Optimization -->
+  <div class="mt-2 flex flex-col gap-3" data-testid="linkedin-optimization">
+    <div class="flex items-center justify-between">
+      <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <i class="fa-brands fa-linkedin text-[#0077B5]" aria-hidden="true"></i>
+        LinkedIn Optimization
+      </h3>
+      <select
+        [value]="selectedLinkedInAccountId()"
+        (change)="setLinkedInAccount($any($event.target).value)"
+        class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        data-testid="linkedin-account-select-opt">
+        @for (acct of linkedInAccountOptions; track acct.accountId) {
+          <option [value]="acct.accountId">{{ acct.label }}</option>
+        }
+      </select>
+    </div>
+
+    @if (linkedInLoading()) {
+      <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-500" data-testid="linkedin-opt-loading">
+        <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+        Loading LinkedIn optimization data...
+      </div>
+    } @else if (linkedInError()) {
+      <div class="rounded-lg border border-dashed border-red-300 bg-red-50 p-4 text-xs text-red-600" data-testid="linkedin-opt-error">
+        {{ linkedInError() }}
+      </div>
+    } @else if (linkedInActionItems().length === 0) {
+      <div class="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6 text-center" data-testid="linkedin-opt-empty">
+        <i class="fa-light fa-circle-check mb-2 text-2xl text-green-400" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">No LinkedIn optimization actions needed.</p>
+      </div>
+    } @else {
+      <div class="flex flex-col gap-2" data-testid="linkedin-action-items">
+        @for (item of linkedInActionItems(); track item.campaignName + item.issue) {
+          <div class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3" data-testid="linkedin-action-item">
+            <span [class]="'mt-0.5 rounded-full px-2 py-0.5 text-xs font-semibold ' + linkedInPriorityClass(item.priority)">
+              {{ item.priority }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-xs font-medium text-gray-800" [title]="item.campaignName">{{ item.campaignName }}</p>
+              <p class="text-xs text-gray-500">{{ item.issue }}</p>
+              <p class="mt-1 text-xs text-blue-600">→ {{ item.action }}</p>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -407,6 +407,7 @@
       <select
         [value]="selectedLinkedInAccountId()"
         (change)="setLinkedInAccount($any($event.target).value)"
+        aria-label="LinkedIn ad account"
         class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
         data-testid="linkedin-account-select-opt">
         @for (acct of linkedInAccountOptions(); track acct.accountId) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.html
@@ -406,13 +406,13 @@
           LinkedIn Optimization
         </h3>
         <select
-          [value]="selectedLinkedInAccountId()"
+          [value]="selectedLinkedInAccountKey()"
           (change)="onLinkedInAccountChange($event)"
           aria-label="LinkedIn ad account"
           class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           data-testid="linkedin-account-select-opt">
-          @for (acct of linkedInAccountOptions(); track acct.accountId) {
-            <option [value]="acct.accountId">{{ acct.label }}</option>
+          @for (acct of linkedInAccountOptions(); track acct.key) {
+            <option [value]="acct.key">{{ acct.label }}</option>
           }
         </select>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -96,7 +96,10 @@ export class OptimizationTabComponent implements OnInit {
             this.fetchLinkedInOptimization();
           }
         },
-        error: () => undefined,
+        error: (err: unknown) => {
+          const httpErr = err as { error?: { message?: string }; message?: string };
+          this.linkedInError.set(httpErr?.error?.message || httpErr?.message || 'Failed to load LinkedIn accounts');
+        },
       });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -186,7 +186,7 @@ export class OptimizationTabComponent implements OnInit {
 
   protected linkedInPriorityClass(p: LinkedInActionItem['priority']): string {
     if (p === 'HIGH') return 'bg-red-100 text-red-700';
-    if (p === 'MEDIUM') return 'bg-amber-100 text-amber-700';
+    if (p === 'MED') return 'bg-amber-100 text-amber-700';
     return 'bg-blue-100 text-blue-700';
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -74,7 +74,7 @@ export class OptimizationTabComponent implements OnInit {
 
   // LinkedIn optimization
   protected readonly linkedInAccountOptions = signal<LinkedInAccountOption[]>([]);
-  protected readonly selectedLinkedInAccountId = signal<string>('');
+  protected readonly selectedLinkedInAccountKey = signal<string>('');
   protected readonly linkedInLoading = signal(false);
   protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
   protected readonly linkedInError = signal<string | null>(null);
@@ -92,7 +92,7 @@ export class OptimizationTabComponent implements OnInit {
         next: (accounts) => {
           this.linkedInAccountOptions.set(accounts);
           if (accounts.length > 0) {
-            this.selectedLinkedInAccountId.set(accounts[0].accountId);
+            this.selectedLinkedInAccountKey.set(accounts[0].key);
             this.fetchLinkedInOptimization();
           }
         },
@@ -153,8 +153,8 @@ export class OptimizationTabComponent implements OnInit {
       });
   }
 
-  protected setLinkedInAccount(accountId: string): void {
-    this.selectedLinkedInAccountId.set(accountId);
+  protected setLinkedInAccount(key: string): void {
+    this.selectedLinkedInAccountKey.set(key);
     this.fetchLinkedInOptimization();
   }
 
@@ -163,13 +163,13 @@ export class OptimizationTabComponent implements OnInit {
   }
 
   protected fetchLinkedInOptimization(): void {
-    const accountId = this.selectedLinkedInAccountId();
-    if (!accountId) return;
+    const accountKey = this.selectedLinkedInAccountKey();
+    if (!accountKey) return;
     this.linkedInSub?.unsubscribe();
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
     this.linkedInSub = this.campaignService
-      .getLinkedInMonitorData(accountId, this.selectedDays())
+      .getLinkedInMonitorData(accountKey, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -29,6 +29,7 @@ export class OptimizationTabComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private monitorSub: Subscription | null = null;
   private keywordsSub: Subscription | null = null;
+  private linkedInSub: Subscription | null = null;
 
   protected readonly dateRangeOptions: DateRangeOption[] = [7, 14, 30];
 
@@ -107,6 +108,7 @@ export class OptimizationTabComponent implements OnInit {
 
   protected refresh(): void {
     this.fetchData();
+    this.fetchLinkedInOptimization();
   }
 
   protected fetchData(): void {
@@ -156,9 +158,10 @@ export class OptimizationTabComponent implements OnInit {
   protected fetchLinkedInOptimization(): void {
     const accountId = this.selectedLinkedInAccountId();
     if (!accountId) return;
+    this.linkedInSub?.unsubscribe();
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
-    this.campaignService
+    this.linkedInSub = this.campaignService
       .getLinkedInMonitorData(accountId, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -180,7 +180,7 @@ export class OptimizationTabComponent implements OnInit {
       });
   }
 
-  protected linkedInPriorityClass(p: string): string {
+  protected linkedInPriorityClass(p: LinkedInActionItem['priority']): string {
     if (p === 'HIGH') return 'bg-red-100 text-red-700';
     if (p === 'MEDIUM') return 'bg-amber-100 text-amber-700';
     return 'bg-blue-100 text-blue-700';

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -158,6 +158,10 @@ export class OptimizationTabComponent implements OnInit {
     this.fetchLinkedInOptimization();
   }
 
+  protected onLinkedInAccountChange(event: Event): void {
+    this.setLinkedInAccount((event.target as HTMLSelectElement).value);
+  }
+
   protected fetchLinkedInOptimization(): void {
     const accountId = this.selectedLinkedInAccountId();
     if (!accountId) return;

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -10,6 +10,7 @@ import type {
   KeywordActionType,
   KeywordMetrics,
   KeywordMetricsResponse,
+  LinkedInAccountOption,
   LinkedInActionItem,
   LinkedInMonitorResponse,
 } from '@lfx-one/shared/interfaces';
@@ -71,17 +72,8 @@ export class OptimizationTabComponent implements OnInit {
   protected readonly hasDisplayCampaigns = computed(() => this.displayCampaigns().length > 0);
 
   // LinkedIn optimization
-  protected readonly linkedInAccountOptions = [
-    { accountId: '509430019', label: 'LF Events' },
-    { accountId: '538170226', label: 'The Linux Foundation' },
-    { accountId: '500928401', label: 'CNCF' },
-    { accountId: '508209098', label: 'LF Education' },
-    { accountId: '537341179', label: 'Agentic AI Foundation' },
-    { accountId: '515244770', label: 'OpenJS Foundation' },
-    { accountId: '514596831', label: 'OpenSSF' },
-    { accountId: '514553720', label: 'OpenSearch Project' },
-  ] as const;
-  protected readonly selectedLinkedInAccountId = signal<string>('509430019');
+  protected readonly linkedInAccountOptions = signal<LinkedInAccountOption[]>([]);
+  protected readonly selectedLinkedInAccountId = signal<string>('');
   protected readonly linkedInLoading = signal(false);
   protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
   protected readonly linkedInError = signal<string | null>(null);
@@ -92,12 +84,25 @@ export class OptimizationTabComponent implements OnInit {
 
   public ngOnInit(): void {
     this.fetchData();
-    this.fetchLinkedInOptimization();
+    this.campaignService
+      .getLinkedInAccounts()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (accounts) => {
+          this.linkedInAccountOptions.set(accounts);
+          if (accounts.length > 0) {
+            this.selectedLinkedInAccountId.set(accounts[0].accountId);
+            this.fetchLinkedInOptimization();
+          }
+        },
+        error: () => undefined,
+      });
   }
 
   protected setDateRange(days: DateRangeOption): void {
     this.selectedDays.set(days);
     this.fetchData();
+    this.fetchLinkedInOptimization();
   }
 
   protected refresh(): void {
@@ -149,10 +154,12 @@ export class OptimizationTabComponent implements OnInit {
   }
 
   protected fetchLinkedInOptimization(): void {
+    const accountId = this.selectedLinkedInAccountId();
+    if (!accountId) return;
     this.linkedInLoading.set(true);
     this.linkedInError.set(null);
     this.campaignService
-      .getLinkedInMonitorData(this.selectedLinkedInAccountId(), this.selectedDays())
+      .getLinkedInMonitorData(accountId, this.selectedDays())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/optimization-tab/optimization-tab.component.ts
@@ -4,7 +4,15 @@
 import { DecimalPipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import type { CampaignMonitorResponse, DateRangeOption, KeywordActionType, KeywordMetrics, KeywordMetricsResponse } from '@lfx-one/shared/interfaces';
+import type {
+  CampaignMonitorResponse,
+  DateRangeOption,
+  KeywordActionType,
+  KeywordMetrics,
+  KeywordMetricsResponse,
+  LinkedInActionItem,
+  LinkedInMonitorResponse,
+} from '@lfx-one/shared/interfaces';
 import { AdsCurrencyPipe, AdsPctPipe, EventLabelPipe, PacingClassPipe, PriorityClassPipe, QualityScoreClassPipe } from '@pipes/campaign-optimization.pipe';
 import { CampaignService } from '@services/campaign.service';
 import type { Subscription } from 'rxjs';
@@ -62,11 +70,29 @@ export class OptimizationTabComponent implements OnInit {
   protected readonly hasLowQualityKeywords = computed(() => this.lowQualityKeywords().length > 0);
   protected readonly hasDisplayCampaigns = computed(() => this.displayCampaigns().length > 0);
 
+  // LinkedIn optimization
+  protected readonly linkedInAccountOptions = [
+    { accountId: '509430019', label: 'LF Events' },
+    { accountId: '538170226', label: 'The Linux Foundation' },
+    { accountId: '500928401', label: 'CNCF' },
+    { accountId: '508209098', label: 'LF Education' },
+    { accountId: '537341179', label: 'Agentic AI Foundation' },
+    { accountId: '515244770', label: 'OpenJS Foundation' },
+    { accountId: '514596831', label: 'OpenSSF' },
+    { accountId: '514553720', label: 'OpenSearch Project' },
+  ] as const;
+  protected readonly selectedLinkedInAccountId = signal<string>('509430019');
+  protected readonly linkedInLoading = signal(false);
+  protected readonly linkedInData = signal<LinkedInMonitorResponse | null>(null);
+  protected readonly linkedInError = signal<string | null>(null);
+  protected readonly linkedInActionItems = computed<LinkedInActionItem[]>(() => this.linkedInData()?.actionItems ?? []);
+
   protected readonly actionInProgress = signal<Record<string, boolean>>({});
   protected readonly actionResults = signal<Record<string, { success: boolean; message: string }>>({});
 
   public ngOnInit(): void {
     this.fetchData();
+    this.fetchLinkedInOptimization();
   }
 
   protected setDateRange(days: DateRangeOption): void {
@@ -115,6 +141,36 @@ export class OptimizationTabComponent implements OnInit {
           this.keywordsLoading.set(false);
         },
       });
+  }
+
+  protected setLinkedInAccount(accountId: string): void {
+    this.selectedLinkedInAccountId.set(accountId);
+    this.fetchLinkedInOptimization();
+  }
+
+  protected fetchLinkedInOptimization(): void {
+    this.linkedInLoading.set(true);
+    this.linkedInError.set(null);
+    this.campaignService
+      .getLinkedInMonitorData(this.selectedLinkedInAccountId(), this.selectedDays())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.linkedInData.set(data);
+          this.linkedInLoading.set(false);
+        },
+        error: (err: unknown) => {
+          const httpErr = err as { error?: { message?: string }; message?: string };
+          this.linkedInError.set(httpErr?.error?.message || httpErr?.message || 'Failed to load LinkedIn data');
+          this.linkedInLoading.set(false);
+        },
+      });
+  }
+
+  protected linkedInPriorityClass(p: string): string {
+    if (p === 'HIGH') return 'bg-red-100 text-red-700';
+    if (p === 'MEDIUM') return 'bg-amber-100 text-amber-700';
+    return 'bg-blue-100 text-blue-700';
   }
 
   protected executeKeywordAction(kw: KeywordMetrics, action: KeywordActionType): void {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -73,8 +73,8 @@ export class CampaignService {
     return this.http.get<LinkedInAccountOption[]>('/api/campaigns/linkedin/accounts');
   }
 
-  public getLinkedInMonitorData(accountId: string, days: number = 30): Observable<LinkedInMonitorResponse> {
-    return this.http.get<LinkedInMonitorResponse>('/api/campaigns/linkedin/monitor', { params: { days, accountId } });
+  public getLinkedInMonitorData(accountKey: string, days: number = 30): Observable<LinkedInMonitorResponse> {
+    return this.http.get<LinkedInMonitorResponse>('/api/campaigns/linkedin/monitor', { params: { days, accountKey } });
   }
 
   public getKeywords(days: number = 30): Observable<KeywordMetricsResponse> {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -18,6 +18,7 @@ import {
   HubSpotUtmCreateResult,
   HubSpotUtmLookupResult,
   KeywordMetricsResponse,
+  LinkedInAccountOption,
   LinkedInMonitorResponse,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
@@ -66,6 +67,10 @@ export class CampaignService {
 
   public getMonitorData(days: number = 30): Observable<CampaignMonitorResponse> {
     return this.http.get<CampaignMonitorResponse>('/api/campaigns/monitor', { params: { days } });
+  }
+
+  public getLinkedInAccounts(): Observable<LinkedInAccountOption[]> {
+    return this.http.get<LinkedInAccountOption[]>('/api/campaigns/linkedin/accounts');
   }
 
   public getLinkedInMonitorData(accountId: string, days: number = 30): Observable<LinkedInMonitorResponse> {

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -18,6 +18,7 @@ import {
   HubSpotUtmCreateResult,
   HubSpotUtmLookupResult,
   KeywordMetricsResponse,
+  LinkedInMonitorResponse,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
 import { exhaustMap, last, map, Observable, of, take, takeWhile, timer } from 'rxjs';
@@ -65,6 +66,10 @@ export class CampaignService {
 
   public getMonitorData(days: number = 30): Observable<CampaignMonitorResponse> {
     return this.http.get<CampaignMonitorResponse>('/api/campaigns/monitor', { params: { days } });
+  }
+
+  public getLinkedInMonitorData(accountId: string, days: number = 30): Observable<LinkedInMonitorResponse> {
+    return this.http.get<LinkedInMonitorResponse>('/api/campaigns/linkedin/monitor', { params: { days, accountId } });
   }
 
   public getKeywords(days: number = 30): Observable<KeywordMetricsResponse> {

--- a/apps/lfx-one/src/server/constants/linkedin.constants.ts
+++ b/apps/lfx-one/src/server/constants/linkedin.constants.ts
@@ -16,6 +16,8 @@ export const LINKEDIN_ACCOUNTS: readonly { accountId: string; label: string; org
   { accountId: '509430019', label: 'LF Events', orgId: '208777' },
 ] as const;
 
+export const LINKEDIN_REQUEST_TIMEOUT_MS = 30_000;
+
 export const LINKEDIN_EMPLOYER_EXCLUSIONS: readonly string[] = ['urn:li:company:33275771', 'urn:li:company:12893459'] as const;
 
 export const LINKEDIN_TARGETING_PROFILES: readonly LinkedInTargetingProfileConfig[] = [

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -313,17 +313,17 @@ export class CampaignController {
   }
 
   public getLinkedInAccounts(_req: Request, res: Response): void {
-    const accounts = LINKEDIN_ACCOUNTS.map((a) => ({ accountId: a.accountId, label: a.label }));
+    const accounts = LINKEDIN_ACCOUNTS.map((a, i) => ({ key: String(i), label: a.label }));
     res.json(accounts);
   }
 
   public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
     const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
-    const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? LINKEDIN_ACCOUNTS[0]?.accountId ?? '');
-    const validAccount = LINKEDIN_ACCOUNTS.find((a) => a.accountId === rawAccountId);
-    if (!validAccount) {
+    const rawKey = String(req.query['accountKey'] ?? '0');
+    const keyIndex = parseInt(rawKey, 10);
+    if (isNaN(keyIndex) || keyIndex < 0 || keyIndex >= LINKEDIN_ACCOUNTS.length) {
       next(
-        ServiceValidationError.forField('accountId', 'Invalid LinkedIn account ID', {
+        ServiceValidationError.forField('accountKey', 'Invalid LinkedIn account key', {
           operation: 'linkedin_monitor',
           service: 'campaign_controller',
           path: req.path,
@@ -331,15 +331,15 @@ export class CampaignController {
       );
       return;
     }
-    const accountId = validAccount.accountId;
-    const startTime = logger.startOperation(req, 'linkedin_monitor', { days, accountId });
+    const accountId = LINKEDIN_ACCOUNTS[keyIndex].accountId;
+    const startTime = logger.startOperation(req, 'linkedin_monitor', { days, accountKey: rawKey });
 
     try {
       const data = await this.linkedInMetricsService.getLinkedInMonitorData(req, accountId, days);
       logger.success(req, 'linkedin_monitor', startTime, { campaigns: data.campaigns.length });
       res.json(data);
     } catch (error) {
-      logger.error(req, 'linkedin_monitor', startTime, error, { days, accountId });
+      logger.error(req, 'linkedin_monitor', startTime, error, { days, accountKey: rawKey });
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -318,10 +318,12 @@ export class CampaignController {
   }
 
   public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
+    const rawDays = String(req.query['days'] ?? '30');
+    const parsedDays = /^\d+$/.test(rawDays) ? Number(rawDays) : NaN;
+    const days = Number.isFinite(parsedDays) ? Math.min(Math.max(parsedDays, 7), 90) : 30;
     const rawKey = String(req.query['accountKey'] ?? '0');
-    const keyIndex = parseInt(rawKey, 10);
-    if (isNaN(keyIndex) || keyIndex < 0 || keyIndex >= LINKEDIN_ACCOUNTS.length) {
+    const keyIndex = /^\d+$/.test(rawKey) ? Number(rawKey) : NaN;
+    if (!Number.isFinite(keyIndex) || keyIndex < 0 || keyIndex >= LINKEDIN_ACCOUNTS.length) {
       next(
         ServiceValidationError.forField('accountKey', 'Invalid LinkedIn account key', {
           operation: 'linkedin_monitor',

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -313,7 +313,7 @@ export class CampaignController {
   }
 
   public getLinkedInAccounts(_req: Request, res: Response): void {
-    const accounts = LINKEDIN_ACCOUNTS.map((a, i) => ({ key: String(i), label: a.label }));
+    const accounts = LINKEDIN_ACCOUNTS.map((a) => ({ key: a.accountId, label: a.label }));
     res.json(accounts);
   }
 
@@ -321,9 +321,9 @@ export class CampaignController {
     const rawDays = String(req.query['days'] ?? '30');
     const parsedDays = /^\d+$/.test(rawDays) ? Number(rawDays) : NaN;
     const days = Number.isFinite(parsedDays) ? Math.min(Math.max(parsedDays, 7), 90) : 30;
-    const rawKey = String(req.query['accountKey'] ?? '0');
-    const keyIndex = /^\d+$/.test(rawKey) ? Number(rawKey) : NaN;
-    if (!Number.isFinite(keyIndex) || keyIndex < 0 || keyIndex >= LINKEDIN_ACCOUNTS.length) {
+    const rawKey = String(req.query['accountKey'] ?? '');
+    const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === rawKey) ?? LINKEDIN_ACCOUNTS[0];
+    if (!account) {
       next(
         ServiceValidationError.forField('accountKey', 'Invalid LinkedIn account key', {
           operation: 'linkedin_monitor',
@@ -333,7 +333,7 @@ export class CampaignController {
       );
       return;
     }
-    const accountId = LINKEDIN_ACCOUNTS[keyIndex].accountId;
+    const accountId = account.accountId;
     const startTime = logger.startOperation(req, 'linkedin_monitor', { days, accountKey: rawKey });
 
     try {

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -319,7 +319,7 @@ export class CampaignController {
 
   public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
     const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
-    const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');
+    const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? LINKEDIN_ACCOUNTS[0]?.accountId ?? '');
     const validAccount = LINKEDIN_ACCOUNTS.find((a) => a.accountId === rawAccountId);
     if (!validAccount) {
       next(

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -322,7 +322,13 @@ export class CampaignController {
     const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');
     const validAccount = LINKEDIN_ACCOUNTS.find((a) => a.accountId === rawAccountId);
     if (!validAccount) {
-      res.status(400).json({ error: 'Invalid LinkedIn account ID' });
+      next(
+        ServiceValidationError.forField('accountId', 'Invalid LinkedIn account ID', {
+          operation: 'linkedin_monitor',
+          service: 'campaign_controller',
+          path: req.path,
+        })
+      );
       return;
     }
     const accountId = validAccount.accountId;

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -12,7 +12,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 
 import { ServiceValidationError } from '../errors';
-import { CampaignMetricsService } from '../services/campaign-metrics.service';
+import { CampaignMetricsService, LinkedInMetricsService } from '../services/campaign-metrics.service';
 import { validateScrapeUrl } from '../helpers/url-validation';
 import { CampaignProxyService } from '../services/campaign-proxy.service';
 import { logger } from '../services/logger.service';
@@ -21,6 +21,7 @@ import { addShutdownHook, isShuttingDown } from '../utils/shutdown';
 export class CampaignController {
   private readonly proxyService = new CampaignProxyService();
   private readonly metricsService = new CampaignMetricsService();
+  private readonly linkedInMetricsService = new LinkedInMetricsService();
   private readonly activeStreams = new Set<Response>();
 
   public constructor() {
@@ -306,6 +307,21 @@ export class CampaignController {
       logger.success(req, 'hubspot_utm_create', startTime, { created: result.created });
       res.json(result);
     } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
+    const accountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');
+    const startTime = logger.startOperation(req, 'linkedin_monitor', { days, accountId });
+
+    try {
+      const data = await this.linkedInMetricsService.getLinkedInMonitorData(req, accountId, days);
+      logger.success(req, 'linkedin_monitor', startTime, { campaigns: data.campaigns.length });
+      res.json(data);
+    } catch (error) {
+      logger.error(req, 'linkedin_monitor', startTime, error, { days, accountId });
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -312,6 +312,11 @@ export class CampaignController {
     }
   }
 
+  public getLinkedInAccounts(_req: Request, res: Response): void {
+    const accounts = LINKEDIN_ACCOUNTS.map((a) => ({ accountId: a.accountId, label: a.label }));
+    res.json(accounts);
+  }
+
   public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
     const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
     const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -11,6 +11,7 @@ import type {
   FlushableResponse,
 } from '@lfx-one/shared/interfaces';
 
+import { LINKEDIN_ACCOUNTS } from '../constants';
 import { ServiceValidationError } from '../errors';
 import { CampaignMetricsService, LinkedInMetricsService } from '../services/campaign-metrics.service';
 import { validateScrapeUrl } from '../helpers/url-validation';
@@ -313,7 +314,13 @@ export class CampaignController {
 
   public async getLinkedInMonitor(req: Request, res: Response, next: NextFunction): Promise<void> {
     const days = Math.min(Math.max(parseInt(String(req.query['days'] ?? '30'), 10) || 30, 7), 90);
-    const accountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');
+    const rawAccountId = String(req.query['accountId'] ?? process.env['LINKEDIN_AD_ACCOUNT_ID'] ?? '509430019');
+    const validAccount = LINKEDIN_ACCOUNTS.find((a) => a.accountId === rawAccountId);
+    if (!validAccount) {
+      res.status(400).json({ error: 'Invalid LinkedIn account ID' });
+      return;
+    }
+    const accountId = validAccount.accountId;
     const startTime = logger.startOperation(req, 'linkedin_monitor', { days, accountId });
 
     try {

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -15,6 +15,7 @@ router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(r
 router.get('/hubspot/utm', (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));
 router.post('/hubspot/utm/create', (req, res, next) => campaignController.createHubSpotUtm(req, res, next));
 router.get('/monitor', (req, res, next) => campaignController.getMonitorData(req, res, next));
+router.get('/linkedin/monitor', (req, res, next) => campaignController.getLinkedInMonitor(req, res, next));
 router.get('/keywords', (req, res, next) => campaignController.getKeywords(req, res, next));
 router.get('/audience', (req, res, next) => campaignController.getAudience(req, res, next));
 router.post('/keywords/actions', (req, res, next) => campaignController.executeKeywordActions(req, res, next));

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -15,6 +15,7 @@ router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(r
 router.get('/hubspot/utm', (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));
 router.post('/hubspot/utm/create', (req, res, next) => campaignController.createHubSpotUtm(req, res, next));
 router.get('/monitor', (req, res, next) => campaignController.getMonitorData(req, res, next));
+router.get('/linkedin/accounts', (req, res) => campaignController.getLinkedInAccounts(req, res));
 router.get('/linkedin/monitor', (req, res, next) => campaignController.getLinkedInMonitor(req, res, next));
 router.get('/keywords', (req, res, next) => campaignController.getKeywords(req, res, next));
 router.get('/audience', (req, res, next) => campaignController.getAudience(req, res, next));

--- a/apps/lfx-one/src/server/services/campaign-metrics.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-metrics.service.ts
@@ -10,11 +10,13 @@ import type {
   CampaignMonitorResponse,
   KeywordMetrics,
   KeywordMetricsResponse,
+  LinkedInMonitorResponse,
   PacingLabel,
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
 import { gaqlSearch } from './campaign-proxy.service';
+import { getLinkedInAnalytics } from './linkedin-ads.service';
 import { logger } from './logger.service';
 
 // ---------------------------------------------------------------------------
@@ -397,4 +399,15 @@ function aggregateDemoBuckets(rows: unknown[], labelExtractor: (row: Record<stri
   }
 
   return [...buckets.values()];
+}
+
+// ---------------------------------------------------------------------------
+// CampaignMetricsService — LinkedIn analytics
+// ---------------------------------------------------------------------------
+
+export class LinkedInMetricsService {
+  public async getLinkedInMonitorData(req: Request, accountId: string, days: number): Promise<LinkedInMonitorResponse> {
+    logger.debug(req, 'linkedin_monitor', 'Fetching LinkedIn campaign analytics', { accountId, days });
+    return getLinkedInAnalytics(req, accountId, days);
+  }
 }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -548,7 +548,6 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
   if (campaigns.length === 0) {
     const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
     const result: LinkedInMonitorResponse = {
-      accountId,
       accountLabel: account?.label ?? accountId,
       pulledAt: new Date().toISOString(),
       dateRange: { mode: `last_${days}_days` },
@@ -744,7 +743,7 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
     }
     if (c.pacingLabel === 'constrained' || c.pacingLabel === 'overspending') {
       actionItems.push({
-        priority: 'MEDIUM',
+        priority: 'MED',
         campaignName: c.campaignName,
         issue: 'Budget constrained — pacing above 90%',
         action: 'Consider increasing budget if event is in peak registration period',
@@ -752,7 +751,7 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
     }
     if (c.ctr > 0 && c.ctr < 0.3) {
       actionItems.push({
-        priority: 'MEDIUM',
+        priority: 'MED',
         campaignName: c.campaignName,
         issue: `Low CTR: ${c.ctr.toFixed(2)}%`,
         action: 'Refresh ad copy or images; review audience targeting',
@@ -760,7 +759,7 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
     }
     if (c.clicks > 50 && c.conversions === 0) {
       actionItems.push({
-        priority: 'MEDIUM',
+        priority: 'MED',
         campaignName: c.campaignName,
         issue: 'Clicks without conversions',
         action: 'Audit LinkedIn Insight Tag on registration landing page',
@@ -791,7 +790,6 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
 
   const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
   const result: LinkedInMonitorResponse = {
-    accountId,
     accountLabel: account?.label ?? accountId,
     pulledAt: new Date().toISOString(),
     dateRange: { mode: `last_${days}_days` },

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -508,7 +508,7 @@ export async function getLinkedInAnalytics(
   };
 
   // --- Fetch campaign list for this account ---
-  const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE)))&count=50`;
+  const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,PAUSED)))&count=100`;
   const campaignsResp = await fetch(campaignsUrl, {
     headers: baseHeaders,
     signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -509,7 +509,7 @@ interface LinkedInCampaignElement {
 
 export async function getLinkedInAnalytics(req: Request | undefined, accountId: string, days: number): Promise<LinkedInMonitorResponse> {
   const startTime = logger.startOperation(req, 'linkedin_analytics', { accountId, days });
-  const token = getLinkedInEnv('LINKEDIN_ACCESS_TOKEN');
+  const token = getAccessToken();
   const version = LINKEDIN_API_VERSION;
 
   const { start, end } = dateRangeParams(days);

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -507,29 +507,36 @@ export async function getLinkedInAnalytics(
     'X-RestLi-Protocol-Version': '2.0.0',
   };
 
-  // --- Fetch campaign list for this account ---
-  const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,PAUSED)))&count=100`;
-  const campaignsResp = await fetch(campaignsUrl, {
-    headers: baseHeaders,
-    signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
-  });
-  if (!campaignsResp.ok) {
-    const text = await campaignsResp.text().catch(() => '');
-    const err = new Error(`LinkedIn adCampaigns fetch failed: ${campaignsResp.status}: ${text.slice(0, 400)}`);
-    logger.error(req, 'linkedin_analytics', startTime, err, { accountId });
-    throw err;
+  // --- Fetch campaign list for this account (paginated) ---
+  interface CampaignElement {
+    id: number;
+    name: string;
+    status: string;
+    totalBudget?: { amount: string };
+    dailyBudget?: { amount: string };
+    runSchedule?: { start: number; end: number };
   }
-  const campaignsData = (await campaignsResp.json()) as {
-    elements?: {
-      id: number;
-      name: string;
-      status: string;
-      totalBudget?: { amount: string };
-      dailyBudget?: { amount: string };
-      runSchedule?: { start: number; end: number };
-    }[];
-  };
-  const campaigns = campaignsData.elements ?? [];
+  const campaigns: CampaignElement[] = [];
+  const pageSize = 100;
+  let campaignStart = 0;
+  while (true) {
+    const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,PAUSED)))&count=${pageSize}&start=${campaignStart}`;
+    const campaignsResp = await fetch(campaignsUrl, {
+      headers: baseHeaders,
+      signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
+    });
+    if (!campaignsResp.ok) {
+      const text = await campaignsResp.text().catch(() => '');
+      const err = new Error(`LinkedIn adCampaigns fetch failed: ${campaignsResp.status}: ${text.slice(0, 400)}`);
+      logger.error(req, 'linkedin_analytics', startTime, err, { accountId });
+      throw err;
+    }
+    const campaignsData = (await campaignsResp.json()) as { elements?: CampaignElement[] };
+    const page = campaignsData.elements ?? [];
+    campaigns.push(...page);
+    if (page.length < pageSize) break;
+    campaignStart += pageSize;
+  }
 
   if (campaigns.length === 0) {
     const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -560,14 +560,13 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
     return result;
   }
 
-  // --- Fetch analytics for all campaigns in one call ---
-  const campaignUrns = campaigns.map((c) => `urn:li:sponsoredCampaign:${c.id}`).join(',');
+  // --- Fetch analytics for all campaigns via account-level filter ---
   const analyticsParams = new URLSearchParams({
     q: 'analytics',
     pivot: 'CAMPAIGN',
     dateRange: `(start:(year:${startParts.year},month:${startParts.month},day:${startParts.day}),end:(year:${endParts.year},month:${endParts.month},day:${endParts.day}))`,
     timeGranularity: 'ALL',
-    campaigns: `List(${campaignUrns})`,
+    accounts: `List(urn:li:sponsoredAccount:${accountId})`,
     fields: 'impressions,clicks,costInLocalCurrency,externalWebsiteConversions,pivot,pivotValue',
   });
 
@@ -603,10 +602,12 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
     }
   }
 
-  // --- Fetch creative metrics per campaign (parallel) ---
+  // --- Fetch creative metrics per campaign (batched, max 5 concurrent) ---
+  const CREATIVE_BATCH_SIZE = 5;
   const creativeAnalyticsMap = new Map<string, LinkedInCreativeMetrics[]>();
   const creativeFetchFailed = new Set<string>();
-  const creativeFetches = campaigns.map(async (camp) => {
+
+  const fetchCreativeForCampaign = async (camp: (typeof campaigns)[number]): Promise<void> => {
     const creativeParams = new URLSearchParams({
       q: 'analytics',
       pivot: 'CREATIVE',
@@ -655,8 +656,12 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
       });
       creativeFetchFailed.add(String(camp.id));
     }
-  });
-  await Promise.allSettled(creativeFetches);
+  };
+
+  for (let i = 0; i < campaigns.length; i += CREATIVE_BATCH_SIZE) {
+    const batch = campaigns.slice(i, i + CREATIVE_BATCH_SIZE);
+    await Promise.allSettled(batch.map((camp) => fetchCreativeForCampaign(camp)));
+  }
 
   // --- Build campaign metrics ---
   const campaignMetrics: LinkedInCampaignMetrics[] = campaigns.map((camp) => {

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -624,7 +624,7 @@ export async function getLinkedInAnalytics(
             creativeName: `Creative ${creativeId}`,
             impressions,
             clicks,
-            ctr: impressions > 0 ? clicks / impressions : 0,
+            ctr: impressions > 0 ? (clicks / impressions) * 100 : 0,
             spend: parseFloat(el.costInLocalCurrency ?? '0'),
             conversions: el.externalWebsiteConversions ?? 0,
             status: 'ACTIVE',
@@ -646,13 +646,18 @@ export async function getLinkedInAnalytics(
     } else if (dailyBudget > 0) {
       pacingPct = (analytics.spend / (dailyBudget * days)) * 100;
     }
-    let pacingLabel: import('@lfx-one/shared/interfaces').LinkedInPacingLabel = 'overspending';
-    if (pacingPct < 40) {
-      pacingLabel = 'underspending';
-    } else if (pacingPct < 90) {
-      pacingLabel = 'normal';
-    } else if (pacingPct < 105) {
-      pacingLabel = 'constrained';
+    const hasBudget = totalBudget > 0 || dailyBudget > 0;
+    let pacingLabel: import('@lfx-one/shared/interfaces').LinkedInPacingLabel = 'normal';
+    if (hasBudget) {
+      if (pacingPct < 40) {
+        pacingLabel = 'underspending';
+      } else if (pacingPct < 90) {
+        pacingLabel = 'normal';
+      } else if (pacingPct < 105) {
+        pacingLabel = 'constrained';
+      } else {
+        pacingLabel = 'overspending';
+      }
     }
     const startMs = camp.runSchedule?.start ?? 0;
     const endMs = camp.runSchedule?.end ?? 0;
@@ -666,7 +671,7 @@ export async function getLinkedInAnalytics(
       spend: analytics.spend,
       impressions: analytics.impressions,
       clicks: analytics.clicks,
-      ctr: analytics.impressions > 0 ? analytics.clicks / analytics.impressions : 0,
+      ctr: analytics.impressions > 0 ? (analytics.clicks / analytics.impressions) * 100 : 0,
       conversions: analytics.conversions,
       pacingPct,
       pacingLabel,
@@ -702,11 +707,11 @@ export async function getLinkedInAnalytics(
         action: 'Consider increasing budget if event is in peak registration period',
       });
     }
-    if (c.ctr > 0 && c.ctr < 0.003) {
+    if (c.ctr > 0 && c.ctr < 0.3) {
       actionItems.push({
         priority: 'MEDIUM',
         campaignName: c.campaignName,
-        issue: `Low CTR: ${(c.ctr * 100).toFixed(2)}%`,
+        issue: `Low CTR: ${c.ctr.toFixed(2)}%`,
         action: 'Refresh ad copy or images; review audience targeting',
       });
     }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -480,7 +480,7 @@ function toDateParts(iso: string): { year: number; month: number; day: number } 
 
 function dateRangeParams(days: number): { start: string; end: string } {
   const end = new Date();
-  const start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate() - days));
+  const start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate() - (days - 1)));
   const endUtc = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
   return {
     start: start.toISOString().split('T')[0],
@@ -596,10 +596,10 @@ export async function getLinkedInAnalytics(
     }
   }
 
-  // --- Fetch creative metrics per campaign ---
+  // --- Fetch creative metrics per campaign (parallel) ---
   const creativeAnalyticsMap = new Map<string, import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[]>();
   const creativeFetchFailed = new Set<string>();
-  for (const camp of campaigns) {
+  const creativeFetches = campaigns.map(async (camp) => {
     const creativeParams = new URLSearchParams({
       q: 'analytics',
       pivot: 'CREATIVE',
@@ -648,7 +648,8 @@ export async function getLinkedInAnalytics(
       });
       creativeFetchFailed.add(String(camp.id));
     }
-  }
+  });
+  await Promise.allSettled(creativeFetches);
 
   // --- Build campaign metrics ---
   const campaignMetrics: import('@lfx-one/shared/interfaces').LinkedInCampaignMetrics[] = campaigns.map((camp) => {
@@ -656,14 +657,21 @@ export async function getLinkedInAnalytics(
     const analytics = analyticsMap.get(urn) ?? { impressions: 0, clicks: 0, spend: 0, conversions: 0 };
     const totalBudget = parseFloat(camp.totalBudget?.amount ?? '0');
     const dailyBudget = parseFloat(camp.dailyBudget?.amount ?? '0');
+    const schedStart = camp.runSchedule?.start ?? 0;
+    const schedEnd = camp.runSchedule?.end ?? 0;
+    const now = Date.now();
+    const rangeStartMs = new Date(start).getTime();
     let pacingPct = 0;
     if (totalBudget > 0) {
-      pacingPct = (analytics.spend / totalBudget) * 100;
+      const flightStart = schedStart || rangeStartMs;
+      const flightEnd = schedEnd || now;
+      const totalFlightDays = Math.max(1, Math.ceil((flightEnd - flightStart) / 86_400_000));
+      const effectiveStart = Math.max(flightStart, rangeStartMs);
+      const effectiveEnd = Math.min(flightEnd, now);
+      const windowDays = Math.max(1, Math.ceil((effectiveEnd - effectiveStart) / 86_400_000));
+      const expectedSpend = (totalBudget / totalFlightDays) * windowDays;
+      pacingPct = expectedSpend > 0 ? (analytics.spend / expectedSpend) * 100 : 0;
     } else if (dailyBudget > 0) {
-      const schedStart = camp.runSchedule?.start ?? 0;
-      const schedEnd = camp.runSchedule?.end ?? 0;
-      const now = Date.now();
-      const rangeStartMs = new Date(start).getTime();
       const effectiveStart = Math.max(schedStart || rangeStartMs, rangeStartMs);
       const effectiveEnd = Math.min(schedEnd || now, now);
       const flightDays = Math.max(1, Math.ceil((effectiveEnd - effectiveStart) / 86_400_000));

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -111,7 +111,7 @@ async function linkedInRequest(
   const response = await fetch(url.toString(), {
     method,
     headers,
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
     ...(body ? { body: JSON.stringify(body) } : {}),
   });
 
@@ -527,7 +527,13 @@ export async function getLinkedInAnalytics(req: Request | undefined, accountId: 
   const pageSize = 100;
   let campaignStart = 0;
   while (true) {
-    const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,PAUSED)))&count=${pageSize}&start=${campaignStart}`;
+    const campaignParams = new URLSearchParams({
+      q: 'search',
+      search: '(status:(values:List(ACTIVE,PAUSED)))',
+      count: String(pageSize),
+      start: String(campaignStart),
+    });
+    const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?${campaignParams.toString()}`;
     const campaignsResp = await fetch(campaignsUrl, {
       headers: baseHeaders,
       signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -563,6 +563,9 @@ export async function getLinkedInAnalytics(
   });
 
   const analyticsMap = new Map<string, { impressions: number; clicks: number; spend: number; conversions: number }>();
+  if (!analyticsResp.ok) {
+    logger.warning(req, 'linkedin_analytics', `LinkedIn adAnalytics returned ${analyticsResp.status} — campaign metrics will show zero`, { accountId });
+  }
   if (analyticsResp.ok) {
     const analyticsData = (await analyticsResp.json()) as {
       elements?: {

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -14,7 +14,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 
 import { LINKEDIN_AD_ACCOUNTS, LINKEDIN_API_VERSION, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
-import { LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants';
+import { LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_REQUEST_TIMEOUT_MS, LINKEDIN_TARGETING_PROFILES } from '../constants';
 
 import type { Request } from 'express';
 

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -4,7 +4,7 @@
 import type { LinkedInCampaignCreateRequest, LinkedInCampaignCreateResult, LinkedInGeoTarget, LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
 
 import { LINKEDIN_AD_ACCOUNTS, LINKEDIN_API_VERSION, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
-import { LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants';
+import { LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants';
 
 import type { Request } from 'express';
 
@@ -467,6 +467,288 @@ export async function executeLinkedInCampaignCreation(req: Request | undefined, 
     logger.error(req, 'linkedin_campaign_create', startTime, error, { event: params.eventName });
     throw error;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Analytics — campaign + creative metrics via adAnalytics
+// ---------------------------------------------------------------------------
+
+function toDateParts(iso: string): { year: number; month: number; day: number } {
+  const [y, m, d] = iso.split('-').map(Number);
+  return { year: y, month: m, day: d };
+}
+
+function dateRangeParams(days: number): { start: string; end: string } {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  return {
+    start: start.toISOString().split('T')[0],
+    end: end.toISOString().split('T')[0],
+  };
+}
+
+export async function getLinkedInAnalytics(
+  req: Request | undefined,
+  accountId: string,
+  days: number
+): Promise<import('@lfx-one/shared/interfaces').LinkedInMonitorResponse> {
+  const startTime = logger.startOperation(req, 'linkedin_analytics', { accountId, days });
+  const token = getLinkedInEnv('LINKEDIN_ACCESS_TOKEN');
+  const version = LINKEDIN_API_VERSION;
+
+  const { start, end } = dateRangeParams(days);
+  const startParts = toDateParts(start);
+  const endParts = toDateParts(end);
+
+  const baseHeaders = {
+    Authorization: `Bearer ${token}`,
+    'LinkedIn-Version': version,
+    'X-RestLi-Protocol-Version': '2.0.0',
+  };
+
+  // --- Fetch campaign list for this account ---
+  const campaignsUrl = `${LINKEDIN_BASE_URL}/adAccounts/${accountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE)))&count=50`;
+  const campaignsResp = await fetch(campaignsUrl, {
+    headers: baseHeaders,
+    signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
+  });
+  if (!campaignsResp.ok) {
+    const err = new Error(`LinkedIn adCampaigns fetch failed: ${campaignsResp.status}`);
+    logger.error(req, 'linkedin_analytics', startTime, err, { accountId });
+    throw err;
+  }
+  const campaignsData = (await campaignsResp.json()) as {
+    elements?: {
+      id: number;
+      name: string;
+      status: string;
+      totalBudget?: { amount: string };
+      dailyBudget?: { amount: string };
+      runSchedule?: { start: number; end: number };
+    }[];
+  };
+  const campaigns = campaignsData.elements ?? [];
+
+  if (campaigns.length === 0) {
+    const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
+    const result: import('@lfx-one/shared/interfaces').LinkedInMonitorResponse = {
+      accountId,
+      accountLabel: account?.label ?? accountId,
+      pulledAt: new Date().toISOString(),
+      dateRange: { mode: `last_${days}_days` },
+      campaigns: [],
+      accountTotals: { spend: 0, impressions: 0, clicks: 0, conversions: 0, campaignCount: 0 },
+      actionItems: [],
+    };
+    logger.success(req, 'linkedin_analytics', startTime, { campaigns: 0 });
+    return result;
+  }
+
+  // --- Fetch analytics for all campaigns in one call ---
+  const campaignUrns = campaigns.map((c) => `urn:li:sponsoredCampaign:${c.id}`).join(',');
+  const analyticsParams = new URLSearchParams({
+    q: 'analytics',
+    pivot: 'CAMPAIGN',
+    dateRange: `(start:(year:${startParts.year},month:${startParts.month},day:${startParts.day}),end:(year:${endParts.year},month:${endParts.month},day:${endParts.day}))`,
+    timeGranularity: 'ALL',
+    campaigns: `List(${campaignUrns})`,
+    fields: 'impressions,clicks,costInLocalCurrency,externalWebsiteConversions,pivot,pivotValue',
+  });
+
+  const analyticsUrl = `${LINKEDIN_BASE_URL}/adAnalytics?${analyticsParams.toString()}`;
+  const analyticsResp = await fetch(analyticsUrl, {
+    headers: baseHeaders,
+    signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
+  });
+
+  const analyticsMap = new Map<string, { impressions: number; clicks: number; spend: number; conversions: number }>();
+  if (analyticsResp.ok) {
+    const analyticsData = (await analyticsResp.json()) as {
+      elements?: {
+        pivotValue?: string;
+        impressions?: number;
+        clicks?: number;
+        costInLocalCurrency?: string;
+        externalWebsiteConversions?: number;
+      }[];
+    };
+    for (const el of analyticsData.elements ?? []) {
+      if (el.pivotValue) {
+        analyticsMap.set(el.pivotValue, {
+          impressions: el.impressions ?? 0,
+          clicks: el.clicks ?? 0,
+          spend: parseFloat(el.costInLocalCurrency ?? '0'),
+          conversions: el.externalWebsiteConversions ?? 0,
+        });
+      }
+    }
+  }
+
+  // --- Fetch creative metrics per campaign ---
+  const creativeAnalyticsMap = new Map<string, import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[]>();
+  for (const camp of campaigns) {
+    const creativeParams = new URLSearchParams({
+      q: 'analytics',
+      pivot: 'CREATIVE',
+      dateRange: `(start:(year:${startParts.year},month:${startParts.month},day:${startParts.day}),end:(year:${endParts.year},month:${endParts.month},day:${endParts.day}))`,
+      timeGranularity: 'ALL',
+      campaigns: `List(urn:li:sponsoredCampaign:${camp.id})`,
+      fields: 'impressions,clicks,costInLocalCurrency,externalWebsiteConversions,pivot,pivotValue',
+    });
+    const creativeResp = await fetch(`${LINKEDIN_BASE_URL}/adAnalytics?${creativeParams.toString()}`, {
+      headers: baseHeaders,
+      signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
+    });
+    if (creativeResp.ok) {
+      const creativeData = (await creativeResp.json()) as {
+        elements?: {
+          pivotValue?: string;
+          impressions?: number;
+          clicks?: number;
+          costInLocalCurrency?: string;
+          externalWebsiteConversions?: number;
+        }[];
+      };
+      const creatives: import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[] = (creativeData.elements ?? []).map((el) => {
+        const creativeId = el.pivotValue?.replace('urn:li:sponsoredCreative:', '') ?? '';
+        const clicks = el.clicks ?? 0;
+        const impressions = el.impressions ?? 0;
+        return {
+          creativeId,
+          creativeName: `Creative ${creativeId}`,
+          impressions,
+          clicks,
+          ctr: impressions > 0 ? clicks / impressions : 0,
+          spend: parseFloat(el.costInLocalCurrency ?? '0'),
+          conversions: el.externalWebsiteConversions ?? 0,
+          status: 'ACTIVE',
+        };
+      });
+      creativeAnalyticsMap.set(String(camp.id), creatives);
+    }
+  }
+
+  // --- Build campaign metrics ---
+  const campaignMetrics: import('@lfx-one/shared/interfaces').LinkedInCampaignMetrics[] = campaigns.map((camp) => {
+    const urn = `urn:li:sponsoredCampaign:${camp.id}`;
+    const analytics = analyticsMap.get(urn) ?? { impressions: 0, clicks: 0, spend: 0, conversions: 0 };
+    const totalBudget = parseFloat(camp.totalBudget?.amount ?? '0');
+    const dailyBudget = parseFloat(camp.dailyBudget?.amount ?? '0');
+    let pacingPct = 0;
+    if (totalBudget > 0) {
+      pacingPct = (analytics.spend / totalBudget) * 100;
+    } else if (dailyBudget > 0) {
+      pacingPct = (analytics.spend / (dailyBudget * days)) * 100;
+    }
+    let pacingLabel: import('@lfx-one/shared/interfaces').LinkedInPacingLabel = 'overspending';
+    if (pacingPct < 40) {
+      pacingLabel = 'underspending';
+    } else if (pacingPct < 90) {
+      pacingLabel = 'normal';
+    } else if (pacingPct < 105) {
+      pacingLabel = 'constrained';
+    }
+    const startMs = camp.runSchedule?.start ?? 0;
+    const endMs = camp.runSchedule?.end ?? 0;
+    return {
+      campaignId: String(camp.id),
+      campaignName: camp.name,
+      eventName: camp.name.split(' | ')[1] ?? camp.name,
+      status: camp.status,
+      totalBudget,
+      dailyBudget,
+      spend: analytics.spend,
+      impressions: analytics.impressions,
+      clicks: analytics.clicks,
+      ctr: analytics.impressions > 0 ? analytics.clicks / analytics.impressions : 0,
+      conversions: analytics.conversions,
+      pacingPct,
+      pacingLabel,
+      creatives: creativeAnalyticsMap.get(String(camp.id)) ?? [],
+      startDate: startMs ? new Date(startMs).toISOString().split('T')[0] : '',
+      endDate: endMs ? new Date(endMs).toISOString().split('T')[0] : '',
+    };
+  });
+
+  // --- Action items ---
+  const actionItems: import('@lfx-one/shared/interfaces').LinkedInActionItem[] = [];
+  for (const c of campaignMetrics) {
+    if (c.creatives.length === 0 && c.status === 'ACTIVE') {
+      actionItems.push({
+        priority: 'HIGH',
+        campaignName: c.campaignName,
+        issue: 'No ad creatives — campaign cannot deliver',
+        action: 'Upload ad images and copy in LinkedIn Campaign Manager to start delivery',
+      });
+    } else if (c.pacingLabel === 'underspending') {
+      actionItems.push({
+        priority: 'HIGH',
+        campaignName: c.campaignName,
+        issue: 'Underspending — pacing below 40%',
+        action: 'Check targeting breadth, bid strategy, or budget floor',
+      });
+    }
+    if (c.pacingLabel === 'constrained' || c.pacingLabel === 'overspending') {
+      actionItems.push({
+        priority: 'MEDIUM',
+        campaignName: c.campaignName,
+        issue: 'Budget constrained — pacing above 90%',
+        action: 'Consider increasing budget if event is in peak registration period',
+      });
+    }
+    if (c.ctr > 0 && c.ctr < 0.003) {
+      actionItems.push({
+        priority: 'MEDIUM',
+        campaignName: c.campaignName,
+        issue: `Low CTR: ${(c.ctr * 100).toFixed(2)}%`,
+        action: 'Refresh ad copy or images; review audience targeting',
+      });
+    }
+    if (c.clicks > 50 && c.conversions === 0) {
+      actionItems.push({
+        priority: 'MEDIUM',
+        campaignName: c.campaignName,
+        issue: 'Clicks without conversions',
+        action: 'Audit LinkedIn Insight Tag on registration landing page',
+      });
+    }
+    if (c.status === 'PAUSED' && (c.totalBudget > 10 || c.dailyBudget > 1)) {
+      actionItems.push({
+        priority: 'LOW',
+        campaignName: c.campaignName,
+        issue: 'Campaign is PAUSED with real budget',
+        action: 'Confirm intentional pause or activate',
+      });
+    }
+  }
+  const priorityOrder: Record<string, number> = { HIGH: 0, MEDIUM: 1, LOW: 2 };
+  actionItems.sort((a, b) => (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3));
+
+  const totals = campaignMetrics.reduce(
+    (acc, c) => ({
+      spend: acc.spend + c.spend,
+      impressions: acc.impressions + c.impressions,
+      clicks: acc.clicks + c.clicks,
+      conversions: acc.conversions + c.conversions,
+      campaignCount: acc.campaignCount + 1,
+    }),
+    { spend: 0, impressions: 0, clicks: 0, conversions: 0, campaignCount: 0 }
+  );
+
+  const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
+  const result: import('@lfx-one/shared/interfaces').LinkedInMonitorResponse = {
+    accountId,
+    accountLabel: account?.label ?? accountId,
+    pulledAt: new Date().toISOString(),
+    dateRange: { mode: `last_${days}_days` },
+    campaigns: campaignMetrics,
+    accountTotals: totals,
+    actionItems,
+  };
+
+  logger.success(req, 'linkedin_analytics', startTime, { campaigns: campaignMetrics.length, actionItems: actionItems.length });
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -630,17 +630,22 @@ export async function getLinkedInAnalytics(
           const impressions = el.impressions ?? 0;
           return {
             creativeId,
-            creativeName: `Creative ${creativeId}`,
+            creativeName: `#${creativeId}`,
             impressions,
             clicks,
             ctr: impressions > 0 ? (clicks / impressions) * 100 : 0,
             spend: parseFloat(el.costInLocalCurrency ?? '0'),
             conversions: el.externalWebsiteConversions ?? 0,
-            status: 'ACTIVE',
+            status: 'UNKNOWN',
           };
         });
       creativeAnalyticsMap.set(String(camp.id), creatives);
     } else {
+      const text = await creativeResp.text().catch(() => '');
+      logger.warning(req, 'linkedin_creative_analytics', `Creative analytics failed for campaign ${camp.id}: ${creativeResp.status}: ${text.slice(0, 200)}`, {
+        campaignId: camp.id,
+        status: creativeResp.status,
+      });
       creativeFetchFailed.add(String(camp.id));
     }
   }
@@ -655,7 +660,14 @@ export async function getLinkedInAnalytics(
     if (totalBudget > 0) {
       pacingPct = (analytics.spend / totalBudget) * 100;
     } else if (dailyBudget > 0) {
-      pacingPct = (analytics.spend / (dailyBudget * days)) * 100;
+      const schedStart = camp.runSchedule?.start ?? 0;
+      const schedEnd = camp.runSchedule?.end ?? 0;
+      const now = Date.now();
+      const rangeStartMs = new Date(start).getTime();
+      const effectiveStart = Math.max(schedStart || rangeStartMs, rangeStartMs);
+      const effectiveEnd = Math.min(schedEnd || now, now);
+      const flightDays = Math.max(1, Math.ceil((effectiveEnd - effectiveStart) / 86_400_000));
+      pacingPct = (analytics.spend / (dailyBudget * flightDays)) * 100;
     }
     const hasBudget = totalBudget > 0 || dailyBudget > 0;
     let pacingLabel: import('@lfx-one/shared/interfaces').LinkedInPacingLabel = 'normal';

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -1,7 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { LinkedInCampaignCreateRequest, LinkedInCampaignCreateResult, LinkedInGeoTarget, LinkedInTargetingProfile } from '@lfx-one/shared/interfaces';
+import type {
+  LinkedInActionItem,
+  LinkedInCampaignCreateRequest,
+  LinkedInCampaignCreateResult,
+  LinkedInCampaignMetrics,
+  LinkedInCreativeMetrics,
+  LinkedInGeoTarget,
+  LinkedInMonitorResponse,
+  LinkedInPacingLabel,
+  LinkedInTargetingProfile,
+} from '@lfx-one/shared/interfaces';
 
 import { LINKEDIN_AD_ACCOUNTS, LINKEDIN_API_VERSION, LINKEDIN_GEO_RESOLVE_MAP } from '@lfx-one/shared/constants';
 import { LINKEDIN_ACCOUNTS, LINKEDIN_EMPLOYER_EXCLUSIONS, LINKEDIN_TARGETING_PROFILES } from '../constants';
@@ -488,11 +498,16 @@ function dateRangeParams(days: number): { start: string; end: string } {
   };
 }
 
-export async function getLinkedInAnalytics(
-  req: Request | undefined,
-  accountId: string,
-  days: number
-): Promise<import('@lfx-one/shared/interfaces').LinkedInMonitorResponse> {
+interface LinkedInCampaignElement {
+  id: number;
+  name: string;
+  status: string;
+  totalBudget?: { amount: string };
+  dailyBudget?: { amount: string };
+  runSchedule?: { start: number; end: number };
+}
+
+export async function getLinkedInAnalytics(req: Request | undefined, accountId: string, days: number): Promise<LinkedInMonitorResponse> {
   const startTime = logger.startOperation(req, 'linkedin_analytics', { accountId, days });
   const token = getLinkedInEnv('LINKEDIN_ACCESS_TOKEN');
   const version = LINKEDIN_API_VERSION;
@@ -508,15 +523,7 @@ export async function getLinkedInAnalytics(
   };
 
   // --- Fetch campaign list for this account (paginated) ---
-  interface CampaignElement {
-    id: number;
-    name: string;
-    status: string;
-    totalBudget?: { amount: string };
-    dailyBudget?: { amount: string };
-    runSchedule?: { start: number; end: number };
-  }
-  const campaigns: CampaignElement[] = [];
+  const campaigns: LinkedInCampaignElement[] = [];
   const pageSize = 100;
   let campaignStart = 0;
   while (true) {
@@ -531,7 +538,7 @@ export async function getLinkedInAnalytics(
       logger.error(req, 'linkedin_analytics', startTime, err, { accountId });
       throw err;
     }
-    const campaignsData = (await campaignsResp.json()) as { elements?: CampaignElement[] };
+    const campaignsData = (await campaignsResp.json()) as { elements?: LinkedInCampaignElement[] };
     const page = campaignsData.elements ?? [];
     campaigns.push(...page);
     if (page.length < pageSize) break;
@@ -540,7 +547,7 @@ export async function getLinkedInAnalytics(
 
   if (campaigns.length === 0) {
     const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
-    const result: import('@lfx-one/shared/interfaces').LinkedInMonitorResponse = {
+    const result: LinkedInMonitorResponse = {
       accountId,
       accountLabel: account?.label ?? accountId,
       pulledAt: new Date().toISOString(),
@@ -597,7 +604,7 @@ export async function getLinkedInAnalytics(
   }
 
   // --- Fetch creative metrics per campaign (parallel) ---
-  const creativeAnalyticsMap = new Map<string, import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[]>();
+  const creativeAnalyticsMap = new Map<string, LinkedInCreativeMetrics[]>();
   const creativeFetchFailed = new Set<string>();
   const creativeFetches = campaigns.map(async (camp) => {
     const creativeParams = new URLSearchParams({
@@ -622,7 +629,7 @@ export async function getLinkedInAnalytics(
           externalWebsiteConversions?: number;
         }[];
       };
-      const creatives: import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[] = (creativeData.elements ?? [])
+      const creatives: LinkedInCreativeMetrics[] = (creativeData.elements ?? [])
         .filter((el) => !!el.pivotValue)
         .map((el) => {
           const creativeId = el.pivotValue!.replace('urn:li:sponsoredCreative:', '');
@@ -630,13 +637,13 @@ export async function getLinkedInAnalytics(
           const impressions = el.impressions ?? 0;
           return {
             creativeId,
-            creativeName: `#${creativeId}`,
+            creativeName: `Creative ${creativeId}`,
             impressions,
             clicks,
             ctr: impressions > 0 ? (clicks / impressions) * 100 : 0,
             spend: parseFloat(el.costInLocalCurrency ?? '0'),
             conversions: el.externalWebsiteConversions ?? 0,
-            status: 'UNKNOWN',
+            status: camp.status,
           };
         });
       creativeAnalyticsMap.set(String(camp.id), creatives);
@@ -652,7 +659,7 @@ export async function getLinkedInAnalytics(
   await Promise.allSettled(creativeFetches);
 
   // --- Build campaign metrics ---
-  const campaignMetrics: import('@lfx-one/shared/interfaces').LinkedInCampaignMetrics[] = campaigns.map((camp) => {
+  const campaignMetrics: LinkedInCampaignMetrics[] = campaigns.map((camp) => {
     const urn = `urn:li:sponsoredCampaign:${camp.id}`;
     const analytics = analyticsMap.get(urn) ?? { impressions: 0, clicks: 0, spend: 0, conversions: 0 };
     const totalBudget = parseFloat(camp.totalBudget?.amount ?? '0');
@@ -678,7 +685,7 @@ export async function getLinkedInAnalytics(
       pacingPct = (analytics.spend / (dailyBudget * flightDays)) * 100;
     }
     const hasBudget = totalBudget > 0 || dailyBudget > 0;
-    let pacingLabel: import('@lfx-one/shared/interfaces').LinkedInPacingLabel = 'normal';
+    let pacingLabel: LinkedInPacingLabel = 'normal';
     if (hasBudget) {
       if (pacingPct < 40) {
         pacingLabel = 'underspending';
@@ -713,7 +720,7 @@ export async function getLinkedInAnalytics(
   });
 
   // --- Action items ---
-  const actionItems: import('@lfx-one/shared/interfaces').LinkedInActionItem[] = [];
+  const actionItems: LinkedInActionItem[] = [];
   for (const c of campaignMetrics) {
     if (c.creatives.length === 0 && c.status === 'ACTIVE' && !creativeFetchFailed.has(c.campaignId)) {
       actionItems.push({
@@ -778,7 +785,7 @@ export async function getLinkedInAnalytics(
   );
 
   const account = LINKEDIN_ACCOUNTS.find((a) => a.accountId === accountId);
-  const result: import('@lfx-one/shared/interfaces').LinkedInMonitorResponse = {
+  const result: LinkedInMonitorResponse = {
     accountId,
     accountLabel: account?.label ?? accountId,
     pulledAt: new Date().toISOString(),

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -480,11 +480,11 @@ function toDateParts(iso: string): { year: number; month: number; day: number } 
 
 function dateRangeParams(days: number): { start: string; end: string } {
   const end = new Date();
-  const start = new Date();
-  start.setDate(start.getDate() - days);
+  const start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate() - days));
+  const endUtc = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
   return {
     start: start.toISOString().split('T')[0],
-    end: end.toISOString().split('T')[0],
+    end: endUtc.toISOString().split('T')[0],
   };
 }
 
@@ -613,21 +613,23 @@ export async function getLinkedInAnalytics(
           externalWebsiteConversions?: number;
         }[];
       };
-      const creatives: import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[] = (creativeData.elements ?? []).map((el) => {
-        const creativeId = el.pivotValue?.replace('urn:li:sponsoredCreative:', '') ?? '';
-        const clicks = el.clicks ?? 0;
-        const impressions = el.impressions ?? 0;
-        return {
-          creativeId,
-          creativeName: `Creative ${creativeId}`,
-          impressions,
-          clicks,
-          ctr: impressions > 0 ? clicks / impressions : 0,
-          spend: parseFloat(el.costInLocalCurrency ?? '0'),
-          conversions: el.externalWebsiteConversions ?? 0,
-          status: 'ACTIVE',
-        };
-      });
+      const creatives: import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[] = (creativeData.elements ?? [])
+        .filter((el) => !!el.pivotValue)
+        .map((el) => {
+          const creativeId = el.pivotValue!.replace('urn:li:sponsoredCreative:', '');
+          const clicks = el.clicks ?? 0;
+          const impressions = el.impressions ?? 0;
+          return {
+            creativeId,
+            creativeName: `Creative ${creativeId}`,
+            impressions,
+            clicks,
+            ctr: impressions > 0 ? clicks / impressions : 0,
+            spend: parseFloat(el.costInLocalCurrency ?? '0'),
+            conversions: el.externalWebsiteConversions ?? 0,
+            status: 'ACTIVE',
+          };
+        });
       creativeAnalyticsMap.set(String(camp.id), creatives);
     }
   }

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -514,7 +514,8 @@ export async function getLinkedInAnalytics(
     signal: AbortSignal.timeout(LINKEDIN_REQUEST_TIMEOUT_MS),
   });
   if (!campaignsResp.ok) {
-    const err = new Error(`LinkedIn adCampaigns fetch failed: ${campaignsResp.status}`);
+    const text = await campaignsResp.text().catch(() => '');
+    const err = new Error(`LinkedIn adCampaigns fetch failed: ${campaignsResp.status}: ${text.slice(0, 400)}`);
     logger.error(req, 'linkedin_analytics', startTime, err, { accountId });
     throw err;
   }
@@ -590,6 +591,7 @@ export async function getLinkedInAnalytics(
 
   // --- Fetch creative metrics per campaign ---
   const creativeAnalyticsMap = new Map<string, import('@lfx-one/shared/interfaces').LinkedInCreativeMetrics[]>();
+  const creativeFetchFailed = new Set<string>();
   for (const camp of campaigns) {
     const creativeParams = new URLSearchParams({
       q: 'analytics',
@@ -631,6 +633,8 @@ export async function getLinkedInAnalytics(
           };
         });
       creativeAnalyticsMap.set(String(camp.id), creatives);
+    } else {
+      creativeFetchFailed.add(String(camp.id));
     }
   }
 
@@ -684,7 +688,7 @@ export async function getLinkedInAnalytics(
   // --- Action items ---
   const actionItems: import('@lfx-one/shared/interfaces').LinkedInActionItem[] = [];
   for (const c of campaignMetrics) {
-    if (c.creatives.length === 0 && c.status === 'ACTIVE') {
+    if (c.creatives.length === 0 && c.status === 'ACTIVE' && !creativeFetchFailed.has(c.campaignId)) {
       actionItems.push({
         priority: 'HIGH',
         campaignName: c.campaignName,

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -497,7 +497,7 @@ export interface OptimizationInsightsResponse {
 // ---------------------------------------------------------------------------
 
 export type LinkedInPacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending';
-export type LinkedInActionPriority = 'HIGH' | 'MEDIUM' | 'LOW';
+export type LinkedInActionPriority = 'HIGH' | 'MED' | 'LOW';
 
 export interface LinkedInCreativeMetrics {
   creativeId: string;
@@ -550,7 +550,6 @@ export interface LinkedInAccountOption {
 }
 
 export interface LinkedInMonitorResponse {
-  accountId: string;
   accountLabel: string;
   pulledAt: string;
   dateRange: { mode: string };

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -493,6 +493,68 @@ export interface OptimizationInsightsResponse {
 }
 
 // ---------------------------------------------------------------------------
+// LinkedIn Ads Monitoring
+// ---------------------------------------------------------------------------
+
+export type LinkedInPacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending';
+export type LinkedInActionPriority = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface LinkedInCreativeMetrics {
+  creativeId: string;
+  creativeName: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  spend: number;
+  conversions: number;
+  status: string;
+}
+
+export interface LinkedInCampaignMetrics {
+  campaignId: string;
+  campaignName: string;
+  eventName: string;
+  status: string;
+  totalBudget: number;
+  dailyBudget: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  conversions: number;
+  pacingPct: number;
+  pacingLabel: LinkedInPacingLabel;
+  creatives: LinkedInCreativeMetrics[];
+  startDate: string;
+  endDate: string;
+}
+
+export interface LinkedInAccountTotals {
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  campaignCount: number;
+}
+
+export interface LinkedInActionItem {
+  priority: LinkedInActionPriority;
+  campaignName: string;
+  issue: string;
+  action: string;
+}
+
+export interface LinkedInMonitorResponse {
+  accountId: string;
+  accountLabel: string;
+  pulledAt: string;
+  dateRange: { mode: string };
+  campaigns: LinkedInCampaignMetrics[];
+  accountTotals: LinkedInAccountTotals;
+  actionItems: LinkedInActionItem[];
+}
+
+// ---------------------------------------------------------------------------
 // HubSpot UTM
 // ---------------------------------------------------------------------------
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -545,7 +545,7 @@ export interface LinkedInActionItem {
 }
 
 export interface LinkedInAccountOption {
-  accountId: string;
+  key: string;
   label: string;
 }
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -544,6 +544,11 @@ export interface LinkedInActionItem {
   action: string;
 }
 
+export interface LinkedInAccountOption {
+  accountId: string;
+  label: string;
+}
+
 export interface LinkedInMonitorResponse {
   accountId: string;
   accountLabel: string;


### PR DESCRIPTION
## Summary
- Add LinkedIn Ads analytics backend (`getLinkedInAnalytics`) with campaign metrics, creative breakdown, pacing analysis, and action item generation
- Add platform switcher (Google/LinkedIn) to the Monitoring tab with account selector for 8 LinkedIn ad accounts
- Add LinkedIn optimization section to the Optimization tab showing prioritized action items (underspending, low CTR, no creatives, etc.)
- Wire full stack: shared interfaces → Express route/controller → Angular service → tab components

LFXV2-2023

Generated with [Claude Code](https://claude.ai/code)