### PR TITLE
feat(campaigns): linkedin dynamic skill resolution and URN fix

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -234,7 +234,6 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('cloud-native')"
-                [attr.aria-pressed]="linkedInTargetingProfile() === 'cloud-native'"
                 [class]="
                   linkedInTargetingProfile() === 'cloud-native'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'
@@ -246,7 +245,6 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('mcp')"
-                [attr.aria-pressed]="linkedInTargetingProfile() === 'mcp'"
                 [class]="
                   linkedInTargetingProfile() === 'mcp'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -234,6 +234,7 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('cloud-native')"
+                [attr.aria-pressed]="linkedInTargetingProfile() === 'cloud-native'"
                 [class]="
                   linkedInTargetingProfile() === 'cloud-native'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'
@@ -245,6 +246,7 @@
               <button
                 type="button"
                 (click)="setLinkedInTargetingProfile('mcp')"
+                [attr.aria-pressed]="linkedInTargetingProfile() === 'mcp'"
                 [class]="
                   linkedInTargetingProfile() === 'mcp'
                     ? 'rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -213,7 +213,6 @@ export class ImplementationTabComponent {
     this.linkedInLifetimeBudget.set((event.target as HTMLInputElement).checked);
   }
 
-
   protected submit(): void {
     const platforms = this.selectedPlatforms();
     const googleSelected = platforms.includes('google-ads');

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -213,6 +213,7 @@ export class ImplementationTabComponent {
     this.linkedInLifetimeBudget.set((event.target as HTMLInputElement).checked);
   }
 
+
   protected submit(): void {
     const platforms = this.selectedPlatforms();
     const googleSelected = platforms.includes('google-ads');

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -455,6 +455,8 @@ export class PlanningTabComponent implements OnInit {
       case 'keywords':
         this.keywords.set(event.data as CampaignKeyword[]);
         break;
+      case 'linkedin_strategy':
+        break;
       case 'error':
         this.refineStatusMessages.update((msgs) => [...msgs, event.data as string]);
         this.isRefineStreaming.set(false);

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -159,11 +159,11 @@ function toMs(dateStr: string, eod = false): number {
   }
   const [y, m, d] = dateStr.split('-').map(Number);
   if (eod) {
-    const nextDayUtc = Date.UTC(y, m - 1, d + 1, 0, 0, 0, 0);
-    if (nextDayUtc <= Date.now()) {
+    const endMs = Date.UTC(y, m - 1, d, 23, 59, 59, 999);
+    if (endMs <= Date.now()) {
       throw new Error(`End date ${dateStr} is in the past`);
     }
-    return Date.UTC(y, m - 1, d, 23, 59, 59, 999);
+    return endMs;
   }
   const utcStart = Date.UTC(y, m - 1, d, 0, 0, 0, 0);
   if (utcStart <= Date.now()) {

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -211,7 +211,7 @@ export async function resolveGeoTargets(locationNames: string[]): Promise<Linked
       const elements = resp.elements || [];
       if (elements.length > 0) {
         const first = elements[0];
-        const resolvedUrn = first.urn || first.id || '';
+        const resolvedUrn = first.urn || first.$URN || first.id || '';
         if (resolvedUrn) {
           resolved.push({
             label: first.name || name,

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -142,6 +142,8 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
           }
         }
       }
+      if (elements.length < pageSize) break;
+      start += pageSize;
     }
   } catch (err) {
     logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}" at ${nestedPath}`, {

--- a/apps/lfx-one/src/server/services/linkedin-ads.service.ts
+++ b/apps/lfx-one/src/server/services/linkedin-ads.service.ts
@@ -142,8 +142,6 @@ async function findByName(nestedPath: string, name: string): Promise<string | nu
           }
         }
       }
-      if (elements.length < pageSize) break;
-      start += pageSize;
     }
   } catch (err) {
     logger.warning(undefined, 'linkedin_find_by_name', `Search failed for "${name}" at ${nestedPath}`, {
@@ -211,7 +209,7 @@ export async function resolveGeoTargets(locationNames: string[]): Promise<Linked
       const elements = resp.elements || [];
       if (elements.length > 0) {
         const first = elements[0];
-        const resolvedUrn = first.urn || first.$URN || first.id || '';
+        const resolvedUrn = first.urn || first.id || '';
         if (resolvedUrn) {
           resolved.push({
             label: first.name || name,


### PR DESCRIPTION
## Summary

- Fix 7 incorrect LinkedIn skill URNs in the cloud-native targeting profile — verified each via LinkedIn `adTargetingEntities` API (e.g. "CI/CD" was targeting "TCP/IP stack", "Linux" was targeting "Securities Market")
- Add hybrid dynamic skill targeting: AI recommends event-specific skills during brief generation, backend resolves names to URNs via LinkedIn typeahead API, merges with profile defaults (deduped) at campaign creation time

## Changes

**Shared types** (`packages/shared/src/interfaces/campaign.interface.ts`):
- Add `LinkedInResolvedSkill` interface (`name` + `urn`)
- Add `recommendedSkills` to `LinkedInBriefCopy`
- Add `additionalSkillUrns` to `LinkedInCampaignCreateRequest`

**LinkedIn service** (`linkedin-ads.service.ts`):
- Add `resolveSkillUrns()` — resolves skill names to URNs via `/v2/adTargetingEntities?q=typeahead` (uses `/v2/` endpoint with `skills` facet — `/rest/` with `skillsV2` returns 400)
- Update `buildTargetingCriteria()` to accept optional `additionalSkillUrns`, deduped against profile defaults
- Thread `additionalSkillUrns` through `createCampaign()` and `executeLinkedInCampaignCreation()`

**Brief pipeline** (`campaign-proxy.service.ts`):
- Update AI prompt to recommend 3-8 event-specific skill names
- Resolve AI-suggested skills to URNs during brief post-processing (alongside geo resolution)
- Pass `additionalSkillUrns` through LinkedIn dispatch

**Frontend** (planning-tab, implementation-tab):
- Extract resolved skills from brief into `LinkedInBriefCopy.recommendedSkills`
- Store as `linkedInAdditionalSkillUrns` signal, pass through campaign creation request

**Constants** (`linkedin.constants.ts`):
- Fix 7 wrong URNs: CI/CD (18443→55466), IaC (25168→55939), Cloud Infrastructure (56320→56388), Linux (25154→301), eBPF (56580→42976 BPF), WebAssembly (56581→58487), Observability (55385→61827)

LFXV2-2023

🤖 Generated with [Claude Code](https://claude.ai/code)