### PR TITLE
fix(events): normalize scheme-less event urls to absolute https

### DIFF
--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -35,7 +35,7 @@ import {
   VisaRequestRow,
   VisaRequestsResponse,
 } from '@lfx-one/shared/interfaces';
-import { formatDateToUTC } from '@lfx-one/shared/utils';
+import { formatDateToUTC, normalizeToUrl } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
@@ -1000,7 +1000,8 @@ export class EventsService {
     return {
       id: row.EVENT_ID,
       name: row.EVENT_NAME,
-      url: row.EVENT_URL ?? '',
+      // normalizeToUrl prepends https:// to scheme-less DB URLs and drops unsafe/invalid ones; '' keeps the non-null contract.
+      url: normalizeToUrl(row.EVENT_URL ?? '') ?? '',
       location: this.formatLocation(row.EVENT_LOCATION, row.EVENT_CITY, row.EVENT_COUNTRY),
       applicationDate: row.APPLICATION_DATE
         ? new Date(row.APPLICATION_DATE).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
@@ -1015,8 +1016,8 @@ export class EventsService {
       id: row.EVENT_ID,
       name: row.EVENT_NAME,
       category: row.EVENT_CATEGORY,
-      url: row.EVENT_URL ?? '',
-      registrationUrl: row.EVENT_REGISTRATION_URL ?? null,
+      url: normalizeToUrl(row.EVENT_URL ?? '') ?? '',
+      registrationUrl: normalizeToUrl(row.EVENT_REGISTRATION_URL ?? ''),
       date: this.formatDateRange(row.EVENT_START_DATE, row.EVENT_END_DATE),
       location: this.formatLocation(row.EVENT_LOCATION, row.EVENT_CITY, row.EVENT_COUNTRY),
       status: row.EVENT_STATUS ?? null,
@@ -1042,8 +1043,8 @@ export class EventsService {
     return {
       id: row.EVENT_ID,
       name: row.EVENT_NAME,
-      url: row.EVENT_URL ?? '',
-      registrationUrl: row.EVENT_REGISTRATION_URL ?? null,
+      url: normalizeToUrl(row.EVENT_URL ?? '') ?? '',
+      registrationUrl: normalizeToUrl(row.EVENT_REGISTRATION_URL ?? ''),
       foundation: row.PROJECT_NAME,
       startDate: new Date(row.EVENT_START_DATE).toISOString(),
       date: this.formatDateRange(row.EVENT_START_DATE, row.EVENT_END_DATE),

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -15,7 +15,7 @@ import type {
   OrgEventsSummary,
   OrgEventsSummaryRow,
 } from '@lfx-one/shared/interfaces';
-import { formatDateToUTC } from '@lfx-one/shared/utils';
+import { formatDateToUTC, normalizeToUrl } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -261,8 +261,9 @@ export class OrgLensEventsService {
       eventLocation: row.EVENT_LOCATION ?? null,
       eventCity: row.EVENT_CITY ?? null,
       eventCountry: row.EVENT_COUNTRY ?? null,
-      eventUrl: row.EVENT_URL ?? null,
-      eventRegistrationUrl: row.EVENT_REGISTRATION_URL ?? null,
+      // normalizeToUrl prepends https:// to scheme-less DB URLs and drops unsafe ones so the template href stays absolute.
+      eventUrl: normalizeToUrl(row.EVENT_URL ?? ''),
+      eventRegistrationUrl: normalizeToUrl(row.EVENT_REGISTRATION_URL ?? ''),
       orgAttendeeCount: row.ORG_REGISTRATION_COUNT || 0,
       eventRegistrationsGoal: row.EVENT_REGISTRATIONS_GOAL ?? null,
       orgSpeakerAcceptedCount: row.ORG_SPEAKER_ACCEPTED_COUNT || 0,

--- a/apps/lfx-one/src/server/services/org-people-event-attendees.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-event-attendees.service.ts
@@ -13,6 +13,7 @@ import type {
   OrgPeopleAllEventAttendeeRow,
   OrgPeopleEventRow,
 } from '@lfx-one/shared/interfaces';
+import { normalizeToUrl } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { SnowflakeService } from './snowflake.service';
@@ -54,7 +55,8 @@ export class OrgPeopleEventAttendeesService {
       eventLocation: row.EVENT_LOCATION,
       eventCity: row.EVENT_CITY,
       eventCountry: row.EVENT_COUNTRY,
-      eventUrl: row.EVENT_URL,
+      // Normalize scheme-less DB URLs (e.g. "regfox.com/..") so a future clickable event name binds a safe absolute href.
+      eventUrl: normalizeToUrl(row.EVENT_URL ?? ''),
       foundationId: row.FOUNDATION_ID,
       foundationName: row.FOUNDATION_NAME,
       eventStartDate: toIsoDate(row.EVENT_START_DATE),


### PR DESCRIPTION
> **WIP / Draft.** Normalizes DB-sourced event URLs so scheme-less values stop rendering as broken relative links.

Ticket: [LFXV2-2185](https://linuxfoundation.atlassian.net/browse/LFXV2-2185)

## Summary
- Some event URLs are stored without a scheme (e.g. `linuxfoundation.regfox.com/<slug>`). Bound directly to a template `[href]`, the browser resolves them as relative paths against the current origin, producing broken links like `https://app.dev.lfx.dev/linuxfoundation.regfox.com/...` (a 404 on the app).
- Route all DB-sourced event URLs through the shared `normalizeToUrl()` helper in the BFF mappers: it prepends `https://` to bare domains and drops unsafe/invalid values (`javascript:`/`data:` schemes, malformed strings, the literal `"NULL"`), so the template always binds an absolute, safe URL.
- Covers three mappers:
  - `org-lens-events.service.ts` — Org Lens Events page (the reported surface; Event Name + Action links)
  - `org-people-event-attendees.service.ts` — Org Lens People → Event Attendees
  - `events.service.ts` — individual-user My / Foundation / Visa event mappers

PROD audit (2026-06-10, `ANALYTICS.SILVER_DIM.EVENTS`): 53 scheme-less `event_url` rows, all `source='regfox'`; on `ANALYTICS.PLATINUM_LFX_ONE.ORG_EVENTS` that surfaces as 52 distinct events across ~97.8k org×event rows. Registration URLs are unaffected (0 scheme-less).

## Out of scope (intentionally)
- Upstream data fix: event URLs should be stored *with* a scheme in `silver_dim_events` (RegFox ingestion). This PR is the consumer-side mitigation; a dbt follow-up will fix the source.
- Literal `"NULL"`-string rows in the URL columns (rendered gracefully as a dash here, but should be real SQL `NULL` upstream).

## Test plan
- [ ] Org Lens Events: a RegFox event (e.g. "LF Decentralized Trust Privacy Workshop July 2026") — Event Name + Action link open `https://linuxfoundation.regfox.com/...`, not the app origin.
- [ ] Already-absolute event URLs render unchanged.
- [ ] Invalid / `"NULL"` values render as a dash, not a broken link.
- [ ] `yarn lint:check` and `yarn check-types` green (verified locally).

[LFXV2-2185]: https://linuxfoundation.atlassian.net/browse/LFXV2-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ