### PR TITLE
feat(committee-members): add Org Lens People -> Committee tab (LFXV2-1872)

### DIFF
--- a/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
@@ -1,0 +1,376 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** People → Committee tab reassign E2E (spec 027 US3 bulk modal + US4 single-edit modal). Deterministic via route mocks. */
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const PEOPLE_COMMITTEE_URL = '/org/people?tab=committee';
+const DATA_LOAD_TIMEOUT = 30_000;
+const TOAST_TIMEOUT = 10_000;
+
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = MOCK_ACCOUNT_ID;
+const MOCK_ACCOUNT_NAME = 'Toyota';
+const MOCK_ACCOUNT_SLUG = 'toyota';
+
+const CHIANING_EMAIL = 'johnny.wang@toyota.com';
+const REPLACEMENT_EMAIL = 'cara.dev@toyota.com';
+
+function entitlementSeat(uid: string, committeeUid: string, committeeName: string) {
+  return {
+    seatId: uid,
+    memberUid: uid,
+    committeeUid,
+    committeeName,
+    committeeCategory: 'Working Group',
+    projectUid: 'uec-root',
+    foundationSlug: 'ultra-ethernet-consortium',
+    foundationName: 'Ultra Ethernet Consortium',
+    role: '',
+    votingStatus: 'Non-voting',
+    appointedBy: 'Membership Entitlement',
+    isOrgEditable: true,
+    reason: null,
+    person: { email: CHIANING_EMAIL, firstName: 'Chianing', lastName: 'Wang', fullName: 'Chianing Wang', jobTitle: 'Infrastructure Architect', initials: 'CW' },
+  };
+}
+
+function committeeMembersResponse() {
+  return {
+    orgUid: MOCK_UID,
+    assignments: [
+      entitlementSeat('m-inc', 'c-inc', 'INC Software Working Area'),
+      entitlementSeat('m-perf', 'c-perf', 'Performance Working Group'),
+      entitlementSeat('m-link', 'c-link', 'Link Layer Working Group'),
+      {
+        seatId: 'm-tsc',
+        memberUid: 'm-tsc',
+        committeeUid: 'c-tsc',
+        committeeName: 'Technical Steering Committee',
+        committeeCategory: 'Technical',
+        projectUid: 'uec-root',
+        foundationSlug: 'ultra-ethernet-consortium',
+        foundationName: 'Ultra Ethernet Consortium',
+        role: 'Member',
+        votingStatus: 'Voting Rep',
+        appointedBy: 'Community',
+        isOrgEditable: false,
+        reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
+        person: {
+          email: CHIANING_EMAIL,
+          firstName: 'Chianing',
+          lastName: 'Wang',
+          fullName: 'Chianing Wang',
+          jobTitle: 'Infrastructure Architect',
+          initials: 'CW',
+        },
+      },
+    ],
+    stats: { individualCount: 1, committeeCount: 4, foundationsCovered: 1 },
+  };
+}
+
+const MOCK_EMPLOYEES = [
+  { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: 'Senior Engineer', initials: 'CD' },
+  { email: 'evan.qa@toyota.com', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
+];
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+async function stubAccountContext(page: Page, opts: { writers: string[] } = { writers: [MOCK_UID] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_UID }],
+        isRootWriter: false,
+      }),
+    })
+  );
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: opts.writers,
+        auditors: [],
+        cascadingWriters: [],
+        cascadingAuditors: [],
+        username: 'e2e-org-people-committee-reassign',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubCommitteeMembers(page: Page, body: unknown = committeeMembersResponse()): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function stubEmployees(page: Page, employees: unknown[] = MOCK_EMPLOYEES, status = 200): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/employees$/, (route) => {
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees }) });
+  });
+}
+
+/** Stubs the PATCH reassign proxy; the handler decides what to return per request. */
+async function stubReassignPatch(page: Page, handler: (route: Route) => Promise<void> | void): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members\/[^/]+\/reassign$/, async (route) => {
+    if (route.request().method() !== 'PATCH') return route.fallback();
+    await handler(route);
+  });
+}
+
+function reassignedSeatBody(seatId: string, committeeUid: string, committeeName: string) {
+  return {
+    orgUid: MOCK_UID,
+    seat: {
+      ...entitlementSeat(seatId, committeeUid, committeeName),
+      person: { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: null, initials: 'CD' },
+    },
+  };
+}
+
+async function gotoCommitteeTab(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PEOPLE_COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  if (!page.url().includes('/org/people')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/people redirected away');
+  }
+  await expect(page.getByTestId('org-people-panel-committee')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.setTimeout(120_000);
+
+test.describe('Org People → Committee — Reassign Committee Roles modal (US3)', () => {
+  test('opens with the expected anatomy and reflects the fixture counts', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+
+    const modal = page.getByTestId('org-people-committee-modal-reassign');
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-modal-reassign-title')).toHaveText('Reassign Committee Roles');
+    // 3 entitlement seats (the non-entitlement TSC seat is excluded), all on 1 foundation.
+    await expect(page.getByTestId('org-people-committee-modal-reassign-subtitle')).toHaveText('3 roles across 1 foundation');
+    await expect(modal.locator('[data-testid^="org-people-committee-modal-reassign-role-row-"]')).toHaveCount(3);
+    await expect(page.getByTestId('org-people-committee-modal-reassign-primary-button')).toContainText('Save Changes (3 roles)');
+  });
+
+  test('deselecting a role updates the Save button count', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-modal-reassign-role-checkbox-m-link').click();
+    await expect(page.getByTestId('org-people-committee-modal-reassign-primary-button')).toContainText('Save Changes (2 roles)');
+  });
+
+  test('Save is disabled until Email / First / Last are filled', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await expect(page.getByTestId('org-people-committee-modal-reassign-primary-button')).toBeDisabled();
+  });
+
+  test('valid Save fans out N PATCHes and refreshes', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      const url = route.request().url();
+      const seatId = url.split('/committee-members/')[1].split('/reassign')[0];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody(seatId, 'c-x', 'Committee')) });
+    });
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-committee-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-committee-toast-success')).toBeVisible({ timeout: TOAST_TIMEOUT });
+    expect(patchCount).toBe(3);
+  });
+
+  test('a 409 on one PATCH surfaces an inline partial-failure error and keeps the modal open', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) => {
+      const url = route.request().url();
+      if (url.includes('/m-link/')) {
+        return route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { message: 'seat changed since you opened the dialog' } }),
+        });
+      }
+      const seatId = url.split('/committee-members/')[1].split('/reassign')[0];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody(seatId, 'c-x', 'Committee')) });
+    });
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-committee-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-committee-modal-reassign-save-error')).toContainText('succeeded');
+    await expect(page.getByTestId('org-people-committee-modal-reassign')).toBeVisible();
+  });
+
+  test('all PATCHes failing surfaces the cleaned error and keeps the modal open', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: { message: 'Reassignment failed — please retry.' } }) })
+    );
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-committee-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-committee-modal-reassign-save-error')).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-modal-reassign')).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-toast-success')).toHaveCount(0);
+  });
+});
+
+test.describe('Org People → Committee — Edit Committee Role modal (US4)', () => {
+  test('opens scoped to one seat with the chip header + current member', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-edit-m-inc').click();
+
+    const modal = page.getByTestId('org-people-committee-modal-edit');
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-modal-edit-title')).toHaveText('Edit Committee Role');
+    await expect(page.getByTestId('org-people-committee-modal-edit-chips')).toContainText('INC Software Working Area');
+    await expect(page.getByTestId('org-people-committee-modal-edit-chips')).toContainText('Ultra Ethernet Consortium');
+    await expect(page.getByTestId('org-people-committee-modal-edit-current')).toContainText('Chianing Wang');
+  });
+
+  test('Save fires exactly one PATCH and shows a success toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(reassignedSeatBody('m-inc', 'c-inc', 'INC Software Working Area')),
+      });
+    });
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-edit-m-inc').click();
+    await page.getByTestId('org-people-committee-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-committee-modal-edit-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-committee-modal-edit-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-committee-modal-edit-primary-button').click();
+
+    await expect(page.getByTestId('org-people-committee-toast-success')).toBeVisible({ timeout: TOAST_TIMEOUT });
+    expect(patchCount).toBe(1);
+  });
+
+  test('a 5xx save keeps the Edit modal open with an inline error and no success toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: { message: 'Reassignment failed — please retry.' } }) })
+    );
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-edit-m-inc').click();
+    await page.getByTestId('org-people-committee-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-committee-modal-edit-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-committee-modal-edit-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-committee-modal-edit-primary-button').click();
+
+    await expect(page.getByTestId('org-people-committee-modal-edit-save-error')).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-modal-edit')).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-toast-success')).toHaveCount(0);
+  });
+
+  test('non-entitlement sub-row shows a disabled Edit pencil', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await expect(page.getByTestId('org-people-committee-edit-m-tsc')).toBeDisabled();
+  });
+
+  test('Cancel closes the Edit modal without firing a PATCH', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(reassignedSeatBody('m-inc', 'c-inc', 'INC Software Working Area')),
+      });
+    });
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-edit-m-inc').click();
+    await expect(page.getByTestId('org-people-committee-modal-edit')).toBeVisible();
+
+    await page.getByTestId('org-people-committee-modal-edit-cancel').click();
+    await expect(page.getByTestId('org-people-committee-modal-edit')).toHaveCount(0);
+    expect(patchCount).toBe(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
@@ -226,7 +226,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     expect(patchCount).toBe(3);
   });
 
-  test('a 409 on one PATCH surfaces an inline partial-failure error and keeps the modal open', async ({ page }) => {
+  test('a 409 on one PATCH closes the modal and surfaces a partial-success warning toast', async ({ page }) => {
     await stubAccountContext(page);
     await stubCommitteeMembers(page);
     await stubEmployees(page);
@@ -250,8 +250,11 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
     await page.getByTestId('org-people-committee-modal-reassign-primary-button').click();
 
-    await expect(page.getByTestId('org-people-committee-modal-reassign-save-error')).toContainText('succeeded');
-    await expect(page.getByTestId('org-people-committee-modal-reassign')).toBeVisible();
+    // Modal resolves on partial success — leaving it open would re-PATCH already-succeeded seats
+    // (their `memberUid` has moved upstream) and 404 them, so the modal closes and a warning toast
+    // summarizes the outcome instead.
+    await expect(page.getByTestId('org-people-committee-modal-reassign')).toHaveCount(0, { timeout: TOAST_TIMEOUT });
+    await expect(page.getByTestId('org-people-committee-toast-success')).toContainText('succeeded', { timeout: TOAST_TIMEOUT });
   });
 
   test('all PATCHes failing surfaces the cleaned error and keeps the modal open', async ({ page }) => {
@@ -348,6 +351,30 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     await gotoCommitteeTab(page);
     await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
     await expect(page.getByTestId('org-people-committee-edit-m-tsc')).toBeDisabled();
+  });
+
+  test('ArrowDown + Enter on the employee combobox selects the highlighted option (keyboard a11y)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+    await stubEmployees(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId('org-people-committee-edit-m-inc').click();
+
+    const emailInput = page.getByTestId('org-people-committee-modal-edit-email-input');
+    await emailInput.fill('toyota.com');
+    await emailInput.press('ArrowDown');
+
+    // The first option in the listbox is highlighted; aria-activedescendant on the input points to its id.
+    await expect(emailInput).toHaveAttribute('aria-activedescendant', 'edit-committee-employee-option-0');
+
+    await emailInput.press('Enter');
+
+    // Selecting via keyboard fills the email + name fields just like the click handler does.
+    await expect(emailInput).toHaveValue(REPLACEMENT_EMAIL);
+    await expect(page.getByTestId('org-people-committee-modal-edit-first-name-input')).toHaveValue('Cara');
+    await expect(page.getByTestId('org-people-committee-modal-edit-last-name-input')).toHaveValue('Dev');
   });
 
   test('Cancel closes the Edit modal without firing a PATCH', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-people-committee-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-committee-tab.spec.ts
@@ -1,0 +1,217 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** People → Committee tab E2E (spec 027 US1 read + US2 filter/expand/sort). Deterministic via route mocks. */
+
+import { expect, Page, test } from '@playwright/test';
+
+const PEOPLE_COMMITTEE_URL = '/org/people?tab=committee';
+const DATA_LOAD_TIMEOUT = 30_000;
+
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = MOCK_ACCOUNT_ID;
+const MOCK_ACCOUNT_NAME = 'Toyota';
+const MOCK_ACCOUNT_SLUG = 'toyota';
+
+// SC-001 dev-mode budget multiplier — `ng serve` adds 3–10× per interaction vs the production build.
+const PERF_DEV_MULTIPLIER = 5;
+
+const CHIANING_EMAIL = 'johnny.wang@toyota.com';
+
+// Three entitlement seats for Chianing Wang, all on Ultra Ethernet Consortium, plus a second person
+// on a different foundation so the stats tiles have concrete multi-foundation values.
+function committeeMembersResponse() {
+  const uec = (uid: string, committeeUid: string, committeeName: string) => ({
+    seatId: uid,
+    memberUid: uid,
+    committeeUid,
+    committeeName,
+    committeeCategory: 'Working Group',
+    projectUid: 'uec-root',
+    foundationSlug: 'ultra-ethernet-consortium',
+    foundationName: 'Ultra Ethernet Consortium',
+    role: '',
+    votingStatus: 'Non-voting',
+    appointedBy: 'Membership Entitlement',
+    isOrgEditable: true,
+    reason: null,
+    person: { email: CHIANING_EMAIL, firstName: 'Chianing', lastName: 'Wang', fullName: 'Chianing Wang', jobTitle: 'Infrastructure Architect', initials: 'CW' },
+  });
+  return {
+    orgUid: MOCK_UID,
+    assignments: [
+      uec('m-inc', 'c-inc', 'INC Software Working Area'),
+      uec('m-perf', 'c-perf', 'Performance Working Group'),
+      uec('m-link', 'c-link', 'Link Layer Working Group'),
+      {
+        seatId: 'm-erick',
+        memberUid: 'm-erick',
+        committeeUid: 'c-tsc',
+        committeeName: 'Technical Steering Committee',
+        committeeCategory: 'Technical',
+        projectUid: 'cncf-root',
+        foundationSlug: 'cncf',
+        foundationName: 'Cloud Native Computing Foundation',
+        role: 'Member',
+        votingStatus: 'Voting Rep',
+        appointedBy: 'Community',
+        isOrgEditable: false,
+        reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
+        person: { email: 'erick.mau@toyota.com', firstName: 'Erick', lastName: 'Mau', fullName: 'Erick Mau', jobTitle: 'Maintainer', initials: 'EM' },
+      },
+    ],
+    stats: { individualCount: 2, committeeCount: 4, foundationsCovered: 2 },
+  };
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+async function stubAccountContext(page: Page, opts: { writers: string[]; auditors?: string[] } = { writers: [MOCK_UID] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_UID }],
+        isRootWriter: false,
+      }),
+    })
+  );
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: opts.writers,
+        auditors: opts.auditors ?? [],
+        cascadingWriters: [],
+        cascadingAuditors: [],
+        username: 'e2e-org-people-committee',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubCommitteeMembers(page: Page, body: unknown = committeeMembersResponse(), status = 200): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function gotoCommitteeTab(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PEOPLE_COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  if (!page.url().includes('/org/people')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/people redirected away');
+  }
+  await expect(page.getByTestId('org-people-panel-committee')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.setTimeout(120_000);
+
+test.describe('Org People → Committee tab (spec 027 US1 + US2)', () => {
+  test('renders the org committee roster grouped by person with correct stats (SC-001 perf + SC-004 counts)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+
+    const start = Date.now();
+    await gotoCommitteeTab(page);
+    await expect(page.getByTestId('org-people-committee-stat-individuals')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    const elapsed = Date.now() - start;
+    // SC-001: prod budget 3000 ms; dev allowance generous (regression guard only).
+    // eslint-disable-next-line no-console
+    console.log(`[SC-001] committee tab load → stats visible: ${elapsed} ms (prod budget 3000 ms; dev allowance ${3000 * PERF_DEV_MULTIPLIER} ms)`);
+    expect(elapsed).toBeLessThan(3000 * PERF_DEV_MULTIPLIER);
+
+    // One row per person (Chianing Wang + Erick Mau).
+    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toBeVisible();
+
+    // SC-004: stat tiles match the table-derived counts.
+    const individuals = await page.getByTestId('org-people-committee-stat-individuals').innerText();
+    const rowCount = await page.locator('[data-testid^="org-people-committee-row-"]').count();
+    expect(parseInt(individuals, 10)).toBe(rowCount);
+    expect(await page.getByTestId('org-people-committee-stat-committees').innerText()).toContain('4');
+    expect(await page.getByTestId('org-people-committee-stat-foundations').innerText()).toContain('2');
+  });
+
+  test('renders the empty state for an org with no committee seats', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page, { orgUid: MOCK_UID, assignments: [], stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 } });
+
+    await gotoCommitteeTab(page);
+    await expect(page.getByTestId('org-people-committee-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('fetch failure renders the error state with a Retry button', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page, { error: { message: 'boom' } }, 500);
+
+    await gotoCommitteeTab(page);
+    await expect(page.getByTestId('org-people-committee-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('as an auditor (read-only), Reassign pencils are disabled', async ({ page }) => {
+    await stubAccountContext(page, { writers: [], auditors: [MOCK_UID] });
+    await stubCommitteeMembers(page);
+
+    await gotoCommitteeTab(page);
+    const pencil = page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`);
+    await expect(pencil).toBeDisabled();
+  });
+
+  test('expands Chianing Wang and shows 3 sub-rows on Ultra Ethernet Consortium (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+
+    const expanded = page.getByTestId(`org-people-committee-expanded-${CHIANING_EMAIL}`);
+    await expect(expanded).toBeVisible();
+    await expect(expanded.locator('[data-testid^="org-people-committee-subrow-"]')).toHaveCount(3);
+  });
+
+  test('search narrows to the matching person row (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+
+    await gotoCommitteeTab(page);
+    await page.getByTestId('org-people-committee-search-input').locator('input').fill('performance');
+
+    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toHaveCount(0);
+  });
+
+  test('committee filter narrows the rows to that committee (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubCommitteeMembers(page);
+
+    await gotoCommitteeTab(page);
+    // The committee dropdown wrapper opens a PrimeNG select; choose "Performance Working Group".
+    await page.getByTestId('org-people-committee-committee-filter').click();
+    await page.getByRole('option', { name: 'Performance Working Group' }).click();
+
+    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
@@ -61,15 +61,15 @@
         }
       } @else {
         <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-individuals">
-          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().individualCount }}</div>
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().individualCount | number }}</div>
           <div class="mt-1 text-xs text-gray-500">Individuals</div>
         </div>
         <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-committees">
-          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().committeeCount }}</div>
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().committeeCount | number }}</div>
           <div class="mt-1 text-xs text-gray-500">Committees</div>
         </div>
         <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-foundations">
-          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().foundationsCovered }}</div>
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().foundationsCovered | number }}</div>
           <div class="mt-1 text-xs text-gray-500">Foundations with committee members</div>
         </div>
       }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
@@ -1,0 +1,272 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-toast position="top-right" key="org-people-committee-toast-success" data-testid="org-people-committee-toast-success" />
+
+<div class="flex flex-col gap-6" data-testid="org-people-committee">
+  <!-- Filter bar -->
+  <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4" data-testid="org-people-committee-filter-bar">
+    <div class="flex-1">
+      <lfx-input-text
+        [form]="filterForm"
+        control="search"
+        placeholder="Search committee members..."
+        icon="fa-light fa-magnifying-glass"
+        styleClass="w-full"
+        size="small"
+        dataTest="org-people-committee-search-input" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="foundation"
+        size="small"
+        [options]="foundationOptions()"
+        styleClass="w-full"
+        ariaLabel="Filter by foundation"
+        dataTest="org-people-committee-foundation-filter" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="committee"
+        size="small"
+        [options]="committeeOptions()"
+        styleClass="w-full"
+        ariaLabel="Filter by committee"
+        dataTest="org-people-committee-committee-filter" />
+    </div>
+  </div>
+
+  @if (fetchError()) {
+    <div role="alert" data-testid="org-people-committee-error">
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-triangle-exclamation"
+        title="Failed to load committee members"
+        subtitle="Please try again."
+        ctaLabel="Retry"
+        ctaIcon="fa-light fa-arrow-rotate-left"
+        (ctaClick)="retry()" />
+    </div>
+  } @else {
+    <!-- Stat cards -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3" data-testid="org-people-committee-stats">
+      @if (isLoading()) {
+        @for (label of statSkeletonLabels; track label) {
+          <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-skeleton">
+            <p-skeleton width="3rem" height="1.5rem" />
+            <div class="mt-2 text-xs text-gray-500">{{ label }}</div>
+          </div>
+        }
+      } @else {
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-individuals">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().individualCount }}</div>
+          <div class="mt-1 text-xs text-gray-500">Individuals</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-committees">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().committeeCount }}</div>
+          <div class="mt-1 text-xs text-gray-500">Committees</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-committee-stat-foundations">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().foundationsCovered }}</div>
+          <div class="mt-1 text-xs text-gray-500">Foundations with committee members</div>
+        </div>
+      }
+    </div>
+
+    <!-- Table -->
+    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="org-people-committee-table">
+      @if (isLoading()) {
+        <div class="divide-y divide-gray-100" data-testid="org-people-committee-table-skeleton">
+          @for (i of tableSkeletonRows; track i) {
+            <div class="flex items-center gap-4 px-4 py-3">
+              <p-skeleton width="1rem" height="1rem" />
+              <div class="flex flex-1 flex-col gap-2">
+                <p-skeleton width="40%" height="0.875rem" />
+                <p-skeleton width="25%" height="0.75rem" />
+              </div>
+              <p-skeleton width="8rem" height="1.25rem" />
+              <p-skeleton width="6rem" height="1.25rem" borderRadius="9999px" />
+            </div>
+          }
+        </div>
+      } @else if (decoratedGroups().length === 0) {
+        <div class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center" data-testid="org-people-committee-empty">
+          <i class="fa-light fa-users-rectangle text-2xl text-gray-300" aria-hidden="true"></i>
+          @if (isFiltering()) {
+            <p class="text-sm text-gray-700">No committee members match the current filters.</p>
+            <p class="text-xs text-gray-500">Try clearing the search or changing the dropdown selections.</p>
+          } @else {
+            <p class="text-sm text-gray-700">No committee members found.</p>
+            <p class="text-xs text-gray-500">Committee members are sourced from LFX committee records.</p>
+          }
+        </div>
+      } @else {
+        <table class="w-full text-sm" data-testid="org-people-committee-rows">
+          <thead class="bg-gray-50">
+            <tr class="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th class="w-7 px-2 py-3"></th>
+              @let aria = ariaSortMap();
+              @let icons = sortIconMap();
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.name">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('name')">
+                  Name
+                  <i [class]="icons.name" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.foundations">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('foundations')">
+                  Foundations
+                  <i [class]="icons.foundations" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.committees">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('committees')">
+                  Committees
+                  <i [class]="icons.committees" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th class="w-12 px-4 py-3 text-right">
+                <span class="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (group of decoratedGroups(); track group.email) {
+              @let expanded = !!expansion()[group.email];
+              <tr
+                class="cursor-pointer border-b border-gray-100 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                role="button"
+                tabindex="0"
+                [attr.aria-expanded]="expanded"
+                [attr.aria-label]="'Toggle committee details for ' + group.displayName"
+                [attr.data-testid]="'org-people-committee-row-' + group.email"
+                (click)="toggleExpansion(group.email)"
+                (keydown)="onRowKeydown($event, group.email)">
+                <td class="px-2 py-3 align-middle">
+                  <i
+                    class="fa-light fa-chevron-right text-gray-400 transition-transform"
+                    [class.rotate-90]="expanded"
+                    [attr.data-testid]="'org-people-committee-expand-' + group.email"
+                    aria-hidden="true"></i>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">
+                      {{ group.initials }}
+                    </div>
+                    <div>
+                      <div class="font-medium text-gray-900">{{ group.displayName }}</div>
+                      @if (group.jobTitle) {
+                        <div class="text-xs text-gray-500">{{ group.jobTitle }}</div>
+                      }
+                    </div>
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex flex-col gap-0.5 text-sm text-gray-700">
+                    @for (label of group.foundationLabels; track label) {
+                      <span [attr.data-testid]="'org-people-committee-foundation-pill-' + label">{{ label }}</span>
+                    }
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <span class="inline-block rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+                    {{ group.committeeCount }} {{ group.committeeCount === 1 ? 'Committee' : 'Committees' }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <span
+                    class="inline-flex"
+                    [pTooltip]="
+                      canEdit() ? (group.editableCount === 0 ? 'No org-reassignable seats for this person' : 'Reassign committee roles') : editDisabledTooltip
+                    "
+                    tooltipPosition="left">
+                    <button
+                      type="button"
+                      class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                      [disabled]="!canEdit() || group.editableCount === 0"
+                      [attr.aria-label]="'Reassign committee roles for ' + group.displayName"
+                      [attr.data-testid]="'org-people-committee-reassign-' + group.email"
+                      (click)="onMainPencilClick(group, $event)">
+                      <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                    </button>
+                  </span>
+                </td>
+              </tr>
+              @if (expanded) {
+                <tr class="bg-slate-50" [attr.data-testid]="'org-people-committee-expanded-' + group.email">
+                  <td colspan="5" class="p-0 pl-11">
+                    <table class="w-full border-collapse">
+                      <thead>
+                        <tr class="border-b border-gray-200 bg-slate-100 text-left text-xs font-semibold uppercase text-gray-400">
+                          <th class="px-4 py-2.5">Foundation</th>
+                          <th class="px-4 py-2.5">Committee</th>
+                          <th class="px-4 py-2.5">Voting Status</th>
+                          <th class="w-12 px-4 py-2.5 text-right">
+                            <span class="sr-only">Edit</span>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        @for (assignment of group.sortedAssignments; track assignment.seatId) {
+                          <tr class="border-b border-gray-200" [attr.data-testid]="'org-people-committee-subrow-' + assignment.seatId">
+                            <td class="px-4 py-2.5 text-sm font-medium text-gray-900">
+                              @if (assignment.showFoundationLabel) {
+                                {{ assignment.foundationName }}
+                              }
+                            </td>
+                            <td class="px-4 py-2.5 text-sm text-gray-700">{{ assignment.committeeName }}</td>
+                            <td class="px-4 py-2.5">
+                              <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="assignment.votingStatusPillClass">
+                                {{ assignment.votingStatus || 'Non-voting' }}
+                              </span>
+                            </td>
+                            <td class="px-4 py-2.5 text-right">
+                              <span
+                                class="inline-flex"
+                                [pTooltip]="
+                                  canEdit()
+                                    ? assignment.isOrgEditable
+                                      ? 'Edit committee role'
+                                      : (assignment.reason ?? 'This seat is foundation-controlled and not editable here.')
+                                    : editDisabledTooltip
+                                "
+                                tooltipPosition="top">
+                                <button
+                                  type="button"
+                                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                                  [disabled]="!canEdit() || !assignment.isOrgEditable"
+                                  [attr.aria-label]="'Edit ' + assignment.committeeName"
+                                  [attr.data-testid]="'org-people-committee-edit-' + assignment.seatId"
+                                  (click)="onSubRowPencilClick(assignment, $event)">
+                                  <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                                </button>
+                              </span>
+                            </td>
+                          </tr>
+                        }
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              }
+            }
+          </tbody>
+        </table>
+      }
+    </div>
+
+    <p class="text-xs text-gray-400" data-testid="org-people-committee-sources">Source: LFX Committee Records</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.html
@@ -186,12 +186,7 @@
                   </span>
                 </td>
                 <td class="px-4 py-3 text-right">
-                  <span
-                    class="inline-flex"
-                    [pTooltip]="
-                      canEdit() ? (group.editableCount === 0 ? 'No org-reassignable seats for this person' : 'Reassign committee roles') : editDisabledTooltip
-                    "
-                    tooltipPosition="left">
+                  <span class="inline-flex" [pTooltip]="group.reassignTooltip" tooltipPosition="left">
                     <button
                       type="button"
                       class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -233,16 +228,7 @@
                               </span>
                             </td>
                             <td class="px-4 py-2.5 text-right">
-                              <span
-                                class="inline-flex"
-                                [pTooltip]="
-                                  canEdit()
-                                    ? assignment.isOrgEditable
-                                      ? 'Edit committee role'
-                                      : (assignment.reason ?? 'This seat is foundation-controlled and not editable here.')
-                                    : editDisabledTooltip
-                                "
-                                tooltipPosition="top">
+                              <span class="inline-flex" [pTooltip]="assignment.editTooltip" tooltipPosition="top">
                                 <button
                                   type="button"
                                   class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -41,7 +42,7 @@ import { buildPersonGroups, decorateAssignments } from './helpers/committee-memb
 @Component({
   selector: 'lfx-org-people-committee-members',
   standalone: true,
-  imports: [ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
+  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
   providers: [MessageService, DialogService],
   templateUrl: './committee-members.component.html',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -173,6 +173,11 @@ export class CommitteeMembersComponent {
       }));
     if (roles.length === 0) return;
 
+    // `group.email` is the grouping key and falls back to a seat `memberUid` when the upstream email is
+    // blank — never pass it as the contact email. Source the person's real email from the assignments so
+    // the modal's duplicate/self-selection guard + typeahead exclusion compare against an actual address.
+    const currentEmail = group.assignments.find((a) => a.person.email)?.person.email ?? '';
+
     const ref = this.dialogService.open(ReassignCommitteeRolesModalComponent, {
       width: '600px',
       modal: true,
@@ -180,7 +185,7 @@ export class CommitteeMembersComponent {
       dismissableMask: true,
       showHeader: false,
       data: {
-        person: { fullName: group.displayName, email: group.email, initials: group.initials },
+        person: { fullName: group.displayName, email: currentEmail, initials: group.initials },
         roles,
         orgUid,
         submit: (intent) => this.performBulkReassign(intent, orgUid),

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -36,7 +36,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { CommitteeMembersService } from '../../services/committee-members.service';
 import { EditCommitteeRoleModalComponent } from './components/edit-committee-role-modal.component';
 import { ReassignCommitteeRolesModalComponent } from './components/reassign-committee-roles-modal.component';
-import { buildPersonGroups, decorateAssignments } from './helpers/committee-members.helper';
+import { buildPersonGroups, decoratePersonGroup } from './helpers/committee-members.helper';
 
 /** Org Lens — People → Committee tab (spec 027). Org-wide, non-Board committee-member roster grouped by person, with filter/sort/expand (US1+US2). Reassign/Edit modals wired in US3/US4. */
 @Component({
@@ -214,7 +214,12 @@ export class CommitteeMembersComponent {
     this.wireDialogToAccountChange(ref);
   }
 
-  // Fan out one PUT per selected seat; refresh after; throw on any failure so the modal can surface an inline retry.
+  // Fan out one PUT per selected seat; refresh after. Full failure throws (modal stays open with the
+  // inline error). Partial success RESOLVES (modal closes) and a warning toast summarizes the result —
+  // succeeded seats already moved upstream, so leaving the modal open with stale `selectedKeys` would
+  // re-PATCH already-succeeded `memberUid`s and 404 them (the original seat no longer exists). The
+  // follow-up "retry just the failures" UX requires a per-role-result contract on `submit`, which is
+  // out of scope for this round (tracked separately).
   private async performBulkReassign(intent: ReassignCommitteeRolesSubmitEvent, orgUid: string): Promise<void> {
     const ops = intent.selected.map((role) =>
       firstValueFrom(
@@ -230,9 +235,9 @@ export class CommitteeMembersComponent {
     const results = await Promise.allSettled(ops);
     this.retry();
 
+    const total = intent.selected.length;
     const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
     if (failures.length === 0) {
-      const total = intent.selected.length;
       this.messageService.add({
         key: 'org-people-committee-toast-success',
         severity: 'success',
@@ -243,12 +248,17 @@ export class CommitteeMembersComponent {
       return;
     }
 
-    const total = intent.selected.length;
     const succeeded = total - failures.length;
     if (succeeded === 0) {
       throw new Error(this.cleanErrorMessage(failures[0].reason));
     }
-    throw new Error(`${succeeded} of ${total} reassignments succeeded. Reopen this dialog to retry the remaining roles with fresh state.`);
+    this.messageService.add({
+      key: 'org-people-committee-toast-success',
+      severity: 'warn',
+      summary: 'Some reassignments did not succeed',
+      detail: `${succeeded} of ${total} succeeded. Reopen this dialog to retry the remaining ${total - succeeded}.`,
+      life: 6000,
+    });
   }
 
   // Single PUT; refresh after; re-throw the cleaned message so the modal can surface an inline retry.
@@ -387,7 +397,8 @@ export class CommitteeMembersComponent {
   }
 
   private initDecoratedGroups(): CommitteeMemberPersonGroupVm[] {
-    return this.sortedGroups().map((g) => ({ ...g, sortedAssignments: decorateAssignments(g) }));
+    const opts = { canEdit: this.canEdit(), editDisabledTooltip: this.editDisabledTooltip };
+    return this.sortedGroups().map((g) => decoratePersonGroup(g, opts));
   }
 
   private initCanEdit(): boolean {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -1,0 +1,416 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, firstValueFrom, map, of, skip, Subject, switchMap, takeUntil, tap } from 'rxjs';
+
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
+import { EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE, votingStatusPillClass } from '@lfx-one/shared/constants';
+import type {
+  CommitteeMemberAssignmentVm,
+  CommitteeMemberPersonGroup,
+  CommitteeMemberPersonGroupVm,
+  CommitteeMembersSortColumn,
+  CommitteeMembersSortDirection,
+  EditCommitteeRoleDialogData,
+  EditCommitteeRoleSubmitEvent,
+  OrgDropdownOption,
+  OrgPeopleCommitteeMembersResponse,
+  ReassignCommitteeRolesDialogData,
+  ReassignCommitteeRolesRoleOption,
+  ReassignCommitteeRolesSubmitEvent,
+} from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
+import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { CommitteeMembersService } from '../../services/committee-members.service';
+import { EditCommitteeRoleModalComponent } from './components/edit-committee-role-modal.component';
+import { ReassignCommitteeRolesModalComponent } from './components/reassign-committee-roles-modal.component';
+import { buildPersonGroups, decorateAssignments } from './helpers/committee-members.helper';
+
+/** Org Lens — People → Committee tab (spec 027). Org-wide, non-Board committee-member roster grouped by person, with filter/sort/expand (US1+US2). Reassign/Edit modals wired in US3/US4. */
+@Component({
+  selector: 'lfx-org-people-committee-members',
+  standalone: true,
+  imports: [ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
+  providers: [MessageService, DialogService],
+  templateUrl: './committee-members.component.html',
+})
+export class CommitteeMembersComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly dataService = inject(CommitteeMembersService);
+  private readonly roleGrants = inject(OrgRoleGrantsService);
+  private readonly messageService = inject(MessageService);
+  private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly tableSkeletonRows: readonly number[] = [0, 1, 2, 3, 4, 5];
+  protected readonly statSkeletonLabels: readonly string[] = ['Individuals', 'Committees', 'Foundations with committee members'];
+  protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
+
+  protected readonly filterForm = new FormGroup({
+    search: new FormControl<string>('', { nonNullable: true }),
+    foundation: new FormControl<string>('', { nonNullable: true }),
+    committee: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  // WritableSignals first (grouped per component-organization convention).
+  protected readonly sortColumn = signal<CommitteeMembersSortColumn>('name');
+  protected readonly sortDirection = signal<CommitteeMembersSortDirection>(1);
+  protected readonly expansion = signal<Record<string, boolean>>({});
+  protected readonly retryTrigger = signal<number>(0);
+  private readonly loadingState = signal<boolean>(true);
+  private readonly fetchErrorState = signal<boolean>(false);
+
+  protected readonly isLoading = this.loadingState.asReadonly();
+  protected readonly fetchError = this.fetchErrorState.asReadonly();
+
+  // Mirror the reactive form into a signal so computeds re-run on input (FormGroup.value is not a signal).
+  private readonly filterValues = toSignal(this.filterForm.valueChanges.pipe(debounceTime(150)), {
+    initialValue: this.filterForm.getRawValue(),
+  });
+
+  // Scoped on the org account id (SFID); gated on `!!uid` so the skeleton holds until the org-selector populates it.
+  private readonly orgUid$ = toObservable(this.accountContext.selectedAccount).pipe(
+    map((account) => account.uid),
+    distinctUntilChanged()
+  );
+
+  protected readonly response: Signal<OrgPeopleCommitteeMembersResponse> = this.initResponse();
+
+  protected readonly stats = computed(() => this.response().stats);
+
+  protected readonly groupedPeople: Signal<CommitteeMemberPersonGroup[]> = computed(() => buildPersonGroups(this.response().assignments));
+  protected readonly foundationOptions: Signal<OrgDropdownOption[]> = computed(() => this.initFoundationOptions());
+  protected readonly committeeOptions: Signal<OrgDropdownOption[]> = computed(() => this.initCommitteeOptions());
+  protected readonly filteredGroups: Signal<CommitteeMemberPersonGroup[]> = computed(() => this.initFilteredGroups());
+  protected readonly sortedGroups: Signal<CommitteeMemberPersonGroup[]> = computed(() => this.initSortedGroups());
+  protected readonly decoratedGroups: Signal<CommitteeMemberPersonGroupVm[]> = computed(() => this.initDecoratedGroups());
+
+  protected readonly isFiltering = computed(() => this.initIsFiltering());
+
+  // Writer-FGA gate (UX); BFF + Heimdall still re-enforce on write.
+  protected readonly canEdit = computed(() => this.initCanEdit());
+
+  protected readonly ariaSortMap = computed(() => this.initAriaSortMap());
+  protected readonly sortIconMap = computed(() => this.initSortIconMap());
+
+  // Cancels in-flight reads + (US3/US4) closes any open dialog when the user switches account mid-flight.
+  private readonly accountCancel$ = new Subject<void>();
+
+  public constructor() {
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
+      this.accountCancel$.next();
+      this.resetAllState();
+    });
+
+    // Cascade reset (FR-006): when the foundation filter changes, clear any committee selection so a
+    // stale committee value (no longer in the narrowed options) can't render a blank <p-select> + a
+    // misleading "no matches" empty state.
+    this.filterForm.controls.foundation.valueChanges.pipe(distinctUntilChanged(), takeUntilDestroyed()).subscribe(() => {
+      if (this.filterForm.controls.committee.value) {
+        this.filterForm.controls.committee.setValue('');
+      }
+    });
+  }
+
+  protected onSort(column: CommitteeMembersSortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update((d) => (d === 1 ? -1 : 1));
+      return;
+    }
+    this.sortColumn.set(column);
+    // Numeric columns default to descending (most-active first); the name column to ascending.
+    this.sortDirection.set(column === 'name' ? 1 : -1);
+  }
+
+  protected toggleExpansion(email: string): void {
+    this.expansion.update((state) => {
+      const next = { ...state };
+      if (next[email]) delete next[email];
+      else next[email] = true;
+      return next;
+    });
+  }
+
+  protected onRowKeydown(event: KeyboardEvent, email: string): void {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    this.toggleExpansion(email);
+  }
+
+  protected retry(): void {
+    this.retryTrigger.update((v) => v + 1);
+  }
+
+  // Main-row Reassign pencil (US3) — opens the bulk modal scoped to one person's Membership-Entitlement seats.
+  protected onMainPencilClick(group: CommitteeMemberPersonGroupVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit() || group.editableCount === 0) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+
+    const roles: ReassignCommitteeRolesRoleOption[] = group.assignments
+      .filter((a) => a.isOrgEditable)
+      .map((a) => ({
+        key: a.memberUid,
+        memberUid: a.memberUid,
+        committeeUid: a.committeeUid,
+        committeeName: a.committeeName,
+        foundationName: a.foundationName,
+        votingStatus: a.votingStatus,
+        votingStatusPillClass: votingStatusPillClass(a.votingStatus),
+      }));
+    if (roles.length === 0) return;
+
+    const ref = this.dialogService.open(ReassignCommitteeRolesModalComponent, {
+      width: '600px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        person: { fullName: group.displayName, email: group.email, initials: group.initials },
+        roles,
+        orgUid,
+        submit: (intent) => this.performBulkReassign(intent, orgUid),
+      } satisfies ReassignCommitteeRolesDialogData,
+    }) as DynamicDialogRef;
+
+    this.wireDialogToAccountChange(ref);
+  }
+
+  // Sub-row Edit pencil (US4) — opens the single-seat modal scoped to one Membership-Entitlement seat.
+  protected onSubRowPencilClick(assignment: CommitteeMemberAssignmentVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit() || !assignment.isOrgEditable) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+
+    const ref = this.dialogService.open(EditCommitteeRoleModalComponent, {
+      width: '560px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        assignment,
+        orgUid,
+        submit: (intent) => this.performSingleReassign(intent, orgUid),
+      } satisfies EditCommitteeRoleDialogData,
+    }) as DynamicDialogRef;
+
+    this.wireDialogToAccountChange(ref);
+  }
+
+  // Fan out one PUT per selected seat; refresh after; throw on any failure so the modal can surface an inline retry.
+  private async performBulkReassign(intent: ReassignCommitteeRolesSubmitEvent, orgUid: string): Promise<void> {
+    const ops = intent.selected.map((role) =>
+      firstValueFrom(
+        this.dataService.reassignSeat(orgUid, role.memberUid, {
+          committeeUid: role.committeeUid,
+          firstName: intent.newPerson.firstName,
+          lastName: intent.newPerson.lastName,
+          email: intent.newPerson.email,
+        })
+      )
+    );
+
+    const results = await Promise.allSettled(ops);
+    this.retry();
+
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failures.length === 0) {
+      const total = intent.selected.length;
+      this.messageService.add({
+        key: 'org-people-committee-toast-success',
+        severity: 'success',
+        summary: 'Committee roles reassigned',
+        detail: `${total} ${total === 1 ? 'role was' : 'roles were'} reassigned.`,
+        life: 3000,
+      });
+      return;
+    }
+
+    const total = intent.selected.length;
+    const succeeded = total - failures.length;
+    if (succeeded === 0) {
+      throw new Error(this.cleanErrorMessage(failures[0].reason));
+    }
+    throw new Error(`${succeeded} of ${total} reassignments succeeded. Reopen this dialog to retry the remaining roles with fresh state.`);
+  }
+
+  // Single PUT; refresh after; re-throw the cleaned message so the modal can surface an inline retry.
+  private async performSingleReassign(intent: EditCommitteeRoleSubmitEvent, orgUid: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.dataService.reassignSeat(orgUid, intent.memberUid, {
+          committeeUid: intent.committeeUid,
+          firstName: intent.newPerson.firstName,
+          lastName: intent.newPerson.lastName,
+          email: intent.newPerson.email,
+        })
+      );
+    } catch (err) {
+      throw new Error(this.cleanErrorMessage(err));
+    }
+    this.messageService.add({
+      key: 'org-people-committee-toast-success',
+      severity: 'success',
+      summary: 'Committee role updated',
+      life: 3000,
+    });
+    this.retry();
+  }
+
+  // Closes the dialog if the user switches account before confirming — prevents cross-org writes.
+  private wireDialogToAccountChange(ref: DynamicDialogRef): void {
+    this.accountCancel$.pipe(takeUntil(ref.onClose), takeUntilDestroyed(this.destroyRef)).subscribe(() => ref.close(null));
+  }
+
+  private cleanErrorMessage(err: unknown): string {
+    return (err as { error?: { error?: { message?: string } } })?.error?.error?.message ?? 'Could not save changes. Please try again.';
+  }
+
+  private initResponse(): Signal<OrgPeopleCommitteeMembersResponse> {
+    return toSignal(
+      combineLatest([this.orgUid$, toObservable(this.retryTrigger)]).pipe(
+        tap(() => {
+          this.loadingState.set(true);
+          this.fetchErrorState.set(false);
+        }),
+        switchMap(([orgUid]) => {
+          if (!orgUid) {
+            // Hold the skeleton until the org selector populates a uid — flipping loadingState to false here
+            // would briefly render the empty state on mount before account-context emits the real uid.
+            return of(EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE);
+          }
+          return this.dataService.getCommitteeMembers(orgUid).pipe(
+            tap(() => this.loadingState.set(false)),
+            catchError(() => {
+              this.fetchErrorState.set(true);
+              this.loadingState.set(false);
+              return of(EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE);
+            })
+          );
+        })
+      ),
+      { initialValue: EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE }
+    );
+  }
+
+  private initFoundationOptions(): OrgDropdownOption[] {
+    const labels = [
+      ...new Set(
+        this.response()
+          .assignments.map((a) => a.foundationName)
+          .filter(Boolean)
+      ),
+    ].sort((a, b) => a.localeCompare(b));
+    return [{ label: 'All Foundations', value: '' }, ...labels.map((l) => ({ label: l, value: l }))];
+  }
+
+  private initCommitteeOptions(): OrgDropdownOption[] {
+    const foundation = this.filterValues().foundation ?? '';
+    const scoped = foundation ? this.response().assignments.filter((a) => a.foundationName === foundation) : this.response().assignments;
+    const labels = [...new Set(scoped.map((a) => a.committeeName).filter(Boolean))].sort((a, b) => a.localeCompare(b));
+    return [{ label: 'All Committees', value: '' }, ...labels.map((l) => ({ label: l, value: l }))];
+  }
+
+  private initIsFiltering(): boolean {
+    const v = this.filterValues();
+    return (v.search ?? '').trim().length > 0 || !!(v.foundation ?? '') || !!(v.committee ?? '');
+  }
+
+  private initFilteredGroups(): CommitteeMemberPersonGroup[] {
+    const v = this.filterValues();
+    const q = (v.search ?? '').trim().toLowerCase();
+    const foundation = v.foundation ?? '';
+    const committee = v.committee ?? '';
+
+    return this.groupedPeople().filter((group) => {
+      if (foundation && !group.assignments.some((a) => a.foundationName === foundation)) return false;
+      if (committee && !group.assignments.some((a) => a.committeeName === committee)) return false;
+      if (q && !this.groupSearchText(group).includes(q)) return false;
+      return true;
+    });
+  }
+
+  /** FR-005: case-insensitive search over name, job title, email, foundation, committee, role, voting, appointed-by. */
+  private groupSearchText(group: CommitteeMemberPersonGroup): string {
+    const parts: (string | null | undefined)[] = [group.displayName, group.jobTitle, group.email];
+    for (const a of group.assignments) {
+      parts.push(a.foundationName, a.committeeName, a.role, a.votingStatus, a.appointedBy);
+    }
+    return parts
+      .filter((p): p is string => Boolean(p))
+      .join(' ')
+      .toLowerCase();
+  }
+
+  private initSortedGroups(): CommitteeMemberPersonGroup[] {
+    const col = this.sortColumn();
+    const dir = this.sortDirection();
+    const copy = [...this.filteredGroups()];
+    copy.sort((a, b) => {
+      if (col === 'foundations') {
+        const cmp = (a.foundationLabels.length - b.foundationLabels.length) * dir;
+        return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName);
+      }
+      if (col === 'committees') {
+        const cmp = (a.committeeCount - b.committeeCount) * dir;
+        return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName);
+      }
+      return a.displayName.localeCompare(b.displayName) * dir;
+    });
+    return copy;
+  }
+
+  private initDecoratedGroups(): CommitteeMemberPersonGroupVm[] {
+    return this.sortedGroups().map((g) => ({ ...g, sortedAssignments: decorateAssignments(g) }));
+  }
+
+  private initCanEdit(): boolean {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    if (!uid) return false;
+    return this.roleGrants.writerSet().has(uid);
+  }
+
+  private initAriaSortMap(): Record<CommitteeMembersSortColumn, 'ascending' | 'descending' | 'none'> {
+    const active = this.sortColumn();
+    const direction: 'ascending' | 'descending' = this.sortDirection() === 1 ? 'ascending' : 'descending';
+    return {
+      name: active === 'name' ? direction : 'none',
+      foundations: active === 'foundations' ? direction : 'none',
+      committees: active === 'committees' ? direction : 'none',
+    };
+  }
+
+  private initSortIconMap(): Record<CommitteeMembersSortColumn, string> {
+    const active = this.sortColumn();
+    const activeIcon = this.sortDirection() === 1 ? 'fa-light fa-sort-up' : 'fa-light fa-sort-down';
+    const iconFor = (col: CommitteeMembersSortColumn): string => (active === col ? activeIcon : 'fa-light fa-sort');
+    return {
+      name: iconFor('name'),
+      foundations: iconFor('foundations'),
+      committees: iconFor('committees'),
+    };
+  }
+
+  private resetAllState(): void {
+    this.filterForm.reset({ search: '', foundation: '', committee: '' });
+    this.sortColumn.set('name');
+    this.sortDirection.set(1);
+    this.expansion.set({});
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -279,7 +279,16 @@ export class CommitteeMembersComponent {
   }
 
   private cleanErrorMessage(err: unknown): string {
-    return (err as { error?: { error?: { message?: string } } })?.error?.error?.message ?? 'Could not save changes. Please try again.';
+    // The BFF returns either `{ error: { message } }` (validation) or `{ error: string }`
+    // (MicroserviceError/BaseApiError) — tolerate both so the server detail survives to the toast.
+    const inner = (err as { error?: { error?: unknown } })?.error?.error;
+    if (typeof inner === 'string' && inner.trim()) {
+      return inner;
+    }
+    if (inner && typeof inner === 'object' && typeof (inner as { message?: unknown }).message === 'string' && (inner as { message: string }).message.trim()) {
+      return (inner as { message: string }).message;
+    }
+    return 'Could not save changes. Please try again.';
   }
 
   private initResponse(): Signal<OrgPeopleCommitteeMembersResponse> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/committee-members.component.ts
@@ -114,9 +114,8 @@ export class CommitteeMembersComponent {
       this.resetAllState();
     });
 
-    // Cascade reset (FR-006): when the foundation filter changes, clear any committee selection so a
-    // stale committee value (no longer in the narrowed options) can't render a blank <p-select> + a
-    // misleading "no matches" empty state.
+    // Cascade reset (FR-006): clear the committee selection when the foundation filter changes so a
+    // stale value can't render a blank <p-select> + a misleading "no matches" state.
     this.filterForm.controls.foundation.valueChanges.pipe(distinctUntilChanged(), takeUntilDestroyed()).subscribe(() => {
       if (this.filterForm.controls.committee.value) {
         this.filterForm.controls.committee.setValue('');
@@ -214,12 +213,8 @@ export class CommitteeMembersComponent {
     this.wireDialogToAccountChange(ref);
   }
 
-  // Fan out one PUT per selected seat; refresh after. Full failure throws (modal stays open with the
-  // inline error). Partial success RESOLVES (modal closes) and a warning toast summarizes the result —
-  // succeeded seats already moved upstream, so leaving the modal open with stale `selectedKeys` would
-  // re-PATCH already-succeeded `memberUid`s and 404 them (the original seat no longer exists). The
-  // follow-up "retry just the failures" UX requires a per-role-result contract on `submit`, which is
-  // out of scope for this round (tracked separately).
+  // Fan out one PUT per seat, then refresh: full failure throws (modal stays open with the inline error);
+  // partial success resolves with a warning toast (re-PATCHing succeeded seats would 404 on a gone seat).
   private async performBulkReassign(intent: ReassignCommitteeRolesSubmitEvent, orgUid: string): Promise<void> {
     const ops = intent.selected.map((role) =>
       firstValueFrom(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.html
@@ -71,6 +71,7 @@
             aria-haspopup="listbox"
             aria-controls="edit-committee-employee-suggestions-id"
             [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-activedescendant]="activeOptionId()"
             [attr.aria-describedby]="
               (emailFormatError() ? 'edit-committee-email-error-id' : null) || (duplicateError() ? 'edit-committee-duplicate-error-id' : null)
             "
@@ -81,6 +82,7 @@
             (ngModelChange)="onEmailChange($event)"
             (focus)="onEmailFocus()"
             (blur)="onEmailBlur()"
+            (keydown)="onEmailKeydown($event)"
             autocomplete="off" />
         </span>
         @if (suggestionsOpen() && filteredEmployees().length > 0) {
@@ -90,13 +92,16 @@
             aria-label="Employee suggestions"
             class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
             data-testid="org-people-committee-modal-edit-employee-suggestions">
-            @for (emp of filteredEmployees(); track emp.email) {
+            @for (emp of filteredEmployees(); track emp.email; let i = $index) {
               <li role="presentation">
                 <button
                   type="button"
                   role="option"
+                  [attr.id]="optionIdPrefix + i"
                   [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  [attr.aria-selected]="activeOptionIndex() === i"
                   class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [class.bg-gray-100]="activeOptionIndex() === i"
                   [attr.data-testid]="'org-people-committee-modal-edit-employee-option-' + emp.email"
                   (mousedown)="$event.preventDefault()"
                   (click)="onSelectEmployee(emp)">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.html
@@ -1,0 +1,192 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (assignment; as seat) {
+  <div class="flex max-h-[80vh] flex-col gap-5 p-5" data-testid="org-people-committee-modal-edit">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-2">
+        <h3 class="text-lg font-semibold text-gray-900" data-testid="org-people-committee-modal-edit-title">Edit Committee Role</h3>
+        <div class="flex flex-wrap items-center gap-2 text-sm" data-testid="org-people-committee-modal-edit-chips">
+          <span class="inline-block rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700">Committee</span>
+          <span class="font-medium text-gray-900">{{ seat.committeeName }}</span>
+          <span class="text-gray-400">&middot;</span>
+          <span class="text-gray-700">{{ seat.foundationName }}</span>
+          <span class="text-gray-400">&middot;</span>
+          <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="votingStatusPillClass(seat.votingStatus)">{{
+            seat.votingStatus || 'Non-voting'
+          }}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-committee-modal-edit-close"
+        aria-label="Close"
+        (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg"></i>
+      </button>
+    </div>
+
+    <!-- Current Member card -->
+    <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="org-people-committee-modal-edit-current">
+      <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Member &middot; Will Be Removed</div>
+      <div class="flex items-center gap-3">
+        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white">
+          {{ seat.person.initials }}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold text-gray-900">{{ seat.person.fullName }}</span>
+          <span class="text-xs text-gray-600">{{ seat.person.email }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Info banner -->
+    <div
+      class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900"
+      role="status"
+      data-testid="org-people-committee-modal-edit-info-banner">
+      <i class="fa-light fa-circle-info mt-0.5 text-blue-600"></i>
+      <span>This role must be held by someone at all times. The person you assign below will immediately replace the current member.</span>
+    </div>
+
+    <!-- Assign to -->
+    <div class="flex flex-col gap-3" data-testid="org-people-committee-modal-edit-assign-form" (keydown)="onFormKeydown($event)">
+      <h4 class="text-sm font-semibold text-gray-900">Assign to</h4>
+
+      <div class="relative flex flex-col gap-1">
+        <label for="edit-committee-email" class="text-xs font-medium text-gray-700">Email <span class="text-red-500">*</span></label>
+        <span class="relative">
+          <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+          <input
+            id="edit-committee-email"
+            pInputText
+            type="email"
+            placeholder="Enter the employee's email address..."
+            class="w-full pl-8"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls="edit-committee-employee-suggestions-id"
+            [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-describedby]="
+              (emailFormatError() ? 'edit-committee-email-error-id' : null) || (duplicateError() ? 'edit-committee-duplicate-error-id' : null)
+            "
+            [attr.aria-invalid]="!!emailFormatError() || !!duplicateError()"
+            data-testid="org-people-committee-modal-edit-email-input"
+            [disabled]="isSaving()"
+            [ngModel]="emailField()"
+            (ngModelChange)="onEmailChange($event)"
+            (focus)="onEmailFocus()"
+            (blur)="onEmailBlur()"
+            autocomplete="off" />
+        </span>
+        @if (suggestionsOpen() && filteredEmployees().length > 0) {
+          <ul
+            id="edit-committee-employee-suggestions-id"
+            role="listbox"
+            aria-label="Employee suggestions"
+            class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            data-testid="org-people-committee-modal-edit-employee-suggestions">
+            @for (emp of filteredEmployees(); track emp.email) {
+              <li role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [attr.data-testid]="'org-people-committee-modal-edit-employee-option-' + emp.email"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="onSelectEmployee(emp)">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">{{ emp.initials }}</div>
+                  <div class="flex min-w-0 flex-col">
+                    <span class="truncate text-sm font-medium text-gray-900">{{ emp.fullName }}</span>
+                    <span class="truncate text-xs text-gray-500">{{ emp.email }}</span>
+                  </div>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+        @if (employeeSearchUnavailable()) {
+          <p class="text-xs text-gray-500" data-testid="org-people-committee-modal-edit-search-unavailable">
+            Employee search is unavailable. You can still enter the member's details manually.
+          </p>
+        }
+        @if (emailFormatError()) {
+          <p id="edit-committee-email-error-id" class="text-xs text-red-600" data-testid="org-people-committee-modal-edit-email-error">
+            {{ emailFormatError() }}
+          </p>
+        }
+        @if (duplicateError()) {
+          <p id="edit-committee-duplicate-error-id" class="text-xs text-red-600" data-testid="org-people-committee-modal-edit-duplicate-error">
+            {{ duplicateError() }}
+          </p>
+        }
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label for="edit-committee-first-name" class="text-xs font-medium text-gray-700">First Name <span class="text-red-500">*</span></label>
+          <input
+            id="edit-committee-first-name"
+            pInputText
+            type="text"
+            placeholder="First name"
+            [ngModel]="firstNameField()"
+            (ngModelChange)="firstNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-committee-modal-edit-first-name-input"
+            autocomplete="off" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="edit-committee-last-name" class="text-xs font-medium text-gray-700">Last Name <span class="text-red-500">*</span></label>
+          <input
+            id="edit-committee-last-name"
+            pInputText
+            type="text"
+            placeholder="Last name"
+            [ngModel]="lastNameField()"
+            (ngModelChange)="lastNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-committee-modal-edit-last-name-input"
+            autocomplete="off" />
+        </div>
+      </div>
+    </div>
+
+    @if (saveError()) {
+      <div
+        class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+        role="alert"
+        data-testid="org-people-committee-modal-edit-save-error">
+        {{ saveError() }}
+      </div>
+    }
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        class="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-committee-modal-edit-cancel"
+        (click)="onCancel()">
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        [disabled]="!saveEnabled()"
+        data-testid="org-people-committee-modal-edit-primary-button"
+        (click)="onSave()">
+        @if (isSaving()) {
+          <i class="fa-light fa-spinner fa-spin"></i>
+        }
+        Save Changes
+      </button>
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
@@ -102,10 +102,8 @@ export class EditCommitteeRoleModalComponent {
     this.activeOptionIndex.set(-1);
   }
 
-  // Active-descendant keyboard handler — ArrowUp/Down wrap-navigate the listbox without moving focus,
-  // Enter selects the highlighted option (else falls through to onFormKeydown's Save), Escape closes.
-  // Without this a keyboard-only user couldn't reach a suggestion: (blur) closes the panel as soon as
-  // focus would move off the input.
+  // Active-descendant keyboard handler: ArrowUp/Down navigate the listbox without moving focus, Enter
+  // selects the highlight (else Save), Escape closes — keyboard users can't reach a suggestion otherwise.
   protected onEmailKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       if (this.suggestionsOpen()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
@@ -41,9 +41,14 @@ export class EditCommitteeRoleModalComponent {
   protected readonly employees = signal<KeyContactEmployee[]>([]);
   protected readonly employeeSearchUnavailable = signal(false);
   protected readonly suggestionsOpen = signal(false);
+  // Active-descendant pattern: keyboard navigates a highlighted option via ArrowUp/Down while focus
+  // stays on the input. -1 means "nothing highlighted yet".
+  protected readonly activeOptionIndex = signal<number>(-1);
+  protected readonly optionIdPrefix = 'edit-committee-employee-option-';
 
   protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
   protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+  protected readonly activeOptionId: Signal<string | null> = computed(() => this.initActiveOptionId());
 
   private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
 
@@ -66,6 +71,9 @@ export class EditCommitteeRoleModalComponent {
   protected onEmailChange(value: string): void {
     this.emailField.set(value);
     this.suggestionsOpen.set(true);
+    // The filtered list re-orders with every keystroke — drop the previous highlight so the user
+    // doesn't accidentally Enter-select a stale option.
+    this.activeOptionIndex.set(-1);
     if (this.duplicateError()) this.duplicateError.set(null);
     if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
       this.emailFormatError.set(null);
@@ -74,6 +82,7 @@ export class EditCommitteeRoleModalComponent {
 
   protected onEmailBlur(): void {
     this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
     this.duplicateError.set(null);
     const value = this.emailField().trim();
     if (value && !EMAIL_REGEX.test(value)) {
@@ -90,6 +99,51 @@ export class EditCommitteeRoleModalComponent {
     this.emailFormatError.set(null);
     this.duplicateError.set(null);
     this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+  }
+
+  // Active-descendant keyboard handler — ArrowUp/Down wrap-navigate the listbox without moving focus,
+  // Enter selects the highlighted option (else falls through to onFormKeydown's Save), Escape closes.
+  // Without this a keyboard-only user couldn't reach a suggestion: (blur) closes the panel as soon as
+  // focus would move off the input.
+  protected onEmailKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      if (this.suggestionsOpen()) {
+        // Swallow so the parent PrimeNG dialog doesn't also close the modal on the same key.
+        event.preventDefault();
+        event.stopPropagation();
+        this.suggestionsOpen.set(false);
+        this.activeOptionIndex.set(-1);
+      }
+      return;
+    }
+
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Enter') return;
+
+    if (!this.suggestionsOpen() && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      this.suggestionsOpen.set(true);
+    }
+
+    const options = this.filteredEmployees();
+    if (options.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? 0 : (idx + 1) % options.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? options.length - 1 : (idx - 1 + options.length) % options.length);
+    } else if (event.key === 'Enter') {
+      const idx = this.activeOptionIndex();
+      if (idx >= 0 && idx < options.length) {
+        // A highlighted option wins over the form-level Save handler.
+        event.preventDefault();
+        event.stopPropagation();
+        this.onSelectEmployee(options[idx]);
+      }
+    }
   }
 
   protected onFormKeydown(event: KeyboardEvent): void {
@@ -165,5 +219,12 @@ export class EditCommitteeRoleModalComponent {
     if (this.lastNameField().trim().length === 0) return false;
     if (this.emailFormatError() || this.duplicateError()) return false;
     return true;
+  }
+
+  private initActiveOptionId(): string | null {
+    const idx = this.activeOptionIndex();
+    if (idx < 0) return null;
+    if (idx >= this.filteredEmployees().length) return null;
+    return `${this.optionIdPrefix}${idx}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/edit-committee-role-modal.component.ts
@@ -1,0 +1,169 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { EMAIL_REGEX, votingStatusPillClass } from '@lfx-one/shared/constants';
+import type { CommitteeMemberAssignment, EditCommitteeRoleDialogData, EditCommitteeRoleSubmitEvent, KeyContactEmployee } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { take } from 'rxjs';
+
+import { CommitteeMembersService } from '../../../services/committee-members.service';
+
+/** Spec 027 US4 — reassign a single Membership-Entitlement committee seat to a new holder. */
+@Component({
+  selector: 'lfx-edit-committee-role-modal',
+  standalone: true,
+  imports: [FormsModule, InputTextModule],
+  templateUrl: './edit-committee-role-modal.component.html',
+})
+export class EditCommitteeRoleModalComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dataService = inject(CommitteeMembersService);
+  private readonly dialogConfig = inject<DynamicDialogConfig<EditCommitteeRoleDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly assignment: CommitteeMemberAssignment | null = this.dialogConfig.data?.assignment ?? null;
+  private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
+
+  protected readonly votingStatusPillClass = votingStatusPillClass;
+
+  protected readonly emailField = signal('');
+  protected readonly firstNameField = signal('');
+  protected readonly lastNameField = signal('');
+  protected readonly emailFormatError = signal<string | null>(null);
+  protected readonly duplicateError = signal<string | null>(null);
+
+  protected readonly isSaving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly employees = signal<KeyContactEmployee[]>([]);
+  protected readonly employeeSearchUnavailable = signal(false);
+  protected readonly suggestionsOpen = signal(false);
+
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
+  protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+
+  private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
+
+  public constructor() {
+    if (this.orgUid) {
+      this.dataService
+        .getEmployees(this.orgUid)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (res) => this.employees.set(res.employees ?? []),
+          error: () => this.employeeSearchUnavailable.set(true),
+        });
+    }
+  }
+
+  protected onEmailFocus(): void {
+    this.suggestionsOpen.set(true);
+  }
+
+  protected onEmailChange(value: string): void {
+    this.emailField.set(value);
+    this.suggestionsOpen.set(true);
+    if (this.duplicateError()) this.duplicateError.set(null);
+    if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onEmailBlur(): void {
+    this.suggestionsOpen.set(false);
+    this.duplicateError.set(null);
+    const value = this.emailField().trim();
+    if (value && !EMAIL_REGEX.test(value)) {
+      this.emailFormatError.set('Enter a valid email address');
+    } else {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onSelectEmployee(employee: KeyContactEmployee): void {
+    this.emailField.set(employee.email);
+    this.firstNameField.set(employee.firstName);
+    this.lastNameField.set(employee.lastName);
+    this.emailFormatError.set(null);
+    this.duplicateError.set(null);
+    this.suggestionsOpen.set(false);
+  }
+
+  protected onFormKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && this.saveEnabled()) {
+      event.preventDefault();
+      this.onSave();
+    }
+  }
+
+  protected onSave(): void {
+    if (!this.saveEnabled() || !this.assignment) return;
+
+    const enteredEmail = this.emailField().trim().toLowerCase();
+    const currentEmail = this.assignment.person.email?.trim().toLowerCase() ?? '';
+    if (enteredEmail === currentEmail) {
+      this.duplicateError.set('This person already holds this role.');
+      return;
+    }
+
+    const intent: EditCommitteeRoleSubmitEvent = {
+      memberUid: this.assignment.memberUid,
+      committeeUid: this.assignment.committeeUid,
+      newPerson: {
+        email: this.emailField().trim(),
+        firstName: this.firstNameField().trim(),
+        lastName: this.lastNameField().trim(),
+      },
+    };
+
+    const submit = this.dialogConfig.data?.submit;
+    if (!submit) {
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.isSaving.set(true);
+    this.saveError.set(null);
+    submit(intent)
+      .then(() => this.dialogRef.close(null))
+      .catch((e: unknown) => {
+        this.isSaving.set(false);
+        this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
+      });
+  }
+
+  protected onCancel(): void {
+    if (this.isSaving()) return;
+    this.dialogRef.close(null);
+  }
+
+  private initExcludedEmails(): Set<string> {
+    const set = new Set<string>();
+    const currentEmail = this.assignment?.person.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  }
+
+  private initFilteredEmployees(): KeyContactEmployee[] {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  }
+
+  private initSaveEnabled(): boolean {
+    if (this.isSaving()) return false;
+    const email = this.emailField().trim();
+    if (!email || !EMAIL_REGEX.test(email)) return false;
+    if (this.firstNameField().trim().length === 0) return false;
+    if (this.lastNameField().trim().length === 0) return false;
+    if (this.emailFormatError() || this.duplicateError()) return false;
+    return true;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.html
@@ -1,0 +1,229 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (person; as currentPerson) {
+  <div class="flex max-h-[80vh] flex-col gap-5 p-5" data-testid="org-people-committee-modal-reassign">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-lg font-semibold text-gray-900" id="reassign-committee-title" data-testid="org-people-committee-modal-reassign-title">
+          Reassign Committee Roles
+        </h3>
+        <p class="text-xs text-gray-500" data-testid="org-people-committee-modal-reassign-subtitle">{{ subtitle() }}</p>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-committee-modal-reassign-close"
+        aria-label="Close"
+        (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg"></i>
+      </button>
+    </div>
+
+    <!-- Current Member card -->
+    <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="org-people-committee-modal-reassign-current">
+      <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Member &middot; Will Be Removed From Selected Roles</div>
+      <div class="flex items-center gap-3">
+        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white">
+          {{ currentPerson.initials }}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold text-gray-900">{{ currentPerson.fullName }}</span>
+          <span class="text-xs text-gray-600">{{ currentPerson.email }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Select roles to reassign -->
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <h4 class="text-sm font-semibold text-gray-900">Select roles to reassign</h4>
+        <label class="flex cursor-pointer items-center gap-2 text-xs text-blue-600">
+          <p-checkbox
+            [binary]="true"
+            [ngModel]="allChecked()"
+            (ngModelChange)="toggleSelectAll()"
+            [disabled]="isSaving()"
+            inputId="reassign-committee-select-all"
+            data-testid="org-people-committee-modal-reassign-select-all" />
+          <span>Select all</span>
+        </label>
+      </div>
+
+      <div class="flex max-h-[260px] flex-col gap-2 overflow-y-auto pr-1" data-testid="org-people-committee-modal-reassign-roles-list">
+        @let checkedMap = checkedKeyMap();
+        @for (role of roles; track role.key) {
+          <div
+            class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+            [attr.data-testid]="'org-people-committee-modal-reassign-role-row-' + role.key">
+            <p-checkbox
+              [binary]="true"
+              [ngModel]="checkedMap[role.key]"
+              (ngModelChange)="toggleRole(role.key)"
+              [disabled]="isSaving()"
+              [attr.data-testid]="'org-people-committee-modal-reassign-role-checkbox-' + role.key" />
+            <span class="inline-block rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700">Committee</span>
+            <div class="flex flex-1 flex-col">
+              <span class="text-sm font-medium text-gray-900">{{ role.committeeName }}</span>
+              <span class="text-xs text-gray-500">{{ role.foundationName }}</span>
+            </div>
+            <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="role.votingStatusPillClass">{{
+              role.votingStatus || 'Non-voting'
+            }}</span>
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Info banner -->
+    <div
+      class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900"
+      role="status"
+      data-testid="org-people-committee-modal-reassign-info-banner">
+      <i class="fa-light fa-circle-info mt-0.5 text-blue-600"></i>
+      <span
+        >Each selected role must be held by someone at all times. The person you assign below will replace the current member in every role you've checked
+        above.</span
+      >
+    </div>
+
+    <!-- Assign to -->
+    <div class="flex flex-col gap-3" data-testid="org-people-committee-modal-reassign-assign-form" (keydown)="onFormKeydown($event)">
+      <h4 class="text-sm font-semibold text-gray-900">Assign to</h4>
+
+      <div class="relative flex flex-col gap-1">
+        <label for="reassign-committee-email" class="text-xs font-medium text-gray-700">Email <span class="text-red-500">*</span></label>
+        <span class="relative">
+          <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+          <input
+            id="reassign-committee-email"
+            pInputText
+            type="email"
+            placeholder="Enter the employee's email address..."
+            class="w-full pl-8"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls="reassign-committee-employee-suggestions-id"
+            [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-describedby]="
+              (emailFormatError() ? 'reassign-committee-email-error-id' : null) || (duplicateError() ? 'reassign-committee-duplicate-error-id' : null)
+            "
+            [attr.aria-invalid]="!!emailFormatError() || !!duplicateError()"
+            data-testid="org-people-committee-modal-reassign-email-input"
+            [disabled]="isSaving()"
+            [ngModel]="emailField()"
+            (ngModelChange)="onEmailChange($event)"
+            (focus)="onEmailFocus()"
+            (blur)="onEmailBlur()"
+            autocomplete="off" />
+        </span>
+        @if (suggestionsOpen() && filteredEmployees().length > 0) {
+          <ul
+            id="reassign-committee-employee-suggestions-id"
+            role="listbox"
+            aria-label="Employee suggestions"
+            class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            data-testid="org-people-committee-modal-reassign-employee-suggestions">
+            @for (emp of filteredEmployees(); track emp.email) {
+              <li role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [attr.data-testid]="'org-people-committee-modal-reassign-employee-option-' + emp.email"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="onSelectEmployee(emp)">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">{{ emp.initials }}</div>
+                  <div class="flex min-w-0 flex-col">
+                    <span class="truncate text-sm font-medium text-gray-900">{{ emp.fullName }}</span>
+                    <span class="truncate text-xs text-gray-500">{{ emp.email }}</span>
+                  </div>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+        @if (employeeSearchUnavailable()) {
+          <p class="text-xs text-gray-500" data-testid="org-people-committee-modal-reassign-search-unavailable">
+            Employee search is unavailable. You can still enter the member's details manually.
+          </p>
+        }
+        @if (emailFormatError()) {
+          <p id="reassign-committee-email-error-id" class="text-xs text-red-600" data-testid="org-people-committee-modal-reassign-email-error">
+            {{ emailFormatError() }}
+          </p>
+        }
+        @if (duplicateError()) {
+          <p id="reassign-committee-duplicate-error-id" class="text-xs text-red-600" data-testid="org-people-committee-modal-reassign-duplicate-error">
+            {{ duplicateError() }}
+          </p>
+        }
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label for="reassign-committee-first-name" class="text-xs font-medium text-gray-700">First Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-committee-first-name"
+            pInputText
+            type="text"
+            placeholder="First name"
+            [ngModel]="firstNameField()"
+            (ngModelChange)="firstNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-committee-modal-reassign-first-name-input"
+            autocomplete="off" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="reassign-committee-last-name" class="text-xs font-medium text-gray-700">Last Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-committee-last-name"
+            pInputText
+            type="text"
+            placeholder="Last name"
+            [ngModel]="lastNameField()"
+            (ngModelChange)="lastNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-committee-modal-reassign-last-name-input"
+            autocomplete="off" />
+        </div>
+      </div>
+    </div>
+
+    @if (saveError()) {
+      <div
+        class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+        role="alert"
+        data-testid="org-people-committee-modal-reassign-save-error">
+        {{ saveError() }}
+      </div>
+    }
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        class="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-committee-modal-reassign-cancel"
+        (click)="onCancel()">
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        [disabled]="!saveEnabled()"
+        data-testid="org-people-committee-modal-reassign-primary-button"
+        (click)="onSave()">
+        @if (isSaving()) {
+          <i class="fa-light fa-spinner fa-spin"></i>
+        }
+        {{ primaryButtonLabel() }}
+      </button>
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.html
@@ -108,6 +108,7 @@
             aria-haspopup="listbox"
             aria-controls="reassign-committee-employee-suggestions-id"
             [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-activedescendant]="activeOptionId()"
             [attr.aria-describedby]="
               (emailFormatError() ? 'reassign-committee-email-error-id' : null) || (duplicateError() ? 'reassign-committee-duplicate-error-id' : null)
             "
@@ -118,6 +119,7 @@
             (ngModelChange)="onEmailChange($event)"
             (focus)="onEmailFocus()"
             (blur)="onEmailBlur()"
+            (keydown)="onEmailKeydown($event)"
             autocomplete="off" />
         </span>
         @if (suggestionsOpen() && filteredEmployees().length > 0) {
@@ -127,13 +129,16 @@
             aria-label="Employee suggestions"
             class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
             data-testid="org-people-committee-modal-reassign-employee-suggestions">
-            @for (emp of filteredEmployees(); track emp.email) {
+            @for (emp of filteredEmployees(); track emp.email; let i = $index) {
               <li role="presentation">
                 <button
                   type="button"
                   role="option"
+                  [attr.id]="optionIdPrefix + i"
                   [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  [attr.aria-selected]="activeOptionIndex() === i"
                   class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [class.bg-gray-100]="activeOptionIndex() === i"
                   [attr.data-testid]="'org-people-committee-modal-reassign-employee-option-' + emp.email"
                   (mousedown)="$event.preventDefault()"
                   (click)="onSelectEmployee(emp)">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
@@ -140,10 +140,8 @@ export class ReassignCommitteeRolesModalComponent {
     this.activeOptionIndex.set(-1);
   }
 
-  // Active-descendant keyboard handler — ArrowUp/Down wrap-navigate the listbox without moving focus,
-  // Enter selects the highlighted option (else falls through to onFormKeydown's Save), Escape closes.
-  // Without this a keyboard-only user couldn't reach a suggestion: (blur) closes the panel as soon as
-  // focus would move off the input.
+  // Active-descendant keyboard handler: ArrowUp/Down navigate the listbox without moving focus, Enter
+  // selects the highlight (else Save), Escape closes — keyboard users can't reach a suggestion otherwise.
   protected onEmailKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       if (this.suggestionsOpen()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
@@ -52,6 +52,10 @@ export class ReassignCommitteeRolesModalComponent {
   protected readonly employees = signal<KeyContactEmployee[]>([]);
   protected readonly employeeSearchUnavailable = signal(false);
   protected readonly suggestionsOpen = signal(false);
+  // Active-descendant pattern: keyboard navigates a highlighted option via ArrowUp/Down while focus
+  // stays on the input. -1 means "nothing highlighted yet".
+  protected readonly activeOptionIndex = signal<number>(-1);
+  protected readonly optionIdPrefix = 'reassign-committee-employee-option-';
 
   protected readonly checkedCount: Signal<number> = computed(() => this.selectedKeys().size);
   protected readonly allChecked: Signal<boolean> = computed(() => this.roles.length > 0 && this.selectedKeys().size === this.roles.length);
@@ -62,6 +66,7 @@ export class ReassignCommitteeRolesModalComponent {
   protected readonly checkedKeyMap: Signal<Record<string, boolean>> = computed(() => this.initCheckedKeyMap());
   protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
   protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+  protected readonly activeOptionId: Signal<string | null> = computed(() => this.initActiveOptionId());
 
   // Hide the current holder's own email from the typeahead — reassigning to themselves is a no-op.
   private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
@@ -104,6 +109,9 @@ export class ReassignCommitteeRolesModalComponent {
   protected onEmailChange(value: string): void {
     this.emailField.set(value);
     this.suggestionsOpen.set(true);
+    // The filtered list re-orders with every keystroke — drop the previous highlight so the user
+    // doesn't accidentally Enter-select a stale option.
+    this.activeOptionIndex.set(-1);
     if (this.duplicateError()) this.duplicateError.set(null);
     if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
       this.emailFormatError.set(null);
@@ -112,6 +120,7 @@ export class ReassignCommitteeRolesModalComponent {
 
   protected onEmailBlur(): void {
     this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
     this.duplicateError.set(null);
     const value = this.emailField().trim();
     if (value && !EMAIL_REGEX.test(value)) {
@@ -128,6 +137,51 @@ export class ReassignCommitteeRolesModalComponent {
     this.emailFormatError.set(null);
     this.duplicateError.set(null);
     this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+  }
+
+  // Active-descendant keyboard handler — ArrowUp/Down wrap-navigate the listbox without moving focus,
+  // Enter selects the highlighted option (else falls through to onFormKeydown's Save), Escape closes.
+  // Without this a keyboard-only user couldn't reach a suggestion: (blur) closes the panel as soon as
+  // focus would move off the input.
+  protected onEmailKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      if (this.suggestionsOpen()) {
+        // Swallow so the parent PrimeNG dialog doesn't also close the modal on the same key.
+        event.preventDefault();
+        event.stopPropagation();
+        this.suggestionsOpen.set(false);
+        this.activeOptionIndex.set(-1);
+      }
+      return;
+    }
+
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Enter') return;
+
+    if (!this.suggestionsOpen() && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      this.suggestionsOpen.set(true);
+    }
+
+    const options = this.filteredEmployees();
+    if (options.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? 0 : (idx + 1) % options.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? options.length - 1 : (idx - 1 + options.length) % options.length);
+    } else if (event.key === 'Enter') {
+      const idx = this.activeOptionIndex();
+      if (idx >= 0 && idx < options.length) {
+        // A highlighted option wins over the form-level Save handler.
+        event.preventDefault();
+        event.stopPropagation();
+        this.onSelectEmployee(options[idx]);
+      }
+    }
   }
 
   protected onFormKeydown(event: KeyboardEvent): void {
@@ -233,5 +287,12 @@ export class ReassignCommitteeRolesModalComponent {
     if (this.lastNameField().trim().length === 0) return false;
     if (this.emailFormatError() || this.duplicateError()) return false;
     return true;
+  }
+
+  private initActiveOptionId(): string | null {
+    const idx = this.activeOptionIndex();
+    if (idx < 0) return null;
+    if (idx >= this.filteredEmployees().length) return null;
+    return `${this.optionIdPrefix}${idx}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/components/reassign-committee-roles-modal.component.ts
@@ -1,0 +1,237 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { EMAIL_REGEX } from '@lfx-one/shared/constants';
+import type {
+  KeyContactEmployee,
+  ReassignCommitteeRolesDialogData,
+  ReassignCommitteeRolesPersonRef,
+  ReassignCommitteeRolesRoleKey,
+  ReassignCommitteeRolesRoleOption,
+  ReassignCommitteeRolesSubmitEvent,
+} from '@lfx-one/shared/interfaces';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { take } from 'rxjs';
+
+import { CommitteeMembersService } from '../../../services/committee-members.service';
+
+/** Spec 027 US3 — bulk-reassign one person's N Membership-Entitlement committee seats; the parent fans out the PUTs. */
+@Component({
+  selector: 'lfx-reassign-committee-roles-modal',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, CheckboxModule],
+  templateUrl: './reassign-committee-roles-modal.component.html',
+})
+export class ReassignCommitteeRolesModalComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dataService = inject(CommitteeMembersService);
+  private readonly dialogConfig = inject<DynamicDialogConfig<ReassignCommitteeRolesDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  // === Dialog-injected data ===
+  protected readonly person: ReassignCommitteeRolesPersonRef | null = this.dialogConfig.data?.person ?? null;
+  protected readonly roles: readonly ReassignCommitteeRolesRoleOption[] = this.dialogConfig.data?.roles ?? [];
+  private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
+
+  // Default: all selected so the common workflow (full reassign) is one click.
+  protected readonly selectedKeys = signal<Set<ReassignCommitteeRolesRoleKey>>(new Set(this.roles.map((r) => r.key)));
+
+  protected readonly emailField = signal('');
+  protected readonly firstNameField = signal('');
+  protected readonly lastNameField = signal('');
+  protected readonly emailFormatError = signal<string | null>(null);
+  protected readonly duplicateError = signal<string | null>(null);
+
+  protected readonly isSaving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly employees = signal<KeyContactEmployee[]>([]);
+  protected readonly employeeSearchUnavailable = signal(false);
+  protected readonly suggestionsOpen = signal(false);
+
+  protected readonly checkedCount: Signal<number> = computed(() => this.selectedKeys().size);
+  protected readonly allChecked: Signal<boolean> = computed(() => this.roles.length > 0 && this.selectedKeys().size === this.roles.length);
+  protected readonly noneChecked: Signal<boolean> = computed(() => this.selectedKeys().size === 0);
+  protected readonly checkedFoundationCount: Signal<number> = computed(() => this.initCheckedFoundationCount());
+  protected readonly subtitle: Signal<string> = computed(() => this.initSubtitle());
+  protected readonly primaryButtonLabel: Signal<string> = computed(() => this.initPrimaryButtonLabel());
+  protected readonly checkedKeyMap: Signal<Record<string, boolean>> = computed(() => this.initCheckedKeyMap());
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
+  protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+
+  // Hide the current holder's own email from the typeahead — reassigning to themselves is a no-op.
+  private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
+
+  public constructor() {
+    if (this.orgUid) {
+      this.dataService
+        .getEmployees(this.orgUid)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (res) => this.employees.set(res.employees ?? []),
+          error: () => this.employeeSearchUnavailable.set(true),
+        });
+    }
+  }
+
+  protected toggleSelectAll(): void {
+    if (this.isSaving()) return;
+    if (this.allChecked()) {
+      this.selectedKeys.set(new Set());
+    } else {
+      this.selectedKeys.set(new Set(this.roles.map((r) => r.key)));
+    }
+  }
+
+  protected toggleRole(key: ReassignCommitteeRolesRoleKey): void {
+    if (this.isSaving()) return;
+    this.selectedKeys.update((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  protected onEmailFocus(): void {
+    this.suggestionsOpen.set(true);
+  }
+
+  protected onEmailChange(value: string): void {
+    this.emailField.set(value);
+    this.suggestionsOpen.set(true);
+    if (this.duplicateError()) this.duplicateError.set(null);
+    if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onEmailBlur(): void {
+    this.suggestionsOpen.set(false);
+    this.duplicateError.set(null);
+    const value = this.emailField().trim();
+    if (value && !EMAIL_REGEX.test(value)) {
+      this.emailFormatError.set('Enter a valid email address');
+    } else {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onSelectEmployee(employee: KeyContactEmployee): void {
+    this.emailField.set(employee.email);
+    this.firstNameField.set(employee.firstName);
+    this.lastNameField.set(employee.lastName);
+    this.emailFormatError.set(null);
+    this.duplicateError.set(null);
+    this.suggestionsOpen.set(false);
+  }
+
+  protected onFormKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && this.saveEnabled()) {
+      event.preventDefault();
+      this.onSave();
+    }
+  }
+
+  protected onSave(): void {
+    if (!this.saveEnabled()) return;
+
+    const enteredEmail = this.emailField().trim().toLowerCase();
+    const currentEmail = this.person?.email?.trim().toLowerCase() ?? '';
+    if (enteredEmail === currentEmail) {
+      this.duplicateError.set('This person already holds the selected role(s).');
+      return;
+    }
+
+    const selectedKeySet = this.selectedKeys();
+    const selected = this.roles.filter((r) => selectedKeySet.has(r.key));
+    if (selected.length === 0) return;
+
+    const intent: ReassignCommitteeRolesSubmitEvent = {
+      newPerson: {
+        email: this.emailField().trim(),
+        firstName: this.firstNameField().trim(),
+        lastName: this.lastNameField().trim(),
+      },
+      selected,
+    };
+
+    const submit = this.dialogConfig.data?.submit;
+    if (!submit) {
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.isSaving.set(true);
+    this.saveError.set(null);
+    submit(intent)
+      .then(() => this.dialogRef.close(null))
+      .catch((e: unknown) => {
+        this.isSaving.set(false);
+        this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
+      });
+  }
+
+  protected onCancel(): void {
+    if (this.isSaving()) return;
+    this.dialogRef.close(null);
+  }
+
+  private initCheckedFoundationCount(): number {
+    const selected = this.selectedKeys();
+    const names = new Set<string>();
+    for (const r of this.roles) if (selected.has(r.key)) names.add(r.foundationName);
+    return names.size;
+  }
+
+  private initSubtitle(): string {
+    const n = this.checkedCount();
+    const m = this.checkedFoundationCount();
+    return `${n} ${n === 1 ? 'role' : 'roles'} across ${m} ${m === 1 ? 'foundation' : 'foundations'}`;
+  }
+
+  private initPrimaryButtonLabel(): string {
+    if (this.isSaving()) return 'Reassigning…';
+    const n = this.checkedCount();
+    return `Save Changes (${n} ${n === 1 ? 'role' : 'roles'})`;
+  }
+
+  private initCheckedKeyMap(): Record<string, boolean> {
+    const selected = this.selectedKeys();
+    const map: Record<string, boolean> = {};
+    for (const r of this.roles) map[r.key] = selected.has(r.key);
+    return map;
+  }
+
+  private initExcludedEmails(): Set<string> {
+    const set = new Set<string>();
+    const currentEmail = this.person?.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  }
+
+  private initFilteredEmployees(): KeyContactEmployee[] {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  }
+
+  private initSaveEnabled(): boolean {
+    if (this.isSaving()) return false;
+    if (this.noneChecked()) return false;
+    const email = this.emailField().trim();
+    if (!email || !EMAIL_REGEX.test(email)) return false;
+    if (this.firstNameField().trim().length === 0) return false;
+    if (this.lastNameField().trim().length === 0) return false;
+    if (this.emailFormatError() || this.duplicateError()) return false;
+    return true;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
@@ -1,24 +1,20 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { votingStatusPillClass } from '@lfx-one/shared/constants';
+import {
+  EDIT_TOOLTIP_DEFAULT,
+  EDIT_TOOLTIP_NOT_ORG_EDITABLE,
+  REASSIGN_TOOLTIP_DEFAULT,
+  REASSIGN_TOOLTIP_NO_EDITABLE_SEATS,
+  votingStatusPillClass,
+} from '@lfx-one/shared/constants';
 import type {
   CommitteeMemberAssignment,
   CommitteeMemberAssignmentVm,
   CommitteeMemberPersonGroup,
   CommitteeMemberPersonGroupVm,
+  CommitteeMembersDecorateOptions,
 } from '@lfx-one/shared/interfaces';
-
-/** Tooltip-decoration inputs that depend on caller state (FGA writer gate + the shared "you can't edit" string). */
-export interface CommitteeMembersDecorateOptions {
-  canEdit: boolean;
-  editDisabledTooltip: string;
-}
-
-const REASSIGN_TOOLTIP_NO_EDITABLE_SEATS = 'No org-reassignable seats for this person';
-const REASSIGN_TOOLTIP_DEFAULT = 'Reassign committee roles';
-const EDIT_TOOLTIP_DEFAULT = 'Edit committee role';
-const EDIT_TOOLTIP_NOT_ORG_EDITABLE = 'This seat is foundation-controlled and not editable here.';
 
 /**
  * Group org-wide seats by person (email key, first-wins display); computes the foundation labels,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
@@ -9,9 +9,6 @@ import type {
   CommitteeMemberPersonGroupVm,
 } from '@lfx-one/shared/interfaces';
 
-// Re-exported so the component template + modals import the pill helper from one place (spec 027).
-export { votingStatusPillClass };
-
 /** Tooltip-decoration inputs that depend on caller state (FGA writer gate + the shared "you can't edit" string). */
 export interface CommitteeMembersDecorateOptions {
   canEdit: boolean;
@@ -24,9 +21,8 @@ const EDIT_TOOLTIP_DEFAULT = 'Edit committee role';
 const EDIT_TOOLTIP_NOT_ORG_EDITABLE = 'This seat is foundation-controlled and not editable here.';
 
 /**
- * Group org-wide seats by person (lowercased email; first-wins for display fields). Computes the
- * distinct-foundation labels, the distinct-committee count, and the editable-seat count that drive
- * the main-row cells + the Reassign-pencil enable gate. Data-model §6 invariants.
+ * Group org-wide seats by person (email key, first-wins display); computes the foundation labels,
+ * committee count, and editable-seat count that drive the row cells + Reassign gate (data-model §6).
  */
 export function buildPersonGroups(assignments: CommitteeMemberAssignment[]): CommitteeMemberPersonGroup[] {
   const byEmail = new Map<string, CommitteeMemberAssignment[]>();
@@ -57,10 +53,8 @@ export function buildPersonGroups(assignments: CommitteeMemberAssignment[]): Com
 }
 
 /**
- * Decorate a person's seats for the expanded sub-table: order by foundation A→Z then committee A→Z,
- * attach the voting-status pill class, flag `showFoundationLabel` on the first sub-row of each
- * foundation block (FR-008), and precompute the per-seat Edit-pencil tooltip so the template
- * binding stays a flat `[pTooltip]="a.editTooltip"` (no nested ternary).
+ * Decorate a person's seats for the sub-table: sort by foundation→committee, attach the pill class,
+ * flag first-of-foundation rows (FR-008), and precompute each Edit tooltip so the template stays flat.
  */
 export function decorateAssignments(group: CommitteeMemberPersonGroup, opts: CommitteeMembersDecorateOptions): CommitteeMemberAssignmentVm[] {
   const sorted = [...group.assignments].sort((a, b) => {
@@ -77,8 +71,8 @@ export function decorateAssignments(group: CommitteeMemberPersonGroup, opts: Com
 }
 
 /**
- * Build the full main-row + sub-row view-model in one place so templates bind flat fields only —
- * keeps tooltip composition (canEdit × editableCount × isOrgEditable × reason) out of the HTML.
+ * Build the full main-row + sub-row view-model in one place so templates bind flat fields only,
+ * keeping tooltip composition (canEdit × editableCount × isOrgEditable × reason) out of the HTML.
  */
 export function decoratePersonGroup(group: CommitteeMemberPersonGroup, opts: CommitteeMembersDecorateOptions): CommitteeMemberPersonGroupVm {
   return {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { votingStatusPillClass } from '@lfx-one/shared/constants';
+import type { CommitteeMemberAssignment, CommitteeMemberAssignmentVm, CommitteeMemberPersonGroup } from '@lfx-one/shared/interfaces';
+
+// Re-exported so the component template + modals import the pill helper from one place (spec 027).
+export { votingStatusPillClass };
+
+/**
+ * Group org-wide seats by person (lowercased email; first-wins for display fields). Computes the
+ * distinct-foundation labels, the distinct-committee count, and the editable-seat count that drive
+ * the main-row cells + the Reassign-pencil enable gate. Data-model §6 invariants.
+ */
+export function buildPersonGroups(assignments: CommitteeMemberAssignment[]): CommitteeMemberPersonGroup[] {
+  const byEmail = new Map<string, CommitteeMemberAssignment[]>();
+  for (const a of assignments) {
+    // Fall back to the seat uid when email is blank so an email-less member still groups into its own row.
+    const key = a.person.email || a.memberUid;
+    const list = byEmail.get(key) ?? [];
+    list.push(a);
+    byEmail.set(key, list);
+  }
+
+  return [...byEmail.values()].map((group) => {
+    const first = group[0];
+    const foundationLabels = [...new Set(group.map((a) => a.foundationName).filter(Boolean))].sort((x, y) => x.localeCompare(y));
+    const committeeCount = new Set(group.map((a) => a.committeeUid)).size;
+    const editableCount = group.filter((a) => a.isOrgEditable).length;
+    return {
+      email: first.person.email || first.memberUid,
+      displayName: first.person.fullName,
+      jobTitle: first.person.jobTitle,
+      initials: first.person.initials,
+      foundationLabels,
+      committeeCount,
+      editableCount,
+      assignments: group,
+    };
+  });
+}
+
+/**
+ * Decorate a person's seats for the expanded sub-table: order by foundation A→Z then committee A→Z,
+ * attach the voting-status pill class, and flag `showFoundationLabel` on the first sub-row of each
+ * foundation block so the foundation name renders once per group (FR-008).
+ */
+export function decorateAssignments(group: CommitteeMemberPersonGroup): CommitteeMemberAssignmentVm[] {
+  const sorted = [...group.assignments].sort((a, b) => {
+    const f = a.foundationName.localeCompare(b.foundationName, undefined, { sensitivity: 'base' });
+    if (f !== 0) return f;
+    return a.committeeName.localeCompare(b.committeeName, undefined, { sensitivity: 'base' });
+  });
+  return sorted.map((a, idx) => ({
+    ...a,
+    votingStatusPillClass: votingStatusPillClass(a.votingStatus),
+    showFoundationLabel: idx === 0 || sorted[idx - 1].foundationName !== a.foundationName,
+  }));
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/committee-members/helpers/committee-members.helper.ts
@@ -2,10 +2,26 @@
 // SPDX-License-Identifier: MIT
 
 import { votingStatusPillClass } from '@lfx-one/shared/constants';
-import type { CommitteeMemberAssignment, CommitteeMemberAssignmentVm, CommitteeMemberPersonGroup } from '@lfx-one/shared/interfaces';
+import type {
+  CommitteeMemberAssignment,
+  CommitteeMemberAssignmentVm,
+  CommitteeMemberPersonGroup,
+  CommitteeMemberPersonGroupVm,
+} from '@lfx-one/shared/interfaces';
 
 // Re-exported so the component template + modals import the pill helper from one place (spec 027).
 export { votingStatusPillClass };
+
+/** Tooltip-decoration inputs that depend on caller state (FGA writer gate + the shared "you can't edit" string). */
+export interface CommitteeMembersDecorateOptions {
+  canEdit: boolean;
+  editDisabledTooltip: string;
+}
+
+const REASSIGN_TOOLTIP_NO_EDITABLE_SEATS = 'No org-reassignable seats for this person';
+const REASSIGN_TOOLTIP_DEFAULT = 'Reassign committee roles';
+const EDIT_TOOLTIP_DEFAULT = 'Edit committee role';
+const EDIT_TOOLTIP_NOT_ORG_EDITABLE = 'This seat is foundation-controlled and not editable here.';
 
 /**
  * Group org-wide seats by person (lowercased email; first-wins for display fields). Computes the
@@ -42,10 +58,11 @@ export function buildPersonGroups(assignments: CommitteeMemberAssignment[]): Com
 
 /**
  * Decorate a person's seats for the expanded sub-table: order by foundation A→Z then committee A→Z,
- * attach the voting-status pill class, and flag `showFoundationLabel` on the first sub-row of each
- * foundation block so the foundation name renders once per group (FR-008).
+ * attach the voting-status pill class, flag `showFoundationLabel` on the first sub-row of each
+ * foundation block (FR-008), and precompute the per-seat Edit-pencil tooltip so the template
+ * binding stays a flat `[pTooltip]="a.editTooltip"` (no nested ternary).
  */
-export function decorateAssignments(group: CommitteeMemberPersonGroup): CommitteeMemberAssignmentVm[] {
+export function decorateAssignments(group: CommitteeMemberPersonGroup, opts: CommitteeMembersDecorateOptions): CommitteeMemberAssignmentVm[] {
   const sorted = [...group.assignments].sort((a, b) => {
     const f = a.foundationName.localeCompare(b.foundationName, undefined, { sensitivity: 'base' });
     if (f !== 0) return f;
@@ -55,5 +72,29 @@ export function decorateAssignments(group: CommitteeMemberPersonGroup): Committe
     ...a,
     votingStatusPillClass: votingStatusPillClass(a.votingStatus),
     showFoundationLabel: idx === 0 || sorted[idx - 1].foundationName !== a.foundationName,
+    editTooltip: buildEditTooltip(a, opts),
   }));
+}
+
+/**
+ * Build the full main-row + sub-row view-model in one place so templates bind flat fields only —
+ * keeps tooltip composition (canEdit × editableCount × isOrgEditable × reason) out of the HTML.
+ */
+export function decoratePersonGroup(group: CommitteeMemberPersonGroup, opts: CommitteeMembersDecorateOptions): CommitteeMemberPersonGroupVm {
+  return {
+    ...group,
+    sortedAssignments: decorateAssignments(group, opts),
+    reassignTooltip: buildReassignTooltip(group, opts),
+  };
+}
+
+function buildReassignTooltip(group: CommitteeMemberPersonGroup, opts: CommitteeMembersDecorateOptions): string {
+  if (!opts.canEdit) return opts.editDisabledTooltip;
+  return group.editableCount === 0 ? REASSIGN_TOOLTIP_NO_EDITABLE_SEATS : REASSIGN_TOOLTIP_DEFAULT;
+}
+
+function buildEditTooltip(assignment: CommitteeMemberAssignment, opts: CommitteeMembersDecorateOptions): string {
+  if (!opts.canEdit) return opts.editDisabledTooltip;
+  if (assignment.isOrgEditable) return EDIT_TOOLTIP_DEFAULT;
+  return assignment.reason ?? EDIT_TOOLTIP_NOT_ORG_EDITABLE;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
@@ -49,6 +49,8 @@
       <lfx-org-people-all-employees />
     } @else if (activeTab() === 'contacts') {
       <lfx-org-people-key-contacts />
+    } @else if (activeTab() === 'committee') {
+      <lfx-org-people-committee-members />
     } @else if (activeTab() === 'training') {
       <lfx-org-people-trainees />
     } @else if (activeTab() === 'events') {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
@@ -12,6 +12,7 @@ import { AccountContextService } from '@services/account-context.service';
 import type { PeopleTabConfig, PeopleTabId } from '@lfx-one/shared/interfaces';
 
 import { AllEmployeesComponent } from './components/all-employees/all-employees.component';
+import { CommitteeMembersComponent } from './components/committee-members/committee-members.component';
 import { ContributorsComponent } from './components/contributors/contributors.component';
 import { EventAttendeesComponent } from './components/event-attendees/event-attendees.component';
 import { KeyContactsComponent } from './components/key-contacts/key-contacts.component';
@@ -24,6 +25,7 @@ import { TraineesComponent } from './components/trainees/trainees.component';
     EmptyStateComponent,
     AllEmployeesComponent,
     KeyContactsComponent,
+    CommitteeMembersComponent,
     TraineesComponent,
     EventAttendeesComponent,
     ContributorsComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/committee-members.service.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/committee-members.service.ts
@@ -1,0 +1,37 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import type {
+  OrgLensEmployeesResponse,
+  OrgPeopleCommitteeMembersResponse,
+  ReassignCommitteeMemberBody,
+  ReassignCommitteeMemberResponse,
+} from '@lfx-one/shared/interfaces';
+
+/** HTTP client for the Org Lens → People → Committee tab (spec 027). Read + single-seat reassign + the reused org-wide employee picker. */
+@Injectable({ providedIn: 'root' })
+export class CommitteeMembersService {
+  private readonly http = inject(HttpClient);
+
+  /** Org-wide non-Board committee-member roster + filter-independent stats. */
+  public getCommitteeMembers(orgUid: string): Observable<OrgPeopleCommitteeMembersResponse> {
+    return this.http.get<OrgPeopleCommitteeMembersResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/people/committee-members`);
+  }
+
+  /** Reassign one Membership-Entitlement seat (used by both the bulk fan-out and the single-edit modal). */
+  public reassignSeat(orgUid: string, seatId: string, body: ReassignCommitteeMemberBody): Observable<ReassignCommitteeMemberResponse> {
+    return this.http.patch<ReassignCommitteeMemberResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/people/committee-members/${encodeURIComponent(seatId)}/reassign`,
+      body
+    );
+  }
+
+  /** Reused spec-026 org-wide people picker (key contacts ∪ committee members, deduped) for the modal typeahead. */
+  public getEmployees(orgUid: string): Observable<OrgLensEmployeesResponse> {
+    return this.http.get<OrgLensEmployeesResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/employees`);
+  }
+}

--- a/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
@@ -1,8 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ORG_CONTRIBUTOR_DEFAULT_TIME_RANGE, PERSON_KEY_PATTERN } from '@lfx-one/shared/constants';
-import type { OrgContributorTimeRange } from '@lfx-one/shared/interfaces';
+import { EMAIL_REGEX, ORG_CONTRIBUTOR_DEFAULT_TIME_RANGE, PERSON_KEY_PATTERN } from '@lfx-one/shared/constants';
+import type { OrgContributorTimeRange, ReassignCommitteeMemberBody } from '@lfx-one/shared/interfaces';
+import { isFilterSafeIdentifier } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -10,6 +11,7 @@ import { assertOrgUid } from '../helpers/org-uid.helper';
 import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { OrgLensPeopleService } from '../services/org-lens-people.service';
+import { OrgPeopleCommitteeMembersService } from '../services/org-people-committee-members.service';
 import { OrgPeopleContributorsService } from '../services/org-people-contributors.service';
 import { OrgPeopleEventAttendeesService } from '../services/org-people-event-attendees.service';
 import { OrgPeopleKeyContactsService } from '../services/org-people-key-contacts.service';
@@ -24,6 +26,7 @@ export class OrgLensPeopleController {
   private readonly traineesService: OrgPeopleTraineesService;
   private readonly eventAttendeesService: OrgPeopleEventAttendeesService;
   private readonly contributorsService: OrgPeopleContributorsService;
+  private readonly committeeMembersService: OrgPeopleCommitteeMembersService;
 
   public constructor() {
     this.service = new OrgLensPeopleService();
@@ -31,6 +34,7 @@ export class OrgLensPeopleController {
     this.traineesService = new OrgPeopleTraineesService();
     this.eventAttendeesService = new OrgPeopleEventAttendeesService();
     this.contributorsService = new OrgPeopleContributorsService();
+    this.committeeMembersService = new OrgPeopleCommitteeMembersService();
   }
 
   /** GET /api/orgs/:orgUid/lens/people/all */
@@ -109,6 +113,62 @@ export class OrgLensPeopleController {
         individual_count: response.stats.individualCount,
         foundations_covered: response.stats.foundationsCovered,
         unfilled_required_role_count: response.stats.unfilledRequiredRoleCount,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:orgUid/lens/people/committee-members — org-wide non-Board committee-member roster + stats (spec 027). */
+  public async getCommitteeMembers(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, 'get_org_people_committee_members', {
+      org_uid: orgUid,
+    });
+
+    try {
+      assertOrgUid(orgUid, 'get_org_people_committee_members');
+
+      const response = await this.committeeMembersService.getCommitteeMembers(req, orgUid);
+
+      logger.success(req, 'get_org_people_committee_members', startTime, {
+        org_uid: orgUid,
+        assignment_count: response.assignments.length,
+        individual_count: response.stats.individualCount,
+        committee_count: response.stats.committeeCount,
+        foundations_covered: response.stats.foundationsCovered,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** PATCH /api/orgs/:orgUid/lens/people/committee-members/:seatId/reassign — reassign one Membership-Entitlement seat (spec 027 US3/US4). */
+  public async reassignCommitteeMember(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const seatId = req.params['seatId'];
+    const startTime = logger.startOperation(req, 'reassign_committee_member', {
+      org_uid: orgUid,
+      seat_id: seatId,
+    });
+
+    try {
+      assertOrgUid(orgUid, 'reassign_committee_member');
+      this.assertSeatId(seatId, 'reassign_committee_member');
+      const body = this.assertReassignBody(req.body, 'reassign_committee_member');
+
+      const response = await this.committeeMembersService.reassignSeat(req, orgUid, seatId, body);
+
+      logger.success(req, 'reassign_committee_member', startTime, {
+        org_uid: orgUid,
+        seat_id: seatId,
+        committee_uid: body.committeeUid,
       });
 
       res.setHeader('Cache-Control', 'no-store');
@@ -210,6 +270,33 @@ export class OrgLensPeopleController {
     if (!PERSON_KEY_PATTERN.test(personKey)) {
       throw ServiceValidationError.forField('personKey', 'Invalid personKey format', { operation });
     }
+  }
+
+  /** Validate the seat id before it is interpolated into the upstream committee-service path (400, not an upstream 5xx). Mirrors OrgLensBoardCommitteeController.assertSeatId. */
+  private assertSeatId(seatId: string | undefined, operation: string): asserts seatId is string {
+    if (!seatId || !isFilterSafeIdentifier(seatId)) {
+      throw ServiceValidationError.forField('seatId', 'seatId path parameter is required and must be a valid identifier', { operation });
+    }
+  }
+
+  /** Validate + normalize the reassign body (committeeUid filter-safe; email lowercased + regex-checked). Mirrors OrgLensBoardCommitteeController.assertReassignBody. */
+  private assertReassignBody(body: unknown, operation: string): ReassignCommitteeMemberBody {
+    const b = (body ?? {}) as Partial<ReassignCommitteeMemberBody>;
+    const committeeUid = typeof b.committeeUid === 'string' ? b.committeeUid.trim() : '';
+    const firstName = typeof b.firstName === 'string' ? b.firstName.trim() : '';
+    const lastName = typeof b.lastName === 'string' ? b.lastName.trim() : '';
+    const email = typeof b.email === 'string' ? b.email.trim().toLowerCase() : '';
+
+    if (!committeeUid || !email || !firstName || !lastName) {
+      throw ServiceValidationError.forField('body', 'committeeUid, firstName, lastName and email are required', { operation });
+    }
+    if (!isFilterSafeIdentifier(committeeUid)) {
+      throw ServiceValidationError.forField('committeeUid', 'committeeUid must be a valid identifier', { operation });
+    }
+    if (!EMAIL_REGEX.test(email)) {
+      throw ServiceValidationError.forField('email', 'email must be a valid email address', { operation });
+    }
+    return { committeeUid, firstName, lastName, email };
   }
 }
 

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -77,6 +77,10 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/people/all', (req, res, next) => orgLensPeopleController.getAllEmployees(req, res, next));
   // Spec 005 (LFXV2-1873) — People → Key Contacts tab (org-wide, read-only). Membership-scoped reads + writes live above on orgLensKeyContactsController.
   router.get('/:orgUid/lens/people/key-contacts', (req, res, next) => orgLensPeopleController.getKeyContacts(req, res, next));
+  // Spec 027 — People → Committee tab (org-wide committee members). Registered BEFORE the `/:personKey/detail`
+  // matcher below so 'committee-members' isn't consumed as a personKey.
+  router.get('/:orgUid/lens/people/committee-members', (req, res, next) => orgLensPeopleController.getCommitteeMembers(req, res, next));
+  router.patch('/:orgUid/lens/people/committee-members/:seatId/reassign', (req, res, next) => orgLensPeopleController.reassignCommitteeMember(req, res, next));
   // LFXV2-1876 — People → Trainees tab. Keep above the `/:personKey/detail` matcher so 'trainees' isn't consumed as a personKey.
   router.get('/:orgUid/lens/people/trainees', (req, res, next) => orgLensPeopleController.getTrainees(req, res, next));
   // LFXV2-1875 — People → Event Attendees tab. Same guard rationale as above ('event-attendees' must not be consumed as a personKey).

--- a/apps/lfx-one/src/server/services/org-lens-board-committee.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-board-committee.service.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { isBoardCategory } from '@lfx-one/shared/constants';
 import type {
   BoardSeat,
   CommitteeSeat,
@@ -21,9 +22,6 @@ import { MicroserviceProxyService } from './microservice-proxy.service';
 import { OrgLensKeyContactsService } from './org-lens-key-contacts.service';
 import { OrgLensMembershipsService } from './org-lens-memberships.service';
 import { ProjectService } from './project.service';
-
-/** committee-service `committee_category` value that routes a seat to the Board section (FR-003). */
-const COMMITTEE_CATEGORY_BOARD = 'Board';
 
 /**
  * Picker roster bound (FR-006 typeahead): cap the org-wide seat drain so opening the Reassign modal
@@ -54,8 +52,8 @@ export class OrgLensBoardCommitteeService {
       return { accountId, foundationId, boardSeats: [], committeeSeats: [] };
     }
     const seats = await this.fetchOrgSeats(req, accountId, { projectUids });
-    const boardSeats = seats.filter((s) => s.committee_category === COMMITTEE_CATEGORY_BOARD).map((s) => this.toBoardSeat(s));
-    const committeeSeats = seats.filter((s) => s.committee_category !== COMMITTEE_CATEGORY_BOARD).map((s) => this.toCommitteeSeat(s));
+    const boardSeats = seats.filter((s) => isBoardCategory(s.committee_category)).map((s) => this.toBoardSeat(s));
+    const committeeSeats = seats.filter((s) => !isBoardCategory(s.committee_category)).map((s) => this.toCommitteeSeat(s));
     return { accountId, foundationId, boardSeats, committeeSeats };
   }
 
@@ -147,7 +145,7 @@ export class OrgLensBoardCommitteeService {
         email: body.email,
       }
     );
-    const seat = upstream.committee_category === COMMITTEE_CATEGORY_BOARD ? this.toBoardSeat(upstream) : this.toCommitteeSeat(upstream);
+    const seat = isBoardCategory(upstream.committee_category) ? this.toBoardSeat(upstream) : this.toCommitteeSeat(upstream);
     logger.debug(req, 'reassign_committee_seat_proxy', 'committee-service returned reassigned seat', {
       org_uid: accountId,
       seat_id: seat.seatId,

--- a/apps/lfx-one/src/server/services/org-lens-board-committee.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-board-committee.service.ts
@@ -156,6 +156,11 @@ export class OrgLensBoardCommitteeService {
     return { accountId, foundationId, seat };
   }
 
+  /** Spec 027: org-wide seat drain (no project filter) for the People → Committee tab. Reuses the private drain + its 200-page fail-closed safety cap so the org-wide roster never duplicates the pagination logic. */
+  public async fetchAllOrgSeats(req: Request, orgUid: string): Promise<CommitteeServiceOrgSeat[]> {
+    return this.fetchOrgSeats(req, orgUid);
+  }
+
   /** Resolve the membership's project family (foundation root + descendants) for seat scoping (spec 026 T007a): SFID → slug (getFoundationSlug) → uid (getProjectIdBySlug) → family (getFoundationProjectUids); `undefined` when unresolvable so callers return an EMPTY list, never the org-wide roster. */
   private async resolveFamilyProjectUids(req: Request, orgUid: string, foundationId: string): Promise<string[] | undefined> {
     try {
@@ -186,8 +191,8 @@ export class OrgLensBoardCommitteeService {
    * Proxy the org's committee seats from committee-service (user token forwarded; Heimdall gates `b2b_org#auditor`).
    * The board/committee tabs always pass a resolved `projectUids` family (root + descendants, spec 026 T014) and
    * drain every page (fail-closed on the safety cap so a truncated roster never ships). The org-wide call (no
-   * `projectUids`) is used ONLY by the Reassign people picker (`getOrgEmployees`), which passes a small `maxPages`
-   * bound + `allowTruncation` so the typeahead never drains the full cross-foundation roster.
+   * `projectUids`) is used by the Reassign people picker (`getOrgEmployees`), and — spec 027 — by the public
+   * `fetchAllOrgSeats` wrapper for the org-wide People → Committee tab read.
    */
   private async fetchOrgSeats(
     req: Request,

--- a/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
@@ -19,12 +19,8 @@ import { OrgLensBoardCommitteeService } from './org-lens-board-committee.service
 import { ProjectService } from './project.service';
 
 /**
- * Org Lens People → Committee tab (spec 027). Serves the org-wide, NON-Board committee-member
- * roster grouped per seat, and proxies single-seat reassigns. Reuses the spec-026
- * committee-service endpoints unchanged (read drain + atomic reassign); the only upstream change is
- * the additive `project_uid`/`project_slug` fields on the seat DTO (decision B) which surface the
- * foundation per seat. Board seats are excluded here (FR-003); foundation display names are enriched
- * once per request via the query-service (D-003).
+ * Org Lens People → Committee tab (spec 027): serves the org-wide NON-Board roster (Board excluded, FR-003)
+ * and proxies single-seat reassigns, reusing the spec-026 drain/reassign with foundation enrichment (D-003).
  */
 export class OrgPeopleCommitteeMembersService {
   private readonly boardCommitteeService: OrgLensBoardCommitteeService;

--- a/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
@@ -1,0 +1,177 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type {
+  CommitteeMemberAssignment,
+  CommitteeMemberPerson,
+  CommitteeMemberStats,
+  CommitteeServiceOrgSeat,
+  OrgPeopleCommitteeMembersResponse,
+  ReassignCommitteeMemberBody,
+  ReassignCommitteeMemberResponse,
+} from '@lfx-one/shared/interfaces';
+import { isBoardCategory } from '@lfx-one/shared/constants';
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+import { MicroserviceProxyService } from './microservice-proxy.service';
+import { OrgLensBoardCommitteeService } from './org-lens-board-committee.service';
+import { ProjectService } from './project.service';
+
+/**
+ * Org Lens People → Committee tab (spec 027). Serves the org-wide, NON-Board committee-member
+ * roster grouped per seat, and proxies single-seat reassigns. Reuses the spec-026
+ * committee-service endpoints unchanged (read drain + atomic reassign); the only upstream change is
+ * the additive `project_uid`/`project_slug` fields on the seat DTO (decision B) which surface the
+ * foundation per seat. Board seats are excluded here (FR-003); foundation display names are enriched
+ * once per request via the query-service (D-003).
+ */
+export class OrgPeopleCommitteeMembersService {
+  private readonly boardCommitteeService: OrgLensBoardCommitteeService;
+  private readonly projectService: ProjectService;
+  private readonly microserviceProxy: MicroserviceProxyService;
+
+  public constructor() {
+    this.boardCommitteeService = new OrgLensBoardCommitteeService();
+    this.projectService = new ProjectService();
+    this.microserviceProxy = new MicroserviceProxyService();
+  }
+
+  /** Org-wide non-Board roster (FR-001/003/004): drain → exclude Board → enrich foundation names → map → stats. */
+  public async getCommitteeMembers(req: Request, orgUid: string): Promise<OrgPeopleCommitteeMembersResponse> {
+    // Org-wide drain: no project filter → committee-service's organization-only scope (every
+    // foundation the org holds seats on); the shared drain enforces the 200-page fail-closed cap.
+    const seats = await this.boardCommitteeService.fetchAllOrgSeats(req, orgUid);
+    const nonBoard = seats.filter((s) => !isBoardCategory(s.committee_category));
+
+    const foundationNames = await this.enrichFoundationNames(req, nonBoard);
+    const assignments = nonBoard.map((s) => this.toAssignment(s, foundationNames));
+    const stats = this.computeStats(assignments);
+
+    return { orgUid, assignments, stats };
+  }
+
+  /** Reassign one Membership-Entitlement seat (FR-017): proxies the spec-026 committee-service atomic reassign. */
+  public async reassignSeat(req: Request, orgUid: string, seatId: string, body: ReassignCommitteeMemberBody): Promise<ReassignCommitteeMemberResponse> {
+    const upstreamPath = `/committees/b2b-org/${orgUid}/seats/${seatId}/reassign`;
+    logger.debug(req, 'reassign_committee_member_proxy', 'Proxying reassign to committee-service', {
+      org_uid: orgUid,
+      seat_id: seatId,
+      committee_uid: body.committeeUid,
+      upstream_path: upstreamPath,
+    });
+    // Verb mapping (matches spec 026 `org-lens-board-committee.service.ts`): the BFF surface is PATCH
+    // (REST partial-update convention), but committee-service defines reassign as PUT — so we issue PUT
+    // here deliberately. NOT a bug: committee-service implements PUT /committees/b2b-org/{uid}/seats/{member_uid}/reassign.
+    const upstream = await this.microserviceProxy.proxyRequest<CommitteeServiceOrgSeat>(
+      req,
+      'LFX_V2_COMMITTEE_SERVICE',
+      upstreamPath,
+      'PUT',
+      { v: '1' },
+      {
+        committee_uid: body.committeeUid,
+        first_name: body.firstName,
+        last_name: body.lastName,
+        email: body.email,
+      }
+    );
+
+    const foundationNames = await this.enrichFoundationNames(req, [upstream]);
+    const seat = this.toAssignment(upstream, foundationNames);
+    logger.debug(req, 'reassign_committee_member_proxy', 'committee-service returned reassigned seat', {
+      org_uid: orgUid,
+      seat_id: seat.seatId,
+      committee_uid: seat.committeeUid,
+    });
+    return { orgUid, seat };
+  }
+
+  /**
+   * D-003 foundation-name enrichment: collect distinct `project_uid`s, batch-fetch projects via the
+   * existing `ProjectService.getProjectsByIds` (chunks 100/req, FGA-aware), project to `Map<uid, name>`.
+   * Fail-soft: on error log a warning and return an empty map (each seat falls back to its `project_slug`).
+   */
+  private async enrichFoundationNames(req: Request, seats: CommitteeServiceOrgSeat[]): Promise<Map<string, string>> {
+    const uids = [...new Set(seats.map((s) => s.project_uid).filter((u): u is string => !!u))];
+    if (uids.length === 0) {
+      return new Map();
+    }
+    try {
+      const byUid = await this.projectService.getProjectsByIds(req, uids);
+      const names = new Map<string, string>();
+      for (const [uid, project] of byUid) {
+        if (project?.name) {
+          names.set(uid, project.name);
+        }
+      }
+      return names;
+    } catch (error) {
+      logger.warning(req, 'enrich_foundation_names', 'project-name enrichment failed; falling back to project_slug', {
+        uid_count: uids.length,
+        err: error,
+      });
+      return new Map();
+    }
+  }
+
+  /** Map an upstream seat to the People-tab `CommitteeMemberAssignment` (camelCase + person envelope + foundation). */
+  private toAssignment(s: CommitteeServiceOrgSeat, foundationNames: Map<string, string>): CommitteeMemberAssignment {
+    const projectUid = s.project_uid ?? '';
+    const foundationSlug = s.project_slug ?? '';
+    return {
+      seatId: s.uid,
+      memberUid: s.uid,
+      committeeUid: s.committee_uid,
+      committeeName: s.committee_name,
+      committeeCategory: s.committee_category,
+      projectUid,
+      foundationSlug,
+      foundationName: foundationNames.get(projectUid) || foundationSlug,
+      role: s.role_name ?? '',
+      votingStatus: s.voting_status ?? '',
+      appointedBy: s.appointed_by ?? '',
+      isOrgEditable: s.is_org_editable,
+      reason: s.reason ?? null,
+      person: this.toPerson(s),
+    };
+  }
+
+  private toPerson(s: CommitteeServiceOrgSeat): CommitteeMemberPerson {
+    const firstName = (s.first_name ?? '').trim();
+    const lastName = (s.last_name ?? '').trim();
+    const email = (s.email ?? '').trim().toLowerCase();
+    const name = `${firstName} ${lastName}`.trim();
+    // Members added by email before their profile resolves have no name upstream — fall back to the
+    // email as the display name (and derive initials from it) so the row is identifiable, not blank.
+    const fullName = name || email;
+    const nameInitials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+    const initials =
+      nameInitials ||
+      email
+        .replace(/[^A-Za-z0-9]/g, '')
+        .slice(0, 2)
+        .toUpperCase();
+    return {
+      email,
+      firstName,
+      lastName,
+      fullName,
+      jobTitle: s.job_title?.trim() ? s.job_title.trim() : null,
+      initials,
+    };
+  }
+
+  /** Filter-independent stats (FR-004): distinct emails / committees / foundations across the FULL roster. */
+  private computeStats(assignments: CommitteeMemberAssignment[]): CommitteeMemberStats {
+    const emails = new Set<string>();
+    const committees = new Set<string>();
+    const foundations = new Set<string>();
+    for (const a of assignments) {
+      if (a.person.email) emails.add(a.person.email);
+      if (a.committeeUid) committees.add(a.committeeUid);
+      if (a.projectUid) foundations.add(a.projectUid);
+    }
+    return { individualCount: emails.size, committeeCount: committees.size, foundationsCovered: foundations.size };
+  }
+}

--- a/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-committee-members.service.ts
@@ -170,7 +170,10 @@ export class OrgPeopleCommitteeMembersService {
     for (const a of assignments) {
       if (a.person.email) emails.add(a.person.email);
       if (a.committeeUid) committees.add(a.committeeUid);
-      if (a.projectUid) foundations.add(a.projectUid);
+      // Count by projectUid, but fall back to the foundation slug when the UID is missing so the tile
+      // never shows 0 foundations while the table still renders foundation values (un-enriched seats).
+      const foundationKey = a.projectUid || a.foundationSlug;
+      if (foundationKey) foundations.add(foundationKey);
     }
     return { individualCount: emails.size, committeeCount: committees.size, foundationsCovered: foundations.size };
   }

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -80,12 +80,7 @@ export function getEffectiveUsername(req: Request): string | null {
   // back to it keeps the LFID-username identity path (#912) working across both Auth0 (nickname/username)
   // and Authelia (preferred_username) without affecting Auth0, where the earlier claims take precedence.
   // Mirrors the Authelia handling already in `getUsernameFromAuth`.
-  return (
-    (req.oidc?.user?.['nickname'] as string) ||
-    (req.oidc?.user?.['username'] as string) ||
-    (req.oidc?.user?.['preferred_username'] as string) ||
-    null
-  );
+  return (req.oidc?.user?.['nickname'] as string) || (req.oidc?.user?.['username'] as string) || (req.oidc?.user?.['preferred_username'] as string) || null;
 }
 
 /**

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -75,7 +75,17 @@ export function getEffectiveUsername(req: Request): string | null {
   if (req.appSession?.['impersonationUser']?.username) {
     return req.appSession['impersonationUser'].username as string;
   }
-  return (req.oidc?.user?.['nickname'] as string) || (req.oidc?.user?.['username'] as string) || null;
+  // `preferred_username` is the Authelia (local/self-hosted OIDC) equivalent of the LFID username —
+  // Authelia's default claims policy emits `preferred_username` but not `nickname`/`username`. Falling
+  // back to it keeps the LFID-username identity path (#912) working across both Auth0 (nickname/username)
+  // and Authelia (preferred_username) without affecting Auth0, where the earlier claims take precedence.
+  // Mirrors the Authelia handling already in `getUsernameFromAuth`.
+  return (
+    (req.oidc?.user?.['nickname'] as string) ||
+    (req.oidc?.user?.['username'] as string) ||
+    (req.oidc?.user?.['preferred_username'] as string) ||
+    null
+  );
 }
 
 /**

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -75,11 +75,8 @@ export function getEffectiveUsername(req: Request): string | null {
   if (req.appSession?.['impersonationUser']?.username) {
     return req.appSession['impersonationUser'].username as string;
   }
-  // `preferred_username` is the Authelia (local/self-hosted OIDC) equivalent of the LFID username —
-  // Authelia's default claims policy emits `preferred_username` but not `nickname`/`username`. Falling
-  // back to it keeps the LFID-username identity path (#912) working across both Auth0 (nickname/username)
-  // and Authelia (preferred_username) without affecting Auth0, where the earlier claims take precedence.
-  // Mirrors the Authelia handling already in `getUsernameFromAuth`.
+  // `preferred_username` is the Authelia LFID-username fallback (#912) — additive last, so Auth0
+  // (nickname/username) precedence is unchanged. Mirrors `getUsernameFromAuth`.
   return (req.oidc?.user?.['nickname'] as string) || (req.oidc?.user?.['username'] as string) || (req.oidc?.user?.['preferred_username'] as string) || null;
 }
 

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -60,6 +60,7 @@ export * from './foundation-projects.constants';
 export * from './marketing-impact.constants';
 export * from './org-people.constants';
 export * from './org-people-key-contacts.constants';
+export * from './org-people-committee-members.constants';
 export * from './org-events.constants';
 export * from './individual-enrollment-catalog';
 export * from './newsletter.constants';

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -1,0 +1,33 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { CommitteeMembersSortColumn, OrgPeopleCommitteeMembersResponse } from '../interfaces';
+
+/** committee-service `committee_category` value that the People → Committee tab EXCLUDES (FR-003). Compared case-insensitively. */
+export const COMMITTEE_CATEGORY_BOARD = 'Board';
+
+/** True when a seat's committee_category is the Board category (case-insensitive, whitespace-trimmed). */
+export function isBoardCategory(category: string | null | undefined): boolean {
+  return (category ?? '').trim().toLowerCase() === COMMITTEE_CATEGORY_BOARD.toLowerCase();
+}
+
+/** Default sort column for the People → Committee table (FR-021). */
+export const ORG_PEOPLE_COMMITTEE_MEMBERS_DEFAULT_SORT_COLUMN: CommitteeMembersSortColumn = 'name';
+
+/** Zero-valued envelope — `toSignal` initialValue + the no-account / no-seats fallback. */
+export const EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE: OrgPeopleCommitteeMembersResponse = {
+  orgUid: '',
+  assignments: [],
+  stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 },
+};
+
+/**
+ * Tailwind pill classes for a seat's voting status. A real voting status (e.g. "Voting Rep")
+ * gets an emerald pill; "Non-voting" / "None" / empty gets a neutral slate pill — matching the
+ * spec-027 wireframe (Non-voting rendered as a gray pill).
+ */
+export function votingStatusPillClass(status: string | null | undefined): string {
+  const s = (status ?? '').trim().toLowerCase();
+  const isVoting = s.length > 0 && s !== 'non-voting' && s !== 'none';
+  return isVoting ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
+}

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -14,6 +14,15 @@ export function isBoardCategory(category: string | null | undefined): boolean {
 /** Default sort column for the People → Committee table (FR-021). */
 export const ORG_PEOPLE_COMMITTEE_MEMBERS_DEFAULT_SORT_COLUMN: CommitteeMembersSortColumn = 'name';
 
+/** Main-row Reassign pencil tooltip — writer can edit, but the person holds no org-reassignable seats. */
+export const REASSIGN_TOOLTIP_NO_EDITABLE_SEATS = 'No org-reassignable seats for this person';
+/** Main-row Reassign pencil tooltip — writer can edit and the person has ≥ 1 reassignable seat. */
+export const REASSIGN_TOOLTIP_DEFAULT = 'Reassign committee roles';
+/** Sub-row Edit pencil tooltip — writer can edit this org-editable seat. */
+export const EDIT_TOOLTIP_DEFAULT = 'Edit committee role';
+/** Sub-row Edit pencil tooltip — seat is foundation-controlled and not editable here (fallback when no upstream reason). */
+export const EDIT_TOOLTIP_NOT_ORG_EDITABLE = 'This seat is foundation-controlled and not editable here.';
+
 /** Zero-valued envelope — `toSignal` initialValue + the no-account / no-seats fallback. */
 export const EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE: OrgPeopleCommitteeMembersResponse = {
   orgUid: '',

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -189,6 +189,10 @@ export * from './org-lens-access.interface';
 export * from './org-people-key-contacts.interface';
 export * from './org-people-key-contacts.internal.interface';
 
+// Org People — Committee tab (spec 027)
+export * from './org-people-committee-members.interface';
+export * from './org-people-committee-members.internal.interface';
+
 // Org People — Trainees tab (LFXV2-1876)
 export * from './org-people-trainees.interface';
 

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -269,6 +269,13 @@ export interface CommitteeServiceOrgSeat {
   committee_uid: string;
   committee_name: string;
   committee_category: string;
+  /**
+   * Spec 027 (committee-service additive DTO fields): the foundation (project) the seat's committee
+   * belongs to. Optional — a member may predate project tagging. Used by the org-wide People →
+   * Committee tab to group/filter/stat by foundation.
+   */
+  project_uid?: string | null;
+  project_slug?: string | null;
   first_name: string;
   last_name: string;
   email: string;

--- a/packages/shared/src/interfaces/org-people-committee-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.interface.ts
@@ -1,0 +1,146 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Spec 027 — Org Lens People → Committee tab. Wire (BFF ↔ client) types for the org-wide,
+// non-Board committee-member roster, plus the bulk Reassign and single Edit modal contracts.
+// The seat data is read live from committee-service (spec 026 endpoints, reused) and re-shaped
+// into a People-tab-friendly envelope by the BFF.
+
+/** The seat holder, mirroring the spec-024 key-contact person shape so the table + modals reuse the same UI primitives. */
+export interface CommitteeMemberPerson {
+  /** Canonical identity — lowercased email; the per-person grouping key. */
+  email: string;
+  firstName: string;
+  lastName: string;
+  /** `"${firstName} ${lastName}".trim()` with a fallback to the email when both names are blank. */
+  fullName: string;
+  jobTitle: string | null;
+  initials: string;
+}
+
+/** One committee seat held by one person on one (non-Board) committee in one foundation. */
+export interface CommitteeMemberAssignment {
+  /** = the upstream committee_member uid; identical to `memberUid` (kept distinct only for spec-026 parity). */
+  seatId: string;
+  /** The reassignment subject (== `seatId`). */
+  memberUid: string;
+  /** The seat's committee — required for the reassign body. */
+  committeeUid: string;
+  committeeName: string;
+  /** Guaranteed NOT to equal "Board" (case-insensitive) — the BFF excludes Board seats from this tab. */
+  committeeCategory: string;
+  /** Foundation (project) identity — the filter-dropdown key. May be empty for un-tagged members. */
+  projectUid: string;
+  /** Foundation slug (= upstream project_slug). Display fallback when the name can't be enriched. */
+  foundationSlug: string;
+  /** Human-readable foundation name — BFF-enriched; falls back to `foundationSlug`. */
+  foundationName: string;
+  role: string;
+  /** Voting status string (e.g. "Voting Rep", "Non-voting"); empty when none. */
+  votingStatus: string;
+  appointedBy: string;
+  /** Endpoint-computed: `appointed_by ≡ "Membership Entitlement"`. The client never re-derives this. */
+  isOrgEditable: boolean;
+  /** Why the seat is not org-editable (null when editable). */
+  reason: string | null;
+  person: CommitteeMemberPerson;
+}
+
+/** Filter-independent stat tiles, computed once at the BFF from the full (unfiltered) roster. */
+export interface CommitteeMemberStats {
+  /** Distinct lowercased emails. */
+  individualCount: number;
+  /** Distinct `committeeUid`. */
+  committeeCount: number;
+  /** Distinct `projectUid` (foundations with committee members). */
+  foundationsCovered: number;
+}
+
+/** Response envelope for `GET /api/orgs/:orgUid/lens/people/committee-members`. */
+export interface OrgPeopleCommitteeMembersResponse {
+  orgUid: string;
+  assignments: CommitteeMemberAssignment[];
+  stats: CommitteeMemberStats;
+}
+
+/** Body for `PATCH /api/orgs/:orgUid/lens/people/committee-members/:seatId/reassign` (one per seat). */
+export interface ReassignCommitteeMemberBody {
+  /** Identifies the seat's committee (the upstream PUT requires it in the body). */
+  committeeUid: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+/** Response from the single-seat reassign proxy — the freshly-created seat (role/voting/appointment preserved). */
+export interface ReassignCommitteeMemberResponse {
+  orgUid: string;
+  seat: CommitteeMemberAssignment;
+}
+
+// ============================================================
+// Bulk "Reassign Committee Roles" modal contracts (one person, N entitlement seats)
+// ============================================================
+
+/** Stable per-role checkbox key — `${memberUid}` (1:1 with seatId). */
+export type ReassignCommitteeRolesRoleKey = string;
+
+/** One checkbox row in the bulk modal — represents the person's hold on one Membership-Entitlement seat. */
+export interface ReassignCommitteeRolesRoleOption {
+  key: ReassignCommitteeRolesRoleKey;
+  memberUid: string;
+  committeeUid: string;
+  committeeName: string;
+  foundationName: string;
+  votingStatus: string;
+  /** Tailwind pill classes for the voting-status badge. */
+  votingStatusPillClass: string;
+}
+
+/** Avatar/name/email summary for the orange "current member" card in the modal header. */
+export interface ReassignCommitteeRolesPersonRef {
+  fullName: string;
+  email: string;
+  initials: string;
+}
+
+/** Dialog input — the person being replaced, their entitlement-seat catalog, the org uid, and a pessimistic submit callback. */
+export interface ReassignCommitteeRolesDialogData {
+  person: ReassignCommitteeRolesPersonRef;
+  /** All Membership-Entitlement seats for the person; pre-selected by default. */
+  roles: ReassignCommitteeRolesRoleOption[];
+  orgUid: string;
+  /** Performs the fan-out write; resolves on all-success, rejects with Error(message) on partial/total failure. */
+  submit: (intent: ReassignCommitteeRolesSubmitEvent) => Promise<void>;
+}
+
+/** Modal → parent submit payload. The parent fans out one PUT per selected role. */
+export interface ReassignCommitteeRolesSubmitEvent {
+  newPerson: { email: string; firstName: string; lastName: string };
+  /** The user's final checkbox state (≥ 1 role). */
+  selected: ReassignCommitteeRolesRoleOption[];
+}
+
+/** Cancel → null; on save the parent already drove the write through `submit`. */
+export type ReassignCommitteeRolesDialogResult = null;
+
+// ============================================================
+// Single "Edit Committee Role" modal contracts (one seat)
+// ============================================================
+
+/** Dialog input — the one seat being edited, the org uid, and a pessimistic submit callback. */
+export interface EditCommitteeRoleDialogData {
+  assignment: CommitteeMemberAssignment;
+  orgUid: string;
+  submit: (intent: EditCommitteeRoleSubmitEvent) => Promise<void>;
+}
+
+/** Modal → parent submit payload for the single-seat reassign. */
+export interface EditCommitteeRoleSubmitEvent {
+  memberUid: string;
+  committeeUid: string;
+  newPerson: { email: string; firstName: string; lastName: string };
+}
+
+/** Cancel → null; on save the parent already drove the write through `submit`. */
+export type EditCommitteeRoleDialogResult = null;

--- a/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
@@ -1,0 +1,42 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Spec 027 — client-only view-model types for the People → Committee tab. Derived from the wire
+// `CommitteeMemberAssignment[]` on render; NOT part of the BFF envelope.
+
+import type { CommitteeMemberAssignment } from './org-people-committee-members.interface';
+
+/** Sortable columns on the main table (FR-021). */
+export type CommitteeMembersSortColumn = 'name' | 'foundations' | 'committees';
+
+/** Sort direction — 1 ascending, -1 descending. */
+export type CommitteeMembersSortDirection = 1 | -1;
+
+/** One person row — derived by grouping assignments by lowercased email (first-wins for display fields). */
+export interface CommitteeMemberPersonGroup {
+  /** Lowercased email — the group identity key. */
+  email: string;
+  displayName: string;
+  jobTitle: string | null;
+  initials: string;
+  /** Distinct foundation names this person holds seats on, sorted A→Z. */
+  foundationLabels: string[];
+  /** Count of distinct `committeeUid` across this person's assignments. */
+  committeeCount: number;
+  /** Count of assignments where `isOrgEditable === true` — drives the main-row Reassign pencil enable. */
+  editableCount: number;
+  /** Raw assignments (unsorted) — consumed by the modal + the decorated sub-rows. */
+  assignments: CommitteeMemberAssignment[];
+}
+
+/** A sub-row decorated for the expanded view — pill class + foundation-rowspan flag computed once. */
+export interface CommitteeMemberAssignmentVm extends CommitteeMemberAssignment {
+  votingStatusPillClass: string;
+  /** True only on the first sub-row of each foundation block (so the label renders once per group). */
+  showFoundationLabel: boolean;
+}
+
+/** A person group with its sub-rows pre-sorted (foundation A→Z, then committee A→Z) + decorated. */
+export interface CommitteeMemberPersonGroupVm extends CommitteeMemberPersonGroup {
+  sortedAssignments: CommitteeMemberAssignmentVm[];
+}

--- a/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
@@ -34,9 +34,13 @@ export interface CommitteeMemberAssignmentVm extends CommitteeMemberAssignment {
   votingStatusPillClass: string;
   /** True only on the first sub-row of each foundation block (so the label renders once per group). */
   showFoundationLabel: boolean;
+  /** Precomputed tooltip for the sub-row Edit pencil — encodes (canEdit × isOrgEditable × reason) so the template stays a flat binding (no nested ternary). */
+  editTooltip: string;
 }
 
 /** A person group with its sub-rows pre-sorted (foundation A→Z, then committee A→Z) + decorated. */
 export interface CommitteeMemberPersonGroupVm extends CommitteeMemberPersonGroup {
   sortedAssignments: CommitteeMemberAssignmentVm[];
+  /** Precomputed tooltip for the main-row Reassign pencil — encodes (canEdit × editableCount) so the template stays a flat binding (no nested ternary). */
+  reassignTooltip: string;
 }

--- a/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
@@ -12,9 +12,9 @@ export type CommitteeMembersSortColumn = 'name' | 'foundations' | 'committees';
 /** Sort direction — 1 ascending, -1 descending. */
 export type CommitteeMembersSortDirection = 1 | -1;
 
-/** One person row — derived by grouping assignments by lowercased email (first-wins for display fields). */
+/** One person row — derived by grouping assignments by lowercased email, falling back to the seat `memberUid` when email is blank (first-wins for display fields). */
 export interface CommitteeMemberPersonGroup {
-  /** Lowercased email — the group identity key. */
+  /** Group identity key — the person's lowercased email, or the seat `memberUid` fallback when email is blank. Not guaranteed to be an email. */
   email: string;
   displayName: string;
   jobTitle: string | null;

--- a/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
@@ -44,3 +44,9 @@ export interface CommitteeMemberPersonGroupVm extends CommitteeMemberPersonGroup
   /** Precomputed tooltip for the main-row Reassign pencil — encodes (canEdit × editableCount) so the template stays a flat binding (no nested ternary). */
   reassignTooltip: string;
 }
+
+/** Tooltip-decoration inputs that depend on caller state (FGA writer gate + the shared "you can't edit" string). */
+export interface CommitteeMembersDecorateOptions {
+  canEdit: boolean;
+  editDisabledTooltip: string;
+}


### PR DESCRIPTION
## Summary
- Adds the **People → Committee** tab: an org-wide, **non-Board** committee-member roster grouped by person, with search + Foundation/Committee filters, sortable columns (Name/Foundations/Committees), and expand-to-seats.
- **Reassign Committee Roles** modal (bulk — re-assign all/some of a person's Membership-Entitlement seats) and **Edit Committee Role** modal (single seat).
- Reuses the spec-026 committee-service read + reassign endpoints (now carrying `project_uid`/`project_slug` — see lfx-v2-committee-service#125). Board seats excluded; stats filter-independent; reassign gated to Membership-Entitlement seats; writer/auditor-gated UI.
- **Auth fix**: `getEffectiveUsername` now falls back to `preferred_username` after `nickname`/`username`, so the LFID-username identity path (#912) resolves under self-hosted OIDC (Authelia) as well as Auth0 — additive; Auth0 precedence and impersonation are unchanged.

## Depends on
- lfx-v2-committee-service#125 (additive `project_uid`/`project_slug` DTO fields). The foundation column/filter/stat populate once that ships; the tab degrades gracefully (slug fallback) otherwise.

## Test plan
- [x] `yarn format:check` / `yarn lint:check` / `yarn build` green
- [x] Playwright e2e: `org-people-committee-tab.spec.ts` (read/empty/error/auditor/expand/search/filter + SC-001 perf + SC-004 stat-count) and `org-people-committee-reassign.spec.ts` (bulk happy/partial/total-fail, single edit happy/5xx, disabled non-entitlement, cancel)
- [x] go-reviewer + ui-reviewer: GREEN (no CRITICAL/HIGH/MEDIUM)
- [x] Verified live in local OrbStack (Authelia) against real committee data: roster renders, Board excluded, foundation populated, stats correct, Reassign/Edit modals open

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)