### PR TITLE
feat(ossprey): shared types, backend service, and frontend service [1/3]

### DIFF
--- a/apps/lfx-one/src/app/shared/services/ossprey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/ossprey.service.ts
@@ -36,6 +36,7 @@ export class OsspreyService {
     return this.http.get<OsspreyPackage>(`/api/ossprey/packages/${encodeURIComponent(purl)}`).pipe(
       catchError((err) => {
         if (err.status === 404) return of(null);
+        console.error('[OsspreyService] getPackage failed', { purl, status: err.status, message: err.message });
         throw err;
       })
     );

--- a/apps/lfx-one/src/app/shared/services/ossprey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/ossprey.service.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of, catchError } from 'rxjs';
+import { OsspreyListParams, OsspreyPackage, OsspreyPackagesResponse } from '@lfx-one/shared/interfaces';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OsspreyService {
+  private readonly http = inject(HttpClient);
+
+  public getPackages(params?: OsspreyListParams): Observable<OsspreyPackagesResponse> {
+    let httpParams = new HttpParams();
+    if (params) {
+      if (params.page) httpParams = httpParams.set('page', String(params.page));
+      if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
+      if (params.ecosystem) httpParams = httpParams.set('ecosystem', params.ecosystem);
+      if (params.lifecycle) httpParams = httpParams.set('lifecycle', params.lifecycle);
+      if (params.busFactor1Only) httpParams = httpParams.set('busFactor1Only', 'true');
+      if (params.staleOnly) httpParams = httpParams.set('staleOnly', 'true');
+      if (params.unstewardedOnly) httpParams = httpParams.set('unstewardedOnly', 'true');
+      if (params.sortBy) httpParams = httpParams.set('sortBy', params.sortBy);
+      if (params.sortDir) httpParams = httpParams.set('sortDir', params.sortDir);
+    }
+    return this.http.get<OsspreyPackagesResponse>('/api/ossprey/packages', { params: httpParams });
+  }
+
+  public getStewardName(id: string): string {
+    return id;
+  }
+
+  public getPackage(purl: string): Observable<OsspreyPackage | null> {
+    return this.http.get<OsspreyPackage>(`/api/ossprey/packages/${encodeURIComponent(purl)}`).pipe(
+      catchError((err) => {
+        if (err.status === 404) return of(null);
+        throw err;
+      })
+    );
+  }
+}

--- a/apps/lfx-one/src/server/controllers/ossprey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/ossprey.controller.ts
@@ -1,0 +1,65 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { OsspreyListParams, OsspreyPackagesResponse } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { getStringQueryParam } from '../helpers/validation.helper';
+import { OsspreyServerService } from '../services/ossprey.service';
+import { logger } from '../services/logger.service';
+
+export class OsspreyController {
+  private readonly osspreyService = new OsspreyServerService();
+
+  public async getPackages(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_ossprey_packages');
+
+    try {
+      const pageRaw = getStringQueryParam(req, 'page');
+      const pageSizeRaw = getStringQueryParam(req, 'pageSize');
+      const params: OsspreyListParams = {
+        page: pageRaw ? Number(pageRaw) : undefined,
+        pageSize: pageSizeRaw ? Number(pageSizeRaw) : undefined,
+        ecosystem: getStringQueryParam(req, 'ecosystem'),
+        lifecycle: getStringQueryParam(req, 'lifecycle'),
+        busFactor1Only: getStringQueryParam(req, 'busFactor1Only') === 'true',
+        staleOnly: getStringQueryParam(req, 'staleOnly') === 'true',
+        unstewardedOnly: getStringQueryParam(req, 'unstewardedOnly') === 'true',
+        sortBy: getStringQueryParam(req, 'sortBy') as OsspreyListParams['sortBy'],
+        sortDir: getStringQueryParam(req, 'sortDir') as OsspreyListParams['sortDir'],
+      };
+
+      const data: OsspreyPackagesResponse = await this.osspreyService.getPackages(req, params);
+
+      logger.success(req, 'get_ossprey_packages', startTime, {
+        package_count: data.packages?.length ?? 0,
+      });
+
+      res.json(data);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getPackage(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_ossprey_package');
+    const purl = decodeURIComponent(req.params['purl'] as string);
+
+    try {
+      const pkg = await this.osspreyService.getPackage(req, purl);
+
+      if (!pkg) {
+        logger.debug(req, 'get_ossprey_package', 'Package not found', { purl });
+        // Intentional: 404 is a valid non-error outcome here, not an exception path.
+        res.status(404).json({ error: 'NOT_FOUND', message: 'Package not found.' });
+        return;
+      }
+
+      logger.success(req, 'get_ossprey_package', startTime, { purl });
+
+      res.json(pkg);
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/ossprey.route.ts
+++ b/apps/lfx-one/src/server/routes/ossprey.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { OsspreyController } from '../controllers/ossprey.controller';
+
+const router = Router();
+const osspreyController = new OsspreyController();
+
+router.get('/packages', osspreyController.getPackages.bind(osspreyController));
+router.get('/packages/:purl', osspreyController.getPackage.bind(osspreyController));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -51,6 +51,7 @@ import enrollmentRouter from './routes/enrollment.route';
 import transactionRouter from './routes/transaction.route';
 import userRouter from './routes/user.route';
 import votesRouter from './routes/votes.route';
+import osspreyRouter from './routes/ossprey.route';
 import { reqSerializer, resSerializer, serverLogger } from './server-logger';
 import { logger } from './services/logger.service';
 import { NatsService } from './services/nats.service';
@@ -241,6 +242,7 @@ app.use('/api/transactions', transactionRouter);
 app.use('/api/changelog', changelogRouter);
 app.use('/api/projects/:projectUid/newsletters', newslettersRouter);
 app.use('/api/invite', inviteRouter);
+app.use('/api/ossprey', osspreyRouter);
 
 app.use('/api/*', apiErrorHandler);
 

--- a/apps/lfx-one/src/server/services/ossprey.service.ts
+++ b/apps/lfx-one/src/server/services/ossprey.service.ts
@@ -267,7 +267,7 @@ export class OsspreyServerService {
     return advisories.map((adv) => ({
       id: adv.osvId,
       severity: adv.severity,
-      description: adv.osvId,
+      description: adv.resolution ?? adv.osvId,
       state: 'Open' as const,
       cvss: null,
       publishedAt: null,

--- a/apps/lfx-one/src/server/services/ossprey.service.ts
+++ b/apps/lfx-one/src/server/services/ossprey.service.ts
@@ -1,0 +1,303 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CDP_CONFIG } from '@lfx-one/shared/constants';
+import {
+  CdpAdvisory,
+  CdpPackageDetail,
+  CdpPackagesListResponse,
+  CdpStewardshipSummary,
+  OsspreyAdvisory,
+  OsspreyListParams,
+  OsspreyPackage,
+  OsspreyPackagesResponse,
+  OspreySeverity,
+} from '@lfx-one/shared/interfaces';
+import { randomUUID } from 'crypto';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { CdpService } from './cdp.service';
+import { logger } from './logger.service';
+
+export class OsspreyServerService {
+  private readonly cdpService = new CdpService();
+
+  private _cdpApiUrl: string | undefined;
+
+  private get cdpApiUrl(): string {
+    return (this._cdpApiUrl ??= (process.env['CDP_API_URL'] || CDP_CONFIG.DEFAULT_STAGING_URL).replace(/\/+$/, ''));
+  }
+
+  public async getPackages(req: Request, params: OsspreyListParams): Promise<OsspreyPackagesResponse> {
+    const requestId = randomUUID();
+
+    try {
+      const token = await this.cdpService.generateToken(req).catch((err: unknown) => {
+        throw new MicroserviceError('Failed to generate CDP token', 401, 'CDP_AUTH_FAILED', {
+          operation: 'get_ossprey_packages',
+          service: 'ossprey_service',
+          originalMessage: err instanceof Error ? err.message : String(err),
+        });
+      });
+      const url = new URL(`${this.cdpApiUrl}${CDP_CONFIG.ENDPOINTS.PACKAGES_LIST}`);
+
+      if (params.page) url.searchParams.set('page', String(params.page));
+      if (params.pageSize) url.searchParams.set('pageSize', String(params.pageSize));
+      if (params.ecosystem) url.searchParams.set('ecosystem', params.ecosystem);
+      if (params.lifecycle) url.searchParams.set('lifecycle', params.lifecycle);
+      if (params.busFactor1Only) url.searchParams.set('busFactor1Only', 'true');
+      if (params.staleOnly) url.searchParams.set('staleOnly', 'true');
+      if (params.unstewardedOnly) url.searchParams.set('unstewardedOnly', 'true');
+      if (params.sortBy) url.searchParams.set('sortBy', params.sortBy);
+      if (params.sortDir) url.searchParams.set('sortDir', params.sortDir);
+
+      logger.debug(req, 'get_ossprey_packages', 'Fetching packages from CDP', {
+        url: url.toString(),
+        params,
+        request_id: requestId,
+      });
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-LFX-Request-ID': requestId,
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '[unreadable error body]');
+        throw new MicroserviceError(`CDP packages list request failed: ${response.statusText}`, response.status, 'CDP_PACKAGES_LIST_ERROR', {
+          operation: 'get_ossprey_packages',
+          service: 'ossprey_service',
+          errorBody: errorText,
+        });
+      }
+
+      const data = (await response.json()) as CdpPackagesListResponse;
+
+      logger.debug(req, 'get_ossprey_packages', 'Fetched packages from CDP', {
+        count: data.packages?.length ?? 0,
+        total: data.total,
+      });
+
+      return {
+        packages: (data.packages ?? []).map((item) => this.mapListItem(item)),
+        total: data.total,
+      };
+    } catch (error) {
+      if (error instanceof MicroserviceError) throw error;
+
+      throw new MicroserviceError('Failed to fetch OSSPREY packages', 502, 'OSSPREY_FETCH_ERROR', {
+        operation: 'get_ossprey_packages',
+        service: 'ossprey_service',
+      });
+    }
+  }
+
+  public async getPackage(req: Request, purl: string): Promise<OsspreyPackage | null> {
+    const requestId = randomUUID();
+
+    try {
+      const token = await this.cdpService.generateToken(req).catch((err: unknown) => {
+        throw new MicroserviceError('Failed to generate CDP token', 401, 'CDP_AUTH_FAILED', {
+          operation: 'get_ossprey_package',
+          service: 'ossprey_service',
+          originalMessage: err instanceof Error ? err.message : String(err),
+        });
+      });
+      const url = new URL(`${this.cdpApiUrl}${CDP_CONFIG.ENDPOINTS.PACKAGE_DETAIL}`);
+      url.searchParams.set('purl', purl);
+
+      logger.debug(req, 'get_ossprey_package', 'Fetching package detail from CDP', {
+        purl,
+        url: url.toString(),
+        request_id: requestId,
+      });
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-LFX-Request-ID': requestId,
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (response.status === 404) {
+        logger.warning(req, 'get_ossprey_package', 'Package not found in CDP', { purl });
+        return null;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '[unreadable error body]');
+        throw new MicroserviceError(`CDP package detail request failed: ${response.statusText}`, response.status, 'CDP_PACKAGE_DETAIL_ERROR', {
+          operation: 'get_ossprey_package',
+          service: 'ossprey_service',
+          errorBody: errorText,
+        });
+      }
+
+      const detail = (await response.json()) as CdpPackageDetail;
+
+      logger.debug(req, 'get_ossprey_package', 'Fetched package detail from CDP', { purl });
+
+      return this.mapPackageDetail(detail);
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.statusCode === 404) return null;
+      if (error instanceof MicroserviceError) throw error;
+
+      throw new MicroserviceError('Failed to fetch OSSPREY package', 502, 'OSSPREY_FETCH_ERROR', {
+        operation: 'get_ossprey_package',
+        service: 'ossprey_service',
+      });
+    }
+  }
+
+  public mapListItem(item: CdpStewardshipSummary): OsspreyPackage {
+    const vulns = item.openVulns;
+    const vulnCount = vulns ? vulns.low + vulns.medium + vulns.high + vulns.critical : 0;
+    const vulnSeverity = this.worstSeverityFromCounts(vulns);
+
+    return {
+      id: item.purl,
+      name: item.name,
+      purl: item.purl,
+      ecosystem: (item.ecosystem as OsspreyPackage['ecosystem']) || 'npm',
+      lifecycle: (item.lifecycle as OsspreyPackage['lifecycle']) || null,
+      healthScore: item.health ?? null,
+      impactScore: item.impact ?? null,
+      busFactor: item.maintainerBusFactor ?? null,
+      monthsStale: null,
+      vulnCount,
+      vulnSeverity,
+      status: (item.stewardship as OsspreyPackage['status']) || 'unassigned',
+      stewardIds: [],
+      lastActivityLabel: '—',
+      lastActivityTime: '',
+      weeklyDownloads: null,
+      dependentCount: null,
+      directDependentCount: null,
+      scoreCardScore: null,
+      lastRelease: null,
+      lastCommit: null,
+      repoUrl: null,
+      supplyChainMapping: null,
+      provenance: null,
+      hasSecurityMd: null,
+      ecosystemReach: null,
+      contactGroup: null,
+      healthBreakdown: [],
+      advisories: [],
+      history: [],
+      assessment: null,
+    };
+  }
+
+  private mapPackageDetail(detail: CdpPackageDetail): OsspreyPackage {
+    const advisories = this.mapAdvisories(detail.security?.advisories ?? []);
+    const vulnSeverity = this.getHighestVulnSeverity(advisories);
+
+    const hs = detail.general?.healthScore;
+    const healthBreakdown: string[] = [];
+    if (hs) {
+      if (hs.maintainerHealth != null) healthBreakdown.push(`${Math.round(hs.maintainerHealth)} / 40`);
+      if (hs.securitySupplyChain != null) healthBreakdown.push(`${Math.round(hs.securitySupplyChain)} / 35`);
+      if (hs.developmentActivity != null) healthBreakdown.push(`${Math.round(hs.developmentActivity)} / 25`);
+    }
+
+    const repo = detail.provenance?.repositoryMapping;
+    const impact = detail.general?.impact;
+    const risk = detail.general?.riskSignals;
+
+    return {
+      id: detail.purl,
+      name: detail.name,
+      purl: detail.purl,
+      ecosystem: (detail.ecosystem as OsspreyPackage['ecosystem']) || 'npm',
+      lifecycle: (risk?.lifecycle as OsspreyPackage['lifecycle']) || null,
+      healthScore: hs?.total ?? null,
+      impactScore: impact?.impactScore ?? null,
+      busFactor: risk?.maintainerBusFactor ?? null,
+      monthsStale: this.calculateMonthsStale(repo?.lastCommitAt),
+      vulnCount: advisories.length,
+      vulnSeverity,
+      status: 'unassigned',
+      stewardIds: [],
+      lastActivityLabel: '—',
+      lastActivityTime: '',
+      weeklyDownloads: impact?.downloadsLastMonth != null ? this.formatNumber(impact.downloadsLastMonth) : null,
+      dependentCount: impact?.dependentPackages != null ? this.formatNumber(impact.dependentPackages) : null,
+      directDependentCount: impact?.dependentRepos != null ? this.formatNumber(impact.dependentRepos) : null,
+      scoreCardScore: risk?.openSSFScorecard != null ? `${risk.openSSFScorecard.toFixed(1)} / 10` : null,
+      lastRelease: this.formatDate(risk?.lastRelease),
+      lastCommit: this.formatDate(repo?.lastCommitAt),
+      repoUrl: this.stripProtocol(repo?.declaredRepo),
+      supplyChainMapping: null,
+      provenance: null,
+      hasSecurityMd: risk?.hasSecurityFile ?? null,
+      ecosystemReach: impact?.transitiveReach ?? null,
+      contactGroup: null,
+      healthBreakdown,
+      advisories,
+      history: [],
+      assessment: null,
+    };
+  }
+
+  private worstSeverityFromCounts(vulns: { low: number; medium: number; high: number; critical: number } | null): OspreySeverity | null {
+    if (!vulns) return null;
+    if (vulns.critical > 0) return 'critical';
+    if (vulns.high > 0) return 'high';
+    if (vulns.medium > 0) return 'medium';
+    if (vulns.low > 0) return 'low';
+    return null;
+  }
+
+  private getHighestVulnSeverity(advisories: OsspreyAdvisory[]): OspreySeverity | null {
+    if (!advisories.length) return null;
+    const order: OspreySeverity[] = ['critical', 'high', 'medium', 'low'];
+    for (const sev of order) {
+      if (advisories.some((a) => a.severity === sev)) return sev;
+    }
+    return null;
+  }
+
+  private mapAdvisories(advisories: CdpAdvisory[]): OsspreyAdvisory[] {
+    return advisories.map((adv) => ({
+      id: adv.osvId,
+      severity: adv.severity,
+      description: adv.osvId,
+      state: 'Open' as const,
+      cvss: null,
+      publishedAt: null,
+      affectedVersionRange: null,
+    }));
+  }
+
+  private calculateMonthsStale(lastCommitAt?: string | null): number | null {
+    if (!lastCommitAt) return null;
+    try {
+      return Math.floor((Date.now() - new Date(lastCommitAt).getTime()) / (1000 * 60 * 60 * 24 * 30));
+    } catch {
+      return null;
+    }
+  }
+
+  private formatNumber(num: number): string {
+    return num.toLocaleString('en-US');
+  }
+
+  private formatDate(isoDate?: string | null): string | null {
+    if (!isoDate) return null;
+    try {
+      return new Date(isoDate).toISOString().split('T')[0];
+    } catch {
+      return null;
+    }
+  }
+
+  private stripProtocol(url?: string | null): string | null {
+    return url ? url.replace(/^https?:\/\//, '') : null;
+  }
+}

--- a/check-headers.sh
+++ b/check-headers.sh
@@ -8,7 +8,7 @@
 # Exits with a 1 if one or more source files are missing a license header
 
 # These are the file patterns we should exclude - these are typically transient files not checked into source control
-exclude_pattern='node_modules|.vendor|.idea|gen|.venv|.ruff_cache|.pytest_cache|.angular|dist|playwright-report|test-results'
+exclude_pattern='node_modules|.vendor|.idea|gen|.venv|.ruff_cache|.pytest_cache|.angular|dist|playwright-report|test-results|design'
 
 files=()
 echo "Scanning source code..."

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -77,5 +77,7 @@ export const CDP_CONFIG = {
     MEMBER_PROJECT_AFFILIATIONS: (memberId: string) => `/v1/members/${memberId}/project-affiliations`,
     MEMBER_PROJECT_AFFILIATION: (memberId: string, projectId: string) => `/v1/members/${memberId}/project-affiliations/${projectId}`,
     ORGANIZATIONS: '/v1/organizations',
+    PACKAGES_LIST: '/v1/packages',
+    PACKAGE_DETAIL: '/v1/packages/detail',
   },
 } as const;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -99,6 +99,9 @@ export * from './sse.interface';
 // Copilot interfaces
 export * from './copilot.interface';
 
+// OSSPREY admin dashboard interfaces
+export * from './ossprey.interface';
+
 // Committee application interfaces
 export * from './committee-application.interface';
 

--- a/packages/shared/src/interfaces/ossprey.interface.ts
+++ b/packages/shared/src/interfaces/ossprey.interface.ts
@@ -1,0 +1,226 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export type OsspreyStatus = 'unassigned' | 'open' | 'assessing' | 'active' | 'needs_attention' | 'escalated' | 'blocked' | 'inactive';
+export type OsspreyLifecycle = 'active' | 'stable' | 'declining' | 'abandoned';
+export type OsspreyEcosystem = 'npm' | 'maven' | 'pypi' | 'go';
+export type OsspreyHealthBand = 'healthy' | 'fair' | 'concerning' | 'critical';
+export type OspreySeverity = 'critical' | 'high' | 'medium' | 'low';
+export type OspreySortKey = 'risk' | 'impact' | 'health' | 'vulns' | 'name';
+
+// ===== CDP Raw Types =====
+
+export interface CdpOpenVulns {
+  low: number;
+  medium: number;
+  high: number;
+  critical: number;
+}
+
+export interface CdpStewardshipSummary {
+  purl: string;
+  name: string;
+  ecosystem: string;
+  lifecycle: string | null;
+  health: number | null;
+  impact: number | null;
+  maintainerBusFactor: number | null;
+  openVulns: CdpOpenVulns | null;
+  stewardship: string;
+  steward: null;
+}
+
+export interface CdpPackagesListResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  filters: Record<string, unknown>;
+  sort: { by: string; dir: string };
+  packages: CdpStewardshipSummary[];
+}
+
+export interface OsspreyPackagesResponse {
+  packages: OsspreyPackage[];
+  total?: number | null;
+}
+
+export interface OsspreyListParams {
+  page?: number;
+  pageSize?: number;
+  ecosystem?: string;
+  lifecycle?: string;
+  busFactor1Only?: boolean;
+  staleOnly?: boolean;
+  unstewardedOnly?: boolean;
+  sortBy?: 'name' | 'health' | 'impact' | 'openVulns';
+  sortDir?: 'asc' | 'desc';
+}
+
+export interface OsspreyDashboardSortSpec {
+  sortBy: OsspreyListParams['sortBy'];
+  sortDir: OsspreyListParams['sortDir'];
+}
+
+export interface CdpAdvisory {
+  osvId: string;
+  severity: OspreySeverity;
+  resolution: string | null;
+}
+
+export interface CdpPackageDetail {
+  purl: string;
+  name: string;
+  ecosystem: string;
+  general: {
+    healthScore: {
+      maintainerHealth: number | null;
+      securitySupplyChain: number | null;
+      developmentActivity: number | null;
+      total: number | null;
+    } | null;
+    impact: {
+      impactScore: number | null;
+      downloadsLastMonth: number | null;
+      dependentPackages: number | null;
+      dependentRepos: number | null;
+      transitiveReach: string | null;
+    } | null;
+    riskSignals: {
+      lifecycle: string | null;
+      maintainerBusFactor: number | null;
+      lastRelease: string | null;
+      hasSecurityFile: boolean | null;
+      openSSFScorecard: number | null;
+    } | null;
+  } | null;
+  assessment: Record<string, unknown>;
+  security: {
+    securityContacts: unknown | null;
+    advisories: CdpAdvisory[];
+    cvd: {
+      isPvrEnabled: boolean | null;
+      hasSecurityPolicyEnabled: boolean | null;
+      tier0Steward: unknown | null;
+      criticalVulnerabilityFlag: boolean;
+    } | null;
+  } | null;
+  provenance: {
+    repositoryMapping: {
+      declaredRepo: string | null;
+      mappingConfidence: number | null;
+      lastCommitAt: string | null;
+    } | null;
+    supplyChainIntegrity: {
+      buildProvenance: unknown | null;
+      signedReleases: unknown | null;
+    } | null;
+  } | null;
+  history: Record<string, unknown>;
+}
+
+// ===== Frontend Types =====
+
+export interface OsspreyAdvisory {
+  id: string;
+  severity: OspreySeverity;
+  description: string;
+  state: 'Open' | 'Patched';
+  cvss?: number | null;
+  publishedAt?: string | null;
+  affectedVersionRange?: {
+    introduced?: string | null;
+    fixed?: string | null;
+    lastAffected?: string | null;
+  } | null;
+}
+
+export interface OsspreyHistoryEntry {
+  label: string;
+  timeAgo: string;
+  type?: 'danger' | 'success';
+}
+
+export interface OsspreyAssessment {
+  posture: string;
+  reviewed: boolean;
+  flagged: boolean;
+  flagNote?: string;
+  draft?: boolean;
+  findings: Array<[string, OspreySeverity | 'low', string]>;
+  remediation: string[];
+  monitoring: string[];
+}
+
+export interface OsspreyContactGroup {
+  name: string;
+  type: string;
+  count: number;
+  coverage: number;
+  packages: string[];
+  hasPvr: boolean;
+  hasSecurityMd: boolean;
+}
+
+export interface OsspreyPackage {
+  id: string;
+  name: string;
+  purl: string;
+  ecosystem: OsspreyEcosystem;
+  lifecycle: OsspreyLifecycle | null;
+  healthScore: number | null;
+  impactScore: number | null;
+  busFactor: number | null;
+  monthsStale: number | null;
+  vulnCount: number;
+  vulnSeverity: OspreySeverity | null;
+  status: OsspreyStatus;
+  stewardIds: string[];
+  lastActivityLabel: string;
+  lastActivityTime: string;
+  weeklyDownloads: string | null;
+  dependentCount: string | null;
+  directDependentCount: string | null;
+  scoreCardScore: string | null;
+  lastRelease: string | null;
+  lastCommit: string | null;
+  repoUrl: string | null;
+  supplyChainMapping: 'High' | 'Medium' | 'Low' | null;
+  provenance: 'Full' | 'Partial' | 'None' | null;
+  hasSecurityMd: boolean | null;
+  ecosystemReach: string | null;
+  contactGroup: OsspreyContactGroup | null;
+  healthBreakdown: string[];
+  assessment: OsspreyAssessment | null;
+  advisories: OsspreyAdvisory[];
+  history: OsspreyHistoryEntry[];
+}
+
+export interface OsspreyFilterState {
+  search: string;
+  tab: OsspreyStatus | 'all';
+  sort: OspreySortKey;
+  ecosystem: OsspreyEcosystem | '';
+  lifecycle: OsspreyLifecycle | '';
+  healthBand: OsspreyHealthBand | '';
+  vulnFilter: 'critical' | 'high' | 'any' | '';
+  busFactor1Only: boolean;
+  staleOnly: boolean;
+  unstewardedOnly: boolean;
+}
+
+export interface OsspreyStatusCounts {
+  all: number;
+  unassigned: number;
+  open: number;
+  assessing: number;
+  active: number;
+  needs_attention: number;
+  escalated: number;
+  blocked: number;
+  inactive: number;
+}
+
+export interface OsspreyFilterChip {
+  label: string;
+  clear: Partial<OsspreyFilterState>;
+}


### PR DESCRIPTION
## Summary

- Adds all shared TypeScript interfaces for the OSSPREY module (`OsspreyPackage`, `OsspreyListParams`, `CdpStewardshipSummary`, etc.) to `@lfx-one/shared`
- Backend `OsspreyServerService` proxying CDP `/v1/packages` and `/v1/packages/detail` endpoints with auth token generation and error handling
- `OsspreyController` with `getPackages` and `getPackage` route handlers
- Frontend `OsspreyService` wiring `/api/ossprey/packages` and `/api/ossprey/packages/:purl`
- CDP API URL and endpoint constants in `api.constants.ts`

## Part of

This is PR 1/3 in a stacked series targeting `release/CM-1223-ossprey-admin-dashboard`. Merge order: 1 → 2 → 3.