### PR TITLE
feat(ossprey): packages tab component [2/3]

### DIFF
--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -112,11 +112,7 @@
                 <span class="osp-flabel">Ecosystem</span>
                 <button class="osp-freset" (click)="draftEcosystem.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftEcosystem()"
-                (change)="draftEcosystem.set($any($event.target).value)"
-                data-testid="ossprey-filter-ecosystem">
+              <select class="osp-fselect" [value]="draftEcosystem()" (change)="onEcosystemChange($event)" data-testid="ossprey-filter-ecosystem">
                 <option value="">All ecosystems</option>
                 <option value="npm">npm</option>
                 <option value="maven">Maven</option>
@@ -131,11 +127,7 @@
                 <span class="osp-flabel">Lifecycle</span>
                 <button class="osp-freset" (click)="draftLifecycle.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftLifecycle()"
-                (change)="draftLifecycle.set($any($event.target).value)"
-                data-testid="ossprey-filter-lifecycle">
+              <select class="osp-fselect" [value]="draftLifecycle()" (change)="onLifecycleChange($event)" data-testid="ossprey-filter-lifecycle">
                 <option value="">All lifecycle</option>
                 <option value="active">Active</option>
                 <option value="stable">Stable</option>
@@ -150,11 +142,7 @@
                 <span class="osp-flabel">Health</span>
                 <button class="osp-freset" (click)="draftHealthBand.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftHealthBand()"
-                (change)="draftHealthBand.set($any($event.target).value)"
-                data-testid="ossprey-filter-health">
+              <select class="osp-fselect" [value]="draftHealthBand()" (change)="onHealthBandChange($event)" data-testid="ossprey-filter-health">
                 <option value="">All health</option>
                 <option value="healthy">Healthy (≥75)</option>
                 <option value="fair">Fair (50–74)</option>
@@ -169,11 +157,7 @@
                 <span class="osp-flabel">Open vulnerabilities</span>
                 <button class="osp-freset" (click)="draftVulnFilter.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftVulnFilter()"
-                (change)="draftVulnFilter.set($any($event.target).value)"
-                data-testid="ossprey-filter-vulns">
+              <select class="osp-fselect" [value]="draftVulnFilter()" (change)="onVulnFilterChange($event)" data-testid="ossprey-filter-vulns">
                 <option value="">Any vulns</option>
                 <option value="any">Has any vulnerability</option>
                 <option value="high">High or above</option>
@@ -189,15 +173,15 @@
               </div>
               <div class="flex flex-col gap-2">
                 <label class="osp-fcheck" data-testid="ossprey-filter-busfactor">
-                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="draftBusFactor1Only.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="onBusFactorToggle($event)" />
                   <span>Bus factor = 1</span>
                 </label>
                 <label class="osp-fcheck" data-testid="ossprey-filter-stale">
-                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="draftStaleOnly.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="onStaleToggle($event)" />
                   <span>No activity ≥18mo</span>
                 </label>
                 <label class="osp-fcheck" data-testid="ossprey-filter-unstewarded">
-                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="draftUnstewardedOnly.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="onUnstewardedToggle($event)" />
                   <span>Unstewarded only</span>
                 </label>
               </div>
@@ -270,7 +254,9 @@
           <div class="t-sub font-mono">{{ pkg.purl }}</div>
         </td>
         <td>
-          <span class="eco-row"><span class="logo-npm">npm</span> {{ pkg.ecosystem }}</span>
+          <span class="eco-row"
+            ><span [class]="getEcosystemIconClass(pkg.ecosystem)">{{ pkg.ecosystem }}</span></span
+          >
         </td>
         <td><lfx-tag [value]="getLifecycleLabel(pkg.lifecycle)" [severity]="getLifecycleTagSeverity(pkg.lifecycle)" /></td>
         <td><lfx-tag [value]="pkg.healthScore !== null ? pkg.healthScore.toString() : '—'" [severity]="getHealthTagSeverity(pkg.healthScore)" /></td>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -12,7 +12,7 @@
       <input
         type="text"
         [value]="filters().search"
-        (input)="filterChange.emit({ search: $any($event.target).value })"
+        (input)="onSearchInput($event)"
         placeholder="Search package, purl, steward, or contact…"
         class="outline-none text-sm bg-transparent flex-1"
         data-testid="ossprey-search" />
@@ -235,7 +235,13 @@
     <ng-template #header>
       <tr>
         <th style="width: 34px">
-          <span class="ck" [class.on]="allSelected()" (click)="onToggleAllClick()"></span>
+          <span
+            class="ck"
+            [class.on]="allSelected()"
+            (click)="onToggleAllClick()"
+            role="checkbox"
+            [attr.aria-checked]="allSelected()"
+            aria-label="Select all packages"></span>
         </th>
         <th>Package</th>
         <th>Ecosystem</th>
@@ -251,7 +257,13 @@
     <ng-template #body let-pkg>
       <tr (click)="packageClick.emit(pkg.id)" class="cursor-pointer">
         <td (click)="$event.stopPropagation()">
-          <span class="ck" [class.on]="isPackageSelected(pkg.id)" (click)="togglePackage.emit({ id: pkg.id, event: $event })"></span>
+          <span
+            class="ck"
+            [class.on]="isPackageSelected(pkg.id)"
+            (click)="togglePackage.emit({ id: pkg.id, event: $event })"
+            role="checkbox"
+            [attr.aria-checked]="isPackageSelected(pkg.id)"
+            [attr.aria-label]="'Select ' + pkg.name"></span>
         </td>
         <td>
           <div class="t-title">{{ pkg.name }}</div>
@@ -275,5 +287,5 @@
       </tr>
     </ng-template>
   </lfx-table>
-  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages · demo subset of 1,842 critical packages</p>
+  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages</p>
 </div>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -1,0 +1,279 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 py-6">
+  <!-- Search -->
+  <div class="osp-qsearch">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+      <input
+        type="text"
+        [value]="filters().search"
+        (input)="filterChange.emit({ search: $any($event.target).value })"
+        placeholder="Search package, purl, steward, or contact…"
+        class="outline-none text-sm bg-transparent flex-1"
+        data-testid="ossprey-search" />
+    </div>
+  </div>
+
+  <!-- Status pills + sort/filter toolbar -->
+  <div class="osp-qrow">
+    <div class="osp-qtabs">
+      <button (click)="filterChange.emit({ tab: 'all' })" [class.on]="filters().tab === 'all'" class="osp-qtab" data-testid="ossprey-pill-all">
+        <span class="lbl">All</span><span class="osp-qcount">{{ statusCounts().all }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'unassigned' })"
+        [class.on]="filters().tab === 'unassigned'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-unassigned">
+        <span class="lbl">Unassigned</span><span class="osp-qcount">{{ statusCounts().unassigned }}</span>
+      </button>
+      <button (click)="filterChange.emit({ tab: 'open' })" [class.on]="filters().tab === 'open'" class="osp-qtab" data-testid="ossprey-pill-open">
+        <span class="lbl">Open</span><span class="osp-qcount">{{ statusCounts().open }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'assessing' })"
+        [class.on]="filters().tab === 'assessing'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-assessing">
+        <span class="lbl">Assessing</span><span class="osp-qcount">{{ statusCounts().assessing }}</span>
+      </button>
+      <button (click)="filterChange.emit({ tab: 'active' })" [class.on]="filters().tab === 'active'" class="osp-qtab" data-testid="ossprey-pill-active">
+        <span class="lbl">Active</span><span class="osp-qcount">{{ statusCounts().active }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'needs_attention' })"
+        [class.on]="filters().tab === 'needs_attention'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-needs-attention">
+        <span class="lbl">Needs attention</span><span class="osp-qcount">{{ statusCounts().needs_attention }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'escalated' })"
+        [class.on]="filters().tab === 'escalated'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-escalated">
+        <span class="lbl">Escalated</span><span class="osp-qcount">{{ statusCounts().escalated }}</span>
+      </button>
+    </div>
+
+    <div class="osp-qactions">
+      <div class="osp-sortwrap">
+        <button class="osp-tbtn osp-sortbtn" (click)="toggleSortMenu()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m3 16 4 4 4-4"></path>
+            <path d="M7 20V4"></path>
+            <path d="M11 4h10"></path>
+            <path d="M11 8h7"></path>
+            <path d="M11 12h4"></path>
+          </svg>
+          Sort:
+          <span>{{
+            filters().sort === 'risk'
+              ? 'Risk priority'
+              : filters().sort === 'impact'
+                ? 'Impact score'
+                : filters().sort === 'health'
+                  ? 'Health (worst first)'
+                  : filters().sort === 'vulns'
+                    ? 'Open vulnerabilities'
+                    : 'Name (A–Z)'
+          }}</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <div class="osp-menu" [class.open]="sortMenuOpen()">
+          <button class="osp-mi" [class.on]="filters().sort === 'risk'" (click)="onSortSelect('risk')">Risk priority</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'impact'" (click)="onSortSelect('impact')">Impact score</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'health'" (click)="onSortSelect('health')">Health (worst first)</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'vulns'" (click)="onSortSelect('vulns')">Open vulnerabilities</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'name'" (click)="onSortSelect('name')">Name (A–Z)</button>
+        </div>
+      </div>
+
+      <div class="osp-filterwrap">
+        <button class="osp-tbtn" (click)="toggleFilterPanel()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+          </svg>
+          Filter
+        </button>
+        <div class="osp-fpanel" [class.open]="filterPanelOpen()">
+          <div class="osp-fpanel-h">Filter</div>
+          <div class="osp-fpanel-body">
+            <!-- Ecosystem -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Ecosystem</span>
+                <button class="osp-freset" (click)="draftEcosystem.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftEcosystem()"
+                (change)="draftEcosystem.set($any($event.target).value)"
+                data-testid="ossprey-filter-ecosystem">
+                <option value="">All ecosystems</option>
+                <option value="npm">npm</option>
+                <option value="maven">Maven</option>
+                <option value="pypi">PyPI</option>
+                <option value="go">Go</option>
+              </select>
+            </div>
+
+            <!-- Lifecycle -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Lifecycle</span>
+                <button class="osp-freset" (click)="draftLifecycle.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftLifecycle()"
+                (change)="draftLifecycle.set($any($event.target).value)"
+                data-testid="ossprey-filter-lifecycle">
+                <option value="">All lifecycle</option>
+                <option value="active">Active</option>
+                <option value="stable">Stable</option>
+                <option value="declining">Declining</option>
+                <option value="abandoned">Abandoned</option>
+              </select>
+            </div>
+
+            <!-- Health -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Health</span>
+                <button class="osp-freset" (click)="draftHealthBand.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftHealthBand()"
+                (change)="draftHealthBand.set($any($event.target).value)"
+                data-testid="ossprey-filter-health">
+                <option value="">All health</option>
+                <option value="healthy">Healthy (≥75)</option>
+                <option value="fair">Fair (50–74)</option>
+                <option value="concerning">Concerning (25–49)</option>
+                <option value="critical">Critical (&lt;25)</option>
+              </select>
+            </div>
+
+            <!-- Open vulnerabilities -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Open vulnerabilities</span>
+                <button class="osp-freset" (click)="draftVulnFilter.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftVulnFilter()"
+                (change)="draftVulnFilter.set($any($event.target).value)"
+                data-testid="ossprey-filter-vulns">
+                <option value="">Any vulns</option>
+                <option value="any">Has any vulnerability</option>
+                <option value="high">High or above</option>
+                <option value="critical">Critical only</option>
+              </select>
+            </div>
+
+            <!-- Coverage gaps -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Coverage gaps</span>
+                <button class="osp-freset" (click)="draftBusFactor1Only.set(false); draftStaleOnly.set(false); draftUnstewardedOnly.set(false)">Reset</button>
+              </div>
+              <div class="flex flex-col gap-2">
+                <label class="osp-fcheck" data-testid="ossprey-filter-busfactor">
+                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="draftBusFactor1Only.set($any($event.target).checked)" />
+                  <span>Bus factor = 1</span>
+                </label>
+                <label class="osp-fcheck" data-testid="ossprey-filter-stale">
+                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="draftStaleOnly.set($any($event.target).checked)" />
+                  <span>No activity ≥18mo</span>
+                </label>
+                <label class="osp-fcheck" data-testid="ossprey-filter-unstewarded">
+                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="draftUnstewardedOnly.set($any($event.target).checked)" />
+                  <span>Unstewarded only</span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="osp-fpanel-foot">
+            <lfx-button label="Reset all" severity="secondary" [outlined]="true" size="small" (onClick)="resetAllFilters()" />
+            <lfx-button label="Apply now" size="small" (onClick)="applyFilters()" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Active filter chips -->
+  @if (activeFilterChips().length > 0) {
+    <div class="osp-chips" data-testid="ossprey-filter-chips">
+      @for (chip of activeFilterChips(); track chip.label) {
+        <span class="osp-fchip">
+          {{ chip.label }}
+          <button (click)="filterChange.emit(chip.clear)" [attr.aria-label]="'Remove ' + chip.label + ' filter'">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </span>
+      }
+      <button class="osp-clearf" (click)="clearFilters.emit()" data-testid="ossprey-clear-filters">Clear filters</button>
+    </div>
+  }
+
+  <!-- Package table -->
+  <lfx-table [value]="filteredPackages()" [rowHover]="true" size="small" styleClass="ossprey-pkg-table" data-testid="ossprey-packages-table">
+    <ng-template #header>
+      <tr>
+        <th style="width: 34px">
+          <span class="ck" [class.on]="allSelected()" (click)="onToggleAllClick()"></span>
+        </th>
+        <th>Package</th>
+        <th>Ecosystem</th>
+        <th>Lifecycle</th>
+        <th>Health</th>
+        <th>Impact</th>
+        <th>Open vulns</th>
+        <th>Steward</th>
+        <th>Stewardship</th>
+        <th>Last activity</th>
+      </tr>
+    </ng-template>
+    <ng-template #body let-pkg>
+      <tr (click)="packageClick.emit(pkg.id)" class="cursor-pointer">
+        <td (click)="$event.stopPropagation()">
+          <span class="ck" [class.on]="isPackageSelected(pkg.id)" (click)="togglePackage.emit({ id: pkg.id, event: $event })"></span>
+        </td>
+        <td>
+          <div class="t-title">{{ pkg.name }}</div>
+          <div class="t-sub font-mono">{{ pkg.purl }}</div>
+        </td>
+        <td>
+          <span class="eco-row"><span class="logo-npm">npm</span> {{ pkg.ecosystem }}</span>
+        </td>
+        <td><lfx-tag [value]="getLifecycleLabel(pkg.lifecycle)" [severity]="getLifecycleTagSeverity(pkg.lifecycle)" /></td>
+        <td><lfx-tag [value]="pkg.healthScore !== null ? pkg.healthScore.toString() : '—'" [severity]="getHealthTagSeverity(pkg.healthScore)" /></td>
+        <td><lfx-tag [value]="pkg.impactScore !== null ? pkg.impactScore.toString() : '—'" severity="secondary" /></td>
+        <td><lfx-tag [value]="pkg.vulnCount + (pkg.vulnSeverity ? ' ' + pkg.vulnSeverity : '')" [severity]="getAdvisoryTagSeverity(pkg.vulnSeverity)" /></td>
+        <td class="text-xs text-gray-600">{{ getStewardNames(pkg.stewardIds) }}</td>
+        <td><lfx-tag [value]="formatStatus(pkg.status)" [severity]="getStatusTagSeverity(pkg.status)" /></td>
+        <td class="text-xs text-gray-500">{{ pkg.lastActivityLabel }}</td>
+      </tr>
+    </ng-template>
+    <ng-template #emptymessage>
+      <tr>
+        <td colspan="10" class="text-center py-8 text-sm text-gray-500">No packages match the current filters.</td>
+      </tr>
+    </ng-template>
+  </lfx-table>
+  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages · demo subset of 1,842 critical packages</p>
+</div>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
@@ -319,11 +319,13 @@
   font-weight: 500;
 }
 
-.logo-npm {
+.logo-npm,
+.logo-maven,
+.logo-pypi,
+.logo-go {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #cb3837;
   color: #fff;
   font-weight: 700;
   font-size: 9px;
@@ -331,6 +333,22 @@
   border-radius: 3px;
   padding: 3px 4px;
   letter-spacing: -0.02em;
+}
+
+.logo-npm {
+  background: #cb3837;
+}
+
+.logo-maven {
+  background: #c71a36;
+}
+
+.logo-pypi {
+  background: #3776ab;
+}
+
+.logo-go {
+  background: #00add8;
 }
 
 .t-title {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
@@ -1,0 +1,429 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 13px;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 9px;
+  background: #fff;
+  width: 100%;
+}
+
+.search svg {
+  width: 15px;
+  height: 15px;
+  color: #90a1b9;
+}
+.search input {
+  border: none;
+  outline: none;
+  font-size: 13px;
+  width: 100%;
+  background: none;
+}
+
+.osp-qrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.osp-qtabs {
+  display: inline-flex;
+  gap: 4px;
+  background: #f1f5f9;
+  padding: 4px;
+  border-radius: 11px;
+  flex-wrap: wrap;
+}
+
+.osp-qtab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #45556c;
+  transition: all 0.12s;
+}
+
+.osp-qtab:hover {
+  color: #0f172b;
+}
+.osp-qtab.on {
+  background: #fff;
+  color: #009aff;
+  box-shadow: 0 1px 2px rgba(2, 39, 65, 0.12);
+}
+
+.osp-qcount {
+  font-size: 11px;
+  font-weight: 700;
+  background: #e2e8f0;
+  color: #45556c;
+  border-radius: 99px;
+  padding: 1px 7px;
+}
+
+.osp-qtab.on .osp-qcount {
+  background: #ecf4ff;
+  color: #0086e0;
+}
+
+.osp-qactions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.osp-tbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 38px;
+  padding: 0 14px;
+  border: 1px solid #cad5e2;
+  border-radius: 9px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  color: #314158;
+  cursor: pointer;
+}
+
+.osp-tbtn:hover {
+  background: #f8fafc;
+}
+.osp-tbtn svg {
+  width: 14px;
+  height: 14px;
+  color: #62748e;
+}
+.osp-sortbtn {
+  background: none;
+  border: none;
+  color: #45556c;
+}
+.osp-sortbtn:hover {
+  background: #f1f5f9;
+}
+
+.osp-sortwrap,
+.osp-filterwrap {
+  position: relative;
+}
+
+.osp-menu {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 11px;
+  box-shadow: 0 14px 36px rgba(2, 39, 65, 0.16);
+  z-index: 60;
+  display: none;
+  min-width: 210px;
+  padding: 6px;
+}
+
+.osp-menu.open {
+  display: block;
+}
+
+.osp-mi {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: none;
+  padding: 9px 11px;
+  border-radius: 7px;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+}
+
+.osp-mi:hover {
+  background: #f8fafc;
+}
+.osp-mi.on {
+  color: #009aff;
+  font-weight: 600;
+}
+
+.osp-fpanel {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  width: 340px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  box-shadow: 0 18px 46px rgba(2, 39, 65, 0.18);
+  z-index: 60;
+  display: none;
+  overflow: hidden;
+}
+
+.osp-fpanel.open {
+  display: block;
+}
+.osp-fpanel-h {
+  padding: 14px 16px;
+  font-size: 14px;
+  font-weight: 700;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.osp-fpanel-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.osp-frow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.osp-frow-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.osp-flabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.osp-freset {
+  font-size: 12px;
+  font-weight: 500;
+  color: #009aff;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.osp-freset:hover {
+  color: #0086e0;
+}
+
+.osp-fselect {
+  width: 100%;
+  appearance: none;
+  padding: 9px 36px 9px 12px;
+  border: 1px solid #cad5e2;
+  border-radius: 8px;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2362748e' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.osp-fselect:focus {
+  border-color: #009aff;
+}
+
+.osp-fcheck {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1.6px solid #cad5e2;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: all 0.12s;
+
+    &:hover {
+      border-color: #009aff;
+    }
+
+    &:checked {
+      background: #009aff;
+      border-color: #009aff;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 12 12' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='2 6 5 9 10 3'%3E%3C/polyline%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+  }
+}
+
+.osp-fpanel-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 16px;
+}
+
+.ck {
+  width: 16px;
+  height: 16px;
+  border: 1.6px solid #cad5e2;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: #fff;
+  vertical-align: middle;
+}
+
+.ck:hover {
+  border-color: #009aff;
+}
+.ck.on {
+  background: #009aff;
+  border-color: #009aff;
+}
+
+.eco-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #45556c;
+  font-weight: 500;
+}
+
+.logo-npm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #cb3837;
+  color: #fff;
+  font-weight: 700;
+  font-size: 9px;
+  line-height: 1;
+  border-radius: 3px;
+  padding: 3px 4px;
+  letter-spacing: -0.02em;
+}
+
+.t-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172b;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.t-sub {
+  font-size: 11.5px;
+  color: #62748e;
+  margin-top: 2px;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:host ::ng-deep .ossprey-pkg-table td {
+  padding-top: 14px;
+  padding-bottom: 14px;
+}
+
+.osp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.osp-fchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #ecf4ff;
+  color: #0086e0;
+  border: 1px solid #bcdcff;
+  border-radius: 999px;
+  padding: 4px 6px 4px 12px;
+  font-size: 12.5px;
+  font-weight: 500;
+
+  button {
+    border: none;
+    background: none;
+    color: #0086e0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    border-radius: 50%;
+
+    &:hover {
+      background: #bcdcff;
+    }
+
+    svg {
+      width: 13px;
+      height: 13px;
+    }
+  }
+}
+
+.osp-clearf {
+  border: none;
+  background: none;
+  font-size: 12px;
+  font-weight: 500;
+  color: #009aff;
+  cursor: pointer;
+  padding: 4px 8px;
+
+  &:hover {
+    color: #0086e0;
+    text-decoration: underline;
+  }
+}
+
+.osp-fbtn-c {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  background: #009aff;
+  color: #fff;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 4px;
+  margin-left: 2px;
+}

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -18,6 +18,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   formatStatus,
   getAdvisoryTagSeverity,
+  getEcosystemIconClass,
   getHealthTagSeverity,
   getLifecycleLabel,
   getLifecycleTagSeverity,
@@ -104,6 +105,7 @@ export class OsspreyPackagesTabComponent {
   protected readonly getLifecycleTagSeverity = getLifecycleTagSeverity;
   protected readonly getHealthTagSeverity = getHealthTagSeverity;
   protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+  protected readonly getEcosystemIconClass = getEcosystemIconClass;
 
   protected isPackageSelected(id: string): boolean {
     return this.selectedPackages().has(id);
@@ -121,6 +123,34 @@ export class OsspreyPackagesTabComponent {
 
   protected onSearchInput(event: Event): void {
     this.filterChange.emit({ search: (event.target as HTMLInputElement).value });
+  }
+
+  protected onEcosystemChange(event: Event): void {
+    this.draftEcosystem.set((event.target as HTMLSelectElement).value as OsspreyEcosystem | '');
+  }
+
+  protected onLifecycleChange(event: Event): void {
+    this.draftLifecycle.set((event.target as HTMLSelectElement).value as OsspreyLifecycle | '');
+  }
+
+  protected onHealthBandChange(event: Event): void {
+    this.draftHealthBand.set((event.target as HTMLSelectElement).value as OsspreyHealthBand | '');
+  }
+
+  protected onVulnFilterChange(event: Event): void {
+    this.draftVulnFilter.set((event.target as HTMLSelectElement).value as 'critical' | 'high' | 'any' | '');
+  }
+
+  protected onBusFactorToggle(event: Event): void {
+    this.draftBusFactor1Only.set((event.target as HTMLInputElement).checked);
+  }
+
+  protected onStaleToggle(event: Event): void {
+    this.draftStaleOnly.set((event.target as HTMLInputElement).checked);
+  }
+
+  protected onUnstewardedToggle(event: Event): void {
+    this.draftUnstewardedOnly.set((event.target as HTMLInputElement).checked);
   }
 
   protected toggleSortMenu(): void {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -115,11 +115,12 @@ export class OsspreyPackagesTabComponent {
 
   protected getStewardNames(stewardIds: string[]): string {
     if (stewardIds.length === 0) return '—';
-    if (stewardIds.length === 1) {
-      const name = this.osspreyService.getStewardName(stewardIds[0]);
-      return name.length > 20 ? name.substring(0, 17) + '...' : name;
-    }
+    if (stewardIds.length === 1) return this.osspreyService.getStewardName(stewardIds[0]);
     return `${stewardIds.length} stewards`;
+  }
+
+  protected onSearchInput(event: Event): void {
+    this.filterChange.emit({ search: (event.target as HTMLInputElement).value });
   }
 
   protected toggleSortMenu(): void {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -1,0 +1,175 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, output, signal } from '@angular/core';
+import {
+  OsspreyEcosystem,
+  OsspreyFilterChip,
+  OsspreyFilterState,
+  OsspreyHealthBand,
+  OsspreyLifecycle,
+  OsspreyPackage,
+  OsspreyStatusCounts,
+} from '@lfx-one/shared/interfaces';
+import { OsspreyService } from '@shared/services/ossprey.service';
+import { ButtonComponent } from '@components/button/button.component';
+import { TableComponent } from '@components/table/table.component';
+import { TagComponent } from '@components/tag/tag.component';
+import {
+  formatStatus,
+  getAdvisoryTagSeverity,
+  getHealthTagSeverity,
+  getLifecycleLabel,
+  getLifecycleTagSeverity,
+  getStatusTagSeverity,
+} from '../../ossprey.utils';
+
+@Component({
+  selector: 'lfx-ossprey-packages-tab',
+  imports: [ButtonComponent, TableComponent, TagComponent],
+  templateUrl: './ossprey-packages-tab.component.html',
+  styleUrl: './ossprey-packages-tab.component.scss',
+})
+export class OsspreyPackagesTabComponent {
+  private readonly osspreyService = inject(OsspreyService);
+
+  public readonly packages = input<OsspreyPackage[]>([]);
+  public readonly filteredPackages = input<OsspreyPackage[]>([]);
+  public readonly statusCounts = input<OsspreyStatusCounts>({
+    all: 0,
+    unassigned: 0,
+    open: 0,
+    assessing: 0,
+    active: 0,
+    needs_attention: 0,
+    escalated: 0,
+    blocked: 0,
+    inactive: 0,
+  });
+  public readonly filters = input<OsspreyFilterState>({
+    search: '',
+    tab: 'all',
+    sort: 'risk',
+    ecosystem: '',
+    lifecycle: '',
+    healthBand: '',
+    vulnFilter: '',
+    busFactor1Only: false,
+    staleOnly: false,
+    unstewardedOnly: false,
+  });
+  public readonly selectedPackages = input<Set<string>>(new Set());
+
+  public readonly filterChange = output<Partial<OsspreyFilterState>>();
+  public readonly sortChange = output<string>();
+  public readonly packageClick = output<string>();
+  public readonly togglePackage = output<{ id: string; event: Event }>();
+  public readonly toggleAll = output<{ checked: boolean }>();
+  public readonly clearFilters = output<void>();
+
+  protected readonly sortMenuOpen = signal(false);
+  protected readonly filterPanelOpen = signal(false);
+
+  // Draft state — synced from filters() when panel opens, committed on Apply
+  protected readonly draftEcosystem = signal<OsspreyEcosystem | ''>('');
+  protected readonly draftLifecycle = signal<OsspreyLifecycle | ''>('');
+  protected readonly draftHealthBand = signal<OsspreyHealthBand | ''>('');
+  protected readonly draftVulnFilter = signal<'critical' | 'high' | 'any' | ''>('');
+  protected readonly draftBusFactor1Only = signal(false);
+  protected readonly draftStaleOnly = signal(false);
+  protected readonly draftUnstewardedOnly = signal(false);
+
+  protected readonly activeFilterChips = computed<OsspreyFilterChip[]>(() => {
+    const f = this.filters();
+    const chips: OsspreyFilterChip[] = [];
+    if (f.ecosystem) chips.push({ label: `Ecosystem: ${f.ecosystem}`, clear: { ecosystem: '' } });
+    if (f.lifecycle) chips.push({ label: `Lifecycle: ${f.lifecycle}`, clear: { lifecycle: '' } });
+    if (f.healthBand) chips.push({ label: `Health: ${f.healthBand}`, clear: { healthBand: '' } });
+    if (f.vulnFilter) chips.push({ label: `Vulns: ${f.vulnFilter}`, clear: { vulnFilter: '' } });
+    if (f.busFactor1Only) chips.push({ label: 'Bus factor = 1', clear: { busFactor1Only: false } });
+    if (f.staleOnly) chips.push({ label: 'No activity ≥18mo', clear: { staleOnly: false } });
+    if (f.unstewardedOnly) chips.push({ label: 'Unstewarded only', clear: { unstewardedOnly: false } });
+    return chips;
+  });
+
+  protected readonly allSelected = computed(() => {
+    const filtered = this.filteredPackages();
+    const selected = this.selectedPackages();
+    return filtered.length > 0 && filtered.every((p) => selected.has(p.id));
+  });
+
+  protected readonly formatStatus = formatStatus;
+  protected readonly getLifecycleLabel = getLifecycleLabel;
+  protected readonly getStatusTagSeverity = getStatusTagSeverity;
+  protected readonly getLifecycleTagSeverity = getLifecycleTagSeverity;
+  protected readonly getHealthTagSeverity = getHealthTagSeverity;
+  protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+
+  protected isPackageSelected(id: string): boolean {
+    return this.selectedPackages().has(id);
+  }
+
+  protected onToggleAllClick(): void {
+    this.toggleAll.emit({ checked: !this.allSelected() });
+  }
+
+  protected getStewardNames(stewardIds: string[]): string {
+    if (stewardIds.length === 0) return '—';
+    if (stewardIds.length === 1) {
+      const name = this.osspreyService.getStewardName(stewardIds[0]);
+      return name.length > 20 ? name.substring(0, 17) + '...' : name;
+    }
+    return `${stewardIds.length} stewards`;
+  }
+
+  protected toggleSortMenu(): void {
+    this.sortMenuOpen.update((v) => !v);
+    this.filterPanelOpen.set(false);
+  }
+
+  protected toggleFilterPanel(): void {
+    const willOpen = !this.filterPanelOpen();
+    this.filterPanelOpen.update((v) => !v);
+    this.sortMenuOpen.set(false);
+    if (willOpen) {
+      const f = this.filters();
+      this.draftEcosystem.set(f.ecosystem);
+      this.draftLifecycle.set(f.lifecycle);
+      this.draftHealthBand.set(f.healthBand);
+      this.draftVulnFilter.set(f.vulnFilter);
+      this.draftBusFactor1Only.set(f.busFactor1Only);
+      this.draftStaleOnly.set(f.staleOnly);
+      this.draftUnstewardedOnly.set(f.unstewardedOnly);
+    }
+  }
+
+  protected applyFilters(): void {
+    this.filterChange.emit({
+      ecosystem: this.draftEcosystem(),
+      lifecycle: this.draftLifecycle(),
+      healthBand: this.draftHealthBand(),
+      vulnFilter: this.draftVulnFilter(),
+      busFactor1Only: this.draftBusFactor1Only(),
+      staleOnly: this.draftStaleOnly(),
+      unstewardedOnly: this.draftUnstewardedOnly(),
+    });
+    this.filterPanelOpen.set(false);
+  }
+
+  protected resetAllFilters(): void {
+    this.draftEcosystem.set('');
+    this.draftLifecycle.set('');
+    this.draftHealthBand.set('');
+    this.draftVulnFilter.set('');
+    this.draftBusFactor1Only.set(false);
+    this.draftStaleOnly.set(false);
+    this.draftUnstewardedOnly.set(false);
+    this.clearFilters.emit();
+    this.filterPanelOpen.set(false);
+  }
+
+  protected onSortSelect(value: string): void {
+    this.sortChange.emit(value);
+    this.sortMenuOpen.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
+
+export function getStatusTagSeverity(status: OsspreyStatus): TagSeverity {
+  const map: Record<OsspreyStatus, TagSeverity> = {
+    unassigned: 'secondary',
+    open: 'info',
+    assessing: 'info',
+    active: 'success',
+    needs_attention: 'warn',
+    escalated: 'danger',
+    blocked: 'danger',
+    inactive: 'secondary',
+  };
+  return map[status] ?? 'secondary';
+}
+
+export function getLifecycleTagSeverity(lifecycle: OsspreyLifecycle | null): TagSeverity {
+  if (!lifecycle) return 'secondary';
+  const map: Record<OsspreyLifecycle, TagSeverity> = {
+    active: 'success',
+    stable: 'info',
+    declining: 'warn',
+    abandoned: 'danger',
+  };
+  return map[lifecycle] ?? 'secondary';
+}
+
+export function getHealthTagSeverity(score: number): TagSeverity {
+  if (score >= 75) return 'success';
+  if (score >= 50) return 'info';
+  if (score >= 25) return 'warn';
+  return 'danger';
+}
+
+export function getAdvisoryTagSeverity(severity: OspreySeverity | null): TagSeverity {
+  if (!severity) return 'secondary';
+  const map: Record<OspreySeverity, TagSeverity> = {
+    critical: 'danger',
+    high: 'danger',
+    medium: 'warn',
+    low: 'info',
+  };
+  return map[severity];
+}
+
+export function formatStatus(status: string): string {
+  return status.replace(/_/g, ' ');
+}
+
+export function getHealthBand(score: number): OsspreyHealthBand {
+  if (score >= 75) return 'healthy';
+  if (score >= 50) return 'fair';
+  if (score >= 25) return 'concerning';
+  return 'critical';
+}
+
+export function getHealthLabel(score: number): string {
+  const band = getHealthBand(score);
+  return band.charAt(0).toUpperCase() + band.slice(1);
+}
+
+export function getLifecycleLabel(lifecycle: OsspreyLifecycle | null): string {
+  if (!lifecycle) return 'Unknown';
+  return lifecycle.charAt(0).toUpperCase() + lifecycle.slice(1);
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
+import { OsspreyEcosystem, OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
 
 export function getStatusTagSeverity(status: OsspreyStatus): TagSeverity {
   const map: Record<OsspreyStatus, TagSeverity> = {
@@ -65,4 +65,14 @@ export function getHealthLabel(score: number): string {
 export function getLifecycleLabel(lifecycle: OsspreyLifecycle | null): string {
   if (!lifecycle) return 'Unknown';
   return lifecycle.charAt(0).toUpperCase() + lifecycle.slice(1);
+}
+
+export function getEcosystemIconClass(ecosystem: OsspreyEcosystem | string): string {
+  const classes: Record<string, string> = {
+    npm: 'logo-npm',
+    maven: 'logo-maven',
+    pypi: 'logo-pypi',
+    go: 'logo-go',
+  };
+  return classes[ecosystem] ?? 'logo-npm';
 }


### PR DESCRIPTION
## Summary

- `OsspreyPackagesTabComponent` — full filterable/sortable package table with filter chips, sort controls, ecosystem icons, health/impact/vuln columns, and status badges
- Row-level bulk-select checkboxes with toggle-all support
- `ossprey.utils.ts` — shared helpers for status labels, severity badge colors, and ecosystem icon mapping

## Part of

This is PR 2/3 in a stacked series targeting `release/CM-1223-ossprey-admin-dashboard`. Depends on PR 1/3. Merge order: 1 → 2 → 3.