### PR TITLE
feat(ossprey): dashboard, package drawer, and routing [3/3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Playwright MCP session artifacts
+.playwright-mcp/
+
 # IDE
 .idea/
 
@@ -65,3 +68,6 @@ snowflake.log
 
 # Playwright MCP
 .playwright-mcp
+
+# Design reference files (Cowork session artifacts, not source code)
+design/

--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -76,8 +76,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "20kB",
+                  "maximumError": "24kB"
                 }
               ],
               "outputHashing": "all",
@@ -97,8 +97,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "20kB",
+                  "maximumError": "24kB"
                 }
               ],
               "outputHashing": "all",

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -345,6 +345,10 @@ export const routes: Routes = [
         redirectTo: 'badges',
         pathMatch: 'full',
       },
+      {
+        path: 'ossprey',
+        loadChildren: () => import('./modules/ossprey/ossprey.routes').then((m) => m.OSSPREY_ROUTES),
+      },
     ],
   },
   // Public-facing user documentation portal (LFXV2-2001).

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -130,6 +130,18 @@ export class MainLayoutComponent {
       ],
     },
     {
+      label: 'Security',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'OSSPREY Program',
+          icon: 'fa-light fa-shield-halved',
+          routerLink: '/ossprey',
+        },
+      ],
+    },
+    {
       label: 'My Growth',
       isSection: true,
       expanded: true,

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.html
@@ -1,0 +1,301 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer [(visible)]="visible" position="right" [modal]="true" [showCloseIcon]="false" [style]="{ width: '24rem' }" data-testid="ossprey-package-drawer">
+  <ng-template #header>
+    @if (packageData()) {
+      <div class="flex flex-col gap-3 w-full">
+        <div class="flex items-start justify-between gap-4">
+          <div class="flex-1 min-w-0">
+            <h2 class="text-lg font-light text-slate-900 truncate">{{ packageData()!.name }}</h2>
+            <div class="flex items-center gap-2 mt-2 flex-wrap">
+              <lfx-tag [value]="packageData()!.ecosystem === 'npm' ? 'npm' : 'Maven'" severity="secondary" />
+              <lfx-tag [value]="getLifecycleLabel(packageData()!.lifecycle)" [severity]="getLifecycleTagSeverity(packageData()!.lifecycle)" />
+            </div>
+          </div>
+          <lfx-button
+            icon="pi pi-times"
+            [text]="true"
+            severity="secondary"
+            ariaLabel="Close"
+            (onClick)="onClose()"
+            [attr.data-testid]="'ossprey-drawer-close'" />
+        </div>
+
+        <!-- Tab Bar -->
+        <div class="flex border-b border-gray-200 -mx-5 px-5">
+          <button
+            (click)="onTabChange('overview')"
+            [class.border-blue-500]="activeTab() === 'overview'"
+            [class.text-blue-600]="activeTab() === 'overview'"
+            [class.border-transparent]="activeTab() !== 'overview'"
+            [class.text-gray-600]="activeTab() !== 'overview'"
+            class="flex-1 px-4 py-3 font-medium text-sm border-b-2 transition-colors"
+            [attr.data-testid]="'ossprey-drawer-tab-overview'">
+            Overview
+          </button>
+          <button
+            (click)="onTabChange('assessment')"
+            [class.border-blue-500]="activeTab() === 'assessment'"
+            [class.text-blue-600]="activeTab() === 'assessment'"
+            [class.border-transparent]="activeTab() !== 'assessment'"
+            [class.text-gray-600]="activeTab() !== 'assessment'"
+            class="flex-1 px-4 py-3 font-medium text-sm border-b-2 transition-colors"
+            [attr.data-testid]="'ossprey-drawer-tab-assessment'">
+            Assessment
+          </button>
+          <button
+            (click)="onTabChange('security')"
+            [class.border-blue-500]="activeTab() === 'security'"
+            [class.text-blue-600]="activeTab() === 'security'"
+            [class.border-transparent]="activeTab() !== 'security'"
+            [class.text-gray-600]="activeTab() !== 'security'"
+            class="flex-1 px-4 py-3 font-medium text-sm border-b-2 transition-colors"
+            [attr.data-testid]="'ossprey-drawer-tab-security'">
+            Security
+          </button>
+          <button
+            (click)="onTabChange('provenance')"
+            [class.border-blue-500]="activeTab() === 'provenance'"
+            [class.text-blue-600]="activeTab() === 'provenance'"
+            [class.border-transparent]="activeTab() !== 'provenance'"
+            [class.text-gray-600]="activeTab() !== 'provenance'"
+            class="flex-1 px-4 py-3 font-medium text-sm border-b-2 transition-colors"
+            [attr.data-testid]="'ossprey-drawer-tab-provenance'">
+            Provenance
+          </button>
+        </div>
+      </div>
+    }
+  </ng-template>
+
+  @if (packageData()) {
+    <!-- ===== OVERVIEW TAB ===== -->
+    @if (activeTab() === 'overview') {
+      <div class="flex flex-col gap-6" [attr.data-testid]="'ossprey-drawer-overview'">
+        <!-- Contact Card -->
+        <div class="border border-gray-200 rounded-lg p-4 bg-blue-50">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center flex-shrink-0">
+              <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <div class="font-semibold text-sm text-slate-900">Security Contact</div>
+              <div class="text-xs text-gray-600 mt-0.5">Assign a maintainer contact</div>
+            </div>
+            <lfx-button label="Assign" [text]="true" severity="info" size="small" styleClass="ml-auto flex-shrink-0" />
+          </div>
+        </div>
+
+        <!-- Health Breakdown -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Health Breakdown</h3>
+          @for (item of packageData()!.healthBreakdown; track item; let i = $index) {
+            <div>
+              <div class="flex justify-between items-center mb-1">
+                <span class="text-xs font-medium text-gray-600">
+                  {{ i === 0 ? 'Maintainer Health' : i === 1 ? 'Security Posture' : 'Dependency Risk' }}
+                </span>
+                <span class="text-xs font-semibold text-gray-900">{{ item }}</span>
+              </div>
+              <div class="w-full bg-gray-200 rounded-full h-1.5 overflow-hidden">
+                <div class="bg-blue-500 h-full" [style.width.%]="getHealthBreakdownPercent(item)"></div>
+              </div>
+            </div>
+          }
+        </div>
+
+        <!-- Impact & Reach -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Impact & Reach</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Impact Score</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.impactScore }}</span>
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Weekly Downloads</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.weeklyDownloads }}</span>
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Direct Dependents</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.directDependentCount }}</span>
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">Ecosystem Reach</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.ecosystemReach }}</span>
+          </div>
+        </div>
+
+        <!-- Key Risk Signals -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Key Risk Signals</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Bus Factor</span>
+            <lfx-tag [value]="(packageData()!.busFactor ?? '—').toString()" [severity]="packageData()!.busFactor === 1 ? 'danger' : 'secondary'" />
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Months Stale</span>
+            <lfx-tag [value]="(packageData()!.monthsStale ?? '—').toString()" [severity]="getMonthsStaleTagSeverity(packageData()!.monthsStale)" />
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">Open Vulnerabilities</span>
+            <lfx-tag [value]="packageData()!.vulnCount.toString()" [severity]="packageData()!.vulnCount > 0 ? 'danger' : 'secondary'" />
+          </div>
+        </div>
+
+        <!-- Timeline -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Timeline</h3>
+          <div class="flex flex-col gap-2">
+            @for (entry of packageData()!.history; track entry.label) {
+              <div class="flex gap-3">
+                <div
+                  class="w-3 h-3 rounded-full flex-shrink-0 mt-1.5"
+                  [class.bg-red-500]="entry.type === 'danger'"
+                  [class.bg-emerald-500]="entry.type === 'success'"
+                  [class.bg-blue-500]="entry.type !== 'danger' && entry.type !== 'success'"></div>
+                <div class="flex-1 min-w-0">
+                  <div class="text-sm font-medium text-slate-900">{{ entry.label }}</div>
+                  <div class="text-xs text-gray-500 mt-0.5">{{ entry.timeAgo }}</div>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- ===== ASSESSMENT TAB ===== -->
+    @if (activeTab() === 'assessment') {
+      <div class="flex flex-col gap-6" [attr.data-testid]="'ossprey-drawer-assessment'">
+        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div class="flex items-start gap-3">
+            <div class="w-5 h-5 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0 mt-0.5">
+              <svg class="w-3 h-3 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path>
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <div class="font-semibold text-sm text-slate-900">No assessment yet</div>
+              <div class="text-xs text-gray-600 mt-1">Start a spot-check assessment to evaluate this package</div>
+              <div class="mt-3">
+                <lfx-button label="Start Assessment" [outlined]="true" severity="info" size="small" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- ===== SECURITY TAB ===== -->
+    @if (activeTab() === 'security') {
+      <div class="flex flex-col gap-6" [attr.data-testid]="'ossprey-drawer-security'">
+        @if (packageData()!.advisories.length > 0) {
+          <div class="flex flex-col gap-3">
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Known Advisories</h3>
+            @for (adv of packageData()!.advisories; track adv.id) {
+              <div class="border border-gray-200 rounded-lg p-3">
+                <div class="flex items-start justify-between gap-2 mb-2">
+                  <div class="font-mono text-xs font-semibold text-slate-900">{{ adv.id }}</div>
+                  <lfx-tag [value]="adv.severity" [severity]="getAdvisoryTagSeverity(adv.severity)" />
+                </div>
+                <div class="text-sm text-gray-700 mb-2">{{ adv.description }}</div>
+                <div class="text-xs text-gray-600">
+                  Status: <span class="font-semibold">{{ adv.state }}</span>
+                </div>
+              </div>
+            }
+          </div>
+        } @else {
+          <lfx-empty-state
+            icon="fa-light fa-shield-check"
+            title="No known advisories"
+            subtitle="This package has no publicly disclosed vulnerabilities"
+            [withCard]="false" />
+        }
+
+        <!-- Security Status -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Security Status</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Has SECURITY.md</span>
+            <lfx-tag [value]="packageData()!.hasSecurityMd ? 'Yes' : 'No'" [severity]="packageData()!.hasSecurityMd ? 'success' : 'secondary'" />
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">Last Commit</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.lastCommit }}</span>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- ===== PROVENANCE TAB ===== -->
+    @if (activeTab() === 'provenance') {
+      <div class="flex flex-col gap-6" [attr.data-testid]="'ossprey-drawer-provenance'">
+        <!-- Repository Mapping -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Repository Mapping</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Repository</span>
+            <a [href]="'https://' + packageData()!.repoUrl" target="_blank" class="text-sm font-semibold text-blue-600 hover:underline truncate"> View </a>
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Last Release</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.lastRelease }}</span>
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">Repository URL</span>
+            <code class="text-xs bg-gray-100 px-2 py-1 rounded font-mono text-gray-600 truncate">
+              {{ packageData()!.repoUrl }}
+            </code>
+          </div>
+        </div>
+
+        <!-- Supply Chain -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Supply Chain Integrity</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Supply Chain Mapping</span>
+            <lfx-tag [value]="packageData()!.supplyChainMapping ?? '—'" [severity]="packageData()!.supplyChainMapping === 'High' ? 'success' : 'secondary'" />
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Provenance</span>
+            <lfx-tag [value]="packageData()!.provenance ?? '—'" [severity]="getProvenanceTagSeverity(packageData()!.provenance)" />
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">ScoreCard Score</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.scoreCardScore }}</span>
+          </div>
+        </div>
+
+        <!-- Dependency Metrics -->
+        <div class="flex flex-col gap-3">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Dependency Metrics</h3>
+          <div class="flex justify-between items-center py-2 border-b border-gray-200">
+            <span class="text-sm text-gray-600">Total Dependents</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.dependentCount }}</span>
+          </div>
+          <div class="flex justify-between items-center py-2">
+            <span class="text-sm text-gray-600">Weekly Downloads</span>
+            <span class="text-sm font-semibold text-slate-900">{{ packageData()!.weeklyDownloads }}</span>
+          </div>
+        </div>
+      </div>
+    }
+  }
+
+  <ng-template #footer>
+    @if (packageData()) {
+      <div class="flex gap-3 w-full">
+        <lfx-button label="Assign Steward" severity="secondary" [outlined]="true" [fluid]="true" [attr.data-testid]="'ossprey-drawer-action-assign'" />
+        <lfx-button label="Escalate" [fluid]="true" [attr.data-testid]="'ossprey-drawer-action-escalate'" />
+      </div>
+    }
+  </ng-template>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.html
@@ -243,7 +243,11 @@
           <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-700">Repository Mapping</h3>
           <div class="flex justify-between items-center py-2 border-b border-gray-200">
             <span class="text-sm text-gray-600">Repository</span>
-            <a [href]="'https://' + packageData()!.repoUrl" target="_blank" class="text-sm font-semibold text-blue-600 hover:underline truncate"> View </a>
+            @if (getSafeRepoUrl(packageData()!.repoUrl); as safeUrl) {
+              <a [href]="safeUrl" target="_blank" rel="noopener noreferrer" class="text-sm font-semibold text-blue-600 hover:underline truncate"> View </a>
+            } @else {
+              <span class="text-sm text-gray-400">—</span>
+            }
           </div>
           <div class="flex justify-between items-center py-2 border-b border-gray-200">
             <span class="text-sm text-gray-600">Last Release</span>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.scss
@@ -1,0 +1,6 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, input, model, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { catchError, of, skip, switchMap } from 'rxjs';
+import { DrawerModule } from 'primeng/drawer';
+
+import { OsspreyPackage } from '@lfx-one/shared/interfaces';
+import { OsspreyService } from '@shared/services/ossprey.service';
+import { ButtonComponent } from '@components/button/button.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { TagSeverity } from '@lfx-one/shared/interfaces';
+import { getAdvisoryTagSeverity, getLifecycleLabel, getLifecycleTagSeverity } from '../../ossprey.utils';
+
+type DrawerTab = 'overview' | 'assessment' | 'security' | 'provenance';
+
+@Component({
+  selector: 'lfx-ossprey-package-drawer',
+  imports: [DrawerModule, ButtonComponent, EmptyStateComponent, TagComponent],
+  templateUrl: './ossprey-package-drawer.component.html',
+  styleUrl: './ossprey-package-drawer.component.scss',
+})
+export class OsspreyPackageDrawerComponent {
+  private readonly osspreyService = inject(OsspreyService);
+
+  public readonly visible = model(false);
+  public readonly packageId = input<string | null>(null);
+
+  protected readonly activeTab = signal<DrawerTab>('overview');
+  protected readonly packageData: Signal<OsspreyPackage | null> = this.initPackageData();
+
+  protected readonly getLifecycleLabel = getLifecycleLabel;
+  protected readonly getLifecycleTagSeverity = getLifecycleTagSeverity;
+  protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+
+  protected onTabChange(tab: DrawerTab): void {
+    this.activeTab.set(tab);
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  protected getHealthBreakdownPercent(item: string): number {
+    const num = parseInt(item, 10);
+    return (num / 40) * 100;
+  }
+
+  protected getMonthsStaleTagSeverity(monthsStale: number | null): TagSeverity {
+    if (monthsStale === null) return 'secondary';
+    return monthsStale >= 18 ? 'warn' : 'secondary';
+  }
+
+  protected getProvenanceTagSeverity(provenance: string | null): TagSeverity {
+    if (!provenance) return 'secondary';
+    if (provenance === 'Full') return 'success';
+    if (provenance === 'Partial') return 'warn';
+    return 'secondary';
+  }
+
+  private initPackageData(): Signal<OsspreyPackage | null> {
+    return toSignal(
+      toObservable(this.visible).pipe(
+        skip(1),
+        switchMap(() => {
+          const id = this.packageId();
+          if (!id) return of(null);
+          return this.osspreyService.getPackage(id).pipe(catchError(() => of(null)));
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-package-drawer/ossprey-package-drawer.component.ts
@@ -45,7 +45,17 @@ export class OsspreyPackageDrawerComponent {
 
   protected getHealthBreakdownPercent(item: string): number {
     const num = parseInt(item, 10);
-    return (num / 40) * 100;
+    return Math.min(100, (num / 40) * 100);
+  }
+
+  protected getSafeRepoUrl(repoUrl: string | null): string | null {
+    if (!repoUrl) return null;
+    try {
+      const url = new URL('https://' + repoUrl);
+      return url.protocol === 'https:' ? url.href : null;
+    } catch {
+      return null;
+    }
   }
 
   protected getMonthsStaleTagSeverity(monthsStale: number | null): TagSeverity {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -112,11 +112,7 @@
                 <span class="osp-flabel">Ecosystem</span>
                 <button class="osp-freset" (click)="draftEcosystem.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftEcosystem()"
-                (change)="draftEcosystem.set($any($event.target).value)"
-                data-testid="ossprey-filter-ecosystem">
+              <select class="osp-fselect" [value]="draftEcosystem()" (change)="onEcosystemChange($event)" data-testid="ossprey-filter-ecosystem">
                 <option value="">All ecosystems</option>
                 <option value="npm">npm</option>
                 <option value="maven">Maven</option>
@@ -131,11 +127,7 @@
                 <span class="osp-flabel">Lifecycle</span>
                 <button class="osp-freset" (click)="draftLifecycle.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftLifecycle()"
-                (change)="draftLifecycle.set($any($event.target).value)"
-                data-testid="ossprey-filter-lifecycle">
+              <select class="osp-fselect" [value]="draftLifecycle()" (change)="onLifecycleChange($event)" data-testid="ossprey-filter-lifecycle">
                 <option value="">All lifecycle</option>
                 <option value="active">Active</option>
                 <option value="stable">Stable</option>
@@ -150,11 +142,7 @@
                 <span class="osp-flabel">Health</span>
                 <button class="osp-freset" (click)="draftHealthBand.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftHealthBand()"
-                (change)="draftHealthBand.set($any($event.target).value)"
-                data-testid="ossprey-filter-health">
+              <select class="osp-fselect" [value]="draftHealthBand()" (change)="onHealthBandChange($event)" data-testid="ossprey-filter-health">
                 <option value="">All health</option>
                 <option value="healthy">Healthy (≥75)</option>
                 <option value="fair">Fair (50–74)</option>
@@ -169,11 +157,7 @@
                 <span class="osp-flabel">Open vulnerabilities</span>
                 <button class="osp-freset" (click)="draftVulnFilter.set('')">Reset</button>
               </div>
-              <select
-                class="osp-fselect"
-                [value]="draftVulnFilter()"
-                (change)="draftVulnFilter.set($any($event.target).value)"
-                data-testid="ossprey-filter-vulns">
+              <select class="osp-fselect" [value]="draftVulnFilter()" (change)="onVulnFilterChange($event)" data-testid="ossprey-filter-vulns">
                 <option value="">Any vulns</option>
                 <option value="any">Has any vulnerability</option>
                 <option value="high">High or above</option>
@@ -189,15 +173,15 @@
               </div>
               <div class="flex flex-col gap-2">
                 <label class="osp-fcheck" data-testid="ossprey-filter-busfactor">
-                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="draftBusFactor1Only.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="onBusFactorToggle($event)" />
                   <span>Bus factor = 1</span>
                 </label>
                 <label class="osp-fcheck" data-testid="ossprey-filter-stale">
-                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="draftStaleOnly.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="onStaleToggle($event)" />
                   <span>No activity ≥18mo</span>
                 </label>
                 <label class="osp-fcheck" data-testid="ossprey-filter-unstewarded">
-                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="draftUnstewardedOnly.set($any($event.target).checked)" />
+                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="onUnstewardedToggle($event)" />
                   <span>Unstewarded only</span>
                 </label>
               </div>
@@ -270,7 +254,9 @@
           <div class="t-sub font-mono">{{ pkg.purl }}</div>
         </td>
         <td>
-          <span class="eco-row"><span class="logo-npm">npm</span> {{ pkg.ecosystem }}</span>
+          <span class="eco-row"
+            ><span [class]="getEcosystemIconClass(pkg.ecosystem)">{{ pkg.ecosystem }}</span></span
+          >
         </td>
         <td><lfx-tag [value]="getLifecycleLabel(pkg.lifecycle)" [severity]="getLifecycleTagSeverity(pkg.lifecycle)" /></td>
         <td><lfx-tag [value]="pkg.healthScore !== null ? pkg.healthScore.toString() : '—'" [severity]="getHealthTagSeverity(pkg.healthScore)" /></td>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -12,7 +12,7 @@
       <input
         type="text"
         [value]="filters().search"
-        (input)="filterChange.emit({ search: $any($event.target).value })"
+        (input)="onSearchInput($event)"
         placeholder="Search package, purl, steward, or contact…"
         class="outline-none text-sm bg-transparent flex-1"
         data-testid="ossprey-search" />
@@ -235,7 +235,13 @@
     <ng-template #header>
       <tr>
         <th style="width: 34px">
-          <span class="ck" [class.on]="allSelected()" (click)="onToggleAllClick()"></span>
+          <span
+            class="ck"
+            [class.on]="allSelected()"
+            (click)="onToggleAllClick()"
+            role="checkbox"
+            [attr.aria-checked]="allSelected()"
+            aria-label="Select all packages"></span>
         </th>
         <th>Package</th>
         <th>Ecosystem</th>
@@ -251,7 +257,13 @@
     <ng-template #body let-pkg>
       <tr (click)="packageClick.emit(pkg.id)" class="cursor-pointer">
         <td (click)="$event.stopPropagation()">
-          <span class="ck" [class.on]="isPackageSelected(pkg.id)" (click)="togglePackage.emit({ id: pkg.id, event: $event })"></span>
+          <span
+            class="ck"
+            [class.on]="isPackageSelected(pkg.id)"
+            (click)="togglePackage.emit({ id: pkg.id, event: $event })"
+            role="checkbox"
+            [attr.aria-checked]="isPackageSelected(pkg.id)"
+            [attr.aria-label]="'Select ' + pkg.name"></span>
         </td>
         <td>
           <div class="t-title">{{ pkg.name }}</div>
@@ -275,5 +287,5 @@
       </tr>
     </ng-template>
   </lfx-table>
-  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages · demo subset of 1,842 critical packages</p>
+  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages</p>
 </div>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.html
@@ -1,0 +1,279 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6 py-6">
+  <!-- Search -->
+  <div class="osp-qsearch">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+      <input
+        type="text"
+        [value]="filters().search"
+        (input)="filterChange.emit({ search: $any($event.target).value })"
+        placeholder="Search package, purl, steward, or contact…"
+        class="outline-none text-sm bg-transparent flex-1"
+        data-testid="ossprey-search" />
+    </div>
+  </div>
+
+  <!-- Status pills + sort/filter toolbar -->
+  <div class="osp-qrow">
+    <div class="osp-qtabs">
+      <button (click)="filterChange.emit({ tab: 'all' })" [class.on]="filters().tab === 'all'" class="osp-qtab" data-testid="ossprey-pill-all">
+        <span class="lbl">All</span><span class="osp-qcount">{{ statusCounts().all }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'unassigned' })"
+        [class.on]="filters().tab === 'unassigned'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-unassigned">
+        <span class="lbl">Unassigned</span><span class="osp-qcount">{{ statusCounts().unassigned }}</span>
+      </button>
+      <button (click)="filterChange.emit({ tab: 'open' })" [class.on]="filters().tab === 'open'" class="osp-qtab" data-testid="ossprey-pill-open">
+        <span class="lbl">Open</span><span class="osp-qcount">{{ statusCounts().open }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'assessing' })"
+        [class.on]="filters().tab === 'assessing'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-assessing">
+        <span class="lbl">Assessing</span><span class="osp-qcount">{{ statusCounts().assessing }}</span>
+      </button>
+      <button (click)="filterChange.emit({ tab: 'active' })" [class.on]="filters().tab === 'active'" class="osp-qtab" data-testid="ossprey-pill-active">
+        <span class="lbl">Active</span><span class="osp-qcount">{{ statusCounts().active }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'needs_attention' })"
+        [class.on]="filters().tab === 'needs_attention'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-needs-attention">
+        <span class="lbl">Needs attention</span><span class="osp-qcount">{{ statusCounts().needs_attention }}</span>
+      </button>
+      <button
+        (click)="filterChange.emit({ tab: 'escalated' })"
+        [class.on]="filters().tab === 'escalated'"
+        class="osp-qtab"
+        data-testid="ossprey-pill-escalated">
+        <span class="lbl">Escalated</span><span class="osp-qcount">{{ statusCounts().escalated }}</span>
+      </button>
+    </div>
+
+    <div class="osp-qactions">
+      <div class="osp-sortwrap">
+        <button class="osp-tbtn osp-sortbtn" (click)="toggleSortMenu()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m3 16 4 4 4-4"></path>
+            <path d="M7 20V4"></path>
+            <path d="M11 4h10"></path>
+            <path d="M11 8h7"></path>
+            <path d="M11 12h4"></path>
+          </svg>
+          Sort:
+          <span>{{
+            filters().sort === 'risk'
+              ? 'Risk priority'
+              : filters().sort === 'impact'
+                ? 'Impact score'
+                : filters().sort === 'health'
+                  ? 'Health (worst first)'
+                  : filters().sort === 'vulns'
+                    ? 'Open vulnerabilities'
+                    : 'Name (A–Z)'
+          }}</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <div class="osp-menu" [class.open]="sortMenuOpen()">
+          <button class="osp-mi" [class.on]="filters().sort === 'risk'" (click)="onSortSelect('risk')">Risk priority</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'impact'" (click)="onSortSelect('impact')">Impact score</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'health'" (click)="onSortSelect('health')">Health (worst first)</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'vulns'" (click)="onSortSelect('vulns')">Open vulnerabilities</button>
+          <button class="osp-mi" [class.on]="filters().sort === 'name'" (click)="onSortSelect('name')">Name (A–Z)</button>
+        </div>
+      </div>
+
+      <div class="osp-filterwrap">
+        <button class="osp-tbtn" (click)="toggleFilterPanel()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+          </svg>
+          Filter
+        </button>
+        <div class="osp-fpanel" [class.open]="filterPanelOpen()">
+          <div class="osp-fpanel-h">Filter</div>
+          <div class="osp-fpanel-body">
+            <!-- Ecosystem -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Ecosystem</span>
+                <button class="osp-freset" (click)="draftEcosystem.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftEcosystem()"
+                (change)="draftEcosystem.set($any($event.target).value)"
+                data-testid="ossprey-filter-ecosystem">
+                <option value="">All ecosystems</option>
+                <option value="npm">npm</option>
+                <option value="maven">Maven</option>
+                <option value="pypi">PyPI</option>
+                <option value="go">Go</option>
+              </select>
+            </div>
+
+            <!-- Lifecycle -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Lifecycle</span>
+                <button class="osp-freset" (click)="draftLifecycle.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftLifecycle()"
+                (change)="draftLifecycle.set($any($event.target).value)"
+                data-testid="ossprey-filter-lifecycle">
+                <option value="">All lifecycle</option>
+                <option value="active">Active</option>
+                <option value="stable">Stable</option>
+                <option value="declining">Declining</option>
+                <option value="abandoned">Abandoned</option>
+              </select>
+            </div>
+
+            <!-- Health -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Health</span>
+                <button class="osp-freset" (click)="draftHealthBand.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftHealthBand()"
+                (change)="draftHealthBand.set($any($event.target).value)"
+                data-testid="ossprey-filter-health">
+                <option value="">All health</option>
+                <option value="healthy">Healthy (≥75)</option>
+                <option value="fair">Fair (50–74)</option>
+                <option value="concerning">Concerning (25–49)</option>
+                <option value="critical">Critical (&lt;25)</option>
+              </select>
+            </div>
+
+            <!-- Open vulnerabilities -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Open vulnerabilities</span>
+                <button class="osp-freset" (click)="draftVulnFilter.set('')">Reset</button>
+              </div>
+              <select
+                class="osp-fselect"
+                [value]="draftVulnFilter()"
+                (change)="draftVulnFilter.set($any($event.target).value)"
+                data-testid="ossprey-filter-vulns">
+                <option value="">Any vulns</option>
+                <option value="any">Has any vulnerability</option>
+                <option value="high">High or above</option>
+                <option value="critical">Critical only</option>
+              </select>
+            </div>
+
+            <!-- Coverage gaps -->
+            <div class="osp-frow">
+              <div class="osp-frow-head">
+                <span class="osp-flabel">Coverage gaps</span>
+                <button class="osp-freset" (click)="draftBusFactor1Only.set(false); draftStaleOnly.set(false); draftUnstewardedOnly.set(false)">Reset</button>
+              </div>
+              <div class="flex flex-col gap-2">
+                <label class="osp-fcheck" data-testid="ossprey-filter-busfactor">
+                  <input type="checkbox" [checked]="draftBusFactor1Only()" (change)="draftBusFactor1Only.set($any($event.target).checked)" />
+                  <span>Bus factor = 1</span>
+                </label>
+                <label class="osp-fcheck" data-testid="ossprey-filter-stale">
+                  <input type="checkbox" [checked]="draftStaleOnly()" (change)="draftStaleOnly.set($any($event.target).checked)" />
+                  <span>No activity ≥18mo</span>
+                </label>
+                <label class="osp-fcheck" data-testid="ossprey-filter-unstewarded">
+                  <input type="checkbox" [checked]="draftUnstewardedOnly()" (change)="draftUnstewardedOnly.set($any($event.target).checked)" />
+                  <span>Unstewarded only</span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="osp-fpanel-foot">
+            <lfx-button label="Reset all" severity="secondary" [outlined]="true" size="small" (onClick)="resetAllFilters()" />
+            <lfx-button label="Apply now" size="small" (onClick)="applyFilters()" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Active filter chips -->
+  @if (activeFilterChips().length > 0) {
+    <div class="osp-chips" data-testid="ossprey-filter-chips">
+      @for (chip of activeFilterChips(); track chip.label) {
+        <span class="osp-fchip">
+          {{ chip.label }}
+          <button (click)="filterChange.emit(chip.clear)" [attr.aria-label]="'Remove ' + chip.label + ' filter'">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </span>
+      }
+      <button class="osp-clearf" (click)="clearFilters.emit()" data-testid="ossprey-clear-filters">Clear filters</button>
+    </div>
+  }
+
+  <!-- Package table -->
+  <lfx-table [value]="filteredPackages()" [rowHover]="true" size="small" styleClass="ossprey-pkg-table" data-testid="ossprey-packages-table">
+    <ng-template #header>
+      <tr>
+        <th style="width: 34px">
+          <span class="ck" [class.on]="allSelected()" (click)="onToggleAllClick()"></span>
+        </th>
+        <th>Package</th>
+        <th>Ecosystem</th>
+        <th>Lifecycle</th>
+        <th>Health</th>
+        <th>Impact</th>
+        <th>Open vulns</th>
+        <th>Steward</th>
+        <th>Stewardship</th>
+        <th>Last activity</th>
+      </tr>
+    </ng-template>
+    <ng-template #body let-pkg>
+      <tr (click)="packageClick.emit(pkg.id)" class="cursor-pointer">
+        <td (click)="$event.stopPropagation()">
+          <span class="ck" [class.on]="isPackageSelected(pkg.id)" (click)="togglePackage.emit({ id: pkg.id, event: $event })"></span>
+        </td>
+        <td>
+          <div class="t-title">{{ pkg.name }}</div>
+          <div class="t-sub font-mono">{{ pkg.purl }}</div>
+        </td>
+        <td>
+          <span class="eco-row"><span class="logo-npm">npm</span> {{ pkg.ecosystem }}</span>
+        </td>
+        <td><lfx-tag [value]="getLifecycleLabel(pkg.lifecycle)" [severity]="getLifecycleTagSeverity(pkg.lifecycle)" /></td>
+        <td><lfx-tag [value]="pkg.healthScore !== null ? pkg.healthScore.toString() : '—'" [severity]="getHealthTagSeverity(pkg.healthScore)" /></td>
+        <td><lfx-tag [value]="pkg.impactScore !== null ? pkg.impactScore.toString() : '—'" severity="secondary" /></td>
+        <td><lfx-tag [value]="pkg.vulnCount + (pkg.vulnSeverity ? ' ' + pkg.vulnSeverity : '')" [severity]="getAdvisoryTagSeverity(pkg.vulnSeverity)" /></td>
+        <td class="text-xs text-gray-600">{{ getStewardNames(pkg.stewardIds) }}</td>
+        <td><lfx-tag [value]="formatStatus(pkg.status)" [severity]="getStatusTagSeverity(pkg.status)" /></td>
+        <td class="text-xs text-gray-500">{{ pkg.lastActivityLabel }}</td>
+      </tr>
+    </ng-template>
+    <ng-template #emptymessage>
+      <tr>
+        <td colspan="10" class="text-center py-8 text-sm text-gray-500">No packages match the current filters.</td>
+      </tr>
+    </ng-template>
+  </lfx-table>
+  <p class="text-xs text-gray-500">Showing {{ filteredPackages().length }} of {{ packages().length }} packages · demo subset of 1,842 critical packages</p>
+</div>

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
@@ -319,11 +319,13 @@
   font-weight: 500;
 }
 
-.logo-npm {
+.logo-npm,
+.logo-maven,
+.logo-pypi,
+.logo-go {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #cb3837;
   color: #fff;
   font-weight: 700;
   font-size: 9px;
@@ -331,6 +333,22 @@
   border-radius: 3px;
   padding: 3px 4px;
   letter-spacing: -0.02em;
+}
+
+.logo-npm {
+  background: #cb3837;
+}
+
+.logo-maven {
+  background: #c71a36;
+}
+
+.logo-pypi {
+  background: #3776ab;
+}
+
+.logo-go {
+  background: #00add8;
 }
 
 .t-title {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.scss
@@ -1,0 +1,429 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 13px;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 9px;
+  background: #fff;
+  width: 100%;
+}
+
+.search svg {
+  width: 15px;
+  height: 15px;
+  color: #90a1b9;
+}
+.search input {
+  border: none;
+  outline: none;
+  font-size: 13px;
+  width: 100%;
+  background: none;
+}
+
+.osp-qrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.osp-qtabs {
+  display: inline-flex;
+  gap: 4px;
+  background: #f1f5f9;
+  padding: 4px;
+  border-radius: 11px;
+  flex-wrap: wrap;
+}
+
+.osp-qtab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #45556c;
+  transition: all 0.12s;
+}
+
+.osp-qtab:hover {
+  color: #0f172b;
+}
+.osp-qtab.on {
+  background: #fff;
+  color: #009aff;
+  box-shadow: 0 1px 2px rgba(2, 39, 65, 0.12);
+}
+
+.osp-qcount {
+  font-size: 11px;
+  font-weight: 700;
+  background: #e2e8f0;
+  color: #45556c;
+  border-radius: 99px;
+  padding: 1px 7px;
+}
+
+.osp-qtab.on .osp-qcount {
+  background: #ecf4ff;
+  color: #0086e0;
+}
+
+.osp-qactions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.osp-tbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 38px;
+  padding: 0 14px;
+  border: 1px solid #cad5e2;
+  border-radius: 9px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  color: #314158;
+  cursor: pointer;
+}
+
+.osp-tbtn:hover {
+  background: #f8fafc;
+}
+.osp-tbtn svg {
+  width: 14px;
+  height: 14px;
+  color: #62748e;
+}
+.osp-sortbtn {
+  background: none;
+  border: none;
+  color: #45556c;
+}
+.osp-sortbtn:hover {
+  background: #f1f5f9;
+}
+
+.osp-sortwrap,
+.osp-filterwrap {
+  position: relative;
+}
+
+.osp-menu {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 11px;
+  box-shadow: 0 14px 36px rgba(2, 39, 65, 0.16);
+  z-index: 60;
+  display: none;
+  min-width: 210px;
+  padding: 6px;
+}
+
+.osp-menu.open {
+  display: block;
+}
+
+.osp-mi {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: none;
+  padding: 9px 11px;
+  border-radius: 7px;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+}
+
+.osp-mi:hover {
+  background: #f8fafc;
+}
+.osp-mi.on {
+  color: #009aff;
+  font-weight: 600;
+}
+
+.osp-fpanel {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  width: 340px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  box-shadow: 0 18px 46px rgba(2, 39, 65, 0.18);
+  z-index: 60;
+  display: none;
+  overflow: hidden;
+}
+
+.osp-fpanel.open {
+  display: block;
+}
+.osp-fpanel-h {
+  padding: 14px 16px;
+  font-size: 14px;
+  font-weight: 700;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.osp-fpanel-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.osp-frow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.osp-frow-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.osp-flabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.osp-freset {
+  font-size: 12px;
+  font-weight: 500;
+  color: #009aff;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.osp-freset:hover {
+  color: #0086e0;
+}
+
+.osp-fselect {
+  width: 100%;
+  appearance: none;
+  padding: 9px 36px 9px 12px;
+  border: 1px solid #cad5e2;
+  border-radius: 8px;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2362748e' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.osp-fselect:focus {
+  border-color: #009aff;
+}
+
+.osp-fcheck {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: #314158;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1.6px solid #cad5e2;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: all 0.12s;
+
+    &:hover {
+      border-color: #009aff;
+    }
+
+    &:checked {
+      background: #009aff;
+      border-color: #009aff;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 12 12' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='2 6 5 9 10 3'%3E%3C/polyline%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+  }
+}
+
+.osp-fpanel-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 16px;
+}
+
+.ck {
+  width: 16px;
+  height: 16px;
+  border: 1.6px solid #cad5e2;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: #fff;
+  vertical-align: middle;
+}
+
+.ck:hover {
+  border-color: #009aff;
+}
+.ck.on {
+  background: #009aff;
+  border-color: #009aff;
+}
+
+.eco-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #45556c;
+  font-weight: 500;
+}
+
+.logo-npm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #cb3837;
+  color: #fff;
+  font-weight: 700;
+  font-size: 9px;
+  line-height: 1;
+  border-radius: 3px;
+  padding: 3px 4px;
+  letter-spacing: -0.02em;
+}
+
+.t-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172b;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.t-sub {
+  font-size: 11.5px;
+  color: #62748e;
+  margin-top: 2px;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:host ::ng-deep .ossprey-pkg-table td {
+  padding-top: 14px;
+  padding-bottom: 14px;
+}
+
+.osp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.osp-fchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #ecf4ff;
+  color: #0086e0;
+  border: 1px solid #bcdcff;
+  border-radius: 999px;
+  padding: 4px 6px 4px 12px;
+  font-size: 12.5px;
+  font-weight: 500;
+
+  button {
+    border: none;
+    background: none;
+    color: #0086e0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    border-radius: 50%;
+
+    &:hover {
+      background: #bcdcff;
+    }
+
+    svg {
+      width: 13px;
+      height: 13px;
+    }
+  }
+}
+
+.osp-clearf {
+  border: none;
+  background: none;
+  font-size: 12px;
+  font-weight: 500;
+  color: #009aff;
+  cursor: pointer;
+  padding: 4px 8px;
+
+  &:hover {
+    color: #0086e0;
+    text-decoration: underline;
+  }
+}
+
+.osp-fbtn-c {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  background: #009aff;
+  color: #fff;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 4px;
+  margin-left: 2px;
+}

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -18,6 +18,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   formatStatus,
   getAdvisoryTagSeverity,
+  getEcosystemIconClass,
   getHealthTagSeverity,
   getLifecycleLabel,
   getLifecycleTagSeverity,
@@ -104,6 +105,7 @@ export class OsspreyPackagesTabComponent {
   protected readonly getLifecycleTagSeverity = getLifecycleTagSeverity;
   protected readonly getHealthTagSeverity = getHealthTagSeverity;
   protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+  protected readonly getEcosystemIconClass = getEcosystemIconClass;
 
   protected isPackageSelected(id: string): boolean {
     return this.selectedPackages().has(id);
@@ -121,6 +123,34 @@ export class OsspreyPackagesTabComponent {
 
   protected onSearchInput(event: Event): void {
     this.filterChange.emit({ search: (event.target as HTMLInputElement).value });
+  }
+
+  protected onEcosystemChange(event: Event): void {
+    this.draftEcosystem.set((event.target as HTMLSelectElement).value as OsspreyEcosystem | '');
+  }
+
+  protected onLifecycleChange(event: Event): void {
+    this.draftLifecycle.set((event.target as HTMLSelectElement).value as OsspreyLifecycle | '');
+  }
+
+  protected onHealthBandChange(event: Event): void {
+    this.draftHealthBand.set((event.target as HTMLSelectElement).value as OsspreyHealthBand | '');
+  }
+
+  protected onVulnFilterChange(event: Event): void {
+    this.draftVulnFilter.set((event.target as HTMLSelectElement).value as 'critical' | 'high' | 'any' | '');
+  }
+
+  protected onBusFactorToggle(event: Event): void {
+    this.draftBusFactor1Only.set((event.target as HTMLInputElement).checked);
+  }
+
+  protected onStaleToggle(event: Event): void {
+    this.draftStaleOnly.set((event.target as HTMLInputElement).checked);
+  }
+
+  protected onUnstewardedToggle(event: Event): void {
+    this.draftUnstewardedOnly.set((event.target as HTMLInputElement).checked);
   }
 
   protected toggleSortMenu(): void {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -115,11 +115,12 @@ export class OsspreyPackagesTabComponent {
 
   protected getStewardNames(stewardIds: string[]): string {
     if (stewardIds.length === 0) return '—';
-    if (stewardIds.length === 1) {
-      const name = this.osspreyService.getStewardName(stewardIds[0]);
-      return name.length > 20 ? name.substring(0, 17) + '...' : name;
-    }
+    if (stewardIds.length === 1) return this.osspreyService.getStewardName(stewardIds[0]);
     return `${stewardIds.length} stewards`;
+  }
+
+  protected onSearchInput(event: Event): void {
+    this.filterChange.emit({ search: (event.target as HTMLInputElement).value });
   }
 
   protected toggleSortMenu(): void {

--- a/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/components/ossprey-packages-tab/ossprey-packages-tab.component.ts
@@ -1,0 +1,175 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, output, signal } from '@angular/core';
+import {
+  OsspreyEcosystem,
+  OsspreyFilterChip,
+  OsspreyFilterState,
+  OsspreyHealthBand,
+  OsspreyLifecycle,
+  OsspreyPackage,
+  OsspreyStatusCounts,
+} from '@lfx-one/shared/interfaces';
+import { OsspreyService } from '@shared/services/ossprey.service';
+import { ButtonComponent } from '@components/button/button.component';
+import { TableComponent } from '@components/table/table.component';
+import { TagComponent } from '@components/tag/tag.component';
+import {
+  formatStatus,
+  getAdvisoryTagSeverity,
+  getHealthTagSeverity,
+  getLifecycleLabel,
+  getLifecycleTagSeverity,
+  getStatusTagSeverity,
+} from '../../ossprey.utils';
+
+@Component({
+  selector: 'lfx-ossprey-packages-tab',
+  imports: [ButtonComponent, TableComponent, TagComponent],
+  templateUrl: './ossprey-packages-tab.component.html',
+  styleUrl: './ossprey-packages-tab.component.scss',
+})
+export class OsspreyPackagesTabComponent {
+  private readonly osspreyService = inject(OsspreyService);
+
+  public readonly packages = input<OsspreyPackage[]>([]);
+  public readonly filteredPackages = input<OsspreyPackage[]>([]);
+  public readonly statusCounts = input<OsspreyStatusCounts>({
+    all: 0,
+    unassigned: 0,
+    open: 0,
+    assessing: 0,
+    active: 0,
+    needs_attention: 0,
+    escalated: 0,
+    blocked: 0,
+    inactive: 0,
+  });
+  public readonly filters = input<OsspreyFilterState>({
+    search: '',
+    tab: 'all',
+    sort: 'risk',
+    ecosystem: '',
+    lifecycle: '',
+    healthBand: '',
+    vulnFilter: '',
+    busFactor1Only: false,
+    staleOnly: false,
+    unstewardedOnly: false,
+  });
+  public readonly selectedPackages = input<Set<string>>(new Set());
+
+  public readonly filterChange = output<Partial<OsspreyFilterState>>();
+  public readonly sortChange = output<string>();
+  public readonly packageClick = output<string>();
+  public readonly togglePackage = output<{ id: string; event: Event }>();
+  public readonly toggleAll = output<{ checked: boolean }>();
+  public readonly clearFilters = output<void>();
+
+  protected readonly sortMenuOpen = signal(false);
+  protected readonly filterPanelOpen = signal(false);
+
+  // Draft state — synced from filters() when panel opens, committed on Apply
+  protected readonly draftEcosystem = signal<OsspreyEcosystem | ''>('');
+  protected readonly draftLifecycle = signal<OsspreyLifecycle | ''>('');
+  protected readonly draftHealthBand = signal<OsspreyHealthBand | ''>('');
+  protected readonly draftVulnFilter = signal<'critical' | 'high' | 'any' | ''>('');
+  protected readonly draftBusFactor1Only = signal(false);
+  protected readonly draftStaleOnly = signal(false);
+  protected readonly draftUnstewardedOnly = signal(false);
+
+  protected readonly activeFilterChips = computed<OsspreyFilterChip[]>(() => {
+    const f = this.filters();
+    const chips: OsspreyFilterChip[] = [];
+    if (f.ecosystem) chips.push({ label: `Ecosystem: ${f.ecosystem}`, clear: { ecosystem: '' } });
+    if (f.lifecycle) chips.push({ label: `Lifecycle: ${f.lifecycle}`, clear: { lifecycle: '' } });
+    if (f.healthBand) chips.push({ label: `Health: ${f.healthBand}`, clear: { healthBand: '' } });
+    if (f.vulnFilter) chips.push({ label: `Vulns: ${f.vulnFilter}`, clear: { vulnFilter: '' } });
+    if (f.busFactor1Only) chips.push({ label: 'Bus factor = 1', clear: { busFactor1Only: false } });
+    if (f.staleOnly) chips.push({ label: 'No activity ≥18mo', clear: { staleOnly: false } });
+    if (f.unstewardedOnly) chips.push({ label: 'Unstewarded only', clear: { unstewardedOnly: false } });
+    return chips;
+  });
+
+  protected readonly allSelected = computed(() => {
+    const filtered = this.filteredPackages();
+    const selected = this.selectedPackages();
+    return filtered.length > 0 && filtered.every((p) => selected.has(p.id));
+  });
+
+  protected readonly formatStatus = formatStatus;
+  protected readonly getLifecycleLabel = getLifecycleLabel;
+  protected readonly getStatusTagSeverity = getStatusTagSeverity;
+  protected readonly getLifecycleTagSeverity = getLifecycleTagSeverity;
+  protected readonly getHealthTagSeverity = getHealthTagSeverity;
+  protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+
+  protected isPackageSelected(id: string): boolean {
+    return this.selectedPackages().has(id);
+  }
+
+  protected onToggleAllClick(): void {
+    this.toggleAll.emit({ checked: !this.allSelected() });
+  }
+
+  protected getStewardNames(stewardIds: string[]): string {
+    if (stewardIds.length === 0) return '—';
+    if (stewardIds.length === 1) {
+      const name = this.osspreyService.getStewardName(stewardIds[0]);
+      return name.length > 20 ? name.substring(0, 17) + '...' : name;
+    }
+    return `${stewardIds.length} stewards`;
+  }
+
+  protected toggleSortMenu(): void {
+    this.sortMenuOpen.update((v) => !v);
+    this.filterPanelOpen.set(false);
+  }
+
+  protected toggleFilterPanel(): void {
+    const willOpen = !this.filterPanelOpen();
+    this.filterPanelOpen.update((v) => !v);
+    this.sortMenuOpen.set(false);
+    if (willOpen) {
+      const f = this.filters();
+      this.draftEcosystem.set(f.ecosystem);
+      this.draftLifecycle.set(f.lifecycle);
+      this.draftHealthBand.set(f.healthBand);
+      this.draftVulnFilter.set(f.vulnFilter);
+      this.draftBusFactor1Only.set(f.busFactor1Only);
+      this.draftStaleOnly.set(f.staleOnly);
+      this.draftUnstewardedOnly.set(f.unstewardedOnly);
+    }
+  }
+
+  protected applyFilters(): void {
+    this.filterChange.emit({
+      ecosystem: this.draftEcosystem(),
+      lifecycle: this.draftLifecycle(),
+      healthBand: this.draftHealthBand(),
+      vulnFilter: this.draftVulnFilter(),
+      busFactor1Only: this.draftBusFactor1Only(),
+      staleOnly: this.draftStaleOnly(),
+      unstewardedOnly: this.draftUnstewardedOnly(),
+    });
+    this.filterPanelOpen.set(false);
+  }
+
+  protected resetAllFilters(): void {
+    this.draftEcosystem.set('');
+    this.draftLifecycle.set('');
+    this.draftHealthBand.set('');
+    this.draftVulnFilter.set('');
+    this.draftBusFactor1Only.set(false);
+    this.draftStaleOnly.set(false);
+    this.draftUnstewardedOnly.set(false);
+    this.clearFilters.emit();
+    this.filterPanelOpen.set(false);
+  }
+
+  protected onSortSelect(value: string): void {
+    this.sortChange.emit(value);
+    this.sortMenuOpen.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
@@ -157,5 +157,5 @@
 </div>
 
 <!-- Package Detail Drawer -->
-<lfx-ossprey-package-drawer [(visible)]="drawerVisible" [packageId]="selectedPackageId()" (visibleChange)="$event || onDrawerClose()">
+<lfx-ossprey-package-drawer [(visible)]="drawerVisible" [packageId]="selectedPackageId()" (visibleChange)="!$event && onDrawerClose()">
 </lfx-ossprey-package-drawer>

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
@@ -1,0 +1,161 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8">
+  <!-- Page Header -->
+  <div class="mt-3 mb-4">
+    <h1 class="font-display font-light text-2xl" data-testid="ossprey-page-title">OSSPREY Program</h1>
+    <p class="mt-1 text-sm text-gray-500">
+      Stewardship coverage across the critical package set. Coverage is the primary metric — most critical packages should reach an active steward and stay
+      there.
+    </p>
+  </div>
+
+  <!-- KPI Metrics Strip -->
+  @if (!loading()) {
+    <div class="osp-v1m" data-testid="ossprey-kpi-strip">
+      <!-- Total packages coverage -->
+      <div class="osp-v1c grad">
+        <div class="osp-v1c-h">
+          <span class="osp-v1c-ic" style="background: var(--blue); color: #fff">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path
+                d="m7.5 4.27 9 5.15M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+              <path d="M3.3 7 12 12l8.7-5" />
+              <path d="M12 22V12" />
+            </svg>
+          </span>
+          Total packages
+        </div>
+        <div class="osp-v1c-num">{{ (packages() ?? []).length }}</div>
+        <div class="osp-v1c-prog">
+          <div class="osp-v1c-bar blue">
+            <i [style.width.%]="coveragePercent()"></i>
+          </div>
+          <div class="osp-v1c-meta">
+            <b>{{ coveragePercent() }}% covered</b> · {{ coveredCount() }} active / assessing
+          </div>
+        </div>
+      </div>
+      <div class="osp-v1d"></div>
+      <!-- Status breakdown list -->
+      <div class="osp-v1slist">
+        <button class="osp-v1r" (click)="onFilterChange({ tab: 'unassigned' })" data-testid="ossprey-kpi-unassigned">
+          <span class="osp-v1r-ic" style="background: #e2e8f0; color: var(--g600)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <line x1="17" y1="8" x2="22" y2="13" />
+              <line x1="22" y1="8" x2="17" y2="13" />
+            </svg>
+          </span>
+          <span class="osp-v1r-l">Unassigned</span>
+          <span class="osp-v1r-v">{{ statusCounts().unassigned }}</span>
+          <span class="chev">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </span>
+        </button>
+        <button class="osp-v1r warn" (click)="onFilterChange({ tab: 'needs_attention' })" data-testid="ossprey-kpi-needs-attention">
+          <span class="osp-v1r-ic" style="background: #f59e0b; color: #fff">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10 10h4" />
+              <path d="M19 7V5a2 2 0 0 0-2-2h-1a2 2 0 0 0-2 2v3" />
+              <path d="M20 21a2 2 0 0 0 2-2v-3.851c0-1.39-2-2.962-2-4.829V8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1z" />
+              <path d="M22 16H2" />
+              <path d="M4 21a2 2 0 0 1-2-2v-3.851c0-1.39 2-2.962 2-4.829V8a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1z" />
+              <path d="M9 7V5a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v2" />
+            </svg>
+          </span>
+          <span class="osp-v1r-l">Needs attention</span>
+          <span class="osp-v1r-v">{{ statusCounts().needs_attention }}</span>
+          <span class="chev">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </span>
+        </button>
+        <button class="osp-v1r danger" (click)="onFilterChange({ tab: 'escalated' })" data-testid="ossprey-kpi-escalated">
+          <span class="osp-v1r-ic" style="background: var(--red); color: #fff">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="12" y1="19" x2="12" y2="5" />
+              <polyline points="5 12 12 5 19 12" />
+            </svg>
+          </span>
+          <span class="osp-v1r-l">Escalated</span>
+          <span class="osp-v1r-v">{{ statusCounts().escalated }}</span>
+          <span class="chev">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  }
+
+  <!-- Packages Tab -->
+  <lfx-ossprey-packages-tab
+    [packages]="packages() ?? []"
+    [filteredPackages]="packages() ?? []"
+    [statusCounts]="statusCounts()"
+    [filters]="filters()"
+    [selectedPackages]="selectedPackages()"
+    (filterChange)="onFilterChange($event)"
+    (sortChange)="onFilterChange({ sort: $any($event) })"
+    (packageClick)="onPackageClick($event)"
+    (togglePackage)="onTogglePackage($event)"
+    (toggleAll)="onToggleAll($event)"
+    (clearFilters)="
+      onFilterChange({
+        search: '',
+        tab: 'all',
+        sort: 'risk',
+        ecosystem: '',
+        lifecycle: '',
+        healthBand: '',
+        vulnFilter: '',
+        busFactor1Only: false,
+        staleOnly: false,
+        unstewardedOnly: false,
+      });
+      clearSelection()
+    ">
+  </lfx-ossprey-packages-tab>
+
+  <!-- Bulk Actions Bar -->
+  @if (showBulkActions()) {
+    <div
+      class="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white border border-gray-300 rounded-xl shadow-lg px-4 py-3 flex items-center gap-3 z-40"
+      data-testid="ossprey-bulk-actions-bar">
+      <button
+        (click)="clearSelection()"
+        class="w-8 h-8 rounded flex items-center justify-center text-gray-600 hover:bg-gray-100 transition-colors"
+        data-testid="ossprey-bulk-close">
+        ✕
+      </button>
+      <div class="text-sm font-semibold text-slate-900">{{ selectedPackages().size }} selected</div>
+      <div class="w-px h-6 bg-gray-300"></div>
+      <button
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors"
+        data-testid="ossprey-bulk-assign">
+        Assign Steward
+      </button>
+      <button
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors"
+        data-testid="ossprey-bulk-escalate">
+        Escalate
+      </button>
+      <button
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors"
+        data-testid="ossprey-bulk-assess">
+        Spot-check
+      </button>
+    </div>
+  }
+</div>
+
+<!-- Package Detail Drawer -->
+<lfx-ossprey-package-drawer [(visible)]="drawerVisible" [packageId]="selectedPackageId()" (visibleChange)="$event || onDrawerClose()">
+</lfx-ossprey-package-drawer>

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.html
@@ -103,25 +103,11 @@
     [filters]="filters()"
     [selectedPackages]="selectedPackages()"
     (filterChange)="onFilterChange($event)"
-    (sortChange)="onFilterChange({ sort: $any($event) })"
+    (sortChange)="onSortChange($event)"
     (packageClick)="onPackageClick($event)"
     (togglePackage)="onTogglePackage($event)"
     (toggleAll)="onToggleAll($event)"
-    (clearFilters)="
-      onFilterChange({
-        search: '',
-        tab: 'all',
-        sort: 'risk',
-        ecosystem: '',
-        lifecycle: '',
-        healthBand: '',
-        vulnFilter: '',
-        busFactor1Only: false,
-        staleOnly: false,
-        unstewardedOnly: false,
-      });
-      clearSelection()
-    ">
+    (clearFilters)="onClearFilters()">
   </lfx-ossprey-packages-tab>
 
   <!-- Bulk Actions Bar -->

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.scss
@@ -1,0 +1,261 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  /* CSS custom properties cascade to all child components */
+  --rail: #002741;
+  --blue: #009aff;
+  --blue-600: #0086e0;
+  --blue-50: #ecf4ff;
+  --blue-100: #dbe9ff;
+  --green: #22c55e;
+  --green-bg: #e9f9ef;
+  --red: #e5484d;
+  --red-bg: #fdeced;
+  --amber: #c2820a;
+  --amber-bg: #fdf3e3;
+  --ink: #0f172b;
+  --g950: #030712;
+  --g700: #314158;
+  --g600: #45556c;
+  --g500: #62748e;
+  --g400: #90a1b9;
+  --g300: #cad5e2;
+  --g200: #e2e8f0;
+  --g100: #f1f5f9;
+  --g50: #f8fafc;
+  --white: #fff;
+  --border: #e2e8f0;
+}
+
+/* ── KPI Metrics Strip ── */
+.osp-v1m {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 20px;
+
+  @media (max-width: 1080px) {
+    flex-wrap: wrap;
+  }
+}
+
+.osp-v1c {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 15px 18px;
+  min-width: 0;
+
+  &.grad {
+    background: linear-gradient(135deg, #e6efff 0%, #f1f7ff 55%, #fbfdff 100%);
+  }
+
+  @media (max-width: 1080px) {
+    flex: 1 1 50%;
+  }
+}
+
+.osp-v1c-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 7px;
+}
+
+.osp-v1c-ic {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+.osp-v1c-num {
+  font-size: 30px;
+  font-weight: 300;
+  color: var(--ink);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin-bottom: 11px;
+}
+
+.osp-v1c-prog {
+  min-width: 0;
+}
+
+.osp-v1c-bar {
+  height: 6px;
+  border-radius: 4px;
+  background: #e2e8f0;
+  overflow: hidden;
+  margin-bottom: 6px;
+
+  i {
+    display: block;
+    height: 100%;
+    border-radius: 4px;
+  }
+
+  &.blue i {
+    background: var(--blue);
+  }
+
+  &.dark i {
+    background: var(--rail);
+  }
+}
+
+.osp-v1c-meta {
+  font-size: 11.5px;
+  color: var(--g500);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  b {
+    color: var(--g700);
+    font-weight: 600;
+  }
+}
+
+.osp-v1d {
+  width: 1px;
+  background: var(--g100);
+  flex-shrink: 0;
+  align-self: stretch;
+}
+
+.osp-v1slist {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 9px 12px;
+  min-width: 0;
+
+  @media (max-width: 1080px) {
+    flex: 1 1 100%;
+  }
+}
+
+.osp-v1r {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 10px;
+  border-radius: 9px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+
+  &:hover {
+    background: var(--g50);
+  }
+
+  &.warn .osp-v1r-v {
+    color: var(--amber);
+  }
+
+  &.danger .osp-v1r-v {
+    color: var(--red);
+  }
+}
+
+.osp-v1r-ic {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+.osp-v1r-l {
+  flex: 1;
+  font-size: 14px;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.osp-v1r-v {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.osp-v1r .chev {
+  color: var(--g400);
+  display: flex;
+  margin-left: 8px;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+/* ── Tabbar ── */
+.osp-tabbar {
+  display: flex;
+  gap: 8px;
+}
+
+.osp-pgtab {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 15px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #62748e;
+  transition: all 0.15s;
+  border-bottom: 2px solid transparent;
+}
+
+.osp-pgtab:hover {
+  color: #314158;
+}
+
+.osp-pgtab.on {
+  color: #009aff;
+  border-bottom-color: #009aff;
+}
+
+.osp-pgtab svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
@@ -1,0 +1,138 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { OsspreyDashboardSortSpec, OsspreyFilterState, OsspreyListParams, OsspreyPackage, OsspreyStatusCounts } from '@lfx-one/shared/interfaces';
+import { switchMap, catchError, of, map, timer } from 'rxjs';
+import { OsspreyService } from '@shared/services/ossprey.service';
+import { OsspreyPackageDrawerComponent } from '../components/ossprey-package-drawer/ossprey-package-drawer.component';
+import { OsspreyPackagesTabComponent } from '../components/ossprey-packages-tab/ossprey-packages-tab.component';
+
+@Component({
+  selector: 'lfx-ossprey-dashboard',
+  imports: [OsspreyPackageDrawerComponent, OsspreyPackagesTabComponent],
+  templateUrl: './ossprey-dashboard.component.html',
+  styleUrl: './ossprey-dashboard.component.scss',
+})
+export class OsspreyDashboardComponent {
+  private readonly osspreyService = inject(OsspreyService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly selectedPackageId = signal<string | null>(null);
+  protected readonly drawerVisible = signal(false);
+  protected readonly selectedPackages = signal<Set<string>>(new Set());
+  protected readonly showBulkActions = computed(() => this.selectedPackages().size > 0);
+
+  protected readonly filters = signal<OsspreyFilterState>({
+    search: '',
+    tab: 'all',
+    sort: 'risk',
+    ecosystem: '',
+    lifecycle: '',
+    healthBand: '',
+    vulnFilter: '',
+    busFactor1Only: false,
+    staleOnly: false,
+    unstewardedOnly: false,
+  });
+
+  protected readonly packages = this.initPackages();
+  protected readonly loading = computed(() => this.packages() === undefined);
+
+  protected readonly coveredCount = computed(() => {
+    return (this.packages() ?? []).filter((p) => p.status === 'active' || p.status === 'assessing').length;
+  });
+
+  protected readonly coveragePercent = computed(() => {
+    const total = (this.packages() ?? []).length;
+    return total === 0 ? 0 : Math.round((this.coveredCount() / total) * 100);
+  });
+
+  protected readonly statusCounts = computed<OsspreyStatusCounts>(() => {
+    const pkgs = this.packages() ?? [];
+    return {
+      all: pkgs.length,
+      unassigned: pkgs.filter((p) => p.status === 'unassigned').length,
+      open: pkgs.filter((p) => p.status === 'open').length,
+      assessing: pkgs.filter((p) => p.status === 'assessing').length,
+      active: pkgs.filter((p) => p.status === 'active').length,
+      needs_attention: pkgs.filter((p) => p.status === 'needs_attention').length,
+      escalated: pkgs.filter((p) => p.status === 'escalated').length,
+      blocked: pkgs.filter((p) => p.status === 'blocked').length,
+      inactive: pkgs.filter((p) => p.status === 'inactive').length,
+    };
+  });
+
+  protected onPackageClick(id: string): void {
+    this.selectedPackageId.set(id);
+    this.drawerVisible.set(true);
+  }
+
+  protected onDrawerClose(): void {
+    this.drawerVisible.set(false);
+    timer(300)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.selectedPackageId.set(null));
+  }
+
+  protected onFilterChange(partial: Partial<OsspreyFilterState>): void {
+    this.filters.update((current) => ({ ...current, ...partial }));
+  }
+
+  protected onTogglePackage(payload: { id: string; event: Event }): void {
+    payload.event.stopPropagation();
+    const selected = new Set(this.selectedPackages());
+    if (selected.has(payload.id)) {
+      selected.delete(payload.id);
+    } else {
+      selected.add(payload.id);
+    }
+    this.selectedPackages.set(selected);
+  }
+
+  protected onToggleAll(payload: { checked: boolean }): void {
+    const pkgs = this.packages() ?? [];
+    const selected = new Set(this.selectedPackages());
+    if (payload.checked) {
+      pkgs.forEach((p) => selected.add(p.id));
+    } else {
+      pkgs.forEach((p) => selected.delete(p.id));
+    }
+    this.selectedPackages.set(selected);
+  }
+
+  protected clearSelection(): void {
+    this.selectedPackages.set(new Set());
+  }
+
+  private initPackages() {
+    return toSignal<OsspreyPackage[] | undefined>(
+      toObservable(this.filters).pipe(
+        switchMap((f) => {
+          // 'risk' is intentionally absent — no sort params means the server applies its
+          // own composite risk ordering rather than a simple field sort.
+          const sortByMap: Record<string, OsspreyDashboardSortSpec> = {
+            impact: { sortBy: 'impact', sortDir: 'desc' },
+            health: { sortBy: 'health', sortDir: 'asc' },
+            vulns: { sortBy: 'openVulns', sortDir: 'desc' },
+            name: { sortBy: 'name', sortDir: 'asc' },
+          };
+          const sortSpec = sortByMap[f.sort];
+          const params: OsspreyListParams = {
+            ...(sortSpec ? { sortBy: sortSpec.sortBy, sortDir: sortSpec.sortDir } : {}),
+            ecosystem: f.ecosystem || undefined,
+            lifecycle: f.lifecycle || undefined,
+            busFactor1Only: f.busFactor1Only || undefined,
+            staleOnly: f.staleOnly || undefined,
+            unstewardedOnly: f.unstewardedOnly || undefined,
+          };
+          return this.osspreyService.getPackages(params).pipe(
+            map((res) => res.packages ?? []),
+            catchError(() => of([] as OsspreyPackage[]))
+          );
+        })
+      )
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
@@ -3,7 +3,14 @@
 
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { OsspreyDashboardSortSpec, OsspreyFilterState, OsspreyListParams, OsspreyPackage, OsspreyStatusCounts } from '@lfx-one/shared/interfaces';
+import {
+  OsspreyDashboardSortSpec,
+  OsspreyFilterState,
+  OsspreyListParams,
+  OsspreyPackage,
+  OspreySortKey,
+  OsspreyStatusCounts,
+} from '@lfx-one/shared/interfaces';
 import { switchMap, catchError, of, map, timer, debounceTime } from 'rxjs';
 import { OsspreyService } from '@shared/services/ossprey.service';
 import { OsspreyPackageDrawerComponent } from '../components/ossprey-package-drawer/ossprey-package-drawer.component';
@@ -104,6 +111,26 @@ export class OsspreyDashboardComponent {
 
   protected clearSelection(): void {
     this.selectedPackages.set(new Set());
+  }
+
+  protected onSortChange(sort: string): void {
+    this.filters.update((current) => ({ ...current, sort: sort as OspreySortKey }));
+  }
+
+  protected onClearFilters(): void {
+    this.onFilterChange({
+      search: '',
+      tab: 'all',
+      sort: 'risk',
+      ecosystem: '',
+      lifecycle: '',
+      healthBand: '',
+      vulnFilter: '',
+      busFactor1Only: false,
+      staleOnly: false,
+      unstewardedOnly: false,
+    });
+    this.clearSelection();
   }
 
   private initPackages() {

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey-dashboard/ossprey-dashboard.component.ts
@@ -4,7 +4,7 @@
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { OsspreyDashboardSortSpec, OsspreyFilterState, OsspreyListParams, OsspreyPackage, OsspreyStatusCounts } from '@lfx-one/shared/interfaces';
-import { switchMap, catchError, of, map, timer } from 'rxjs';
+import { switchMap, catchError, of, map, timer, debounceTime } from 'rxjs';
 import { OsspreyService } from '@shared/services/ossprey.service';
 import { OsspreyPackageDrawerComponent } from '../components/ossprey-package-drawer/ossprey-package-drawer.component';
 import { OsspreyPackagesTabComponent } from '../components/ossprey-packages-tab/ossprey-packages-tab.component';
@@ -109,6 +109,7 @@ export class OsspreyDashboardComponent {
   private initPackages() {
     return toSignal<OsspreyPackage[] | undefined>(
       toObservable(this.filters).pipe(
+        debounceTime(300),
         switchMap((f) => {
           // 'risk' is intentionally absent — no sort params means the server applies its
           // own composite risk ordering rather than a simple field sort.

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey.routes.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey.routes.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Routes } from '@angular/router';
+import { authGuard } from '@shared/guards/auth.guard';
+
+export const OSSPREY_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./ossprey-dashboard/ossprey-dashboard.component').then((m) => m.OsspreyDashboardComponent),
+    canActivate: [authGuard],
+  },
+];

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
+
+export function getStatusTagSeverity(status: OsspreyStatus): TagSeverity {
+  const map: Record<OsspreyStatus, TagSeverity> = {
+    unassigned: 'secondary',
+    open: 'info',
+    assessing: 'info',
+    active: 'success',
+    needs_attention: 'warn',
+    escalated: 'danger',
+    blocked: 'danger',
+    inactive: 'secondary',
+  };
+  return map[status] ?? 'secondary';
+}
+
+export function getLifecycleTagSeverity(lifecycle: OsspreyLifecycle | null): TagSeverity {
+  if (!lifecycle) return 'secondary';
+  const map: Record<OsspreyLifecycle, TagSeverity> = {
+    active: 'success',
+    stable: 'info',
+    declining: 'warn',
+    abandoned: 'danger',
+  };
+  return map[lifecycle] ?? 'secondary';
+}
+
+export function getHealthTagSeverity(score: number): TagSeverity {
+  if (score >= 75) return 'success';
+  if (score >= 50) return 'info';
+  if (score >= 25) return 'warn';
+  return 'danger';
+}
+
+export function getAdvisoryTagSeverity(severity: OspreySeverity | null): TagSeverity {
+  if (!severity) return 'secondary';
+  const map: Record<OspreySeverity, TagSeverity> = {
+    critical: 'danger',
+    high: 'danger',
+    medium: 'warn',
+    low: 'info',
+  };
+  return map[severity];
+}
+
+export function formatStatus(status: string): string {
+  return status.replace(/_/g, ' ');
+}
+
+export function getHealthBand(score: number): OsspreyHealthBand {
+  if (score >= 75) return 'healthy';
+  if (score >= 50) return 'fair';
+  if (score >= 25) return 'concerning';
+  return 'critical';
+}
+
+export function getHealthLabel(score: number): string {
+  const band = getHealthBand(score);
+  return band.charAt(0).toUpperCase() + band.slice(1);
+}
+
+export function getLifecycleLabel(lifecycle: OsspreyLifecycle | null): string {
+  if (!lifecycle) return 'Unknown';
+  return lifecycle.charAt(0).toUpperCase() + lifecycle.slice(1);
+}

--- a/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
+++ b/apps/lfx-one/src/app/modules/ossprey/ossprey.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
+import { OsspreyEcosystem, OsspreyHealthBand, OsspreyLifecycle, OsspreyStatus, OspreySeverity, TagSeverity } from '@lfx-one/shared/interfaces';
 
 export function getStatusTagSeverity(status: OsspreyStatus): TagSeverity {
   const map: Record<OsspreyStatus, TagSeverity> = {
@@ -65,4 +65,14 @@ export function getHealthLabel(score: number): string {
 export function getLifecycleLabel(lifecycle: OsspreyLifecycle | null): string {
   if (!lifecycle) return 'Unknown';
   return lifecycle.charAt(0).toUpperCase() + lifecycle.slice(1);
+}
+
+export function getEcosystemIconClass(ecosystem: OsspreyEcosystem | string): string {
+  const classes: Record<string, string> = {
+    npm: 'logo-npm',
+    maven: 'logo-maven',
+    pypi: 'logo-pypi',
+    go: 'logo-go',
+  };
+  return classes[ecosystem] ?? 'logo-npm';
 }

--- a/apps/lfx-one/src/app/shared/services/ossprey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/ossprey.service.ts
@@ -36,6 +36,7 @@ export class OsspreyService {
     return this.http.get<OsspreyPackage>(`/api/ossprey/packages/${encodeURIComponent(purl)}`).pipe(
       catchError((err) => {
         if (err.status === 404) return of(null);
+        console.error('[OsspreyService] getPackage failed', { purl, status: err.status, message: err.message });
         throw err;
       })
     );

--- a/apps/lfx-one/src/app/shared/services/ossprey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/ossprey.service.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of, catchError } from 'rxjs';
+import { OsspreyListParams, OsspreyPackage, OsspreyPackagesResponse } from '@lfx-one/shared/interfaces';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OsspreyService {
+  private readonly http = inject(HttpClient);
+
+  public getPackages(params?: OsspreyListParams): Observable<OsspreyPackagesResponse> {
+    let httpParams = new HttpParams();
+    if (params) {
+      if (params.page) httpParams = httpParams.set('page', String(params.page));
+      if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
+      if (params.ecosystem) httpParams = httpParams.set('ecosystem', params.ecosystem);
+      if (params.lifecycle) httpParams = httpParams.set('lifecycle', params.lifecycle);
+      if (params.busFactor1Only) httpParams = httpParams.set('busFactor1Only', 'true');
+      if (params.staleOnly) httpParams = httpParams.set('staleOnly', 'true');
+      if (params.unstewardedOnly) httpParams = httpParams.set('unstewardedOnly', 'true');
+      if (params.sortBy) httpParams = httpParams.set('sortBy', params.sortBy);
+      if (params.sortDir) httpParams = httpParams.set('sortDir', params.sortDir);
+    }
+    return this.http.get<OsspreyPackagesResponse>('/api/ossprey/packages', { params: httpParams });
+  }
+
+  public getStewardName(id: string): string {
+    return id;
+  }
+
+  public getPackage(purl: string): Observable<OsspreyPackage | null> {
+    return this.http.get<OsspreyPackage>(`/api/ossprey/packages/${encodeURIComponent(purl)}`).pipe(
+      catchError((err) => {
+        if (err.status === 404) return of(null);
+        throw err;
+      })
+    );
+  }
+}

--- a/apps/lfx-one/src/server/controllers/ossprey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/ossprey.controller.ts
@@ -1,0 +1,65 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { OsspreyListParams, OsspreyPackagesResponse } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { getStringQueryParam } from '../helpers/validation.helper';
+import { OsspreyServerService } from '../services/ossprey.service';
+import { logger } from '../services/logger.service';
+
+export class OsspreyController {
+  private readonly osspreyService = new OsspreyServerService();
+
+  public async getPackages(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_ossprey_packages');
+
+    try {
+      const pageRaw = getStringQueryParam(req, 'page');
+      const pageSizeRaw = getStringQueryParam(req, 'pageSize');
+      const params: OsspreyListParams = {
+        page: pageRaw ? Number(pageRaw) : undefined,
+        pageSize: pageSizeRaw ? Number(pageSizeRaw) : undefined,
+        ecosystem: getStringQueryParam(req, 'ecosystem'),
+        lifecycle: getStringQueryParam(req, 'lifecycle'),
+        busFactor1Only: getStringQueryParam(req, 'busFactor1Only') === 'true',
+        staleOnly: getStringQueryParam(req, 'staleOnly') === 'true',
+        unstewardedOnly: getStringQueryParam(req, 'unstewardedOnly') === 'true',
+        sortBy: getStringQueryParam(req, 'sortBy') as OsspreyListParams['sortBy'],
+        sortDir: getStringQueryParam(req, 'sortDir') as OsspreyListParams['sortDir'],
+      };
+
+      const data: OsspreyPackagesResponse = await this.osspreyService.getPackages(req, params);
+
+      logger.success(req, 'get_ossprey_packages', startTime, {
+        package_count: data.packages?.length ?? 0,
+      });
+
+      res.json(data);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getPackage(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_ossprey_package');
+    const purl = decodeURIComponent(req.params['purl'] as string);
+
+    try {
+      const pkg = await this.osspreyService.getPackage(req, purl);
+
+      if (!pkg) {
+        logger.debug(req, 'get_ossprey_package', 'Package not found', { purl });
+        // Intentional: 404 is a valid non-error outcome here, not an exception path.
+        res.status(404).json({ error: 'NOT_FOUND', message: 'Package not found.' });
+        return;
+      }
+
+      logger.success(req, 'get_ossprey_package', startTime, { purl });
+
+      res.json(pkg);
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/ossprey.route.ts
+++ b/apps/lfx-one/src/server/routes/ossprey.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { OsspreyController } from '../controllers/ossprey.controller';
+
+const router = Router();
+const osspreyController = new OsspreyController();
+
+router.get('/packages', osspreyController.getPackages.bind(osspreyController));
+router.get('/packages/:purl', osspreyController.getPackage.bind(osspreyController));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -51,6 +51,7 @@ import enrollmentRouter from './routes/enrollment.route';
 import transactionRouter from './routes/transaction.route';
 import userRouter from './routes/user.route';
 import votesRouter from './routes/votes.route';
+import osspreyRouter from './routes/ossprey.route';
 import { reqSerializer, resSerializer, serverLogger } from './server-logger';
 import { logger } from './services/logger.service';
 import { NatsService } from './services/nats.service';
@@ -241,6 +242,7 @@ app.use('/api/transactions', transactionRouter);
 app.use('/api/changelog', changelogRouter);
 app.use('/api/projects/:projectUid/newsletters', newslettersRouter);
 app.use('/api/invite', inviteRouter);
+app.use('/api/ossprey', osspreyRouter);
 
 app.use('/api/*', apiErrorHandler);
 

--- a/apps/lfx-one/src/server/services/ossprey.service.ts
+++ b/apps/lfx-one/src/server/services/ossprey.service.ts
@@ -267,7 +267,7 @@ export class OsspreyServerService {
     return advisories.map((adv) => ({
       id: adv.osvId,
       severity: adv.severity,
-      description: adv.osvId,
+      description: adv.resolution ?? adv.osvId,
       state: 'Open' as const,
       cvss: null,
       publishedAt: null,

--- a/apps/lfx-one/src/server/services/ossprey.service.ts
+++ b/apps/lfx-one/src/server/services/ossprey.service.ts
@@ -1,0 +1,303 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CDP_CONFIG } from '@lfx-one/shared/constants';
+import {
+  CdpAdvisory,
+  CdpPackageDetail,
+  CdpPackagesListResponse,
+  CdpStewardshipSummary,
+  OsspreyAdvisory,
+  OsspreyListParams,
+  OsspreyPackage,
+  OsspreyPackagesResponse,
+  OspreySeverity,
+} from '@lfx-one/shared/interfaces';
+import { randomUUID } from 'crypto';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { CdpService } from './cdp.service';
+import { logger } from './logger.service';
+
+export class OsspreyServerService {
+  private readonly cdpService = new CdpService();
+
+  private _cdpApiUrl: string | undefined;
+
+  private get cdpApiUrl(): string {
+    return (this._cdpApiUrl ??= (process.env['CDP_API_URL'] || CDP_CONFIG.DEFAULT_STAGING_URL).replace(/\/+$/, ''));
+  }
+
+  public async getPackages(req: Request, params: OsspreyListParams): Promise<OsspreyPackagesResponse> {
+    const requestId = randomUUID();
+
+    try {
+      const token = await this.cdpService.generateToken(req).catch((err: unknown) => {
+        throw new MicroserviceError('Failed to generate CDP token', 401, 'CDP_AUTH_FAILED', {
+          operation: 'get_ossprey_packages',
+          service: 'ossprey_service',
+          originalMessage: err instanceof Error ? err.message : String(err),
+        });
+      });
+      const url = new URL(`${this.cdpApiUrl}${CDP_CONFIG.ENDPOINTS.PACKAGES_LIST}`);
+
+      if (params.page) url.searchParams.set('page', String(params.page));
+      if (params.pageSize) url.searchParams.set('pageSize', String(params.pageSize));
+      if (params.ecosystem) url.searchParams.set('ecosystem', params.ecosystem);
+      if (params.lifecycle) url.searchParams.set('lifecycle', params.lifecycle);
+      if (params.busFactor1Only) url.searchParams.set('busFactor1Only', 'true');
+      if (params.staleOnly) url.searchParams.set('staleOnly', 'true');
+      if (params.unstewardedOnly) url.searchParams.set('unstewardedOnly', 'true');
+      if (params.sortBy) url.searchParams.set('sortBy', params.sortBy);
+      if (params.sortDir) url.searchParams.set('sortDir', params.sortDir);
+
+      logger.debug(req, 'get_ossprey_packages', 'Fetching packages from CDP', {
+        url: url.toString(),
+        params,
+        request_id: requestId,
+      });
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-LFX-Request-ID': requestId,
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '[unreadable error body]');
+        throw new MicroserviceError(`CDP packages list request failed: ${response.statusText}`, response.status, 'CDP_PACKAGES_LIST_ERROR', {
+          operation: 'get_ossprey_packages',
+          service: 'ossprey_service',
+          errorBody: errorText,
+        });
+      }
+
+      const data = (await response.json()) as CdpPackagesListResponse;
+
+      logger.debug(req, 'get_ossprey_packages', 'Fetched packages from CDP', {
+        count: data.packages?.length ?? 0,
+        total: data.total,
+      });
+
+      return {
+        packages: (data.packages ?? []).map((item) => this.mapListItem(item)),
+        total: data.total,
+      };
+    } catch (error) {
+      if (error instanceof MicroserviceError) throw error;
+
+      throw new MicroserviceError('Failed to fetch OSSPREY packages', 502, 'OSSPREY_FETCH_ERROR', {
+        operation: 'get_ossprey_packages',
+        service: 'ossprey_service',
+      });
+    }
+  }
+
+  public async getPackage(req: Request, purl: string): Promise<OsspreyPackage | null> {
+    const requestId = randomUUID();
+
+    try {
+      const token = await this.cdpService.generateToken(req).catch((err: unknown) => {
+        throw new MicroserviceError('Failed to generate CDP token', 401, 'CDP_AUTH_FAILED', {
+          operation: 'get_ossprey_package',
+          service: 'ossprey_service',
+          originalMessage: err instanceof Error ? err.message : String(err),
+        });
+      });
+      const url = new URL(`${this.cdpApiUrl}${CDP_CONFIG.ENDPOINTS.PACKAGE_DETAIL}`);
+      url.searchParams.set('purl', purl);
+
+      logger.debug(req, 'get_ossprey_package', 'Fetching package detail from CDP', {
+        purl,
+        url: url.toString(),
+        request_id: requestId,
+      });
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-LFX-Request-ID': requestId,
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (response.status === 404) {
+        logger.warning(req, 'get_ossprey_package', 'Package not found in CDP', { purl });
+        return null;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '[unreadable error body]');
+        throw new MicroserviceError(`CDP package detail request failed: ${response.statusText}`, response.status, 'CDP_PACKAGE_DETAIL_ERROR', {
+          operation: 'get_ossprey_package',
+          service: 'ossprey_service',
+          errorBody: errorText,
+        });
+      }
+
+      const detail = (await response.json()) as CdpPackageDetail;
+
+      logger.debug(req, 'get_ossprey_package', 'Fetched package detail from CDP', { purl });
+
+      return this.mapPackageDetail(detail);
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.statusCode === 404) return null;
+      if (error instanceof MicroserviceError) throw error;
+
+      throw new MicroserviceError('Failed to fetch OSSPREY package', 502, 'OSSPREY_FETCH_ERROR', {
+        operation: 'get_ossprey_package',
+        service: 'ossprey_service',
+      });
+    }
+  }
+
+  public mapListItem(item: CdpStewardshipSummary): OsspreyPackage {
+    const vulns = item.openVulns;
+    const vulnCount = vulns ? vulns.low + vulns.medium + vulns.high + vulns.critical : 0;
+    const vulnSeverity = this.worstSeverityFromCounts(vulns);
+
+    return {
+      id: item.purl,
+      name: item.name,
+      purl: item.purl,
+      ecosystem: (item.ecosystem as OsspreyPackage['ecosystem']) || 'npm',
+      lifecycle: (item.lifecycle as OsspreyPackage['lifecycle']) || null,
+      healthScore: item.health ?? null,
+      impactScore: item.impact ?? null,
+      busFactor: item.maintainerBusFactor ?? null,
+      monthsStale: null,
+      vulnCount,
+      vulnSeverity,
+      status: (item.stewardship as OsspreyPackage['status']) || 'unassigned',
+      stewardIds: [],
+      lastActivityLabel: '—',
+      lastActivityTime: '',
+      weeklyDownloads: null,
+      dependentCount: null,
+      directDependentCount: null,
+      scoreCardScore: null,
+      lastRelease: null,
+      lastCommit: null,
+      repoUrl: null,
+      supplyChainMapping: null,
+      provenance: null,
+      hasSecurityMd: null,
+      ecosystemReach: null,
+      contactGroup: null,
+      healthBreakdown: [],
+      advisories: [],
+      history: [],
+      assessment: null,
+    };
+  }
+
+  private mapPackageDetail(detail: CdpPackageDetail): OsspreyPackage {
+    const advisories = this.mapAdvisories(detail.security?.advisories ?? []);
+    const vulnSeverity = this.getHighestVulnSeverity(advisories);
+
+    const hs = detail.general?.healthScore;
+    const healthBreakdown: string[] = [];
+    if (hs) {
+      if (hs.maintainerHealth != null) healthBreakdown.push(`${Math.round(hs.maintainerHealth)} / 40`);
+      if (hs.securitySupplyChain != null) healthBreakdown.push(`${Math.round(hs.securitySupplyChain)} / 35`);
+      if (hs.developmentActivity != null) healthBreakdown.push(`${Math.round(hs.developmentActivity)} / 25`);
+    }
+
+    const repo = detail.provenance?.repositoryMapping;
+    const impact = detail.general?.impact;
+    const risk = detail.general?.riskSignals;
+
+    return {
+      id: detail.purl,
+      name: detail.name,
+      purl: detail.purl,
+      ecosystem: (detail.ecosystem as OsspreyPackage['ecosystem']) || 'npm',
+      lifecycle: (risk?.lifecycle as OsspreyPackage['lifecycle']) || null,
+      healthScore: hs?.total ?? null,
+      impactScore: impact?.impactScore ?? null,
+      busFactor: risk?.maintainerBusFactor ?? null,
+      monthsStale: this.calculateMonthsStale(repo?.lastCommitAt),
+      vulnCount: advisories.length,
+      vulnSeverity,
+      status: 'unassigned',
+      stewardIds: [],
+      lastActivityLabel: '—',
+      lastActivityTime: '',
+      weeklyDownloads: impact?.downloadsLastMonth != null ? this.formatNumber(impact.downloadsLastMonth) : null,
+      dependentCount: impact?.dependentPackages != null ? this.formatNumber(impact.dependentPackages) : null,
+      directDependentCount: impact?.dependentRepos != null ? this.formatNumber(impact.dependentRepos) : null,
+      scoreCardScore: risk?.openSSFScorecard != null ? `${risk.openSSFScorecard.toFixed(1)} / 10` : null,
+      lastRelease: this.formatDate(risk?.lastRelease),
+      lastCommit: this.formatDate(repo?.lastCommitAt),
+      repoUrl: this.stripProtocol(repo?.declaredRepo),
+      supplyChainMapping: null,
+      provenance: null,
+      hasSecurityMd: risk?.hasSecurityFile ?? null,
+      ecosystemReach: impact?.transitiveReach ?? null,
+      contactGroup: null,
+      healthBreakdown,
+      advisories,
+      history: [],
+      assessment: null,
+    };
+  }
+
+  private worstSeverityFromCounts(vulns: { low: number; medium: number; high: number; critical: number } | null): OspreySeverity | null {
+    if (!vulns) return null;
+    if (vulns.critical > 0) return 'critical';
+    if (vulns.high > 0) return 'high';
+    if (vulns.medium > 0) return 'medium';
+    if (vulns.low > 0) return 'low';
+    return null;
+  }
+
+  private getHighestVulnSeverity(advisories: OsspreyAdvisory[]): OspreySeverity | null {
+    if (!advisories.length) return null;
+    const order: OspreySeverity[] = ['critical', 'high', 'medium', 'low'];
+    for (const sev of order) {
+      if (advisories.some((a) => a.severity === sev)) return sev;
+    }
+    return null;
+  }
+
+  private mapAdvisories(advisories: CdpAdvisory[]): OsspreyAdvisory[] {
+    return advisories.map((adv) => ({
+      id: adv.osvId,
+      severity: adv.severity,
+      description: adv.osvId,
+      state: 'Open' as const,
+      cvss: null,
+      publishedAt: null,
+      affectedVersionRange: null,
+    }));
+  }
+
+  private calculateMonthsStale(lastCommitAt?: string | null): number | null {
+    if (!lastCommitAt) return null;
+    try {
+      return Math.floor((Date.now() - new Date(lastCommitAt).getTime()) / (1000 * 60 * 60 * 24 * 30));
+    } catch {
+      return null;
+    }
+  }
+
+  private formatNumber(num: number): string {
+    return num.toLocaleString('en-US');
+  }
+
+  private formatDate(isoDate?: string | null): string | null {
+    if (!isoDate) return null;
+    try {
+      return new Date(isoDate).toISOString().split('T')[0];
+    } catch {
+      return null;
+    }
+  }
+
+  private stripProtocol(url?: string | null): string | null {
+    return url ? url.replace(/^https?:\/\//, '') : null;
+  }
+}

--- a/check-headers.sh
+++ b/check-headers.sh
@@ -8,7 +8,7 @@
 # Exits with a 1 if one or more source files are missing a license header
 
 # These are the file patterns we should exclude - these are typically transient files not checked into source control
-exclude_pattern='node_modules|.vendor|.idea|gen|.venv|.ruff_cache|.pytest_cache|.angular|dist|playwright-report|test-results'
+exclude_pattern='node_modules|.vendor|.idea|gen|.venv|.ruff_cache|.pytest_cache|.angular|dist|playwright-report|test-results|design'
 
 files=()
 echo "Scanning source code..."

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -77,5 +77,7 @@ export const CDP_CONFIG = {
     MEMBER_PROJECT_AFFILIATIONS: (memberId: string) => `/v1/members/${memberId}/project-affiliations`,
     MEMBER_PROJECT_AFFILIATION: (memberId: string, projectId: string) => `/v1/members/${memberId}/project-affiliations/${projectId}`,
     ORGANIZATIONS: '/v1/organizations',
+    PACKAGES_LIST: '/v1/packages',
+    PACKAGE_DETAIL: '/v1/packages/detail',
   },
 } as const;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -99,6 +99,9 @@ export * from './sse.interface';
 // Copilot interfaces
 export * from './copilot.interface';
 
+// OSSPREY admin dashboard interfaces
+export * from './ossprey.interface';
+
 // Committee application interfaces
 export * from './committee-application.interface';
 

--- a/packages/shared/src/interfaces/ossprey.interface.ts
+++ b/packages/shared/src/interfaces/ossprey.interface.ts
@@ -1,0 +1,226 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export type OsspreyStatus = 'unassigned' | 'open' | 'assessing' | 'active' | 'needs_attention' | 'escalated' | 'blocked' | 'inactive';
+export type OsspreyLifecycle = 'active' | 'stable' | 'declining' | 'abandoned';
+export type OsspreyEcosystem = 'npm' | 'maven' | 'pypi' | 'go';
+export type OsspreyHealthBand = 'healthy' | 'fair' | 'concerning' | 'critical';
+export type OspreySeverity = 'critical' | 'high' | 'medium' | 'low';
+export type OspreySortKey = 'risk' | 'impact' | 'health' | 'vulns' | 'name';
+
+// ===== CDP Raw Types =====
+
+export interface CdpOpenVulns {
+  low: number;
+  medium: number;
+  high: number;
+  critical: number;
+}
+
+export interface CdpStewardshipSummary {
+  purl: string;
+  name: string;
+  ecosystem: string;
+  lifecycle: string | null;
+  health: number | null;
+  impact: number | null;
+  maintainerBusFactor: number | null;
+  openVulns: CdpOpenVulns | null;
+  stewardship: string;
+  steward: null;
+}
+
+export interface CdpPackagesListResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  filters: Record<string, unknown>;
+  sort: { by: string; dir: string };
+  packages: CdpStewardshipSummary[];
+}
+
+export interface OsspreyPackagesResponse {
+  packages: OsspreyPackage[];
+  total?: number | null;
+}
+
+export interface OsspreyListParams {
+  page?: number;
+  pageSize?: number;
+  ecosystem?: string;
+  lifecycle?: string;
+  busFactor1Only?: boolean;
+  staleOnly?: boolean;
+  unstewardedOnly?: boolean;
+  sortBy?: 'name' | 'health' | 'impact' | 'openVulns';
+  sortDir?: 'asc' | 'desc';
+}
+
+export interface OsspreyDashboardSortSpec {
+  sortBy: OsspreyListParams['sortBy'];
+  sortDir: OsspreyListParams['sortDir'];
+}
+
+export interface CdpAdvisory {
+  osvId: string;
+  severity: OspreySeverity;
+  resolution: string | null;
+}
+
+export interface CdpPackageDetail {
+  purl: string;
+  name: string;
+  ecosystem: string;
+  general: {
+    healthScore: {
+      maintainerHealth: number | null;
+      securitySupplyChain: number | null;
+      developmentActivity: number | null;
+      total: number | null;
+    } | null;
+    impact: {
+      impactScore: number | null;
+      downloadsLastMonth: number | null;
+      dependentPackages: number | null;
+      dependentRepos: number | null;
+      transitiveReach: string | null;
+    } | null;
+    riskSignals: {
+      lifecycle: string | null;
+      maintainerBusFactor: number | null;
+      lastRelease: string | null;
+      hasSecurityFile: boolean | null;
+      openSSFScorecard: number | null;
+    } | null;
+  } | null;
+  assessment: Record<string, unknown>;
+  security: {
+    securityContacts: unknown | null;
+    advisories: CdpAdvisory[];
+    cvd: {
+      isPvrEnabled: boolean | null;
+      hasSecurityPolicyEnabled: boolean | null;
+      tier0Steward: unknown | null;
+      criticalVulnerabilityFlag: boolean;
+    } | null;
+  } | null;
+  provenance: {
+    repositoryMapping: {
+      declaredRepo: string | null;
+      mappingConfidence: number | null;
+      lastCommitAt: string | null;
+    } | null;
+    supplyChainIntegrity: {
+      buildProvenance: unknown | null;
+      signedReleases: unknown | null;
+    } | null;
+  } | null;
+  history: Record<string, unknown>;
+}
+
+// ===== Frontend Types =====
+
+export interface OsspreyAdvisory {
+  id: string;
+  severity: OspreySeverity;
+  description: string;
+  state: 'Open' | 'Patched';
+  cvss?: number | null;
+  publishedAt?: string | null;
+  affectedVersionRange?: {
+    introduced?: string | null;
+    fixed?: string | null;
+    lastAffected?: string | null;
+  } | null;
+}
+
+export interface OsspreyHistoryEntry {
+  label: string;
+  timeAgo: string;
+  type?: 'danger' | 'success';
+}
+
+export interface OsspreyAssessment {
+  posture: string;
+  reviewed: boolean;
+  flagged: boolean;
+  flagNote?: string;
+  draft?: boolean;
+  findings: Array<[string, OspreySeverity | 'low', string]>;
+  remediation: string[];
+  monitoring: string[];
+}
+
+export interface OsspreyContactGroup {
+  name: string;
+  type: string;
+  count: number;
+  coverage: number;
+  packages: string[];
+  hasPvr: boolean;
+  hasSecurityMd: boolean;
+}
+
+export interface OsspreyPackage {
+  id: string;
+  name: string;
+  purl: string;
+  ecosystem: OsspreyEcosystem;
+  lifecycle: OsspreyLifecycle | null;
+  healthScore: number | null;
+  impactScore: number | null;
+  busFactor: number | null;
+  monthsStale: number | null;
+  vulnCount: number;
+  vulnSeverity: OspreySeverity | null;
+  status: OsspreyStatus;
+  stewardIds: string[];
+  lastActivityLabel: string;
+  lastActivityTime: string;
+  weeklyDownloads: string | null;
+  dependentCount: string | null;
+  directDependentCount: string | null;
+  scoreCardScore: string | null;
+  lastRelease: string | null;
+  lastCommit: string | null;
+  repoUrl: string | null;
+  supplyChainMapping: 'High' | 'Medium' | 'Low' | null;
+  provenance: 'Full' | 'Partial' | 'None' | null;
+  hasSecurityMd: boolean | null;
+  ecosystemReach: string | null;
+  contactGroup: OsspreyContactGroup | null;
+  healthBreakdown: string[];
+  assessment: OsspreyAssessment | null;
+  advisories: OsspreyAdvisory[];
+  history: OsspreyHistoryEntry[];
+}
+
+export interface OsspreyFilterState {
+  search: string;
+  tab: OsspreyStatus | 'all';
+  sort: OspreySortKey;
+  ecosystem: OsspreyEcosystem | '';
+  lifecycle: OsspreyLifecycle | '';
+  healthBand: OsspreyHealthBand | '';
+  vulnFilter: 'critical' | 'high' | 'any' | '';
+  busFactor1Only: boolean;
+  staleOnly: boolean;
+  unstewardedOnly: boolean;
+}
+
+export interface OsspreyStatusCounts {
+  all: number;
+  unassigned: number;
+  open: number;
+  assessing: number;
+  active: number;
+  needs_attention: number;
+  escalated: number;
+  blocked: number;
+  inactive: number;
+}
+
+export interface OsspreyFilterChip {
+  label: string;
+  clear: Partial<OsspreyFilterState>;
+}


### PR DESCRIPTION
## Summary

- `OsspreyDashboardComponent` — page shell with KPI strip (total packages, coverage %, unassigned/needs-attention/escalated counts), filter state management, bulk-actions bar, and drawer integration
- `OsspreyPackageDrawerComponent` — slide-in detail panel showing health breakdown, advisories, impact scores, and stewardship info for a selected package
- `ossprey.routes.ts` lazy-loaded route module, wired into `app.routes.ts` and main-layout navigation

## Part of

This is PR 3/3 in a stacked series targeting `release/CM-1223-ossprey-admin-dashboard`. Depends on PRs 1/3 and 2/3. Merge order: 1 → 2 → 3.

## Protected file changes (intentional)

- `angular.json` — component style budget bumped (6→20kB) to accommodate the packages tab SCSS
- `server.ts` — ossprey route registered at `/api/ossprey`
- `check-headers.sh` — `design/` added to license-check exclude pattern