### PR TITLE
feat(board-members): add Org Lens People -> Board tab (LFXV2-1871)

### DIFF
--- a/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
@@ -114,21 +114,21 @@ async function stubAccountContext(page: Page, opts: { writers: string[] } = { wr
 }
 
 async function stubBoardMembers(page: Page, body: unknown = boardMembersResponse()): Promise<void> {
-  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members$/, (route) => {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members(?:\?.*)?$/, (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
   });
 }
 
 async function stubEmployees(page: Page, employees: unknown[] = MOCK_EMPLOYEES, status = 200): Promise<void> {
-  await page.route(/\/api\/orgs\/[^/]+\/lens\/employees$/, (route) => {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/employees(?:\?.*)?$/, (route) => {
     return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees }) });
   });
 }
 
 /** Stubs the PATCH board reassign proxy; the handler decides what to return per request. */
 async function stubReassignPatch(page: Page, handler: (route: Route) => Promise<void> | void): Promise<void> {
-  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members\/[^/]+\/reassign$/, async (route) => {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members\/[^/]+\/reassign(?:\?.*)?$/, async (route) => {
     if (route.request().method() !== 'PATCH') return route.fallback();
     await handler(route);
   });

--- a/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
@@ -1,0 +1,406 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** People → Board tab reassign E2E (spec 028 US3 bulk modal + US4 single-edit modal). Deterministic via route mocks. */
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const PEOPLE_BOARD_URL = '/org/people?tab=board';
+const DATA_LOAD_TIMEOUT = 30_000;
+const TOAST_TIMEOUT = 10_000;
+
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = MOCK_ACCOUNT_ID;
+const MOCK_ACCOUNT_NAME = 'Toyota';
+const MOCK_ACCOUNT_SLUG = 'toyota';
+
+const MASAKI_EMAIL = 'masaki.isetani@toyota.com';
+const KENSUKE_EMAIL = 'kensuke.hanaoka@toyota.com';
+const REPLACEMENT_EMAIL = 'cara.dev@toyota.com';
+
+const MASAKI = { email: MASAKI_EMAIL, firstName: 'Masaki', lastName: 'Isetani', fullName: 'Masaki Isetani', jobTitle: 'Senior Manager', initials: 'MI' };
+const KENSUKE = { email: KENSUKE_EMAIL, firstName: 'Kensuke', lastName: 'Hanaoka', fullName: 'Kensuke Hanaoka', jobTitle: 'Engineer', initials: 'KH' };
+
+function masakiSeat(uid: string, foundationName: string, foundationSlug: string, projectUid: string, votingStatus: string) {
+  return {
+    seatId: uid,
+    memberUid: uid,
+    committeeUid: `c-${uid}`,
+    committeeName: 'Steering Committee',
+    committeeCategory: 'Board',
+    projectUid,
+    foundationSlug,
+    foundationName,
+    role: '',
+    votingStatus,
+    appointedBy: 'Membership Entitlement',
+    isOrgEditable: true,
+    reason: null,
+    person: MASAKI,
+  };
+}
+
+function boardMembersResponse() {
+  return {
+    orgUid: MOCK_UID,
+    assignments: [
+      masakiSeat('m-masaki-agl', 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
+      masakiSeat('m-masaki-hl', 'Hyperledger Foundation', 'hyperledger-foundation', 'hl-root', 'Non-voting'),
+      {
+        seatId: 'm-kensuke',
+        memberUid: 'm-kensuke',
+        committeeUid: 'c-kensuke',
+        committeeName: 'Steering Committee',
+        committeeCategory: 'Board',
+        projectUid: 'agl-root',
+        foundationSlug: 'automotive-grade-linux',
+        foundationName: 'Automotive Grade Linux',
+        role: '',
+        votingStatus: 'Non-voting',
+        appointedBy: 'Board Election',
+        isOrgEditable: false,
+        reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
+        person: KENSUKE,
+      },
+    ],
+    stats: { totalBoardMembers: 2, votingCount: 1, nonVotingCount: 2, foundationsCovered: 2 },
+  };
+}
+
+const MOCK_EMPLOYEES = [
+  { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: 'Senior Engineer', initials: 'CD' },
+  { email: 'evan.qa@toyota.com', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
+];
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+async function stubAccountContext(page: Page, opts: { writers: string[] } = { writers: [MOCK_UID] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_UID }],
+        isRootWriter: false,
+      }),
+    })
+  );
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: opts.writers,
+        auditors: [],
+        cascadingWriters: [],
+        cascadingAuditors: [],
+        username: 'e2e-org-people-board-reassign',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubBoardMembers(page: Page, body: unknown = boardMembersResponse()): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function stubEmployees(page: Page, employees: unknown[] = MOCK_EMPLOYEES, status = 200): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/employees$/, (route) => {
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees }) });
+  });
+}
+
+/** Stubs the PATCH board reassign proxy; the handler decides what to return per request. */
+async function stubReassignPatch(page: Page, handler: (route: Route) => Promise<void> | void): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members\/[^/]+\/reassign$/, async (route) => {
+    if (route.request().method() !== 'PATCH') return route.fallback();
+    await handler(route);
+  });
+}
+
+function reassignedSeatBody(seatId: string) {
+  return {
+    orgUid: MOCK_UID,
+    seat: {
+      ...masakiSeat(seatId, 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
+      person: { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: null, initials: 'CD' },
+    },
+  };
+}
+
+async function gotoBoardTab(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PEOPLE_BOARD_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  if (!page.url().includes('/org/people')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/people redirected away');
+  }
+  await expect(page.getByTestId('org-people-panel-board')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.setTimeout(120_000);
+
+test.describe('Org People → Board — Reassign Board Roles modal (US3)', () => {
+  test('opens with the expected anatomy and reflects the fixture counts', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+
+    const modal = page.getByTestId('org-people-board-modal-reassign');
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId('org-people-board-modal-reassign-title')).toHaveText('Reassign Board Roles');
+    await expect(page.getByTestId('org-people-board-modal-reassign-subtitle')).toHaveText('2 roles across 2 foundations');
+    await expect(modal.locator('[data-testid^="org-people-board-modal-reassign-role-row-"]')).toHaveCount(2);
+    await expect(page.getByTestId('org-people-board-modal-reassign-primary-button')).toContainText('Save Changes (2 roles)');
+  });
+
+  test('deselecting a role updates the Save button count', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-modal-reassign-role-checkbox-m-masaki-hl').click();
+    await expect(page.getByTestId('org-people-board-modal-reassign-primary-button')).toContainText('Save Changes (1 role)');
+  });
+
+  test('Save is disabled until Email / First / Last are filled', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await expect(page.getByTestId('org-people-board-modal-reassign-primary-button')).toBeDisabled();
+  });
+
+  test('valid Save fans out N PATCHes and refreshes', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      const url = route.request().url();
+      const seatId = url.split('/board-members/')[1].split('/reassign')[0];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody(seatId)) });
+    });
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-board-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-board-toast-success')).toBeVisible({ timeout: TOAST_TIMEOUT });
+    expect(patchCount).toBe(2);
+  });
+
+  test('a 409 on one PATCH closes the modal and surfaces a partial-success warning toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) => {
+      const url = route.request().url();
+      if (url.includes('/m-masaki-hl/')) {
+        return route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { message: 'seat changed since you opened the dialog' } }),
+        });
+      }
+      const seatId = url.split('/board-members/')[1].split('/reassign')[0];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody(seatId)) });
+    });
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-board-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-board-modal-reassign')).toHaveCount(0, { timeout: TOAST_TIMEOUT });
+    await expect(page.getByTestId('org-people-board-toast-success')).toContainText('succeeded', { timeout: TOAST_TIMEOUT });
+  });
+
+  test('all PATCHes failing surfaces the cleaned error and keeps the modal open', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: { message: 'Reassignment failed — please retry.' } }) })
+    );
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-board-modal-reassign-primary-button').click();
+
+    await expect(page.getByTestId('org-people-board-modal-reassign-save-error')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-modal-reassign')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-toast-success')).toHaveCount(0);
+  });
+});
+
+test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
+  test('opens scoped to one seat with the chip header + current member', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+
+    const modal = page.getByTestId('org-people-board-modal-edit');
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId('org-people-board-modal-edit-title')).toHaveText('Edit Board Role');
+    await expect(page.getByTestId('org-people-board-modal-edit-chips')).toContainText('Automotive Grade Linux');
+    await expect(page.getByTestId('org-people-board-modal-edit-current')).toContainText('Masaki Isetani');
+  });
+
+  test('Save fires exactly one PATCH and shows a success toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-masaki-agl')) });
+    });
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId('org-people-board-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-board-modal-edit-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-board-modal-edit-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-board-modal-edit-primary-button').click();
+
+    await expect(page.getByTestId('org-people-board-toast-success')).toBeVisible({ timeout: TOAST_TIMEOUT });
+    expect(patchCount).toBe(1);
+  });
+
+  test('a 5xx save keeps the Edit modal open with an inline error and no success toast', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    await stubReassignPatch(page, (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: { message: 'Reassignment failed — please retry.' } }) })
+    );
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId('org-people-board-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
+    await page.getByTestId('org-people-board-modal-edit-first-name-input').fill('Cara');
+    await page.getByTestId('org-people-board-modal-edit-last-name-input').fill('Dev');
+    await page.getByTestId('org-people-board-modal-edit-primary-button').click();
+
+    await expect(page.getByTestId('org-people-board-modal-edit-save-error')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-modal-edit')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-toast-success')).toHaveCount(0);
+  });
+
+  test('foundation-controlled sub-row shows "Why can\'t I edit?" instead of an Edit pencil', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`).click();
+    await expect(page.getByTestId('org-people-board-why-m-kensuke')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-edit-m-kensuke')).toHaveCount(0);
+  });
+
+  test('ArrowDown + Enter on the employee combobox selects the highlighted option (keyboard a11y)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+
+    const emailInput = page.getByTestId('org-people-board-modal-edit-email-input');
+    await emailInput.fill('toyota.com');
+    await emailInput.press('ArrowDown');
+
+    // The first option in the listbox is highlighted; aria-activedescendant on the input points to its id.
+    await expect(emailInput).toHaveAttribute('aria-activedescendant', 'edit-board-employee-option-0');
+
+    await emailInput.press('Enter');
+
+    // Selecting via keyboard fills the email + name fields just like the click handler does.
+    await expect(emailInput).toHaveValue(REPLACEMENT_EMAIL);
+    await expect(page.getByTestId('org-people-board-modal-edit-first-name-input')).toHaveValue('Cara');
+    await expect(page.getByTestId('org-people-board-modal-edit-last-name-input')).toHaveValue('Dev');
+  });
+
+  test('ArrowDown + Enter on the bulk Reassign combobox selects the highlighted option (keyboard a11y)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+
+    const emailInput = page.getByTestId('org-people-board-modal-reassign-email-input');
+    await emailInput.fill('toyota.com');
+    await emailInput.press('ArrowDown');
+    await expect(emailInput).toHaveAttribute('aria-activedescendant', 'reassign-board-employee-option-0');
+
+    await emailInput.press('Enter');
+    await expect(emailInput).toHaveValue(REPLACEMENT_EMAIL);
+    await expect(page.getByTestId('org-people-board-modal-reassign-first-name-input')).toHaveValue('Cara');
+    await expect(page.getByTestId('org-people-board-modal-reassign-last-name-input')).toHaveValue('Dev');
+  });
+
+  test('Cancel closes the Edit modal without firing a PATCH', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+    await stubEmployees(page);
+    let patchCount = 0;
+    await stubReassignPatch(page, (route) => {
+      patchCount += 1;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-masaki-agl')) });
+    });
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await expect(page.getByTestId('org-people-board-modal-edit')).toBeVisible();
+
+    await page.getByTestId('org-people-board-modal-edit-cancel').click();
+    await expect(page.getByTestId('org-people-board-modal-edit')).toHaveCount(0);
+    expect(patchCount).toBe(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/** People → Board tab reassign E2E (spec 028 US3 bulk modal + US4 single-edit modal). Deterministic via route mocks. */
+/** People → Board tab reassign E2E (bulk reassign modal + single-edit modal). Deterministic via route mocks. */
 
 import { expect, Page, Route, test } from '@playwright/test';
 

--- a/apps/lfx-one/e2e/org-people-board-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-tab.spec.ts
@@ -1,0 +1,309 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** People → Board tab E2E (spec 028 US1 read + US2 filter/expand/sort). Deterministic via route mocks. Inverted-filter sibling of org-people-committee-tab.spec.ts. */
+
+import { expect, Page, test } from '@playwright/test';
+
+const PEOPLE_BOARD_URL = '/org/people?tab=board';
+const DATA_LOAD_TIMEOUT = 30_000;
+
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+const MOCK_UID = MOCK_ACCOUNT_ID;
+const MOCK_ACCOUNT_NAME = 'Toyota';
+const MOCK_ACCOUNT_SLUG = 'toyota';
+
+// SC-001 dev-mode budget multiplier — `ng serve` adds 3–10× per interaction vs the production build.
+const PERF_DEV_MULTIPLIER = 5;
+
+const KENSUKE_EMAIL = 'kensuke.hanaoka@toyota.com';
+const KENTA_EMAIL = 'kenta.tada@toyota.com';
+const MASAKI_EMAIL = 'masaki.isetani@toyota.com';
+const YASUSHI_EMAIL = 'yasushi.ando@toyota.com';
+
+// Models the Toyota board screenshot: 4 members, 2 voting + 3 non-voting seats, 3 foundations.
+// Kensuke + Yasushi are foundation-controlled (read-only → "Why can't I edit?"); Kenta + Masaki hold
+// Membership-Entitlement seats (editable). Masaki spans 2 foundations with mixed voting status.
+function boardMembersResponse() {
+  const seat = (
+    uid: string,
+    committeeName: string,
+    projectUid: string,
+    foundationName: string,
+    foundationSlug: string,
+    votingStatus: string,
+    isOrgEditable: boolean,
+    person: { email: string; firstName: string; lastName: string; fullName: string; jobTitle: string; initials: string }
+  ) => ({
+    seatId: uid,
+    memberUid: uid,
+    committeeUid: `c-${uid}`,
+    committeeName,
+    committeeCategory: 'Board',
+    projectUid,
+    foundationSlug,
+    foundationName,
+    role: '',
+    votingStatus,
+    appointedBy: isOrgEditable ? 'Membership Entitlement' : 'Board Election',
+    isOrgEditable,
+    reason: isOrgEditable ? null : "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
+    person,
+  });
+  const kensuke = { email: KENSUKE_EMAIL, firstName: 'Kensuke', lastName: 'Hanaoka', fullName: 'Kensuke Hanaoka', jobTitle: 'Engineer', initials: 'KH' };
+  const kenta = { email: KENTA_EMAIL, firstName: 'Kenta', lastName: 'Tada', fullName: 'Kenta Tada', jobTitle: 'Principal Software Engineer', initials: 'KT' };
+  const masaki = {
+    email: MASAKI_EMAIL,
+    firstName: 'Masaki',
+    lastName: 'Isetani',
+    fullName: 'Masaki Isetani',
+    jobTitle: 'Senior Manager, Open Source Strategy',
+    initials: 'MI',
+  };
+  const yasushi = {
+    email: YASUSHI_EMAIL,
+    firstName: 'Yasushi',
+    lastName: 'Ando',
+    fullName: 'Yasushi Ando',
+    jobTitle: 'Distinguished Engineer',
+    initials: 'YA',
+  };
+  return {
+    orgUid: MOCK_UID,
+    assignments: [
+      seat('m-kensuke', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, kensuke),
+      seat('m-kenta', 'Governing Board', 'ebpf-root', 'eBPF Foundation', 'ebpf-foundation', 'Voting', true, kenta),
+      seat('m-masaki-agl', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Voting', true, masaki),
+      seat('m-masaki-hl', 'Governing Board', 'hl-root', 'Hyperledger Foundation', 'hyperledger-foundation', 'Non-voting', true, masaki),
+      seat('m-yasushi', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, yasushi),
+    ],
+    stats: { totalBoardMembers: 4, votingCount: 2, nonVotingCount: 3, foundationsCovered: 3 },
+  };
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+async function stubAccountContext(page: Page, opts: { writers: string[]; auditors?: string[] } = { writers: [MOCK_UID] }): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['contributor'],
+        personaProjects: {},
+        projects: [],
+        organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_UID }],
+        isRootWriter: false,
+      }),
+    })
+  );
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        writers: opts.writers,
+        auditors: opts.auditors ?? [],
+        cascadingWriters: [],
+        cascadingAuditors: [],
+        username: 'e2e-org-people-board',
+        loaded_at: new Date().toISOString(),
+      }),
+    })
+  );
+}
+
+async function stubBoardMembers(page: Page, body: unknown = boardMembersResponse(), status = 200): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+async function gotoBoardTab(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(PEOPLE_BOARD_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  if (!page.url().includes('/org/people')) {
+    test.skip(true, 'org-lens-enabled flag appears off — /org/people redirected away');
+  }
+  await expect(page.getByTestId('org-people-panel-board')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+}
+
+test.setTimeout(120_000);
+
+test.describe('Org People → Board tab (spec 028 US1 + US2)', () => {
+  test('renders the org board roster grouped by person with correct stats (SC-001 perf + SC-004 counts)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    const start = Date.now();
+    await gotoBoardTab(page);
+    await expect(page.getByTestId('org-people-board-stat-total')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    const elapsed = Date.now() - start;
+    // eslint-disable-next-line no-console
+    console.log(`[SC-001] board tab load → stats visible: ${elapsed} ms (prod budget 3000 ms; dev allowance ${3000 * PERF_DEV_MULTIPLIER} ms)`);
+    expect(elapsed).toBeLessThan(3000 * PERF_DEV_MULTIPLIER);
+
+    // One row per person (4 members).
+    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`)).toBeVisible();
+
+    // SC-004: total tile == distinct row count; voting + non-voting == total seat count.
+    const total = await page.getByTestId('org-people-board-stat-total').innerText();
+    const rowCount = await page.locator('[data-testid^="org-people-board-row-"]').count();
+    expect(parseInt(total, 10)).toBe(rowCount);
+    expect(await page.getByTestId('org-people-board-stat-voting').innerText()).toContain('2');
+    expect(await page.getByTestId('org-people-board-stat-nonvoting').innerText()).toContain('3');
+    expect(await page.getByTestId('org-people-board-stat-foundations').innerText()).toContain('3');
+
+    // FR-024 provenance caption.
+    await expect(page.getByTestId('org-people-board-source-caption')).toContainText('LFX Membership Board Representatives');
+  });
+
+  test('single-seat member shows one verbatim voting pill; multi-foundation member shows aggregate count pills', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    // Kensuke holds one board seat → a single "Non-voting" pill.
+    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toContainText('Non-voting');
+    // Masaki holds 2 foundations with mixed voting → "1 Voting" + "1 Non-voting" count pills + a Foundations badge.
+    const masaki = page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`);
+    await expect(masaki).toContainText('1 Voting');
+    await expect(masaki).toContainText('1 Non-voting');
+    await expect(masaki).toContainText('2 Foundations');
+  });
+
+  test('renders the empty state for an org with no board seats', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page, {
+      orgUid: MOCK_UID,
+      assignments: [],
+      stats: { totalBoardMembers: 0, votingCount: 0, nonVotingCount: 0, foundationsCovered: 0 },
+    });
+
+    await gotoBoardTab(page);
+    await expect(page.getByTestId('org-people-board-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('fetch failure renders the error state with a Retry button', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page, { error: { message: 'boom' } }, 500);
+
+    await gotoBoardTab(page);
+    await expect(page.getByTestId('org-people-board-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('foundation-controlled seat shows "Why can\'t I edit?" instead of a Reassign pencil', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    // Kensuke is foundation-controlled → no enabled pencil, the "Why can't I edit?" affordance instead.
+    await expect(page.getByTestId(`org-people-board-why-${KENSUKE_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-reassign-${KENSUKE_EMAIL}`)).toHaveCount(0);
+    // Kenta holds an entitlement seat → the live Reassign pencil.
+    await expect(page.getByTestId(`org-people-board-reassign-${KENTA_EMAIL}`)).toBeVisible();
+  });
+
+  test('clicking "Why can\'t I edit?" opens the explanatory modal and "Got it" closes it', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-why-${KENSUKE_EMAIL}`).click();
+
+    const modal = page.getByTestId('org-people-board-modal-why');
+    await expect(modal).toBeVisible();
+    await expect(page.getByTestId('org-people-board-modal-why-title')).toHaveText("Why can't I edit this member?");
+    await expect(page.getByTestId('org-people-board-modal-why-body')).not.toBeEmpty();
+
+    await page.getByTestId('org-people-board-modal-why-got-it').click();
+    await expect(page.getByTestId('org-people-board-modal-why')).toHaveCount(0);
+  });
+
+  test('as an auditor (read-only), every row shows "Why can\'t I edit?" and no enabled pencil', async ({ page }) => {
+    await stubAccountContext(page, { writers: [], auditors: [MOCK_UID] });
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await expect(page.getByTestId(`org-people-board-why-${KENTA_EMAIL}`)).toBeVisible();
+    await expect(page.locator('[data-testid^="org-people-board-reassign-"]')).toHaveCount(0);
+  });
+
+  test('expands Masaki and shows 2 board sub-rows (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+
+    const expanded = page.getByTestId(`org-people-board-expanded-${MASAKI_EMAIL}`);
+    await expect(expanded).toBeVisible();
+    await expect(expanded.locator('[data-testid^="org-people-board-subrow-"]')).toHaveCount(2);
+  });
+
+  test('search narrows to the matching person row (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId('org-people-board-search-input').locator('input').fill('Hanaoka');
+
+    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toHaveCount(0);
+  });
+
+  test('foundation filter narrows the rows (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId('org-people-board-foundation-filter').click();
+    await page.getByRole('option', { name: 'eBPF Foundation', exact: true }).click();
+
+    // Only people with an eBPF board seat (Kenta) remain.
+    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toHaveCount(0);
+  });
+
+  test('status filter "Voting" narrows to people with a voting board seat (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByTestId('org-people-board-status-filter').click();
+    await page.getByRole('option', { name: 'Voting', exact: true }).click();
+
+    // Kenta (voting) + Masaki (one voting seat) remain; Kensuke + Yasushi (non-voting only) removed.
+    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${YASUSHI_EMAIL}`)).toHaveCount(0);
+  });
+
+  test('sort by Foundations desc puts the most-foundations person first (US2)', async ({ page }) => {
+    await stubAccountContext(page);
+    await stubBoardMembers(page);
+
+    await gotoBoardTab(page);
+    await page.getByRole('button', { name: /Foundations/i }).click();
+
+    const firstRow = page.locator('[data-testid^="org-people-board-row-"]').first();
+    // Masaki holds 2 foundations — the max — so descending sort floats them to the top.
+    await expect(firstRow).toHaveAttribute('data-testid', `org-people-board-row-${MASAKI_EMAIL}`);
+  });
+});

--- a/apps/lfx-one/e2e/org-people-board-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-tab.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/** People → Board tab E2E (spec 028 US1 read + US2 filter/expand/sort). Deterministic via route mocks. Inverted-filter sibling of org-people-committee-tab.spec.ts. */
+/** People → Board tab E2E (read + filter/expand/sort). Deterministic via route mocks. Inverted-filter sibling of org-people-committee-tab.spec.ts. */
 
 import { expect, Page, test } from '@playwright/test';
 
@@ -145,7 +145,7 @@ async function gotoBoardTab(page: Page): Promise<void> {
 
 test.setTimeout(120_000);
 
-test.describe('Org People → Board tab (spec 028 US1 + US2)', () => {
+test.describe('Org People → Board tab', () => {
   test('renders the org board roster grouped by person with correct stats (SC-001 perf + SC-004 counts)', async ({ page }) => {
     await stubAccountContext(page);
     await stubBoardMembers(page);

--- a/apps/lfx-one/e2e/org-people-board-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-tab.spec.ts
@@ -165,7 +165,7 @@ test.describe('Org People → Board tab', () => {
     // SC-004: total tile == distinct row count; voting + non-voting == total seat count.
     const total = await page.getByTestId('org-people-board-stat-total').innerText();
     const rowCount = await page.locator('[data-testid^="org-people-board-row-"]').count();
-    expect(parseInt(total, 10)).toBe(rowCount);
+    expect(Number(total.replace(/,/g, ''))).toBe(rowCount);
     expect(await page.getByTestId('org-people-board-stat-voting').innerText()).toContain('2');
     expect(await page.getByTestId('org-people-board-stat-nonvoting').innerText()).toContain('3');
     expect(await page.getByTestId('org-people-board-stat-foundations').innerText()).toContain('3');

--- a/apps/lfx-one/e2e/org-people-board-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-tab.spec.ts
@@ -123,7 +123,7 @@ async function stubAccountContext(page: Page, opts: { writers: string[]; auditor
 }
 
 async function stubBoardMembers(page: Page, body: unknown = boardMembersResponse(), status = 200): Promise<void> {
-  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members$/, (route) => {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/board-members(?:\?.*)?$/, (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
   });
@@ -206,6 +206,10 @@ test.describe('Org People → Board tab', () => {
 
     await gotoBoardTab(page);
     await expect(page.getByTestId('org-people-board-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // The error state's recovery affordance is the shared empty-state CTA button labelled "Retry".
+    const retry = page.getByRole('button', { name: /Retry/i });
+    await expect(retry).toBeVisible();
+    await expect(retry).toBeEnabled();
   });
 
   test('foundation-controlled seat shows "Why can\'t I edit?" instead of a Reassign pencil', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.html
@@ -1,0 +1,286 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-toast position="top-right" key="org-people-board-toast-success" data-testid="org-people-board-toast-success" />
+
+<div class="flex flex-col gap-6" data-testid="org-people-board">
+  <!-- Filter bar -->
+  <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4" data-testid="org-people-board-filter-bar">
+    <div class="flex-1">
+      <lfx-input-text
+        [form]="filterForm"
+        control="search"
+        placeholder="Search board members..."
+        icon="fa-light fa-magnifying-glass"
+        styleClass="w-full"
+        size="small"
+        dataTest="org-people-board-search-input" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="foundation"
+        size="small"
+        [options]="foundationOptions()"
+        styleClass="w-full"
+        ariaLabel="Filter by foundation"
+        dataTest="org-people-board-foundation-filter" />
+    </div>
+    <div class="w-full md:w-56">
+      <lfx-select
+        [form]="filterForm"
+        control="status"
+        size="small"
+        [options]="statusOptions"
+        styleClass="w-full"
+        ariaLabel="Filter by voting status"
+        dataTest="org-people-board-status-filter" />
+    </div>
+  </div>
+
+  @if (fetchError()) {
+    <div role="alert" data-testid="org-people-board-error">
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-triangle-exclamation"
+        title="Failed to load board members"
+        subtitle="Please try again."
+        ctaLabel="Retry"
+        ctaIcon="fa-light fa-arrow-rotate-left"
+        (ctaClick)="retry()" />
+    </div>
+  } @else {
+    <!-- Stat cards -->
+    <div class="grid grid-cols-2 gap-4 lg:grid-cols-4" data-testid="org-people-board-stats">
+      @if (isLoading()) {
+        @for (label of statSkeletonLabels; track label) {
+          <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-board-stat-skeleton">
+            <p-skeleton width="3rem" height="1.5rem" />
+            <div class="mt-2 text-xs text-gray-500">{{ label }}</div>
+          </div>
+        }
+      } @else {
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-board-stat-total">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().totalBoardMembers | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Total Board Members</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-board-stat-voting">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().votingCount | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Voting</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-board-stat-nonvoting">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().nonVotingCount | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Non-voting</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="org-people-board-stat-foundations">
+          <div class="text-2xl font-semibold leading-none text-gray-900">{{ stats().foundationsCovered | number }}</div>
+          <div class="mt-1 text-xs text-gray-500">Foundations with a board member</div>
+        </div>
+      }
+    </div>
+
+    <!-- Table -->
+    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white" data-testid="org-people-board-table">
+      @if (isLoading()) {
+        <div class="divide-y divide-gray-100" data-testid="org-people-board-table-skeleton">
+          @for (i of tableSkeletonRows; track i) {
+            <div class="flex items-center gap-4 px-4 py-3">
+              <p-skeleton width="1rem" height="1rem" />
+              <div class="flex flex-1 flex-col gap-2">
+                <p-skeleton width="40%" height="0.875rem" />
+                <p-skeleton width="25%" height="0.75rem" />
+              </div>
+              <p-skeleton width="8rem" height="1.25rem" />
+              <p-skeleton width="6rem" height="1.25rem" borderRadius="9999px" />
+            </div>
+          }
+        </div>
+      } @else if (decoratedGroups().length === 0) {
+        <div class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center" data-testid="org-people-board-empty">
+          <i class="fa-light fa-user-tie text-2xl text-gray-300" aria-hidden="true"></i>
+          @if (isFiltering()) {
+            <p class="text-sm text-gray-700">No board members match the current filters.</p>
+            <p class="text-xs text-gray-500">Try clearing the search or changing the dropdown selections.</p>
+          } @else {
+            <p class="text-sm text-gray-700">No board members found.</p>
+            <p class="text-xs text-gray-500">Board members are sourced from LFX membership board representatives.</p>
+          }
+        </div>
+      } @else {
+        <table class="w-full text-sm" data-testid="org-people-board-rows">
+          <thead class="bg-gray-50">
+            <tr class="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th class="w-7 px-2 py-3"></th>
+              @let aria = ariaSortMap();
+              @let icons = sortIconMap();
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.name">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('name')">
+                  Name
+                  <i [class]="icons.name" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium" [attr.aria-sort]="aria.foundations">
+                <button
+                  type="button"
+                  class="inline-flex w-full items-center gap-1 bg-transparent p-0 text-left text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  (click)="onSort('foundations')">
+                  Foundations
+                  <i [class]="icons.foundations" aria-hidden="true"></i>
+                </button>
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium">Voting Status</th>
+              <th class="w-32 px-4 py-3 text-right">
+                <span class="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (group of decoratedGroups(); track group.email) {
+              @let expanded = !!expansion()[group.email];
+              <tr
+                class="cursor-pointer border-b border-gray-100 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                role="button"
+                tabindex="0"
+                [attr.aria-expanded]="expanded"
+                [attr.aria-label]="'Toggle board details for ' + group.displayName"
+                [attr.data-testid]="'org-people-board-row-' + group.email"
+                (click)="toggleExpansion(group.email)"
+                (keydown)="onRowKeydown($event, group.email)">
+                <td class="px-2 py-3 align-middle">
+                  <i
+                    class="fa-light fa-chevron-right text-gray-400 transition-transform"
+                    [class.rotate-90]="expanded"
+                    [attr.data-testid]="'org-people-board-expand-' + group.email"
+                    aria-hidden="true"></i>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">
+                      {{ group.initials }}
+                    </div>
+                    <div>
+                      <div class="font-medium text-gray-900">{{ group.displayName }}</div>
+                      @if (group.jobTitle) {
+                        <div class="text-xs text-gray-500">{{ group.jobTitle }}</div>
+                      }
+                    </div>
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  @if (group.foundationLabels.length === 1) {
+                    <span class="text-sm text-gray-700" [attr.data-testid]="'org-people-board-foundation-pill-' + group.foundationLabels[0]">{{
+                      group.foundationLabels[0]
+                    }}</span>
+                  } @else {
+                    <span
+                      class="inline-block rounded-full border border-gray-200 bg-gray-50 px-2.5 py-0.5 text-xs font-medium text-gray-600"
+                      [attr.data-testid]="'org-people-board-foundation-count-' + group.email">
+                      {{ group.foundationLabels.length }} Foundations
+                    </span>
+                  }
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    @for (pill of group.votingPills; track pill.label) {
+                      <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="pill.pillClass">{{ pill.label }}</span>
+                    }
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  @if (canEdit() && group.editableCount > 0) {
+                    <span class="inline-flex" [pTooltip]="group.reassignTooltip" tooltipPosition="left">
+                      <button
+                        type="button"
+                        class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        [attr.aria-label]="'Reassign board roles for ' + group.displayName"
+                        [attr.data-testid]="'org-people-board-reassign-' + group.email"
+                        (click)="onMainPencilClick(group, $event)">
+                        <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                      </button>
+                    </span>
+                  } @else {
+                    <button
+                      type="button"
+                      class="text-xs font-medium text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      [pTooltip]="group.reassignTooltip"
+                      tooltipPosition="left"
+                      [attr.aria-label]="group.reassignTooltip"
+                      [attr.data-testid]="'org-people-board-why-' + group.email"
+                      (click)="onWhyCantEdit(group.reassignTooltip, $event)">
+                      Why can't I edit?
+                    </button>
+                  }
+                </td>
+              </tr>
+              @if (expanded) {
+                <tr class="bg-slate-50" [attr.data-testid]="'org-people-board-expanded-' + group.email">
+                  <td colspan="5" class="p-0 pl-11">
+                    <table class="w-full border-collapse">
+                      <thead>
+                        <tr class="border-b border-gray-200 bg-slate-100 text-left text-xs font-semibold uppercase text-gray-400">
+                          <th class="px-4 py-2.5">Foundation</th>
+                          <th class="px-4 py-2.5">Board / Committee</th>
+                          <th class="px-4 py-2.5">Voting Status</th>
+                          <th class="w-32 px-4 py-2.5 text-right">
+                            <span class="sr-only">Edit</span>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        @for (assignment of group.sortedAssignments; track assignment.seatId) {
+                          <tr class="border-b border-gray-200" [attr.data-testid]="'org-people-board-subrow-' + assignment.seatId">
+                            <td class="px-4 py-2.5 text-sm font-medium text-gray-900">
+                              @if (assignment.showFoundationLabel) {
+                                {{ assignment.foundationName }}
+                              }
+                            </td>
+                            <td class="px-4 py-2.5 text-sm text-gray-700">{{ assignment.committeeName }}</td>
+                            <td class="px-4 py-2.5">
+                              <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="assignment.votingStatusPillClass">
+                                {{ assignment.votingStatus || 'Non-voting' }}
+                              </span>
+                            </td>
+                            <td class="px-4 py-2.5 text-right">
+                              @if (canEdit() && assignment.isOrgEditable) {
+                                <span class="inline-flex" [pTooltip]="assignment.editTooltip" tooltipPosition="top">
+                                  <button
+                                    type="button"
+                                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                                    [attr.aria-label]="'Edit ' + assignment.committeeName"
+                                    [attr.data-testid]="'org-people-board-edit-' + assignment.seatId"
+                                    (click)="onSubRowPencilClick(assignment, $event)">
+                                    <i class="fa-light fa-pencil" aria-hidden="true"></i>
+                                  </button>
+                                </span>
+                              } @else {
+                                <button
+                                  type="button"
+                                  class="text-xs font-medium text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                                  [pTooltip]="assignment.editTooltip"
+                                  tooltipPosition="top"
+                                  [attr.aria-label]="assignment.editTooltip"
+                                  [attr.data-testid]="'org-people-board-why-' + assignment.seatId"
+                                  (click)="onWhyCantEdit(assignment.editTooltip, $event)">
+                                  Why can't I edit?
+                                </button>
+                              }
+                            </td>
+                          </tr>
+                        }
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              }
+            }
+          </tbody>
+        </table>
+      }
+    </div>
+
+    <p class="text-xs text-gray-400" data-testid="org-people-board-source-caption">{{ sourceCaption }}</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
@@ -47,7 +47,7 @@ import { ReassignBoardRolesModalComponent } from './components/reassign-board-ro
 import { WhyCantEditBoardModalComponent } from './components/why-cant-edit-board-modal.component';
 import { buildBoardPersonGroups, decorateBoardPersonGroup } from './helpers/board-members.helper';
 
-/** Org Lens — People → Board tab (spec 028). Org-wide, Board-only roster grouped by person, with filter/sort/expand (US1+US2) and Reassign/Edit modals (US3/US4). Inverted-filter sibling of the spec-027 Committee tab. */
+/** Org Lens — People → Board tab. Org-wide, Board-only roster grouped by person, with filter/sort/expand and Reassign/Edit modals. Inverted-filter sibling of the Committee tab. */
 @Component({
   selector: 'lfx-org-people-board-members',
   standalone: true,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
@@ -1,0 +1,439 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, firstValueFrom, map, of, skip, Subject, switchMap, takeUntil, tap } from 'rxjs';
+
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
+import {
+  EMPTY_ORG_PEOPLE_BOARD_MEMBERS_RESPONSE,
+  isVotingStatus,
+  ORG_PEOPLE_BOARD_SOURCE_CAPTION,
+  ORG_PEOPLE_BOARD_STAT_LABELS,
+  ORG_PEOPLE_BOARD_STATUS_OPTIONS,
+  votingStatusPillClass,
+} from '@lfx-one/shared/constants';
+import type {
+  BoardMemberPersonGroup,
+  BoardMemberPersonGroupVm,
+  BoardMembersSortColumn,
+  BoardMembersSortDirection,
+  CommitteeMemberAssignmentVm,
+  EditCommitteeRoleDialogData,
+  EditCommitteeRoleSubmitEvent,
+  OrgDropdownOption,
+  OrgPeopleBoardMembersResponse,
+  ReassignCommitteeRolesDialogData,
+  ReassignCommitteeRolesRoleOption,
+  ReassignCommitteeRolesSubmitEvent,
+  WhyCantEditBoardDialogData,
+} from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
+import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { BoardMembersService } from '../../services/board-members.service';
+import { EditBoardRoleModalComponent } from './components/edit-board-role-modal.component';
+import { ReassignBoardRolesModalComponent } from './components/reassign-board-roles-modal.component';
+import { WhyCantEditBoardModalComponent } from './components/why-cant-edit-board-modal.component';
+import { buildBoardPersonGroups, decorateBoardPersonGroup } from './helpers/board-members.helper';
+
+/** Org Lens — People → Board tab (spec 028). Org-wide, Board-only roster grouped by person, with filter/sort/expand (US1+US2) and Reassign/Edit modals (US3/US4). Inverted-filter sibling of the spec-027 Committee tab. */
+@Component({
+  selector: 'lfx-org-people-board-members',
+  standalone: true,
+  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, SelectComponent, SkeletonModule, EmptyStateComponent, ToastModule, TooltipModule],
+  providers: [MessageService, DialogService],
+  templateUrl: './board-members.component.html',
+})
+export class BoardMembersComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly dataService = inject(BoardMembersService);
+  private readonly roleGrants = inject(OrgRoleGrantsService);
+  private readonly messageService = inject(MessageService);
+  private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly tableSkeletonRows: readonly number[] = [0, 1, 2, 3, 4, 5];
+  protected readonly statSkeletonLabels: readonly string[] = ORG_PEOPLE_BOARD_STAT_LABELS;
+  protected readonly statusOptions: OrgDropdownOption[] = [...ORG_PEOPLE_BOARD_STATUS_OPTIONS];
+  protected readonly sourceCaption = ORG_PEOPLE_BOARD_SOURCE_CAPTION;
+  protected readonly votingStatusPillClass = votingStatusPillClass;
+  protected readonly editDisabledTooltip = 'Only admins can edit. To view a list of admins, visit the Access page.';
+
+  protected readonly filterForm = new FormGroup({
+    search: new FormControl<string>('', { nonNullable: true }),
+    foundation: new FormControl<string>('', { nonNullable: true }),
+    status: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  protected readonly sortColumn = signal<BoardMembersSortColumn>('name');
+  protected readonly sortDirection = signal<BoardMembersSortDirection>(1);
+  protected readonly expansion = signal<Record<string, boolean>>({});
+  protected readonly retryTrigger = signal<number>(0);
+  private readonly loadingState = signal<boolean>(true);
+  private readonly fetchErrorState = signal<boolean>(false);
+
+  protected readonly isLoading = this.loadingState.asReadonly();
+  protected readonly fetchError = this.fetchErrorState.asReadonly();
+
+  // Mirror the reactive form into a signal so computeds re-run on input (FormGroup.value is not a signal).
+  private readonly filterValues = toSignal(this.filterForm.valueChanges.pipe(debounceTime(150)), {
+    initialValue: this.filterForm.getRawValue(),
+  });
+
+  // Scoped on the org account id (SFID); gated on `!!uid` so the skeleton holds until the org-selector populates it.
+  private readonly orgUid$ = toObservable(this.accountContext.selectedAccount).pipe(
+    map((account) => account.uid),
+    distinctUntilChanged()
+  );
+
+  protected readonly response: Signal<OrgPeopleBoardMembersResponse> = this.initResponse();
+
+  protected readonly stats = computed(() => this.response().stats);
+
+  protected readonly groupedPeople: Signal<BoardMemberPersonGroup[]> = computed(() => buildBoardPersonGroups(this.response().assignments));
+  protected readonly foundationOptions: Signal<OrgDropdownOption[]> = computed(() => this.initFoundationOptions());
+  protected readonly filteredGroups: Signal<BoardMemberPersonGroup[]> = computed(() => this.initFilteredGroups());
+  protected readonly sortedGroups: Signal<BoardMemberPersonGroup[]> = computed(() => this.initSortedGroups());
+  protected readonly decoratedGroups: Signal<BoardMemberPersonGroupVm[]> = computed(() => this.initDecoratedGroups());
+
+  protected readonly isFiltering = computed(() => this.initIsFiltering());
+
+  // Writer-FGA gate (UX); BFF + Heimdall still re-enforce on write.
+  protected readonly canEdit = computed(() => this.initCanEdit());
+
+  protected readonly ariaSortMap = computed(() => this.initAriaSortMap());
+  protected readonly sortIconMap = computed(() => this.initSortIconMap());
+
+  // Cancels in-flight reads + closes any open dialog when the user switches account mid-flight.
+  private readonly accountCancel$ = new Subject<void>();
+
+  public constructor() {
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
+      this.accountCancel$.next();
+      this.resetAllState();
+    });
+  }
+
+  protected onSort(column: BoardMembersSortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update((d) => (d === 1 ? -1 : 1));
+      return;
+    }
+    this.sortColumn.set(column);
+    // Numeric columns default to descending (most-active first); the name column to ascending.
+    this.sortDirection.set(column === 'name' ? 1 : -1);
+  }
+
+  protected toggleExpansion(email: string): void {
+    this.expansion.update((state) => {
+      const next = { ...state };
+      if (next[email]) delete next[email];
+      else next[email] = true;
+      return next;
+    });
+  }
+
+  protected onRowKeydown(event: KeyboardEvent, email: string): void {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    this.toggleExpansion(email);
+  }
+
+  protected retry(): void {
+    this.retryTrigger.update((v) => v + 1);
+  }
+
+  // Main-row Reassign pencil (US3) — opens the bulk modal scoped to one person's Membership-Entitlement board seats.
+  protected onMainPencilClick(group: BoardMemberPersonGroupVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit() || group.editableCount === 0) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+
+    const roles: ReassignCommitteeRolesRoleOption[] = group.assignments
+      .filter((a) => a.isOrgEditable)
+      .map((a) => ({
+        key: a.memberUid,
+        memberUid: a.memberUid,
+        committeeUid: a.committeeUid,
+        committeeName: a.committeeName,
+        foundationName: a.foundationName,
+        votingStatus: a.votingStatus,
+        votingStatusPillClass: votingStatusPillClass(a.votingStatus),
+      }));
+    if (roles.length === 0) return;
+
+    // `group.email` is the grouping key and falls back to a seat `memberUid` when the upstream email is
+    // blank — never pass it as the contact email. Source the person's real email from the assignments.
+    const currentEmail = group.assignments.find((a) => a.person.email)?.person.email ?? '';
+
+    const ref = this.dialogService.open(ReassignBoardRolesModalComponent, {
+      width: '600px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        person: { fullName: group.displayName, email: currentEmail, initials: group.initials },
+        roles,
+        orgUid,
+        submit: (intent) => this.performBulkReassign(intent, orgUid),
+      } satisfies ReassignCommitteeRolesDialogData,
+    }) as DynamicDialogRef;
+
+    this.wireDialogToAccountChange(ref);
+  }
+
+  // Sub-row Edit pencil (US4) — opens the single-seat modal scoped to one Membership-Entitlement board seat.
+  protected onSubRowPencilClick(assignment: CommitteeMemberAssignmentVm, event: Event): void {
+    event.stopPropagation();
+    if (!this.canEdit() || !assignment.isOrgEditable) return;
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!orgUid) return;
+
+    const ref = this.dialogService.open(EditBoardRoleModalComponent, {
+      width: '560px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: {
+        assignment,
+        orgUid,
+        submit: (intent) => this.performSingleReassign(intent, orgUid),
+      } satisfies EditCommitteeRoleDialogData,
+    }) as DynamicDialogRef;
+
+    this.wireDialogToAccountChange(ref);
+  }
+
+  // "Why can't I edit?" affordance (FR-009/FR-012) — opens an explanatory modal; buttons close-only for now.
+  protected onWhyCantEdit(reason: string, event: Event): void {
+    event.stopPropagation();
+    this.dialogService.open(WhyCantEditBoardModalComponent, {
+      width: '440px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      showHeader: false,
+      data: { reason } satisfies WhyCantEditBoardDialogData,
+    });
+  }
+
+  // Fan out one PUT per seat, then refresh: full failure throws (modal stays open with the inline error);
+  // partial success resolves with a warning toast (re-PATCHing succeeded seats would 404 on a gone seat).
+  private async performBulkReassign(intent: ReassignCommitteeRolesSubmitEvent, orgUid: string): Promise<void> {
+    const ops = intent.selected.map((role) =>
+      firstValueFrom(
+        this.dataService.reassignSeat(orgUid, role.memberUid, {
+          committeeUid: role.committeeUid,
+          firstName: intent.newPerson.firstName,
+          lastName: intent.newPerson.lastName,
+          email: intent.newPerson.email,
+        })
+      )
+    );
+
+    const results = await Promise.allSettled(ops);
+    this.retry();
+
+    const total = intent.selected.length;
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failures.length === 0) {
+      this.messageService.add({
+        key: 'org-people-board-toast-success',
+        severity: 'success',
+        summary: 'Board roles reassigned',
+        detail: `${total} ${total === 1 ? 'role was' : 'roles were'} reassigned.`,
+        life: 3000,
+      });
+      return;
+    }
+
+    const succeeded = total - failures.length;
+    if (succeeded === 0) {
+      throw new Error(this.cleanErrorMessage(failures[0].reason));
+    }
+    this.messageService.add({
+      key: 'org-people-board-toast-success',
+      severity: 'warn',
+      summary: 'Some reassignments did not succeed',
+      detail: `${succeeded} of ${total} succeeded. Reopen this dialog to retry the remaining ${total - succeeded}.`,
+      life: 6000,
+    });
+  }
+
+  // Single PUT; refresh after; re-throw the cleaned message so the modal can surface an inline retry.
+  private async performSingleReassign(intent: EditCommitteeRoleSubmitEvent, orgUid: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.dataService.reassignSeat(orgUid, intent.memberUid, {
+          committeeUid: intent.committeeUid,
+          firstName: intent.newPerson.firstName,
+          lastName: intent.newPerson.lastName,
+          email: intent.newPerson.email,
+        })
+      );
+    } catch (err) {
+      throw new Error(this.cleanErrorMessage(err));
+    }
+    this.messageService.add({
+      key: 'org-people-board-toast-success',
+      severity: 'success',
+      summary: 'Board role updated',
+      life: 3000,
+    });
+    this.retry();
+  }
+
+  // Closes the dialog if the user switches account before confirming — prevents cross-org writes.
+  private wireDialogToAccountChange(ref: DynamicDialogRef): void {
+    this.accountCancel$.pipe(takeUntil(ref.onClose), takeUntilDestroyed(this.destroyRef)).subscribe(() => ref.close(null));
+  }
+
+  private cleanErrorMessage(err: unknown): string {
+    // The BFF returns either `{ error: { message } }` (validation) or `{ error: string }`
+    // (MicroserviceError/BaseApiError) — tolerate both so the server detail survives to the toast.
+    const inner = (err as { error?: { error?: unknown } })?.error?.error;
+    if (typeof inner === 'string' && inner.trim()) {
+      return inner;
+    }
+    if (inner && typeof inner === 'object' && typeof (inner as { message?: unknown }).message === 'string' && (inner as { message: string }).message.trim()) {
+      return (inner as { message: string }).message;
+    }
+    return 'Could not save changes. Please try again.';
+  }
+
+  private initResponse(): Signal<OrgPeopleBoardMembersResponse> {
+    return toSignal(
+      combineLatest([this.orgUid$, toObservable(this.retryTrigger)]).pipe(
+        tap(() => {
+          this.loadingState.set(true);
+          this.fetchErrorState.set(false);
+        }),
+        switchMap(([orgUid]) => {
+          if (!orgUid) {
+            // Hold the skeleton until the org selector populates a uid — flipping loadingState to false here
+            // would briefly render the empty state on mount before account-context emits the real uid.
+            return of(EMPTY_ORG_PEOPLE_BOARD_MEMBERS_RESPONSE);
+          }
+          return this.dataService.getBoardMembers(orgUid).pipe(
+            tap(() => this.loadingState.set(false)),
+            catchError(() => {
+              this.fetchErrorState.set(true);
+              this.loadingState.set(false);
+              return of(EMPTY_ORG_PEOPLE_BOARD_MEMBERS_RESPONSE);
+            })
+          );
+        })
+      ),
+      { initialValue: EMPTY_ORG_PEOPLE_BOARD_MEMBERS_RESPONSE }
+    );
+  }
+
+  private initFoundationOptions(): OrgDropdownOption[] {
+    const labels = [
+      ...new Set(
+        this.response()
+          .assignments.map((a) => a.foundationName)
+          .filter(Boolean)
+      ),
+    ].sort((a, b) => a.localeCompare(b));
+    return [{ label: 'All Foundations', value: '' }, ...labels.map((l) => ({ label: l, value: l }))];
+  }
+
+  private initIsFiltering(): boolean {
+    const v = this.filterValues();
+    return (v.search ?? '').trim().length > 0 || !!(v.foundation ?? '') || !!(v.status ?? '');
+  }
+
+  private initFilteredGroups(): BoardMemberPersonGroup[] {
+    const v = this.filterValues();
+    const q = (v.search ?? '').trim().toLowerCase();
+    const foundation = v.foundation ?? '';
+    const status = v.status ?? '';
+
+    return this.groupedPeople().filter((group) => {
+      if (foundation && !group.assignments.some((a) => a.foundationName === foundation)) return false;
+      if (status === 'voting' && !group.assignments.some((a) => isVotingStatus(a.votingStatus))) return false;
+      if (status === 'non-voting' && !group.assignments.some((a) => !isVotingStatus(a.votingStatus))) return false;
+      if (q && !this.groupSearchText(group).includes(q)) return false;
+      return true;
+    });
+  }
+
+  /** FR-005: case-insensitive search over name, job title, email, foundation, board/committee, role, voting, appointed-by. */
+  private groupSearchText(group: BoardMemberPersonGroup): string {
+    const parts: (string | null | undefined)[] = [group.displayName, group.jobTitle, group.email];
+    for (const a of group.assignments) {
+      parts.push(a.foundationName, a.committeeName, a.role, a.votingStatus, a.appointedBy);
+    }
+    return parts
+      .filter((p): p is string => Boolean(p))
+      .join(' ')
+      .toLowerCase();
+  }
+
+  private initSortedGroups(): BoardMemberPersonGroup[] {
+    const col = this.sortColumn();
+    const dir = this.sortDirection();
+    const copy = [...this.filteredGroups()];
+    copy.sort((a, b) => {
+      if (col === 'foundations') {
+        const cmp = (a.foundationLabels.length - b.foundationLabels.length) * dir;
+        return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName);
+      }
+      return a.displayName.localeCompare(b.displayName) * dir;
+    });
+    return copy;
+  }
+
+  private initDecoratedGroups(): BoardMemberPersonGroupVm[] {
+    const opts = { canEdit: this.canEdit(), editDisabledTooltip: this.editDisabledTooltip };
+    return this.sortedGroups().map((g) => decorateBoardPersonGroup(g, opts));
+  }
+
+  private initCanEdit(): boolean {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    if (!uid) return false;
+    return this.roleGrants.writerSet().has(uid);
+  }
+
+  private initAriaSortMap(): Record<BoardMembersSortColumn, 'ascending' | 'descending' | 'none'> {
+    const active = this.sortColumn();
+    const direction: 'ascending' | 'descending' = this.sortDirection() === 1 ? 'ascending' : 'descending';
+    return {
+      name: active === 'name' ? direction : 'none',
+      foundations: active === 'foundations' ? direction : 'none',
+    };
+  }
+
+  private initSortIconMap(): Record<BoardMembersSortColumn, string> {
+    const active = this.sortColumn();
+    const activeIcon = this.sortDirection() === 1 ? 'fa-light fa-sort-up' : 'fa-light fa-sort-down';
+    const iconFor = (col: BoardMembersSortColumn): string => (active === col ? activeIcon : 'fa-light fa-sort');
+    return {
+      name: iconFor('name'),
+      foundations: iconFor('foundations'),
+    };
+  }
+
+  private resetAllState(): void {
+    this.filterForm.reset({ search: '', foundation: '', status: '' });
+    this.sortColumn.set('name');
+    this.sortDirection.set(1);
+    this.expansion.set({});
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/board-members.component.ts
@@ -222,14 +222,16 @@ export class BoardMembersComponent {
   // "Why can't I edit?" affordance (FR-009/FR-012) — opens an explanatory modal; buttons close-only for now.
   protected onWhyCantEdit(reason: string, event: Event): void {
     event.stopPropagation();
-    this.dialogService.open(WhyCantEditBoardModalComponent, {
+    const ref = this.dialogService.open(WhyCantEditBoardModalComponent, {
       width: '440px',
       modal: true,
       closable: true,
       dismissableMask: true,
       showHeader: false,
       data: { reason } satisfies WhyCantEditBoardDialogData,
-    });
+    }) as DynamicDialogRef;
+
+    this.wireDialogToAccountChange(ref);
   }
 
   // Fan out one PUT per seat, then refresh: full failure throws (modal stays open with the inline error);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.html
@@ -1,0 +1,192 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (assignment; as seat) {
+  <div class="flex max-h-[80vh] flex-col gap-5 p-5" data-testid="org-people-board-modal-edit">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-2">
+        <h3 class="text-lg font-semibold text-gray-900" data-testid="org-people-board-modal-edit-title">Edit Board Role</h3>
+        <div class="flex flex-wrap items-center gap-2 text-sm" data-testid="org-people-board-modal-edit-chips">
+          <span class="inline-block rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700">Board</span>
+          <span class="font-medium text-gray-900">{{ seat.committeeName }}</span>
+          <span class="text-gray-400">&middot;</span>
+          <span class="text-gray-700">{{ seat.foundationName }}</span>
+          <span class="text-gray-400">&middot;</span>
+          <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="votingStatusPillClass(seat.votingStatus)">{{
+            seat.votingStatus || 'Non-voting'
+          }}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-board-modal-edit-close"
+        aria-label="Close"
+        (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg"></i>
+      </button>
+    </div>
+
+    <!-- Current Member card -->
+    <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="org-people-board-modal-edit-current">
+      <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Member &middot; Will Be Removed</div>
+      <div class="flex items-center gap-3">
+        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white">
+          {{ seat.person.initials }}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold text-gray-900">{{ seat.person.fullName }}</span>
+          <span class="text-xs text-gray-600">{{ seat.person.email }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Info banner -->
+    <div
+      class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900"
+      role="status"
+      data-testid="org-people-board-modal-edit-info-banner">
+      <i class="fa-light fa-circle-info mt-0.5 text-blue-600"></i>
+      <span>This role must be held by someone at all times. The person you assign below will immediately replace the current member.</span>
+    </div>
+
+    <!-- Assign to -->
+    <div class="flex flex-col gap-3" data-testid="org-people-board-modal-edit-assign-form" (keydown)="onFormKeydown($event)">
+      <h4 class="text-sm font-semibold text-gray-900">Assign to</h4>
+
+      <div class="relative flex flex-col gap-1">
+        <label for="edit-board-email" class="text-xs font-medium text-gray-700">Email <span class="text-red-500">*</span></label>
+        <span class="relative">
+          <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+          <input
+            id="edit-board-email"
+            pInputText
+            type="email"
+            placeholder="Enter the employee's email address..."
+            class="w-full pl-8"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls="edit-board-employee-suggestions-id"
+            [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-activedescendant]="activeOptionId()"
+            [attr.aria-describedby]="(emailFormatError() ? 'edit-board-email-error-id' : null) || (duplicateError() ? 'edit-board-duplicate-error-id' : null)"
+            [attr.aria-invalid]="!!emailFormatError() || !!duplicateError()"
+            data-testid="org-people-board-modal-edit-email-input"
+            [disabled]="isSaving()"
+            [ngModel]="emailField()"
+            (ngModelChange)="onEmailChange($event)"
+            (focus)="onEmailFocus()"
+            (blur)="onEmailBlur()"
+            (keydown)="onEmailKeydown($event)"
+            autocomplete="off" />
+        </span>
+        @if (suggestionsOpen() && filteredEmployees().length > 0) {
+          <ul
+            id="edit-board-employee-suggestions-id"
+            role="listbox"
+            aria-label="Employee suggestions"
+            class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            data-testid="org-people-board-modal-edit-employee-suggestions">
+            @for (emp of filteredEmployees(); track emp.email; let i = $index) {
+              <li role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  [attr.id]="optionIdPrefix + i"
+                  [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  [attr.aria-selected]="activeOptionIndex() === i"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [class.bg-gray-100]="activeOptionIndex() === i"
+                  [attr.data-testid]="'org-people-board-modal-edit-employee-option-' + emp.email"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="onSelectEmployee(emp)">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">{{ emp.initials }}</div>
+                  <div class="flex min-w-0 flex-col">
+                    <span class="truncate text-sm font-medium text-gray-900">{{ emp.fullName }}</span>
+                    <span class="truncate text-xs text-gray-500">{{ emp.email }}</span>
+                  </div>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+        @if (employeeSearchUnavailable()) {
+          <p class="text-xs text-gray-500" data-testid="org-people-board-modal-edit-search-unavailable">
+            Employee search is unavailable. You can still enter the member's details manually.
+          </p>
+        }
+        @if (emailFormatError()) {
+          <p id="edit-board-email-error-id" class="text-xs text-red-600" data-testid="org-people-board-modal-edit-email-error">
+            {{ emailFormatError() }}
+          </p>
+        }
+        @if (duplicateError()) {
+          <p id="edit-board-duplicate-error-id" class="text-xs text-red-600" data-testid="org-people-board-modal-edit-duplicate-error">
+            {{ duplicateError() }}
+          </p>
+        }
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label for="edit-board-first-name" class="text-xs font-medium text-gray-700">First Name <span class="text-red-500">*</span></label>
+          <input
+            id="edit-board-first-name"
+            pInputText
+            type="text"
+            placeholder="First name"
+            [ngModel]="firstNameField()"
+            (ngModelChange)="firstNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-board-modal-edit-first-name-input"
+            autocomplete="off" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="edit-board-last-name" class="text-xs font-medium text-gray-700">Last Name <span class="text-red-500">*</span></label>
+          <input
+            id="edit-board-last-name"
+            pInputText
+            type="text"
+            placeholder="Last name"
+            [ngModel]="lastNameField()"
+            (ngModelChange)="lastNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-board-modal-edit-last-name-input"
+            autocomplete="off" />
+        </div>
+      </div>
+    </div>
+
+    @if (saveError()) {
+      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700" role="alert" data-testid="org-people-board-modal-edit-save-error">
+        {{ saveError() }}
+      </div>
+    }
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        class="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-board-modal-edit-cancel"
+        (click)="onCancel()">
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        [disabled]="!saveEnabled()"
+        data-testid="org-people-board-modal-edit-primary-button"
+        (click)="onSave()">
+        @if (isSaving()) {
+          <i class="fa-light fa-spinner fa-spin"></i>
+        }
+        Save Changes
+      </button>
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.ts
@@ -12,7 +12,7 @@ import { take } from 'rxjs';
 
 import { BoardMembersService } from '../../../services/board-members.service';
 
-/** Spec 028 US4 — reassign a single Membership-Entitlement board seat to a new holder. Reuses the spec-027 committee modal contracts (D-103). */
+/** Reassign a single Membership-Entitlement board seat to a new holder. Reuses the committee modal contracts. */
 @Component({
   selector: 'lfx-edit-board-role-modal',
   standalone: true,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/edit-board-role-modal.component.ts
@@ -1,0 +1,228 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { EMAIL_REGEX, votingStatusPillClass } from '@lfx-one/shared/constants';
+import type { CommitteeMemberAssignment, EditCommitteeRoleDialogData, EditCommitteeRoleSubmitEvent, KeyContactEmployee } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { take } from 'rxjs';
+
+import { BoardMembersService } from '../../../services/board-members.service';
+
+/** Spec 028 US4 — reassign a single Membership-Entitlement board seat to a new holder. Reuses the spec-027 committee modal contracts (D-103). */
+@Component({
+  selector: 'lfx-edit-board-role-modal',
+  standalone: true,
+  imports: [FormsModule, InputTextModule],
+  templateUrl: './edit-board-role-modal.component.html',
+})
+export class EditBoardRoleModalComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dataService = inject(BoardMembersService);
+  private readonly dialogConfig = inject<DynamicDialogConfig<EditCommitteeRoleDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly assignment: CommitteeMemberAssignment | null = this.dialogConfig.data?.assignment ?? null;
+  private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
+
+  protected readonly votingStatusPillClass = votingStatusPillClass;
+
+  protected readonly emailField = signal('');
+  protected readonly firstNameField = signal('');
+  protected readonly lastNameField = signal('');
+  protected readonly emailFormatError = signal<string | null>(null);
+  protected readonly duplicateError = signal<string | null>(null);
+
+  protected readonly isSaving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly employees = signal<KeyContactEmployee[]>([]);
+  protected readonly employeeSearchUnavailable = signal(false);
+  protected readonly suggestionsOpen = signal(false);
+  // Active-descendant pattern: keyboard navigates a highlighted option via ArrowUp/Down while focus
+  // stays on the input. -1 means "nothing highlighted yet".
+  protected readonly activeOptionIndex = signal<number>(-1);
+  protected readonly optionIdPrefix = 'edit-board-employee-option-';
+
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
+  protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+  protected readonly activeOptionId: Signal<string | null> = computed(() => this.initActiveOptionId());
+
+  private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
+
+  public constructor() {
+    if (this.orgUid) {
+      this.dataService
+        .getEmployees(this.orgUid)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (res) => this.employees.set(res.employees ?? []),
+          error: () => this.employeeSearchUnavailable.set(true),
+        });
+    }
+  }
+
+  protected onEmailFocus(): void {
+    this.suggestionsOpen.set(true);
+  }
+
+  protected onEmailChange(value: string): void {
+    this.emailField.set(value);
+    this.suggestionsOpen.set(true);
+    // The filtered list re-orders with every keystroke — drop the previous highlight so the user
+    // doesn't accidentally Enter-select a stale option.
+    this.activeOptionIndex.set(-1);
+    if (this.duplicateError()) this.duplicateError.set(null);
+    if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onEmailBlur(): void {
+    this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+    this.duplicateError.set(null);
+    const value = this.emailField().trim();
+    if (value && !EMAIL_REGEX.test(value)) {
+      this.emailFormatError.set('Enter a valid email address');
+    } else {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onSelectEmployee(employee: KeyContactEmployee): void {
+    this.emailField.set(employee.email);
+    this.firstNameField.set(employee.firstName);
+    this.lastNameField.set(employee.lastName);
+    this.emailFormatError.set(null);
+    this.duplicateError.set(null);
+    this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+  }
+
+  // Active-descendant keyboard handler: ArrowUp/Down navigate the listbox without moving focus, Enter
+  // selects the highlight (else Save), Escape closes — keyboard users can't reach a suggestion otherwise.
+  protected onEmailKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      if (this.suggestionsOpen()) {
+        // Swallow so the parent PrimeNG dialog doesn't also close the modal on the same key.
+        event.preventDefault();
+        event.stopPropagation();
+        this.suggestionsOpen.set(false);
+        this.activeOptionIndex.set(-1);
+      }
+      return;
+    }
+
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Enter') return;
+
+    if (!this.suggestionsOpen() && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      this.suggestionsOpen.set(true);
+    }
+
+    const options = this.filteredEmployees();
+    if (options.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? 0 : (idx + 1) % options.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? options.length - 1 : (idx - 1 + options.length) % options.length);
+    } else if (event.key === 'Enter') {
+      const idx = this.activeOptionIndex();
+      if (idx >= 0 && idx < options.length) {
+        // A highlighted option wins over the form-level Save handler.
+        event.preventDefault();
+        event.stopPropagation();
+        this.onSelectEmployee(options[idx]);
+      }
+    }
+  }
+
+  protected onFormKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && this.saveEnabled()) {
+      event.preventDefault();
+      this.onSave();
+    }
+  }
+
+  protected onSave(): void {
+    if (!this.saveEnabled() || !this.assignment) return;
+
+    const enteredEmail = this.emailField().trim().toLowerCase();
+    const currentEmail = this.assignment.person.email?.trim().toLowerCase() ?? '';
+    if (enteredEmail === currentEmail) {
+      this.duplicateError.set('This person already holds this role.');
+      return;
+    }
+
+    const intent: EditCommitteeRoleSubmitEvent = {
+      memberUid: this.assignment.memberUid,
+      committeeUid: this.assignment.committeeUid,
+      newPerson: {
+        email: this.emailField().trim(),
+        firstName: this.firstNameField().trim(),
+        lastName: this.lastNameField().trim(),
+      },
+    };
+
+    const submit = this.dialogConfig.data?.submit;
+    if (!submit) {
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.isSaving.set(true);
+    this.saveError.set(null);
+    submit(intent)
+      .then(() => this.dialogRef.close(null))
+      .catch((e: unknown) => {
+        this.isSaving.set(false);
+        this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
+      });
+  }
+
+  protected onCancel(): void {
+    if (this.isSaving()) return;
+    this.dialogRef.close(null);
+  }
+
+  private initExcludedEmails(): Set<string> {
+    const set = new Set<string>();
+    const currentEmail = this.assignment?.person.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  }
+
+  private initFilteredEmployees(): KeyContactEmployee[] {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  }
+
+  private initSaveEnabled(): boolean {
+    if (this.isSaving()) return false;
+    const email = this.emailField().trim();
+    if (!email || !EMAIL_REGEX.test(email)) return false;
+    if (this.firstNameField().trim().length === 0) return false;
+    if (this.lastNameField().trim().length === 0) return false;
+    if (this.emailFormatError() || this.duplicateError()) return false;
+    return true;
+  }
+
+  private initActiveOptionId(): string | null {
+    const idx = this.activeOptionIndex();
+    if (idx < 0) return null;
+    if (idx >= this.filteredEmployees().length) return null;
+    return `${this.optionIdPrefix}${idx}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.html
@@ -1,0 +1,232 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (person; as currentPerson) {
+  <div class="flex max-h-[80vh] flex-col gap-5 p-5" data-testid="org-people-board-modal-reassign">
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-lg font-semibold text-gray-900" id="reassign-board-title" data-testid="org-people-board-modal-reassign-title">Reassign Board Roles</h3>
+        <p class="text-xs text-gray-500" data-testid="org-people-board-modal-reassign-subtitle">{{ subtitle() }}</p>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-board-modal-reassign-close"
+        aria-label="Close"
+        (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg"></i>
+      </button>
+    </div>
+
+    <!-- Current Member card -->
+    <div class="flex flex-col gap-3 rounded-md border border-amber-200 bg-amber-50 p-4" data-testid="org-people-board-modal-reassign-current">
+      <div class="text-xs font-semibold uppercase tracking-wide text-amber-800">Current Member &middot; Will Be Removed From Selected Roles</div>
+      <div class="flex items-center gap-3">
+        <div class="flex h-9 w-9 items-center justify-center rounded-full bg-purple-500 text-sm font-semibold text-white">
+          {{ currentPerson.initials }}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold text-gray-900">{{ currentPerson.fullName }}</span>
+          <span class="text-xs text-gray-600">{{ currentPerson.email }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Select roles to reassign -->
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <h4 class="text-sm font-semibold text-gray-900">Select roles to reassign</h4>
+        <label class="flex cursor-pointer items-center gap-2 text-xs text-blue-600">
+          <p-checkbox
+            [binary]="true"
+            [ngModel]="allChecked()"
+            (ngModelChange)="toggleSelectAll()"
+            [disabled]="isSaving()"
+            inputId="reassign-board-select-all"
+            data-testid="org-people-board-modal-reassign-select-all" />
+          <span>Select all</span>
+        </label>
+      </div>
+
+      <div class="flex max-h-[260px] flex-col gap-2 overflow-y-auto pr-1" data-testid="org-people-board-modal-reassign-roles-list">
+        @let checkedMap = checkedKeyMap();
+        @for (role of roles; track role.key) {
+          <div
+            class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+            [attr.data-testid]="'org-people-board-modal-reassign-role-row-' + role.key">
+            <p-checkbox
+              [binary]="true"
+              [ngModel]="checkedMap[role.key]"
+              (ngModelChange)="toggleRole(role.key)"
+              [disabled]="isSaving()"
+              [attr.data-testid]="'org-people-board-modal-reassign-role-checkbox-' + role.key" />
+            <span class="inline-block rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700">Board</span>
+            <div class="flex flex-1 flex-col">
+              <span class="text-sm font-medium text-gray-900">{{ role.committeeName }}</span>
+              <span class="text-xs text-gray-500">{{ role.foundationName }}</span>
+            </div>
+            <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium" [class]="role.votingStatusPillClass">{{
+              role.votingStatus || 'Non-voting'
+            }}</span>
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Info banner -->
+    <div
+      class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900"
+      role="status"
+      data-testid="org-people-board-modal-reassign-info-banner">
+      <i class="fa-light fa-circle-info mt-0.5 text-blue-600"></i>
+      <span
+        >Each selected role must be held by someone at all times. The person you assign below will replace the current member in every role you've checked
+        above.</span
+      >
+    </div>
+
+    <!-- Assign to -->
+    <div class="flex flex-col gap-3" data-testid="org-people-board-modal-reassign-assign-form" (keydown)="onFormKeydown($event)">
+      <h4 class="text-sm font-semibold text-gray-900">Assign to</h4>
+
+      <div class="relative flex flex-col gap-1">
+        <label for="reassign-board-email" class="text-xs font-medium text-gray-700">Email <span class="text-red-500">*</span></label>
+        <span class="relative">
+          <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+          <input
+            id="reassign-board-email"
+            pInputText
+            type="email"
+            placeholder="Enter the employee's email address..."
+            class="w-full pl-8"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls="reassign-board-employee-suggestions-id"
+            [attr.aria-expanded]="suggestionsOpen() && filteredEmployees().length > 0"
+            [attr.aria-activedescendant]="activeOptionId()"
+            [attr.aria-describedby]="
+              (emailFormatError() ? 'reassign-board-email-error-id' : null) || (duplicateError() ? 'reassign-board-duplicate-error-id' : null)
+            "
+            [attr.aria-invalid]="!!emailFormatError() || !!duplicateError()"
+            data-testid="org-people-board-modal-reassign-email-input"
+            [disabled]="isSaving()"
+            [ngModel]="emailField()"
+            (ngModelChange)="onEmailChange($event)"
+            (focus)="onEmailFocus()"
+            (blur)="onEmailBlur()"
+            (keydown)="onEmailKeydown($event)"
+            autocomplete="off" />
+        </span>
+        @if (suggestionsOpen() && filteredEmployees().length > 0) {
+          <ul
+            id="reassign-board-employee-suggestions-id"
+            role="listbox"
+            aria-label="Employee suggestions"
+            class="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+            data-testid="org-people-board-modal-reassign-employee-suggestions">
+            @for (emp of filteredEmployees(); track emp.email; let i = $index) {
+              <li role="presentation">
+                <button
+                  type="button"
+                  role="option"
+                  [attr.id]="optionIdPrefix + i"
+                  [attr.aria-label]="emp.fullName + ' (' + emp.email + ')'"
+                  [attr.aria-selected]="activeOptionIndex() === i"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                  [class.bg-gray-100]="activeOptionIndex() === i"
+                  [attr.data-testid]="'org-people-board-modal-reassign-employee-option-' + emp.email"
+                  (mousedown)="$event.preventDefault()"
+                  (click)="onSelectEmployee(emp)">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-full bg-purple-500 text-xs font-semibold text-white">{{ emp.initials }}</div>
+                  <div class="flex min-w-0 flex-col">
+                    <span class="truncate text-sm font-medium text-gray-900">{{ emp.fullName }}</span>
+                    <span class="truncate text-xs text-gray-500">{{ emp.email }}</span>
+                  </div>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+        @if (employeeSearchUnavailable()) {
+          <p class="text-xs text-gray-500" data-testid="org-people-board-modal-reassign-search-unavailable">
+            Employee search is unavailable. You can still enter the member's details manually.
+          </p>
+        }
+        @if (emailFormatError()) {
+          <p id="reassign-board-email-error-id" class="text-xs text-red-600" data-testid="org-people-board-modal-reassign-email-error">
+            {{ emailFormatError() }}
+          </p>
+        }
+        @if (duplicateError()) {
+          <p id="reassign-board-duplicate-error-id" class="text-xs text-red-600" data-testid="org-people-board-modal-reassign-duplicate-error">
+            {{ duplicateError() }}
+          </p>
+        }
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label for="reassign-board-first-name" class="text-xs font-medium text-gray-700">First Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-board-first-name"
+            pInputText
+            type="text"
+            placeholder="First name"
+            [ngModel]="firstNameField()"
+            (ngModelChange)="firstNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-board-modal-reassign-first-name-input"
+            autocomplete="off" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="reassign-board-last-name" class="text-xs font-medium text-gray-700">Last Name <span class="text-red-500">*</span></label>
+          <input
+            id="reassign-board-last-name"
+            pInputText
+            type="text"
+            placeholder="Last name"
+            [ngModel]="lastNameField()"
+            (ngModelChange)="lastNameField.set($event)"
+            [disabled]="isSaving()"
+            data-testid="org-people-board-modal-reassign-last-name-input"
+            autocomplete="off" />
+        </div>
+      </div>
+    </div>
+
+    @if (saveError()) {
+      <div
+        class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+        role="alert"
+        data-testid="org-people-board-modal-reassign-save-error">
+        {{ saveError() }}
+      </div>
+    }
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        class="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50"
+        [disabled]="isSaving()"
+        data-testid="org-people-board-modal-reassign-cancel"
+        (click)="onCancel()">
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        [disabled]="!saveEnabled()"
+        data-testid="org-people-board-modal-reassign-primary-button"
+        (click)="onSave()">
+        @if (isSaving()) {
+          <i class="fa-light fa-spinner fa-spin"></i>
+        }
+        {{ primaryButtonLabel() }}
+      </button>
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.ts
@@ -1,0 +1,296 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { EMAIL_REGEX } from '@lfx-one/shared/constants';
+import type {
+  KeyContactEmployee,
+  ReassignCommitteeRolesDialogData,
+  ReassignCommitteeRolesPersonRef,
+  ReassignCommitteeRolesRoleKey,
+  ReassignCommitteeRolesRoleOption,
+  ReassignCommitteeRolesSubmitEvent,
+} from '@lfx-one/shared/interfaces';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { take } from 'rxjs';
+
+import { BoardMembersService } from '../../../services/board-members.service';
+
+/** Spec 028 US3 — bulk-reassign one person's N Membership-Entitlement board seats; the parent fans out the PUTs. Reuses the spec-027 committee modal contracts (D-103). */
+@Component({
+  selector: 'lfx-reassign-board-roles-modal',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, CheckboxModule],
+  templateUrl: './reassign-board-roles-modal.component.html',
+})
+export class ReassignBoardRolesModalComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dataService = inject(BoardMembersService);
+  private readonly dialogConfig = inject<DynamicDialogConfig<ReassignCommitteeRolesDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  // === Dialog-injected data ===
+  protected readonly person: ReassignCommitteeRolesPersonRef | null = this.dialogConfig.data?.person ?? null;
+  protected readonly roles: readonly ReassignCommitteeRolesRoleOption[] = this.dialogConfig.data?.roles ?? [];
+  private readonly orgUid: string = this.dialogConfig.data?.orgUid ?? '';
+
+  // Default: all selected so the common workflow (full reassign) is one click.
+  protected readonly selectedKeys = signal<Set<ReassignCommitteeRolesRoleKey>>(new Set(this.roles.map((r) => r.key)));
+
+  protected readonly emailField = signal('');
+  protected readonly firstNameField = signal('');
+  protected readonly lastNameField = signal('');
+  protected readonly emailFormatError = signal<string | null>(null);
+  protected readonly duplicateError = signal<string | null>(null);
+
+  protected readonly isSaving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly employees = signal<KeyContactEmployee[]>([]);
+  protected readonly employeeSearchUnavailable = signal(false);
+  protected readonly suggestionsOpen = signal(false);
+  // Active-descendant pattern: keyboard navigates a highlighted option via ArrowUp/Down while focus
+  // stays on the input. -1 means "nothing highlighted yet".
+  protected readonly activeOptionIndex = signal<number>(-1);
+  protected readonly optionIdPrefix = 'reassign-board-employee-option-';
+
+  protected readonly checkedCount: Signal<number> = computed(() => this.selectedKeys().size);
+  protected readonly allChecked: Signal<boolean> = computed(() => this.roles.length > 0 && this.selectedKeys().size === this.roles.length);
+  protected readonly noneChecked: Signal<boolean> = computed(() => this.selectedKeys().size === 0);
+  protected readonly checkedFoundationCount: Signal<number> = computed(() => this.initCheckedFoundationCount());
+  protected readonly subtitle: Signal<string> = computed(() => this.initSubtitle());
+  protected readonly primaryButtonLabel: Signal<string> = computed(() => this.initPrimaryButtonLabel());
+  protected readonly checkedKeyMap: Signal<Record<string, boolean>> = computed(() => this.initCheckedKeyMap());
+  protected readonly filteredEmployees: Signal<KeyContactEmployee[]> = computed(() => this.initFilteredEmployees());
+  protected readonly saveEnabled: Signal<boolean> = computed(() => this.initSaveEnabled());
+  protected readonly activeOptionId: Signal<string | null> = computed(() => this.initActiveOptionId());
+
+  // Hide the current holder's own email from the typeahead — reassigning to themselves is a no-op.
+  private readonly excludedEmails: Signal<Set<string>> = computed(() => this.initExcludedEmails());
+
+  public constructor() {
+    if (this.orgUid) {
+      this.dataService
+        .getEmployees(this.orgUid)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (res) => this.employees.set(res.employees ?? []),
+          error: () => this.employeeSearchUnavailable.set(true),
+        });
+    }
+  }
+
+  protected toggleSelectAll(): void {
+    if (this.isSaving()) return;
+    if (this.allChecked()) {
+      this.selectedKeys.set(new Set());
+    } else {
+      this.selectedKeys.set(new Set(this.roles.map((r) => r.key)));
+    }
+  }
+
+  protected toggleRole(key: ReassignCommitteeRolesRoleKey): void {
+    if (this.isSaving()) return;
+    this.selectedKeys.update((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  protected onEmailFocus(): void {
+    this.suggestionsOpen.set(true);
+  }
+
+  protected onEmailChange(value: string): void {
+    this.emailField.set(value);
+    this.suggestionsOpen.set(true);
+    // The filtered list re-orders with every keystroke — drop the previous highlight so the user
+    // doesn't accidentally Enter-select a stale option.
+    this.activeOptionIndex.set(-1);
+    if (this.duplicateError()) this.duplicateError.set(null);
+    if (this.emailFormatError() && EMAIL_REGEX.test(value.trim())) {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onEmailBlur(): void {
+    this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+    this.duplicateError.set(null);
+    const value = this.emailField().trim();
+    if (value && !EMAIL_REGEX.test(value)) {
+      this.emailFormatError.set('Enter a valid email address');
+    } else {
+      this.emailFormatError.set(null);
+    }
+  }
+
+  protected onSelectEmployee(employee: KeyContactEmployee): void {
+    this.emailField.set(employee.email);
+    this.firstNameField.set(employee.firstName);
+    this.lastNameField.set(employee.lastName);
+    this.emailFormatError.set(null);
+    this.duplicateError.set(null);
+    this.suggestionsOpen.set(false);
+    this.activeOptionIndex.set(-1);
+  }
+
+  // Active-descendant keyboard handler: ArrowUp/Down navigate the listbox without moving focus, Enter
+  // selects the highlight (else Save), Escape closes — keyboard users can't reach a suggestion otherwise.
+  protected onEmailKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      if (this.suggestionsOpen()) {
+        // Swallow so the parent PrimeNG dialog doesn't also close the modal on the same key.
+        event.preventDefault();
+        event.stopPropagation();
+        this.suggestionsOpen.set(false);
+        this.activeOptionIndex.set(-1);
+      }
+      return;
+    }
+
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Enter') return;
+
+    if (!this.suggestionsOpen() && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      this.suggestionsOpen.set(true);
+    }
+
+    const options = this.filteredEmployees();
+    if (options.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? 0 : (idx + 1) % options.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const idx = this.activeOptionIndex();
+      this.activeOptionIndex.set(idx < 0 ? options.length - 1 : (idx - 1 + options.length) % options.length);
+    } else if (event.key === 'Enter') {
+      const idx = this.activeOptionIndex();
+      if (idx >= 0 && idx < options.length) {
+        // A highlighted option wins over the form-level Save handler.
+        event.preventDefault();
+        event.stopPropagation();
+        this.onSelectEmployee(options[idx]);
+      }
+    }
+  }
+
+  protected onFormKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && this.saveEnabled()) {
+      event.preventDefault();
+      this.onSave();
+    }
+  }
+
+  protected onSave(): void {
+    if (!this.saveEnabled()) return;
+
+    const enteredEmail = this.emailField().trim().toLowerCase();
+    const currentEmail = this.person?.email?.trim().toLowerCase() ?? '';
+    if (enteredEmail === currentEmail) {
+      this.duplicateError.set('This person already holds the selected role(s).');
+      return;
+    }
+
+    const selectedKeySet = this.selectedKeys();
+    const selected = this.roles.filter((r) => selectedKeySet.has(r.key));
+    if (selected.length === 0) return;
+
+    const intent: ReassignCommitteeRolesSubmitEvent = {
+      newPerson: {
+        email: this.emailField().trim(),
+        firstName: this.firstNameField().trim(),
+        lastName: this.lastNameField().trim(),
+      },
+      selected,
+    };
+
+    const submit = this.dialogConfig.data?.submit;
+    if (!submit) {
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.isSaving.set(true);
+    this.saveError.set(null);
+    submit(intent)
+      .then(() => this.dialogRef.close(null))
+      .catch((e: unknown) => {
+        this.isSaving.set(false);
+        this.saveError.set(e instanceof Error ? e.message : 'Could not save changes. Please try again.');
+      });
+  }
+
+  protected onCancel(): void {
+    if (this.isSaving()) return;
+    this.dialogRef.close(null);
+  }
+
+  private initCheckedFoundationCount(): number {
+    const selected = this.selectedKeys();
+    const names = new Set<string>();
+    for (const r of this.roles) if (selected.has(r.key)) names.add(r.foundationName);
+    return names.size;
+  }
+
+  private initSubtitle(): string {
+    const n = this.checkedCount();
+    const m = this.checkedFoundationCount();
+    return `${n} ${n === 1 ? 'role' : 'roles'} across ${m} ${m === 1 ? 'foundation' : 'foundations'}`;
+  }
+
+  private initPrimaryButtonLabel(): string {
+    if (this.isSaving()) return 'Reassigning…';
+    const n = this.checkedCount();
+    return `Save Changes (${n} ${n === 1 ? 'role' : 'roles'})`;
+  }
+
+  private initCheckedKeyMap(): Record<string, boolean> {
+    const selected = this.selectedKeys();
+    const map: Record<string, boolean> = {};
+    for (const r of this.roles) map[r.key] = selected.has(r.key);
+    return map;
+  }
+
+  private initExcludedEmails(): Set<string> {
+    const set = new Set<string>();
+    const currentEmail = this.person?.email?.trim().toLowerCase();
+    if (currentEmail) set.add(currentEmail);
+    return set;
+  }
+
+  private initFilteredEmployees(): KeyContactEmployee[] {
+    const query = this.emailField().trim().toLowerCase();
+    if (!query) return [];
+    const excluded = this.excludedEmails();
+    return this.employees()
+      .filter((e) => !excluded.has(e.email.trim().toLowerCase()))
+      .filter((e) => e.email.toLowerCase().includes(query) || e.fullName.toLowerCase().includes(query))
+      .slice(0, 8);
+  }
+
+  private initSaveEnabled(): boolean {
+    if (this.isSaving()) return false;
+    if (this.noneChecked()) return false;
+    const email = this.emailField().trim();
+    if (!email || !EMAIL_REGEX.test(email)) return false;
+    if (this.firstNameField().trim().length === 0) return false;
+    if (this.lastNameField().trim().length === 0) return false;
+    if (this.emailFormatError() || this.duplicateError()) return false;
+    return true;
+  }
+
+  private initActiveOptionId(): string | null {
+    const idx = this.activeOptionIndex();
+    if (idx < 0) return null;
+    if (idx >= this.filteredEmployees().length) return null;
+    return `${this.optionIdPrefix}${idx}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/reassign-board-roles-modal.component.ts
@@ -20,7 +20,7 @@ import { take } from 'rxjs';
 
 import { BoardMembersService } from '../../../services/board-members.service';
 
-/** Spec 028 US3 — bulk-reassign one person's N Membership-Entitlement board seats; the parent fans out the PUTs. Reuses the spec-027 committee modal contracts (D-103). */
+/** Bulk-reassign one person's N Membership-Entitlement board seats; the parent fans out the PUTs. Reuses the committee modal contracts. */
 @Component({
   selector: 'lfx-reassign-board-roles-modal',
   standalone: true,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.html
@@ -1,0 +1,38 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex max-h-[80vh] flex-col items-center gap-4 p-6 text-center" data-testid="org-people-board-modal-why">
+  <button
+    type="button"
+    class="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+    aria-label="Close"
+    data-testid="org-people-board-modal-why-close"
+    (click)="onClose()">
+    <i class="fa-light fa-xmark text-lg"></i>
+  </button>
+
+  <div class="flex h-14 w-14 items-center justify-center rounded-full border-2 border-blue-400 text-blue-500">
+    <i class="fa-light fa-circle-info text-2xl" aria-hidden="true"></i>
+  </div>
+
+  <h3 class="text-xl font-bold text-gray-900" data-testid="org-people-board-modal-why-title">Why can't I edit this member?</h3>
+
+  <p class="text-sm leading-relaxed text-gray-600" data-testid="org-people-board-modal-why-body">{{ reason }}</p>
+
+  <div class="mt-2 flex items-center justify-center gap-3">
+    <button
+      type="button"
+      class="inline-flex items-center justify-center rounded-md bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      data-testid="org-people-board-modal-why-got-it"
+      (click)="onClose()">
+      Got it
+    </button>
+    <button
+      type="button"
+      class="inline-flex items-center justify-center rounded-md border border-gray-200 bg-gray-50 px-5 py-2 text-sm font-semibold text-blue-600 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      data-testid="org-people-board-modal-why-contact"
+      (click)="onClose()">
+      Contact Foundation
+    </button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.ts
@@ -1,0 +1,24 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import type { WhyCantEditBoardDialogData } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+/** Spec 028 — explains why a board seat/member is read-only (foundation-controlled or no writer authority). Buttons close-only for now. */
+@Component({
+  selector: 'lfx-why-cant-edit-board-modal',
+  standalone: true,
+  imports: [],
+  templateUrl: './why-cant-edit-board-modal.component.html',
+})
+export class WhyCantEditBoardModalComponent {
+  private readonly dialogConfig = inject<DynamicDialogConfig<WhyCantEditBoardDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly reason: string = this.dialogConfig.data?.reason ?? '';
+
+  protected onClose(): void {
+    this.dialogRef.close(null);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/components/why-cant-edit-board-modal.component.ts
@@ -5,7 +5,7 @@ import { Component, inject } from '@angular/core';
 import type { WhyCantEditBoardDialogData } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
-/** Spec 028 — explains why a board seat/member is read-only (foundation-controlled or no writer authority). Buttons close-only for now. */
+/** Explains why a board seat/member is read-only (foundation-controlled or no writer authority). Buttons close-only for now. */
 @Component({
   selector: 'lfx-why-cant-edit-board-modal',
   standalone: true,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  EDIT_TOOLTIP_DEFAULT,
+  EDIT_TOOLTIP_NOT_ORG_EDITABLE,
+  isVotingStatus,
+  REASSIGN_TOOLTIP_DEFAULT,
+  REASSIGN_TOOLTIP_NO_EDITABLE_SEATS,
+  votingStatusPillClass,
+} from '@lfx-one/shared/constants';
+import type {
+  BoardMemberPersonGroup,
+  BoardMemberPersonGroupVm,
+  BoardVotingPill,
+  CommitteeMemberAssignment,
+  CommitteeMemberAssignmentVm,
+  CommitteeMembersDecorateOptions,
+} from '@lfx-one/shared/interfaces';
+
+/** Group org-wide Board seats by person (email key, first-wins) → foundation labels + voting/non-voting + editable counts (spec 028 data-model §6). */
+export function buildBoardPersonGroups(assignments: CommitteeMemberAssignment[]): BoardMemberPersonGroup[] {
+  const byEmail = new Map<string, CommitteeMemberAssignment[]>();
+  for (const a of assignments) {
+    // Fall back to the seat uid when email is blank so an email-less member still groups into its own row.
+    const key = a.person.email || a.memberUid;
+    const list = byEmail.get(key) ?? [];
+    list.push(a);
+    byEmail.set(key, list);
+  }
+
+  return [...byEmail.values()].map((group) => {
+    const first = group[0];
+    const foundationLabels = [...new Set(group.map((a) => a.foundationName).filter(Boolean))].sort((x, y) => x.localeCompare(y));
+    const votingCount = group.filter((a) => isVotingStatus(a.votingStatus)).length;
+    const nonVotingCount = group.length - votingCount;
+    const editableCount = group.filter((a) => a.isOrgEditable).length;
+    return {
+      email: first.person.email || first.memberUid,
+      displayName: first.person.fullName,
+      jobTitle: first.person.jobTitle,
+      initials: first.person.initials,
+      foundationLabels,
+      votingCount,
+      nonVotingCount,
+      editableCount,
+      assignments: group,
+    };
+  });
+}
+
+/** Sub-table rows: sort foundation→committee, attach pill class, flag first-of-foundation (FR-008), precompute each Edit tooltip. */
+export function decorateBoardAssignments(group: BoardMemberPersonGroup, opts: CommitteeMembersDecorateOptions): CommitteeMemberAssignmentVm[] {
+  const sorted = [...group.assignments].sort((a, b) => {
+    const f = a.foundationName.localeCompare(b.foundationName, undefined, { sensitivity: 'base' });
+    if (f !== 0) return f;
+    return a.committeeName.localeCompare(b.committeeName, undefined, { sensitivity: 'base' });
+  });
+  return sorted.map((a, idx) => ({
+    ...a,
+    votingStatusPillClass: votingStatusPillClass(a.votingStatus),
+    showFoundationLabel: idx === 0 || sorted[idx - 1].foundationName !== a.foundationName,
+    editTooltip: buildEditTooltip(a, opts),
+  }));
+}
+
+/** Full main-row + sub-row view-model in one place (sub-rows, main-row voting pills, Reassign tooltip) so templates stay flat. */
+export function decorateBoardPersonGroup(group: BoardMemberPersonGroup, opts: CommitteeMembersDecorateOptions): BoardMemberPersonGroupVm {
+  return {
+    ...group,
+    sortedAssignments: decorateBoardAssignments(group, opts),
+    votingPills: buildVotingPills(group),
+    reassignTooltip: buildReassignTooltip(group, opts),
+  };
+}
+
+/** Main-row Voting Status cell: one verbatim pill for a single-seat person, else aggregate "X Voting"/"Y Non-voting" pills (omit zero) (FR-002). */
+function buildVotingPills(group: BoardMemberPersonGroup): BoardVotingPill[] {
+  if (group.assignments.length === 1) {
+    const status = group.assignments[0].votingStatus;
+    return [{ label: status || 'Non-voting', pillClass: votingStatusPillClass(status) }];
+  }
+  const pills: BoardVotingPill[] = [];
+  if (group.votingCount > 0) {
+    pills.push({ label: `${group.votingCount} Voting`, pillClass: votingStatusPillClass('Voting') });
+  }
+  if (group.nonVotingCount > 0) {
+    pills.push({ label: `${group.nonVotingCount} Non-voting`, pillClass: votingStatusPillClass('Non-voting') });
+  }
+  return pills;
+}
+
+function buildReassignTooltip(group: BoardMemberPersonGroup, opts: CommitteeMembersDecorateOptions): string {
+  if (!opts.canEdit) return opts.editDisabledTooltip;
+  return group.editableCount === 0 ? REASSIGN_TOOLTIP_NO_EDITABLE_SEATS : REASSIGN_TOOLTIP_DEFAULT;
+}
+
+function buildEditTooltip(assignment: CommitteeMemberAssignment, opts: CommitteeMembersDecorateOptions): string {
+  if (!opts.canEdit) return opts.editDisabledTooltip;
+  if (assignment.isOrgEditable) return EDIT_TOOLTIP_DEFAULT;
+  return assignment.reason ?? EDIT_TOOLTIP_NOT_ORG_EDITABLE;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import {
-  EDIT_TOOLTIP_DEFAULT,
+  EDIT_TOOLTIP_BOARD_DEFAULT,
   EDIT_TOOLTIP_NOT_ORG_EDITABLE,
   isVotingStatus,
-  REASSIGN_TOOLTIP_DEFAULT,
+  REASSIGN_TOOLTIP_BOARD_DEFAULT,
   REASSIGN_TOOLTIP_NO_EDITABLE_SEATS,
   votingStatusPillClass,
 } from '@lfx-one/shared/constants';
@@ -92,11 +92,11 @@ function buildVotingPills(group: BoardMemberPersonGroup): BoardVotingPill[] {
 
 function buildReassignTooltip(group: BoardMemberPersonGroup, opts: CommitteeMembersDecorateOptions): string {
   if (!opts.canEdit) return opts.editDisabledTooltip;
-  return group.editableCount === 0 ? REASSIGN_TOOLTIP_NO_EDITABLE_SEATS : REASSIGN_TOOLTIP_DEFAULT;
+  return group.editableCount === 0 ? REASSIGN_TOOLTIP_NO_EDITABLE_SEATS : REASSIGN_TOOLTIP_BOARD_DEFAULT;
 }
 
 function buildEditTooltip(assignment: CommitteeMemberAssignment, opts: CommitteeMembersDecorateOptions): string {
   if (!opts.canEdit) return opts.editDisabledTooltip;
-  if (assignment.isOrgEditable) return EDIT_TOOLTIP_DEFAULT;
+  if (assignment.isOrgEditable) return EDIT_TOOLTIP_BOARD_DEFAULT;
   return assignment.reason ?? EDIT_TOOLTIP_NOT_ORG_EDITABLE;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/board-members/helpers/board-members.helper.ts
@@ -18,7 +18,7 @@ import type {
   CommitteeMembersDecorateOptions,
 } from '@lfx-one/shared/interfaces';
 
-/** Group org-wide Board seats by person (email key, first-wins) → foundation labels + voting/non-voting + editable counts (spec 028 data-model §6). */
+/** Group org-wide Board seats by person (email key, first-wins) → foundation labels + voting/non-voting + editable counts. */
 export function buildBoardPersonGroups(assignments: CommitteeMemberAssignment[]): BoardMemberPersonGroup[] {
   const byEmail = new Map<string, CommitteeMemberAssignment[]>();
   for (const a of assignments) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.html
@@ -49,6 +49,8 @@
       <lfx-org-people-all-employees />
     } @else if (activeTab() === 'contacts') {
       <lfx-org-people-key-contacts />
+    } @else if (activeTab() === 'board') {
+      <lfx-org-people-board-members />
     } @else if (activeTab() === 'committee') {
       <lfx-org-people-committee-members />
     } @else if (activeTab() === 'training') {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/org-people.component.ts
@@ -12,6 +12,7 @@ import { AccountContextService } from '@services/account-context.service';
 import type { PeopleTabConfig, PeopleTabId } from '@lfx-one/shared/interfaces';
 
 import { AllEmployeesComponent } from './components/all-employees/all-employees.component';
+import { BoardMembersComponent } from './components/board-members/board-members.component';
 import { CommitteeMembersComponent } from './components/committee-members/committee-members.component';
 import { ContributorsComponent } from './components/contributors/contributors.component';
 import { EventAttendeesComponent } from './components/event-attendees/event-attendees.component';
@@ -25,6 +26,7 @@ import { TraineesComponent } from './components/trainees/trainees.component';
     EmptyStateComponent,
     AllEmployeesComponent,
     KeyContactsComponent,
+    BoardMembersComponent,
     CommitteeMembersComponent,
     TraineesComponent,
     EventAttendeesComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/board-members.service.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/board-members.service.ts
@@ -1,0 +1,37 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import type {
+  OrgLensEmployeesResponse,
+  OrgPeopleBoardMembersResponse,
+  ReassignCommitteeMemberBody,
+  ReassignCommitteeMemberResponse,
+} from '@lfx-one/shared/interfaces';
+
+/** HTTP client for the Org Lens → People → Board tab (spec 028). Read + single-seat reassign + the reused org-wide employee picker. */
+@Injectable({ providedIn: 'root' })
+export class BoardMembersService {
+  private readonly http = inject(HttpClient);
+
+  /** Org-wide Board roster + filter-independent stats. */
+  public getBoardMembers(orgUid: string): Observable<OrgPeopleBoardMembersResponse> {
+    return this.http.get<OrgPeopleBoardMembersResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/people/board-members`);
+  }
+
+  /** Reassign one Membership-Entitlement board seat (used by both the bulk fan-out and the single-edit modal). */
+  public reassignSeat(orgUid: string, seatId: string, body: ReassignCommitteeMemberBody): Observable<ReassignCommitteeMemberResponse> {
+    return this.http.patch<ReassignCommitteeMemberResponse>(
+      `/api/orgs/${encodeURIComponent(orgUid)}/lens/people/board-members/${encodeURIComponent(seatId)}/reassign`,
+      body
+    );
+  }
+
+  /** Reused spec-026 org-wide people picker (key contacts ∪ committee members, deduped) for the modal typeahead. */
+  public getEmployees(orgUid: string): Observable<OrgLensEmployeesResponse> {
+    return this.http.get<OrgLensEmployeesResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/employees`);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/board-members.service.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/services/board-members.service.ts
@@ -12,7 +12,7 @@ import type {
   ReassignCommitteeMemberResponse,
 } from '@lfx-one/shared/interfaces';
 
-/** HTTP client for the Org Lens → People → Board tab (spec 028). Read + single-seat reassign + the reused org-wide employee picker. */
+/** HTTP client for the Org Lens → People → Board tab. Read + single-seat reassign + the reused org-wide employee picker. */
 @Injectable({ providedIn: 'root' })
 export class BoardMembersService {
   private readonly http = inject(HttpClient);

--- a/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
@@ -11,6 +11,7 @@ import { assertOrgUid } from '../helpers/org-uid.helper';
 import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { OrgLensPeopleService } from '../services/org-lens-people.service';
+import { OrgPeopleBoardMembersService } from '../services/org-people-board-members.service';
 import { OrgPeopleCommitteeMembersService } from '../services/org-people-committee-members.service';
 import { OrgPeopleContributorsService } from '../services/org-people-contributors.service';
 import { OrgPeopleEventAttendeesService } from '../services/org-people-event-attendees.service';
@@ -27,6 +28,7 @@ export class OrgLensPeopleController {
   private readonly eventAttendeesService: OrgPeopleEventAttendeesService;
   private readonly contributorsService: OrgPeopleContributorsService;
   private readonly committeeMembersService: OrgPeopleCommitteeMembersService;
+  private readonly boardMembersService: OrgPeopleBoardMembersService;
 
   public constructor() {
     this.service = new OrgLensPeopleService();
@@ -35,6 +37,7 @@ export class OrgLensPeopleController {
     this.eventAttendeesService = new OrgPeopleEventAttendeesService();
     this.contributorsService = new OrgPeopleContributorsService();
     this.committeeMembersService = new OrgPeopleCommitteeMembersService();
+    this.boardMembersService = new OrgPeopleBoardMembersService();
   }
 
   /** GET /api/orgs/:orgUid/lens/people/all */
@@ -166,6 +169,63 @@ export class OrgLensPeopleController {
       const response = await this.committeeMembersService.reassignSeat(req, orgUid, seatId, body);
 
       logger.success(req, 'reassign_committee_member', startTime, {
+        org_uid: orgUid,
+        seat_id: seatId,
+        committee_uid: body.committeeUid,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** GET /api/orgs/:orgUid/lens/people/board-members — org-wide Board-only roster + stats (spec 028). */
+  public async getBoardMembers(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, 'get_org_people_board_members', {
+      org_uid: orgUid,
+    });
+
+    try {
+      assertOrgUid(orgUid, 'get_org_people_board_members');
+
+      const response = await this.boardMembersService.getBoardMembers(req, orgUid);
+
+      logger.success(req, 'get_org_people_board_members', startTime, {
+        org_uid: orgUid,
+        assignment_count: response.assignments.length,
+        total_board_members: response.stats.totalBoardMembers,
+        voting_count: response.stats.votingCount,
+        non_voting_count: response.stats.nonVotingCount,
+        foundations_covered: response.stats.foundationsCovered,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /** PATCH /api/orgs/:orgUid/lens/people/board-members/:seatId/reassign — reassign one Membership-Entitlement board seat (spec 028 US3/US4). */
+  public async reassignBoardMember(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const orgUid = req.params['orgUid'];
+    const seatId = req.params['seatId'];
+    const startTime = logger.startOperation(req, 'reassign_board_member', {
+      org_uid: orgUid,
+      seat_id: seatId,
+    });
+
+    try {
+      assertOrgUid(orgUid, 'reassign_board_member');
+      this.assertSeatId(seatId, 'reassign_board_member');
+      const body = this.assertReassignBody(req.body, 'reassign_board_member');
+
+      const response = await this.boardMembersService.reassignSeat(req, orgUid, seatId, body);
+
+      logger.success(req, 'reassign_board_member', startTime, {
         org_uid: orgUid,
         seat_id: seatId,
         committee_uid: body.committeeUid,

--- a/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-people.controller.ts
@@ -181,7 +181,7 @@ export class OrgLensPeopleController {
     }
   }
 
-  /** GET /api/orgs/:orgUid/lens/people/board-members — org-wide Board-only roster + stats (spec 028). */
+  /** GET /api/orgs/:orgUid/lens/people/board-members — org-wide Board-only roster + stats. */
   public async getBoardMembers(req: Request, res: Response, next: NextFunction): Promise<void> {
     const orgUid = req.params['orgUid'];
     const startTime = logger.startOperation(req, 'get_org_people_board_members', {
@@ -209,7 +209,7 @@ export class OrgLensPeopleController {
     }
   }
 
-  /** PATCH /api/orgs/:orgUid/lens/people/board-members/:seatId/reassign — reassign one Membership-Entitlement board seat (spec 028 US3/US4). */
+  /** PATCH /api/orgs/:orgUid/lens/people/board-members/:seatId/reassign — reassign one Membership-Entitlement board seat. */
   public async reassignBoardMember(req: Request, res: Response, next: NextFunction): Promise<void> {
     const orgUid = req.params['orgUid'];
     const seatId = req.params['seatId'];

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -83,7 +83,7 @@ function buildOrgsRouter(): Router {
   // matcher below so 'committee-members' isn't consumed as a personKey.
   router.get('/:orgUid/lens/people/committee-members', (req, res, next) => orgLensPeopleController.getCommitteeMembers(req, res, next));
   router.patch('/:orgUid/lens/people/committee-members/:seatId/reassign', (req, res, next) => orgLensPeopleController.reassignCommitteeMember(req, res, next));
-  // Spec 028 — People → Board tab (org-wide Board-only members). Registered BEFORE the `/:personKey/detail`
+  // People → Board tab (org-wide Board-only members). Registered BEFORE the `/:personKey/detail`
   // matcher below so 'board-members' isn't consumed as a personKey.
   router.get('/:orgUid/lens/people/board-members', (req, res, next) => orgLensPeopleController.getBoardMembers(req, res, next));
   router.patch('/:orgUid/lens/people/board-members/:seatId/reassign', (req, res, next) => orgLensPeopleController.reassignBoardMember(req, res, next));

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -83,6 +83,10 @@ function buildOrgsRouter(): Router {
   // matcher below so 'committee-members' isn't consumed as a personKey.
   router.get('/:orgUid/lens/people/committee-members', (req, res, next) => orgLensPeopleController.getCommitteeMembers(req, res, next));
   router.patch('/:orgUid/lens/people/committee-members/:seatId/reassign', (req, res, next) => orgLensPeopleController.reassignCommitteeMember(req, res, next));
+  // Spec 028 — People → Board tab (org-wide Board-only members). Registered BEFORE the `/:personKey/detail`
+  // matcher below so 'board-members' isn't consumed as a personKey.
+  router.get('/:orgUid/lens/people/board-members', (req, res, next) => orgLensPeopleController.getBoardMembers(req, res, next));
+  router.patch('/:orgUid/lens/people/board-members/:seatId/reassign', (req, res, next) => orgLensPeopleController.reassignBoardMember(req, res, next));
   // LFXV2-1876 — People → Trainees tab. Keep above the `/:personKey/detail` matcher so 'trainees' isn't consumed as a personKey.
   router.get('/:orgUid/lens/people/trainees', (req, res, next) => orgLensPeopleController.getTrainees(req, res, next));
   // LFXV2-1875 — People → Event Attendees tab. Same guard rationale as above ('event-attendees' must not be consumed as a personKey).

--- a/apps/lfx-one/src/server/services/committee-seat-assignment.mapper.ts
+++ b/apps/lfx-one/src/server/services/committee-seat-assignment.mapper.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Spec 028 (D-101) — shared seat→assignment mapper extracted from `OrgPeopleCommitteeMembersService`
+// so both the Committee tab (spec 027) and the Board tab (spec 028) reuse the same foundation-name
+// enrichment + camelCase mapping with zero duplication. Behavior is byte-identical to the original
+// private methods; the committee read/reassign responses are unchanged.
+
+import type { CommitteeMemberAssignment, CommitteeMemberPerson, CommitteeServiceOrgSeat } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+import { ProjectService } from './project.service';
+
+/** D-003 foundation-name enrichment: distinct `project_uid`s → `ProjectService.getProjectsByIds` (chunks 100/req, FGA-aware) → `Map<uid, name>`; fail-soft to empty map (each seat falls back to `project_slug`). */
+export async function enrichFoundationNames(req: Request, seats: CommitteeServiceOrgSeat[], projectService: ProjectService): Promise<Map<string, string>> {
+  const uids = [...new Set(seats.map((s) => s.project_uid).filter((u): u is string => !!u))];
+  if (uids.length === 0) {
+    return new Map();
+  }
+  try {
+    const byUid = await projectService.getProjectsByIds(req, uids);
+    const names = new Map<string, string>();
+    for (const [uid, project] of byUid) {
+      if (project?.name) {
+        names.set(uid, project.name);
+      }
+    }
+    return names;
+  } catch (error) {
+    logger.warning(req, 'enrich_foundation_names', 'project-name enrichment failed; falling back to project_slug', {
+      uid_count: uids.length,
+      err: error,
+    });
+    return new Map();
+  }
+}
+
+/** Map an upstream seat to the People-tab `CommitteeMemberAssignment` (camelCase + person envelope + foundation). */
+export function toAssignment(s: CommitteeServiceOrgSeat, foundationNames: Map<string, string>): CommitteeMemberAssignment {
+  const projectUid = s.project_uid ?? '';
+  const foundationSlug = s.project_slug ?? '';
+  return {
+    seatId: s.uid,
+    memberUid: s.uid,
+    committeeUid: s.committee_uid,
+    committeeName: s.committee_name,
+    committeeCategory: s.committee_category,
+    projectUid,
+    foundationSlug,
+    foundationName: foundationNames.get(projectUid) || foundationSlug,
+    role: s.role_name ?? '',
+    votingStatus: s.voting_status ?? '',
+    appointedBy: s.appointed_by ?? '',
+    isOrgEditable: s.is_org_editable,
+    reason: s.reason ?? null,
+    person: toPerson(s),
+  };
+}
+
+/** Build the seat holder's person envelope: lowercased email, fullName fallback to email, derived initials. */
+export function toPerson(s: CommitteeServiceOrgSeat): CommitteeMemberPerson {
+  const firstName = (s.first_name ?? '').trim();
+  const lastName = (s.last_name ?? '').trim();
+  const email = (s.email ?? '').trim().toLowerCase();
+  const name = `${firstName} ${lastName}`.trim();
+  // Members added by email before their profile resolves have no name upstream — fall back to the
+  // email as the display name (and derive initials from it) so the row is identifiable, not blank.
+  const fullName = name || email;
+  const nameInitials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+  const initials =
+    nameInitials ||
+    email
+      .replace(/[^A-Za-z0-9]/g, '')
+      .slice(0, 2)
+      .toUpperCase();
+  return {
+    email,
+    firstName,
+    lastName,
+    fullName,
+    jobTitle: s.job_title?.trim() ? s.job_title.trim() : null,
+    initials,
+  };
+}

--- a/apps/lfx-one/src/server/services/committee-seat-assignment.mapper.ts
+++ b/apps/lfx-one/src/server/services/committee-seat-assignment.mapper.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Spec 028 (D-101) — shared seat→assignment mapper extracted from `OrgPeopleCommitteeMembersService`
-// so both the Committee tab (spec 027) and the Board tab (spec 028) reuse the same foundation-name
-// enrichment + camelCase mapping with zero duplication. Behavior is byte-identical to the original
-// private methods; the committee read/reassign responses are unchanged.
+// Shared seat→assignment mapper extracted from `OrgPeopleCommitteeMembersService` so both the
+// Committee tab and the Board tab reuse the same foundation-name enrichment + camelCase mapping
+// with zero duplication. Behavior is byte-identical to the original private methods; the committee
+// read/reassign responses are unchanged.
 
 import type { CommitteeMemberAssignment, CommitteeMemberPerson, CommitteeServiceOrgSeat } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';

--- a/apps/lfx-one/src/server/services/org-people-board-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-board-members.service.ts
@@ -18,7 +18,7 @@ import { MicroserviceProxyService } from './microservice-proxy.service';
 import { OrgLensBoardCommitteeService } from './org-lens-board-committee.service';
 import { ProjectService } from './project.service';
 
-/** Org Lens People → Board tab (spec 028): org-wide Board-ONLY roster (FR-003, inverse of the Committee tab) + single-seat reassign, reusing the spec-026 drain + shared seat-mapper (D-101/D-003). */
+/** Org Lens People → Board tab: org-wide Board-ONLY roster (the inverse of the Committee tab) + single-seat reassign, reusing the shared committee-service drain + seat-mapper. */
 export class OrgPeopleBoardMembersService {
   private readonly boardCommitteeService: OrgLensBoardCommitteeService;
   private readonly projectService: ProjectService;
@@ -45,7 +45,7 @@ export class OrgPeopleBoardMembersService {
     return { orgUid, assignments, stats };
   }
 
-  /** Reassign one Membership-Entitlement board seat (FR-017): proxies the spec-026 committee-service atomic reassign. */
+  /** Reassign one Membership-Entitlement board seat: proxies the committee-service atomic reassign. */
   public async reassignSeat(req: Request, orgUid: string, seatId: string, body: ReassignCommitteeMemberBody): Promise<ReassignCommitteeMemberResponse> {
     const upstreamPath = `/committees/b2b-org/${orgUid}/seats/${seatId}/reassign`;
     logger.debug(req, 'reassign_board_member_proxy', 'Proxying reassign to committee-service', {
@@ -54,7 +54,7 @@ export class OrgPeopleBoardMembersService {
       committee_uid: body.committeeUid,
       upstream_path: upstreamPath,
     });
-    // Verb mapping (matches spec 026/027 `org-people-committee-members.service.ts`): the BFF surface is
+    // Verb mapping (matches `org-people-committee-members.service.ts`): the BFF surface is
     // PATCH (REST partial-update convention), but committee-service defines reassign as PUT — so we issue
     // PUT here deliberately. NOT a bug: committee-service implements PUT /committees/b2b-org/{uid}/seats/{member_uid}/reassign.
     const upstream = await this.microserviceProxy.proxyRequest<CommitteeServiceOrgSeat>(

--- a/apps/lfx-one/src/server/services/org-people-board-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-board-members.service.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  BoardMemberStats,
   CommitteeMemberAssignment,
-  CommitteeMemberStats,
   CommitteeServiceOrgSeat,
-  OrgPeopleCommitteeMembersResponse,
+  OrgPeopleBoardMembersResponse,
   ReassignCommitteeMemberBody,
   ReassignCommitteeMemberResponse,
 } from '@lfx-one/shared/interfaces';
-import { isBoardCategory } from '@lfx-one/shared/constants';
+import { isBoardCategory, isVotingStatus } from '@lfx-one/shared/constants';
 import { Request } from 'express';
 
 import { enrichFoundationNames, toAssignment } from './committee-seat-assignment.mapper';
@@ -18,11 +18,8 @@ import { MicroserviceProxyService } from './microservice-proxy.service';
 import { OrgLensBoardCommitteeService } from './org-lens-board-committee.service';
 import { ProjectService } from './project.service';
 
-/**
- * Org Lens People → Committee tab (spec 027): serves the org-wide NON-Board roster (Board excluded, FR-003)
- * and proxies single-seat reassigns, reusing the spec-026 drain/reassign with foundation enrichment (D-003).
- */
-export class OrgPeopleCommitteeMembersService {
+/** Org Lens People → Board tab (spec 028): org-wide Board-ONLY roster (FR-003, inverse of the Committee tab) + single-seat reassign, reusing the spec-026 drain + shared seat-mapper (D-101/D-003). */
+export class OrgPeopleBoardMembersService {
   private readonly boardCommitteeService: OrgLensBoardCommitteeService;
   private readonly projectService: ProjectService;
   private readonly microserviceProxy: MicroserviceProxyService;
@@ -33,32 +30,33 @@ export class OrgPeopleCommitteeMembersService {
     this.microserviceProxy = new MicroserviceProxyService();
   }
 
-  /** Org-wide non-Board roster (FR-001/003/004): drain → exclude Board → enrich foundation names → map → stats. */
-  public async getCommitteeMembers(req: Request, orgUid: string): Promise<OrgPeopleCommitteeMembersResponse> {
+  /** Org-wide Board roster (FR-001/003/004): drain → KEEP Board → enrich foundation names → map → board stats. */
+  public async getBoardMembers(req: Request, orgUid: string): Promise<OrgPeopleBoardMembersResponse> {
     // Org-wide drain: no project filter → committee-service's organization-only scope (every
     // foundation the org holds seats on); the shared drain enforces the 200-page fail-closed cap.
     const seats = await this.boardCommitteeService.fetchAllOrgSeats(req, orgUid);
-    const nonBoard = seats.filter((s) => !isBoardCategory(s.committee_category));
+    // KEEP only Board-category seats — the exact inverse of the Committee tab's `!isBoardCategory`.
+    const board = seats.filter((s) => isBoardCategory(s.committee_category));
 
-    const foundationNames = await enrichFoundationNames(req, nonBoard, this.projectService);
-    const assignments = nonBoard.map((s) => toAssignment(s, foundationNames));
+    const foundationNames = await enrichFoundationNames(req, board, this.projectService);
+    const assignments = board.map((s) => toAssignment(s, foundationNames));
     const stats = this.computeStats(assignments);
 
     return { orgUid, assignments, stats };
   }
 
-  /** Reassign one Membership-Entitlement seat (FR-017): proxies the spec-026 committee-service atomic reassign. */
+  /** Reassign one Membership-Entitlement board seat (FR-017): proxies the spec-026 committee-service atomic reassign. */
   public async reassignSeat(req: Request, orgUid: string, seatId: string, body: ReassignCommitteeMemberBody): Promise<ReassignCommitteeMemberResponse> {
     const upstreamPath = `/committees/b2b-org/${orgUid}/seats/${seatId}/reassign`;
-    logger.debug(req, 'reassign_committee_member_proxy', 'Proxying reassign to committee-service', {
+    logger.debug(req, 'reassign_board_member_proxy', 'Proxying reassign to committee-service', {
       org_uid: orgUid,
       seat_id: seatId,
       committee_uid: body.committeeUid,
       upstream_path: upstreamPath,
     });
-    // Verb mapping (matches spec 026 `org-lens-board-committee.service.ts`): the BFF surface is PATCH
-    // (REST partial-update convention), but committee-service defines reassign as PUT — so we issue PUT
-    // here deliberately. NOT a bug: committee-service implements PUT /committees/b2b-org/{uid}/seats/{member_uid}/reassign.
+    // Verb mapping (matches spec 026/027 `org-people-committee-members.service.ts`): the BFF surface is
+    // PATCH (REST partial-update convention), but committee-service defines reassign as PUT — so we issue
+    // PUT here deliberately. NOT a bug: committee-service implements PUT /committees/b2b-org/{uid}/seats/{member_uid}/reassign.
     const upstream = await this.microserviceProxy.proxyRequest<CommitteeServiceOrgSeat>(
       req,
       'LFX_V2_COMMITTEE_SERVICE',
@@ -75,7 +73,7 @@ export class OrgPeopleCommitteeMembersService {
 
     const foundationNames = await enrichFoundationNames(req, [upstream], this.projectService);
     const seat = toAssignment(upstream, foundationNames);
-    logger.debug(req, 'reassign_committee_member_proxy', 'committee-service returned reassigned seat', {
+    logger.debug(req, 'reassign_board_member_proxy', 'committee-service returned reassigned seat', {
       org_uid: orgUid,
       seat_id: seat.seatId,
       committee_uid: seat.committeeUid,
@@ -83,19 +81,21 @@ export class OrgPeopleCommitteeMembersService {
     return { orgUid, seat };
   }
 
-  /** Filter-independent stats (FR-004): distinct emails / committees / foundations across the FULL roster. */
-  private computeStats(assignments: CommitteeMemberAssignment[]): CommitteeMemberStats {
+  /** Filter-independent board stats (FR-004): distinct members / voting seats / non-voting seats / distinct foundations. */
+  private computeStats(assignments: CommitteeMemberAssignment[]): BoardMemberStats {
     const emails = new Set<string>();
-    const committees = new Set<string>();
     const foundations = new Set<string>();
+    let votingCount = 0;
+    let nonVotingCount = 0;
     for (const a of assignments) {
       if (a.person.email) emails.add(a.person.email);
-      if (a.committeeUid) committees.add(a.committeeUid);
-      // Count by projectUid, but fall back to the foundation slug when the UID is missing so the tile
+      // Count by projectUid, falling back to the foundation slug when the UID is missing so the tile
       // never shows 0 foundations while the table still renders foundation values (un-enriched seats).
       const foundationKey = a.projectUid || a.foundationSlug;
       if (foundationKey) foundations.add(foundationKey);
+      if (isVotingStatus(a.votingStatus)) votingCount += 1;
+      else nonVotingCount += 1;
     }
-    return { individualCount: emails.size, committeeCount: committees.size, foundationsCovered: foundations.size };
+    return { totalBoardMembers: emails.size, votingCount, nonVotingCount, foundationsCovered: foundations.size };
   }
 }

--- a/apps/lfx-one/src/server/services/org-people-board-members.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-board-members.service.ts
@@ -83,12 +83,13 @@ export class OrgPeopleBoardMembersService {
 
   /** Filter-independent board stats (FR-004): distinct members / voting seats / non-voting seats / distinct foundations. */
   private computeStats(assignments: CommitteeMemberAssignment[]): BoardMemberStats {
-    const emails = new Set<string>();
+    const memberKeys = new Set<string>();
     const foundations = new Set<string>();
     let votingCount = 0;
     let nonVotingCount = 0;
     for (const a of assignments) {
-      if (a.person.email) emails.add(a.person.email);
+      // Match the table's grouping key so an email-less seat still counts as one distinct member.
+      memberKeys.add(a.person.email || a.memberUid);
       // Count by projectUid, falling back to the foundation slug when the UID is missing so the tile
       // never shows 0 foundations while the table still renders foundation values (un-enriched seats).
       const foundationKey = a.projectUid || a.foundationSlug;
@@ -96,6 +97,6 @@ export class OrgPeopleBoardMembersService {
       if (isVotingStatus(a.votingStatus)) votingCount += 1;
       else nonVotingCount += 1;
     }
-    return { totalBoardMembers: emails.size, votingCount, nonVotingCount, foundationsCovered: foundations.size };
+    return { totalBoardMembers: memberKeys.size, votingCount, nonVotingCount, foundationsCovered: foundations.size };
   }
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -61,6 +61,7 @@ export * from './marketing-impact.constants';
 export * from './org-people.constants';
 export * from './org-contributions.constants';
 export * from './org-people-key-contacts.constants';
+export * from './org-people-board-members.constants';
 export * from './org-people-committee-members.constants';
 export * from './org-events.constants';
 export * from './individual-enrollment-catalog';

--- a/packages/shared/src/constants/org-people-board-members.constants.ts
+++ b/packages/shared/src/constants/org-people-board-members.constants.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { BoardMembersSortColumn, OrgDropdownOption, OrgPeopleBoardMembersResponse } from '../interfaces';
+
+/** Default sort column for the People → Board table (FR-021). */
+export const ORG_PEOPLE_BOARD_MEMBERS_DEFAULT_SORT_COLUMN: BoardMembersSortColumn = 'name';
+
+/** Stat-tile labels (header + skeleton), in display order, matching the screenshot (FR-004). */
+export const ORG_PEOPLE_BOARD_STAT_LABELS: readonly string[] = ['Total Board Members', 'Voting', 'Non-voting', 'Foundations with a board member'];
+
+/** Table provenance caption (FR-024). */
+export const ORG_PEOPLE_BOARD_SOURCE_CAPTION = 'Source: LFX Membership Board Representatives';
+
+/** "All Statuses" dropdown options for the voting-status filter (FR-007). */
+export const ORG_PEOPLE_BOARD_STATUS_OPTIONS: readonly OrgDropdownOption[] = [
+  { label: 'All Statuses', value: '' },
+  { label: 'Voting', value: 'voting' },
+  { label: 'Non-voting', value: 'non-voting' },
+];
+
+/** Zero-valued envelope — `toSignal` initialValue + the no-account / no-seats fallback. */
+export const EMPTY_ORG_PEOPLE_BOARD_MEMBERS_RESPONSE: OrgPeopleBoardMembersResponse = {
+  orgUid: '',
+  assignments: [],
+  stats: { totalBoardMembers: 0, votingCount: 0, nonVotingCount: 0, foundationsCovered: 0 },
+};

--- a/packages/shared/src/constants/org-people-board-members.constants.ts
+++ b/packages/shared/src/constants/org-people-board-members.constants.ts
@@ -12,6 +12,11 @@ export const ORG_PEOPLE_BOARD_STAT_LABELS: readonly string[] = ['Total Board Mem
 /** Table provenance caption (FR-024). */
 export const ORG_PEOPLE_BOARD_SOURCE_CAPTION = 'Source: LFX Membership Board Representatives';
 
+/** Main-row Reassign pencil tooltip — writer can edit and the person has >= 1 reassignable board seat. */
+export const REASSIGN_TOOLTIP_BOARD_DEFAULT = 'Reassign board roles';
+/** Sub-row Edit pencil tooltip — writer can edit this org-editable board seat. */
+export const EDIT_TOOLTIP_BOARD_DEFAULT = 'Edit board role';
+
 /** "All Statuses" dropdown options for the voting-status filter (FR-007). */
 export const ORG_PEOPLE_BOARD_STATUS_OPTIONS: readonly OrgDropdownOption[] = [
   { label: 'All Statuses', value: '' },

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -30,13 +30,13 @@ export const EMPTY_ORG_PEOPLE_COMMITTEE_MEMBERS_RESPONSE: OrgPeopleCommitteeMemb
   stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 },
 };
 
-/**
- * Tailwind pill classes for a seat's voting status. A real voting status (e.g. "Voting Rep")
- * gets an emerald pill; "Non-voting" / "None" / empty gets a neutral slate pill — matching the
- * spec-027 wireframe (Non-voting rendered as a gray pill).
- */
-export function votingStatusPillClass(status: string | null | undefined): string {
+/** True when a voting status is VOTING (non-empty, not "non-voting"/"none"); the single classifier shared by the pill + Board stat tiles + Board "All Statuses" filter (D-102). */
+export function isVotingStatus(status: string | null | undefined): boolean {
   const s = (status ?? '').trim().toLowerCase();
-  const isVoting = s.length > 0 && s !== 'non-voting' && s !== 'none';
-  return isVoting ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
+  return s.length > 0 && s !== 'non-voting' && s !== 'none';
+}
+
+/** Tailwind pill classes for a voting status — emerald when voting, neutral slate when "Non-voting"/"None"/empty. Delegates to `isVotingStatus` (D-102). */
+export function votingStatusPillClass(status: string | null | undefined): string {
+  return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -189,8 +189,10 @@ export * from './org-lens-access.interface';
 export * from './org-people-key-contacts.interface';
 export * from './org-people-key-contacts.internal.interface';
 
-// Org People — Committee tab (spec 027)
+// Org People — Board tab
 export * from './org-people-board-members.interface';
+
+// Org People — Committee tab
 export * from './org-people-committee-members.interface';
 export * from './org-people-committee-members.internal.interface';
 

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -190,6 +190,7 @@ export * from './org-people-key-contacts.interface';
 export * from './org-people-key-contacts.internal.interface';
 
 // Org People — Committee tab (spec 027)
+export * from './org-people-board-members.interface';
 export * from './org-people-committee-members.interface';
 export * from './org-people-committee-members.internal.interface';
 

--- a/packages/shared/src/interfaces/org-people-board-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-board-members.interface.ts
@@ -17,7 +17,7 @@ export interface BoardMemberStats {
   votingCount: number;
   /** Count of board seats classified as non-voting. */
   nonVotingCount: number;
-  /** Distinct `projectUid` (foundations with a board member). */
+  /** Distinct foundations with a board member — keyed by `projectUid`, falling back to `foundationSlug` when the UID is missing. */
   foundationsCovered: number;
 }
 

--- a/packages/shared/src/interfaces/org-people-board-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-board-members.interface.ts
@@ -1,11 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Spec 028 — Org Lens People → Board tab. Wire (BFF ↔ client) + client view-model types for the
-// org-wide, Board-ONLY roster. This is the inverted-filter sibling of spec 027 (People → Committee
-// tab): a board seat is a committee seat whose category is Board, so the per-seat wire shape is
-// reused verbatim from `org-people-committee-members.interface.ts` (D-103). Only the stats shape,
-// the per-person aggregation (voting counts), and the envelope differ.
+// Org Lens People → Board tab. Wire (BFF ↔ client) + client view-model types for the org-wide,
+// Board-ONLY roster. A board seat is a committee seat whose category is Board, so the per-seat wire
+// shape is reused verbatim from `org-people-committee-members.interface.ts`; only the stats shape,
+// the per-person aggregation (voting counts), and the response envelope differ here.
 
 import type { CommitteeMemberAssignment } from './org-people-committee-members.interface';
 import type { CommitteeMemberAssignmentVm } from './org-people-committee-members.internal.interface';

--- a/packages/shared/src/interfaces/org-people-board-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-board-members.interface.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Spec 028 — Org Lens People → Board tab. Wire (BFF ↔ client) + client view-model types for the
+// org-wide, Board-ONLY roster. This is the inverted-filter sibling of spec 027 (People → Committee
+// tab): a board seat is a committee seat whose category is Board, so the per-seat wire shape is
+// reused verbatim from `org-people-committee-members.interface.ts` (D-103). Only the stats shape,
+// the per-person aggregation (voting counts), and the envelope differ.
+
+import type { CommitteeMemberAssignment } from './org-people-committee-members.interface';
+import type { CommitteeMemberAssignmentVm } from './org-people-committee-members.internal.interface';
+
+/** Filter-independent board stat tiles, computed once at the BFF from the full (unfiltered) roster (FR-004). */
+export interface BoardMemberStats {
+  /** Distinct board members (lowercased emails). */
+  totalBoardMembers: number;
+  /** Count of board seats classified as voting (`isVotingStatus`). */
+  votingCount: number;
+  /** Count of board seats classified as non-voting. */
+  nonVotingCount: number;
+  /** Distinct `projectUid` (foundations with a board member). */
+  foundationsCovered: number;
+}
+
+/** Response envelope for `GET /api/orgs/:orgUid/lens/people/board-members`. Every assignment is a Board-category seat. */
+export interface OrgPeopleBoardMembersResponse {
+  orgUid: string;
+  /** One record per Board seat; `isBoardCategory(committeeCategory) === true` for every entry. */
+  assignments: CommitteeMemberAssignment[];
+  stats: BoardMemberStats;
+}
+
+/** Sortable columns on the Board table (FR-021). Voting Status is categorical — not sortable. */
+export type BoardMembersSortColumn = 'name' | 'foundations';
+
+/** Sort direction — 1 ascending, -1 descending. */
+export type BoardMembersSortDirection = 1 | -1;
+
+/** A voting-status pill rendered in the main-row Voting Status cell (single verbatim pill, or aggregate count pills). */
+export interface BoardVotingPill {
+  label: string;
+  pillClass: string;
+}
+
+/** One person row — derived by grouping assignments by lowercased email (first-wins display fields). */
+export interface BoardMemberPersonGroup {
+  /** Group identity key — lowercased email, or the seat `memberUid` fallback when email is blank. */
+  email: string;
+  displayName: string;
+  jobTitle: string | null;
+  initials: string;
+  /** Distinct foundation names this person holds a board seat on, sorted A→Z. */
+  foundationLabels: string[];
+  /** Count of this person's board seats classified as voting. */
+  votingCount: number;
+  /** Count of this person's board seats classified as non-voting. */
+  nonVotingCount: number;
+  /** Count of assignments where `isOrgEditable === true` — drives the main-row Reassign affordance. */
+  editableCount: number;
+  /** Raw assignments (unsorted) — consumed by the modal + the decorated sub-rows. */
+  assignments: CommitteeMemberAssignment[];
+}
+
+/** Dialog input for the "Why can't I edit this member?" modal — the explanation text to render (FR-009/FR-012 affordance). */
+export interface WhyCantEditBoardDialogData {
+  reason: string;
+}
+
+/** A person group with sub-rows pre-sorted (foundation A→Z, then board/committee A→Z) + decorated. */
+export interface BoardMemberPersonGroupVm extends BoardMemberPersonGroup {
+  sortedAssignments: CommitteeMemberAssignmentVm[];
+  /** Voting Status cell content: one verbatim pill for a single-seat person, else aggregate count pills. */
+  votingPills: BoardVotingPill[];
+  /** Precomputed tooltip/explanation for the main-row Reassign affordance ("Why can't I edit?" copy when disabled). */
+  reassignTooltip: string;
+}


### PR DESCRIPTION
## Summary

Replaces the **"Coming soon"** placeholder on the Org Lens **People -> Board** tab with a live, org-wide, person-grouped roster of every **Board-category** committee seat the selected organization holds. It is the inverted-filter sibling of the spec-027 Committee tab — it keeps **only** `isBoardCategory` seats (the exact complement of the Committee tab) via the shared `@lfx-one/shared` helper, so the two tabs can never drift or double-count.

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-1871

### What's included
- **BFF**: new `GET /api/orgs/:orgUid/lens/people/board-members` (drain org-wide seats -> keep Board -> foundation-name enrichment -> board stats) and `PATCH .../board-members/:seatId/reassign`, both proxying the existing committee-service reads/writes **unchanged**.
- **Shared mapper extraction (DRY)**: `committee-seat-assignment.mapper.ts` is now consumed by both the committee and board services — no behavior change to the shipped Committee tab.
- **Single voting classifier**: `isVotingStatus()` drives the voting pill, the 4 stat tiles (Total Board Members / Voting / Non-voting / Foundations with a board member), and the **All Statuses** filter.
- **UI**: `BoardMembersComponent` with Name / Foundations / Voting Status / Actions columns, search + **All Foundations** + **All Statuses** filters, expand-to-seats, sort on Name + Foundations (Voting Status not sortable), and a **"Why can't I edit?"** affordance + explanatory modal for foundation-controlled seats. Org-controllable (Membership Entitlement) board seats reuse the committee Reassign/Edit modal contracts.
- All shared types/constants live in `packages/shared`.

### Upstream dependency
The board read relies on `project_uid` / `project_slug` on the committee-service `OrgCommitteeSeat` DTO, added in **lfx-v2-committee-service#125** (`feat/LFXV2-1872`, still open). **No new committee-service endpoint, route, Heimdall RuleSet, OpenFGA relation, or DTO field is introduced by this PR** — it is a pure BFF-filter + new UI surface.

## Test plan

- [x] `yarn lint:check`, `yarn check-types`, `yarn format:check`, `yarn build` all green
- [x] New Playwright e2e: `org-people-board-tab.spec.ts` (read / stats / filter / expand / sort / empty / error / "Why can't I edit?" modal) + `org-people-board-reassign.spec.ts` (bulk + single reassign, partial-failure, keyboard combobox, gating)
- [x] Live verified in the local OrbStack cluster against the real committee-service `committee-api:local` (PR #125): board-only roster renders, `project_uid`/`project_slug` flow end to end, board-only invariant proven disjoint from the Committee tab, reassign/edit gating + "Why can't I edit?" modal confirmed
- [ ] CI Playwright e2e (`e2e-tests.yml`) green

> No unit tests — `lfx-v2-ui` is Playwright-e2e only per the project constitution.

Made with [Cursor](https://cursor.com)