### PR TITLE
feat(crowdfunding): gate module behind crowdfunding-enabled feature flag

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { authGuard } from './shared/guards/auth.guard';
 import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
+import { crowdfundingEnabledGuard } from './shared/guards/crowdfunding-enabled.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
 
@@ -338,6 +339,7 @@ export const routes: Routes = [
       {
         path: 'crowdfunding',
         data: { lens: 'me' },
+        canMatch: [crowdfundingEnabledGuard],
         loadChildren: () => import('./modules/crowdfunding/crowdfunding.routes').then((m) => m.CROWDFUNDING_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -7,7 +7,16 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { LensSwitcherComponent } from '@components/lens-switcher/lens-switcher.component';
 import { SidebarComponent } from '@components/sidebar/sidebar.component';
-import { ALL_LENSES, COMMITTEE_LABEL, DOCUMENT_LABEL, MAILING_LIST_LABEL, ORG_LENS_ENABLED_FLAG, SURVEY_LABEL, VOTE_LABEL } from '@lfx-one/shared/constants';
+import {
+  ALL_LENSES,
+  COMMITTEE_LABEL,
+  CROWDFUNDING_ENABLED_FLAG,
+  DOCUMENT_LABEL,
+  MAILING_LIST_LABEL,
+  ORG_LENS_ENABLED_FLAG,
+  SURVEY_LABEL,
+  VOTE_LABEL,
+} from '@lfx-one/shared/constants';
 import { Lens, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { AnalyticsService } from '@services/analytics.service';
 import { AppService } from '@services/app.service';
@@ -45,6 +54,8 @@ export class MainLayoutComponent {
 
   /** Dark-launch gate; falls back to Me Lens nav when off. */
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
+  /** Dark-launch gate; collapses Crowdfunding sub-nav to an external link when off. */
+  private readonly isCrowdfundingEnabled = this.featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false);
 
   // Expose mobile sidebar state from service (writable for two-way binding with p-drawer)
   protected readonly showMobileSidebar = this.appService.showMobileSidebar;
@@ -74,77 +85,17 @@ export class MainLayoutComponent {
         return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
       }
       case 'org':
-        return this.isOrgLensEnabled() ? this.orgLensItems : this.meLensItems;
+        return this.isOrgLensEnabled() ? this.orgLensItems : this.meLensItems();
       default:
-        return this.meLensItems;
+        return this.meLensItems();
     }
   });
 
   // --- Me Lens Items ---
-  private readonly meLensItems: SidebarMenuItem[] = [
-    {
-      label: 'My Dashboard',
-      icon: 'fa-light fa-grid-2',
-      routerLink: '/',
-    },
-    {
-      label: 'My Engagement',
-      isSection: true,
-      expanded: true,
-      items: [
-        {
-          label: 'My Meetings',
-          icon: 'fa-light fa-calendar',
-          routerLink: '/meetings',
-        },
-        {
-          label: 'My Events',
-          icon: 'fa-light fa-ticket',
-          routerLink: '/events',
-        },
-        {
-          label: 'My ' + COMMITTEE_LABEL.plural,
-          icon: 'fa-light fa-users-rectangle',
-          routerLink: '/groups',
-        },
-        {
-          label: 'My ' + MAILING_LIST_LABEL.plural,
-          icon: 'fa-light fa-envelope',
-          routerLink: '/mailing-lists',
-        },
-        {
-          label: 'My ' + VOTE_LABEL.plural,
-          icon: 'fa-light fa-check-to-slot',
-          routerLink: '/votes',
-        },
-        {
-          label: 'My ' + SURVEY_LABEL.plural,
-          icon: 'fa-light fa-clipboard-list',
-          routerLink: '/surveys',
-        },
-        {
-          label: 'My ' + DOCUMENT_LABEL.plural,
-          icon: 'fa-light fa-folder-open',
-          routerLink: '/documents',
-        },
-      ],
-    },
-    {
-      label: 'My Growth',
-      isSection: true,
-      expanded: true,
-      items: [
-        {
-          label: 'Training & Certifications',
-          icon: 'fa-light fa-graduation-cap',
-          routerLink: '/me/training',
-        },
-        {
-          label: 'Mentorships',
-          icon: 'fa-light fa-chalkboard-teacher',
-          url: environment.urls.mentorship,
-        },
-        {
+  // Computed so the Crowdfunding nav entry reacts to the feature flag in real time.
+  private readonly meLensItems = computed((): SidebarMenuItem[] => {
+    const crowdfundingItem: SidebarMenuItem = this.isCrowdfundingEnabled()
+      ? {
           label: 'Crowdfunding',
           icon: 'fa-light fa-circle-dollar',
           isGroup: true,
@@ -161,37 +112,108 @@ export class MainLayoutComponent {
               routerLink: '/crowdfunding/donations',
             },
           ],
-        },
-        {
-          label: 'Badges',
-          icon: 'fa-light fa-award',
-          routerLink: '/badges',
-        },
-      ],
-    },
-    {
-      label: 'My Account',
-      isSection: true,
-      expanded: true,
-      items: [
-        {
-          label: 'Profile',
-          icon: 'fa-light fa-user',
-          routerLink: '/profile',
-        },
-        {
-          label: 'Settings',
-          icon: 'fa-light fa-gear',
-          routerLink: '/settings',
-        },
-        {
-          label: 'Transactions',
-          icon: 'fa-light fa-receipt',
-          routerLink: '/me/transactions',
-        },
-      ],
-    },
-  ];
+        }
+      : {
+          label: 'Crowdfunding',
+          icon: 'fa-light fa-circle-dollar',
+          url: environment.urls.crowdfunding,
+        };
+
+    return [
+      {
+        label: 'My Dashboard',
+        icon: 'fa-light fa-grid-2',
+        routerLink: '/',
+      },
+      {
+        label: 'My Engagement',
+        isSection: true,
+        expanded: true,
+        items: [
+          {
+            label: 'My Meetings',
+            icon: 'fa-light fa-calendar',
+            routerLink: '/meetings',
+          },
+          {
+            label: 'My Events',
+            icon: 'fa-light fa-ticket',
+            routerLink: '/events',
+          },
+          {
+            label: 'My ' + COMMITTEE_LABEL.plural,
+            icon: 'fa-light fa-users-rectangle',
+            routerLink: '/groups',
+          },
+          {
+            label: 'My ' + MAILING_LIST_LABEL.plural,
+            icon: 'fa-light fa-envelope',
+            routerLink: '/mailing-lists',
+          },
+          {
+            label: 'My ' + VOTE_LABEL.plural,
+            icon: 'fa-light fa-check-to-slot',
+            routerLink: '/votes',
+          },
+          {
+            label: 'My ' + SURVEY_LABEL.plural,
+            icon: 'fa-light fa-clipboard-list',
+            routerLink: '/surveys',
+          },
+          {
+            label: 'My ' + DOCUMENT_LABEL.plural,
+            icon: 'fa-light fa-folder-open',
+            routerLink: '/documents',
+          },
+        ],
+      },
+      {
+        label: 'My Growth',
+        isSection: true,
+        expanded: true,
+        items: [
+          {
+            label: 'Training & Certifications',
+            icon: 'fa-light fa-graduation-cap',
+            routerLink: '/me/training',
+          },
+          {
+            label: 'Mentorships',
+            icon: 'fa-light fa-chalkboard-teacher',
+            url: environment.urls.mentorship,
+          },
+          crowdfundingItem,
+          {
+            label: 'Badges',
+            icon: 'fa-light fa-award',
+            routerLink: '/badges',
+          },
+        ],
+      },
+      {
+        label: 'My Account',
+        isSection: true,
+        expanded: true,
+        items: [
+          {
+            label: 'Profile',
+            icon: 'fa-light fa-user',
+            routerLink: '/profile',
+          },
+          {
+            label: 'Settings',
+            icon: 'fa-light fa-gear',
+            routerLink: '/settings',
+          },
+          {
+            label: 'Transactions',
+            icon: 'fa-light fa-receipt',
+            routerLink: '/me/transactions',
+          },
+        ],
+      },
+    ];
+  });
 
   // Whether the currently selected foundation has project-level data in Snowflake.
   // Drives the conditional "Projects" sidebar entry — hidden when the foundation has no rows.

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -117,6 +117,7 @@ export class MainLayoutComponent {
           label: 'Crowdfunding',
           icon: 'fa-light fa-circle-dollar',
           url: environment.urls.crowdfunding,
+          target: '_self',
         };
 
     return [

--- a/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
@@ -41,6 +41,7 @@ export const crowdfundingEnabledGuard: CanMatchFn = async () => {
   }
 
   if (!featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false)()) {
+    // `return false` stops Angular matching any other route while the browser processes the external redirect.
     window.location.replace(environment.urls.crowdfunding);
     return false;
   }

--- a/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { CanMatchFn } from '@angular/router';
+import { environment } from '@environments/environment';
+import { CROWDFUNDING_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
+
+import { FeatureFlagService } from '../services/feature-flag.service';
+
+/** CanMatch guard for /crowdfunding/* gating the dark-launched module behind the `crowdfunding-enabled` flag.
+ *  SSR defers to browser (LD is browser-only). Browser waits for provider READY (5s timeout).
+ *  When flag is OFF or provider never becomes ready, redirects to the external crowdfunding app. */
+export const crowdfundingEnabledGuard: CanMatchFn = async () => {
+  const platformId = inject(PLATFORM_ID);
+
+  // On the server LaunchDarkly is unavailable — let the route match and let the
+  // browser-side run of this guard make the real decision after hydration.
+  if (!isPlatformBrowser(platformId)) {
+    return true;
+  }
+
+  const featureFlagService = inject(FeatureFlagService);
+
+  if (!featureFlagService.providerReady()) {
+    const ready = await firstValueFrom(
+      toObservable(featureFlagService.providerReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(5000),
+        catchError(() => of(false))
+      )
+    );
+    // Provider never became ready (no client id / LD unreachable) → redirect to external app.
+    if (!ready) {
+      window.location.href = environment.urls.crowdfunding;
+      return false;
+    }
+  }
+
+  if (!featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false)()) {
+    window.location.href = environment.urls.crowdfunding;
+    return false;
+  }
+
+  return true;
+};

--- a/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/crowdfunding-enabled.guard.ts
@@ -35,13 +35,13 @@ export const crowdfundingEnabledGuard: CanMatchFn = async () => {
     );
     // Provider never became ready (no client id / LD unreachable) → redirect to external app.
     if (!ready) {
-      window.location.href = environment.urls.crowdfunding;
+      window.location.replace(environment.urls.crowdfunding);
       return false;
     }
   }
 
   if (!featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false)()) {
-    window.location.href = environment.urls.crowdfunding;
+    window.location.replace(environment.urls.crowdfunding);
     return false;
   }
 

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MIT
 
 export const ORG_LENS_ENABLED_FLAG = 'org-lens-enabled';
+export const CROWDFUNDING_ENABLED_FLAG = 'crowdfunding-enabled';


### PR DESCRIPTION
## Summary

- Add `CROWDFUNDING_ENABLED_FLAG = 'crowdfunding-enabled'` constant to `feature-flags.constants.ts`
- Add `crowdfundingEnabledGuard` (`CanMatchFn`) mirroring `orgLensEnabledGuard` — SSR defers to browser, browser waits on LD provider ready (5s timeout), redirects to `environment.urls.crowdfunding` when flag is off or LD is unreachable
- Wire `canMatch: [crowdfundingEnabledGuard]` on the `/crowdfunding` route in `app.routes.ts`
- Convert `meLensItems` to `computed()` in `MainLayoutComponent` — Crowdfunding nav entry switches between the full `isGroup` sub-nav (My Initiatives + My Donations) when the flag is on, and a plain external `url` link to the standalone crowdfunding app when the flag is off; updates reactively via LD streaming without a page reload

## LaunchDarkly setup required

Create a boolean flag with key `crowdfunding-enabled` in each LD environment (default `false`). No `LD_CLIENT_ID` changes needed — existing env var is reused.