### PR TITLE
fix(crowdfunding): allow editing of pending and submitted initiatives

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -2,12 +2,9 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div
-  class="flex items-center gap-4 p-5"
-  [class.cursor-pointer]="isClickable()"
-  [class.hover:bg-gray-50]="isClickable()"
-  [class.opacity-80]="!isClickable()"
-  [attr.role]="isClickable() ? 'button' : null"
-  [attr.tabindex]="isClickable() ? 0 : null"
+  class="flex items-center gap-4 p-5 cursor-pointer hover:bg-gray-50"
+  role="button"
+  tabindex="0"
   [attr.aria-label]="initiative().name"
   [attr.data-testid]="'initiative-card-' + initiative().id"
   (click)="onCardClick()"

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
@@ -30,16 +30,13 @@ export class InitiativeCardComponent {
 
   protected readonly progressPercent = this.initProgressPercent();
 
-  protected readonly isClickable = computed(() => this.initiative().status !== 'pending' && this.initiative().status !== 'submitted');
   protected readonly publicPageUrl = computed(() => `${environment.urls.crowdfunding.replace(/\/+$/, '')}/initiatives/${this.initiative().slug}`);
 
   protected readonly formattedRaised = computed(() => formatCurrency((this.initiative().fundingStatus?.amountRaisedCents ?? 0) / 100));
   protected readonly formattedGoal: Signal<string | null> = this.initFormattedGoal();
 
   protected onCardClick(): void {
-    if (this.isClickable()) {
-      this.cardClick.emit(this.initiative().slug);
-    }
+    this.cardClick.emit(this.initiative().slug);
   }
 
   private initFormattedGoal(): Signal<string | null> {


### PR DESCRIPTION
## Summary

  - Removes the `isClickable` gate in `initiative-card.component.ts` that blocked navigation for `pending` and `submitted` initiatives
  - Makes the initiative card unconditionally interactive (static `cursor-pointer`, `role="button"`, `tabindex="0"`) so all statuses navigate to the detail page
  - No backend changes needed — the existing Settings drawer and `PATCH /api/crowdfunding/initiatives/:id` already support updates for any status