### PR TITLE
feat(meetings): decouple AI summary from recording toggle (LFXV2-2207)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -52,8 +52,20 @@
         <!-- Enable Recording -->
         <lfx-feature-toggle [feature]="recordingFeature" [form]="form()"></lfx-feature-toggle>
 
-        <!-- Generate Transcripts -->
-        <lfx-feature-toggle [feature]="transcriptFeature" [form]="form()"></lfx-feature-toggle>
+        <!-- AI Meeting Summary (with nested settings) -->
+        <lfx-feature-toggle [feature]="aiSummaryFeature" [form]="form()">
+          @if (form().get('zoom_ai_enabled')?.value) {
+            <div class="mt-4 pt-4 border-t border-gray-200">
+              <div class="flex items-center justify-between">
+                <div>
+                  <label for="require-ai-approval" class="text-neutral-950">Require AI Summary Approval</label>
+                  <p class="text-sm text-gray-500">AI summary must be reviewed before sharing</p>
+                </div>
+                <lfx-toggle [form]="form()" control="require_ai_summary_approval" id="require-ai-approval" data-testid="require-ai-approval-toggle"></lfx-toggle>
+              </div>
+            </div>
+          }
+        </lfx-feature-toggle>
 
         <!-- Recording & Summary Access (shown when recording OR AI summary is enabled) -->
         @if (form().get('recording_enabled')?.value || form().get('zoom_ai_enabled')?.value) {
@@ -76,23 +88,11 @@
 
     <!-- Right Column - Remaining Features -->
     <div class="flex flex-col gap-3">
+      <!-- Generate Transcripts -->
+      <lfx-feature-toggle [feature]="transcriptFeature" [form]="form()"></lfx-feature-toggle>
+
       <!-- YouTube Auto-upload -->
       <lfx-feature-toggle [feature]="youtubeFeature" [form]="form()"></lfx-feature-toggle>
-
-      <!-- AI Meeting Summary (with nested settings) -->
-      <lfx-feature-toggle [feature]="aiSummaryFeature" [form]="form()">
-        @if (form().get('zoom_ai_enabled')?.value) {
-          <div class="mt-4 pt-4 border-t border-gray-200">
-            <div class="flex items-center justify-between">
-              <div>
-                <label for="require-ai-approval" class="text-neutral-950">Require AI Summary Approval</label>
-                <p class="text-sm text-gray-500">AI summary must be reviewed before sharing</p>
-              </div>
-              <lfx-toggle [form]="form()" control="require_ai_summary_approval" id="require-ai-approval" data-testid="require-ai-approval-toggle"></lfx-toggle>
-            </div>
-          </div>
-        }
-      </lfx-feature-toggle>
 
       <!-- Show in Public Calendar -->
       <lfx-feature-toggle [feature]="calendarFeature" [form]="form()"></lfx-feature-toggle>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -61,16 +61,28 @@
                   <label for="require-ai-approval" class="text-neutral-950">Require AI Summary Approval</label>
                   <p class="text-sm text-gray-500">AI summary must be reviewed before sharing</p>
                 </div>
-                <lfx-toggle [form]="form()" control="require_ai_summary_approval" id="require-ai-approval" data-testid="require-ai-approval-toggle"></lfx-toggle>
+                <lfx-toggle
+                  [form]="form()"
+                  control="require_ai_summary_approval"
+                  id="require-ai-approval"
+                  data-testid="require-ai-approval-toggle"></lfx-toggle>
               </div>
             </div>
           }
         </lfx-feature-toggle>
 
-        <!-- Recording & Summary Access (shown when recording OR AI summary is enabled) -->
+        <!-- Artifact access (shown when recording OR AI summary is enabled) -->
         @if (form().get('recording_enabled')?.value || form().get('zoom_ai_enabled')?.value) {
           <div class="mt-2 pt-4 border-t border-gray-200">
-            <label for="artifact-visibility" class="block text-neutral-950 mb-2">Recording & Summary Access</label>
+            <label for="artifact-visibility" class="block text-neutral-950 mb-2">
+              @if (form().get('recording_enabled')?.value && form().get('zoom_ai_enabled')?.value) {
+                Recording & Summary Access
+              } @else if (form().get('recording_enabled')?.value) {
+                Recording Access
+              } @else {
+                Summary Access
+              }
+            </label>
             <lfx-select
               size="small"
               [form]="form()"
@@ -80,7 +92,7 @@
               styleClass="w-full"
               id="artifact-visibility"
               data-testid="artifact-visibility-select"></lfx-select>
-            <p class="mt-1 text-sm text-gray-500">Who can access recordings, transcripts, and AI summaries</p>
+            <p class="mt-1 text-sm text-gray-500">Who can access recordings, transcripts, and/or AI summaries</p>
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -49,27 +49,28 @@
       <div class="flex flex-col gap-3">
         <h4 class="text-neutral-950">Meeting Features</h4>
 
-        <!-- Enable Recording (with nested settings) -->
-        <lfx-feature-toggle [feature]="recordingFeature" [form]="form()">
-          @if (form().get('recording_enabled')?.value) {
-            <div class="mt-4 pt-4 border-t border-gray-200">
-              <label for="artifact-visibility" class="block text-neutral-950 mb-2">Recording & Summary Access</label>
-              <lfx-select
-                size="small"
-                [form]="form()"
-                control="artifact_visibility"
-                [options]="artifactVisibilityOptions"
-                placeholder="Select artifact visibility"
-                styleClass="w-full"
-                id="artifact-visibility"
-                data-testid="artifact-visibility-select"></lfx-select>
-              <p class="mt-1 text-sm text-gray-500">Who can access recordings, transcripts, and AI summaries</p>
-            </div>
-          }
-        </lfx-feature-toggle>
+        <!-- Enable Recording -->
+        <lfx-feature-toggle [feature]="recordingFeature" [form]="form()"></lfx-feature-toggle>
 
         <!-- Generate Transcripts -->
         <lfx-feature-toggle [feature]="transcriptFeature" [form]="form()"></lfx-feature-toggle>
+
+        <!-- Recording & Summary Access (shown when recording OR AI summary is enabled) -->
+        @if (form().get('recording_enabled')?.value || form().get('zoom_ai_enabled')?.value) {
+          <div class="mt-2 pt-4 border-t border-gray-200">
+            <label for="artifact-visibility" class="block text-neutral-950 mb-2">Recording & Summary Access</label>
+            <lfx-select
+              size="small"
+              [form]="form()"
+              control="artifact_visibility"
+              [options]="artifactVisibilityOptions"
+              placeholder="Select artifact visibility"
+              styleClass="w-full"
+              id="artifact-visibility"
+              data-testid="artifact-visibility-select"></lfx-select>
+            <p class="mt-1 text-sm text-gray-500">Who can access recordings, transcripts, and AI summaries</p>
+          </div>
+        }
       </div>
     </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
@@ -46,7 +46,7 @@ export class MeetingPlatformFeaturesComponent implements OnInit {
       .get('recording_enabled')
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((recordingEnabled: boolean) => {
-        const dependentControls = ['transcript_enabled', 'zoom_ai_enabled', 'youtube_upload_enabled'];
+        const dependentControls = ['transcript_enabled', 'youtube_upload_enabled'];
 
         dependentControls.forEach((controlName) => {
           const control = this.form().get(controlName);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -497,9 +497,9 @@ export class MeetingManageComponent {
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,
       youtube_upload_enabled: formValue.recording_enabled ? formValue.youtube_upload_enabled || false : false,
       show_meeting_attendees: false, // Coming Soon — disabled in form
-      ai_summary_enabled: formValue.recording_enabled ? formValue.zoom_ai_enabled || false : false,
-      require_ai_summary_approval: formValue.recording_enabled && formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
-      artifact_visibility: formValue.recording_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
+      ai_summary_enabled: formValue.zoom_ai_enabled || false,
+      require_ai_summary_approval: formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
+      artifact_visibility: formValue.recording_enabled || formValue.zoom_ai_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
       recurrence: recurrenceObject,
       platform: formValue.platform || DEFAULT_MEETING_TOOL,
       committees: formValue.committees || [],
@@ -741,7 +741,6 @@ export class MeetingManageComponent {
     if (meeting.recording_enabled) {
       this.form().get('transcript_enabled')?.enable();
       this.form().get('youtube_upload_enabled')?.enable();
-      this.form().get('zoom_ai_enabled')?.enable();
     }
 
     this.form().patchValue({
@@ -936,7 +935,7 @@ export class MeetingManageComponent {
         transcript_enabled: new FormControl({ value: false, disabled: true }),
         youtube_upload_enabled: new FormControl({ value: false, disabled: true }),
         show_meeting_attendees: new FormControl({ value: false, disabled: true }),
-        zoom_ai_enabled: new FormControl({ value: false, disabled: true }),
+        zoom_ai_enabled: new FormControl(false),
         require_ai_summary_approval: new FormControl(false),
         artifact_visibility: new FormControl(DEFAULT_ARTIFACT_VISIBILITY),
 


### PR DESCRIPTION
# Summary

Meeting hosts can now enable AI summary without turning on recording. Artifact visibility controls appear whenever either recording or AI summary is active, with clearer contextual labels for who can access each artifact type. The AI summary and transcript toggles were also reordered for a more logical setup flow.