### PR TITLE
fix(crowdfunding): expose type-specific fields for event and security audit initiatives (DO NOT MERGE)

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -97,6 +97,88 @@
           <label for="settings-website" class="text-sm font-medium text-gray-700">Website URL</label>
           <lfx-input-text [form]="form" control="websiteUrl" id="settings-website" type="url" placeholder="https://example.org" />
         </div>
+
+        <!-- Event dates — shown for event-type initiatives only -->
+        @if (isEventType()) {
+          <div class="border-t border-gray-100 pt-5 flex flex-col gap-5" data-testid="settings-event-dates">
+            <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Event Dates</h3>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-event-start">
+              <label for="settings-event-start" class="text-sm font-medium text-gray-700">Event start date</label>
+              <input
+                type="date"
+                id="settings-event-start"
+                [formControl]="eventStartDateControl"
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                data-testid="settings-event-start-input" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-event-end">
+              <label for="settings-event-end" class="text-sm font-medium text-gray-700">Event end date</label>
+              <input
+                type="date"
+                id="settings-event-end"
+                [formControl]="eventEndDateControl"
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                data-testid="settings-event-end-input" />
+            </div>
+          </div>
+        }
+
+        <!-- Security audit details — shown for security_audit initiatives only -->
+        @if (isSecurityAudit()) {
+          <div class="border-t border-gray-100 pt-5 flex flex-col gap-5" data-testid="settings-security-audit">
+            <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Security Audit Details</h3>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-monetization">
+              <label for="settings-monetization" class="text-sm font-medium text-gray-700">Monetization strategy</label>
+              <lfx-textarea
+                [form]="form"
+                control="monetizationStrategy"
+                id="settings-monetization"
+                styleClass="w-full"
+                [rows]="3"
+                placeholder="Describe your monetization strategy…" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-security-strategy">
+              <label for="settings-security-strategy" class="text-sm font-medium text-gray-700">Current security strategy</label>
+              <lfx-textarea
+                [form]="form"
+                control="currentSecurityStrategy"
+                id="settings-security-strategy"
+                styleClass="w-full"
+                [rows]="3"
+                placeholder="Describe your current security strategy…" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-license">
+              <label for="settings-license" class="text-sm font-medium text-gray-700">License type</label>
+              <lfx-input-text [form]="form" control="licenseType" id="settings-license" placeholder="e.g. Apache 2.0, MIT" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-total-budget">
+              <label for="settings-total-budget" class="text-sm font-medium text-gray-700">Total budget (USD)</label>
+              <input
+                type="number"
+                id="settings-total-budget"
+                [formControl]="totalBudgetCentsControl"
+                min="0"
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="0"
+                data-testid="settings-total-budget-input" />
+              <p class="text-xs text-gray-400">Enter the total budget in US dollars.</p>
+            </div>
+
+            <div class="flex items-center gap-3" data-testid="settings-field-terms">
+              <p-toggleSwitch
+                [ngModel]="termsConditionsControl.value"
+                (onChange)="termsConditionsControl.setValue($event.checked)"
+                inputId="settings-terms" />
+              <label for="settings-terms" class="text-sm font-medium text-gray-700 cursor-pointer">I agree to the terms and conditions</label>
+            </div>
+          </div>
+        }
       </div>
     }
 

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -213,14 +213,6 @@
               <p class="text-xs text-gray-400">Enter the total budget in US dollars.</p>
             </div>
 
-            <div class="flex items-center gap-3" data-testid="settings-field-terms">
-              <p-toggleSwitch
-                [ngModel]="termsConditionsControl.value"
-                (onChange)="termsConditionsControl.setValue($event.checked)"
-                inputId="settings-terms" />
-              <label for="settings-terms" class="text-sm font-medium text-gray-700 cursor-pointer">I agree to the terms and conditions</label>
-            </div>
-
             <!-- Contacts -->
             <div class="flex flex-col gap-4" data-testid="settings-contacts">
               <div class="flex items-center justify-between">

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -98,13 +98,27 @@
           <lfx-input-text [form]="form" control="websiteUrl" id="settings-website" type="url" placeholder="https://example.org" />
         </div>
 
-        <!-- Event dates — shown for event-type initiatives only -->
+        <!-- Code of Conduct URL — all types -->
+        <div class="flex flex-col gap-1.5" data-testid="settings-field-coc">
+          <label for="settings-coc" class="text-sm font-medium text-gray-700">Code of Conduct URL</label>
+          <lfx-input-text [form]="form" control="cocUrl" id="settings-coc" type="url" placeholder="https://example.org/code-of-conduct" />
+        </div>
+
+        <!-- CII Project ID — project type only -->
+        @if (isProjectType()) {
+          <div class="flex flex-col gap-1.5" data-testid="settings-field-cii">
+            <label for="settings-cii" class="text-sm font-medium text-gray-700">CII Project ID</label>
+            <lfx-input-text [form]="form" control="ciiProjectId" id="settings-cii" placeholder="CII Best Practices badge ID" />
+          </div>
+        }
+
+        <!-- Event details — shown for event-type initiatives only -->
         @if (isEventType()) {
-          <div class="border-t border-gray-100 pt-5 flex flex-col gap-5" data-testid="settings-event-dates">
-            <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Event Dates</h3>
+          <div class="border-t border-gray-100 pt-5 flex flex-col gap-5" data-testid="settings-event-details">
+            <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Event Details</h3>
 
             <div class="flex flex-col gap-1.5" data-testid="settings-field-event-start">
-              <label for="settings-event-start" class="text-sm font-medium text-gray-700">Event start date</label>
+              <label for="settings-event-start" class="text-sm font-medium text-gray-700">Start date</label>
               <input
                 type="date"
                 id="settings-event-start"
@@ -114,13 +128,42 @@
             </div>
 
             <div class="flex flex-col gap-1.5" data-testid="settings-field-event-end">
-              <label for="settings-event-end" class="text-sm font-medium text-gray-700">Event end date</label>
+              <label for="settings-event-end" class="text-sm font-medium text-gray-700">End date</label>
               <input
                 type="date"
                 id="settings-event-end"
                 [formControl]="eventEndDateControl"
                 class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 data-testid="settings-event-end-input" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-registration-url">
+              <label for="settings-registration-url" class="text-sm font-medium text-gray-700">Registration URL</label>
+              <lfx-input-text [form]="form" control="applicationUrl" id="settings-registration-url" type="url" placeholder="https://eventbrite.com/…" />
+            </div>
+
+            <div class="flex flex-col gap-1.5" data-testid="settings-field-eventbrite-url">
+              <label for="settings-eventbrite-url" class="text-sm font-medium text-gray-700">Eventbrite URL</label>
+              <lfx-input-text [form]="form" control="eventbriteUrl" id="settings-eventbrite-url" type="url" placeholder="https://eventbrite.com/e/…" />
+            </div>
+
+            <div class="grid grid-cols-2 gap-3" data-testid="settings-event-location">
+              <div class="flex flex-col gap-1.5">
+                <label for="settings-city" class="text-sm font-medium text-gray-700">City</label>
+                <lfx-input-text [form]="form" control="city" id="settings-city" placeholder="San Francisco" />
+              </div>
+              <div class="flex flex-col gap-1.5">
+                <label for="settings-country" class="text-sm font-medium text-gray-700">Country</label>
+                <lfx-input-text [form]="form" control="country" id="settings-country" placeholder="US" />
+              </div>
+            </div>
+
+            <div class="flex items-center gap-3" data-testid="settings-field-is-online">
+              <p-toggleSwitch
+                [ngModel]="isOnlineControl.value"
+                (onChange)="isOnlineControl.setValue($event.checked)"
+                inputId="settings-is-online" />
+              <label for="settings-is-online" class="text-sm font-medium text-gray-700 cursor-pointer">Online event</label>
             </div>
           </div>
         }
@@ -176,6 +219,64 @@
                 (onChange)="termsConditionsControl.setValue($event.checked)"
                 inputId="settings-terms" />
               <label for="settings-terms" class="text-sm font-medium text-gray-700 cursor-pointer">I agree to the terms and conditions</label>
+            </div>
+
+            <!-- Contacts -->
+            <div class="flex flex-col gap-4" data-testid="settings-contacts">
+              <div class="flex items-center justify-between">
+                <h4 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Contacts</h4>
+              </div>
+
+              @for (group of contactGroups(); track $index) {
+                <div class="flex flex-col gap-3 p-4 border border-gray-200 rounded-lg" [attr.data-testid]="'settings-contact-' + $index">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-700">
+                      @for (ct of CONTACT_TYPES; track ct.value) {
+                        @if (ct.value === group.value['contactType']) { {{ ct.label }} }
+                      }
+                    </span>
+                    <button
+                      type="button"
+                      (click)="removeContact($index)"
+                      class="text-gray-400 hover:text-red-500 transition-colors"
+                      [attr.aria-label]="'Remove contact ' + ($index + 1)">
+                      <i class="fa-light fa-trash-can text-sm" aria-hidden="true"></i>
+                    </button>
+                  </div>
+                  <div class="grid grid-cols-2 gap-3">
+                    <div class="flex flex-col gap-1">
+                      <label class="text-xs font-medium text-gray-600">First name</label>
+                      <lfx-input-text [form]="group" control="firstName" placeholder="First name" />
+                    </div>
+                    <div class="flex flex-col gap-1">
+                      <label class="text-xs font-medium text-gray-600">Last name</label>
+                      <lfx-input-text [form]="group" control="lastName" placeholder="Last name" />
+                    </div>
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-medium text-gray-600">Email</label>
+                    <lfx-input-text [form]="group" control="email" type="email" placeholder="contact@example.org" />
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-medium text-gray-600">Phone</label>
+                    <lfx-input-text [form]="group" control="phoneNumber" type="tel" placeholder="+1 (555) 000-0000" />
+                  </div>
+                </div>
+              }
+
+              <div class="flex gap-2 flex-wrap" data-testid="settings-add-contact-buttons">
+                @for (ct of CONTACT_TYPES; track ct.value) {
+                  @if (!usedContactTypes().includes(ct.value)) {
+                    <lfx-button
+                      [label]="'Add ' + ct.label"
+                      icon="fa-light fa-plus"
+                      severity="secondary"
+                      size="small"
+                      (onClick)="addContact(ct.value)"
+                      [attr.data-testid]="'settings-add-contact-' + ct.value" />
+                  }
+                }
+              </div>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -127,7 +127,7 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly initiativeInitial = computed(() => this.initiative().name.charAt(0));
   protected readonly isEventType = computed(() => this.initiative().initiativeType === FundType.EVENT);
   protected readonly isSecurityAudit = computed(() => this.initiative().initiativeType === FundType.SECURITY_AUDIT);
-  protected readonly isProjectType = computed(() => this.initiative().initiativeType === ('project' as FundType));
+  protected readonly isProjectType = computed(() => this.initiative().initiativeType === FundType.GENERAL_FUND);
 
   protected get eventStartDateControl(): FormControl { return this.form.controls['eventStartDate'] as FormControl; }
   protected get eventEndDateControl(): FormControl { return this.form.controls['eventEndDate'] as FormControl; }
@@ -163,7 +163,7 @@ export class InitiativeSettingsDrawerComponent {
           monetizationStrategy: init.ostifDetail?.monetizationStrategy ?? '',
           currentSecurityStrategy: init.ostifDetail?.currentSecurityStrategy ?? '',
           licenseType: init.ostifDetail?.licenseType ?? '',
-          totalBudgetCents: init.ostifDetail?.totalBudgetCents ?? null,
+          totalBudgetCents: init.ostifDetail?.totalBudgetCents != null ? init.ostifDetail.totalBudgetCents / 100 : null,
         });
         this.logoUrl.set(init.logoUrl ?? '');
         this.logoUploadError.set(null);
@@ -250,7 +250,7 @@ export class InitiativeSettingsDrawerComponent {
           monetizationStrategy: monetizationStrategy || undefined,
           currentSecurityStrategy: currentSecurityStrategy || undefined,
           licenseType: licenseType || undefined,
-          totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents) : undefined,
+          totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents * 100) : undefined,
         };
         const contactGs = this.contactGroups();
         if (contactGs.length > 0) {

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -71,10 +71,18 @@ export class InitiativeSettingsDrawerComponent {
     description: new FormControl('', [Validators.required, Validators.maxLength(500)]),
     topics: new FormControl<string[]>([], Validators.required),
     websiteUrl: new FormControl(''),
+    cocUrl: new FormControl(''),
     goal: new FormControl<number | null>(null, [Validators.min(0)]),
+    // project-only
+    ciiProjectId: new FormControl(''),
     // event-type only
     eventStartDate: new FormControl<string>(''),
     eventEndDate: new FormControl<string>(''),
+    applicationUrl: new FormControl(''),
+    eventbriteUrl: new FormControl(''),
+    country: new FormControl(''),
+    city: new FormControl(''),
+    isOnline: new FormControl<boolean>(false),
     // security_audit (ostif) only
     monetizationStrategy: new FormControl<string>(''),
     currentSecurityStrategy: new FormControl<string>(''),
@@ -89,6 +97,13 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly logoUploadError = signal<string | null>(null);
   protected readonly distributionItems = signal<FundDistributionItem[]>(DEFAULT_FUND_DISTRIBUTION.map((i) => ({ ...i })));
   protected readonly beneficiaryGroups = signal<FormGroup[]>([]);
+  protected readonly contactGroups = signal<FormGroup[]>([]);
+
+  protected readonly CONTACT_TYPES = [
+    { value: 'primary', label: 'Primary Contact' },
+    { value: 'secondary', label: 'Secondary Contact' },
+    { value: 'technical_lead', label: 'Technical Lead' },
+  ];
 
   protected readonly hasEnabledCategories = computed(() => this.distributionItems().some((i) => i.enabled));
   protected readonly totalAllocated = computed(() =>
@@ -113,9 +128,11 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly initiativeInitial = computed(() => this.initiative().name.charAt(0));
   protected readonly isEventType = computed(() => this.initiative().initiativeType === FundType.EVENT);
   protected readonly isSecurityAudit = computed(() => this.initiative().initiativeType === FundType.SECURITY_AUDIT);
+  protected readonly isProjectType = computed(() => this.initiative().initiativeType === ('project' as FundType));
 
   protected get eventStartDateControl(): FormControl { return this.form.controls['eventStartDate'] as FormControl; }
   protected get eventEndDateControl(): FormControl { return this.form.controls['eventEndDate'] as FormControl; }
+  protected get isOnlineControl(): FormControl { return this.form.controls['isOnline'] as FormControl; }
   protected get totalBudgetCentsControl(): FormControl { return this.form.controls['totalBudgetCents'] as FormControl; }
   protected get termsConditionsControl(): FormControl { return this.form.controls['termsConditions'] as FormControl; }
 
@@ -135,9 +152,16 @@ export class InitiativeSettingsDrawerComponent {
           description: init.description,
           topics: existingTopics,
           websiteUrl: init.websiteUrl ?? '',
+          cocUrl: init.cocUrl ?? '',
           goal: init.fundingStatus?.goalsTotalCents != null ? init.fundingStatus.goalsTotalCents / 100 : null,
+          ciiProjectId: init.ciiProjectId ?? '',
           eventStartDate: init.eventStartDate ? init.eventStartDate.substring(0, 10) : '',
           eventEndDate: init.eventEndDate ? init.eventEndDate.substring(0, 10) : '',
+          applicationUrl: init.applicationUrl ?? '',
+          eventbriteUrl: init.eventbriteUrl ?? '',
+          country: init.country ?? '',
+          city: init.city ?? '',
+          isOnline: init.isOnline ?? false,
           monetizationStrategy: init.ostifDetail?.monetizationStrategy ?? '',
           currentSecurityStrategy: init.ostifDetail?.currentSecurityStrategy ?? '',
           licenseType: init.ostifDetail?.licenseType ?? '',
@@ -158,6 +182,7 @@ export class InitiativeSettingsDrawerComponent {
           })
         );
         this.beneficiaryGroups.set([]);
+        this.contactGroups.set((init.contacts ?? []).map((c) => this.makeContactGroup(c)));
         this.activeSettingsTab.set('details');
       });
   }
@@ -175,21 +200,31 @@ export class InitiativeSettingsDrawerComponent {
     this.saving.set(true);
 
     try {
-      const { name, description, topics, websiteUrl, goal, eventStartDate, eventEndDate, monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents, termsConditions } =
-        this.form.value as {
-          name: string;
-          description: string;
-          topics: string[];
-          websiteUrl: string;
-          goal: number | null;
-          eventStartDate: string;
-          eventEndDate: string;
-          monetizationStrategy: string;
-          currentSecurityStrategy: string;
-          licenseType: string;
-          totalBudgetCents: number | null;
-          termsConditions: boolean;
-        };
+      const {
+        name, description, topics, websiteUrl, cocUrl, goal, ciiProjectId,
+        eventStartDate, eventEndDate, applicationUrl, eventbriteUrl, country, city, isOnline,
+        monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents, termsConditions,
+      } = this.form.value as {
+        name: string;
+        description: string;
+        topics: string[];
+        websiteUrl: string;
+        cocUrl: string;
+        goal: number | null;
+        ciiProjectId: string;
+        eventStartDate: string;
+        eventEndDate: string;
+        applicationUrl: string;
+        eventbriteUrl: string;
+        country: string;
+        city: string;
+        isOnline: boolean;
+        monetizationStrategy: string;
+        currentSecurityStrategy: string;
+        licenseType: string;
+        totalBudgetCents: number | null;
+        termsConditions: boolean;
+      };
 
       const input: UpdateInitiativeInput = {
         name,
@@ -197,11 +232,21 @@ export class InitiativeSettingsDrawerComponent {
         industry: topics.join(','),
         logoUrl: this.logoUrl(),
         websiteUrl: websiteUrl || undefined,
+        cocUrl: cocUrl || undefined,
       };
+
+      if (this.isProjectType()) {
+        input.ciiProjectId = ciiProjectId || undefined;
+      }
 
       if (this.isEventType()) {
         input.eventStartDate = eventStartDate || undefined;
         input.eventEndDate = eventEndDate || undefined;
+        input.applicationUrl = applicationUrl || undefined;
+        input.eventbriteUrl = eventbriteUrl || undefined;
+        input.country = country || undefined;
+        input.city = city || undefined;
+        input.isOnline = isOnline;
       }
 
       if (this.isSecurityAudit()) {
@@ -212,6 +257,17 @@ export class InitiativeSettingsDrawerComponent {
           totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents) : undefined,
           termsConditions,
         };
+        const contactGs = this.contactGroups();
+        if (contactGs.length > 0) {
+          input.contacts = contactGs.map((g) => ({
+            contactType: g.value.contactType as string,
+            firstName: (g.value.firstName as string) || undefined,
+            lastName: (g.value.lastName as string) || undefined,
+            email: (g.value.email as string) || undefined,
+            phoneNumber: (g.value.phoneNumber as string) || undefined,
+            preferredContactMethod: (g.value.preferredContactMethod as string) || undefined,
+          }));
+        }
       }
 
       if (goal != null) {
@@ -339,5 +395,28 @@ export class InitiativeSettingsDrawerComponent {
 
   protected removeBeneficiary(index: number): void {
     this.beneficiaryGroups.update((groups) => groups.filter((_, i) => i !== index));
+  }
+
+  protected addContact(contactType: string): void {
+    this.contactGroups.update((groups) => [...groups, this.makeContactGroup({ contactType })]);
+  }
+
+  protected removeContact(index: number): void {
+    this.contactGroups.update((groups) => groups.filter((_, i) => i !== index));
+  }
+
+  protected usedContactTypes(): string[] {
+    return this.contactGroups().map((g) => g.value.contactType as string);
+  }
+
+  private makeContactGroup(c: { contactType: string; firstName?: string; lastName?: string; email?: string; phoneNumber?: string; preferredContactMethod?: string }): FormGroup {
+    return new FormGroup({
+      contactType: new FormControl(c.contactType ?? ''),
+      firstName: new FormControl(c.firstName ?? ''),
+      lastName: new FormControl(c.lastName ?? ''),
+      email: new FormControl(c.email ?? '', Validators.email),
+      phoneNumber: new FormControl(c.phoneNumber ?? ''),
+      preferredContactMethod: new FormControl(c.preferredContactMethod ?? 'email'),
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -88,7 +88,6 @@ export class InitiativeSettingsDrawerComponent {
     currentSecurityStrategy: new FormControl<string>(''),
     licenseType: new FormControl<string>(''),
     totalBudgetCents: new FormControl<number | null>(null, [Validators.min(0)]),
-    termsConditions: new FormControl<boolean>(false),
   });
 
   protected readonly saving = signal(false);
@@ -134,7 +133,6 @@ export class InitiativeSettingsDrawerComponent {
   protected get eventEndDateControl(): FormControl { return this.form.controls['eventEndDate'] as FormControl; }
   protected get isOnlineControl(): FormControl { return this.form.controls['isOnline'] as FormControl; }
   protected get totalBudgetCentsControl(): FormControl { return this.form.controls['totalBudgetCents'] as FormControl; }
-  protected get termsConditionsControl(): FormControl { return this.form.controls['termsConditions'] as FormControl; }
 
   public constructor() {
     toObservable(this.visible)
@@ -166,7 +164,6 @@ export class InitiativeSettingsDrawerComponent {
           currentSecurityStrategy: init.ostifDetail?.currentSecurityStrategy ?? '',
           licenseType: init.ostifDetail?.licenseType ?? '',
           totalBudgetCents: init.ostifDetail?.totalBudgetCents ?? null,
-          termsConditions: init.ostifDetail?.termsConditions ?? false,
         });
         this.logoUrl.set(init.logoUrl ?? '');
         this.logoUploadError.set(null);
@@ -203,7 +200,7 @@ export class InitiativeSettingsDrawerComponent {
       const {
         name, description, topics, websiteUrl, cocUrl, goal, ciiProjectId,
         eventStartDate, eventEndDate, applicationUrl, eventbriteUrl, country, city, isOnline,
-        monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents, termsConditions,
+        monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents,
       } = this.form.value as {
         name: string;
         description: string;
@@ -223,7 +220,6 @@ export class InitiativeSettingsDrawerComponent {
         currentSecurityStrategy: string;
         licenseType: string;
         totalBudgetCents: number | null;
-        termsConditions: boolean;
       };
 
       const input: UpdateInitiativeInput = {
@@ -255,7 +251,6 @@ export class InitiativeSettingsDrawerComponent {
           currentSecurityStrategy: currentSecurityStrategy || undefined,
           licenseType: licenseType || undefined,
           totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents) : undefined,
-          termsConditions,
         };
         const contactGs = this.contactGroups();
         if (contactGs.length > 0) {

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -129,10 +129,18 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly isSecurityAudit = computed(() => this.initiative().initiativeType === FundType.SECURITY_AUDIT);
   protected readonly isProjectType = computed(() => this.initiative().initiativeType === FundType.GENERAL_FUND);
 
-  protected get eventStartDateControl(): FormControl { return this.form.controls['eventStartDate'] as FormControl; }
-  protected get eventEndDateControl(): FormControl { return this.form.controls['eventEndDate'] as FormControl; }
-  protected get isOnlineControl(): FormControl { return this.form.controls['isOnline'] as FormControl; }
-  protected get totalBudgetCentsControl(): FormControl { return this.form.controls['totalBudgetCents'] as FormControl; }
+  protected get eventStartDateControl(): FormControl {
+    return this.form.controls['eventStartDate'] as FormControl;
+  }
+  protected get eventEndDateControl(): FormControl {
+    return this.form.controls['eventEndDate'] as FormControl;
+  }
+  protected get isOnlineControl(): FormControl {
+    return this.form.controls['isOnline'] as FormControl;
+  }
+  protected get totalBudgetCentsControl(): FormControl {
+    return this.form.controls['totalBudgetCents'] as FormControl;
+  }
 
   public constructor() {
     toObservable(this.visible)
@@ -198,9 +206,24 @@ export class InitiativeSettingsDrawerComponent {
 
     try {
       const {
-        name, description, topics, websiteUrl, cocUrl, goal, ciiProjectId,
-        eventStartDate, eventEndDate, applicationUrl, eventbriteUrl, country, city, isOnline,
-        monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents,
+        name,
+        description,
+        topics,
+        websiteUrl,
+        cocUrl,
+        goal,
+        ciiProjectId,
+        eventStartDate,
+        eventEndDate,
+        applicationUrl,
+        eventbriteUrl,
+        country,
+        city,
+        isOnline,
+        monetizationStrategy,
+        currentSecurityStrategy,
+        licenseType,
+        totalBudgetCents,
       } = this.form.value as {
         name: string;
         description: string;
@@ -404,7 +427,14 @@ export class InitiativeSettingsDrawerComponent {
     return this.contactGroups().map((g) => g.value.contactType as string);
   }
 
-  private makeContactGroup(c: { contactType: string; firstName?: string; lastName?: string; email?: string; phoneNumber?: string; preferredContactMethod?: string }): FormGroup {
+  private makeContactGroup(c: {
+    contactType: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phoneNumber?: string;
+    preferredContactMethod?: string;
+  }): FormGroup {
     return new FormGroup({
       contactType: new FormControl(c.contactType ?? ''),
       firstName: new FormControl(c.firstName ?? ''),

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -275,17 +275,14 @@ export class InitiativeSettingsDrawerComponent {
           licenseType: licenseType || undefined,
           totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents * 100) : undefined,
         };
-        const contactGs = this.contactGroups();
-        if (contactGs.length > 0) {
-          input.contacts = contactGs.map((g) => ({
-            contactType: g.value.contactType as string,
-            firstName: (g.value.firstName as string) || undefined,
-            lastName: (g.value.lastName as string) || undefined,
-            email: (g.value.email as string) || undefined,
-            phoneNumber: (g.value.phoneNumber as string) || undefined,
-            preferredContactMethod: (g.value.preferredContactMethod as string) || undefined,
-          }));
-        }
+        input.contacts = this.contactGroups().map((g) => ({
+          contactType: g.value.contactType as string,
+          firstName: (g.value.firstName as string) || undefined,
+          lastName: (g.value.lastName as string) || undefined,
+          email: (g.value.email as string) || undefined,
+          phoneNumber: (g.value.phoneNumber as string) || undefined,
+          preferredContactMethod: (g.value.preferredContactMethod as string) || undefined,
+        }));
       }
 
       if (goal != null) {

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_FUND_DISTRIBUTION,
   MAX_LOGO_SIZE_BYTES,
 } from '@lfx-one/shared/constants';
+import { FundType } from '@lfx-one/shared/enums';
 import { FundDistributionItem, InitiativeDetail, TabOption, UpdateInitiativeInput } from '@lfx-one/shared/interfaces';
 import { CrowdfundingService } from '@services/crowdfunding.service';
 
@@ -71,6 +72,15 @@ export class InitiativeSettingsDrawerComponent {
     topics: new FormControl<string[]>([], Validators.required),
     websiteUrl: new FormControl(''),
     goal: new FormControl<number | null>(null, [Validators.min(0)]),
+    // event-type only
+    eventStartDate: new FormControl<string>(''),
+    eventEndDate: new FormControl<string>(''),
+    // security_audit (ostif) only
+    monetizationStrategy: new FormControl<string>(''),
+    currentSecurityStrategy: new FormControl<string>(''),
+    licenseType: new FormControl<string>(''),
+    totalBudgetCents: new FormControl<number | null>(null, [Validators.min(0)]),
+    termsConditions: new FormControl<boolean>(false),
   });
 
   protected readonly saving = signal(false);
@@ -101,6 +111,13 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly nameLength = computed(() => this.formValue().name?.length ?? 0);
   protected readonly descriptionLength = computed(() => this.formValue().description?.length ?? 0);
   protected readonly initiativeInitial = computed(() => this.initiative().name.charAt(0));
+  protected readonly isEventType = computed(() => this.initiative().initiativeType === FundType.EVENT);
+  protected readonly isSecurityAudit = computed(() => this.initiative().initiativeType === FundType.SECURITY_AUDIT);
+
+  protected get eventStartDateControl(): FormControl { return this.form.controls['eventStartDate'] as FormControl; }
+  protected get eventEndDateControl(): FormControl { return this.form.controls['eventEndDate'] as FormControl; }
+  protected get totalBudgetCentsControl(): FormControl { return this.form.controls['totalBudgetCents'] as FormControl; }
+  protected get termsConditionsControl(): FormControl { return this.form.controls['termsConditions'] as FormControl; }
 
   public constructor() {
     toObservable(this.visible)
@@ -119,6 +136,13 @@ export class InitiativeSettingsDrawerComponent {
           topics: existingTopics,
           websiteUrl: init.websiteUrl ?? '',
           goal: init.fundingStatus?.goalsTotalCents != null ? init.fundingStatus.goalsTotalCents / 100 : null,
+          eventStartDate: init.eventStartDate ? init.eventStartDate.substring(0, 10) : '',
+          eventEndDate: init.eventEndDate ? init.eventEndDate.substring(0, 10) : '',
+          monetizationStrategy: init.ostifDetail?.monetizationStrategy ?? '',
+          currentSecurityStrategy: init.ostifDetail?.currentSecurityStrategy ?? '',
+          licenseType: init.ostifDetail?.licenseType ?? '',
+          totalBudgetCents: init.ostifDetail?.totalBudgetCents ?? null,
+          termsConditions: init.ostifDetail?.termsConditions ?? false,
         });
         this.logoUrl.set(init.logoUrl ?? '');
         this.logoUploadError.set(null);
@@ -151,13 +175,21 @@ export class InitiativeSettingsDrawerComponent {
     this.saving.set(true);
 
     try {
-      const { name, description, topics, websiteUrl, goal } = this.form.value as {
-        name: string;
-        description: string;
-        topics: string[];
-        websiteUrl: string;
-        goal: number | null;
-      };
+      const { name, description, topics, websiteUrl, goal, eventStartDate, eventEndDate, monetizationStrategy, currentSecurityStrategy, licenseType, totalBudgetCents, termsConditions } =
+        this.form.value as {
+          name: string;
+          description: string;
+          topics: string[];
+          websiteUrl: string;
+          goal: number | null;
+          eventStartDate: string;
+          eventEndDate: string;
+          monetizationStrategy: string;
+          currentSecurityStrategy: string;
+          licenseType: string;
+          totalBudgetCents: number | null;
+          termsConditions: boolean;
+        };
 
       const input: UpdateInitiativeInput = {
         name,
@@ -166,6 +198,21 @@ export class InitiativeSettingsDrawerComponent {
         logoUrl: this.logoUrl(),
         websiteUrl: websiteUrl || undefined,
       };
+
+      if (this.isEventType()) {
+        input.eventStartDate = eventStartDate || undefined;
+        input.eventEndDate = eventEndDate || undefined;
+      }
+
+      if (this.isSecurityAudit()) {
+        input.ostifDetail = {
+          monetizationStrategy: monetizationStrategy || undefined,
+          currentSecurityStrategy: currentSecurityStrategy || undefined,
+          licenseType: licenseType || undefined,
+          totalBudgetCents: totalBudgetCents != null ? Math.round(totalBudgetCents) : undefined,
+          termsConditions,
+        };
+      }
 
       if (goal != null) {
         const goalCents = Math.round(goal * 100);

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -281,6 +281,32 @@ export class CrowdfundingController {
         input.status = rawStatus as CrowdfundingInitiativeStatus;
       }
 
+      if (typeof body['eventStartDate'] === 'string') input.eventStartDate = body['eventStartDate'];
+      if (typeof body['eventEndDate'] === 'string') input.eventEndDate = body['eventEndDate'];
+
+      if (body['ostifDetail'] !== null && typeof body['ostifDetail'] === 'object') {
+        const o = body['ostifDetail'] as Record<string, unknown>;
+        input.ostifDetail = {
+          monetizationStrategy: typeof o['monetizationStrategy'] === 'string' ? o['monetizationStrategy'] : undefined,
+          currentSecurityStrategy: typeof o['currentSecurityStrategy'] === 'string' ? o['currentSecurityStrategy'] : undefined,
+          licenseType: typeof o['licenseType'] === 'string' ? o['licenseType'] : undefined,
+          totalBudgetCents: typeof o['totalBudgetCents'] === 'number' ? o['totalBudgetCents'] : undefined,
+          termsConditions: typeof o['termsConditions'] === 'boolean' ? o['termsConditions'] : undefined,
+        };
+      }
+
+      if (Array.isArray(body['contacts'])) {
+        input.contacts = (body['contacts'] as Record<string, unknown>[]).map((c) => ({
+          contactType: typeof c['contactType'] === 'string' ? c['contactType'] : '',
+          firstName: typeof c['firstName'] === 'string' ? c['firstName'] : undefined,
+          lastName: typeof c['lastName'] === 'string' ? c['lastName'] : undefined,
+          email: typeof c['email'] === 'string' ? c['email'] : undefined,
+          phoneNumber: typeof c['phoneNumber'] === 'string' ? c['phoneNumber'] : undefined,
+          otherContactOption: typeof c['otherContactOption'] === 'string' ? c['otherContactOption'] : undefined,
+          preferredContactMethod: typeof c['preferredContactMethod'] === 'string' ? c['preferredContactMethod'] : undefined,
+        }));
+      }
+
       if (Array.isArray(body['goals'])) {
         input.goals = (body['goals'] as Record<string, unknown>[]).map((g) => ({
           name: typeof g['name'] === 'string' ? g['name'] : 'Annual Funding Goal',

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -284,8 +284,8 @@ export class CrowdfundingController {
       if (typeof body['cocUrl'] === 'string') input.cocUrl = body['cocUrl'].trim() || undefined;
       if (typeof body['acceptFunding'] === 'boolean') input.acceptFunding = body['acceptFunding'];
       if (typeof body['ciiProjectId'] === 'string') input.ciiProjectId = body['ciiProjectId'].trim() || undefined;
-      if (typeof body['eventStartDate'] === 'string') input.eventStartDate = body['eventStartDate'];
-      if (typeof body['eventEndDate'] === 'string') input.eventEndDate = body['eventEndDate'];
+      if (typeof body['eventStartDate'] === 'string') input.eventStartDate = body['eventStartDate'].trim() || undefined;
+      if (typeof body['eventEndDate'] === 'string') input.eventEndDate = body['eventEndDate'].trim() || undefined;
       if (typeof body['applicationUrl'] === 'string') input.applicationUrl = body['applicationUrl'].trim() || undefined;
       if (typeof body['eventbriteUrl'] === 'string') input.eventbriteUrl = body['eventbriteUrl'].trim() || undefined;
       if (typeof body['country'] === 'string') input.country = body['country'].trim() || undefined;

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -281,8 +281,16 @@ export class CrowdfundingController {
         input.status = rawStatus as CrowdfundingInitiativeStatus;
       }
 
+      if (typeof body['cocUrl'] === 'string') input.cocUrl = body['cocUrl'].trim() || undefined;
+      if (typeof body['acceptFunding'] === 'boolean') input.acceptFunding = body['acceptFunding'];
+      if (typeof body['ciiProjectId'] === 'string') input.ciiProjectId = body['ciiProjectId'].trim() || undefined;
       if (typeof body['eventStartDate'] === 'string') input.eventStartDate = body['eventStartDate'];
       if (typeof body['eventEndDate'] === 'string') input.eventEndDate = body['eventEndDate'];
+      if (typeof body['applicationUrl'] === 'string') input.applicationUrl = body['applicationUrl'].trim() || undefined;
+      if (typeof body['eventbriteUrl'] === 'string') input.eventbriteUrl = body['eventbriteUrl'].trim() || undefined;
+      if (typeof body['country'] === 'string') input.country = body['country'].trim() || undefined;
+      if (typeof body['city'] === 'string') input.city = body['city'].trim() || undefined;
+      if (typeof body['isOnline'] === 'boolean') input.isOnline = body['isOnline'];
 
       if (body['ostifDetail'] !== null && typeof body['ostifDetail'] === 'object') {
         const o = body['ostifDetail'] as Record<string, unknown>;

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -303,6 +303,28 @@ export class CrowdfundingService {
     if (input.logoUrl !== undefined) body.logo_url = input.logoUrl;
     if (input.websiteUrl !== undefined) body.website_url = input.websiteUrl;
     if (input.status !== undefined) body.status = input.status;
+    if (input.eventStartDate !== undefined) body.event_start_date = input.eventStartDate;
+    if (input.eventEndDate !== undefined) body.event_end_date = input.eventEndDate;
+    if (input.ostifDetail !== undefined) {
+      body.ostif_detail = {
+        monetization_strategy: input.ostifDetail.monetizationStrategy,
+        current_security_strategy: input.ostifDetail.currentSecurityStrategy,
+        license_type: input.ostifDetail.licenseType,
+        total_budget_cents: input.ostifDetail.totalBudgetCents,
+        terms_conditions: input.ostifDetail.termsConditions,
+      };
+    }
+    if (input.contacts !== undefined) {
+      body.contacts = input.contacts.map((c) => ({
+        contact_type: c.contactType,
+        first_name: c.firstName,
+        last_name: c.lastName,
+        email: c.email,
+        phone_number: c.phoneNumber,
+        other_contact_option: c.otherContactOption,
+        preferred_contact_method: c.preferredContactMethod,
+      }));
+    }
     if (input.goals !== undefined) {
       body.goals = input.goals.map((g): BackendGoalInput => ({ name: g.name, amount_cents: g.amountCents }));
     }

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -42,6 +42,11 @@ import { logger } from './logger.service';
 
 const cfBaseUrl = (): string => (process.env['CROWDFUNDING_API_BASE_URL'] || '').replace(/\/+$/, '');
 
+/** Converts a YYYY-MM-DD date string to RFC3339 (required by the Go backend's time.Time JSON decoder). */
+function toRFC3339Date(date: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? `${date}T00:00:00Z` : date;
+}
+
 const CF_TIMEOUT_MS = 30_000;
 
 function throwCfNetworkError(operation: string, error: unknown): never {
@@ -302,9 +307,17 @@ export class CrowdfundingService {
     if (input.industry !== undefined) body.industry = input.industry;
     if (input.logoUrl !== undefined) body.logo_url = input.logoUrl;
     if (input.websiteUrl !== undefined) body.website_url = input.websiteUrl;
+    if (input.cocUrl !== undefined) body.coc_url = input.cocUrl;
+    if (input.acceptFunding !== undefined) body.accept_funding = input.acceptFunding;
     if (input.status !== undefined) body.status = input.status;
-    if (input.eventStartDate !== undefined) body.event_start_date = input.eventStartDate;
-    if (input.eventEndDate !== undefined) body.event_end_date = input.eventEndDate;
+    if (input.ciiProjectId !== undefined) body.cii_project_id = input.ciiProjectId;
+    if (input.eventStartDate !== undefined) body.event_start_date = input.eventStartDate ? toRFC3339Date(input.eventStartDate) : input.eventStartDate;
+    if (input.eventEndDate !== undefined) body.event_end_date = input.eventEndDate ? toRFC3339Date(input.eventEndDate) : input.eventEndDate;
+    if (input.applicationUrl !== undefined) body.application_url = input.applicationUrl;
+    if (input.eventbriteUrl !== undefined) body.eventbrite_url = input.eventbriteUrl;
+    if (input.country !== undefined) body.country = input.country;
+    if (input.city !== undefined) body.city = input.city;
+    if (input.isOnline !== undefined) body.is_online = input.isOnline;
     if (input.ostifDetail !== undefined) {
       body.ostif_detail = {
         monetization_strategy: input.ostifDetail.monetizationStrategy,

--- a/apps/lfx-one/src/server/types/crowdfunding.types.ts
+++ b/apps/lfx-one/src/server/types/crowdfunding.types.ts
@@ -21,6 +21,35 @@ export interface BackendSponsor {
   total_cents: number;
 }
 
+export interface BackendOSTIFDetail {
+  monetization_strategy?: string;
+  current_security_strategy?: string;
+  license_type?: string;
+  total_budget_cents: number;
+  terms_conditions: boolean;
+}
+
+export interface BackendContact {
+  id: string;
+  contact_type: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  phone_number?: string;
+  other_contact_option?: string;
+  preferred_contact_method?: string;
+}
+
+export interface BackendContactInput {
+  contact_type: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  phone_number?: string;
+  other_contact_option?: string;
+  preferred_contact_method?: string;
+}
+
 export interface BackendInitiative {
   id: string;
   initiative_type: string;
@@ -33,11 +62,18 @@ export interface BackendInitiative {
   color?: string;
   logo_url?: string;
   website_url?: string;
+  coc_url?: string;
+  accept_funding: boolean;
   country?: string;
   city?: string;
+  is_online: boolean;
   application_url?: string;
+  eventbrite_url?: string;
   event_start_date?: string;
   event_end_date?: string;
+  entity_details?: Record<string, string>;
+  ostif_detail?: BackendOSTIFDetail;
+  contacts?: BackendContact[];
   created_on: string;
   updated_on: string;
   financials?: {
@@ -137,6 +173,14 @@ export interface BackendBeneficiaryInput {
   email?: string;
 }
 
+export interface BackendOSTIFDetailInput {
+  monetization_strategy?: string;
+  current_security_strategy?: string;
+  license_type?: string;
+  total_budget_cents?: number;
+  terms_conditions?: boolean;
+}
+
 /** Snake_case PATCH body sent to PATCH /v1/me/initiatives/{id} on the upstream crowdfunding service. */
 export interface BackendUpdateInitiativeInput {
   name?: string;
@@ -145,6 +189,10 @@ export interface BackendUpdateInitiativeInput {
   logo_url?: string;
   website_url?: string;
   status?: string;
+  event_start_date?: string;
+  event_end_date?: string;
+  ostif_detail?: BackendOSTIFDetailInput;
+  contacts?: BackendContactInput[];
   goals?: BackendGoalInput[];
   beneficiaries?: BackendBeneficiaryInput[];
 }

--- a/apps/lfx-one/src/server/types/crowdfunding.types.ts
+++ b/apps/lfx-one/src/server/types/crowdfunding.types.ts
@@ -71,6 +71,7 @@ export interface BackendInitiative {
   eventbrite_url?: string;
   event_start_date?: string;
   event_end_date?: string;
+  cii_project_id?: string;
   entity_details?: Record<string, string>;
   ostif_detail?: BackendOSTIFDetail;
   contacts?: BackendContact[];
@@ -188,9 +189,20 @@ export interface BackendUpdateInitiativeInput {
   industry?: string;
   logo_url?: string;
   website_url?: string;
+  coc_url?: string;
+  accept_funding?: boolean;
   status?: string;
+  // project-only
+  cii_project_id?: string;
+  // event-only
   event_start_date?: string;
   event_end_date?: string;
+  application_url?: string;
+  eventbrite_url?: string;
+  country?: string;
+  city?: string;
+  is_online?: boolean;
+  // security_audit-only
   ostif_detail?: BackendOSTIFDetailInput;
   contacts?: BackendContactInput[];
   goals?: BackendGoalInput[];

--- a/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
+++ b/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
@@ -8,7 +8,9 @@ import {
   FinancialSummary,
   FundingGoal,
   InitiativeBase,
+  InitiativeContact,
   InitiativeDetail,
+  OSTIFDetail,
   SponsorEntry,
   CrowdfundingInitiativeStatus,
   MyDonation,
@@ -20,9 +22,11 @@ import {
 import { FundType } from '@lfx-one/shared/enums';
 
 import {
+  BackendContact,
   BackendDonation,
   BackendGoal,
   BackendInitiative,
+  BackendOSTIFDetail,
   BackendSponsor,
   BackendSubscription,
   BackendTransaction,
@@ -71,6 +75,13 @@ export function mapToInitiativeBase(b: BackendInitiative): InitiativeBase {
 export function mapToInitiativeDetail(b: BackendInitiative): InitiativeDetail {
   return {
     ...mapToInitiativeBase(b),
+    cocUrl: b.coc_url,
+    acceptFunding: b.accept_funding,
+    isOnline: b.is_online,
+    eventbriteUrl: b.eventbrite_url,
+    entityDetails: b.entity_details,
+    ostifDetail: b.ostif_detail ? mapOSTIFDetail(b.ostif_detail) : undefined,
+    contacts: (b.contacts ?? []).map(mapContact),
     currentBalanceCents: b.financials?.available_balance_cents,
     sponsors: (b.sponsors ?? []).map(mapSponsor),
     fundingGoals: (b.goals ?? []).map(mapFundingGoal),
@@ -80,6 +91,29 @@ export function mapToInitiativeDetail(b: BackendInitiative): InitiativeDetail {
     impactStats: undefined,
     projectHealthStats: undefined,
     projectHealthRating: undefined,
+  };
+}
+
+function mapOSTIFDetail(o: BackendOSTIFDetail): OSTIFDetail {
+  return {
+    monetizationStrategy: o.monetization_strategy,
+    currentSecurityStrategy: o.current_security_strategy,
+    licenseType: o.license_type,
+    totalBudgetCents: o.total_budget_cents,
+    termsConditions: o.terms_conditions,
+  };
+}
+
+function mapContact(c: BackendContact): InitiativeContact {
+  return {
+    id: c.id,
+    contactType: c.contact_type,
+    firstName: c.first_name,
+    lastName: c.last_name,
+    email: c.email,
+    phoneNumber: c.phone_number,
+    otherContactOption: c.other_contact_option,
+    preferredContactMethod: c.preferred_contact_method,
   };
 }
 

--- a/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
+++ b/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
@@ -62,6 +62,7 @@ export function mapToInitiativeBase(b: BackendInitiative): InitiativeBase {
     applicationUrl: b.application_url,
     eventStartDate: b.event_start_date,
     eventEndDate: b.event_end_date,
+    ciiProjectId: b.cii_project_id,
     fundingStatus: b.financials
       ? {
           goalsTotalCents: b.financials.goals_total_cents,

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -142,8 +142,8 @@ export interface OSTIFDetail {
   monetizationStrategy?: string;
   currentSecurityStrategy?: string;
   licenseType?: string;
-  totalBudgetCents: number;
-  termsConditions: boolean;
+  totalBudgetCents?: number;
+  termsConditions?: boolean;
 }
 
 export interface InitiativeContact {

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -36,6 +36,7 @@ export interface InitiativeBase {
   applicationUrl?: string;
   eventStartDate?: string;
   eventEndDate?: string;
+  ciiProjectId?: string;
   initiativeStats?: InitiativeStats;
   fundingStatus?: FundingStatus;
 }
@@ -315,9 +316,20 @@ export interface UpdateInitiativeInput {
   industry?: string;
   logoUrl?: string;
   websiteUrl?: string;
+  cocUrl?: string;
+  acceptFunding?: boolean;
   status?: CrowdfundingInitiativeStatus;
+  // project-only
+  ciiProjectId?: string;
+  // event-only
   eventStartDate?: string;
   eventEndDate?: string;
+  applicationUrl?: string;
+  eventbriteUrl?: string;
+  country?: string;
+  city?: string;
+  isOnline?: boolean;
+  // security_audit-only
   ostifDetail?: UpdateOSTIFDetailInput;
   contacts?: UpdateContactInput[];
   goals?: UpdateGoalInput[];

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -137,8 +137,34 @@ export interface ProjectHealthStat {
   value: string;
 }
 
+export interface OSTIFDetail {
+  monetizationStrategy?: string;
+  currentSecurityStrategy?: string;
+  licenseType?: string;
+  totalBudgetCents: number;
+  termsConditions: boolean;
+}
+
+export interface InitiativeContact {
+  id: string;
+  contactType: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phoneNumber?: string;
+  otherContactOption?: string;
+  preferredContactMethod?: string;
+}
+
 /** Full initiative data returned by the GET /initiatives/:slug detail endpoint. */
 export interface InitiativeDetail extends InitiativeBase {
+  cocUrl?: string;
+  acceptFunding?: boolean;
+  isOnline?: boolean;
+  eventbriteUrl?: string;
+  entityDetails?: Record<string, string>;
+  ostifDetail?: OSTIFDetail;
+  contacts?: InitiativeContact[];
   githubUrl?: string;
   currentBalanceCents?: number;
   sponsors?: SponsorEntry[];
@@ -265,6 +291,24 @@ export interface UpdateBeneficiaryInput {
   email?: string;
 }
 
+export interface UpdateOSTIFDetailInput {
+  monetizationStrategy?: string;
+  currentSecurityStrategy?: string;
+  licenseType?: string;
+  totalBudgetCents?: number;
+  termsConditions?: boolean;
+}
+
+export interface UpdateContactInput {
+  contactType: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phoneNumber?: string;
+  otherContactOption?: string;
+  preferredContactMethod?: string;
+}
+
 export interface UpdateInitiativeInput {
   name?: string;
   description?: string;
@@ -272,6 +316,10 @@ export interface UpdateInitiativeInput {
   logoUrl?: string;
   websiteUrl?: string;
   status?: CrowdfundingInitiativeStatus;
+  eventStartDate?: string;
+  eventEndDate?: string;
+  ostifDetail?: UpdateOSTIFDetailInput;
+  contacts?: UpdateContactInput[];
   goals?: UpdateGoalInput[];
   beneficiaries?: UpdateBeneficiaryInput[];
 }


### PR DESCRIPTION
## Summary

- Event initiatives had no way to view or edit event start/end dates after creation — the CF backend returns these fields but the Self Serve BFF and UI never surfaced them
- Security audit initiatives had the same gap for OSTIF detail fields (monetization strategy, security strategy, license type, total budget, T&C acceptance) and contacts
- This fix wires the full type-specific data through the BFF and adds conditional UI sections to the initiative settings drawer

## Changes

**Server-side wire types** (`apps/lfx-one/src/server/types/crowdfunding.types.ts`):
- Added `BackendOSTIFDetail`, `BackendContact`, `BackendContactInput` interfaces
- Extended `BackendInitiative` with `ostif_detail`, `contacts`, `entity_details`, `coc_url`, `accept_funding`, `is_online`, `eventbrite_url`
- Extended `BackendUpdateInitiativeInput` with `event_start_date`, `event_end_date`, `ostif_detail`, `contacts`

**Shared interfaces** (`packages/shared/src/interfaces/crowdfunding.interface.ts`):
- Added `OSTIFDetail`, `InitiativeContact`, `UpdateOSTIFDetailInput`, `UpdateContactInput`
- Extended `InitiativeDetail` and `UpdateInitiativeInput` with all new fields

**Mapper** (`apps/lfx-one/src/server/utils/crowdfunding-mapper.ts`):
- `mapToInitiativeDetail` now maps OSTIF detail, contacts, and remaining entity fields

**Server service + controller**:
- `updateInitiative()` forwards event dates and OSTIF detail to the CF backend

**Settings drawer UI**:
- Event date pickers (start + end) appear only for `event` type initiatives
- Security audit section (monetization strategy, security strategy, license type, total budget, T&C toggle) appears only for `security_audit` type
- Both sections pre-populate from existing data on drawer open and are included in the PATCH payload on save

No backend changes needed — the CF API already returns and accepts all these fields.

## Test plan

- [ ] Open an event-type initiative in My Initiatives → click Edit → confirm "Event Dates" section appears with existing dates pre-populated
- [ ] Update event dates and save → confirm dates are persisted (refresh and re-open drawer)
- [ ] Open a security audit initiative → confirm "Security Audit Details" section appears with existing values
- [ ] Update OSTIF fields and save → confirm values are persisted
- [ ] Open a non-event, non-security-audit initiative → confirm neither section appears
- [ ] Verify build passes: `yarn ng build --configuration development`

🤖 Generated with [Claude Code](https://claude.ai/code)