### PR TITLE
fix(meetings): route 403 upstream errors to unavailable page

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -374,6 +374,10 @@ export const routes: Routes = [
     loadComponent: () => import('./modules/meetings/meeting-not-found/meeting-not-found.component').then((m) => m.MeetingNotFoundComponent),
   },
   {
+    path: 'meetings/unavailable',
+    loadComponent: () => import('./modules/meetings/meeting-unavailable/meeting-unavailable.component').then((m) => m.MeetingUnavailableComponent),
+  },
+  {
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
   },

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -566,7 +566,9 @@ export class MeetingJoinComponent implements OnInit {
                 project: res.project as Partial<Project> | null,
               })),
               catchError((error) => {
-                if ([404, 403, 400].includes(error.status)) {
+                if (error.status === 403) {
+                  this.router.navigate(['/meetings/unavailable']);
+                } else if ([404, 400].includes(error.status)) {
                   this.router.navigate(['/meetings/not-found']);
                 }
                 return EMPTY;
@@ -595,7 +597,9 @@ export class MeetingJoinComponent implements OnInit {
                   })
                 );
               }
-              if ([403, 400].includes(error.status)) {
+              if (error.status === 403) {
+                this.router.navigate(['/meetings/unavailable']);
+              } else if (error.status === 400) {
                 this.router.navigate(['/meetings/not-found']);
               }
               return EMPTY;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-unavailable/meeting-unavailable.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-unavailable/meeting-unavailable.component.html
@@ -1,0 +1,61 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="bg-gray-50">
+  <!-- Main Content -->
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-4xl mx-auto">
+      <!-- Meeting Unavailable Card -->
+      <lfx-card class="mb-6" data-testid="meeting-unavailable-card">
+        <div class="text-center py-12">
+          <!-- Error Icon -->
+          <div class="flex justify-center mb-6">
+            <div class="w-24 h-24 bg-amber-50 rounded-full flex items-center justify-center">
+              <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400"></i>
+            </div>
+          </div>
+
+          <!-- Error Message -->
+          <h1 class="mb-3" data-testid="error-title">Meeting Temporarily Unavailable</h1>
+
+          <p class="text-gray-600 mb-6 max-w-lg mx-auto" data-testid="error-description">
+            This meeting is temporarily unavailable. Our team is aware of the issue and working to resolve it.
+          </p>
+
+          <!-- Guidance -->
+          <div class="bg-gray-50 rounded-lg p-6 mb-8 text-left max-w-lg mx-auto">
+            <h3 class="text-sm font-medium text-gray-700 mb-3">What you can do:</h3>
+            <ul class="text-sm text-gray-600 flex flex-col gap-2">
+              <li class="flex items-start gap-2">
+                <i class="fa-light fa-circle-dot text-gray-400 mt-1 text-xs"></i>
+                <span>Try again in a few minutes</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <i class="fa-light fa-circle-dot text-gray-400 mt-1 text-xs"></i>
+                <span>If the issue persists, contact support with the meeting URL</span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Action Buttons -->
+          <div class="flex sm:items-center flex-col sm:flex-row gap-6 justify-center">
+            <lfx-button routerLink="/" class="flex items-center" size="small" data-testid="go-home-button">
+              <i class="fa-light fa-home mr-2"></i>
+              <span>Go to Projects Dashboard</span>
+            </lfx-button>
+
+            <lfx-button
+              lfxOpenIntercom
+              class="flex items-center"
+              data-testid="contact-support-button"
+              icon="fa-light fa-life-ring"
+              label="Contact Support"
+              size="small"
+              severity="secondary">
+            </lfx-button>
+          </div>
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-unavailable/meeting-unavailable.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-unavailable/meeting-unavailable.component.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
+
+@Component({
+  selector: 'lfx-meeting-unavailable',
+  imports: [RouterLink, ButtonComponent, CardComponent, OpenIntercomDirective],
+  templateUrl: './meeting-unavailable.component.html',
+})
+export class MeetingUnavailableComponent {}


### PR DESCRIPTION
## Summary

- Adds `MeetingUnavailableComponent` at `/meetings/unavailable` — shown when the upstream returns 403 (gateway authorization failure)
- In `meeting-join.component.ts`, 403 now navigates to `/meetings/unavailable` instead of `/meetings/not-found`
- 400 and genuine 404 still navigate to `/meetings/not-found` (unchanged behaviour for data/not-found cases)

## Why

All public meeting links on `app.lfx.dev` are currently broken (LFXV2-2217): Heimdall is returning 403 to the app's M2M token on `GET /itx/meetings/*`. Because the frontend collapsed any 4xx into `/meetings/not-found`, users (and on-call) saw "Meeting not found" with zero indication of an upstream auth failure.

A 403 is not a missing resource — it's an access denial. The new `/meetings/unavailable` page ("temporarily unavailable, try again") correctly communicates a transient service issue and makes future auth regressions immediately diagnosable without log access.

## Test plan

- [ ] Verify a meeting that currently returns 403 renders `/meetings/unavailable` page with "Meeting Temporarily Unavailable" heading
- [ ] Verify a genuinely missing meeting (404) still renders `/meetings/not-found`
- [ ] Verify a past meeting occurrence ID that 403s also lands on `/meetings/unavailable`
- [ ] `yarn build` passes (no SSR breakage)

## Related

- LFXV2-2217 — backend ticket for the Heimdall/M2M authorization regression (platform team to fix)
- LFXV2-1298 — parent bug tracking "Meeting not Found" recurrence

🤖 Generated with [Claude Code](https://claude.ai/claude-code)