### PR TITLE
feat(docs): documentation portal UI improvements

### DIFF
--- a/apps/lfx-one/scripts/lib/build-manifest.mjs
+++ b/apps/lfx-one/scripts/lib/build-manifest.mjs
@@ -154,7 +154,7 @@ export function buildDocsManifest({ records }) {
       url: '/docs',
       sourcePath: '',
       topic: '',
-      title: 'LFX Self Serve Documentation',
+      title: 'LFX Documentation',
       description: 'Browse user guides for the LFX Self Serve product.',
       bodyHtml: '',
       headings: [],
@@ -263,7 +263,7 @@ function buildTaxonomyTree(articles, topics) {
   /** @type {import('@lfx-one/shared').DocsTaxonomyNode} */
   const tree = {
     slug: '',
-    title: root?.title ?? 'LFX Self Serve Documentation',
+    title: root?.title ?? 'LFX Documentation',
     url: '/docs',
     children: [],
   };

--- a/apps/lfx-one/scripts/lib/build-manifest.mjs
+++ b/apps/lfx-one/scripts/lib/build-manifest.mjs
@@ -23,19 +23,19 @@ const MANIFEST_SCHEMA_VERSION = 1;
  * the manifest.
  */
 const DOCS_TAXONOMY_ORDER = [
-  'badges',
-  'committees',
   'dashboards',
-  'documents',
-  'events',
-  'mailing-lists',
   'meetings',
+  'events',
+  'committees',
+  'mailing-lists',
+  'votes',
+  'surveys',
+  'documents',
+  'trainings',
+  'badges',
   'profile',
   'settings',
-  'surveys',
-  'trainings',
   'transactions',
-  'votes',
 ];
 
 /**

--- a/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
@@ -38,7 +38,7 @@
       }
     </div>
 
-    <div class="flex-grow px-5 pt-6 pb-[100px] md:px-8">
+    <div class="flex-grow px-[32px] pb-[100px]">
       <router-outlet />
     </div>
 

--- a/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
@@ -41,5 +41,8 @@
     <div class="flex-grow px-5 md:px-8 py-6">
       <router-outlet />
     </div>
+
+    <!-- App footer — constrained to the 1024px docs content width -->
+    <lfx-footer class="mx-auto mt-auto w-full max-w-[1024px] p-8" cookie-tracking="true"></lfx-footer>
   </main>
 </div>

--- a/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.html
@@ -38,7 +38,7 @@
       }
     </div>
 
-    <div class="flex-grow px-5 md:px-8 py-6">
+    <div class="flex-grow px-5 pt-6 pb-[100px] md:px-8">
       <router-outlet />
     </div>
 

--- a/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/docs-layout/docs-layout.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, CUSTOM_ELEMENTS_SCHEMA, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { LensSwitcherComponent } from '@components/lens-switcher/lens-switcher.component';
@@ -40,6 +40,7 @@ import { UserService } from '../../shared/services/user.service';
   imports: [RouterModule, LensSwitcherComponent, DocsSidebarNavComponent],
   templateUrl: './docs-layout.component.html',
   styleUrl: './docs-layout.component.scss',
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class DocsLayoutComponent {
   protected readonly userService = inject(UserService);

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="relative w-full max-w-xl" data-testid="docs-search">
+<div class="relative w-full" [class.max-w-xl]="!fullWidth()" data-testid="docs-search">
   <label class="sr-only" for="docs-search-input">Search documentation</label>
   <div class="relative flex items-center">
     <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 text-gray-400" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
@@ -45,7 +45,7 @@
                   <span class="font-semibold text-gray-900">{{ hit.title }}</span>
                   @if (hit.topic) {
                     <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                      {{ topicLabel(hit.topic) }}
+                      {{ topicLabelRecord()[hit.topic] ?? hit.topic }}
                     </span>
                   }
                 </span>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.html
@@ -44,8 +44,8 @@
                 <span class="flex items-center gap-2">
                   <span class="font-semibold text-gray-900">{{ hit.title }}</span>
                   @if (hit.topic) {
-                    <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs uppercase tracking-wide text-gray-600">
-                      {{ hit.topic }}
+                    <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                      {{ topicLabel(hit.topic) }}
                     </span>
                   }
                 </span>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, ElementRef, HostListener, inject, signal, viewChild } from '@angular/core';
+import { Component, computed, ElementRef, HostListener, inject, input, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
@@ -42,6 +42,9 @@ export class DocsSearchComponent {
   private readonly searchService = inject(DocsSearchService);
   private readonly router = inject(Router);
   private readonly host = inject(ElementRef<HTMLElement>);
+
+  // When true, the search box fills its container instead of capping at max-w-xl.
+  public readonly fullWidth = input(false);
 
   protected readonly inputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
 

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
@@ -45,9 +45,12 @@ export class DocsSearchComponent {
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly manifest = inject(DocsManifestService);
 
-  // Maps a topic slug to its display name so result chips show the proper
-  // topic label (e.g. 'committees' → 'Groups') rather than the raw slug.
-  private readonly topicNames = new Map(this.manifest.getTopics().map((topic) => [topic.slug, topic.name]));
+  // Maps each topic slug to its sentence-cased display name so result chips show
+  // the proper label (e.g. 'committees' → 'Groups'). A computed record keeps the
+  // template lookup to a plain property access — no method calls in the template.
+  protected readonly topicLabelRecord = computed<Record<string, string | undefined>>(() =>
+    Object.fromEntries(this.manifest.getTopics().map((topic) => [topic.slug, topic.name.charAt(0).toUpperCase() + topic.name.slice(1).toLowerCase()]))
+  );
 
   // When true, the search box fills its container instead of capping at max-w-xl.
   public readonly fullWidth = input(false);
@@ -98,12 +101,6 @@ export class DocsSearchComponent {
         this.activeIndex.set(results.length > 0 ? 0 : -1);
         this.searching.set(false);
       });
-  }
-
-  /** Sentence-cased topic name for the result chip, resolved from the slug. */
-  protected topicLabel(slug: string): string {
-    const name = this.topicNames.get(slug) ?? slug.replace(/-/g, ' ');
-    return name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
   }
 
   protected onFocus(): void {

--- a/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-search/docs-search.component.ts
@@ -9,6 +9,7 @@ import { debounceTime, distinctUntilChanged, of, switchMap } from 'rxjs';
 
 import type { DocsSearchHit } from '@lfx-one/shared/interfaces';
 
+import { DocsManifestService } from '../../services/docs-manifest.service';
 import { DocsSearchService } from '../../services/docs-search.service';
 
 /**
@@ -42,6 +43,11 @@ export class DocsSearchComponent {
   private readonly searchService = inject(DocsSearchService);
   private readonly router = inject(Router);
   private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly manifest = inject(DocsManifestService);
+
+  // Maps a topic slug to its display name so result chips show the proper
+  // topic label (e.g. 'committees' → 'Groups') rather than the raw slug.
+  private readonly topicNames = new Map(this.manifest.getTopics().map((topic) => [topic.slug, topic.name]));
 
   // When true, the search box fills its container instead of capping at max-w-xl.
   public readonly fullWidth = input(false);
@@ -92,6 +98,12 @@ export class DocsSearchComponent {
         this.activeIndex.set(results.length > 0 ? 0 : -1);
         this.searching.set(false);
       });
+  }
+
+  /** Sentence-cased topic name for the result chip, resolved from the slug. */
+  protected topicLabel(slug: string): string {
+    const name = this.topicNames.get(slug) ?? slug.replace(/-/g, ' ');
+    return name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
   }
 
   protected onFocus(): void {

--- a/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
@@ -3,11 +3,7 @@
 
 <div class="flex flex-col items-center h-full bg-blue-900 py-6" data-testid="docs-sidebar-nav">
   <!-- LF Logo -->
-  <a
-    routerLink="/docs"
-    class="mb-4 flex items-center justify-center px-3 focus:outline-none"
-    aria-label="LFX Documentation"
-    data-testid="docs-sidebar-logo">
+  <a routerLink="/docs" class="mb-4 flex items-center justify-center px-3 focus:outline-none" aria-label="LFX Documentation" data-testid="docs-sidebar-logo">
     <img src="/images/logo_lf_white.svg" alt="Linux Foundation" class="w-6 h-6" />
   </a>
 

--- a/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
@@ -28,7 +28,7 @@
           'bg-blue-500': isDocsActive(),
           'group-hover:bg-white/10': !isDocsActive(),
         }">
-        <i class="fa-light fa-book text-xl"></i>
+        <i [ngClass]="isDocsActive() ? 'fa-solid fa-book' : 'fa-light fa-book'" class="text-xl"></i>
       </div>
     </a>
   </div>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-sidebar-nav/docs-sidebar-nav.component.html
@@ -6,7 +6,7 @@
   <a
     routerLink="/docs"
     class="mb-4 flex items-center justify-center px-3 focus:outline-none"
-    aria-label="LFX Self Serve Documentation"
+    aria-label="LFX Documentation"
     data-testid="docs-sidebar-logo">
     <img src="/images/logo_lf_white.svg" alt="Linux Foundation" class="w-6 h-6" />
   </a>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.html
@@ -6,16 +6,12 @@
   class="group flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-blue-500 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
   [attr.aria-label]="'Browse ' + topic().name + ' documentation, ' + articleCountLabel()"
   data-testid="docs-topic-card">
-  <div class="flex items-center gap-2.5">
-    @if (topic().icon) {
-      <span class="flex h-9 w-9 items-center justify-center rounded-md bg-blue-50 text-blue-600 transition-colors group-hover:bg-blue-100">
-        <i [class]="topic().icon" aria-hidden="true"></i>
-      </span>
-    }
-    <h2 class="text-base font-semibold text-gray-900 group-hover:text-blue-700">
-      {{ topic().name }}
-    </h2>
-  </div>
+  <span class="flex h-[32px] w-[32px] items-center justify-center rounded-[8px] text-gray-900 {{ containerBg() }}">
+    <i [class]="iconClass()" aria-hidden="true"></i>
+  </span>
+  <h2 class="text-base font-semibold text-gray-900 group-hover:text-blue-700">
+    {{ topic().name }}
+  </h2>
   @if (topic().description) {
     <p class="text-sm text-gray-600">{{ topic().description }}</p>
   }
@@ -23,6 +19,6 @@
     <span class="text-xs uppercase tracking-wide text-gray-500">
       {{ articleCountLabel() }}
     </span>
-    <i class="fa-light fa-arrow-right text-sm text-gray-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600" aria-hidden="true"></i>
+    <i class="fa-light fa-angle-right text-sm text-gray-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600" aria-hidden="true"></i>
   </div>
 </a>

--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.html
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.html
@@ -6,7 +6,7 @@
   class="group flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-blue-500 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
   [attr.aria-label]="'Browse ' + topic().name + ' documentation, ' + articleCountLabel()"
   data-testid="docs-topic-card">
-  <span class="flex h-[32px] w-[32px] items-center justify-center rounded-[8px] text-gray-900 {{ containerBg() }}">
+  <span class="flex h-[32px] w-[32px] items-center justify-center rounded-[8px] {{ containerClass() }}">
     <i [class]="iconClass()" aria-hidden="true"></i>
   </span>
   <h2 class="text-base font-semibold text-gray-900 group-hover:text-blue-700">

--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
@@ -27,10 +27,33 @@ import type { DocsTopic } from '@lfx-one/shared/interfaces';
 export class DocsTopicCardComponent {
   public readonly topic = input.required<DocsTopic>();
 
+  // Per-topic tile visuals: a fa-light icon that fits the topic and a light
+  // palette-color container background. Icons render in gray-900 (set on the
+  // container). Class strings are written in full so Tailwind's JIT detects them.
+  private readonly topicVisuals: Record<string, { icon: string; bg: string }> = {
+    badges: { icon: 'fa-light fa-award', bg: 'bg-amber-100' },
+    committees: { icon: 'fa-light fa-user-group', bg: 'bg-blue-100' },
+    dashboards: { icon: 'fa-light fa-gauge-high', bg: 'bg-violet-100' },
+    documents: { icon: 'fa-light fa-file-lines', bg: 'bg-blue-100' },
+    events: { icon: 'fa-light fa-calendar-star', bg: 'bg-emerald-100' },
+    'mailing-lists': { icon: 'fa-light fa-envelope', bg: 'bg-violet-100' },
+    meetings: { icon: 'fa-light fa-video', bg: 'bg-amber-100' },
+    profile: { icon: 'fa-light fa-id-badge', bg: 'bg-emerald-100' },
+    settings: { icon: 'fa-light fa-gear', bg: 'bg-gray-100' },
+    surveys: { icon: 'fa-light fa-square-poll-vertical', bg: 'bg-amber-100' },
+    trainings: { icon: 'fa-light fa-graduation-cap', bg: 'bg-blue-100' },
+    transactions: { icon: 'fa-light fa-receipt', bg: 'bg-emerald-100' },
+    votes: { icon: 'fa-light fa-check-to-slot', bg: 'bg-violet-100' },
+  };
+
   protected readonly articleCountLabel = computed(() => {
     const n = this.topic().articleSlugs.length;
     return `${n} article${n === 1 ? '' : 's'}`;
   });
 
   protected readonly url = computed(() => `/docs/${this.topic().slug}`);
+
+  protected readonly iconClass = computed(() => this.topicVisuals[this.topic().slug]?.icon ?? this.topic().icon ?? 'fa-light fa-file-lines');
+
+  protected readonly containerBg = computed(() => this.topicVisuals[this.topic().slug]?.bg ?? 'bg-blue-100');
 }

--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
@@ -27,23 +27,26 @@ import type { DocsTopic } from '@lfx-one/shared/interfaces';
 export class DocsTopicCardComponent {
   public readonly topic = input.required<DocsTopic>();
 
-  // Per-topic tile visuals: a fa-light icon that fits the topic and a light
-  // palette-color container background. Icons render in gray-900 (set on the
-  // container). Class strings are written in full so Tailwind's JIT detects them.
-  private readonly topicVisuals: Record<string, { icon: string; bg: string }> = {
-    badges: { icon: 'fa-light fa-award', bg: 'bg-amber-100' },
-    committees: { icon: 'fa-light fa-user-group', bg: 'bg-blue-100' },
-    dashboards: { icon: 'fa-light fa-gauge-high', bg: 'bg-violet-100' },
-    documents: { icon: 'fa-light fa-file-lines', bg: 'bg-blue-100' },
-    events: { icon: 'fa-light fa-calendar-star', bg: 'bg-emerald-100' },
-    'mailing-lists': { icon: 'fa-light fa-envelope', bg: 'bg-violet-100' },
-    meetings: { icon: 'fa-light fa-video', bg: 'bg-amber-100' },
-    profile: { icon: 'fa-light fa-id-badge', bg: 'bg-emerald-100' },
-    settings: { icon: 'fa-light fa-gear', bg: 'bg-gray-100' },
-    surveys: { icon: 'fa-light fa-square-poll-vertical', bg: 'bg-amber-100' },
-    trainings: { icon: 'fa-light fa-graduation-cap', bg: 'bg-blue-100' },
-    transactions: { icon: 'fa-light fa-receipt', bg: 'bg-emerald-100' },
-    votes: { icon: 'fa-light fa-check-to-slot', bg: 'bg-violet-100' },
+  // Per-topic tile visuals: a fa-light icon that fits the topic and the icon
+  // container's color classes (background + icon text color). Colors group by
+  // importance — Dashboard uses a gray-900 fill, the primary group bold blue,
+  // and the secondary group bold violet, all with a white icon; the least
+  // prominent group keeps a light-gray tint with a gray-900 icon. Class strings
+  // are written in full so Tailwind's JIT detects them.
+  private readonly topicVisuals: Record<string, { icon: string; container: string }> = {
+    dashboards: { icon: 'fa-light fa-gauge-high', container: 'bg-gray-900 text-white' },
+    meetings: { icon: 'fa-light fa-video', container: 'bg-blue-500 text-white' },
+    events: { icon: 'fa-light fa-calendar-star', container: 'bg-blue-500 text-white' },
+    committees: { icon: 'fa-light fa-user-group', container: 'bg-blue-500 text-white' },
+    'mailing-lists': { icon: 'fa-light fa-envelope', container: 'bg-blue-500 text-white' },
+    votes: { icon: 'fa-light fa-check-to-slot', container: 'bg-blue-500 text-white' },
+    surveys: { icon: 'fa-light fa-square-poll-vertical', container: 'bg-blue-500 text-white' },
+    documents: { icon: 'fa-light fa-file-lines', container: 'bg-blue-500 text-white' },
+    trainings: { icon: 'fa-light fa-graduation-cap', container: 'bg-violet-600 text-white' },
+    badges: { icon: 'fa-light fa-award', container: 'bg-violet-600 text-white' },
+    profile: { icon: 'fa-light fa-id-badge', container: 'bg-gray-100 text-gray-900' },
+    settings: { icon: 'fa-light fa-gear', container: 'bg-gray-100 text-gray-900' },
+    transactions: { icon: 'fa-light fa-receipt', container: 'bg-gray-100 text-gray-900' },
   };
 
   protected readonly articleCountLabel = computed(() => {
@@ -55,5 +58,5 @@ export class DocsTopicCardComponent {
 
   protected readonly iconClass = computed(() => this.topicVisuals[this.topic().slug]?.icon ?? this.topic().icon ?? 'fa-light fa-file-lines');
 
-  protected readonly containerBg = computed(() => this.topicVisuals[this.topic().slug]?.bg ?? 'bg-blue-100');
+  protected readonly containerClass = computed(() => this.topicVisuals[this.topic().slug]?.container ?? 'bg-blue-100 text-gray-900');
 }

--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
@@ -27,26 +27,27 @@ import type { DocsTopic } from '@lfx-one/shared/interfaces';
 export class DocsTopicCardComponent {
   public readonly topic = input.required<DocsTopic>();
 
-  // Per-topic tile visuals: a fa-light icon that fits the topic and the icon
-  // container's color classes (background + icon text color). Colors group by
-  // importance — Dashboard uses a gray-900 fill, the primary group bold blue,
-  // and the secondary group bold violet, all with a white icon; the least
-  // prominent group keeps a light-gray tint with a gray-900 icon. Class strings
-  // are written in full so Tailwind's JIT detects them.
+  // Per-topic tile visuals: a FontAwesome icon (name aligned with the app
+  // navigation menu / lens entries) and the icon container's color classes
+  // (background + icon text color). Colors group by importance — Dashboard uses
+  // a gray-900 fill, the primary group bold blue, and the secondary group bold
+  // violet, all with a white SOLID icon; the least prominent group keeps a
+  // light-gray tint with a gray-900 LIGHT icon. Class strings are written in
+  // full so Tailwind's JIT detects them.
   private readonly topicVisuals: Record<string, { icon: string; container: string }> = {
-    dashboards: { icon: 'fa-light fa-gauge-high', container: 'bg-gray-900 text-white' },
-    meetings: { icon: 'fa-light fa-video', container: 'bg-blue-500 text-white' },
-    events: { icon: 'fa-light fa-calendar-star', container: 'bg-blue-500 text-white' },
-    committees: { icon: 'fa-light fa-user-group', container: 'bg-blue-500 text-white' },
-    'mailing-lists': { icon: 'fa-light fa-envelope', container: 'bg-blue-500 text-white' },
-    votes: { icon: 'fa-light fa-check-to-slot', container: 'bg-blue-500 text-white' },
-    surveys: { icon: 'fa-light fa-square-poll-vertical', container: 'bg-blue-500 text-white' },
-    documents: { icon: 'fa-light fa-file-lines', container: 'bg-blue-500 text-white' },
-    trainings: { icon: 'fa-light fa-graduation-cap', container: 'bg-violet-600 text-white' },
-    badges: { icon: 'fa-light fa-award', container: 'bg-violet-600 text-white' },
-    profile: { icon: 'fa-light fa-id-badge', container: 'bg-gray-100 text-gray-900' },
-    settings: { icon: 'fa-light fa-gear', container: 'bg-gray-100 text-gray-900' },
-    transactions: { icon: 'fa-light fa-receipt', container: 'bg-gray-100 text-gray-900' },
+    dashboards: { icon: 'fa-solid fa-grid-2', container: 'bg-gray-900 text-white' },
+    meetings: { icon: 'fa-solid fa-calendar', container: 'bg-blue-500 text-white' },
+    events: { icon: 'fa-solid fa-ticket', container: 'bg-blue-500 text-white' },
+    committees: { icon: 'fa-solid fa-users-rectangle', container: 'bg-blue-500 text-white' },
+    'mailing-lists': { icon: 'fa-solid fa-envelope', container: 'bg-blue-500 text-white' },
+    votes: { icon: 'fa-solid fa-check-to-slot', container: 'bg-blue-500 text-white' },
+    surveys: { icon: 'fa-solid fa-clipboard-list', container: 'bg-blue-500 text-white' },
+    documents: { icon: 'fa-solid fa-folder-open', container: 'bg-blue-500 text-white' },
+    trainings: { icon: 'fa-solid fa-graduation-cap', container: 'bg-violet-600 text-white' },
+    badges: { icon: 'fa-solid fa-award', container: 'bg-violet-600 text-white' },
+    profile: { icon: 'fa-light fa-user', container: 'bg-gray-200 text-gray-900' },
+    settings: { icon: 'fa-light fa-gear', container: 'bg-gray-200 text-gray-900' },
+    transactions: { icon: 'fa-light fa-receipt', container: 'bg-gray-200 text-gray-900' },
   };
 
   protected readonly articleCountLabel = computed(() => {

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -38,47 +38,54 @@
       <lfx-docs-search class="w-full md:w-80" data-testid="docs-article-search" />
     </div>
 
-    <header class="flex flex-col gap-3">
-      <div>
-        <h1 class="font-display text-3xl font-light" data-testid="docs-article-title">
-          {{ a.title }}
-        </h1>
-        @if (a.description) {
-          <p class="mt-1 text-sm text-gray-500" data-testid="docs-article-description">
-            {{ a.description }}
-          </p>
-        }
-      </div>
-      @if (a.lastUpdated) {
-        <p class="flex items-center gap-1.5 text-xs text-gray-500" data-testid="docs-article-updated">
-          <i class="fa-light fa-clock-rotate-left" aria-hidden="true"></i>
-          <span>
-            Last updated
-            <time [attr.datetime]="a.lastUpdated">{{ a.lastUpdated | date: 'mediumDate' : 'UTC' }}</time>
-          </span>
-        </p>
-      }
-    </header>
-
-    <div class="prose prose-lfx mt-4 max-w-none" [innerHTML]="a.bodyHtml" data-testid="docs-article-body"></div>
-
-    @if (siblings().length > 0) {
-      <aside class="mt-8 flex flex-col gap-3 border-t border-gray-200 pt-6" aria-labelledby="docs-siblings-heading">
-        <h2 id="docs-siblings-heading" class="text-base font-semibold text-gray-900">More in this topic</h2>
-        <ul class="flex flex-col gap-2" data-testid="docs-article-siblings">
-          @for (sibling of siblings(); track sibling.slug) {
-            <li>
-              <a
-                [routerLink]="sibling.url"
-                class="block rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                data-testid="docs-article-sibling-link">
-                {{ sibling.title }}
-              </a>
-            </li>
+    <!-- Two-column body: article content (left) + "More in this topic" rail (right, sticky) -->
+    <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-10">
+      <div class="flex min-w-0 flex-1 flex-col gap-6">
+        <header class="flex flex-col gap-3">
+          <div>
+            <h1 class="font-display text-3xl font-light" data-testid="docs-article-title">
+              {{ a.title }}
+            </h1>
+            @if (a.description) {
+              <p class="mt-1 text-sm text-gray-500" data-testid="docs-article-description">
+                {{ a.description }}
+              </p>
+            }
+          </div>
+          @if (a.lastUpdated) {
+            <p class="flex items-center gap-1.5 text-xs text-gray-500" data-testid="docs-article-updated">
+              <i class="fa-light fa-clock-rotate-left" aria-hidden="true"></i>
+              <span>
+                Last updated
+                <time [attr.datetime]="a.lastUpdated">{{ a.lastUpdated | date: 'mediumDate' : 'UTC' }}</time>
+              </span>
+            </p>
           }
-        </ul>
-      </aside>
-    }
+        </header>
+
+        <div class="prose prose-lfx mt-4 max-w-none" [innerHTML]="a.bodyHtml" data-testid="docs-article-body"></div>
+      </div>
+
+      @if (siblings().length > 0) {
+        <aside
+          class="flex flex-col gap-3 border-t border-gray-200 pt-6 lg:sticky lg:top-[105px] lg:mt-6 lg:w-1/4 lg:shrink-0 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0"
+          aria-labelledby="docs-siblings-heading">
+          <h2 id="docs-siblings-heading" class="text-xs uppercase tracking-wide text-gray-500">More in this topic</h2>
+          <ul class="flex flex-col gap-2" data-testid="docs-article-siblings">
+            @for (sibling of siblings(); track sibling.slug) {
+              <li>
+                <a
+                  [routerLink]="sibling.url"
+                  class="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  data-testid="docs-article-sibling-link">
+                  {{ sibling.title }}
+                </a>
+              </li>
+            }
+          </ul>
+        </aside>
+      }
+    </div>
   </article>
 } @else {
   <p class="text-gray-500" data-testid="docs-article-empty">Article not found.</p>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -7,26 +7,34 @@
     <div
       class="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-gray-200 bg-white py-4"
       data-testid="docs-article-topbar">
-      @if (a.breadcrumb.length > 1) {
-        <nav aria-label="Breadcrumb" data-testid="docs-breadcrumb">
-          <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500">
-            @for (item of a.breadcrumb; let last = $last; track item.slug) {
-              <li class="flex items-center gap-2">
-                @if (!last) {
-                  <a [routerLink]="item.url" class="hover:text-primary hover:underline" data-testid="docs-breadcrumb-link">
-                    {{ item.title }}
-                  </a>
-                  <span aria-hidden="true">/</span>
-                } @else {
-                  <span class="text-gray-800" aria-current="page">{{ item.title }}</span>
-                }
-              </li>
-            }
-          </ol>
-        </nav>
-      } @else {
-        <span></span>
-      }
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          (click)="goBack()"
+          aria-label="Go back to the previous page"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          data-testid="docs-article-back">
+          <i class="fa-light fa-angle-left" aria-hidden="true"></i>
+        </button>
+        @if (a.breadcrumb.length > 1) {
+          <nav aria-label="Breadcrumb" data-testid="docs-breadcrumb">
+            <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500">
+              @for (item of a.breadcrumb; let last = $last; track item.slug) {
+                <li class="flex items-center gap-2">
+                  @if (!last) {
+                    <a [routerLink]="item.url" class="hover:text-primary hover:underline" data-testid="docs-breadcrumb-link">
+                      {{ item.title }}
+                    </a>
+                    <span aria-hidden="true">/</span>
+                  } @else {
+                    <span class="text-gray-800" aria-current="page">{{ item.title }}</span>
+                  }
+                </li>
+              }
+            </ol>
+          </nav>
+        }
+      </div>
       <lfx-docs-search data-testid="docs-article-search" />
     </div>
 

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -3,27 +3,32 @@
 
 @if (article(); as a) {
   <article class="mx-auto flex max-w-[1024px] flex-col gap-6 pt-6" data-testid="docs-article">
-    <div class="flex justify-end">
+    <!-- Sticky top bar: breadcrumb on the left, search on the right -->
+    <div
+      class="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-gray-200 bg-white py-4"
+      data-testid="docs-article-topbar">
+      @if (a.breadcrumb.length > 1) {
+        <nav aria-label="Breadcrumb" data-testid="docs-breadcrumb">
+          <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500">
+            @for (item of a.breadcrumb; let last = $last; track item.slug) {
+              <li class="flex items-center gap-2">
+                @if (!last) {
+                  <a [routerLink]="item.url" class="hover:text-primary hover:underline" data-testid="docs-breadcrumb-link">
+                    {{ item.title }}
+                  </a>
+                  <span aria-hidden="true">/</span>
+                } @else {
+                  <span class="text-gray-800" aria-current="page">{{ item.title }}</span>
+                }
+              </li>
+            }
+          </ol>
+        </nav>
+      } @else {
+        <span></span>
+      }
       <lfx-docs-search data-testid="docs-article-search" />
     </div>
-    @if (a.breadcrumb.length > 1) {
-      <nav aria-label="Breadcrumb" data-testid="docs-breadcrumb">
-        <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500">
-          @for (item of a.breadcrumb; let last = $last; track item.slug) {
-            <li class="flex items-center gap-2">
-              @if (!last) {
-                <a [routerLink]="item.url" class="hover:text-primary hover:underline" data-testid="docs-breadcrumb-link">
-                  {{ item.title }}
-                </a>
-                <span aria-hidden="true">/</span>
-              } @else {
-                <span class="text-gray-800" aria-current="page">{{ item.title }}</span>
-              }
-            </li>
-          }
-        </ol>
-      </nav>
-    }
 
     <header class="flex flex-col gap-3">
       <div>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (article(); as a) {
-  <article class="mx-auto flex max-w-3xl flex-col gap-6" data-testid="docs-article">
+  <article class="mx-auto flex max-w-[1024px] flex-col gap-6" data-testid="docs-article">
     <div class="flex justify-end">
       <lfx-docs-search data-testid="docs-article-search" />
     </div>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -26,14 +26,16 @@
     }
 
     <header class="flex flex-col gap-3">
-      <h1 class="text-3xl font-bold text-gray-900" data-testid="docs-article-title">
-        {{ a.title }}
-      </h1>
-      @if (a.description) {
-        <p class="text-base text-gray-600" data-testid="docs-article-description">
-          {{ a.description }}
-        </p>
-      }
+      <div>
+        <h1 class="font-display text-3xl font-light" data-testid="docs-article-title">
+          {{ a.title }}
+        </h1>
+        @if (a.description) {
+          <p class="mt-1 text-sm text-gray-500" data-testid="docs-article-description">
+            {{ a.description }}
+          </p>
+        }
+      </div>
       @if (a.lastUpdated) {
         <p class="flex items-center gap-1.5 text-xs text-gray-500" data-testid="docs-article-updated">
           <i class="fa-light fa-clock-rotate-left" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (article(); as a) {
-  <article class="mx-auto flex max-w-[1024px] flex-col gap-6" data-testid="docs-article">
+  <article class="mx-auto flex max-w-[1024px] flex-col gap-6 pt-6" data-testid="docs-article">
     <div class="flex justify-end">
       <lfx-docs-search data-testid="docs-article-search" />
     </div>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -60,7 +60,7 @@
       }
     </header>
 
-    <div class="prose prose-lfx max-w-none" [innerHTML]="a.bodyHtml" data-testid="docs-article-body"></div>
+    <div class="prose prose-lfx mt-4 max-w-none" [innerHTML]="a.bodyHtml" data-testid="docs-article-body"></div>
 
     @if (siblings().length > 0) {
       <aside class="mt-8 flex flex-col gap-3 border-t border-gray-200 pt-6" aria-labelledby="docs-siblings-heading">

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -5,7 +5,7 @@
   <article class="mx-auto flex max-w-[1024px] flex-col gap-6 pt-6" data-testid="docs-article">
     <!-- Sticky top bar: breadcrumb on the left, search on the right -->
     <div
-      class="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-gray-200 bg-white py-4"
+      class="sticky top-0 z-20 flex flex-col gap-3 border-b border-gray-200 bg-white py-4 md:flex-row md:items-center md:justify-between md:gap-4"
       data-testid="docs-article-topbar">
       <div class="flex items-center gap-3">
         <button
@@ -35,7 +35,7 @@
           </nav>
         }
       </div>
-      <lfx-docs-search data-testid="docs-article-search" />
+      <lfx-docs-search class="w-full md:w-80" data-testid="docs-article-search" />
     </div>
 
     <header class="flex flex-col gap-3">

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
@@ -146,7 +146,7 @@ export class DocsArticleComponent {
     if (!a) return;
 
     const canonical = `${DOCS_CANONICAL_ORIGIN}${a.url}`;
-    this.title.setTitle(`${a.title} · LFX Self Serve Documentation`);
+    this.title.setTitle(`${a.title} · LFX Documentation`);
     this.meta.updateTag({ name: 'description', content: a.description });
     this.meta.updateTag({ property: 'og:title', content: a.title });
     this.meta.updateTag({ property: 'og:description', content: a.description });

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, DOCUMENT } from '@angular/common';
+import { DatePipe, DOCUMENT, Location } from '@angular/common';
 import { Component, computed, ElementRef, HostListener, inject } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Meta, Title } from '@angular/platform-browser';
@@ -62,6 +62,7 @@ export class DocsArticleComponent {
   private readonly meta = inject(Meta);
   private readonly document = inject(DOCUMENT);
   private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly location = inject(Location);
 
   /** Article resolved by `docsArticleResolver` — guaranteed non-null on a successful navigation. */
   protected readonly article = this.initArticle();
@@ -84,6 +85,11 @@ export class DocsArticleComponent {
     toObservable(this.article)
       .pipe(takeUntilDestroyed())
       .subscribe(() => this.applyMetadata());
+  }
+
+  /** Navigates to the previous page in browser history (back button in the top bar). */
+  protected goBack(): void {
+    this.location.back();
   }
 
   @HostListener('click', ['$event'])

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="mx-auto flex max-w-[1024px] flex-col gap-8" data-testid="docs-landing">
+<div class="mx-auto flex max-w-[1024px] flex-col gap-8 pt-[32px]" data-testid="docs-landing">
   <header class="flex flex-col gap-4">
     <div>
       <h1 class="font-display text-3xl font-light">LFX Documentation</h1>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="mx-auto flex max-w-5xl flex-col gap-8" data-testid="docs-landing">
+<div class="mx-auto flex max-w-[1024px] flex-col gap-8" data-testid="docs-landing">
   <header class="flex flex-col gap-3">
     <h1 class="text-3xl font-bold text-gray-900">LFX Self Serve Documentation</h1>
     <p class="max-w-3xl text-base text-gray-600">Browse user guides, FAQs, and how-tos. Pick a topic below to dive in.</p>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
@@ -4,7 +4,7 @@
 <div class="mx-auto flex max-w-[1024px] flex-col gap-8" data-testid="docs-landing">
   <header class="flex flex-col gap-4">
     <div>
-      <h1 class="font-display text-3xl font-light">LFX Self Serve Documentation</h1>
+      <h1 class="font-display text-3xl font-light">LFX Documentation</h1>
       <p class="mt-1 text-sm text-gray-500">Browse user guides, FAQs, and how-tos. Pick a topic below to dive in.</p>
     </div>
 

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
@@ -2,9 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="mx-auto flex max-w-[1024px] flex-col gap-8" data-testid="docs-landing">
-  <header class="flex flex-col gap-3">
-    <h1 class="text-3xl font-bold text-gray-900">LFX Self Serve Documentation</h1>
-    <p class="max-w-3xl text-base text-gray-600">Browse user guides, FAQs, and how-tos. Pick a topic below to dive in.</p>
+  <header class="flex flex-col gap-4">
+    <div>
+      <h1 class="font-display text-3xl font-light">LFX Self Serve Documentation</h1>
+      <p class="mt-1 text-sm text-gray-500">Browse user guides, FAQs, and how-tos. Pick a topic below to dive in.</p>
+    </div>
 
     <lfx-docs-search data-testid="docs-landing-search" />
   </header>

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.html
@@ -8,7 +8,7 @@
       <p class="mt-1 text-sm text-gray-500">Browse user guides, FAQs, and how-tos. Pick a topic below to dive in.</p>
     </div>
 
-    <lfx-docs-search data-testid="docs-landing-search" />
+    <lfx-docs-search [fullWidth]="true" data-testid="docs-landing-search" />
   </header>
 
   @if (topics.length > 0) {

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-landing/docs-landing.component.ts
@@ -11,7 +11,7 @@ import { DocsSearchComponent } from '../../components/docs-search/docs-search.co
 import { DocsTopicCardComponent } from '../../components/docs-topic-card/docs-topic-card.component';
 import { DocsManifestService } from '../../services/docs-manifest.service';
 
-const LANDING_TITLE = 'LFX Self Serve Documentation';
+const LANDING_TITLE = 'LFX Documentation';
 const LANDING_DESCRIPTION = 'Browse user guides, FAQs, and how-tos for the LFX Self Serve product — meetings, committees, mailing lists, and more.';
 
 /**

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
@@ -40,7 +40,7 @@ export class DocsNotFoundComponent implements OnInit {
   protected readonly topics: DocsTopic[] = this.docsManifest.getTopics();
 
   public ngOnInit(): void {
-    const title = 'Page not found · LFX Self Serve Documentation';
+    const title = 'Page not found · LFX Documentation';
     const description = 'The documentation page you requested could not be found.';
 
     this.title.setTitle(title);

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -4,7 +4,7 @@
 @if (mobile()) {
   <div class="flex items-center gap-1 px-3 py-2" data-testid="lens-switcher-mobile">
     @for (lens of lenses(); track lens.id) {
-      @let isActive = activeLensId() === lens.id;
+      @let isActive = !isDocsActive() && activeLensId() === lens.id;
       <button
         type="button"
         (click)="setLens(lens.id)"
@@ -73,7 +73,7 @@
     <!-- Lens Buttons -->
     <div class="flex flex-col items-center gap-3 flex-1">
       @for (lens of lenses(); track lens.id) {
-        @let isActive = activeLensId() === lens.id;
+        @let isActive = !isDocsActive() && activeLensId() === lens.id;
         <button
           type="button"
           (click)="setLens(lens.id)"
@@ -121,7 +121,7 @@
             'bg-blue-500': isDocsActive(),
             'group-hover:bg-white/10': !isDocsActive(),
           }">
-          <i class="fa-light fa-book text-xl"></i>
+          <i [ngClass]="isDocsActive() ? 'fa-solid fa-book' : 'fa-light fa-book'" class="text-xl"></i>
         </div>
       </a>
 

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -108,7 +108,9 @@ export default {
               letterSpacing: '-0.01em',
             },
             h1: { fontSize: '2.25rem', lineHeight: '1.15', marginTop: '0', marginBottom: '1rem' },
-            h2: { fontSize: '1.75rem', lineHeight: '1.2', marginTop: '2rem', marginBottom: '0.75rem' },
+            // Article sections (markdown `##`) render at h4 scale with a 32px top gap — the
+            // semantic <h2> tag is kept (the article title is <h1>) but de-emphasized visually.
+            h2: { fontSize: '1.125rem', lineHeight: '1.4', marginTop: '32px', marginBottom: '12px' },
             h3: { fontSize: '1.375rem', lineHeight: '1.3', marginTop: '1.5rem', marginBottom: '0.5rem' },
             h4: { fontSize: '1.125rem', lineHeight: '1.4', marginTop: '1.25rem', marginBottom: '0.5rem' },
             code: {

--- a/docs/user/committees/index.md
+++ b/docs/user/committees/index.md
@@ -1,5 +1,5 @@
 ---
-title: My Groups
+title: Groups
 description: View, create, and manage project committees (groups) in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Committees

--- a/packages/shared/src/constants/docs.constant.ts
+++ b/packages/shared/src/constants/docs.constant.ts
@@ -39,17 +39,17 @@ export const DOCS_CANONICAL_ORIGIN = 'https://app.lfx.dev';
  * is no longer guaranteed for that topic until the constant is updated.
  */
 export const DOCS_TAXONOMY_ORDER: readonly string[] = [
-  'badges',
-  'committees',
   'dashboards',
-  'documents',
-  'events',
-  'mailing-lists',
   'meetings',
+  'events',
+  'committees',
+  'mailing-lists',
+  'votes',
+  'surveys',
+  'documents',
+  'trainings',
+  'badges',
   'profile',
   'settings',
-  'surveys',
-  'trainings',
   'transactions',
-  'votes',
 ] as const;


### PR DESCRIPTION
## What

A set of UI/UX improvements to the public Documentation (`docs`) portal — landing page, article pages, the docs sidebar, and topic search.

## Changes

**Layout & spacing**
- Constrain documentation page containers to **1024px** max-width (landing + article)
- **32px** side padding across docs pages; **32px** top padding on the landing
- App footer added to all docs pages, constrained to the 1024px content width, with a 100px gap from content

**Landing page**
- Header restyled to the standard app typography (Roboto Slab Light); title renamed to **"LFX Documentation"**
- Full-width search bar
- Topic cards: icon tiles aligned with the app menu (lens) icons, reordered by importance, recolored (dark-blue Dashboard, blue primary group, violet secondary, gray tertiary), `angle-right` chevrons
- **"Groups"** topic renamed (was "My Groups")

**Article pages**
- Sticky top bar combining breadcrumb + search, with a back button (browser history)
- Section titles styled at h4 scale (32px top / 12px bottom margins); larger header→body gap
- "More in this topic" moved into a **sticky right rail** (1/4 width) with a left divider
- Search dropdown topic chips now show proper **sentence-case topic names**

**Sidebar**
- Documentation icon goes solid when active (matching the lens buttons)
- Lens buttons no longer stay highlighted while on docs pages

## Notes

- **No JIRA ticket** — design-session UI polish.
- Touches `packages/shared` (docs taxonomy order constant) and the docs build script (`build-manifest.mjs`), plus the shared `lens-switcher`.
- ~20 commits, small diff (~270 lines).

## Verification

All changes verified live in the running app via browser inspection (computed styles, layout measurements, sticky behavior, hover states). Preflight passed: license headers, format, lint, build, protected files, DCO + GPG signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
