### PR TITLE
fix(committees): skip date range validators when enable_voting is false

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
@@ -253,6 +253,6 @@
   <!-- Form Actions -->
   <div class="flex justify-end gap-3 pt-6 border-t">
     <lfx-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="onCancel()" size="small" type="button"></lfx-button>
-    <lfx-button [label]="isEditing ? 'Update Member' : 'Add Member'" [loading]="submitting()" [disabled]="submitting()" (onClick)="onSubmit()" size="small"></lfx-button>
+    <lfx-button [label]="isEditing ? 'Update Member' : 'Add Member'" [loading]="submitting()" [disabled]="submitting()" type="submit" size="small"></lfx-button>
   </div>
 </form>

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
@@ -253,6 +253,6 @@
   <!-- Form Actions -->
   <div class="flex justify-end gap-3 pt-6 border-t">
     <lfx-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="onCancel()" size="small" type="button"></lfx-button>
-    <lfx-button [label]="isEditing ? 'Update Member' : 'Add Member'" [loading]="submitting()" [disabled]="submitting()" type="submit" size="small"></lfx-button>
+    <lfx-button [label]="isEditing ? 'Update Member' : 'Add Member'" [loading]="submitting()" [disabled]="submitting()" (onClick)="onSubmit()" size="small"></lfx-button>
   </div>
 </form>

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -322,10 +322,12 @@ export class MemberFormComponent {
         permission: new FormControl<CommitteePermissionLevel>('member'),
       },
       {
-        validators: [
-          MemberFormComponent.dateRangeValidator('role_start', 'role_end'),
-          MemberFormComponent.dateRangeValidator('voting_status_start', 'voting_status_end'),
-        ],
+        validators: this.committee?.enable_voting
+          ? [
+              MemberFormComponent.dateRangeValidator('role_start', 'role_end'),
+              MemberFormComponent.dateRangeValidator('voting_status_start', 'voting_status_end'),
+            ]
+          : [],
       }
     );
   }


### PR DESCRIPTION
## Root cause

`member-form.component.ts` applies `dateRangeValidator` for `role_start/role_end` and `voting_status_start/voting_status_end` **unconditionally**, even when `enable_voting = false`. When a member has stale dates in the DB where `start_date > end_date` (imported/migrated data), the form-level validator fires and `this.form().valid === false`.

The error messages for these validators are inside `@if (committee?.enable_voting)` — so with `enable_voting = false` the error is silently hidden. The user sees no invalid state, but the API call is never made.

This was confirmed by a network recording: clicking "Update Member" for Gala Malbasic fires a Plausible `"Form: Submission"` event (proving `onSubmit()` runs) but no member API request appears. A different member (Jautau White) in the same WG does trigger the API call.

## Changes

- **`member-form.component.ts`**: Gate `dateRangeValidator` calls on `this.committee?.enable_voting` — matches the template's `@if (committee?.enable_voting)` guard so validation and UI stay in sync

Fixes: https://linuxfoundation.atlassian.net/browse/LFXV2-2218

## Test plan

- [ ] Edit Gala Malbasic in WG `26b5f91f-93bf-4418-8ac9-c355c754f1c0` — verify "Update Member" now fires the API call and saves
- [ ] Change permission from Member → Manage for the same member — verify permission updates
- [ ] Edit a member in a voting-enabled committee — verify date range validation still works (start > end shows error)
- [ ] Verify "Add Member" flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)