### PR TITLE
fix(routing): prevent default project slug from polluting entity URLs

### DIFF
--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -166,10 +166,14 @@ export class NavigationService {
     const priority = lens === 'foundation' ? BOARD_SCOPED_PERSONA_PRIORITY : PROJECT_SCOPED_PERSONA_PRIORITY;
     const defaultItem = this.pickItemByPersonaPriority(page.items, priority);
     const context = lensItemToProjectContext(defaultItem);
+    // Only write ?project= to the URL if it was already present — prevents the default
+    // selection from injecting a wrong project slug into entity-specific URLs (e.g.
+    // /project/groups/:id) that a user navigated to without an explicit project context.
+    const syncUrl = !!this.router.parseUrl(this.router.url).queryParams['project'];
     if (lens === 'foundation') {
-      this.projectContextService.setFoundation(context);
+      this.projectContextService.setFoundation(context, syncUrl);
     } else {
-      this.projectContextService.setProject(context);
+      this.projectContextService.setProject(context, syncUrl);
     }
   }
 

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -169,7 +169,7 @@ export class NavigationService {
     // Only write ?project= to the URL if it was already present — prevents the default
     // selection from injecting a wrong project slug into entity-specific URLs (e.g.
     // /project/groups/:id) that a user navigated to without an explicit project context.
-    const syncUrl = !!this.router.parseUrl(this.router.url).queryParams['project'];
+    const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
     if (lens === 'foundation') {
       this.projectContextService.setFoundation(context, syncUrl);
     } else {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -50,20 +50,24 @@ export class ProjectContextService {
     this.cookieService.delete(this.projectStorageKey, '/');
   }
 
-  public setFoundation(foundation: ProjectContext): void {
+  public setFoundation(foundation: ProjectContext, syncUrl = true): void {
     if (isSameProjectContext(this.foundationSelection(), foundation)) {
       return;
     }
     this.foundationSelection.set(foundation);
-    this.syncProjectQueryParam(foundation.slug);
+    if (syncUrl) {
+      this.syncProjectQueryParam(foundation.slug);
+    }
   }
 
-  public setProject(project: ProjectContext): void {
+  public setProject(project: ProjectContext, syncUrl = true): void {
     if (isSameProjectContext(this.projectSelection(), project)) {
       return;
     }
     this.projectSelection.set(project);
-    this.syncProjectQueryParam(project.slug);
+    if (syncUrl) {
+      this.syncProjectQueryParam(project.slug);
+    }
   }
 
   public clearFoundation(): void {


### PR DESCRIPTION
## Summary

- **Root cause:** PR #701 added `syncProjectQueryParam()` to `setProject()`/`setFoundation()` to make URLs copy-paste-safe. But `NavigationService.applyDefaultSelection()` also calls `setProject()` when picking a default on page load — so navigating to a group/committee URL without `?project=` would result in `?project=<user's default slug>` being injected, even when that project had nothing to do with the entity.
- **Fix:** `setProject()`/`setFoundation()` now accept a `syncUrl` flag (default `true`). `applyDefaultSelection()` passes `syncUrl=false` when the current URL has no `?project=`, setting the internal context (sidebar highlights) without touching the URL.
- **Scope:** Explicit user selections (project dropdown, guard-resolved `?project=slug` deep links) are unaffected.

## Introduced in

PR #701 (`feat/routing: add project deep link support via ?project=<slug>`, May 14 2026). PR #713 didn't introduce it but made it more visible by adding hybrid persona preloading, which triggers more project-loading cycles.

## Test plan

- [ ] Navigate directly to a group URL without `?project=` (e.g. `https://app.lfx.dev/project/groups/da97df1f-13cd-4f09-815d-6381faf7cf77`) — URL should not gain `?project=energnn` or any other slug
- [ ] Navigate via project dropdown — `?project=<slug>` should still be written to the URL
- [ ] Paste a URL with `?project=slug` — correct project loads and slug stays in URL
- [ ] Invite URL flow — verify accepting an invite no longer appends wrong `?project=` to the return URL