### PR TITLE
fix(committees): add project slug to create meeting query params (LFXV2-2223)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.html
@@ -95,7 +95,7 @@
             size="small"
             [class]="isCalendarView() ? 'md:ml-auto' : ''"
             [routerLink]="['/meetings', 'create']"
-            [queryParams]="{ committee_uid: committee().uid }"
+            [queryParams]="createMeetingQueryParams()"
             data-testid="committee-meetings-create-btn"></lfx-button>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -67,6 +67,10 @@ export class CommitteeMeetingsComponent {
   public isListView = computed(() => this.viewMode() === 'list');
   public isCalendarView = computed(() => this.viewMode() === 'calendar');
 
+  // Query params for the create-meeting route. Includes project slug so writerGuard
+  // can resolve write access — without it the guard redirects to the lens overview.
+  public createMeetingQueryParams: Signal<Record<string, string>> = this.initCreateMeetingQueryParams();
+
   // Form for search + filter controls (bound in template)
   public searchForm = new FormGroup({
     search: new FormControl(''),
@@ -170,6 +174,17 @@ export class CommitteeMeetingsComponent {
   }
 
   // Private initializer functions
+
+  private initCreateMeetingQueryParams(): Signal<Record<string, string>> {
+    return computed(() => {
+      const committee = this.committee();
+      const params: Record<string, string> = { committee_uid: committee.uid };
+      if (committee.project_slug) {
+        params['project'] = committee.project_slug;
+      }
+      return params;
+    });
+  }
 
   private initUpcomingMeetings(): Signal<Meeting[]> {
     return toSignal(


### PR DESCRIPTION
# Summary

The committee meetings page now passes the project slug alongside the committee UID when navigating to create a meeting. Without the project parameter, writerGuard could not resolve write access and redirected users back to the lens overview instead of opening the create flow.
