### PR TITLE
feat(committees): add project query param to vote and survey create links (LFXV2-2225)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.html
@@ -17,7 +17,7 @@
           severity="info"
           size="small"
           [routerLink]="['/surveys', 'create']"
-          [queryParams]="{ committee_uid: committee().uid }"
+          [queryParams]="createSurveyQueryParams()"
           data-testid="committee-surveys-create-btn"></lfx-button>
       }
     </lfx-surveys-table>
@@ -30,7 +30,7 @@
           severity="info"
           size="small"
           [routerLink]="['/surveys', 'create']"
-          [queryParams]="{ committee_uid: committee().uid }"
+          [queryParams]="createSurveyQueryParams()"
           data-testid="committee-surveys-empty-create-btn"></lfx-button>
       </div>
     }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
@@ -6,6 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { Committee, Survey } from '@lfx-one/shared/interfaces';
+import { buildCommitteeCreateQueryParams } from '@lfx-one/shared/utils';
 import { SurveysTableComponent } from '@app/modules/surveys/components/surveys-table/surveys-table.component';
 import { SurveyResultsDrawerComponent } from '@app/modules/surveys/components/survey-results-drawer/survey-results-drawer.component';
 import { SurveyService } from '@services/survey.service';
@@ -45,14 +46,7 @@ export class CommitteeSurveysComponent {
 
   // Private initializer functions
   private initCreateSurveyQueryParams(): Signal<Record<string, string>> {
-    return computed(() => {
-      const committee = this.committee();
-      const params: Record<string, string> = { committee_uid: committee.uid };
-      if (committee.project_slug) {
-        params['project'] = committee.project_slug;
-      }
-      return params;
-    });
+    return computed(() => buildCommitteeCreateQueryParams(this.committee()));
   }
 
   private initSurveys(): Signal<Survey[]> {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, inject, input, model, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -27,6 +27,8 @@ export class CommitteeSurveysComponent {
   public committee = input.required<Committee>();
   public canEdit = input<boolean>(false);
 
+  public createSurveyQueryParams: Signal<Record<string, string>> = this.initCreateSurveyQueryParams();
+
   // State
   public loading = signal<boolean>(true);
   public resultsDrawerVisible = model<boolean>(false);
@@ -43,6 +45,17 @@ export class CommitteeSurveysComponent {
   }
 
   // Private initializer functions
+  private initCreateSurveyQueryParams(): Signal<Record<string, string>> {
+    return computed(() => {
+      const committee = this.committee();
+      const params: Record<string, string> = { committee_uid: committee.uid };
+      if (committee.project_slug) {
+        params['project'] = committee.project_slug;
+      }
+      return params;
+    });
+  }
+
   private initSurveys(): Signal<Survey[]> {
     return toSignal(
       toObservable(this.committee).pipe(

--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
@@ -27,8 +27,6 @@ export class CommitteeSurveysComponent {
   public committee = input.required<Committee>();
   public canEdit = input<boolean>(false);
 
-  public createSurveyQueryParams: Signal<Record<string, string>> = this.initCreateSurveyQueryParams();
-
   // State
   public loading = signal<boolean>(true);
   public resultsDrawerVisible = model<boolean>(false);
@@ -37,6 +35,7 @@ export class CommitteeSurveysComponent {
 
   // Data
   public surveys: Signal<Survey[]> = this.initSurveys();
+  public createSurveyQueryParams: Signal<Record<string, string>> = this.initCreateSurveyQueryParams();
 
   public viewSurveyResults(survey: Survey): void {
     this.selectedSurveyId.set(survey.uid);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
@@ -18,7 +18,7 @@
           severity="info"
           size="small"
           [routerLink]="['/votes', 'create']"
-          [queryParams]="{ committee_uid: committee().uid }"
+          [queryParams]="createVoteQueryParams()"
           data-testid="committee-votes-create-btn"></lfx-button>
       }
     </lfx-votes-table>
@@ -31,7 +31,7 @@
           severity="info"
           size="small"
           [routerLink]="['/votes', 'create']"
-          [queryParams]="{ committee_uid: committee().uid }"
+          [queryParams]="createVoteQueryParams()"
           data-testid="committee-votes-empty-create-btn"></lfx-button>
       </div>
     }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -6,6 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { Committee, Vote } from '@lfx-one/shared/interfaces';
+import { buildCommitteeCreateQueryParams } from '@lfx-one/shared/utils';
 import { VotesTableComponent } from '@app/modules/votes/components/votes-table/votes-table.component';
 import { VoteResultsDrawerComponent } from '@app/modules/votes/components/vote-results-drawer/vote-results-drawer.component';
 import { VoteService } from '@services/vote.service';
@@ -47,14 +48,7 @@ export class CommitteeVotesComponent {
 
   // Private initializer functions
   private initCreateVoteQueryParams(): Signal<Record<string, string>> {
-    return computed(() => {
-      const committee = this.committee();
-      const params: Record<string, string> = { committee_uid: committee.uid };
-      if (committee.project_slug) {
-        params['project'] = committee.project_slug;
-      }
-      return params;
-    });
+    return computed(() => buildCommitteeCreateQueryParams(this.committee()));
   }
 
   private initVotes(): Signal<Vote[]> {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, inject, input, model, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -27,6 +27,8 @@ export class CommitteeVotesComponent {
   public committee = input.required<Committee>();
   public canEdit = input<boolean>(false);
 
+  public createVoteQueryParams: Signal<Record<string, string>> = this.initCreateVoteQueryParams();
+
   // State
   public loading = signal<boolean>(true);
   public resultsDrawerVisible = model<boolean>(false);
@@ -45,6 +47,17 @@ export class CommitteeVotesComponent {
   }
 
   // Private initializer functions
+  private initCreateVoteQueryParams(): Signal<Record<string, string>> {
+    return computed(() => {
+      const committee = this.committee();
+      const params: Record<string, string> = { committee_uid: committee.uid };
+      if (committee.project_slug) {
+        params['project'] = committee.project_slug;
+      }
+      return params;
+    });
+  }
+
   private initVotes(): Signal<Vote[]> {
     return toSignal(
       toObservable(this.committee).pipe(

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -27,8 +27,6 @@ export class CommitteeVotesComponent {
   public committee = input.required<Committee>();
   public canEdit = input<boolean>(false);
 
-  public createVoteQueryParams: Signal<Record<string, string>> = this.initCreateVoteQueryParams();
-
   // State
   public loading = signal<boolean>(true);
   public resultsDrawerVisible = model<boolean>(false);
@@ -37,6 +35,7 @@ export class CommitteeVotesComponent {
 
   // Data
   public votes: Signal<Vote[]> = this.initVotes();
+  public createVoteQueryParams: Signal<Record<string, string>> = this.initCreateVoteQueryParams();
 
   /** Opens the vote results drawer for the selected vote. */
   public viewVoteResults(voteUid: string): void {

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Committee, CommitteeMember } from '../interfaces';
-import { canManageCommitteeMembers, resolveCommitteeMemberPermission } from './committee.utils';
+import { buildCommitteeCreateQueryParams, canManageCommitteeMembers, resolveCommitteeMemberPermission } from './committee.utils';
 
 /** Minimal committee builder — only the fields the resolver reads. */
 function committee(overrides: Partial<Committee> = {}): Committee {
@@ -107,6 +107,19 @@ describe('resolveCommitteeMemberPermission', () => {
 
   it('returns member for a null committee', () => {
     expect(resolveCommitteeMemberPermission(null, member())).toEqual({ level: 'member', inherited: false });
+  });
+});
+
+describe('buildCommitteeCreateQueryParams', () => {
+  it('includes the project slug when present', () => {
+    expect(buildCommitteeCreateQueryParams(committee({ uid: 'cmte-9', project_slug: 'my-project' }))).toEqual({
+      committee_uid: 'cmte-9',
+      project: 'my-project',
+    });
+  });
+
+  it('omits the project key when the committee has no project slug', () => {
+    expect(buildCommitteeCreateQueryParams(committee({ uid: 'cmte-9' }))).toEqual({ committee_uid: 'cmte-9' });
   });
 });
 

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -59,6 +59,18 @@ export function getGroupBehavioralClass(category: string | undefined): GroupBeha
   return 'other';
 }
 
+/**
+ * Build the query params used when navigating to create a vote or survey for a committee.
+ * Always includes `committee_uid`; includes `project` only when the committee carries a project slug.
+ */
+export function buildCommitteeCreateQueryParams(committee: Committee): Record<string, string> {
+  const params: Record<string, string> = { committee_uid: committee.uid };
+  if (committee.project_slug) {
+    params['project'] = committee.project_slug;
+  }
+  return params;
+}
+
 // ── Per-type query helpers ──────────────────────────────────────────────────
 
 /** True for governing-board type */


### PR DESCRIPTION
# Summary

When creating a vote or survey from a committee page, the create links now include the committee's project slug as a query parameter alongside `committee_uid`. This preserves project context in the URL so the create flow stays scoped to the correct project instead of falling back to a default.

Made with [Cursor](https://cursor.com)