### PR TITLE
fix(navigation): promote Crowdfunding to its own Me lens section

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -102,31 +102,36 @@ export class MainLayoutComponent {
   // --- Me Lens Items ---
   // Computed so both Crowdfunding and Security/OSSPREY nav entries react to their feature flags in real time.
   private readonly meLensItems = computed((): SidebarMenuItem[] => {
-    const crowdfundingItem: SidebarMenuItem = this.isCrowdfundingEnabled()
-      ? {
-          label: 'Crowdfunding',
-          icon: 'fa-light fa-circle-dollar',
-          isGroup: true,
-          expanded: true,
-          items: [
-            {
-              label: 'My Initiatives',
-              icon: 'fa-light fa-hand-holding-heart',
-              routerLink: '/crowdfunding/initiatives',
-            },
-            {
-              label: 'My Donations',
-              icon: 'fa-light fa-heart',
-              routerLink: '/crowdfunding/donations',
-            },
-          ],
-        }
-      : {
-          label: 'Crowdfunding',
-          icon: 'fa-light fa-circle-dollar',
-          url: environment.urls.crowdfunding,
-          target: '_self',
-        };
+    const crowdfundingEnabled = this.isCrowdfundingEnabled();
+
+    // Flag OFF: no internal pages exist, so Crowdfunding stays a single external
+    // link inside the My Growth section (its original placement).
+    const crowdfundingLink: SidebarMenuItem = {
+      label: 'Crowdfunding',
+      icon: 'fa-light fa-circle-dollar',
+      url: environment.urls.crowdfunding,
+      target: '_self',
+    };
+
+    // Flag ON: Crowdfunding is promoted to its own top-level section (peer of
+    // My Engagement / My Growth), with its sub-pages as section children.
+    const crowdfundingSection: SidebarMenuItem = {
+      label: 'Crowdfunding',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'My Initiatives',
+          icon: 'fa-light fa-box-dollar',
+          routerLink: '/crowdfunding/initiatives',
+        },
+        {
+          label: 'My Donations',
+          icon: 'fa-light fa-hand-heart',
+          routerLink: '/crowdfunding/donations',
+        },
+      ],
+    };
 
     return [
       {
@@ -203,7 +208,7 @@ export class MainLayoutComponent {
             icon: 'fa-light fa-chalkboard-teacher',
             url: environment.urls.mentorship,
           },
-          crowdfundingItem,
+          ...(crowdfundingEnabled ? [] : [crowdfundingLink]),
           {
             label: 'Badges',
             icon: 'fa-light fa-award',
@@ -211,6 +216,7 @@ export class MainLayoutComponent {
           },
         ],
       },
+      ...(crowdfundingEnabled ? [crowdfundingSection] : []),
       {
         label: 'My Account',
         isSection: true,


### PR DESCRIPTION
## What

In the **Me lens** sidebar, Crowdfunding now renders as its own top-level menu
section (a peer of *My Engagement* and *My Growth*) instead of a collapsible
accordion nested inside *My Growth* — when the `crowdfunding-enabled` feature
flag is ON.

The two child icons are also corrected:

- **My Initiatives** → `fa-light fa-box-dollar`
- **My Donations** → `fa-light fa-hand-heart`

## How

The change is contained to the `meLensItems` computed signal in
`main-layout.component.ts`:

- The flag-ON config becomes an `isSection` (always-expanded header + divider,
  non-collapsible) placed at the top level, immediately after the *My Growth*
  section, with My Initiatives / My Donations as section children.
- It is removed from inside the *My Growth* `items` array.
- Conditional inclusion uses the `...(cond ? [item] : [])` spread pattern (no
  nested ternaries, per repo conventions).

No routes, services, feature-flag plumbing, or the sidebar renderer changed —
the existing `SidebarMenuItem.isSection` flag already drives section rendering.

## Feature-flag behavior

- **Flag ON** — top-level Crowdfunding section with the two sub-pages.
- **Flag OFF** — unchanged from today: a single external link to the
  crowdfunding site, kept in its original spot inside *My Growth*.

## Verification

- Confirmed live in the running app (flag forced ON locally, then reverted):
  Crowdfunding renders as a section after *My Growth*, both new icons display as
  real glyphs, and it no longer appears inside *My Growth*.
- Flag-OFF path verified to still show the external link inside *My Growth*.
- `yarn check-types`, `yarn lint:check`, `yarn format:check`, and `yarn build`
  (SSR) all pass; license headers and protected-file checks pass.

## Notes

- No JIRA ticket — this is a small, self-contained nav fix; branch named
  `fix/crowdfunding-menu` by request rather than `fix/LFXV2-xxxx`. Happy to link
  a ticket if one is required.
