### PR TITLE
feat(dashboards): add consistent mom comparisons to overview kpi cards

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -239,6 +239,7 @@ export class EmailCtrDrawerComponent {
     const defaultValue: EmailCtrResponse = {
       currentCtr: 0,
       changePercentage: 0,
+      momChangePercentage: 0,
       trend: 'up',
       monthlyData: [],
       monthlyLabels: [],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -239,7 +239,7 @@ export class EmailCtrDrawerComponent {
     const defaultValue: EmailCtrResponse = {
       currentCtr: 0,
       changePercentage: 0,
-      momChangePercentage: 0,
+      momChangePercentage: null,
       trend: 'up',
       monthlyData: [],
       monthlyLabels: [],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -153,7 +153,7 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   emailCtr: {
     currentCtr: 0,
     changePercentage: 0,
-    momChangePercentage: 0,
+    momChangePercentage: null,
     trend: 'up' as const,
     monthlyData: [],
     monthlyLabels: [],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -153,6 +153,7 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   emailCtr: {
     currentCtr: 0,
     changePercentage: 0,
+    momChangePercentage: 0,
     trend: 'up' as const,
     monthlyData: [],
     monthlyLabels: [],

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -71,7 +71,7 @@ export class EmailTabComponent {
 
       const totalSends = data.monthlySends?.reduce((s, v) => s + v, 0) ?? 0;
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
-      const changePct = data.changePercentage;
+      const changePct = data.momChangePercentage;
 
       const sendsMom = this.computeMomPct(data.monthlySends);
       const opensMom = this.computeMomPct(data.monthlyOpens);
@@ -137,7 +137,7 @@ export class EmailTabComponent {
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${(data.currentCtr ?? 0).toFixed(2)}%`,
-          momChange: formatChangePct(changePct, 'vs avg'),
+          momChange: formatChangePct(changePct, 'MoM'),
           momTrend: trendDirection(changePct),
           momTrendClass: trendColorClass(changePct),
           yoyChange: null,

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -73,8 +73,8 @@ export class EmailTabComponent {
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
       const changePct = data.momChangePercentage;
 
-      const sendsMom = this.computeMomPct(data.monthlySends);
-      const opensMom = this.computeMomPct(data.monthlyOpens);
+      const sendsMom = computeMomPct(data.monthlySends);
+      const opensMom = computeMomPct(data.monthlyOpens);
 
       const sends = data.monthlySends ?? [];
       const opens = data.monthlyOpens ?? [];
@@ -86,7 +86,7 @@ export class EmailTabComponent {
 
       const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
       const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
-      const openRateMom = this.computeMomPctFromValues(currentOpenRate, prevOpenRate);
+      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
         {
@@ -187,16 +187,5 @@ export class EmailTabComponent {
           })
         );
     });
-  }
-
-  // === Private Helpers ===
-  private computeMomPct(arr: number[] | undefined): number | null {
-    if (!arr || arr.length < 2) return null;
-    return this.computeMomPctFromValues(arr.at(-1) ?? 0, arr.at(-2) ?? 0);
-  }
-
-  private computeMomPctFromValues(current: number, previous: number): number | null {
-    if (previous === 0) return null;
-    return ((current - previous) / previous) * 100;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -77,6 +77,9 @@ export class OverviewTabComponent {
       if (data.revenueImpact) {
         const ri = data.revenueImpact;
         const yoyPct = ri.changePercentage;
+        const trend = ri.paidMedia?.monthlyTrend ?? [];
+        const revMomPct = this.computeMomFromTrend(trend, (m) => m.revenue);
+        const roasMomPct = this.computeMomFromTrend(trend, (m) => m.roas);
         cards.push(
           {
             id: 'attributed-revenue',
@@ -84,9 +87,9 @@ export class OverviewTabComponent {
             icon: 'fa-light fa-dollar-sign',
             iconClass: 'bg-green-100 text-green-600',
             value: formatCurrency(ri.revenueAttributed),
-            momChange: null,
-            momTrend: 'neutral',
-            momTrendClass: 'text-gray-500',
+            momChange: formatChangePct(revMomPct, 'MoM'),
+            momTrend: trendDirection(revMomPct),
+            momTrendClass: trendColorClass(revMomPct),
             yoyChange: formatChangePct(yoyPct, 'YoY'),
             yoyTrend: trendDirection(yoyPct),
             yoyTrendClass: trendColorClass(yoyPct),
@@ -97,9 +100,9 @@ export class OverviewTabComponent {
             icon: 'fa-light fa-chart-line-up',
             iconClass: 'bg-blue-100 text-blue-600',
             value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
-            momChange: null,
-            momTrend: 'neutral',
-            momTrendClass: 'text-gray-500',
+            momChange: formatChangePct(roasMomPct, 'MoM'),
+            momTrend: trendDirection(roasMomPct),
+            momTrendClass: trendColorClass(roasMomPct),
             yoyChange: null,
             yoyTrend: 'neutral',
             yoyTrendClass: 'text-gray-500',
@@ -127,14 +130,14 @@ export class OverviewTabComponent {
 
       if (data.emailCtr) {
         const ec = data.emailCtr;
-        const momPct = ec.changePercentage;
+        const momPct = ec.momChangePercentage;
         cards.push({
           id: 'email-ctr',
           label: 'Email CTR',
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${(ec.currentCtr ?? 0).toFixed(2)}%`,
-          momChange: formatChangePct(momPct, 'vs avg'),
+          momChange: formatChangePct(momPct, 'MoM'),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),
           yoyChange: null,
@@ -172,7 +175,15 @@ export class OverviewTabComponent {
 
       const name = this.foundationName();
       const foundation = name ? name : 'all LF projects';
-      return `Compared to ${momLabel} and ${yoyLabel} · Linear attribution · ${foundation}`;
+      return `vs. ${momLabel} (MoM) · vs. ${yoyLabel} (YoY) · Linear attribution · ${foundation}`;
     });
+  }
+
+  private computeMomFromTrend<T>(trend: T[], extractor: (item: T) => number): number | null {
+    if (trend.length < 2) return null;
+    const current = extractor(trend[trend.length - 1]);
+    const prior = extractor(trend[trend.length - 2]);
+    if (prior === 0) return null;
+    return Math.round(((current - prior) / prior) * 1000) / 10;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import { formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rxjs';
 
@@ -78,8 +78,8 @@ export class OverviewTabComponent {
         const ri = data.revenueImpact;
         const yoyPct = ri.changePercentage;
         const trend = ri.paidMedia?.monthlyTrend ?? [];
-        const revMomPct = this.computeMomFromTrend(trend, (m) => m.revenue);
-        const roasMomPct = this.computeMomFromTrend(trend, (m) => m.roas);
+        const revMomPct = computeMomPct(trend.map((m) => m.revenue));
+        const roasMomPct = computeMomPct(trend.map((m) => m.roas));
         cards.push(
           {
             id: 'attributed-revenue',
@@ -177,13 +177,5 @@ export class OverviewTabComponent {
       const foundation = name ? name : 'all LF projects';
       return `vs. ${momLabel} (MoM) · vs. ${yoyLabel} (YoY) · Linear attribution · ${foundation}`;
     });
-  }
-
-  private computeMomFromTrend<T>(trend: T[], extractor: (item: T) => number): number | null {
-    if (trend.length < 2) return null;
-    const current = extractor(trend[trend.length - 1]);
-    const prior = extractor(trend[trend.length - 2]);
-    if (prior === 0) return null;
-    return Math.round(((current - prior) / prior) * 1000) / 10;
   }
 }

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -863,7 +863,7 @@ export class AnalyticsService {
         return of({
           currentCtr: 0,
           changePercentage: 0,
-          momChangePercentage: 0,
+          momChangePercentage: null,
           trend: 'up' as const,
           monthlyData: [],
           monthlyLabels: [],

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -863,6 +863,7 @@ export class AnalyticsService {
         return of({
           currentCtr: 0,
           changePercentage: 0,
+          momChangePercentage: 0,
           trend: 'up' as const,
           monthlyData: [],
           monthlyLabels: [],

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2069,7 +2069,7 @@ export class ProjectService {
       const classificationParams = classification ? [classification] : [];
       const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
 
-      // Query 1: KPI card — current CTR + MoM change from email_ctr_summary
+      // Query 1: KPI card — current CTR fallback from email_ctr_summary
       // Uses pre-computed CTR_LAST_COMPLETED_MONTH — cannot be month-filtered
       const summaryQuery = `
         SELECT
@@ -2088,7 +2088,6 @@ export class ProjectService {
         SELECT
           PUBLISHED_MONTH,
           PUBLISHED_MONTH_DATE,
-          ROUND(SUM(TOTAL_OPENS) * 100.0 / NULLIF(SUM(TOTAL_SENDS), 0), 1) AS MONTHLY_CTR,
           SUM(TOTAL_SENDS) AS TOTAL_SENDS,
           SUM(TOTAL_OPENS) AS TOTAL_OPENS
         FROM ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CTR_BY_MONTH
@@ -2135,10 +2134,12 @@ export class ProjectService {
 
       const [summaryResult, monthlyResult, campaignResult, campaignPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ PROJECT_NAME: string; CTR_LAST_COMPLETED_MONTH: number }>(summaryQuery, [...foundationParams, ...classificationParams]),
-        this.snowflakeService.execute<{ PUBLISHED_MONTH: string; PUBLISHED_MONTH_DATE: string; MONTHLY_CTR: number; TOTAL_SENDS: number; TOTAL_OPENS: number }>(
-          monthlyQuery,
-          [monthDate, monthDate, ...foundationParams, ...classificationParams]
-        ),
+        this.snowflakeService.execute<{ PUBLISHED_MONTH: string; PUBLISHED_MONTH_DATE: string; TOTAL_SENDS: number; TOTAL_OPENS: number }>(monthlyQuery, [
+          monthDate,
+          monthDate,
+          ...foundationParams,
+          ...classificationParams,
+        ]),
         this.snowflakeService.execute<{ PROJECT_NAME: string; LF_SUB_DOMAIN_CLASSIFICATION: string; AVG_CTR: number }>(campaignQuery, [
           ...foundationParams,
           ...classificationParams,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2177,7 +2177,17 @@ export class ProjectService {
       ]);
 
       if (summaryResult.rows.length === 0 && monthlyResult.rows.length === 0) {
-        return { currentCtr: 0, changePercentage: 0, trend: 'up', monthlyData: [], monthlyLabels: [], campaignGroups: [], monthlySends: [], monthlyOpens: [] };
+        return {
+          currentCtr: 0,
+          changePercentage: 0,
+          momChangePercentage: 0,
+          trend: 'up',
+          monthlyData: [],
+          monthlyLabels: [],
+          campaignGroups: [],
+          monthlySends: [],
+          monthlyOpens: [],
+        };
       }
 
       // Use summary row for KPI card values
@@ -2195,6 +2205,15 @@ export class ProjectService {
           changePercentage = Math.round(((currentCtr - avg) / avg) * 1000) / 10;
         }
       }
+      let momChangePercentage = 0;
+      if (monthlyData.length >= 2) {
+        const current = monthlyData[monthlyData.length - 1];
+        const prior = monthlyData[monthlyData.length - 2];
+        if (prior > 0) {
+          momChangePercentage = Math.round(((current - prior) / prior) * 1000) / 10;
+        }
+      }
+
       const monthlySends = monthlyResult.rows.map((row) => row.TOTAL_SENDS ?? 0);
       const monthlyOpens = monthlyResult.rows.map((row) => row.TOTAL_OPENS ?? 0);
       const monthlyLabels = monthlyResult.rows.map((row) => {
@@ -2296,6 +2315,7 @@ export class ProjectService {
       return {
         currentCtr,
         changePercentage,
+        momChangePercentage,
         trend: changePercentage >= 0 ? 'up' : 'down',
         monthlyData,
         monthlyLabels,
@@ -2310,7 +2330,17 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         err: error,
       });
-      return { currentCtr: 0, changePercentage: 0, trend: 'up', monthlyData: [], monthlyLabels: [], campaignGroups: [], monthlySends: [], monthlyOpens: [] };
+      return {
+        currentCtr: 0,
+        changePercentage: 0,
+        momChangePercentage: 0,
+        trend: 'up',
+        monthlyData: [],
+        monthlyLabels: [],
+        campaignGroups: [],
+        monthlySends: [],
+        monthlyOpens: [],
+      };
     }
   }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2189,7 +2189,12 @@ export class ProjectService {
       // Note: Snowflake values are already percentages (e.g., 2.32 = 2.32%), no conversion needed
       const summaryRow = summaryResult.rows[0];
 
-      const rawMonthlyCtrs = monthlyResult.rows.map((row) => row.MONTHLY_CTR ?? 0);
+      // Compute unrounded CTR from raw sends/opens for MoM precision
+      const rawMonthlyCtrs = monthlyResult.rows.map((row) => {
+        const sends = row.TOTAL_SENDS ?? 0;
+        const opens = row.TOTAL_OPENS ?? 0;
+        return sends > 0 ? (opens * 100) / sends : 0;
+      });
       const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2074,8 +2074,7 @@ export class ProjectService {
       const summaryQuery = `
         SELECT
           PROJECT_NAME,
-          CTR_LAST_COMPLETED_MONTH,
-          CTR_MOM_CHANGE
+          CTR_LAST_COMPLETED_MONTH
         FROM ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CTR_SUMMARY
         WHERE 1=1
           ${foundationFilter}
@@ -2135,10 +2134,7 @@ export class ProjectService {
       `;
 
       const [summaryResult, monthlyResult, campaignResult, campaignPerfResult] = await Promise.all([
-        this.snowflakeService.execute<{ PROJECT_NAME: string; CTR_LAST_COMPLETED_MONTH: number; CTR_MOM_CHANGE: number }>(summaryQuery, [
-          ...foundationParams,
-          ...classificationParams,
-        ]),
+        this.snowflakeService.execute<{ PROJECT_NAME: string; CTR_LAST_COMPLETED_MONTH: number }>(summaryQuery, [...foundationParams, ...classificationParams]),
         this.snowflakeService.execute<{ PUBLISHED_MONTH: string; PUBLISHED_MONTH_DATE: string; MONTHLY_CTR: number; TOTAL_SENDS: number; TOTAL_OPENS: number }>(
           monthlyQuery,
           [monthDate, monthDate, ...foundationParams, ...classificationParams]
@@ -2180,7 +2176,7 @@ export class ProjectService {
         return {
           currentCtr: 0,
           changePercentage: 0,
-          momChangePercentage: 0,
+          momChangePercentage: null,
           trend: 'up',
           monthlyData: [],
           monthlyLabels: [],
@@ -2193,14 +2189,12 @@ export class ProjectService {
       // Note: Snowflake values are already percentages (e.g., 2.32 = 2.32%), no conversion needed
       const summaryRow = summaryResult.rows[0];
 
-      const monthlyData = monthlyResult.rows.map((row) => Math.round((row.MONTHLY_CTR ?? 0) * 10) / 10);
+      const rawMonthlyCtrs = monthlyResult.rows.map((row) => row.MONTHLY_CTR ?? 0);
+      const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
-      // Source currentCtr from the month-filtered series when available so the KPI
-      // value and MoM comparison always refer to the same month window.
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
       const currentCtr = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : summaryCtr;
 
-      // Compute change as current CTR vs 6-month average (more stable than MoM)
       let changePercentage = 0;
       if (monthlyData.length >= 2 && currentCtr > 0) {
         const avg = monthlyData.reduce((sum, v) => sum + v, 0) / monthlyData.length;
@@ -2208,12 +2202,13 @@ export class ProjectService {
           changePercentage = Math.round(((currentCtr - avg) / avg) * 1000) / 10;
         }
       }
-      let momChangePercentage = 0;
-      if (monthlyData.length >= 2) {
-        const current = monthlyData[monthlyData.length - 1];
-        const prior = monthlyData[monthlyData.length - 2];
+
+      let momChangePercentage: number | null = null;
+      if (rawMonthlyCtrs.length >= 2) {
+        const current = rawMonthlyCtrs[rawMonthlyCtrs.length - 1];
+        const prior = rawMonthlyCtrs[rawMonthlyCtrs.length - 2];
         if (prior > 0) {
-          momChangePercentage = Math.round(((current - prior) / prior) * 1000) / 10;
+          momChangePercentage = ((current - prior) / prior) * 100;
         }
       }
 
@@ -2336,7 +2331,7 @@ export class ProjectService {
       return {
         currentCtr: 0,
         changePercentage: 0,
-        momChangePercentage: 0,
+        momChangePercentage: null,
         trend: 'up',
         monthlyData: [],
         monthlyLabels: [],

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2190,12 +2190,15 @@ export class ProjectService {
         };
       }
 
-      // Use summary row for KPI card values
       // Note: Snowflake values are already percentages (e.g., 2.32 = 2.32%), no conversion needed
       const summaryRow = summaryResult.rows[0];
-      const currentCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
 
       const monthlyData = monthlyResult.rows.map((row) => Math.round((row.MONTHLY_CTR ?? 0) * 10) / 10);
+
+      // Source currentCtr from the month-filtered series when available so the KPI
+      // value and MoM comparison always refer to the same month window.
+      const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
+      const currentCtr = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : summaryCtr;
 
       // Compute change as current CTR vs 6-month average (more stable than MoM)
       let changePercentage = 0;

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2804,6 +2804,7 @@ export interface EmailTypeBreakdown {
 export interface EmailCtrResponse {
   currentCtr: number;
   changePercentage: number;
+  momChangePercentage: number;
   trend: 'up' | 'down';
   monthlyData: number[];
   monthlyLabels: string[];

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2804,7 +2804,7 @@ export interface EmailTypeBreakdown {
 export interface EmailCtrResponse {
   currentCtr: number;
   changePercentage: number;
-  momChangePercentage: number;
+  momChangePercentage: number | null;
   trend: 'up' | 'down';
   monthlyData: number[];
   monthlyLabels: string[];


### PR DESCRIPTION
## Summary
- Add month-over-month (MoM) comparisons to all 4 Marketing Impact overview KPI cards for consistency
- Revenue card: add MoM (from `paidMedia.monthlyTrend`) alongside existing YoY
- ROAS card: add MoM (was blank before)
- Email CTR card: replace misleading "vs avg" label with real MoM (new `momChangePercentage` field computed from last 2 monthly CTR values in backend)
- Web Sessions card: unchanged (already had MoM)
- Update subtitle to "vs. {month} (MoM) · vs. {month} (YoY) · Linear attribution · {foundation}" format

## Changes
- **`packages/shared/src/interfaces/analytics-data.interface.ts`** — add `momChangePercentage` to `EmailCtrResponse`
- **`apps/lfx-one/src/server/services/project.service.ts`** — compute MoM from last 2 `monthlyData` entries in `getEmailCtr`, update return + fallbacks
- **`apps/lfx-one/src/app/shared/services/analytics.service.ts`** — add `momChangePercentage: 0` to `getEmailCtr` catchError fallback
- **`apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts`** — wire MoM to Revenue/ROAS/Email CTR cards, update subtitle format, add `computeMomFromTrend` helper
- **`apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts`** — use `momChangePercentage` with "MoM" label for CTR card
- **`apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts`** — add `momChangePercentage: 0` to `EMPTY_ED_EVOLUTION_DATA.emailCtr`
- **`apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts`** — add `momChangePercentage: 0` to drawer default value

LFXV2-2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)