### PR TITLE
feat(crowdfunding): use single-subscription endpoint for donation detail

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
@@ -9,7 +9,7 @@ import { concatMap, filter, map, scan, startWith, switchMap, tap } from 'rxjs/op
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 
-import { CrowdfundingTransaction, RecurringDonation, RecurringDonationsResponse } from '@lfx-one/shared/interfaces';
+import { CrowdfundingTransaction, RecurringDonation } from '@lfx-one/shared/interfaces';
 import { DEFAULT_CROWDFUNDING_PAGE_SIZE } from '@lfx-one/shared/constants';
 import { CrowdfundingService } from '@app/shared/services/crowdfunding.service';
 import { ButtonComponent } from '@components/button/button.component';
@@ -91,8 +91,8 @@ export class RecurringDonationDetailComponent {
       this.route.paramMap.pipe(
         map((params) => params.get('id') ?? ''),
         switchMap((id) =>
-          this.crowdfundingService.getMyRecurringDonations().pipe(
-            map((res: RecurringDonationsResponse) => res.data.find((d) => d.id === id)),
+          this.crowdfundingService.getRecurringDonationById(id).pipe(
+            map((d) => d ?? undefined),
             tap(() => this.isLoading.set(false))
           )
         )

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -74,8 +74,9 @@ export class CrowdfundingService {
   }
 
   public getRecurringDonationById(id: string): Observable<RecurringDonation | null> {
+    if (!id.trim()) return of(null);
     return this.http
-      .get<RecurringDonation>(`/api/crowdfunding/recurring-donations/${encodeURIComponent(id)}`)
+      .get<RecurringDonation>(`/api/crowdfunding/recurring-donations/${encodeURIComponent(id.trim())}`)
       .pipe(catchError(this.handleCfError(null, 'getRecurringDonationById')));
   }
 

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -24,6 +24,7 @@ import {
   MyDonationsResponse,
   PaymentMethod,
   PresignedURLResult,
+  RecurringDonation,
   RecurringDonationsResponse,
   UpdateInitiativeInput,
 } from '@lfx-one/shared/interfaces';
@@ -70,6 +71,12 @@ export class CrowdfundingService {
 
   public getMyDonationStats(): Observable<DonationStats> {
     return this.http.get<DonationStats>('/api/crowdfunding/donation-stats').pipe(catchError(this.handleCfError(EMPTY_DONATION_STATS, 'getMyDonationStats')));
+  }
+
+  public getRecurringDonationById(id: string): Observable<RecurringDonation | null> {
+    return this.http
+      .get<RecurringDonation>(`/api/crowdfunding/recurring-donations/${encodeURIComponent(id)}`)
+      .pipe(catchError(this.handleCfError(null, 'getRecurringDonationById')));
   }
 
   public getMyRecurringDonations(): Observable<RecurringDonationsResponse> {

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -304,6 +304,35 @@ export class CrowdfundingController {
     }
   }
 
+  // GET /api/crowdfunding/recurring-donations/:id
+  public async getRecurringDonationById(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_recurring_donation_by_id');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_recurring_donation_by_id' });
+      }
+
+      const { id } = req.params;
+      if (!id || !id.trim()) {
+        throw ServiceValidationError.forField('id', 'Subscription id is required', { operation: 'get_recurring_donation_by_id' });
+      }
+
+      const donation = await this.crowdfundingService.getRecurringDonationById(req, id.trim());
+
+      if (!donation) {
+        res.status(404).json({ message: `Recurring donation '${id}' not found` });
+        return;
+      }
+
+      logger.success(req, 'get_recurring_donation_by_id', startTime, { id });
+
+      res.json(donation);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   /** GET /api/crowdfunding/initiatives/:slug — fetch a single initiative by slug. */
   public async getInitiativeBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_initiative_by_slug');

--- a/apps/lfx-one/src/server/routes/crowdfunding.route.ts
+++ b/apps/lfx-one/src/server/routes/crowdfunding.route.ts
@@ -16,6 +16,7 @@ router.post('/payment-method', (req, res, next) => crowdfundingController.saveMy
 router.get('/payment-method', (req, res, next) => crowdfundingController.getMyPaymentMethod(req, res, next));
 router.delete('/payment-method', (req, res, next) => crowdfundingController.deleteMyPaymentMethod(req, res, next));
 router.get('/donation-stats', (req, res, next) => crowdfundingController.getMyDonationStats(req, res, next));
+router.get('/recurring-donations/:id', (req, res, next) => crowdfundingController.getRecurringDonationById(req, res, next));
 router.get('/recurring-donations', (req, res, next) => crowdfundingController.getMyRecurringDonations(req, res, next));
 router.get('/my-donations', (req, res, next) => crowdfundingController.getMyDonations(req, res, next));
 router.post('/presigned-url', (req, res, next) => crowdfundingController.getPresignedUrl(req, res, next));

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -287,8 +287,8 @@ export class CrowdfundingService {
     const startTime = logger.startOperation(req, 'cf_get_recurring_donation_by_id', { subscriptionId });
 
     const raw = await cfFetchNullable<BackendSubscription>(req, 'getRecurringDonationById', `/v1/me/subscriptions/${encodeURIComponent(subscriptionId)}`);
-    if (!raw) {
-      logger.warning(req, 'cf_get_recurring_donation_by_id', 'Subscription not found', { subscriptionId });
+    if (!raw || raw.status === 'canceled') {
+      logger.warning(req, 'cf_get_recurring_donation_by_id', 'Subscription not found', { subscriptionId, status: raw?.status });
       return null;
     }
 

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -10,6 +10,7 @@ import {
   MyDonationsResponse,
   PaymentMethod,
   PresignedURLResult,
+  RecurringDonation,
   RecurringDonationsResponse,
   UpdateInitiativeInput,
 } from '@lfx-one/shared/interfaces';
@@ -280,6 +281,19 @@ export class CrowdfundingService {
 
     logger.success(req, 'cf_get_my_donations', startTime, { total: raw.meta.total });
     return { data: raw.data.map(mapCfDonationToMyDonation), total: raw.meta.total, pageSize: raw.meta.limit, offset: raw.meta.offset };
+  }
+
+  public async getRecurringDonationById(req: Request, subscriptionId: string): Promise<RecurringDonation | null> {
+    const startTime = logger.startOperation(req, 'cf_get_recurring_donation_by_id', { subscriptionId });
+
+    const raw = await cfFetchNullable<BackendSubscription>(req, 'getRecurringDonationById', `/v1/me/subscriptions/${encodeURIComponent(subscriptionId)}`);
+    if (!raw) {
+      logger.warning(req, 'cf_get_recurring_donation_by_id', 'Subscription not found', { subscriptionId });
+      return null;
+    }
+
+    logger.success(req, 'cf_get_recurring_donation_by_id', startTime, { subscriptionId });
+    return mapSubscriptionToRecurringDonation(raw);
   }
 
   public async cancelSubscription(req: Request, subscriptionId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Replace fetch-all-then-filter pattern on the recurring-donation detail page with the new `GET /v1/me/subscriptions/{id}` upstream endpoint
- Add backend service method `getRecurringDonationById`, controller handler, and Express route `GET /api/crowdfunding/recurring-donations/:id`
- Wire Angular service and detail component through the single fetch — eliminates the full-list over-fetch that previously paged all subscriptions (500/page) just to render one record

## Notes
- No JIRA ticket — discovered as an available upstream API improvement during development
- The list endpoint (`getMyRecurringDonations`) is unchanged; only the detail page switches to fetch-by-id