### PR TITLE
fix(routing): correct project context when navigating directly to entity URLs

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -519,7 +519,10 @@ export class CommitteeViewComponent {
       name: committee.project_name || committee.foundation_name || committee.project_slug,
       slug: committee.project_slug,
     };
-    if (committee.is_foundation) {
+    // Mirror projectQueryParamGuard's lens decision: foundation routes set foundation context,
+    // project routes (and everything else) set project context. This ensures the sidebar reflects
+    // the group's owning entity regardless of whether it's technically a foundation or project.
+    if (this.router.url.startsWith('/foundation/')) {
       this.projectContextService.setFoundation(context);
     } else {
       this.projectContextService.setProject(context);

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -47,8 +47,9 @@ import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { SafeUrlPipe } from '@pipes/safe-url.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, distinctUntilChanged, EMPTY, filter, finalize, map, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, EMPTY, filter, finalize, map, of, switchMap, take } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
+import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
 import { JoinApplicationDialogComponent } from '../components/join-application-dialog/join-application-dialog.component';
 
@@ -263,16 +264,7 @@ export class CommitteeViewComponent {
       this.invitationService.loadPendingInvitations().pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe();
     }
 
-    // Sync the project/foundation context to the group's actual owning project when data loads.
-    // applyDefaultSelection() picks the user's default project before this page loads — this
-    // corrects it so the sidebar reflects the group's real project rather than an unrelated one.
-    toObservable(this.committee)
-      .pipe(
-        filter((c): c is Committee => !!c?.project_uid && !!c.project_slug),
-        distinctUntilChanged((a, b) => a.uid === b.uid),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe((committee) => this.syncProjectContextFromCommittee(committee));
+    syncEntityProjectContext(this.committee, this.projectContextService, this.router, this.destroyRef);
 
     // Flush any deferred decline on destroy so navigating away still commits it.
     this.destroyRef.onDestroy(() => {
@@ -511,23 +503,6 @@ export class CommitteeViewComponent {
   }
 
   // -- Private methods --
-
-  private syncProjectContextFromCommittee(committee: Committee): void {
-    if (!committee.project_uid || !committee.project_slug) return;
-    const context: ProjectContext = {
-      uid: committee.project_uid,
-      name: committee.project_name || committee.foundation_name || committee.project_slug,
-      slug: committee.project_slug,
-    };
-    // Mirror projectQueryParamGuard's lens decision: foundation routes set foundation context,
-    // project routes (and everything else) set project context. This ensures the sidebar reflects
-    // the group's owning entity regardless of whether it's technically a foundation or project.
-    if (this.router.url.startsWith('/foundation/')) {
-      this.projectContextService.setFoundation(context);
-    } else {
-      this.projectContextService.setProject(context);
-    }
-  }
 
   /** Cancels the deferred timer and fires the upstream decline immediately (destroy flush). */
   private flushDecline(inviteUid: string): void {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -47,7 +47,7 @@ import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { SafeUrlPipe } from '@pipes/safe-url.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, EMPTY, filter, finalize, map, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, EMPTY, filter, finalize, map, of, switchMap, take } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
 import { JoinApplicationDialogComponent } from '../components/join-application-dialog/join-application-dialog.component';
@@ -262,6 +262,17 @@ export class CommitteeViewComponent {
     if (isPlatformBrowser(this.platformId)) {
       this.invitationService.loadPendingInvitations().pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe();
     }
+
+    // Sync the project/foundation context to the group's actual owning project when data loads.
+    // applyDefaultSelection() picks the user's default project before this page loads — this
+    // corrects it so the sidebar reflects the group's real project rather than an unrelated one.
+    toObservable(this.committee)
+      .pipe(
+        filter((c): c is Committee => !!c?.project_uid && !!c.project_slug),
+        distinctUntilChanged((a, b) => a.uid === b.uid),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((committee) => this.syncProjectContextFromCommittee(committee));
 
     // Flush any deferred decline on destroy so navigating away still commits it.
     this.destroyRef.onDestroy(() => {
@@ -500,6 +511,21 @@ export class CommitteeViewComponent {
   }
 
   // -- Private methods --
+
+  private syncProjectContextFromCommittee(committee: Committee): void {
+    if (!committee.project_uid || !committee.project_slug) return;
+    const context: ProjectContext = {
+      uid: committee.project_uid,
+      name: committee.project_name || committee.foundation_name || committee.project_slug,
+      slug: committee.project_slug,
+    };
+    if (committee.is_foundation) {
+      this.projectContextService.setFoundation(context);
+    } else {
+      this.projectContextService.setProject(context);
+    }
+  }
+
   /** Cancels the deferred timer and fires the upstream decline immediately (destroy flush). */
   private flushDecline(inviteUid: string): void {
     const pending = this.pendingDeclines.get(inviteUid);

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -179,5 +179,4 @@ export class MailingListViewComponent {
       return uid ? ['/mailing-lists', uid, 'edit'] : ['/mailing-lists'];
     });
   }
-
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { LowerCasePipe } from '@angular/common';
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -17,13 +17,14 @@ import {
   MAILING_LIST_VISIBILITY_LABELS,
 } from '@lfx-one/shared/constants';
 import { MailingListAudienceAccess } from '@lfx-one/shared/enums';
-import { CommitteeReference, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
+import { CommitteeReference, GroupsIOMailingList, ProjectContext } from '@lfx-one/shared/interfaces';
 import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
 import { MailingListService } from '@services/mailing-list.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, combineLatest, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filter, of, switchMap } from 'rxjs';
 
 import { MailingListMembersComponent } from '../components/mailing-list-members/mailing-list-members.component';
 
@@ -49,6 +50,8 @@ export class MailingListViewComponent {
   private readonly router = inject(Router);
   private readonly mailingListService = inject(MailingListService);
   private readonly messageService = inject(MessageService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Back-navigation label injected from router state at navigation time
   private readonly navBackLabel: string | null = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
@@ -77,6 +80,16 @@ export class MailingListViewComponent {
   public readonly visibilityLabel: Signal<string> = this.initVisibilityLabel();
   public readonly groupsIoUrl: Signal<string | null> = this.initGroupsIoUrl();
   public readonly editRoute: Signal<string[]> = this.initEditRoute();
+
+  public constructor() {
+    toObservable(this.mailingList)
+      .pipe(
+        filter((ml): ml is GroupsIOMailingList => !!ml?.project_uid && !!ml.project_slug),
+        distinctUntilChanged((a, b) => a.uid === b.uid),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((ml) => this.syncProjectContextFromMailingList(ml));
+  }
 
   public refreshData(): void {
     this.refresh.next();
@@ -169,5 +182,18 @@ export class MailingListViewComponent {
       const uid = this.mailingList()?.uid;
       return uid ? ['/mailing-lists', uid, 'edit'] : ['/mailing-lists'];
     });
+  }
+
+  private syncProjectContextFromMailingList(ml: GroupsIOMailingList): void {
+    const context: ProjectContext = {
+      uid: ml.project_uid,
+      name: ml.project_name || ml.project_slug,
+      slug: ml.project_slug,
+    };
+    if (this.router.url.startsWith('/foundation/')) {
+      this.projectContextService.setFoundation(context);
+    } else {
+      this.projectContextService.setProject(context);
+    }
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -3,7 +3,7 @@
 
 import { LowerCasePipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -17,14 +17,16 @@ import {
   MAILING_LIST_VISIBILITY_LABELS,
 } from '@lfx-one/shared/constants';
 import { MailingListAudienceAccess } from '@lfx-one/shared/enums';
-import { CommitteeReference, GroupsIOMailingList, ProjectContext } from '@lfx-one/shared/interfaces';
+import { CommitteeReference, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
 import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
 import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filter, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, of, switchMap } from 'rxjs';
+
+import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 
 import { MailingListMembersComponent } from '../components/mailing-list-members/mailing-list-members.component';
 
@@ -82,13 +84,7 @@ export class MailingListViewComponent {
   public readonly editRoute: Signal<string[]> = this.initEditRoute();
 
   public constructor() {
-    toObservable(this.mailingList)
-      .pipe(
-        filter((ml): ml is GroupsIOMailingList => !!ml?.project_uid && !!ml.project_slug),
-        distinctUntilChanged((a, b) => a.uid === b.uid),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe((ml) => this.syncProjectContextFromMailingList(ml));
+    syncEntityProjectContext(this.mailingList, this.projectContextService, this.router, this.destroyRef);
   }
 
   public refreshData(): void {
@@ -184,16 +180,4 @@ export class MailingListViewComponent {
     });
   }
 
-  private syncProjectContextFromMailingList(ml: GroupsIOMailingList): void {
-    const context: ProjectContext = {
-      uid: ml.project_uid,
-      name: ml.project_name || ml.project_slug,
-      slug: ml.project_slug,
-    };
-    if (this.router.url.startsWith('/foundation/')) {
-      this.projectContextService.setFoundation(context);
-    } else {
-      this.projectContextService.setProject(context);
-    }
-  }
 }

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -3,7 +3,7 @@
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, input, model, Signal, signal } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
 import { OrgSelectorComponent } from '@components/org-selector/org-selector.component';
@@ -51,6 +51,7 @@ export class SidebarComponent {
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
   private readonly navigationService = inject(NavigationService);
+  private readonly router = inject(Router);
   private readonly userService = inject(UserService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly accountContextService = inject(AccountContextService);
@@ -151,6 +152,18 @@ export class SidebarComponent {
     } else {
       this.projectContextService.setProject(context);
       this.lensService.setLens('project');
+    }
+    // When on an entity detail page (e.g. /project/mailing-lists/:id or /project/groups/:id),
+    // switching project context should land on the new project's dashboard — staying on the
+    // current entity would show data from the wrong project until the user navigates away.
+    this.redirectFromEntityPageIfNeeded();
+  }
+
+  private redirectFromEntityPageIfNeeded(): void {
+    const segments = this.router.url.split('?')[0].split('/').filter(Boolean);
+    // Entity detail pages match /project/<section>/<id> (exactly 3 segments)
+    if (segments.length === 3 && segments[0] === 'project') {
+      this.router.navigate(['/project', 'overview']);
     }
   }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -156,14 +156,18 @@ export class SidebarComponent {
     // When on an entity detail page (e.g. /project/mailing-lists/:id or /project/groups/:id),
     // switching project context should land on the new project's dashboard — staying on the
     // current entity would show data from the wrong project until the user navigates away.
-    this.redirectFromEntityPageIfNeeded();
+    this.redirectFromEntityPageIfNeeded(context.slug);
   }
 
-  private redirectFromEntityPageIfNeeded(): void {
+  private redirectFromEntityPageIfNeeded(projectSlug: string): void {
     const segments = this.router.url.split('?')[0].split('/').filter(Boolean);
-    // Entity detail pages match /project/<section>/<id> (exactly 3 segments)
-    if (segments.length === 3 && segments[0] === 'project') {
-      this.router.navigate(['/project', 'overview']);
+    // Entity detail pages match /<lens>/<section>/<id> (exactly 3 segments, project or foundation prefix)
+    if (segments.length === 3 && (segments[0] === 'project' || segments[0] === 'foundation')) {
+      // Use activeLens() (updated synchronously by setLens() above) for the destination prefix.
+      // Pass the slug explicitly — router.url lags behind location.replaceState so
+      // queryParamsHandling:'preserve' would carry stale params.
+      const lensPrefix = this.activeLens() === 'foundation' ? 'foundation' : 'project';
+      this.router.navigate([`/${lensPrefix}`, 'overview'], { queryParams: { project: projectSlug } });
     }
   }
 

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -157,19 +157,27 @@ export class NavigationService {
 
     state.pendingDefaultSelection.set(false);
 
+    // Only write ?project= to the URL if it was already present — prevents the default
+    // selection from injecting a wrong project slug into entity-specific URLs (e.g.
+    // /project/groups/:id) that a user navigated to without an explicit project context.
+    const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+
     // Preserve an explicit selection (e.g., Me lens → Open) — selected_uid ensures it's in the page.
     const existing = lens === 'foundation' ? this.projectContextService.selectedFoundation() : this.projectContextService.selectedProject();
     if (existing?.uid && page.items.some((item) => item.uid === existing.uid)) {
       return;
     }
 
+    // On entity deep-link pages (no ?project= in URL), preserve any context already set by
+    // syncEntityProjectContext — even if the owning entity's project isn't in this lens's items
+    // (e.g. a foundation-owned entity accessed via the project lens, like a TLF mailing list).
+    if (!syncUrl && existing?.uid) {
+      return;
+    }
+
     const priority = lens === 'foundation' ? BOARD_SCOPED_PERSONA_PRIORITY : PROJECT_SCOPED_PERSONA_PRIORITY;
     const defaultItem = this.pickItemByPersonaPriority(page.items, priority);
     const context = lensItemToProjectContext(defaultItem);
-    // Only write ?project= to the URL if it was already present — prevents the default
-    // selection from injecting a wrong project slug into entity-specific URLs (e.g.
-    // /project/groups/:id) that a user navigated to without an explicit project context.
-    const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
     if (lens === 'foundation') {
       this.projectContextService.setFoundation(context, syncUrl);
     } else {

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -13,10 +13,10 @@ import { ProjectContextService } from '../services/project-context.service';
  * Syncs the active project/foundation context to the owning project of the given
  * entity whenever its data loads or changes. Call once from the component constructor.
  *
- * Mirrors projectQueryParamGuard's lens decision: /foundation/* routes set the
- * foundation context; all other routes (project lens, top-level) set the project
- * context. This prevents the navigation service's default selection from leaving an
- * unrelated project slug active when navigating directly to an entity URL.
+ * Lens decision is URL-prefix based: /foundation/* routes set the foundation context;
+ * all other routes (project lens, top-level) set the project context. This prevents
+ * the navigation service's default selection from leaving an unrelated project slug
+ * active when navigating directly to an entity URL.
  */
 export function syncEntityProjectContext<T extends EntityWithProject>(
   entitySignal: Signal<T | null>,

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -4,18 +4,10 @@
 import { DestroyRef, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { ProjectContext } from '@lfx-one/shared/interfaces';
+import { EntityWithProject, ProjectContext } from '@lfx-one/shared/interfaces';
 import { distinctUntilChanged, filter } from 'rxjs';
 
 import { ProjectContextService } from '../services/project-context.service';
-
-interface EntityWithProject {
-  uid: string;
-  project_uid: string;
-  project_slug?: string | null;
-  project_name?: string | null;
-  foundation_name?: string | null;
-}
 
 /**
  * Syncs the active project/foundation context to the owning project of the given

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -27,7 +27,7 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
   toObservable(entitySignal)
     .pipe(
       filter((entity): entity is T & { project_slug: string } => !!entity?.project_uid && !!entity?.project_slug),
-      distinctUntilChanged((a, b) => a.uid === b.uid),
+      distinctUntilChanged((a, b) => a.uid === b.uid && a.project_uid === b.project_uid && a.project_slug === b.project_slug),
       takeUntilDestroyed(destroyRef)
     )
     .subscribe((entity) => {
@@ -36,10 +36,14 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
         name: entity.project_name || entity.foundation_name || entity.project_slug,
         slug: entity.project_slug,
       };
+      // Only write ?project= to the URL if it was already present — mirrors the same
+      // guard in NavigationService.applyDefaultSelection() to prevent injecting a wrong
+      // project slug into entity-specific deep-link URLs (e.g. /project/groups/:id).
+      const syncUrl = 'project' in router.parseUrl(router.url).queryParams;
       if (router.url.startsWith('/foundation/')) {
-        projectContextService.setFoundation(context);
+        projectContextService.setFoundation(context, syncUrl);
       } else {
-        projectContextService.setProject(context);
+        projectContextService.setProject(context, syncUrl);
       }
     });
 }

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -1,0 +1,53 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DestroyRef, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { ProjectContext } from '@lfx-one/shared/interfaces';
+import { distinctUntilChanged, filter } from 'rxjs';
+
+import { ProjectContextService } from '../services/project-context.service';
+
+interface EntityWithProject {
+  uid: string;
+  project_uid: string;
+  project_slug?: string | null;
+  project_name?: string | null;
+  foundation_name?: string | null;
+}
+
+/**
+ * Syncs the active project/foundation context to the owning project of the given
+ * entity whenever its data loads or changes. Call once from the component constructor.
+ *
+ * Mirrors projectQueryParamGuard's lens decision: /foundation/* routes set the
+ * foundation context; all other routes (project lens, top-level) set the project
+ * context. This prevents the navigation service's default selection from leaving an
+ * unrelated project slug active when navigating directly to an entity URL.
+ */
+export function syncEntityProjectContext<T extends EntityWithProject>(
+  entitySignal: Signal<T | null>,
+  projectContextService: ProjectContextService,
+  router: Router,
+  destroyRef: DestroyRef
+): void {
+  toObservable(entitySignal)
+    .pipe(
+      filter((entity): entity is T & { project_slug: string } => !!entity?.project_uid && !!entity?.project_slug),
+      distinctUntilChanged((a, b) => a.uid === b.uid),
+      takeUntilDestroyed(destroyRef)
+    )
+    .subscribe((entity) => {
+      const context: ProjectContext = {
+        uid: entity.project_uid,
+        name: entity.project_name || entity.foundation_name || entity.project_slug,
+        slug: entity.project_slug,
+      };
+      if (router.url.startsWith('/foundation/')) {
+        projectContextService.setFoundation(context);
+      } else {
+        projectContextService.setProject(context);
+      }
+    });
+}

--- a/packages/shared/src/interfaces/entity-project-context.interface.ts
+++ b/packages/shared/src/interfaces/entity-project-context.interface.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Minimal shape required for syncing project context from an entity detail signal. */
+export interface EntityWithProject {
+  uid: string;
+  project_uid: string;
+  project_slug?: string | null;
+  project_name?: string | null;
+  foundation_name?: string | null;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -234,3 +234,6 @@ export * from './crowdfunding.interface';
 
 // Donut chart interfaces
 export * from './donut-chart.interface';
+
+// Entity project context interfaces
+export * from './entity-project-context.interface';


### PR DESCRIPTION
## Summary

- Navigating directly to `/project/groups/:id` or `/project/mailing-lists/:id` (without `?project=`) injected the user's default project slug into both the URL and the sidebar, even when the entity belonged to a completely different project
- Root cause: `NavigationService.applyDefaultSelection()` always called `setProject()`/`setFoundation()` with `syncUrl=true`, polluting the URL with a wrong slug; and entity detail pages had no mechanism to correct the context after the entity data loaded

## Changes

- **`project-context.service.ts`** — Added optional `syncUrl` parameter to `setProject()` and `setFoundation()`; defaults to `true` for backward compatibility
- **`navigation.service.ts`** — In `applyDefaultSelection()`, check `'project' in queryParams` (key presence, not truthiness) to skip URL sync when navigating to entity URLs without an explicit `?project=`
- **`entity-project-context.util.ts`** (new) — Shared utility `syncEntityProjectContext()` that subscribes to an entity signal and updates the project/foundation context once data loads; mirrors `projectQueryParamGuard`'s lens decision (`/foundation/*` → `setFoundation`, all others → `setProject`)
- **`entity-project-context.interface.ts`** (new in shared package) — `EntityWithProject` interface consumed by the utility
- **`committee-view.component.ts`** — Uses `syncEntityProjectContext()` replacing an inline subscription + private method
- **`mailing-list-view.component.ts`** — Same replacement

## Test plan

- [ ] Open a new browser tab and paste a group URL belonging to a different project (e.g. TLF group on an account defaulting to `agstack`) — sidebar should show TLF, not agstack; `?project=` should NOT appear in the URL
- [ ] Same for a mailing list URL belonging to a different project
- [ ] Navigate normally via the sidebar — `?project=` sync still works (not broken)
- [ ] Navigating to a URL that already has `?project=someSlug` still sets context from the query param via `projectQueryParamGuard`
- [ ] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)