### PR TITLE
docs(crowdfunding): add user documentation for crowdfunding section

### DIFF
--- a/apps/lfx-one/scripts/lib/build-manifest.mjs
+++ b/apps/lfx-one/scripts/lib/build-manifest.mjs
@@ -36,6 +36,7 @@ const DOCS_TAXONOMY_ORDER = [
   'profile',
   'settings',
   'transactions',
+  'crowdfunding',
 ];
 
 /**

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -29,8 +29,15 @@ Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sideb
 
 ## Key concepts
 
-- **Initiative**: A fundraising campaign for an open-source project. Initiatives have a type (General Fund, Security Audit, Mentorship, or Event) and a status (Active, Pending, or Archived).
-- **Recurring donation**: A monthly subscription that automatically charges a saved payment method each billing cycle.
+- **Initiative**: A fundraising campaign for an open-source project. Initiatives have a type (General Fund, Security Audit, Mentorship, or Event) and a status that determines their visibility and whether they accept donations.
+- **Initiative status**: Initiatives move through the following statuses:
+  - **Published** (shown under the Active filter) — the initiative is live and accepting donations
+  - **Pending** — the initiative has been created and is awaiting review before going live
+  - **Submitted** — the initiative has been submitted for final approval; still under review
+  - **Hidden** (shown under the Archived filter) — the initiative has been archived and no longer accepts donations
+  - **Declined** (shown under the Archived filter) — the initiative was not approved during review
+- **Recurring donation**: A monthly subscription that automatically charges a saved payment method each billing cycle. A recurring donation subscription can be Active or Paused.
+- **Paused recurring donation**: A recurring donation subscription that is temporarily on hold. No charges are processed while a subscription is paused.
 - **One-time donation**: A single charge made to an initiative without a recurring subscription.
 - **Payment method**: A saved credit or debit card used to process donations.
 

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -1,0 +1,40 @@
+---
+title: Crowdfunding
+description: Manage your crowdfunding initiatives and track your donations in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, initiatives, donations, funding, sponsors]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+The Crowdfunding section lets you manage the fundraising initiatives you own and track the donations you have made to Linux Foundation projects. It is organized into two areas: **My Initiatives** for initiative owners and **My Donations** for contributors.
+
+## What you can do
+
+- View and manage crowdfunding initiatives you have created
+- Monitor funding stats including total raised and sponsor count
+- Track your donation history across one-time and recurring contributions
+- Manage saved payment methods
+- Cancel or review recurring donation subscriptions
+
+## Who this applies to
+
+All authenticated users can access the Crowdfunding section. **My Initiatives** is relevant to users who have created or submitted crowdfunding initiatives. **My Donations** is relevant to users who have contributed to any initiative.
+
+## Navigation
+
+Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sidebar under the **Me** lens. The section expands to show **My Initiatives** (route: `/crowdfunding/initiatives`) and **My Donations** (route: `/crowdfunding/donations`).
+
+## Key concepts
+
+- **Initiative**: A fundraising campaign for an open source project. Initiatives have a type (General Fund, Security Audit, Mentorship, or Event) and a status (Active, Pending, or Archived).
+- **Recurring donation**: A monthly subscription that automatically charges a saved payment method each billing cycle.
+- **One-time donation**: A single charge made to an initiative without a recurring subscription.
+- **Payment method**: A saved credit or debit card used to process donations.
+
+## Related sections
+
+- [Transactions](../transactions/) — view purchase and billing history across all LFX products
+- [Profile](../profile/) — manage your account details associated with your donations

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -25,7 +25,7 @@ All authenticated users can access the Crowdfunding section. **My Initiatives** 
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sidebar under the **Me** lens. The section expands to show **My Initiatives** (route: `/crowdfunding/initiatives`) and **My Donations** (route: `/crowdfunding/donations`).
+Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sidebar under the **Me** lens. The section expands to show **My Initiatives** ([app.lfx.dev/crowdfunding/initiatives](https://app.lfx.dev/crowdfunding/initiatives)) and **My Donations** ([app.lfx.dev/crowdfunding/donations](https://app.lfx.dev/crowdfunding/donations)).
 
 ## Key concepts
 

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -29,7 +29,7 @@ Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sideb
 
 ## Key concepts
 
-- **Initiative**: A fundraising campaign for an open source project. Initiatives have a type (General Fund, Security Audit, Mentorship, or Event) and a status (Active, Pending, or Archived).
+- **Initiative**: A fundraising campaign for an open-source project. Initiatives have a type (General Fund, Security Audit, Mentorship, or Event) and a status (Active, Pending, or Archived).
 - **Recurring donation**: A monthly subscription that automatically charges a saved payment method each billing cycle.
 - **One-time donation**: A single charge made to an initiative without a recurring subscription.
 - **Payment method**: A saved credit or debit card used to process donations.

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -29,17 +29,9 @@ The detail page is organized into a header and two tabs.
 ## Edit an initiative
 
 1. Open an initiative from the [View Initiatives](../view-initiatives/) page.
-2. Select **Edit Initiative** to open the settings drawer.
-3. Update fields across the four settings tabs:
-
-| Tab                    | Editable fields                                                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Initiative Details** | Name (up to 100 characters), description (up to 500 characters), topics, website URL                                                |
-| **Branding**           | Logo image (PNG, JPEG, GIF, or WebP; maximum 2 MB)                                                                                  |
-| **Beneficiaries**      | Add or remove beneficiaries by name and email                                                                                       |
-| **Funding**            | Funding goal amount; funding distribution percentages across Development, Marketing, Meetups, Bug Bounty, Travel, and Documentation |
-
-4. Save your changes.
+1. Select **Edit Initiative** to open the settings drawer.
+1. Update fields across the four settings tabs — Initiative Details (name, description, topics, website URL), Branding (logo image), Beneficiaries (add or remove by name and email), and Funding (goal amount and distribution percentages across Development, Marketing, Meetups, Bug Bounty, Travel, and Documentation).
+1. Save your changes.
 
 ## Archive an initiative
 

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -1,0 +1,71 @@
+---
+title: Manage Initiatives
+description: How to view initiative details, edit settings, and archive or activate an initiative in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, initiatives, manage, edit, archive, activate]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+Select an initiative from the [View Initiatives](../view-initiatives/) page to open its detail page. From the detail page you can review financials, edit initiative settings, and change the initiative's status.
+
+## Initiative detail page
+
+The detail page is organized into a header and two tabs.
+
+**Header** shows:
+
+- Initiative name and fund type (General Fund, Security Audit, Mentorship, or Event)
+- Description and industry tags
+- Initiative logo or fund-type icon
+- Current status badge
+
+**Overview tab** — sponsors, financial summary, and announcements.
+
+**Financials tab** — detailed funding goals, distribution breakdown, and transaction history.
+
+## Edit an initiative
+
+1. Open an initiative from the [View Initiatives](../view-initiatives/) page.
+2. Select **Edit Initiative** to open the settings drawer.
+3. Update fields across the four settings tabs:
+
+| Tab                    | Editable fields                                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Initiative Details** | Name (up to 100 characters), description (up to 500 characters), topics, website URL                                                |
+| **Branding**           | Logo image (PNG, JPEG, GIF, or WebP; maximum 2 MB)                                                                                  |
+| **Beneficiaries**      | Add or remove beneficiaries by name and email                                                                                       |
+| **Funding**            | Funding goal amount; funding distribution percentages across Development, Marketing, Meetups, Bug Bounty, Travel, and Documentation |
+
+4. Save your changes.
+
+## Archive an initiative
+
+Archiving an initiative changes its status to Hidden. The initiative no longer appears publicly and stops accepting donations.
+
+1. Open a **Published** initiative from the [View Initiatives](../view-initiatives/) page.
+2. Select the **More** menu (⋯) in the initiative header.
+3. Select **Archive Initiative**.
+4. Confirm the action.
+
+The initiative moves to the **Archived** group in the initiatives list.
+
+## Activate an archived initiative
+
+Activating an initiative changes its status back to Published. The initiative becomes publicly visible and resumes accepting donations.
+
+1. Open an **Archived** initiative from the [View Initiatives](../view-initiatives/) page.
+2. Select the **More** menu (⋯) in the initiative header.
+3. Select **Activate Initiative**.
+4. Confirm the action.
+
+The initiative moves to the **Active** group in the initiatives list.
+
+> **Note:** The **More** menu is only available for Published or Archived initiatives. Initiatives with a Pending or Submitted status do not have status-change actions available.
+
+## Related
+
+- [View Initiatives](../view-initiatives/) — browse and filter your full list of initiatives
+- [My Donations](../my-donations/) — view your donation history and manage payment methods

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -9,6 +9,8 @@ last_updated: 2026-06-16
 intercom_collection: Crowdfunding
 ---
 
+These steps apply to users who have created crowdfunding initiatives. If you have not created any initiatives, this section does not apply to your account.
+
 Select an initiative from the [View Initiatives](../view-initiatives/) page to open its detail page. From the detail page you can review financials, edit initiative settings, and change the initiative's status.
 
 ## Initiative detail page
@@ -35,7 +37,7 @@ The detail page is organized into a header and two tabs.
 
 ## Archive an initiative
 
-Archiving an initiative changes its status to Hidden. The initiative no longer appears publicly and stops accepting donations.
+Archiving an initiative changes its status to Hidden. The initiative no longer appears publicly and stops accepting new donations. Existing recurring donors are not automatically notified and their subscriptions are not cancelled — they will need to cancel their recurring donations manually. See [Manage Recurring Donations](../manage-recurring-donations/) for how donors can cancel a subscription.
 
 1. Open a **Published** initiative from the [View Initiatives](../view-initiatives/) page.
 2. Select the **More** menu (⋯) in the initiative header.
@@ -65,6 +67,17 @@ Each initiative has a fund type that describes its purpose:
 - **Security Audit** — funds a third-party security review or penetration test of the project's code
 - **Mentorship** — funds a mentorship program that trains new contributors to the project
 - **Event** — funds a conference, summit, or community event organized around the project
+
+## Frequently asked
+
+**What happens to recurring donors when I archive an initiative?**
+Archiving an initiative stops the initiative from accepting new donations, but it does not automatically cancel the recurring subscriptions of existing donors. Donors who have an active recurring donation to the initiative will continue to be charged until they cancel their subscriptions manually.
+
+**Can I reactivate an archived initiative?**
+Yes. An archived initiative can be reactivated at any time by selecting **Activate Initiative** from the **More** menu (⋯). The initiative will return to Published status and resume accepting donations.
+
+**Why can't I see the More menu on my initiative?**
+The **More** menu for archiving and activating is only available for initiatives with a Published or Archived (Hidden) status. Initiatives that are Pending or Submitted are still under review and cannot be manually archived or activated until the review is complete.
 
 ## Related
 

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -17,7 +17,7 @@ The detail page is organized into a header and two tabs.
 
 **Header** shows:
 
-- Initiative name and fund type (General Fund, Security Audit, Mentorship, or Event)
+- Initiative name and fund type — see [Fund types](#fund-types) below
 - Description and industry tags
 - Initiative logo or fund-type icon
 - Current status badge
@@ -56,6 +56,15 @@ Activating an initiative changes its status back to Published. The initiative be
 The initiative moves to the **Active** group in the initiatives list.
 
 > **Note:** The **More** menu is only available for Published or Archived initiatives. Initiatives with a Pending or Submitted status do not have status-change actions available.
+
+## Fund types
+
+Each initiative has a fund type that describes its purpose:
+
+- **General Fund** — supports the project's general development and operating expenses
+- **Security Audit** — funds a third-party security review or penetration test of the project's code
+- **Mentorship** — funds a mentorship program that trains new contributors to the project
+- **Event** — funds a conference, summit, or community event organized around the project
 
 ## Related
 

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -24,13 +24,15 @@ The new card appears in your payment methods list and can be used for future don
 
 ## Delete a payment method
 
+> **Before deleting:** If a recurring donation is using this card, it will fail on the next billing cycle. Update the payment method on that subscription before removing the card — see [Manage Recurring Donations](../manage-recurring-donations/).
+
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
 3. Scroll to the **Payment Methods** section at the bottom of the page.
 4. Select **Delete** next to the card you want to remove.
 5. Confirm the deletion.
 
-The card is removed from your account. Any active recurring donations that use this card may need to be updated.
+The card is removed from your account.
 
 ## Related
 

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -1,0 +1,38 @@
+---
+title: Manage Payment Methods
+description: How to add and remove saved payment methods for crowdfunding donations in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, payment methods, add, delete, credit card]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+Your saved payment methods are listed at the bottom of the My Donations page. Each entry shows the card brand, the last four digits, and the expiry date. You can add a new card or remove an existing one at any time.
+
+## Add a payment method
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
+3. Scroll to the **Payment Methods** section at the bottom of the page.
+4. Select **Add Payment Method**.
+5. Enter your card number, expiry date, and CVC in the dialog that appears.
+6. Confirm to save the card.
+
+The new card appears in your payment methods list and can be used for future donations.
+
+## Delete a payment method
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
+3. Scroll to the **Payment Methods** section at the bottom of the page.
+4. Select **Delete** next to the card you want to remove.
+5. Confirm the deletion.
+
+The card is removed from your account. Any active recurring donations that use this card may need to be updated.
+
+## Related
+
+- [View Donations](../view-donations/) — see your donation history and recurring subscriptions
+- [Manage Recurring Donations](../manage-recurring-donations/) — cancel or review a recurring subscription

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -17,14 +17,14 @@ Your saved payment methods are listed at the bottom of the My Donations page. Ea
 2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
 3. Scroll to the **Payment Methods** section at the bottom of the page.
 4. Select **Add Payment Method**.
-5. Enter your card number, expiry date, and CVC in the dialog that appears.
+5. Enter your card number, expiry date, and CVC (the 3-digit security code on the back of the card) in the dialog that appears.
 6. Confirm to save the card.
 
 The new card appears in your payment methods list and can be used for future donations.
 
 ## Delete a payment method
 
-> **Before deleting:** If a recurring donation is using this card, it will fail on the next billing cycle. Update the payment method on that subscription before removing the card — see [Manage Recurring Donations](../manage-recurring-donations/).
+> **Before deleting:** If you delete a card that is linked to an active recurring donation, that donation will fail on the next billing cycle because there is no longer a valid payment method to charge. To avoid a missed charge, cancel the recurring donation before removing the card — see [Manage Recurring Donations](../manage-recurring-donations/).
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
@@ -33,6 +33,14 @@ The new card appears in your payment methods list and can be used for future don
 5. Confirm the deletion.
 
 The card is removed from your account.
+
+## Frequently asked
+
+**Will deleting a payment method cancel my recurring donations?**
+No. Deleting a card does not automatically cancel any recurring donations linked to it. Those donations will fail on the next billing cycle because there is no valid payment method to charge. To stop future charges, cancel the recurring donation before removing the card — see [Manage Recurring Donations](../manage-recurring-donations/).
+
+**Can I add the same card again after deleting it?**
+Yes. You can re-add any card at any time by selecting **Add Payment Method** and entering the card details again.
 
 ## Related
 

--- a/docs/user/crowdfunding/manage-recurring-donations/index.md
+++ b/docs/user/crowdfunding/manage-recurring-donations/index.md
@@ -1,0 +1,43 @@
+---
+title: Manage Recurring Donations
+description: How to view recurring donation details and cancel a recurring subscription in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, recurring donations, cancel, subscription, manage]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+A recurring donation is a monthly subscription that automatically charges your saved payment method each billing cycle. You can view the details of a recurring donation and cancel it at any time from the recurring donation detail page.
+
+## View recurring donation details
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
+3. Find the recurring donation in the recurring donations list.
+4. Select the donation name to open its detail page.
+
+The detail page shows:
+
+- Initiative name and fund type
+- Subscription status (Active or Paused)
+- Monthly charge amount
+- Billing description
+- Subscription start date
+- Next charge date
+- Total amount contributed to date
+- Full charge history with the date, period, amount, and status (Paid, Pending, or Failed) of each past charge
+
+## Cancel a recurring donation
+
+1. Open the recurring donation detail page (see steps above).
+2. Select **Cancel Recurring Donation**.
+3. Confirm the cancellation in the dialog that appears.
+
+Cancelling stops all future charges for this subscription. Past charges are not refunded. The donation moves out of your active recurring donations list.
+
+## Related
+
+- [View Donations](../view-donations/) — see your full donation history including one-time contributions
+- [Manage Payment Methods](../manage-payment-methods/) — add or remove the payment methods used for donations

--- a/docs/user/crowdfunding/manage-recurring-donations/index.md
+++ b/docs/user/crowdfunding/manage-recurring-donations/index.md
@@ -21,13 +21,16 @@ A recurring donation is a monthly subscription that automatically charges your s
 The detail page shows:
 
 - Initiative name and fund type
-- Subscription status (Active or Paused)
+- Subscription status — **Active** means the subscription is running and charges will continue on the next billing date; **Paused** means the subscription is temporarily on hold and no charges are being processed
 - Monthly charge amount
 - Billing description
 - Subscription start date
 - Next charge date
 - Total amount contributed to date
-- Full charge history with the date, period, amount, and status (Paid, Pending, or Failed) of each past charge
+- Full charge history with the date, period, amount, and status of each past charge:
+  - **Paid** — the charge was successfully processed
+  - **Pending** — the charge is being processed and the outcome is not yet confirmed
+  - **Failed** — the charge could not be processed, usually because the payment method was declined or expired; check that your saved card is valid and not expired (see [Manage Payment Methods](../manage-payment-methods/))
 
 ## Cancel a recurring donation
 
@@ -35,7 +38,21 @@ The detail page shows:
 2. Select **Cancel Recurring Donation**.
 3. Confirm the cancellation in the dialog that appears.
 
-Cancelling stops all future charges for this subscription. Past charges are not refunded. The donation moves out of your active recurring donations list.
+Cancelling a recurring donation stops all future charges for that subscription immediately. Past charges are not refunded. The subscription is removed from your active recurring donations list, but all past charges remain visible in your donation history table on the [View Donations](../view-donations/) page.
+
+## Frequently asked
+
+**Will I be charged again after I cancel a recurring donation?**
+No. Cancelling a recurring donation stops all future charges immediately. You will not be billed on any future billing date for that subscription.
+
+**Can I get a refund after cancelling?**
+Cancelling a recurring donation does not refund any past charges. Only future charges are stopped.
+
+**Why does a charge show a Failed status?**
+A charge fails when the linked payment method cannot be processed — for example, because the card is expired, declined, or no longer saved on your account. Check that your saved card is valid and up to date under [Manage Payment Methods](../manage-payment-methods/).
+
+**What does a Paused subscription mean?**
+A Paused subscription is temporarily on hold. No charges are processed while the subscription is paused, and no action is needed from you. The subscription resumes automatically when the pause period ends.
 
 ## Related
 

--- a/docs/user/crowdfunding/my-donations/index.md
+++ b/docs/user/crowdfunding/my-donations/index.md
@@ -20,7 +20,7 @@ The My Donations page shows all contributions you have made to crowdfunding init
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Crowdfunding → My Donations** from the left navigation sidebar (route: `/crowdfunding/donations`).
+Go to [app.lfx.dev/crowdfunding/donations](https://app.lfx.dev/crowdfunding/donations) or select **Crowdfunding → My Donations** from the left navigation sidebar.
 
 ## Sub-pages
 

--- a/docs/user/crowdfunding/my-donations/index.md
+++ b/docs/user/crowdfunding/my-donations/index.md
@@ -1,0 +1,34 @@
+---
+title: My Donations
+description: View your donation history, manage payment methods, and manage recurring donations in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, donations, recurring, payment methods, history]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+The My Donations page shows all contributions you have made to crowdfunding initiatives. It provides a summary stats bar, a list of your active recurring donations, a saved payment methods section, and a full donation history table.
+
+## What you can do
+
+- View your total donations and the number of initiatives you have supported
+- Browse your active recurring donation subscriptions and one-time donations
+- Open a recurring donation detail page to review charge history or cancel the subscription
+- Add or remove saved payment methods
+
+## Navigation
+
+Go to **app.lfx.dev** and select **Crowdfunding → My Donations** from the left navigation sidebar (route: `/crowdfunding/donations`).
+
+## Sub-pages
+
+- [View Donations](../view-donations/) — stats bar, donation history, and recurring donations list
+- [Manage Payment Methods](../manage-payment-methods/) — add and remove saved payment methods
+- [Manage Recurring Donations](../manage-recurring-donations/) — view details and cancel recurring subscriptions
+
+## Related
+
+- [My Initiatives](../my-initiatives/) — manage the initiatives you have created
+- [Transactions](../../transactions/) — view purchase history across all LFX products

--- a/docs/user/crowdfunding/my-initiatives/index.md
+++ b/docs/user/crowdfunding/my-initiatives/index.md
@@ -19,7 +19,7 @@ The My Initiatives page lists all crowdfunding initiatives you have created, gro
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Crowdfunding → My Initiatives** from the left navigation sidebar (route: `/crowdfunding/initiatives`).
+Go to [app.lfx.dev/crowdfunding/initiatives](https://app.lfx.dev/crowdfunding/initiatives) or select **Crowdfunding → My Initiatives** from the left navigation sidebar.
 
 ## Sub-pages
 

--- a/docs/user/crowdfunding/my-initiatives/index.md
+++ b/docs/user/crowdfunding/my-initiatives/index.md
@@ -1,0 +1,31 @@
+---
+title: My Initiatives
+description: View and manage the crowdfunding initiatives you have created in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, initiatives, manage, funding]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+The My Initiatives page lists all crowdfunding initiatives you have created, grouped by their current status. You can monitor funding progress, view initiative details, edit settings, and archive or activate initiatives from this section.
+
+## What you can do
+
+- View all your initiatives grouped by status (Active, Pending, Archived)
+- Monitor high-level stats: active initiative count, total raised, and total sponsors
+- Open an initiative detail page to view financials, edit settings, or change its status
+
+## Navigation
+
+Go to **app.lfx.dev** and select **Crowdfunding → My Initiatives** from the left navigation sidebar (route: `/crowdfunding/initiatives`).
+
+## Sub-pages
+
+- [View Initiatives](../view-initiatives/) — list and stats for all your initiatives
+- [Manage Initiatives](../manage-initiatives/) — open a detail page, edit settings, and archive or activate an initiative
+
+## Related
+
+- [My Donations](../my-donations/) — track your contribution history and manage payment methods

--- a/docs/user/crowdfunding/view-donations/index.md
+++ b/docs/user/crowdfunding/view-donations/index.md
@@ -1,0 +1,49 @@
+---
+title: View Donations
+description: How to view your donation history, stats, and recurring donations in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, donations, view, history, recurring, one-time]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+The View Donations page gives you a complete picture of your crowdfunding contributions. It shows a stats bar, a list of active recurring donations, and a paginated table of all your donation history.
+
+## Stats bar
+
+At the top of the page, a stats bar summarizes your contribution activity:
+
+- **Total Donated** — the cumulative amount you have contributed across all initiatives
+- **Initiatives Supported** — the number of distinct initiatives you have donated to
+- **Active Recurring** — your total monthly recurring commitment and the count of active subscriptions
+
+## Recurring donations
+
+Below the stats bar, your active recurring donation subscriptions are listed. Each entry shows the initiative name, fund type, monthly amount, and billing status.
+
+Select a recurring donation to open its detail page where you can review the full charge history and cancel the subscription if needed.
+
+## Donation history
+
+A paginated table lists all your donations in chronological order, including both recurring and one-time contributions. Each row shows:
+
+- Initiative name and fund type
+- Donation date
+- Donation kind (Monthly or One-time)
+- Amount
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Crowdfunding → My Donations** from the left navigation sidebar.
+3. Review the stats bar for an overview of your contribution activity.
+4. Scroll down to the recurring donations list to see your active subscriptions.
+5. Scroll further to the donation history table to see all past contributions.
+6. Select a recurring donation to open its detail page.
+
+## Related
+
+- [Manage Recurring Donations](../manage-recurring-donations/) — cancel or review a recurring subscription in detail
+- [Manage Payment Methods](../manage-payment-methods/) — add or remove a saved payment method

--- a/docs/user/crowdfunding/view-initiatives/index.md
+++ b/docs/user/crowdfunding/view-initiatives/index.md
@@ -39,6 +39,15 @@ Each filter pill shows the count of initiatives in that group. The list supports
 4. Select a status filter pill (**Active**, **Pending**, or **Archived**) to narrow the list.
 5. Select an initiative card to open its detail page.
 
+## Fund types
+
+Each initiative has a fund type that describes its purpose:
+
+- **General Fund** — supports the project's general development and operating expenses
+- **Security Audit** — funds a third-party security review or penetration test of the project's code
+- **Mentorship** — funds a mentorship program that trains new contributors to the project
+- **Event** — funds a conference, summit, or community event organized around the project
+
 ## Related
 
 - [Manage Initiatives](../manage-initiatives/) — edit settings, archive, or activate an initiative from its detail page

--- a/docs/user/crowdfunding/view-initiatives/index.md
+++ b/docs/user/crowdfunding/view-initiatives/index.md
@@ -1,0 +1,45 @@
+---
+title: View Initiatives
+description: How to view and filter your crowdfunding initiatives by status in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, initiatives, view, status, list]
+last_generated: 2026-06-16
+last_updated: 2026-06-16
+intercom_collection: Crowdfunding
+---
+
+The View Initiatives page shows all crowdfunding initiatives you have created, along with a summary stats bar and a filterable list grouped by initiative status.
+
+## Stats bar
+
+At the top of the page, a stats bar shows a high-level summary across all your initiatives:
+
+- **Active Initiatives** — the number of initiatives with a published status that are currently accepting donations
+- **Total Raised** — the cumulative amount raised across all your initiatives; includes a monthly gain indicator when there is positive growth in the current month
+- **Total Sponsors** — the total number of unique sponsors across all your initiatives
+
+## Initiative list
+
+Below the stats bar, your initiatives are displayed as cards. Use the status filter pills to switch between groups:
+
+| Filter       | Included statuses                                                      |
+| ------------ | ---------------------------------------------------------------------- |
+| **Active**   | Published — the initiative is live and accepting donations             |
+| **Pending**  | Pending or Submitted — the initiative is under review and not yet live |
+| **Archived** | Hidden or Declined — the initiative is no longer accepting donations   |
+
+Each filter pill shows the count of initiatives in that group. The list supports pagination with a load-more button.
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Crowdfunding → My Initiatives** from the left navigation sidebar.
+3. Review the stats bar for an overview of your fundraising activity.
+4. Select a status filter pill (**Active**, **Pending**, or **Archived**) to narrow the list.
+5. Select an initiative card to open its detail page.
+
+## Related
+
+- [Manage Initiatives](../manage-initiatives/) — edit settings, archive, or activate an initiative from its detail page
+- [My Initiatives](../my-initiatives/) — overview of the My Initiatives section

--- a/packages/shared/src/constants/docs.constant.ts
+++ b/packages/shared/src/constants/docs.constant.ts
@@ -52,4 +52,5 @@ export const DOCS_TAXONOMY_ORDER: readonly string[] = [
   'profile',
   'settings',
   'transactions',
+  'crowdfunding',
 ] as const;


### PR DESCRIPTION
## Summary

- Add 8 user-facing documentation pages for the new Crowdfunding section covering My Initiatives (topic landing, view initiatives, manage initiatives) and My Donations (topic landing, view donations, manage payment methods, manage recurring donations)
- Register `crowdfunding` in `DOCS_TAXONOMY_ORDER` in both the shared constants package and the build-manifest script
- Regenerate `search-index.json` to include the new crowdfunding articles