### PR TITLE
feat(org-lens): redirect membership Renew/Join links to Enrollment app

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -27,6 +27,7 @@ import type {
   DiscoverOpportunityRow,
 } from '@lfx-one/shared/interfaces';
 import { foundationInitials, foundationLogoSquareClasses } from '../components/org-overview-foundations-and-projects/helpers/foundation-logo.helper';
+import { environment } from '@environments/environment';
 
 @Component({
   selector: 'lfx-org-memberships',
@@ -126,8 +127,9 @@ export class OrgMembershipsComponent {
 
   protected readonly discoverState: Signal<OrgMembershipsPageState> = computed(() => this.initDiscoverState());
 
-  private readonly renewBaseUrl = computed(() => this.initRenewBaseUrl());
-  private readonly joinBaseUrl = computed(() => this.initJoinBaseUrl());
+  // Renew (Expired tab) and Join (Discover tab) both hand off to the Enrollment app,
+  // scoped to a foundation via the `?project=<foundation_slug>` query param.
+  private readonly enrollmentBaseUrl = environment.urls.enrollment.replace(/\/+$/, '');
 
   private lastOrgUid: string | null = null;
 
@@ -182,14 +184,9 @@ export class OrgMembershipsComponent {
 
   // --- Private init methods for multi-line computed() (component-organization convention) ---
 
-  private initRenewBaseUrl(): string {
-    const slug = encodeURIComponent(this.accountContext.selectedAccount()?.accountSlug ?? '');
-    return `https://myorg.lfx.dev/${slug}/project/project-group-membership`;
-  }
-
-  private initJoinBaseUrl(): string {
-    const slug = encodeURIComponent(this.accountContext.selectedAccount()?.accountSlug ?? '');
-    return `https://myorg.lfx.dev/${slug}/project`;
+  private buildEnrollmentUrl(foundationSlug: string): string {
+    if (!foundationSlug) return this.enrollmentBaseUrl;
+    return `${this.enrollmentBaseUrl}?project=${encodeURIComponent(foundationSlug)}`;
   }
 
   private initTierOptions(): OrgDropdownOption[] {
@@ -216,7 +213,6 @@ export class OrgMembershipsComponent {
   private initExpiredMemberships(): ExpiredMembershipRow[] {
     const data = this.expiredData();
     if (!data) return [];
-    const baseUrl = this.renewBaseUrl();
     let rows = data.memberships;
     const search = this.expiredSearchTerm().toLowerCase();
     if (search) {
@@ -229,7 +225,7 @@ export class OrgMembershipsComponent {
       expirationDateFormatted: this.formatDateFull(m.expirationDate),
       tierStartFormatted: this.formatDateFull(m.tierStartDate),
       tierEndFormatted: this.formatDateFull(m.tierEndDate),
-      renewUrl: `${baseUrl}/${encodeURIComponent(m.foundationId)}`,
+      renewUrl: this.buildEnrollmentUrl(m.foundationSlug),
     }));
   }
 
@@ -243,12 +239,11 @@ export class OrgMembershipsComponent {
   private initDiscoverOpportunities(): DiscoverOpportunityRow[] {
     const data = this.discoverData();
     if (!data) return [];
-    const baseUrl = this.joinBaseUrl();
     return data.opportunities.map((o) => ({
       ...o,
       initials: foundationInitials(o.foundationName),
       logoClasses: foundationLogoSquareClasses(o.foundationId),
-      joinUrl: `${baseUrl}/${encodeURIComponent(o.foundationId)}/membership`,
+      joinUrl: this.buildEnrollmentUrl(o.foundationSlug),
     }));
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -127,8 +127,6 @@ export class OrgMembershipsComponent {
 
   protected readonly discoverState: Signal<OrgMembershipsPageState> = computed(() => this.initDiscoverState());
 
-  // Renew (Expired tab) and Join (Discover tab) both hand off to the Enrollment app,
-  // scoped to a foundation via the `?project=<foundation_slug>` query param.
   private readonly enrollmentBaseUrl = environment.urls.enrollment.replace(/\/+$/, '');
 
   private lastOrgUid: string | null = null;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -182,11 +182,6 @@ export class OrgMembershipsComponent {
 
   // --- Private init methods for multi-line computed() (component-organization convention) ---
 
-  private buildEnrollmentUrl(foundationSlug: string): string {
-    if (!foundationSlug) return this.enrollmentBaseUrl;
-    return `${this.enrollmentBaseUrl}?project=${encodeURIComponent(foundationSlug)}`;
-  }
-
   private initTierOptions(): OrgDropdownOption[] {
     return [{ label: 'All Membership Levels', value: '' }, ...this.allTiers().map((t) => ({ label: t, value: t }))];
   }
@@ -268,6 +263,11 @@ export class OrgMembershipsComponent {
     } catch {
       return dateString;
     }
+  }
+
+  private buildEnrollmentUrl(foundationSlug: string): string {
+    if (!foundationSlug) return this.enrollmentBaseUrl;
+    return `${this.enrollmentBaseUrl}?project=${encodeURIComponent(foundationSlug)}`;
   }
 
   // --- Private fetch methods ---

--- a/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-memberships.service.ts
@@ -41,6 +41,7 @@ interface RawMembershipRow {
 interface RawExpiredRow {
   FOUNDATION_ID: string;
   FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string | null;
   FOUNDATION_LOGO_URL: string | null;
   MEMBERSHIP_TIER_DISPLAY_NAME: string;
   TIER_START_DATE: string | null;
@@ -52,6 +53,7 @@ interface RawExpiredRow {
 interface RawDiscoverRow {
   FOUNDATION_ID: string;
   FOUNDATION_NAME: string;
+  FOUNDATION_SLUG: string | null;
   FOUNDATION_LOGO_URL: string | null;
   PROJECT_TYPE: string | null;
   SUGGESTED_TIER: string | null;
@@ -135,6 +137,7 @@ export class OrgLensMembershipsService {
       SELECT
         FOUNDATION_ID,
         FOUNDATION_NAME,
+        FOUNDATION_SLUG,
         FOUNDATION_LOGO_URL,
         MEMBERSHIP_TIER_DISPLAY_NAME,
         TIER_START_DATE,
@@ -155,6 +158,7 @@ export class OrgLensMembershipsService {
     let memberships: OrgExpiredMembership[] = result.rows.map((raw) => ({
       foundationId: raw.FOUNDATION_ID,
       foundationName: raw.FOUNDATION_NAME,
+      foundationSlug: raw.FOUNDATION_SLUG ?? '',
       foundationLogo: raw.FOUNDATION_LOGO_URL,
       membershipTier: raw.MEMBERSHIP_TIER_DISPLAY_NAME,
       tierStartDate: this.formatDate(raw.TIER_START_DATE),
@@ -176,6 +180,7 @@ export class OrgLensMembershipsService {
       SELECT
         FOUNDATION_ID,
         FOUNDATION_NAME,
+        FOUNDATION_SLUG,
         FOUNDATION_LOGO_URL,
         PROJECT_TYPE,
         SUGGESTED_TIER,
@@ -196,6 +201,7 @@ export class OrgLensMembershipsService {
     const opportunities: OrgDiscoverOpportunity[] = result.rows.map((raw) => ({
       foundationId: raw.FOUNDATION_ID,
       foundationName: raw.FOUNDATION_NAME,
+      foundationSlug: raw.FOUNDATION_SLUG ?? '',
       foundationLogo: raw.FOUNDATION_LOGO_URL,
       category: raw.PROJECT_TYPE ?? '',
       suggestedTier: raw.SUGGESTED_TIER ?? '',

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -33,6 +33,8 @@ export interface OrgActiveMembershipsResponse {
 export interface OrgExpiredMembership {
   foundationId: string;
   foundationName: string;
+  /** Foundation URL slug used to build the enrollment app renew link (?project=<slug>). */
+  foundationSlug: string;
   foundationLogo: string | null;
   membershipTier: string;
   tierStartDate: string | null;
@@ -49,6 +51,8 @@ export interface OrgExpiredMembershipsResponse {
 export interface OrgDiscoverOpportunity {
   foundationId: string;
   foundationName: string;
+  /** Foundation URL slug used to build the enrollment app join link (?project=<slug>). */
+  foundationSlug: string;
   foundationLogo: string | null;
   category: string;
   suggestedTier: string;

--- a/packages/shared/src/interfaces/org-memberships.interface.ts
+++ b/packages/shared/src/interfaces/org-memberships.interface.ts
@@ -33,7 +33,6 @@ export interface OrgActiveMembershipsResponse {
 export interface OrgExpiredMembership {
   foundationId: string;
   foundationName: string;
-  /** Foundation URL slug used to build the enrollment app renew link (?project=<slug>). */
   foundationSlug: string;
   foundationLogo: string | null;
   membershipTier: string;
@@ -51,7 +50,6 @@ export interface OrgExpiredMembershipsResponse {
 export interface OrgDiscoverOpportunity {
   foundationId: string;
   foundationName: string;
-  /** Foundation URL slug used to build the enrollment app join link (?project=<slug>). */
   foundationSlug: string;
   foundationLogo: string | null;
   category: string;


### PR DESCRIPTION
## Summary

On the Org Lens **Memberships** page (`/org/memberships`), the **Renew** link (Expired tab) and **Join** link (Discover tab) pointed at the deprecated **myOrg v1** app (`https://myorg.lfx.dev/...`). They now redirect to the **Enrollment app**, scoped to the foundation via `?project=<foundation_slug>`, using the per-environment base URL already configured in `environment.urls.enrollment`:

| Env | Enrollment URL |
|-----|----------------|
| Dev | `https://joinnow.dev.platform.linuxfoundation.org?project={foundation_slug}` |
| Staging | `https://joinnow.staging.platform.linuxfoundation.org?project={foundation_slug}` |
| Prod | `https://enrollment.lfx.linuxfoundation.org?project={foundation_slug}` |

## What changed

- **`org-memberships.component.ts`** — replaced the two hardcoded myOrg base-URL builders with a single `enrollmentBaseUrl` derived from `environment.urls.enrollment` (trailing slash normalized) and a `buildEnrollmentUrl(foundationSlug)` helper. `renewUrl`/`joinUrl` now use the foundation slug; an empty slug falls back to the enrollment base with no `?project=` param.
- **`org-lens-memberships.service.ts`** — added `FOUNDATION_SLUG` to the Expired and Discover Snowflake `SELECT`s, raw row interfaces, and mappings. The column already exists in the backing platinum tables (`ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_EXPIRED_MEMBERSHIPS` and `ORG_LENS_DISCOVER_MEMBERSHIPS`) — no dbt/schema change required.
- **`org-memberships.interface.ts`** — added `foundationSlug` to `OrgExpiredMembership` and `OrgDiscoverOpportunity` (additive, non-breaking).

Jira: [LFXV2-2247](https://linuxfoundation.atlassian.net/browse/LFXV2-2247)

## Test plan

- [ ] Verify `lint`, `check-types`, and `build` pass (all green locally).
- [ ] On the Expired tab, a `renew` action row's **Renew** link opens `…enrollment…?project=<foundation_slug>` in a new tab.
- [ ] On the Discover tab, the **Join** link opens `…enrollment…?project=<foundation_slug>` in a new tab.
- [ ] Confirm the resolved host matches the deployed environment (dev/staging/prod).
- [ ] Confirm links retain `target="_blank" rel="noopener noreferrer"`.

Made with [Cursor](https://cursor.com)

[LFXV2-2247]: https://linuxfoundation.atlassian.net/browse/LFXV2-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ