### PR TITLE
fix(meetings): use white text on calendar event entries

### DIFF
--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -26,10 +26,28 @@
           .fc-timegrid-event.meeting-event {
             &:not(.fc-event-future) {
               @apply bg-gray-100 #{!important};
+
+              // Restore dark text — white-on-gray-100 is unreadable.
+              .fc-event-title {
+                @apply text-gray-500 #{!important};
+              }
+
+              .fc-event-time {
+                @apply text-gray-500 #{!important};
+              }
             }
 
             &.fc-event-future {
               @apply bg-blue-50 #{!important};
+
+              // Restore dark text — white-on-blue-50 is unreadable.
+              .fc-event-title {
+                @apply text-blue-700 #{!important};
+              }
+
+              .fc-event-time {
+                @apply text-blue-900 #{!important};
+              }
             }
           }
         }
@@ -98,20 +116,20 @@
 
         &.meeting-event {
           .fc-event-title {
-            @apply font-medium leading-tight overflow-hidden line-clamp-2 text-gray-400;
+            @apply font-medium leading-tight overflow-hidden line-clamp-2 text-white;
           }
 
           .fc-event-time {
-            @apply font-semibold mr-1 block mb-0.5 text-[11px] text-gray-400;
+            @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
           }
 
           &.fc-event-future {
             .fc-event-title {
-              @apply font-medium leading-tight overflow-hidden line-clamp-2 text-blue-700;
+              @apply font-medium leading-tight overflow-hidden line-clamp-2 text-white;
             }
 
             .fc-event-time {
-              @apply font-semibold mr-1 block mb-0.5 text-[11px] text-blue-900;
+              @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
             }
           }
         }


### PR DESCRIPTION
## Summary

- Calendar event tiles in the month view had grey/dark-toned text on a solid blue background, making them difficult to read
- Change `fc-event-title` and `fc-event-time` text to `text-white` globally for the month view
- Restore dark text (`text-gray-500` / `text-blue-700`/`text-blue-900`) in the timegrid-scoped overrides, where backgrounds are forced to light (`gray-100` / `blue-50`) and white text would be invisible

Fixes LFXV2-2283 (child of June 2026 Bugs epic LFXV2-1947).

🤖 Generated with [Claude Code](https://claude.com/claude-code)