### PR TITLE
feat(dashboards): add period-based date filtering to marketing impact

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -40,7 +40,7 @@ export class AttributionSectionComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -65,18 +65,18 @@ export class AttributionSectionComponent {
   private initAttributionData(): Signal<MarketingAttributionResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, month$]).pipe(
-        switchMap(([slug, focus, month]) => {
+      combineLatest([slug$, focus$, period$]).pipe(
+        switchMap(([slug, focus, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
-          return this.analyticsService.getMarketingAttribution(slug, classification, month || undefined).pipe(
+          return this.analyticsService.getMarketingAttribution(slug, classification, period || undefined).pipe(
             catchError(() => of(null)),
             finalize(() => this.loading.set(false))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -24,7 +24,7 @@ export class EmailTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -43,18 +43,18 @@ export class EmailTabComponent {
   private initEmailData(): Signal<EmailCtrResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, month$]).pipe(
-        switchMap(([slug, focus, month]) => {
+      combineLatest([slug$, focus$, period$]).pipe(
+        switchMap(([slug, focus, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
-          return this.analyticsService.getEmailCtr(slug, classification, month || undefined).pipe(
+          return this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(
             finalize(() => this.loading.set(false)),
             catchError(() => of(null))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -44,7 +44,7 @@
 @if (!isProjectWebsites()) {
   <lfx-attribution-section
     [foundationSlug]="foundationSlug()"
-    [selectedMonth]="selectedMonth()"
+    [selectedPeriod]="selectedPeriod()"
     [foundationName]="foundationName()"
     [focusProgram]="focusProgram()"
     data-testid="overview-tab-attribution-section" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatCurrency, formatNumber, isPeriodMonth, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rxjs';
 
@@ -25,7 +25,7 @@ export class OverviewTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -43,11 +43,11 @@ export class OverviewTabComponent {
   private initOverviewKpiData(): Signal<OverviewKpiData> {
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, month$]).pipe(
-        switchMap(([slug, focus, month]) => {
+      combineLatest([slug$, focus$, period$]).pipe(
+        switchMap(([slug, focus, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of({ revenueImpact: null, brandReach: null, emailCtr: null });
@@ -58,10 +58,10 @@ export class OverviewTabComponent {
           return forkJoin({
             revenueImpact: isWebOnly
               ? of(null)
-              : this.analyticsService.getRevenueImpact(slug, classification, month || undefined).pipe(catchError(() => of(null))),
-            // getBrandReach uses pre-computed _30D columns that cannot be month-filtered
+              : this.analyticsService.getRevenueImpact(slug, classification, period || undefined).pipe(catchError(() => of(null))),
+            // getBrandReach uses pre-computed _30D columns that cannot be period-filtered
             brandReach: this.analyticsService.getBrandReach(slug, classification).pipe(catchError(() => of(null))),
-            emailCtr: isWebOnly ? of(null) : this.analyticsService.getEmailCtr(slug, classification, month || undefined).pipe(catchError(() => of(null))),
+            emailCtr: isWebOnly ? of(null) : this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(catchError(() => of(null))),
           }).pipe(finalize(() => this.loading.set(false)));
         })
       ),
@@ -153,8 +153,9 @@ export class OverviewTabComponent {
 
   private initSummaryTitle(): Signal<string> {
     return computed(() => {
-      const monthValue = this.selectedMonth();
-      const [year, month] = monthValue.split('-').map(Number);
+      const periodValue = this.selectedPeriod();
+      if (!isPeriodMonth(periodValue)) return 'Performance summary';
+      const [year, month] = periodValue.split('-').map(Number);
       if (!year || !month) return 'Performance summary';
       const monthName = new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' });
       return `${monthName} performance summary`;
@@ -163,8 +164,12 @@ export class OverviewTabComponent {
 
   private initSummarySubtitle(): Signal<string> {
     return computed(() => {
-      const monthValue = this.selectedMonth();
-      const [year, month] = monthValue.split('-').map(Number);
+      const periodValue = this.selectedPeriod();
+      if (!isPeriodMonth(periodValue)) {
+        const name = this.foundationName();
+        return name ? `Linear attribution · ${name}` : '';
+      }
+      const [year, month] = periodValue.split('-').map(Number);
       if (!year || !month) return '';
       const date = new Date(Date.UTC(year, month - 1, 1));
       const priorMonth = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1));

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -82,7 +82,7 @@ export class OverviewTabComponent {
     return computed(() => {
       const data = this.overviewKpiData();
       const isMonth = isPeriodMonth(this.selectedPeriod());
-      const changeSuffix = isMonth ? 'MoM' : 'Period';
+      const changeSuffix: 'MoM' | 'Period' = isMonth ? 'MoM' : 'Period';
       const cards: PerformanceSummaryKpi[] = [];
 
       if (data.revenueImpact) {
@@ -130,7 +130,7 @@ export class OverviewTabComponent {
           icon: 'fa-light fa-globe',
           iconClass: 'bg-violet-100 text-violet-600',
           value: formatNumber(br.totalMonthlySessions),
-          momChange: formatChangePct(momPct, changeSuffix),
+          momChange: formatChangePct(momPct, 'MoM'),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),
           yoyChange: null,
@@ -195,7 +195,7 @@ export class OverviewTabComponent {
       const yoyLabel = priorYear.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
 
       const name = this.foundationName();
-      const foundation = name ? name : 'all LF projects';
+      const foundation = name || 'all LF projects';
       return `vs. ${momLabel} (MoM) · vs. ${yoyLabel} (YoY) · Linear attribution · ${foundation}`;
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -5,7 +5,16 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import { computeMomPct, formatChangePct, formatCurrency, formatNumber, isPeriodMonth, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import {
+  computeMomPct,
+  formatChangePct,
+  formatCurrency,
+  formatNumber,
+  isPeriodMonth,
+  resolvePeriodRange,
+  trendColorClass,
+  trendDirection,
+} from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rxjs';
 
@@ -72,11 +81,13 @@ export class OverviewTabComponent {
   private initPerformanceSummaryKpis(): Signal<PerformanceSummaryKpi[]> {
     return computed(() => {
       const data = this.overviewKpiData();
+      const isMonth = isPeriodMonth(this.selectedPeriod());
+      const changeSuffix = isMonth ? 'MoM' : 'Period';
       const cards: PerformanceSummaryKpi[] = [];
 
       if (data.revenueImpact) {
         const ri = data.revenueImpact;
-        const yoyPct = ri.changePercentage;
+        const yoyPct = isMonth ? ri.changePercentage : null;
         const trend = ri.paidMedia?.monthlyTrend ?? [];
         const revMomPct = computeMomPct(trend.map((m) => m.revenue));
         const roasMomPct = computeMomPct(trend.map((m) => m.roas));
@@ -87,7 +98,7 @@ export class OverviewTabComponent {
             icon: 'fa-light fa-dollar-sign',
             iconClass: 'bg-green-100 text-green-600',
             value: formatCurrency(ri.revenueAttributed),
-            momChange: formatChangePct(revMomPct, 'MoM'),
+            momChange: formatChangePct(revMomPct, changeSuffix),
             momTrend: trendDirection(revMomPct),
             momTrendClass: trendColorClass(revMomPct),
             yoyChange: formatChangePct(yoyPct, 'YoY'),
@@ -100,7 +111,7 @@ export class OverviewTabComponent {
             icon: 'fa-light fa-chart-line-up',
             iconClass: 'bg-blue-100 text-blue-600',
             value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
-            momChange: formatChangePct(roasMomPct, 'MoM'),
+            momChange: formatChangePct(roasMomPct, changeSuffix),
             momTrend: trendDirection(roasMomPct),
             momTrendClass: trendColorClass(roasMomPct),
             yoyChange: null,
@@ -119,7 +130,7 @@ export class OverviewTabComponent {
           icon: 'fa-light fa-globe',
           iconClass: 'bg-violet-100 text-violet-600',
           value: formatNumber(br.totalMonthlySessions),
-          momChange: formatChangePct(momPct, 'MoM'),
+          momChange: formatChangePct(momPct, changeSuffix),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),
           yoyChange: null,
@@ -137,7 +148,7 @@ export class OverviewTabComponent {
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
           value: `${(ec.currentCtr ?? 0).toFixed(2)}%`,
-          momChange: formatChangePct(momPct, 'MoM'),
+          momChange: formatChangePct(momPct, changeSuffix),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),
           yoyChange: null,
@@ -154,7 +165,10 @@ export class OverviewTabComponent {
   private initSummaryTitle(): Signal<string> {
     return computed(() => {
       const periodValue = this.selectedPeriod();
-      if (!isPeriodMonth(periodValue)) return 'Performance summary';
+      if (!isPeriodMonth(periodValue)) {
+        const resolved = resolvePeriodRange(periodValue);
+        return resolved ? `${resolved.label} performance summary` : 'Performance summary';
+      }
       const [year, month] = periodValue.split('-').map(Number);
       if (!year || !month) return 'Performance summary';
       const monthName = new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' });
@@ -166,8 +180,10 @@ export class OverviewTabComponent {
     return computed(() => {
       const periodValue = this.selectedPeriod();
       if (!isPeriodMonth(periodValue)) {
+        const resolved = resolvePeriodRange(periodValue);
         const name = this.foundationName();
-        return name ? `Linear attribution · ${name}` : '';
+        const foundation = name || 'all LF projects';
+        return resolved ? `${resolved.label} · Linear attribution · ${foundation}` : '';
       }
       const [year, month] = periodValue.split('-').map(Number);
       if (!year || !month) return '';

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -56,7 +56,7 @@ export class PerformanceMarketingTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -130,11 +130,11 @@ export class PerformanceMarketingTabComponent {
   private initSocialReachData(): Signal<SocialReachResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, month$]).pipe(
-        switchMap(([slug, focus, month]) => {
+      combineLatest([slug$, focus$, period$]).pipe(
+        switchMap(([slug, focus, period]) => {
           this.expandedProjects.set(new Set());
           this.expandedPlatforms.set(new Set());
           if (!slug) {
@@ -143,7 +143,7 @@ export class PerformanceMarketingTabComponent {
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
-          return this.analyticsService.getSocialReach(slug, classification, month || undefined).pipe(
+          return this.analyticsService.getSocialReach(slug, classification, period || undefined).pipe(
             catchError(() => of(null)),
             finalize(() => this.loading.set(false))
           );
@@ -329,18 +329,18 @@ export class PerformanceMarketingTabComponent {
 
   private initKeywordData(): Signal<KeywordPerformanceResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, month$]).pipe(
-        switchMap(([slug, month]) => {
+      combineLatest([slug$, period$]).pipe(
+        switchMap(([slug, period]) => {
           this.expandedKeywords.set(new Set());
           if (!slug) {
             this.keywordLoading.set(false);
             return of(null);
           }
           this.keywordLoading.set(true);
-          return this.analyticsService.getKeywordPerformance(slug, month || undefined).pipe(
+          return this.analyticsService.getKeywordPerformance(slug, period || undefined).pipe(
             catchError(() => of(null)),
             finalize(() => this.keywordLoading.set(false))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -23,7 +23,7 @@ export class SocialAccountsTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -39,17 +39,17 @@ export class SocialAccountsTabComponent {
   // === Private Initializers ===
   private initSocialData(): Signal<SocialMediaResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, month$]).pipe(
-        switchMap(([slug, month]) => {
+      combineLatest([slug$, period$]).pipe(
+        switchMap(([slug, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getSocialMedia(slug, month || undefined).pipe(
+          return this.analyticsService.getSocialMedia(slug, period || undefined).pipe(
             finalize(() => this.loading.set(false)),
             catchError(() => of(null))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-listening-tab/social-listening-tab.component.ts
@@ -32,7 +32,7 @@ export class SocialListeningTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -58,17 +58,17 @@ export class SocialListeningTabComponent {
   // === Private Initializers ===
   private initBrandData(): Signal<BrandHealthResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, month$]).pipe(
-        switchMap(([slug, month]) => {
+      combineLatest([slug$, period$]).pipe(
+        switchMap(([slug, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
-          return this.analyticsService.getBrandHealth(slug, true, month || undefined).pipe(
+          return this.analyticsService.getBrandHealth(slug, true, period || undefined).pipe(
             finalize(() => this.loading.set(false)),
             catchError(() => of(null))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -24,7 +24,7 @@ export class WebActivityTabComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedMonth = input<string>('');
+  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
@@ -41,18 +41,18 @@ export class WebActivityTabComponent {
   private initWebData(): Signal<WebActivitiesSummaryResponse | null> {
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
-    const month$ = toObservable(this.selectedMonth);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, month$]).pipe(
-        switchMap(([slug, focus, month]) => {
+      combineLatest([slug$, focus$, period$]).pipe(
+        switchMap(([slug, focus, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
-          return this.analyticsService.getWebActivitiesSummary(slug, classification, month || undefined).pipe(
+          return this.analyticsService.getWebActivitiesSummary(slug, classification, period || undefined).pipe(
             catchError(() => of(null)),
             finalize(() => this.loading.set(false))
           );

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -22,14 +22,14 @@
         data-testid="marketing-impact-export-pdf" />
       <lfx-select
         [form]="headerForm"
-        control="month"
-        [options]="monthOptions"
+        control="period"
+        [options]="periodOptions"
         optionLabel="label"
         optionValue="value"
-        placeholder="Select month"
-        ariaLabel="Select reporting month"
+        placeholder="Select period"
+        ariaLabel="Select reporting period"
         styleClass="w-[180px]"
-        data-testid="marketing-impact-month-picker" />
+        data-testid="marketing-impact-period-picker" />
     </div>
   </div>
 
@@ -75,49 +75,49 @@
       @if (selectedTab() === 'overview') {
         <lfx-overview-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-overview-tab" />
       } @else if (selectedTab() === 'attribution') {
         <lfx-attribution-section
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-attribution-tab" />
       } @else if (selectedTab() === 'performance-marketing') {
         <lfx-performance-marketing-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-performance-marketing-tab" />
       } @else if (selectedTab() === 'email') {
         <lfx-email-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-email-tab" />
       } @else if (selectedTab() === 'web-activity') {
         <lfx-web-activity-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-web-activity-tab" />
       } @else if (selectedTab() === 'social-accounts') {
         <lfx-social-accounts-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-social-accounts-tab" />
       } @else if (selectedTab() === 'social-listening') {
         <lfx-social-listening-tab
           [foundationSlug]="foundationSlug()"
-          [selectedMonth]="selectedMonth()"
+          [selectedPeriod]="selectedPeriod()"
           [foundationName]="foundationName()"
           [focusProgram]="selectedFocus()"
           data-testid="marketing-impact-social-listening-tab" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -8,14 +8,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FOCUS_VISIBLE_TABS, MARKETING_IMPACT_FOCUS_OPTIONS, MARKETING_IMPACT_TABS } from '@lfx-one/shared/constants';
-import { buildMarketingImpactMonthOptions, getDefaultMarketingImpactMonth } from '@lfx-one/shared/utils';
+import { buildMarketingImpactPeriodOptions, getDefaultMarketingImpactPeriod } from '@lfx-one/shared/utils';
 import { ProjectContextService } from '@services/project-context.service';
 import { startWith } from 'rxjs';
 
 import type {
   FilterPillOption,
   MarketingImpactFocusProgram,
-  MarketingImpactMonthOption,
+  MarketingImpactPeriodOption,
   MarketingImpactTab,
   MarketingImpactTabOption,
 } from '@lfx-one/shared/interfaces';
@@ -50,14 +50,14 @@ export class MarketingImpactComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
   private readonly fb = inject(FormBuilder);
-  private readonly defaultMonth = getDefaultMarketingImpactMonth();
+  private readonly defaultPeriod = getDefaultMarketingImpactPeriod();
 
   // === Forms ===
   protected readonly headerForm = this.fb.nonNullable.group({
-    month: [this.defaultMonth],
+    period: [this.defaultPeriod],
   });
 
-  protected readonly monthOptions: MarketingImpactMonthOption[] = buildMarketingImpactMonthOptions();
+  protected readonly periodOptions: MarketingImpactPeriodOption[] = buildMarketingImpactPeriodOptions();
   protected readonly focusOptions: FilterPillOption[] = MARKETING_IMPACT_FOCUS_OPTIONS;
   protected readonly tabs: MarketingImpactTabOption[] = MARKETING_IMPACT_TABS;
 
@@ -69,7 +69,7 @@ export class MarketingImpactComponent {
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
   protected readonly foundationName = computed(() => this.projectContextService.selectedFoundation()?.name ?? '');
   protected readonly foundationSlug = computed(() => this.projectContextService.selectedFoundation()?.slug);
-  protected readonly selectedMonth: Signal<string> = this.initSelectedMonth();
+  protected readonly selectedPeriod: Signal<string> = this.initSelectedPeriod();
   protected readonly contextLabel: Signal<string> = this.initContextLabel();
   protected readonly visibleTabs: Signal<MarketingImpactTabOption[]> = this.initVisibleTabs();
 
@@ -91,9 +91,9 @@ export class MarketingImpactComponent {
   }
 
   // === Private Initializers ===
-  private initSelectedMonth(): Signal<string> {
-    return toSignal(this.headerForm.controls.month.valueChanges.pipe(startWith(this.defaultMonth)), {
-      initialValue: this.defaultMonth,
+  private initSelectedPeriod(): Signal<string> {
+    return toSignal(this.headerForm.controls.period.valueChanges.pipe(startWith(this.defaultPeriod)), {
+      initialValue: this.defaultPeriod,
     });
   }
 
@@ -107,11 +107,11 @@ export class MarketingImpactComponent {
   private initContextLabel(): Signal<string> {
     return computed(() => {
       const name = this.foundationName();
-      const monthValue = this.selectedMonth();
-      const option = this.monthOptions.find((o) => o.value === monthValue);
-      const monthLabel = option?.label ?? '';
-      if (!name || !monthLabel) return '';
-      return `Cross-channel performance for ${name} · ${monthLabel}`;
+      const periodValue = this.selectedPeriod();
+      const option = this.periodOptions.find((o) => o.value === periodValue);
+      const periodLabel = option?.label ?? '';
+      if (!name || !periodLabel) return '';
+      return `Cross-channel performance for ${name} · ${periodLabel}`;
     });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -835,9 +835,11 @@ export class AnalyticsService {
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable of web activities summary response
    */
-  public getWebActivitiesSummary(foundationSlug: string, classification?: string, month?: string): Observable<WebActivitiesSummaryResponse> {
+  public getWebActivitiesSummary(foundationSlug: string, classification?: string, period?: string): Observable<WebActivitiesSummaryResponse> {
     return this.http
-      .get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', { params: this.buildFoundationParams(foundationSlug, classification, month) })
+      .get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', {
+        params: this.buildFoundationParams(foundationSlug, classification, period),
+      })
       .pipe(
         catchError(() => {
           return of({
@@ -857,8 +859,8 @@ export class AnalyticsService {
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable of email CTR response
    */
-  public getEmailCtr(foundationSlug: string, classification?: string, month?: string): Observable<EmailCtrResponse> {
-    return this.http.get<EmailCtrResponse>('/api/analytics/email-ctr', { params: this.buildFoundationParams(foundationSlug, classification, month) }).pipe(
+  public getEmailCtr(foundationSlug: string, classification?: string, period?: string): Observable<EmailCtrResponse> {
+    return this.http.get<EmailCtrResponse>('/api/analytics/email-ctr', { params: this.buildFoundationParams(foundationSlug, classification, period) }).pipe(
       catchError(() => {
         return of({
           currentCtr: 0,
@@ -881,8 +883,8 @@ export class AnalyticsService {
    * @param foundationSlug - Foundation slug used to filter metrics
    * @returns Social media response with followers, platforms, engagement, and trend data
    */
-  public getSocialMedia(foundationSlug: string, month?: string): Observable<SocialMediaResponse> {
-    return this.http.get<SocialMediaResponse>('/api/analytics/social-media', { params: this.buildFoundationParams(foundationSlug, undefined, month) }).pipe(
+  public getSocialMedia(foundationSlug: string, period?: string): Observable<SocialMediaResponse> {
+    return this.http.get<SocialMediaResponse>('/api/analytics/social-media', { params: this.buildFoundationParams(foundationSlug, undefined, period) }).pipe(
       catchError(() => {
         return of({
           totalFollowers: 0,
@@ -902,9 +904,9 @@ export class AnalyticsService {
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Social reach response with ROAS, impressions, and monthly trends
    */
-  public getSocialReach(foundationSlug: string, classification?: string, month?: string): Observable<SocialReachResponse> {
+  public getSocialReach(foundationSlug: string, classification?: string, period?: string): Observable<SocialReachResponse> {
     return this.http
-      .get<SocialReachResponse>('/api/analytics/social-reach', { params: this.buildFoundationParams(foundationSlug, classification, month) })
+      .get<SocialReachResponse>('/api/analytics/social-reach', { params: this.buildFoundationParams(foundationSlug, classification, period) })
       .pipe(
         catchError(() => {
           return of({
@@ -923,9 +925,9 @@ export class AnalyticsService {
       );
   }
 
-  public getKeywordPerformance(foundationSlug: string, month?: string): Observable<KeywordPerformanceResponse> {
+  public getKeywordPerformance(foundationSlug: string, period?: string): Observable<KeywordPerformanceResponse> {
     return this.http
-      .get<KeywordPerformanceResponse>('/api/analytics/keyword-performance', { params: this.buildFoundationParams(foundationSlug, undefined, month) })
+      .get<KeywordPerformanceResponse>('/api/analytics/keyword-performance', { params: this.buildFoundationParams(foundationSlug, undefined, period) })
       .pipe(
         catchError(() => {
           return of({
@@ -1235,8 +1237,8 @@ export class AnalyticsService {
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @returns Observable emitting mention totals, sentiment percentages, and monthly history (or zeroed defaults on error)
    */
-  public getBrandHealth(foundationSlug: string, includeMentions = false, month?: string): Observable<BrandHealthResponse> {
-    const params: Record<string, string> = { foundationSlug, ...(includeMentions && { includeMentions: 'true' }), ...(month && { month }) };
+  public getBrandHealth(foundationSlug: string, includeMentions = false, period?: string): Observable<BrandHealthResponse> {
+    const params: Record<string, string> = { foundationSlug, ...(includeMentions && { includeMentions: 'true' }), ...(period && { period }) };
     return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params }).pipe(
       catchError(() =>
         of({
@@ -1260,9 +1262,9 @@ export class AnalyticsService {
    * @param classification Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable emitting pipeline/revenue totals, attribution breakdowns, and event registration data (or zeroed defaults on error)
    */
-  public getRevenueImpact(foundationSlug: string, classification?: string, month?: string): Observable<RevenueImpactResponse> {
+  public getRevenueImpact(foundationSlug: string, classification?: string, period?: string): Observable<RevenueImpactResponse> {
     return this.http
-      .get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: this.buildFoundationParams(foundationSlug, classification, month) })
+      .get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: this.buildFoundationParams(foundationSlug, classification, period) })
       .pipe(
         catchError(() =>
           of({
@@ -1288,9 +1290,9 @@ export class AnalyticsService {
    * @param classification Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable emitting channel summary + project drill-down (or empty defaults on error)
    */
-  public getMarketingAttribution(foundationSlug: string, classification?: string, month?: string): Observable<MarketingAttributionResponse> {
+  public getMarketingAttribution(foundationSlug: string, classification?: string, period?: string): Observable<MarketingAttributionResponse> {
     return this.http
-      .get<MarketingAttributionResponse>('/api/analytics/marketing-attribution', { params: this.buildFoundationParams(foundationSlug, classification, month) })
+      .get<MarketingAttributionResponse>('/api/analytics/marketing-attribution', { params: this.buildFoundationParams(foundationSlug, classification, period) })
       .pipe(catchError(() => of({ channels: [], projects: [] })));
   }
 
@@ -1314,10 +1316,10 @@ export class AnalyticsService {
       );
   }
 
-  private buildFoundationParams(foundationSlug: string, classification?: string, month?: string): Record<string, string> {
+  private buildFoundationParams(foundationSlug: string, classification?: string, period?: string): Record<string, string> {
     const params: Record<string, string> = { foundationSlug };
     if (classification) params['classification'] = classification;
-    if (month) params['month'] = month;
+    if (period) params['period'] = period;
     return params;
   }
 }

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -5,7 +5,7 @@ import { SALESFORCE_ACCOUNT_ID_PATTERN } from '@lfx-one/shared/constants';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
-import { assertHealthMetricsRange, getStringQueryParam, getValidatedClassification, getValidatedMonth, parseEntityType } from '../helpers/validation.helper';
+import { assertHealthMetricsRange, getStringQueryParam, getValidatedClassification, getValidatedPeriod, parseEntityType } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { OrgInvolvementService } from '../services/org-involvement.service';
 import { OrganizationService } from '../services/organization.service';
@@ -1944,9 +1944,9 @@ export class AnalyticsController {
       }
 
       const classification = getValidatedClassification(req, 'get_web_activities_summary');
-      const month = getValidatedMonth(req, 'get_web_activities_summary');
+      const period = getValidatedPeriod(req, 'get_web_activities_summary');
 
-      const response = await this.projectService.getWebActivitiesSummary(foundationSlug, classification, month);
+      const response = await this.projectService.getWebActivitiesSummary(foundationSlug, classification, period);
 
       logger.success(req, 'get_web_activities_summary', startTime, {
         foundation_slug: foundationSlug,
@@ -1990,9 +1990,9 @@ export class AnalyticsController {
       }
 
       const classification = getValidatedClassification(req, 'get_email_ctr');
-      const month = getValidatedMonth(req, 'get_email_ctr');
+      const period = getValidatedPeriod(req, 'get_email_ctr');
 
-      const response = await this.projectService.getEmailCtr(foundationSlug, classification, month);
+      const response = await this.projectService.getEmailCtr(foundationSlug, classification, period);
 
       logger.success(req, 'get_email_ctr', startTime, {
         foundation_slug: foundationSlug,
@@ -2036,9 +2036,9 @@ export class AnalyticsController {
       }
 
       const classification = getValidatedClassification(req, 'get_social_reach');
-      const month = getValidatedMonth(req, 'get_social_reach');
+      const period = getValidatedPeriod(req, 'get_social_reach');
 
-      const response = await this.projectService.getSocialReach(foundationSlug, classification, month);
+      const response = await this.projectService.getSocialReach(foundationSlug, classification, period);
 
       logger.success(req, 'get_social_reach', startTime, {
         foundation_slug: foundationSlug,
@@ -2081,9 +2081,9 @@ export class AnalyticsController {
         });
       }
 
-      const month = getValidatedMonth(req, 'get_keyword_performance');
+      const period = getValidatedPeriod(req, 'get_keyword_performance');
 
-      const response = await this.projectService.getKeywordPerformance(foundationSlug, month);
+      const response = await this.projectService.getKeywordPerformance(foundationSlug, period);
 
       logger.success(req, 'get_keyword_performance', startTime, {
         foundation_slug: foundationSlug,
@@ -2124,9 +2124,9 @@ export class AnalyticsController {
         });
       }
 
-      const month = getValidatedMonth(req, 'get_social_media');
+      const period = getValidatedPeriod(req, 'get_social_media');
 
-      const response = await this.projectService.getSocialMedia(foundationSlug, month);
+      const response = await this.projectService.getSocialMedia(foundationSlug, period);
 
       logger.success(req, 'get_social_media', startTime, {
         foundation_slug: foundationSlug,
@@ -2711,8 +2711,8 @@ export class AnalyticsController {
       }
 
       const includeMentions = getStringQueryParam(req, 'includeMentions') === 'true';
-      const month = getValidatedMonth(req, 'get_brand_health');
-      const response = await this.projectService.getBrandHealth(foundationSlug, includeMentions, month);
+      const period = getValidatedPeriod(req, 'get_brand_health');
+      const response = await this.projectService.getBrandHealth(foundationSlug, includeMentions, period);
 
       logger.success(req, 'get_brand_health', startTime, {
         foundation_slug: foundationSlug,
@@ -2750,9 +2750,9 @@ export class AnalyticsController {
       }
 
       const classification = getValidatedClassification(req, 'get_revenue_impact');
-      const month = getValidatedMonth(req, 'get_revenue_impact');
+      const period = getValidatedPeriod(req, 'get_revenue_impact');
 
-      const response = await this.projectService.getRevenueImpact(foundationSlug, classification, month);
+      const response = await this.projectService.getRevenueImpact(foundationSlug, classification, period);
 
       logger.success(req, 'get_revenue_impact', startTime, {
         foundation_slug: foundationSlug,
@@ -2792,9 +2792,9 @@ export class AnalyticsController {
       }
 
       const classification = getValidatedClassification(req, 'get_marketing_attribution');
-      const month = getValidatedMonth(req, 'get_marketing_attribution');
+      const period = getValidatedPeriod(req, 'get_marketing_attribution');
 
-      const response = await this.projectService.getMarketingAttribution(foundationSlug, classification, month);
+      const response = await this.projectService.getMarketingAttribution(foundationSlug, classification, period);
 
       logger.success(req, 'get_marketing_attribution', startTime, {
         foundation_slug: foundationSlug,

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -176,8 +176,8 @@ export function getValidatedMonth(req: Request, operation: string): string | und
 
   const [year, mo] = month.split('-').map(Number);
   const now = new Date();
-  const currentYear = now.getFullYear();
-  const currentMonth = now.getMonth() + 1;
+  const currentYear = now.getUTCFullYear();
+  const currentMonth = now.getUTCMonth() + 1;
   if (year > currentYear || (year === currentYear && mo > currentMonth)) {
     throw ServiceValidationError.forField('month', 'Month cannot be in the future.', { operation });
   }

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -3,9 +3,11 @@
 
 import { Request, NextFunction } from 'express';
 import { HEALTH_METRICS_RANGES, MONTH_FORMAT_REGEX, VALID_CLASSIFICATIONS, isHealthMetricsRange } from '@lfx-one/shared/constants';
+import { resolvePeriodRange } from '@lfx-one/shared/utils';
 import { ServiceValidationError } from '../errors';
 
 import type { HealthMetricsRange, OsspreyStatus, OsspreyHealthBand, OspreySortKey } from '@lfx-one/shared/interfaces';
+import type { ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
 import type { OsspreyListParams } from '@lfx-one/shared/interfaces';
 
 /**
@@ -181,6 +183,28 @@ export function getValidatedMonth(req: Request, operation: string): string | und
   }
 
   return month;
+}
+
+/** Validates an optional `period` query param (YTD preset, trailing preset, or YYYY-MM month). Falls back to `month` param for backward compatibility. Returns a resolved date range or undefined. */
+export function getValidatedPeriod(req: Request, operation: string): ResolvedPeriodRange | undefined {
+  const period = getStringQueryParam(req, 'period');
+  if (!period) {
+    const month = getValidatedMonth(req, operation);
+    if (!month) return undefined;
+    const range = resolvePeriodRange(month);
+    if (!range) {
+      throw ServiceValidationError.forField('month', 'Invalid month value.', { operation });
+    }
+    return range;
+  }
+
+  const range = resolvePeriodRange(period);
+  if (!range) {
+    throw ServiceValidationError.forField('period', 'Invalid period value. Expected "ytd", "last-3", "last-6", or YYYY-MM (e.g. 2026-05).', {
+      operation,
+    });
+  }
+  return range;
 }
 
 /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2203,10 +2203,11 @@ export class ProjectService {
       const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
-      const periodSends = monthlyResult.rows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
-      const periodOpens = monthlyResult.rows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
+      const periodRows = monthlyResult.rows.filter((row) => row.PUBLISHED_MONTH_DATE >= resolved.startDate);
+      const periodSends = periodRows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
+      const periodOpens = periodRows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
       const periodCtr = periodSends > 0 ? Math.round(((periodOpens * 100) / periodSends) * 10) / 10 : 0;
-      const currentCtr = monthlyResult.rows.length > 0 ? periodCtr : summaryCtr;
+      const currentCtr = periodRows.length > 0 ? periodCtr : summaryCtr;
 
       let changePercentage = 0;
       if (monthlyData.length >= 2 && currentCtr > 0) {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2139,7 +2139,7 @@ export class ProjectService {
       const [summaryResult, monthlyResult, campaignResult, campaignPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ PROJECT_NAME: string; CTR_LAST_COMPLETED_MONTH: number }>(summaryQuery, [...foundationParams, ...classificationParams]),
         this.snowflakeService.execute<{ PUBLISHED_MONTH: string; PUBLISHED_MONTH_DATE: string; TOTAL_SENDS: number; TOTAL_OPENS: number }>(monthlyQuery, [
-          resolved.startDate,
+          this.trendStartDate(resolved),
           resolved.endDate,
           ...foundationParams,
           ...classificationParams,
@@ -2203,7 +2203,10 @@ export class ProjectService {
       const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
-      const currentCtr = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : summaryCtr;
+      const periodSends = monthlyResult.rows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
+      const periodOpens = monthlyResult.rows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
+      const periodCtr = periodSends > 0 ? Math.round(((periodOpens * 100) / periodSends) * 10) / 10 : 0;
+      const currentCtr = monthlyResult.rows.length > 0 ? periodCtr : summaryCtr;
 
       let changePercentage = 0;
       if (monthlyData.length >= 2 && currentCtr > 0) {
@@ -2481,13 +2484,13 @@ export class ProjectService {
           ...classificationParams,
         ]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(monthlyRoasQuery, [
-          resolved.startDate,
+          this.trendStartDate(resolved),
           resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [
-          resolved.startDate,
+          this.trendStartDate(resolved),
           resolved.endDate,
           ...foundationParams,
           ...classificationParams,
@@ -2569,9 +2572,10 @@ export class ProjectService {
       const totalReach = impressionsResult.rows[0]?.TOTAL_IMPRESSIONS ?? 0;
       const totalSpend = impressionsResult.rows[0]?.TOTAL_SPEND ?? 0;
       const totalRevenue = impressionsResult.rows[0]?.TOTAL_REVENUE ?? 0;
-      const currentRoas = roasKpiResult.rows[0]?.ROAS ?? 0;
+      const periodRoas = totalSpend > 0 ? totalRevenue / totalSpend : 0;
+      const currentRoas = roasKpiResult.rows[0]?.ROAS ?? periodRoas;
       const previousRoas = roasKpiResult.rows[1]?.ROAS ?? 0;
-      const roas = currentRoas;
+      const roas = periodRoas;
       const roasMomPct = previousRoas > 0 ? ((currentRoas - previousRoas) / previousRoas) * 100 : 0;
 
       if (monthlyImpressionsResult.rows.length === 0) {
@@ -5148,7 +5152,10 @@ export class ProjectService {
       const positiveMentionsQuery = `
         SELECT TITLE, BODY, AUTHOR, AUTHOR_PROFILE_LINK, SOURCE_PLATFORM, SOCIAL_NETWORK, SENTIMENT, URL, MENTION_TS
         FROM ANALYTICS.PLATINUM_LFX_ONE.BRAND_HEALTH_MENTIONS
-        WHERE SENTIMENT = 'positive' ${mentionsFilter}
+        WHERE SENTIMENT = 'positive'
+          AND MENTION_TS >= TO_DATE(?)
+          AND MENTION_TS < TO_DATE(?)
+          ${mentionsFilter}
         ORDER BY RELEVANCE_SCORE DESC, MENTION_TS DESC
         LIMIT 10
       `;
@@ -5156,7 +5163,10 @@ export class ProjectService {
       const negativeMentionsQuery = `
         SELECT TITLE, BODY, AUTHOR, AUTHOR_PROFILE_LINK, SOURCE_PLATFORM, SOCIAL_NETWORK, SENTIMENT, URL, MENTION_TS
         FROM ANALYTICS.PLATINUM_LFX_ONE.BRAND_HEALTH_MENTIONS
-        WHERE SENTIMENT = 'negative' ${mentionsFilter}
+        WHERE SENTIMENT = 'negative'
+          AND MENTION_TS >= TO_DATE(?)
+          AND MENTION_TS < TO_DATE(?)
+          ${mentionsFilter}
         ORDER BY RELEVANCE_SCORE DESC, MENTION_TS DESC
         LIMIT 10
       `;
@@ -5186,14 +5196,21 @@ export class ProjectService {
         this.snowflakeService.execute<{
           MONTH_START_DATE: string;
           MENTION_COUNT: number;
-        }>(monthlyTrendQuery, isUmbrella ? [resolved.startDate, resolved.endDate] : [foundationSlug, resolved.startDate, resolved.endDate]),
+        }>(
+          monthlyTrendQuery,
+          isUmbrella ? [this.trendStartDate(resolved), resolved.endDate] : [foundationSlug, this.trendStartDate(resolved), resolved.endDate]
+        ),
         this.snowflakeService.execute<{
           PROJECT_NAME: string;
           MENTION_COUNT_30D: number;
           PROJECT_RANK?: number;
         }>(topProjectsQuery, sovParams),
-        includeMentions ? this.snowflakeService.execute<MentionRow>(positiveMentionsQuery, mentionsParams) : Promise.resolve(emptyMentionRows),
-        includeMentions ? this.snowflakeService.execute<MentionRow>(negativeMentionsQuery, mentionsParams) : Promise.resolve(emptyMentionRows),
+        includeMentions
+          ? this.snowflakeService.execute<MentionRow>(positiveMentionsQuery, [resolved.startDate, resolved.endDate, ...mentionsParams])
+          : Promise.resolve(emptyMentionRows),
+        includeMentions
+          ? this.snowflakeService.execute<MentionRow>(negativeMentionsQuery, [resolved.startDate, resolved.endDate, ...mentionsParams])
+          : Promise.resolve(emptyMentionRows),
       ]);
 
       if (summaryResult.rows.length === 0) {
@@ -5510,8 +5527,8 @@ export class ProjectService {
           }>(
             monthlyTrendQuery,
             isUmbrella
-              ? [resolved.startDate, resolved.endDate, ...classificationParams]
-              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
+              ? [this.trendStartDate(resolved), resolved.endDate, ...classificationParams]
+              : [foundationSlug, this.trendStartDate(resolved), resolved.endDate, ...classificationParams]
           ),
           this.snowflakeService.execute<{
             PROJECT_NAME: string;
@@ -6472,6 +6489,13 @@ export class ProjectService {
     });
 
     return { totalProjectsBySlug, totalMembersBySlug, totalValueBySlug, healthScoresBySlug };
+  }
+
+  private trendStartDate(resolved: ResolvedPeriodRange): string {
+    if (resolved.type !== 'month') return resolved.startDate;
+    const [year, month] = resolved.startDate.split('-').map(Number);
+    const d = new Date(year, month - 1 - 1, 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
   }
 
   private defaultPeriodRange(): ResolvedPeriodRange {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2203,7 +2203,7 @@ export class ProjectService {
       const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
-      const periodRows = monthlyResult.rows.filter((row) => row.PUBLISHED_MONTH_DATE >= resolved.startDate);
+      const periodRows = monthlyResult.rows.filter((row) => (ProjectService.toIsoDate(row.PUBLISHED_MONTH_DATE) ?? '') >= resolved.startDate);
       const periodSends = periodRows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
       const periodOpens = periodRows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
       const periodCtr = periodSends > 0 ? Math.round(((periodOpens * 100) / periodSends) * 10) / 10 : 0;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -115,7 +115,7 @@ import {
   WebActivitiesSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 import type { PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
+import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -1982,7 +1982,7 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // Query 1: Total sessions & page views per domain classification
       // Uses pre-computed _LAST_30_DAYS columns — cannot be month-filtered
@@ -2071,7 +2071,7 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // Query 1: KPI card — current CTR fallback from email_ctr_summary
       // Uses pre-computed CTR_LAST_COMPLETED_MONTH — cannot be month-filtered
@@ -2371,7 +2371,7 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // Block 1: Total impressions, spend, revenue (period range)
       // Uses LAST_TOUCH_REVENUE as the default attribution model across all blocks
@@ -2822,7 +2822,7 @@ export class ProjectService {
       const isUmbrella = foundationSlug === 'tlf';
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       const channelQuery = isUmbrella
         ? `
@@ -3151,7 +3151,7 @@ export class ProjectService {
       const isUmbrella = foundationSlug === 'tlf';
       const foundationFilter = isUmbrella ? '' : 'AND FOUNDATION_SLUG = ?';
       const foundationParams = isUmbrella ? [] : [foundationSlug];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // Query 1: KPI cards — total followers, platforms, growth (aggregated)
       // Uses pre-computed columns — cannot be month-filtered
@@ -5084,7 +5084,7 @@ export class ProjectService {
       const isUmbrella = foundationSlug === 'tlf';
       const sovFilter = isUmbrella ? '' : 'WHERE FOUNDATION_SLUG = ?';
       const sovParams = isUmbrella ? [] : [foundationSlug];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // SHARE_OF_VOICE has per-platform rows with raw mention counts and sentiment percentages
       // Uses pre-computed _30D columns — cannot be month-filtered
@@ -5115,7 +5115,6 @@ export class ProjectService {
           AND MONTH_START_DATE < TO_DATE(?)
         GROUP BY MONTH_START_DATE
         ORDER BY MONTH_START_DATE DESC
-        LIMIT 6
       `
         : `
         SELECT MONTH_START_DATE, MENTION_COUNT
@@ -5124,7 +5123,6 @@ export class ProjectService {
           AND MONTH_START_DATE >= TO_DATE(?)
           AND MONTH_START_DATE < TO_DATE(?)
         ORDER BY MONTH_START_DATE DESC
-        LIMIT 6
       `;
 
       // Uses pre-computed _30D columns — cannot be month-filtered
@@ -5283,7 +5281,7 @@ export class ProjectService {
       const isUmbrella = foundationSlug === 'tlf';
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       // PIPELINE_SUMMARY uses pre-computed _YTD columns — cannot be month-filtered
       const pipelineQuery = isUmbrella
@@ -5375,7 +5373,6 @@ export class ProjectService {
           ${classificationFilter}
         GROUP BY CAMPAIGN_MONTH
         ORDER BY CAMPAIGN_MONTH DESC
-        LIMIT 6
       `
         : `
         SELECT CAMPAIGN_MONTH,
@@ -5390,7 +5387,6 @@ export class ProjectService {
           ${classificationFilter}
         GROUP BY CAMPAIGN_MONTH
         ORDER BY CAMPAIGN_MONTH DESC
-        LIMIT 6
       `;
 
       // Per-project per-channel impressions — period range
@@ -6193,7 +6189,7 @@ export class ProjectService {
 
     try {
       const { filterAnd: foundationFilter, params: foundationParams } = buildFoundationFilter(foundationSlug);
-      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
+      const resolved = period ?? this.defaultPeriodRange();
 
       const perfQuery = `
       WITH top_keywords AS (
@@ -6476,6 +6472,14 @@ export class ProjectService {
     });
 
     return { totalProjectsBySlug, totalMembersBySlug, totalValueBySlug, healthScoresBySlug };
+  }
+
+  private defaultPeriodRange(): ResolvedPeriodRange {
+    const resolved = resolvePeriodRange(getDefaultMarketingImpactMonth());
+    if (!resolved) {
+      throw new ServiceValidationError([{ field: 'period', message: 'Unable to resolve default period range', code: 'INVALID_PERIOD' }]);
+    }
+    return resolved;
   }
 
   private getRangeSuffix(range: string, convention: string = 'standard'): string {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -6477,7 +6477,7 @@ export class ProjectService {
   private defaultPeriodRange(): ResolvedPeriodRange {
     const resolved = resolvePeriodRange(getDefaultMarketingImpactMonth());
     if (!resolved) {
-      throw new ServiceValidationError([{ field: 'period', message: 'Unable to resolve default period range', code: 'INVALID_PERIOD' }]);
+      throw ServiceValidationError.forField('period', 'Unable to resolve default period range');
     }
     return resolved;
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -114,8 +114,8 @@ import {
   UploadProjectDocumentRequest,
   WebActivitiesSummaryResponse,
 } from '@lfx-one/shared/interfaces';
-import type { PaidProjectPerformance } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation, nullifyEmptyStrings } from '@lfx-one/shared/utils';
+import type { PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -1969,11 +1969,11 @@ export class ProjectService {
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG (aggregates all projects under the foundation)
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g. 'Events', 'Corporate')
    */
-  public async getWebActivitiesSummary(foundationSlug: string, classification?: string, month?: string): Promise<WebActivitiesSummaryResponse> {
+  public async getWebActivitiesSummary(foundationSlug: string, classification?: string, period?: ResolvedPeriodRange): Promise<WebActivitiesSummaryResponse> {
     logger.debug(undefined, 'get_web_activities_summary', 'Fetching web activities summary from Snowflake', {
       foundation_slug: foundationSlug,
       classification,
-      month,
+      period: period?.label,
     });
 
     try {
@@ -1982,7 +1982,7 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       // Query 1: Total sessions & page views per domain classification
       // Uses pre-computed _LAST_30_DAYS columns — cannot be month-filtered
@@ -1999,7 +1999,7 @@ export class ProjectService {
         ORDER BY TOTAL_SESSIONS DESC
       `;
 
-      // Query 2: Weekly sessions for trend chart (6 months ending at selected month)
+      // Query 2: Weekly sessions for trend chart (period range)
       // WEB_ACTIVITIES_BY_PROJECT does not have LF_SUB_DOMAIN_CLASSIFICATION,
       // so the trend chart always shows all-program totals.
       const dailyQuery = `
@@ -2007,8 +2007,8 @@ export class ProjectService {
           DATE_TRUNC('WEEK', ACTIVITY_DATE) AS ACTIVITY_DATE,
           SUM(DAILY_SESSIONS) AS DAILY_SESSIONS
         FROM ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_PROJECT
-        WHERE ACTIVITY_DATE >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND ACTIVITY_DATE < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE ACTIVITY_DATE >= TO_DATE(?)
+          AND ACTIVITY_DATE < TO_DATE(?)
           ${foundationFilter}
         GROUP BY DATE_TRUNC('WEEK', ACTIVITY_DATE)
         ORDER BY ACTIVITY_DATE ASC
@@ -2019,7 +2019,11 @@ export class ProjectService {
           ...foundationParams,
           ...classificationParams,
         ]),
-        this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, [monthDate, monthDate, ...foundationParams]),
+        this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, [
+          resolved.startDate,
+          resolved.endDate,
+          ...foundationParams,
+        ]),
       ]);
 
       const domainGroups = summaryResult.rows.map((row) => ({
@@ -2054,11 +2058,11 @@ export class ProjectService {
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g. 'Events', 'Corporate')
    * @returns Email CTR response with monthly trend and change percentage
    */
-  public async getEmailCtr(foundationSlug: string, classification?: string, month?: string): Promise<EmailCtrResponse> {
+  public async getEmailCtr(foundationSlug: string, classification?: string, period?: ResolvedPeriodRange): Promise<EmailCtrResponse> {
     logger.debug(undefined, 'get_email_ctr', 'Fetching email CTR from Snowflake Platinum tables', {
       foundation_slug: foundationSlug,
       classification,
-      month,
+      period: period?.label,
     });
 
     try {
@@ -2067,7 +2071,7 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       // Query 1: KPI card — current CTR fallback from email_ctr_summary
       // Uses pre-computed CTR_LAST_COMPLETED_MONTH — cannot be month-filtered
@@ -2081,7 +2085,7 @@ export class ProjectService {
           ${classificationFilter}
       `;
 
-      // Query 2: Monthly CTR trend (bar chart, 6 months ending at selected month) from email_ctr_by_month
+      // Query 2: Monthly CTR trend (bar chart, period range) from email_ctr_by_month
       // Aggregate across LF_SUB_DOMAIN_CLASSIFICATION rows (Corporate, Projects, Training, Events)
       // so we get one row per month with totals, not 4 rows per month.
       const monthlyQuery = `
@@ -2091,8 +2095,8 @@ export class ProjectService {
           SUM(TOTAL_SENDS) AS TOTAL_SENDS,
           SUM(TOTAL_OPENS) AS TOTAL_OPENS
         FROM ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CTR_BY_MONTH
-        WHERE PUBLISHED_MONTH_DATE >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND PUBLISHED_MONTH_DATE < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE PUBLISHED_MONTH_DATE >= TO_DATE(?)
+          AND PUBLISHED_MONTH_DATE < TO_DATE(?)
           ${foundationFilter}
           ${classificationFilter}
         GROUP BY PUBLISHED_MONTH, PUBLISHED_MONTH_DATE
@@ -2113,7 +2117,7 @@ export class ProjectService {
         ORDER BY CTR_LAST_6_MONTHS DESC
       `;
 
-      // Query 4: Per-campaign performance from email_campaign_performance (6 months ending at selected month)
+      // Query 4: Per-campaign performance from email_campaign_performance (period range)
       // Note: EMAIL_CAMPAIGN_PERFORMANCE does not have LF_SUB_DOMAIN_CLASSIFICATION — no classification filter here
       const campaignPerfQuery = `
         SELECT
@@ -2125,8 +2129,8 @@ export class ProjectService {
           ROUND(SUM(OPENS) * 100.0 / NULLIF(SUM(SENDS), 0), 1) AS OPEN_RATE,
           ROUND(SUM(CLICKS) * 100.0 / NULLIF(SUM(SENDS), 0), 1) AS CTR
         FROM ANALYTICS.PLATINUM_LFX_ONE.EMAIL_CAMPAIGN_PERFORMANCE
-        WHERE PUBLISHED_MONTH_DATE >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND PUBLISHED_MONTH_DATE < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE PUBLISHED_MONTH_DATE >= TO_DATE(?)
+          AND PUBLISHED_MONTH_DATE < TO_DATE(?)
           ${foundationFilter}
         GROUP BY MARKETING_EMAIL_NAME, EMAIL_TYPE
         ORDER BY TOTAL_SENDS DESC
@@ -2135,8 +2139,8 @@ export class ProjectService {
       const [summaryResult, monthlyResult, campaignResult, campaignPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ PROJECT_NAME: string; CTR_LAST_COMPLETED_MONTH: number }>(summaryQuery, [...foundationParams, ...classificationParams]),
         this.snowflakeService.execute<{ PUBLISHED_MONTH: string; PUBLISHED_MONTH_DATE: string; TOTAL_SENDS: number; TOTAL_OPENS: number }>(monthlyQuery, [
-          monthDate,
-          monthDate,
+          resolved.startDate,
+          resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
@@ -2153,7 +2157,7 @@ export class ProjectService {
             TOTAL_CLICKS: number;
             OPEN_RATE: number;
             CTR: number;
-          }>(campaignPerfQuery, [monthDate, monthDate, ...foundationParams])
+          }>(campaignPerfQuery, [resolved.startDate, resolved.endDate, ...foundationParams])
           .catch((error) => {
             logger.warning(undefined, 'get_email_ctr', 'Optional campaign breakdown query failed, degrading gracefully', {
               foundation_slug: foundationSlug,
@@ -2354,8 +2358,12 @@ export class ProjectService {
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG
    * @returns Social reach response with ROAS, impressions, spend, revenue, and monthly trends
    */
-  public async getSocialReach(foundationSlug: string, classification?: string, month?: string): Promise<SocialReachResponse> {
-    logger.debug(undefined, 'get_social_reach', 'Fetching paid social reach from Snowflake', { foundation_slug: foundationSlug, classification, month });
+  public async getSocialReach(foundationSlug: string, classification?: string, period?: ResolvedPeriodRange): Promise<SocialReachResponse> {
+    logger.debug(undefined, 'get_social_reach', 'Fetching paid social reach from Snowflake', {
+      foundation_slug: foundationSlug,
+      classification,
+      period: period?.label,
+    });
 
     try {
       const isUmbrella = foundationSlug === 'tlf';
@@ -2363,58 +2371,58 @@ export class ProjectService {
       const foundationParams = isUmbrella ? [] : [foundationSlug];
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
-      // Block 1: Total impressions, spend, revenue (6 months ending at selected month)
+      // Block 1: Total impressions, spend, revenue (period range)
       // Uses LAST_TOUCH_REVENUE as the default attribution model across all blocks
       const impressionsQuery = `
       SELECT SUM(IMPRESSIONS) AS TOTAL_IMPRESSIONS, SUM(SPEND) AS TOTAL_SPEND, SUM(LAST_TOUCH_REVENUE) AS TOTAL_REVENUE
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND CAMPAIGN_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+        AND CAMPAIGN_MONTH < TO_DATE(?)
         ${foundationFilter}
         ${classificationFilter}
     `;
 
-      // Block 2: ROAS KPI — last two completed months relative to selected month for MoM (last-touch attribution)
+      // Block 2: ROAS KPI — last two completed months before period end for MoM (last-touch attribution)
       const roasKpiQuery = `
       SELECT
         CAMPAIGN_MONTH,
         ROUND(DIV0(SUM(LAST_TOUCH_REVENUE), NULLIF(SUM(SPEND), 0)), 2) AS ROAS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH < DATE_TRUNC('MONTH', TO_DATE(?))
-        AND CAMPAIGN_MONTH >= DATEADD('MONTH', -2, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH < TO_DATE(?)
+        AND CAMPAIGN_MONTH >= DATEADD('MONTH', -2, TO_DATE(?))
         ${foundationFilter}
         ${classificationFilter}
       GROUP BY CAMPAIGN_MONTH
       ORDER BY CAMPAIGN_MONTH DESC
     `;
 
-      // Block 3: Monthly ROAS trend (bar chart, 6 months ending at selected month, last-touch attribution)
+      // Block 3: Monthly ROAS trend (bar chart, period range, last-touch attribution)
       const monthlyRoasQuery = `
       SELECT CAMPAIGN_MONTH, ROUND(DIV0(SUM(LAST_TOUCH_REVENUE), NULLIF(SUM(SPEND), 0)), 2) AS ROAS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND CAMPAIGN_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+        AND CAMPAIGN_MONTH < TO_DATE(?)
         ${foundationFilter}
         ${classificationFilter}
       GROUP BY CAMPAIGN_MONTH
       ORDER BY CAMPAIGN_MONTH
     `;
 
-      // Block 4: Monthly impressions (bar chart, 6 months ending at selected month)
+      // Block 4: Monthly impressions (bar chart, period range)
       const monthlyImpressionsQuery = `
       SELECT CAMPAIGN_MONTH, SUM(IMPRESSIONS) AS IMPRESSIONS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND CAMPAIGN_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+        AND CAMPAIGN_MONTH < TO_DATE(?)
         ${foundationFilter}
         ${classificationFilter}
       GROUP BY CAMPAIGN_MONTH
       ORDER BY CAMPAIGN_MONTH
     `;
 
-      // Block 5: Project + campaign level performance breakdown (6 months ending at selected month)
+      // Block 5: Project + campaign level performance breakdown (period range)
       // All blocks use LAST_TOUCH_REVENUE as the default attribution model
       const projectPerfQuery = `
       SELECT
@@ -2428,8 +2436,8 @@ export class ProjectService {
         SUM(IMPRESSIONS) AS IMPRESSIONS,
         SUM(CLICKS) AS CLICKS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND CAMPAIGN_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+        AND CAMPAIGN_MONTH < TO_DATE(?)
         ${foundationFilter}
         ${classificationFilter}
       GROUP BY PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE
@@ -2451,8 +2459,8 @@ export class ProjectService {
         ROUND(DIV0(SUM(CONV), NULLIF(SUM(CLICKS), 0)) * 100, 2) AS CONV_RATE,
         SUM(CONV) AS CONVERSIONS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-      WHERE CAMPAIGN_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND CAMPAIGN_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+        AND CAMPAIGN_MONTH < TO_DATE(?)
         ${foundationFilter}
         ${classificationFilter}
       GROUP BY CHANNEL, CAMPAIGN_NAME
@@ -2461,26 +2469,26 @@ export class ProjectService {
 
       const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, projectPerfResult, platformPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ TOTAL_IMPRESSIONS: number; TOTAL_SPEND: number; TOTAL_REVENUE: number }>(impressionsQuery, [
-          monthDate,
-          monthDate,
+          resolved.startDate,
+          resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(roasKpiQuery, [
-          monthDate,
-          monthDate,
+          resolved.endDate,
+          resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(monthlyRoasQuery, [
-          monthDate,
-          monthDate,
+          resolved.startDate,
+          resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [
-          monthDate,
-          monthDate,
+          resolved.startDate,
+          resolved.endDate,
           ...foundationParams,
           ...classificationParams,
         ]),
@@ -2498,7 +2506,7 @@ export class ProjectService {
             SESSIONS: number;
             IMPRESSIONS: number;
             CLICKS: number;
-          }>(projectPerfQuery, [monthDate, monthDate, ...foundationParams, ...classificationParams])
+          }>(projectPerfQuery, [resolved.startDate, resolved.endDate, ...foundationParams, ...classificationParams])
           .catch((error) => {
             logger.warning(undefined, 'get_social_reach', 'Optional project breakdown query failed, degrading gracefully', {
               foundation_slug: foundationSlug,
@@ -2534,7 +2542,7 @@ export class ProjectService {
             CPC: number;
             CONV_RATE: number;
             CONVERSIONS: number;
-          }>(platformPerfQuery, [monthDate, monthDate, ...foundationParams, ...classificationParams])
+          }>(platformPerfQuery, [resolved.startDate, resolved.endDate, ...foundationParams, ...classificationParams])
           .catch((error) => {
             logger.warning(undefined, 'get_social_reach', 'Optional platform breakdown query failed, degrading gracefully', {
               foundation_slug: foundationSlug,
@@ -2802,19 +2810,19 @@ export class ProjectService {
    * @param foundationSlug - Foundation slug or 'tlf' for umbrella aggregation
    * @returns Channel summary + project drill-down
    */
-  public async getMarketingAttribution(foundationSlug: string, classification?: string, month?: string): Promise<MarketingAttributionResponse> {
+  public async getMarketingAttribution(foundationSlug: string, classification?: string, period?: ResolvedPeriodRange): Promise<MarketingAttributionResponse> {
     const startTime = Date.now();
     logger.debug(undefined, 'get_marketing_attribution', 'Fetching marketing attribution from Snowflake', {
       foundation_slug: foundationSlug,
       classification,
-      month,
+      period: period?.label,
     });
 
     try {
       const isUmbrella = foundationSlug === 'tlf';
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       const channelQuery = isUmbrella
         ? `
@@ -2827,8 +2835,8 @@ export class ProjectService {
                SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
                SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
       `
@@ -2843,8 +2851,8 @@ export class ProjectService {
                SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
       `;
@@ -2860,8 +2868,8 @@ export class ProjectService {
                SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
                SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY PROJECT_NAME, CHANNEL
       `
@@ -2876,13 +2884,15 @@ export class ProjectService {
                SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY PROJECT_NAME, CHANNEL
       `;
 
-      const params = isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams];
+      const params = isUmbrella
+        ? [resolved.startDate, resolved.endDate, ...classificationParams]
+        : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams];
 
       interface ChannelRow {
         CHANNEL: string;
@@ -3131,14 +3141,17 @@ export class ProjectService {
    * @param foundationSlug - Foundation slug used to filter by FOUNDATION_SLUG
    * @returns Social media response with followers, platform breakdown, and trend data
    */
-  public async getSocialMedia(foundationSlug: string, month?: string): Promise<SocialMediaResponse> {
-    logger.debug(undefined, 'get_social_media', 'Fetching social media data from Snowflake Platinum tables', { foundation_slug: foundationSlug, month });
+  public async getSocialMedia(foundationSlug: string, period?: ResolvedPeriodRange): Promise<SocialMediaResponse> {
+    logger.debug(undefined, 'get_social_media', 'Fetching social media data from Snowflake Platinum tables', {
+      foundation_slug: foundationSlug,
+      period: period?.label,
+    });
 
     try {
       const isUmbrella = foundationSlug === 'tlf';
       const foundationFilter = isUmbrella ? '' : 'AND FOUNDATION_SLUG = ?';
       const foundationParams = isUmbrella ? [] : [foundationSlug];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       // Query 1: KPI cards — total followers, platforms, growth (aggregated)
       // Uses pre-computed columns — cannot be month-filtered
@@ -3178,14 +3191,14 @@ export class ProjectService {
       ORDER BY FOLLOWERS DESC
     `;
 
-      // Query 3: Follower growth trend (6 months ending at selected month, aggregated per month)
+      // Query 3: Follower growth trend (period range, aggregated per month)
       const trendQuery = `
       SELECT
         SNAPSHOT_MONTH,
         SUM(TOTAL_FOLLOWERS) AS TOTAL_FOLLOWERS
       FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_FOLLOWER_TREND
-      WHERE SNAPSHOT_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND SNAPSHOT_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE SNAPSHOT_MONTH >= TO_DATE(?)
+        AND SNAPSHOT_MONTH < TO_DATE(?)
         ${foundationFilter}
       GROUP BY SNAPSHOT_MONTH
       ORDER BY SNAPSHOT_MONTH ASC
@@ -3202,7 +3215,11 @@ export class ProjectService {
           POSTS_30D: number;
           IMPRESSIONS: number;
         }>(platformQuery, [...foundationParams]),
-        this.snowflakeService.execute<{ SNAPSHOT_MONTH: string; TOTAL_FOLLOWERS: number }>(trendQuery, [monthDate, monthDate, ...foundationParams]),
+        this.snowflakeService.execute<{ SNAPSHOT_MONTH: string; TOTAL_FOLLOWERS: number }>(trendQuery, [
+          resolved.startDate,
+          resolved.endDate,
+          ...foundationParams,
+        ]),
       ]);
 
       if (overviewResult.rows.length === 0) {
@@ -5043,9 +5060,12 @@ export class ProjectService {
    * Get brand health metrics from Snowflake (Share of Voice)
    * Queries ANALYTICS.PLATINUM_LFX_ONE.SHARE_OF_VOICE, SHARE_OF_VOICE_MONTHLY_TREND, SHARE_OF_VOICE_TOP_PROJECTS
    */
-  public async getBrandHealth(foundationSlug: string, includeMentions = false, month?: string): Promise<BrandHealthResponse> {
+  public async getBrandHealth(foundationSlug: string, includeMentions = false, period?: ResolvedPeriodRange): Promise<BrandHealthResponse> {
     const startTime = Date.now();
-    logger.debug(undefined, 'get_brand_health', 'Fetching brand health (Share of Voice) from Snowflake', { foundation_slug: foundationSlug, month });
+    logger.debug(undefined, 'get_brand_health', 'Fetching brand health (Share of Voice) from Snowflake', {
+      foundation_slug: foundationSlug,
+      period: period?.label,
+    });
 
     const defaultResponse: BrandHealthResponse = {
       totalMentions: 0,
@@ -5064,7 +5084,7 @@ export class ProjectService {
       const isUmbrella = foundationSlug === 'tlf';
       const sovFilter = isUmbrella ? '' : 'WHERE FOUNDATION_SLUG = ?';
       const sovParams = isUmbrella ? [] : [foundationSlug];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       // SHARE_OF_VOICE has per-platform rows with raw mention counts and sentiment percentages
       // Uses pre-computed _30D columns — cannot be month-filtered
@@ -5087,13 +5107,12 @@ export class ProjectService {
 
       // MOM_CHANGE_PCT in SHARE_OF_VOICE_MONTHLY_TREND is a mention-volume delta, not a sentiment delta.
       // Re-aggregate per-month mention counts (when umbrella) so monthlyMentions is correct across foundations.
-      // 6 months ending at the selected month.
       const monthlyTrendQuery = isUmbrella
         ? `
         SELECT MONTH_START_DATE, SUM(MENTION_COUNT) AS MENTION_COUNT
         FROM ANALYTICS.PLATINUM_LFX_ONE.SHARE_OF_VOICE_MONTHLY_TREND
-        WHERE MONTH_START_DATE >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND MONTH_START_DATE < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE MONTH_START_DATE >= TO_DATE(?)
+          AND MONTH_START_DATE < TO_DATE(?)
         GROUP BY MONTH_START_DATE
         ORDER BY MONTH_START_DATE DESC
         LIMIT 6
@@ -5102,8 +5121,8 @@ export class ProjectService {
         SELECT MONTH_START_DATE, MENTION_COUNT
         FROM ANALYTICS.PLATINUM_LFX_ONE.SHARE_OF_VOICE_MONTHLY_TREND
         WHERE FOUNDATION_SLUG = ?
-          AND MONTH_START_DATE >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND MONTH_START_DATE < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND MONTH_START_DATE >= TO_DATE(?)
+          AND MONTH_START_DATE < TO_DATE(?)
         ORDER BY MONTH_START_DATE DESC
         LIMIT 6
       `;
@@ -5169,7 +5188,7 @@ export class ProjectService {
         this.snowflakeService.execute<{
           MONTH_START_DATE: string;
           MENTION_COUNT: number;
-        }>(monthlyTrendQuery, isUmbrella ? [monthDate, monthDate] : [foundationSlug, monthDate, monthDate]),
+        }>(monthlyTrendQuery, isUmbrella ? [resolved.startDate, resolved.endDate] : [foundationSlug, resolved.startDate, resolved.endDate]),
         this.snowflakeService.execute<{
           PROJECT_NAME: string;
           MENTION_COUNT_30D: number;
@@ -5252,15 +5271,19 @@ export class ProjectService {
    * Get marketing-attributed revenue metrics from Snowflake
    * Queries ANALYTICS.PLATINUM_LFX_ONE.PIPELINE_SUMMARY and PAID_ADS_ATTRIBUTION
    */
-  public async getRevenueImpact(foundationSlug: string, classification?: string, month?: string): Promise<RevenueImpactResponse> {
+  public async getRevenueImpact(foundationSlug: string, classification?: string, period?: ResolvedPeriodRange): Promise<RevenueImpactResponse> {
     const startTime = Date.now();
-    logger.debug(undefined, 'get_revenue_impact', 'Fetching revenue impact from Snowflake', { foundation_slug: foundationSlug, classification, month });
+    logger.debug(undefined, 'get_revenue_impact', 'Fetching revenue impact from Snowflake', {
+      foundation_slug: foundationSlug,
+      classification,
+      period: period?.label,
+    });
 
     try {
       const isUmbrella = foundationSlug === 'tlf';
       const classificationFilter = classification ? 'AND LF_SUB_DOMAIN_CLASSIFICATION = ?' : '';
       const classificationParams = classification ? [classification] : [];
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       // PIPELINE_SUMMARY uses pre-computed _YTD columns — cannot be month-filtered
       const pipelineQuery = isUmbrella
@@ -5316,13 +5339,13 @@ export class ProjectService {
           ${classificationFilter}
       `;
 
-      // Attribution channels — 6 months ending at selected month, aggregated by paid-social channel
+      // Attribution channels — period range, aggregated by paid-social channel
       const channelsQuery = isUmbrella
         ? `
         SELECT CHANNEL, SUM(IMPRESSIONS) AS IMPRESSIONS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-        WHERE CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
         ORDER BY IMPRESSIONS DESC
@@ -5331,14 +5354,14 @@ export class ProjectService {
         SELECT CHANNEL, SUM(IMPRESSIONS) AS IMPRESSIONS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
         WHERE FOUNDATION_SLUG = ?
-          AND CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
         ORDER BY IMPRESSIONS DESC
       `;
 
-      // Paid media monthly trend — 6 months ending at selected month (inclusive)
+      // Paid media monthly trend — period range
       const monthlyTrendQuery = isUmbrella
         ? `
         SELECT CAMPAIGN_MONTH,
@@ -5347,8 +5370,8 @@ export class ProjectService {
                SUM(IMPRESSIONS) AS IMPRESSIONS,
                CASE WHEN SUM(SPEND) > 0 THEN SUM(FIRST_TOUCH_REVENUE) / SUM(SPEND) ELSE 0 END AS FIRST_TOUCH_ROAS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_MONTH
-        WHERE CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CAMPAIGN_MONTH
         ORDER BY CAMPAIGN_MONTH DESC
@@ -5362,21 +5385,21 @@ export class ProjectService {
                CASE WHEN SUM(SPEND) > 0 THEN SUM(FIRST_TOUCH_REVENUE) / SUM(SPEND) ELSE 0 END AS FIRST_TOUCH_ROAS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_MONTH
         WHERE FOUNDATION_SLUG = ?
-          AND CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CAMPAIGN_MONTH
         ORDER BY CAMPAIGN_MONTH DESC
         LIMIT 6
       `;
 
-      // Per-project per-channel impressions — 6 months ending at selected month
+      // Per-project per-channel impressions — period range
       const projectBreakdownQuery = isUmbrella
         ? `
         SELECT PROJECT_NAME, CHANNEL, SUM(IMPRESSIONS) AS IMPRESSIONS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
-        WHERE CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY PROJECT_NAME, CHANNEL
         ORDER BY PROJECT_NAME, IMPRESSIONS DESC
@@ -5385,14 +5408,14 @@ export class ProjectService {
         SELECT PROJECT_NAME, CHANNEL, SUM(IMPRESSIONS) AS IMPRESSIONS
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
         WHERE FOUNDATION_SLUG = ?
-          AND CAMPAIGN_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND CAMPAIGN_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND CAMPAIGN_MONTH >= TO_DATE(?)
+          AND CAMPAIGN_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY PROJECT_NAME, CHANNEL
         ORDER BY PROJECT_NAME, IMPRESSIONS DESC
       `;
 
-      // Event-registration attribution — per-channel totals, 6 months ending at selected month (inclusive)
+      // Event-registration attribution — per-channel totals, period range
       const eventAttrChannelQuery = isUmbrella
         ? `
         SELECT CHANNEL,
@@ -5400,8 +5423,8 @@ export class ProjectService {
                SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS,
                SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATION_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
         ORDER BY SESSIONS DESC
@@ -5413,8 +5436,8 @@ export class ProjectService {
                SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATION_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY CHANNEL
         ORDER BY SESSIONS DESC
@@ -5425,8 +5448,8 @@ export class ProjectService {
         ? `
         SELECT TO_CHAR(SESSION_MONTH, 'YYYY-MM') AS MONTH, CHANNEL, SUM(SESSIONS) AS SESSIONS, SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATION_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+        WHERE SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY SESSION_MONTH, CHANNEL
         ORDER BY SESSION_MONTH ASC
@@ -5435,8 +5458,8 @@ export class ProjectService {
         SELECT TO_CHAR(SESSION_MONTH, 'YYYY-MM') AS MONTH, CHANNEL, SUM(SESSIONS) AS SESSIONS, SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATION_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD(month, -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND SESSION_MONTH < DATEADD(month, 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND SESSION_MONTH >= TO_DATE(?)
+          AND SESSION_MONTH < TO_DATE(?)
           ${classificationFilter}
         GROUP BY SESSION_MONTH, CHANNEL
         ORDER BY SESSION_MONTH ASC
@@ -5476,21 +5499,33 @@ export class ProjectService {
           this.snowflakeService.execute<{
             CHANNEL: string;
             IMPRESSIONS: number;
-          }>(channelsQuery, isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams]),
+          }>(
+            channelsQuery,
+            isUmbrella
+              ? [resolved.startDate, resolved.endDate, ...classificationParams]
+              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
+          ),
           this.snowflakeService.execute<{
             CAMPAIGN_MONTH: string;
             SPEND: number;
             FIRST_TOUCH_REVENUE: number;
             IMPRESSIONS: number;
             FIRST_TOUCH_ROAS: number;
-          }>(monthlyTrendQuery, isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams]),
+          }>(
+            monthlyTrendQuery,
+            isUmbrella
+              ? [resolved.startDate, resolved.endDate, ...classificationParams]
+              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
+          ),
           this.snowflakeService.execute<{
             PROJECT_NAME: string;
             CHANNEL: string;
             IMPRESSIONS: number;
           }>(
             projectBreakdownQuery,
-            isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams]
+            isUmbrella
+              ? [resolved.startDate, resolved.endDate, ...classificationParams]
+              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
           ),
           this.snowflakeService.execute<{
             CHANNEL: string;
@@ -5499,7 +5534,9 @@ export class ProjectService {
             LAST_TOUCH_REVENUE: number;
           }>(
             eventAttrChannelQuery,
-            isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams]
+            isUmbrella
+              ? [resolved.startDate, resolved.endDate, ...classificationParams]
+              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
           ),
           this.snowflakeService.execute<{
             MONTH: string;
@@ -5508,7 +5545,9 @@ export class ProjectService {
             LAST_TOUCH_REVENUE: number;
           }>(
             eventAttrMonthlyQuery,
-            isUmbrella ? [monthDate, monthDate, ...classificationParams] : [foundationSlug, monthDate, monthDate, ...classificationParams]
+            isUmbrella
+              ? [resolved.startDate, resolved.endDate, ...classificationParams]
+              : [foundationSlug, resolved.startDate, resolved.endDate, ...classificationParams]
           ),
         ]);
 
@@ -6146,20 +6185,23 @@ export class ProjectService {
    * Queries PAID_ADS_KEYWORD_PERFORMANCE (daily grain, aggregated) and
    * PAID_ADS_KEYWORD_ATTRIBUTION (monthly grain, aggregated) for attributed revenue.
    */
-  public async getKeywordPerformance(foundationSlug: string, month?: string): Promise<KeywordPerformanceResponse> {
-    logger.debug(undefined, 'get_keyword_performance', 'Fetching keyword performance from Snowflake', { foundation_slug: foundationSlug, month });
+  public async getKeywordPerformance(foundationSlug: string, period?: ResolvedPeriodRange): Promise<KeywordPerformanceResponse> {
+    logger.debug(undefined, 'get_keyword_performance', 'Fetching keyword performance from Snowflake', {
+      foundation_slug: foundationSlug,
+      period: period?.label,
+    });
 
     try {
       const { filterAnd: foundationFilter, params: foundationParams } = buildFoundationFilter(foundationSlug);
-      const monthDate = month ? `${month}-01` : new Date().toISOString().slice(0, 10);
+      const resolved = period ?? resolvePeriodRange(new Date().toISOString().slice(0, 7))!;
 
       const perfQuery = `
       WITH top_keywords AS (
         SELECT KEYWORD_TEXT, KEYWORD_MATCH_TYPE, SUM(SPEND) AS KEYWORD_SPEND
         FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE
         WHERE RECORD_TYPE = 'keyword'
-          AND DATE_DAY >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-          AND DATE_DAY < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+          AND DATE_DAY >= TO_DATE(?)
+          AND DATE_DAY < TO_DATE(?)
           ${foundationFilter}
         GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
         ORDER BY KEYWORD_SPEND DESC
@@ -6182,8 +6224,8 @@ export class ProjectService {
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_PERFORMANCE p
       INNER JOIN top_keywords k
         ON p.KEYWORD_TEXT = k.KEYWORD_TEXT AND p.KEYWORD_MATCH_TYPE = k.KEYWORD_MATCH_TYPE
-      WHERE p.DATE_DAY >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND p.DATE_DAY < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE p.DATE_DAY >= TO_DATE(?)
+        AND p.DATE_DAY < TO_DATE(?)
         ${foundationFilter}
       GROUP BY p.KEYWORD_TEXT, p.KEYWORD_MATCH_TYPE, p.RECORD_TYPE, p.SEARCH_TERM, p.SEARCH_TERM_MATCH_TYPE
       ORDER BY k.KEYWORD_SPEND DESC, p.RECORD_TYPE
@@ -6200,8 +6242,8 @@ export class ProjectService {
         SUM(ATTRIBUTED_LT_CONVERSIONS) AS ATTRIBUTED_LT_CONVERSIONS,
         CASE WHEN SUM(KEYWORD_SPEND) > 0 THEN SUM(ATTRIBUTED_LT_REVENUE) / SUM(KEYWORD_SPEND) ELSE 0 END AS ATTRIBUTED_LT_ROAS
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_ADS_KEYWORD_ATTRIBUTION
-      WHERE STAT_MONTH >= DATEADD('MONTH', -5, DATE_TRUNC('MONTH', TO_DATE(?)))
-        AND STAT_MONTH < DATEADD('MONTH', 1, DATE_TRUNC('MONTH', TO_DATE(?)))
+      WHERE STAT_MONTH >= TO_DATE(?)
+        AND STAT_MONTH < TO_DATE(?)
         ${foundationFilter}
       GROUP BY KEYWORD_TEXT, KEYWORD_MATCH_TYPE
       ORDER BY KEYWORD_SPEND DESC
@@ -6209,8 +6251,15 @@ export class ProjectService {
       `;
 
       const [perfResult, attrResult] = await Promise.all([
-        this.snowflakeService.execute<KeywordPerformanceRow>(perfQuery, [monthDate, monthDate, ...foundationParams, monthDate, monthDate, ...foundationParams]),
-        this.snowflakeService.execute<KeywordAttributionRow>(attrQuery, [monthDate, monthDate, ...foundationParams]).catch((error) => {
+        this.snowflakeService.execute<KeywordPerformanceRow>(perfQuery, [
+          resolved.startDate,
+          resolved.endDate,
+          ...foundationParams,
+          resolved.startDate,
+          resolved.endDate,
+          ...foundationParams,
+        ]),
+        this.snowflakeService.execute<KeywordAttributionRow>(attrQuery, [resolved.startDate, resolved.endDate, ...foundationParams]).catch((error) => {
           logger.warning(undefined, 'get_keyword_performance', 'Attribution query failed, degrading gracefully', {
             foundation_slug: foundationSlug,
             err: error,

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -9,14 +9,6 @@ import type {
   RevenueImpactResponse,
 } from './analytics-data.interface';
 
-/** Month option for the Marketing Impact page month picker. */
-export interface MarketingImpactMonthOption {
-  /** Display label (e.g., "April 2026") */
-  label: string;
-  /** ISO-style value for API use (e.g., "2026-04") */
-  value: string;
-}
-
 /** Period option for the Marketing Impact date range picker. */
 export interface MarketingImpactPeriodOption {
   label: string;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -17,6 +17,24 @@ export interface MarketingImpactMonthOption {
   value: string;
 }
 
+/** Period option for the Marketing Impact date range picker. */
+export interface MarketingImpactPeriodOption {
+  label: string;
+  value: string;
+  group: 'preset' | 'month';
+}
+
+/** Valid period preset identifiers. */
+export type MarketingImpactPeriodPreset = 'ytd' | 'last-3' | 'last-6';
+
+/** Resolved date range from a validated period parameter. */
+export interface ResolvedPeriodRange {
+  type: 'month' | 'ytd' | 'trailing';
+  startDate: string;
+  endDate: string;
+  label: string;
+}
+
 /** Tab option for the Marketing Impact section tabs. */
 export interface MarketingImpactTabOption {
   id: MarketingImpactTab;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -21,11 +21,7 @@ export interface MarketingImpactMonthOption {
 export interface MarketingImpactPeriodOption {
   label: string;
   value: string;
-  group: 'preset' | 'month';
 }
-
-/** Valid period preset identifiers. */
-export type MarketingImpactPeriodPreset = 'ytd' | 'last-3' | 'last-6';
 
 /** Resolved date range from a validated period parameter. */
 export interface ResolvedPeriodRange {

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -1,25 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { MarketingImpactMonthOption, MarketingImpactPeriodOption, ResolvedPeriodRange } from '../interfaces/marketing-impact.interface';
+import type { MarketingImpactPeriodOption, ResolvedPeriodRange } from '../interfaces/marketing-impact.interface';
 
-/** Number of past months to show in the Marketing Impact month picker. */
+/** Number of past months to show in the Marketing Impact period picker. */
 const MONTH_COUNT = 12;
-
-/** Builds the last 12 month options in descending order for the month picker. */
-export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[] {
-  const now = new Date();
-  const options: MarketingImpactMonthOption[] = [];
-
-  for (let i = 1; i <= MONTH_COUNT; i++) {
-    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-    options.push({ label, value });
-  }
-
-  return options;
-}
 
 /** Returns the default reporting month (previous calendar month, UTC). */
 export function getDefaultMarketingImpactMonth(): string {

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -21,11 +21,11 @@ export function buildMarketingImpactMonthOptions(): MarketingImpactMonthOption[]
   return options;
 }
 
-/** Returns the default reporting month (previous calendar month). */
+/** Returns the default reporting month (previous calendar month, UTC). */
 export function getDefaultMarketingImpactMonth(): string {
   const now = new Date();
-  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
+  const prev = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  return `${prev.getUTCFullYear()}-${String(prev.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 // === Trend Helpers ===
@@ -109,23 +109,25 @@ export function isPeriodMonth(value: string): boolean {
 /** Resolves a period value to a concrete date range with start/end dates in YYYY-MM-DD format. */
 export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
   const now = new Date();
+  const utcYear = now.getUTCFullYear();
+  const utcMonth = now.getUTCMonth() + 1;
 
   if (isPeriodPreset(period)) {
-    const endDate = firstOfMonth(now.getFullYear(), now.getMonth() + 1);
+    const endDate = firstOfMonth(utcYear, utcMonth + 1);
 
     if (period === 'ytd') {
       return {
         type: 'ytd',
-        startDate: `${now.getFullYear()}-01-01`,
+        startDate: `${utcYear}-01-01`,
         endDate,
-        label: `Year to Date (${now.getFullYear()})`,
+        label: `Year to Date (${utcYear})`,
       };
     }
 
     const months = period === 'last-3' ? 3 : 6;
     return {
       type: 'trailing',
-      startDate: firstOfMonth(now.getFullYear(), now.getMonth() + 1 - months),
+      startDate: firstOfMonth(utcYear, utcMonth + 1 - months),
       endDate,
       label: `Last ${months} months`,
     };
@@ -133,11 +135,11 @@ export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
 
   if (isPeriodMonth(period)) {
     const [year, mo] = period.split('-').map(Number);
-    if (year > now.getFullYear() || (year === now.getFullYear() && mo > now.getMonth() + 1)) {
+    if (year > utcYear || (year === utcYear && mo > utcMonth)) {
       return null;
     }
-    const date = new Date(year, mo - 1, 1);
-    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const date = new Date(Date.UTC(year, mo - 1, 1));
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
     return {
       type: 'month',
       startDate: firstOfMonth(year, mo),
@@ -150,6 +152,6 @@ export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
 }
 
 function firstOfMonth(year: number, month: number): string {
-  const d = new Date(year, month - 1, 1);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+  const d = new Date(Date.UTC(year, month - 1, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-01`;
 }

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -68,16 +68,16 @@ export function computeMomPct(arr: number[] | undefined): number | null {
 // === Period Utilities ===
 
 const PERIOD_PRESETS = ['ytd', 'last-3', 'last-6'] as const;
-const MONTH_REGEX = /^\d{4}-\d{2}$/;
+const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 
 /** Builds grouped period options: presets first, then individual months. */
 export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption[] {
   const now = new Date();
   const currentYear = now.getFullYear();
   const presets: MarketingImpactPeriodOption[] = [
-    { label: `Year to Date (${currentYear})`, value: 'ytd', group: 'preset' },
-    { label: 'Last 3 months', value: 'last-3', group: 'preset' },
-    { label: 'Last 6 months', value: 'last-6', group: 'preset' },
+    { label: `Year to Date (${currentYear})`, value: 'ytd' },
+    { label: 'Last 3 months', value: 'last-3' },
+    { label: 'Last 6 months', value: 'last-6' },
   ];
 
   const months: MarketingImpactPeriodOption[] = [];
@@ -85,7 +85,7 @@ export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption
     const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-    months.push({ label, value, group: 'month' });
+    months.push({ label, value });
   }
 
   return [...presets, ...months];

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { MarketingImpactMonthOption } from '../interfaces/marketing-impact.interface';
+import type { MarketingImpactMonthOption, MarketingImpactPeriodOption, ResolvedPeriodRange } from '../interfaces/marketing-impact.interface';
 
 /** Number of past months to show in the Marketing Impact month picker. */
 const MONTH_COUNT = 12;
@@ -63,4 +63,93 @@ export function computeMomPct(arr: number[] | undefined): number | null {
   const previous = arr.at(-2) ?? 0;
   if (previous === 0) return null;
   return ((current - previous) / previous) * 100;
+}
+
+// === Period Utilities ===
+
+const PERIOD_PRESETS = ['ytd', 'last-3', 'last-6'] as const;
+const MONTH_REGEX = /^\d{4}-\d{2}$/;
+
+/** Builds grouped period options: presets first, then individual months. */
+export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption[] {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const presets: MarketingImpactPeriodOption[] = [
+    { label: `Year to Date (${currentYear})`, value: 'ytd', group: 'preset' },
+    { label: 'Last 3 months', value: 'last-3', group: 'preset' },
+    { label: 'Last 6 months', value: 'last-6', group: 'preset' },
+  ];
+
+  const months: MarketingImpactPeriodOption[] = [];
+  for (let i = 1; i <= MONTH_COUNT; i++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    months.push({ label, value, group: 'month' });
+  }
+
+  return [...presets, ...months];
+}
+
+/** Returns the default period value (previous calendar month as YYYY-MM). */
+export function getDefaultMarketingImpactPeriod(): string {
+  return getDefaultMarketingImpactMonth();
+}
+
+/** Checks whether a period string is a preset identifier. */
+export function isPeriodPreset(value: string): value is (typeof PERIOD_PRESETS)[number] {
+  return (PERIOD_PRESETS as readonly string[]).includes(value);
+}
+
+/** Checks whether a period string is a valid YYYY-MM month. */
+export function isPeriodMonth(value: string): boolean {
+  return MONTH_REGEX.test(value);
+}
+
+/** Resolves a period value to a concrete date range with start/end dates in YYYY-MM-DD format. */
+export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
+  const now = new Date();
+
+  if (isPeriodPreset(period)) {
+    const endDate = firstOfMonth(now.getFullYear(), now.getMonth() + 1);
+
+    if (period === 'ytd') {
+      return {
+        type: 'ytd',
+        startDate: `${now.getFullYear()}-01-01`,
+        endDate,
+        label: `Year to Date (${now.getFullYear()})`,
+      };
+    }
+
+    const months = period === 'last-3' ? 3 : 6;
+    return {
+      type: 'trailing',
+      startDate: firstOfMonth(now.getFullYear(), now.getMonth() + 1 - months),
+      endDate,
+      label: `Last ${months} months`,
+    };
+  }
+
+  if (isPeriodMonth(period)) {
+    const [year, mo] = period.split('-').map(Number);
+    if (year > now.getFullYear() || (year === now.getFullYear() && mo > now.getMonth() + 1)) {
+      return null;
+    }
+    const date = new Date(year, mo - 1, 1);
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    return {
+      type: 'month',
+      startDate: firstOfMonth(year, mo),
+      endDate: firstOfMonth(year, mo + 1),
+      label,
+    };
+  }
+
+  return null;
+}
+
+function firstOfMonth(year: number, month: number): string {
+  const d = new Date(year, month - 1, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
 }

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -98,7 +98,7 @@ export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
   const utcMonth = now.getUTCMonth() + 1;
 
   if (isPeriodPreset(period)) {
-    const endDate = firstOfMonth(utcYear, utcMonth + 1);
+    const endDate = firstOfMonth(utcYear, utcMonth);
 
     if (period === 'ytd') {
       return {
@@ -112,7 +112,7 @@ export function resolvePeriodRange(period: string): ResolvedPeriodRange | null {
     const months = period === 'last-3' ? 3 : 6;
     return {
       type: 'trailing',
-      startDate: firstOfMonth(utcYear, utcMonth + 1 - months),
+      startDate: firstOfMonth(utcYear, utcMonth - months),
       endDate,
       label: `Last ${months} months`,
     };

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -58,7 +58,7 @@ const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 /** Builds grouped period options: presets first, then individual months. */
 export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption[] {
   const now = new Date();
-  const currentYear = now.getFullYear();
+  const currentYear = now.getUTCFullYear();
   const presets: MarketingImpactPeriodOption[] = [
     { label: `Year to Date (${currentYear})`, value: 'ytd' },
     { label: 'Last 3 months', value: 'last-3' },
@@ -67,9 +67,9 @@ export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption
 
   const months: MarketingImpactPeriodOption[] = [];
   for (let i = 1; i <= MONTH_COUNT; i++) {
-    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
+    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+    const value = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
     months.push({ label, value });
   }
 


### PR DESCRIPTION
## Summary
- Replace single-month picker with a period selector supporting YTD, last-3, last-6 presets and individual month selection across the Marketing Impact dashboard
- All 8 marketing endpoints updated to accept `ResolvedPeriodRange` with uniform `WHERE col >= TO_DATE(?) AND col < TO_DATE(?)` queries, backward-compatible via `?month=` fallback
- Overview KPI cards dynamically label change indicators ("MoM" for months, "Period" for presets) and suppress YoY for non-month presets
- Tightened month regex validation, removed trend query `LIMIT 6` so multi-month periods return all data points

## Changes
- **Shared**: `ResolvedPeriodRange`, `MarketingImpactPeriodOption` interfaces; `resolvePeriodRange()`, `buildMarketingImpactPeriodOptions()`, `isPeriodMonth()` utilities
- **Backend**: `getValidatedPeriod()` validator with `?month=` fallback; all 8 `ProjectService` marketing methods accept `ResolvedPeriodRange`; `defaultPeriodRange()` helper using previous calendar month
- **Frontend**: `analytics.service.ts` param rename; parent component period selector; all 7 tab components renamed `selectedMonth` → `selectedPeriod`; overview summary title/subtitle uses period label

LFXV2-2263