### PR TITLE
fix(meetings): select content-bearing past meeting summary (LFXV2-2222)

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -34,7 +34,7 @@ import {
   UpdateMeetingRequest,
   UpdatePastMeetingSummaryRequest,
 } from '@lfx-one/shared/interfaces';
-import { buildRecurrenceNeverEndDate, getPastMeetingTranscriptUrl, mapITXResponseToMeetingRsvp, transformV1SummaryToV2 } from '@lfx-one/shared/utils';
+import { buildRecurrenceNeverEndDate, getPastMeetingTranscriptUrl, mapITXResponseToMeetingRsvp, selectPrimaryPastMeetingSummary } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
@@ -930,8 +930,15 @@ export class MeetingService {
         return null;
       }
 
-      // Always transform from V1 summary format to V2
-      const summary = transformV1SummaryToV2(resources[0].data);
+      const summary = selectPrimaryPastMeetingSummary(resources);
+
+      if (summary && resources.length > 1) {
+        logger.info(req, 'get_past_meeting_summary', 'Selected summary among multiple', {
+          past_meeting_id: pastMeetingUid,
+          total: resources.length,
+          selected_uid: summary.uid,
+        });
+      }
 
       return summary;
     } catch (error) {

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -200,4 +200,30 @@ describe('selectPrimaryPastMeetingSummary', () => {
 
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('content-no-ts');
   });
+
+  it('treats whitespace-only content as empty and prefers a genuinely content-bearing record', () => {
+    const resources = [
+      summaryResource('whitespace-first', { uid: 'whitespace-first', content: '   ' }),
+      summaryResource('real-content', { uid: 'real-content', content: 'Actual summary text' }),
+    ];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('real-content');
+  });
+
+  it('falls back to created_at for recency when updated_at is absent', () => {
+    const resources = [
+      summaryResource('older-created', {
+        uid: 'older-created',
+        content: 'Older summary',
+        created_at: '2026-01-01T10:00:00Z',
+      }),
+      summaryResource('newer-created', {
+        uid: 'newer-created',
+        content: 'Newer summary',
+        created_at: '2026-03-01T10:00:00Z',
+      }),
+    ];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer-created');
+  });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -9,8 +9,8 @@ import '@angular/compiler';
 import { describe, expect, it } from 'vitest';
 
 import { RecurrenceType } from '../enums';
-import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting } from '../interfaces';
-import { buildRecurrenceSummary, resolveOccurrenceRecurrence, sortPastMeetingsDescending } from './meeting.utils';
+import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
+import { buildRecurrenceSummary, resolveOccurrenceRecurrence, selectPrimaryPastMeetingSummary, sortPastMeetingsDescending } from './meeting.utils';
 
 /**
  * Builds a minimal PastMeeting fixture. The sort only reads `scheduled_start_time`/`start_time`,
@@ -133,5 +133,71 @@ describe('resolveOccurrenceRecurrence', () => {
     const pattern = { ...resolved, patternType: 'monthly', monthlyType: 'dayOfWeek', endType: 'never' } as CustomRecurrencePattern;
 
     expect(buildRecurrenceSummary(pattern).fullSummary).toBe('Monthly on the 1st Thursday');
+  });
+});
+
+function summaryResource(id: string, data: Partial<PastMeetingSummary> & { content?: string; edited_content?: string }): QueryServiceItem<PastMeetingSummary> {
+  return {
+    id,
+    type: 'v1_past_meeting_summary',
+    data: data as PastMeetingSummary,
+  };
+}
+
+describe('selectPrimaryPastMeetingSummary', () => {
+  it('returns null for empty or undefined input', () => {
+    expect(selectPrimaryPastMeetingSummary([])).toBeNull();
+    expect(selectPrimaryPastMeetingSummary(undefined)).toBeNull();
+  });
+
+  it('returns a single empty-content record unchanged', () => {
+    const resources = [summaryResource('empty-1', { uid: 'empty-1', content: '' })];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('empty-1');
+  });
+
+  it('prefers a content-bearing record when an empty one sorts first (LFXV2-2222)', () => {
+    const resources = [
+      summaryResource('empty-first', { uid: 'empty-first', content: '' }),
+      summaryResource('content-second', { uid: 'content-second', content: 'AI generated summary text' }),
+    ];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('content-second');
+  });
+
+  it('returns the newest summary when multiple records have content', () => {
+    const resources = [
+      summaryResource('older', {
+        uid: 'older',
+        content: 'Older summary',
+        updated_at: '2026-01-01T10:00:00Z',
+      }),
+      summaryResource('newer', {
+        uid: 'newer',
+        content: 'Newer summary',
+        updated_at: '2026-03-01T10:00:00Z',
+      }),
+    ];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer');
+  });
+
+  it('falls back to the first record when all summaries are empty', () => {
+    const resources = [summaryResource('first', { uid: 'first', content: '' }), summaryResource('second', { uid: 'second', content: '' })];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('first');
+  });
+
+  it('selects content over empty even when the content record lacks timestamps', () => {
+    const resources = [
+      summaryResource('empty-with-ts', {
+        uid: 'empty-with-ts',
+        content: '',
+        updated_at: '2026-06-01T10:00:00Z',
+      }),
+      summaryResource('content-no-ts', { uid: 'content-no-ts', content: 'Summary without timestamps' }),
+    ];
+
+    expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('content-no-ts');
   });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -182,8 +182,11 @@ describe('selectPrimaryPastMeetingSummary', () => {
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer');
   });
 
-  it('falls back to the first record when all summaries are empty', () => {
-    const resources = [summaryResource('first', { uid: 'first', content: '' }), summaryResource('second', { uid: 'second', content: '' })];
+  it('falls back to the first record when all summaries are empty, even with differing timestamps', () => {
+    const resources = [
+      summaryResource('first', { uid: 'first', content: '', updated_at: '2026-01-01T10:00:00Z' }),
+      summaryResource('second', { uid: 'second', content: '', updated_at: '2026-06-01T10:00:00Z' }),
+    ];
 
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('first');
   });

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -549,13 +549,19 @@ export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeeting
 }
 
 function summaryRecency(summary: PastMeetingSummary): number {
-  const ts = summary.updated_at || summary.created_at || '';
-  const parsed = ts ? Date.parse(ts) : NaN;
-  return Number.isNaN(parsed) ? 0 : parsed;
+  // Try updated_at first, but fall back to created_at when it's missing or unparsable
+  const updated = summary.updated_at ? Date.parse(summary.updated_at) : NaN;
+  if (!Number.isNaN(updated)) {
+    return updated;
+  }
+  const created = summary.created_at ? Date.parse(summary.created_at) : NaN;
+  return Number.isNaN(created) ? 0 : created;
 }
 
 function summaryHasContent(summary: PastMeetingSummary): boolean {
-  return !!(summary.summary_data?.edited_content || summary.summary_data?.content);
+  const editedContent = summary.summary_data?.edited_content?.trim();
+  const content = summary.summary_data?.content?.trim();
+  return Boolean(editedContent || content);
 }
 
 /** Picks the best summary when multiple v1_past_meeting_summary records share one occurrence (LFXV2-2222). */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -12,6 +12,7 @@ import {
   PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
+  QueryServiceItem,
   RecurrenceSummary,
   SummaryData,
   TranscriptCue,
@@ -545,6 +546,29 @@ export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeeting
     created_at: summary.created_at || raw.summary_created_time || '',
     updated_at: summary.updated_at || raw.summary_last_modified_time || raw.modified_at || '',
   };
+}
+
+function summaryRecency(summary: PastMeetingSummary): number {
+  const ts = summary.updated_at || summary.created_at || '';
+  const parsed = ts ? Date.parse(ts) : NaN;
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function summaryHasContent(summary: PastMeetingSummary): boolean {
+  return !!(summary.summary_data?.edited_content || summary.summary_data?.content);
+}
+
+/** Picks the best summary when multiple v1_past_meeting_summary records share one occurrence (LFXV2-2222). */
+export function selectPrimaryPastMeetingSummary(resources: QueryServiceItem<PastMeetingSummary>[] | undefined | null): PastMeetingSummary | null {
+  if (!resources || resources.length === 0) {
+    return null;
+  }
+
+  const transformed = resources.map((resource) => transformV1SummaryToV2(resource.data));
+  const withContent = transformed.filter(summaryHasContent);
+  const pool = withContent.length > 0 ? withContent : transformed;
+
+  return pool.reduce((best, current) => (summaryRecency(current) > summaryRecency(best) ? current : best));
 }
 
 /**

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -572,9 +572,13 @@ export function selectPrimaryPastMeetingSummary(resources: QueryServiceItem<Past
 
   const transformed = resources.map((resource) => transformV1SummaryToV2(resource.data));
   const withContent = transformed.filter(summaryHasContent);
-  const pool = withContent.length > 0 ? withContent : transformed;
 
-  return pool.reduce((best, current) => (summaryRecency(current) > summaryRecency(best) ? current : best));
+  // No content-bearing record: preserve input (query-service UID) order — legacy resources[0] behavior.
+  if (withContent.length === 0) {
+    return transformed[0];
+  }
+
+  return withContent.reduce((best, current) => (summaryRecency(current) > summaryRecency(best) ? current : best));
 }
 
 /**


### PR DESCRIPTION
# Summary

Some past meetings had AI-generated summaries indexed in V2 but nothing showed on their LFX meeting pages. The root cause was on the read path: a single occurrence can have multiple `v1_past_meeting_summary` records — some with real content, some empty. The query service returns them ordered by UID, and the server blindly took the first record. When an empty-content record's UID sorted first, the page rendered nothing while a content-bearing summary sat untouched in the same response.

This adds a `selectPrimaryPastMeetingSummary` util in `@lfx-one/shared` that transforms each record and picks the best one — preferring records that actually have content, then the newest by `updated_at`/`created_at`, with a stable fallback to input order. When no record has content, behavior is unchanged (falls back to the first), so single-summary and no-summary occurrences don't regress. The server's `getPastMeetingSummary` now calls this util instead of taking `resources[0]`, and logs at INFO when it selects among multiple records so the duplicate-record anomaly is visible in production.

The fix is entirely on the read path — no backend/indexer change, no reindex, no data migration. Why empty-content records get indexed in the first place is tracked separately as a follow-up.