### PR TITLE
fix(profile): disable save until affiliation periods complete

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -198,7 +198,7 @@
           label="Save changes"
           severity="primary"
           size="small"
-          [disabled]="hasNoWorkExperience() || hasOverlap() || hasValidationErrors()"
+          [disabled]="hasNoWorkExperience() || hasOverlap() || hasValidationErrors() || hasIncompletePeriods()"
           (onClick)="save()"
           data-testid="timeline-save" />
       </div>

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.ts
@@ -46,9 +46,7 @@ export class AffiliationTimelineDialogComponent {
   public readonly hasNoWorkExperience: Signal<boolean> = computed(() => this.companyOrgs().length === 0);
   public readonly hasUnverifiedWorkExperienceOnly: Signal<boolean> = computed(() => this.workExperience().length > 0 && this.companyOrgs().length === 0);
   public readonly hasValidationErrors: Signal<boolean> = this.initHasValidationErrors();
-  public readonly hasIncompletePeriods: Signal<boolean> = computed(() =>
-    this.organizations().some((org) => org.enabled && !this.areAllPeriodsComplete(org.organization))
-  );
+  public readonly hasIncompletePeriods: Signal<boolean> = computed(() => this.organizations().some((org) => org.enabled && !this.periodsComplete(org)));
   public readonly availableYearsMap: Signal<Map<string, { label: string; value: string }[]>> = this.initAvailableYearsMap();
   public readonly periodErrorsMap: Signal<Map<string, AffiliationPeriodErrors>> = this.initPeriodErrorsMap();
 
@@ -125,10 +123,7 @@ export class AffiliationTimelineDialogComponent {
 
   public areAllPeriodsComplete(orgName: string): boolean {
     const org = this.organizations().find((o) => o.organization === orgName);
-    if (!org || org.periods.length === 0) {
-      return false;
-    }
-    return org.periods.every((p) => p.startMonth && p.startYear && (p.isPresent || (p.endMonth && p.endYear)));
+    return !!org && this.periodsComplete(org);
   }
 
   public save(): void {
@@ -173,6 +168,11 @@ export class AffiliationTimelineDialogComponent {
 
   public cancel(): void {
     this.ref.close(null);
+  }
+
+  // Every period has a start (month + year) and either is "Present" or has a complete end.
+  private periodsComplete(org: AffiliationEditOrg): boolean {
+    return org.periods.length > 0 && org.periods.every((p) => p.startMonth && p.startYear && (p.isPresent || (p.endMonth && p.endYear)));
   }
 
   private buildInitialState(): AffiliationEditOrg[] {

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.ts
@@ -46,6 +46,9 @@ export class AffiliationTimelineDialogComponent {
   public readonly hasNoWorkExperience: Signal<boolean> = computed(() => this.companyOrgs().length === 0);
   public readonly hasUnverifiedWorkExperienceOnly: Signal<boolean> = computed(() => this.workExperience().length > 0 && this.companyOrgs().length === 0);
   public readonly hasValidationErrors: Signal<boolean> = this.initHasValidationErrors();
+  public readonly hasIncompletePeriods: Signal<boolean> = computed(() =>
+    this.organizations().some((org) => org.enabled && !this.areAllPeriodsComplete(org.organization))
+  );
   public readonly availableYearsMap: Signal<Map<string, { label: string; value: string }[]>> = this.initAvailableYearsMap();
   public readonly periodErrorsMap: Signal<Map<string, AffiliationPeriodErrors>> = this.initPeriodErrorsMap();
 


### PR DESCRIPTION
## Summary

- In the **Edit project affiliation(s)** dialog, the **Save changes** button stayed clickable when an enabled org had a period with required fields unfilled (missing/partial start month or year, or a non-"Present" period with no end date) — clicking it did nothing because `save()` silently skips incomplete periods.
- Gate Save on a new `hasIncompletePeriods` signal (reuses the existing `areAllPeriodsComplete`, checking only **enabled** orgs), so the button is visibly disabled until every required field is set or the period is marked Present.
- Toggling all orgs off still leaves Save enabled, so clearing affiliations continues to work.

Follow-up to #968.

LFXV2-2220
