### PR TITLE
feat(dashboards): add expandable domain rows to web activity tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -34,6 +34,7 @@
         <div class="flex flex-col gap-0" role="table" aria-label="Web activity by domain" data-testid="web-activity-table">
           <!-- Table header -->
           <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+            <span class="w-6"></span>
             <span class="w-44 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">DOMAIN</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSIONS</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PAGE VIEWS</span>
@@ -41,9 +42,24 @@
             <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSION SHARE</span>
           </div>
 
-          <!-- Rows -->
+          <!-- Domain group rows -->
           @for (row of domainRows(); track row.domain) {
-            <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'web-activity-row-' + row.domain">
+            @let isExpanded = expandedDomains().has(row.domain);
+            <!-- Parent row -->
+            <div
+              class="flex cursor-pointer items-center gap-3 border-b border-gray-100 py-2.5 hover:bg-gray-50"
+              role="row"
+              tabindex="0"
+              [attr.data-testid]="'web-activity-row-' + row.domain"
+              [attr.aria-expanded]="row.domains.length > 0 ? isExpanded : undefined"
+              (click)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
+              (keydown.enter)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
+              (keydown.space)="row.domains.length > 0 && toggleDomainExpand(row.domain); $event.preventDefault()">
+              <span class="flex w-6 items-center justify-center">
+                @if (row.domains.length > 0) {
+                  <i class="fa-solid fa-chevron-right text-[10px] text-gray-400 transition-transform duration-200" [class.rotate-90]="isExpanded"></i>
+                }
+              </span>
               <span class="w-44 truncate text-xs font-medium text-gray-700" role="cell">{{ row.domain }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.sessions }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.pageViews }}</span>
@@ -55,6 +71,28 @@
                 <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sessionShareFormatted }}</span>
               </div>
             </div>
+
+            <!-- Expanded child domain rows -->
+            @if (isExpanded) {
+              @for (detail of row.domains; track detail.host) {
+                <div
+                  class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2"
+                  role="row"
+                  [attr.data-testid]="'web-activity-detail-' + detail.host">
+                  <span class="w-6"></span>
+                  <span class="w-44 truncate pl-4 text-xs text-gray-500" role="cell">{{ detail.host }}</span>
+                  <span class="w-24 text-right text-xs text-gray-600" role="cell">{{ detail.sessions }}</span>
+                  <span class="w-24 text-right text-xs text-gray-600" role="cell">{{ detail.pageViews }}</span>
+                  <span class="w-24 text-right text-xs text-gray-400" role="cell"> {{ detail.newUsers }} / {{ detail.returningUsers }} </span>
+                  <div class="flex flex-1 items-center gap-2" role="cell">
+                    <div class="h-1.5 flex-1 rounded-full bg-gray-100">
+                      <div class="h-1.5 rounded-full bg-blue-300" [style.width.%]="detail.sessionShare"></div>
+                    </div>
+                    <span class="w-10 text-right text-[10px] text-gray-400">{{ detail.sessionShareFormatted }}</span>
+                  </div>
+                </div>
+              }
+            }
           }
         </div>
       } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -58,7 +58,10 @@
               (keydown.space)="$event.preventDefault(); row.domains.length > 0 && toggleDomainExpand(row.domain)">
               <span class="flex w-6 items-center justify-center">
                 @if (row.domains.length > 0) {
-                  <i class="fa-solid fa-chevron-right text-[10px] text-gray-400 transition-transform duration-200" [class.rotate-90]="isExpanded"></i>
+                  <i
+                    class="fa-solid fa-chevron-right text-[10px] text-gray-400 transition-transform duration-200"
+                    [class.rotate-90]="isExpanded"
+                    aria-hidden="true"></i>
                 }
               </span>
               <span class="w-44 truncate text-xs font-medium text-gray-700" role="cell">{{ row.domain }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -47,14 +47,15 @@
             @let isExpanded = expandedDomains().has(row.domain);
             <!-- Parent row -->
             <div
-              class="flex cursor-pointer items-center gap-3 border-b border-gray-100 py-2.5 hover:bg-gray-50"
+              class="flex items-center gap-3 border-b border-gray-100 py-2.5 hover:bg-gray-50"
               role="row"
-              tabindex="0"
+              [class.cursor-pointer]="row.domains.length > 0"
+              [attr.tabindex]="row.domains.length > 0 ? 0 : null"
               [attr.data-testid]="'web-activity-row-' + row.domain"
-              [attr.aria-expanded]="row.domains.length > 0 ? isExpanded : undefined"
+              [attr.aria-expanded]="row.domains.length > 0 ? isExpanded : null"
               (click)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
               (keydown.enter)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
-              (keydown.space)="row.domains.length > 0 && toggleDomainExpand(row.domain); $event.preventDefault()">
+              (keydown.space)="$event.preventDefault(); row.domains.length > 0 && toggleDomainExpand(row.domain)">
               <span class="flex w-6 items-center justify-center">
                 @if (row.domains.length > 0) {
                   <i class="fa-solid fa-chevron-right text-[10px] text-gray-400 transition-transform duration-200" [class.rotate-90]="isExpanded"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.html
@@ -34,7 +34,7 @@
         <div class="flex flex-col gap-0" role="table" aria-label="Web activity by domain" data-testid="web-activity-table">
           <!-- Table header -->
           <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
-            <span class="w-6"></span>
+            <span class="w-6" role="columnheader"></span>
             <span class="w-44 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">DOMAIN</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SESSIONS</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PAGE VIEWS</span>
@@ -47,16 +47,17 @@
             @let isExpanded = expandedDomains().has(row.domain);
             <!-- Parent row -->
             <div
-              class="flex items-center gap-3 border-b border-gray-100 py-2.5 hover:bg-gray-50"
+              class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
               role="row"
               [class.cursor-pointer]="row.domains.length > 0"
+              [class.hover:bg-gray-50]="row.domains.length > 0"
               [attr.tabindex]="row.domains.length > 0 ? 0 : null"
               [attr.data-testid]="'web-activity-row-' + row.domain"
               [attr.aria-expanded]="row.domains.length > 0 ? isExpanded : null"
               (click)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
               (keydown.enter)="row.domains.length > 0 && toggleDomainExpand(row.domain)"
               (keydown.space)="$event.preventDefault(); row.domains.length > 0 && toggleDomainExpand(row.domain)">
-              <span class="flex w-6 items-center justify-center">
+              <span class="flex w-6 items-center justify-center" role="cell">
                 @if (row.domains.length > 0) {
                   <i
                     class="fa-solid fa-chevron-right text-[10px] text-gray-400 transition-transform duration-200"
@@ -69,8 +70,15 @@
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.pageViews }}</span>
               <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.pagesPerSession }}</span>
               <div class="flex flex-1 items-center gap-2" role="cell">
-                <div class="h-2 flex-1 rounded-full bg-gray-100">
-                  <div class="h-2 rounded-full bg-blue-500" [style.width.%]="row.sessionShare"></div>
+                <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    class="h-full rounded-full bg-blue-500"
+                    role="progressbar"
+                    [attr.aria-valuenow]="row.sessionShare"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    [attr.aria-label]="row.domain + ' session share: ' + row.sessionShareFormatted"
+                    [style.width.%]="row.sessionShare"></div>
                 </div>
                 <span class="w-10 text-right text-[11px] text-gray-500">{{ row.sessionShareFormatted }}</span>
               </div>
@@ -83,14 +91,21 @@
                   class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2"
                   role="row"
                   [attr.data-testid]="'web-activity-detail-' + detail.host">
-                  <span class="w-6"></span>
+                  <span class="w-6" role="cell"></span>
                   <span class="w-44 truncate pl-4 text-xs text-gray-500" role="cell">{{ detail.host }}</span>
                   <span class="w-24 text-right text-xs text-gray-600" role="cell">{{ detail.sessions }}</span>
                   <span class="w-24 text-right text-xs text-gray-600" role="cell">{{ detail.pageViews }}</span>
                   <span class="w-24 text-right text-xs text-gray-400" role="cell"> {{ detail.newUsers }} / {{ detail.returningUsers }} </span>
                   <div class="flex flex-1 items-center gap-2" role="cell">
-                    <div class="h-1.5 flex-1 rounded-full bg-gray-100">
-                      <div class="h-1.5 rounded-full bg-blue-300" [style.width.%]="detail.sessionShare"></div>
+                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+                      <div
+                        class="h-full rounded-full bg-blue-300"
+                        role="progressbar"
+                        [attr.aria-valuenow]="detail.sessionShare"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        [attr.aria-label]="detail.host + ' session share: ' + detail.sessionShareFormatted"
+                        [style.width.%]="detail.sessionShare"></div>
                     </div>
                     <span class="w-10 text-right text-[10px] text-gray-400">{{ detail.sessionShareFormatted }}</span>
                   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -8,7 +8,13 @@ import { formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
-import type { MarketingImpactFocusProgram, PerformanceSummaryKpi, WebActivitiesSummaryResponse, WebActivityDomainRow } from '@lfx-one/shared/interfaces';
+import type {
+  MarketingImpactFocusProgram,
+  PerformanceSummaryKpi,
+  WebActivitiesSummaryResponse,
+  WebActivityDomainDetailRow,
+  WebActivityDomainRow,
+} from '@lfx-one/shared/interfaces';
 
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
@@ -30,12 +36,26 @@ export class WebActivityTabComponent {
 
   // === WritableSignals ===
   protected readonly loading = signal(false);
+  protected readonly expandedDomains = signal<Set<string>>(new Set());
 
   // === Computed Signals ===
   protected readonly webData: Signal<WebActivitiesSummaryResponse | null> = this.initWebData();
   protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
   protected readonly domainRows: Signal<WebActivityDomainRow[]> = this.initDomainRows();
   protected readonly hasDomains = computed(() => this.domainRows().length > 0);
+
+  // === Protected Methods ===
+  protected toggleDomainExpand(domain: string): void {
+    this.expandedDomains.update((current) => {
+      const next = new Set(current);
+      if (next.has(domain)) {
+        next.delete(domain);
+      } else {
+        next.add(domain);
+      }
+      return next;
+    });
+  }
 
   // === Private Initializers ===
   private initWebData(): Signal<WebActivitiesSummaryResponse | null> {
@@ -51,6 +71,7 @@ export class WebActivityTabComponent {
             return of(null);
           }
           this.loading.set(true);
+          this.expandedDomains.set(new Set());
           const classification = FOCUS_TO_CLASSIFICATION[focus];
           return this.analyticsService.getWebActivitiesSummary(slug, classification, period || undefined).pipe(
             catchError(() => of(null)),
@@ -126,6 +147,18 @@ export class WebActivityTabComponent {
         .sort((a, b) => b.totalSessions - a.totalSessions)
         .map((d): WebActivityDomainRow => {
           const share = totalSessions > 0 ? (d.totalSessions / totalSessions) * 100 : 0;
+          const domainDetails: WebActivityDomainDetailRow[] = (d.domains ?? []).map((detail) => {
+            const detailShare = totalSessions > 0 ? (detail.sessions / totalSessions) * 100 : 0;
+            return {
+              host: detail.host,
+              sessions: formatNumber(detail.sessions),
+              pageViews: formatNumber(detail.pageViews),
+              newUsers: formatNumber(detail.newUsers),
+              returningUsers: formatNumber(detail.returningUsers),
+              sessionShare: detailShare,
+              sessionShareFormatted: `${Math.round(detailShare)}%`,
+            };
+          });
           return {
             domain: d.domainGroup,
             sessions: formatNumber(d.totalSessions),
@@ -133,6 +166,7 @@ export class WebActivityTabComponent {
             pagesPerSession: d.totalSessions > 0 ? (d.totalPageViews / d.totalSessions).toFixed(1) : '0.0',
             sessionShare: share,
             sessionShareFormatted: `${Math.round(share)}%`,
+            domains: domainDetails,
           };
         });
     });

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/web-activity-tab/web-activity-tab.component.ts
@@ -148,7 +148,7 @@ export class WebActivityTabComponent {
         .map((d): WebActivityDomainRow => {
           const share = totalSessions > 0 ? (d.totalSessions / totalSessions) * 100 : 0;
           const domainDetails: WebActivityDomainDetailRow[] = (d.domains ?? []).map((detail) => {
-            const detailShare = totalSessions > 0 ? (detail.sessions / totalSessions) * 100 : 0;
+            const detailShare = d.totalSessions > 0 ? (detail.sessions / d.totalSessions) * 100 : 0;
             return {
               host: detail.host,
               sessions: formatNumber(detail.sessions),

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -113,6 +113,7 @@ import {
   UniqueContributorsWeeklyRow,
   UploadProjectDocumentRequest,
   WebActivitiesSummaryResponse,
+  WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
 import type { PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
@@ -2014,7 +2015,23 @@ export class ProjectService {
         ORDER BY ACTIVITY_DATE ASC
       `;
 
-      const [summaryResult, dailyResult] = await Promise.all([
+      // Query 3: Per-domain detail within each classification group
+      const domainDetailQuery = `
+        SELECT
+          LF_SUB_DOMAIN_CLASSIFICATION,
+          FIRST_PAGE_URL_HOST,
+          TOTAL_SESSIONS_LAST_30_DAYS AS SESSIONS,
+          TOTAL_PAGE_VIEWS_LAST_30_DAYS AS PAGE_VIEWS,
+          TOTAL_NEW_USERS_LAST_30_DAYS AS NEW_USERS,
+          TOTAL_RETURNING_USERS_LAST_30_DAYS AS RETURNING_USERS
+        FROM ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_DOMAIN
+        WHERE 1=1
+          ${foundationFilter}
+          ${classificationFilter}
+        ORDER BY LF_SUB_DOMAIN_CLASSIFICATION, SESSIONS DESC
+      `;
+
+      const [summaryResult, dailyResult, domainDetailResult] = await Promise.all([
         this.snowflakeService.execute<{ LF_SUB_DOMAIN_CLASSIFICATION: string; TOTAL_SESSIONS: number; TOTAL_PAGE_VIEWS: number }>(summaryQuery, [
           ...foundationParams,
           ...classificationParams,
@@ -2024,12 +2041,35 @@ export class ProjectService {
           resolved.endDate,
           ...foundationParams,
         ]),
+        this.snowflakeService.execute<{
+          LF_SUB_DOMAIN_CLASSIFICATION: string;
+          FIRST_PAGE_URL_HOST: string;
+          SESSIONS: number;
+          PAGE_VIEWS: number;
+          NEW_USERS: number;
+          RETURNING_USERS: number;
+        }>(domainDetailQuery, [...foundationParams, ...classificationParams]),
       ]);
+
+      const domainsByGroup = new Map<string, WebActivityDomainDetail[]>();
+      for (const row of domainDetailResult.rows) {
+        const group = row.LF_SUB_DOMAIN_CLASSIFICATION || 'Other';
+        const details = domainsByGroup.get(group) ?? [];
+        details.push({
+          host: row.FIRST_PAGE_URL_HOST,
+          sessions: row.SESSIONS ?? 0,
+          pageViews: row.PAGE_VIEWS ?? 0,
+          newUsers: row.NEW_USERS ?? 0,
+          returningUsers: row.RETURNING_USERS ?? 0,
+        });
+        domainsByGroup.set(group, details);
+      }
 
       const domainGroups = summaryResult.rows.map((row) => ({
         domainGroup: row.LF_SUB_DOMAIN_CLASSIFICATION || 'Other',
         totalSessions: row.TOTAL_SESSIONS ?? 0,
         totalPageViews: row.TOTAL_PAGE_VIEWS ?? 0,
+        domains: domainsByGroup.get(row.LF_SUB_DOMAIN_CLASSIFICATION || 'Other') ?? [],
       }));
 
       const totalSessions = domainGroups.reduce((sum, g) => sum + g.totalSessions, 0);

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2539,12 +2539,24 @@ export interface WebActivitiesSummaryRow {
 }
 
 /**
+ * Individual domain within a classification group (from WEB_ACTIVITIES_BY_DOMAIN)
+ */
+export interface WebActivityDomainDetail {
+  host: string;
+  sessions: number;
+  pageViews: number;
+  newUsers: number;
+  returningUsers: number;
+}
+
+/**
  * Domain group breakdown in the API response
  */
 export interface WebActivitiesDomainGroup {
   domainGroup: string;
   totalSessions: number;
   totalPageViews: number;
+  domains: WebActivityDomainDetail[];
 }
 
 /**

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -145,6 +145,17 @@ export interface SentimentBar {
   negativeLabel: string;
 }
 
+/** View-model row for an individual domain inside a classification group. */
+export interface WebActivityDomainDetailRow {
+  host: string;
+  sessions: string;
+  pageViews: string;
+  newUsers: string;
+  returningUsers: string;
+  sessionShare: number;
+  sessionShareFormatted: string;
+}
+
 /** View-model row for the web activity domain table. */
 export interface WebActivityDomainRow {
   domain: string;
@@ -153,6 +164,7 @@ export interface WebActivityDomainRow {
   pagesPerSession: string;
   sessionShare: number;
   sessionShareFormatted: string;
+  domains: WebActivityDomainDetailRow[];
 }
 
 /** View-model row for the platform performance table. */


### PR DESCRIPTION
## Summary

- Query `PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_DOMAIN` for per-host metrics (sessions, page views, new/returning users) within each classification group
- Add expand/collapse chevrons to domain group rows using the `signal<Set<string>>` pattern from performance-marketing-tab
- Nested child rows show individual domains with session share bars

## Changes

### Shared (`packages/shared/`)
- `analytics-data.interface.ts`: Added `WebActivityDomainDetail` interface and `domains` array to `WebActivitiesDomainGroup`
- `marketing-impact.interface.ts`: Added `WebActivityDomainDetailRow` view-model and `domains` array to `WebActivityDomainRow`

### Backend (`apps/lfx-one/src/server/`)
- `project.service.ts`: Added Query 3 to `getWebActivitiesSummary()` — fetches from `WEB_ACTIVITIES_BY_DOMAIN`, groups by classification, attaches to each domain group

### Frontend (`apps/lfx-one/src/app/modules/dashboards/marketing-impact/`)
- `web-activity-tab.component.ts`: Added `expandedDomains` signal, `toggleDomainExpand()` method, domain detail row mapping, reset on data reload
- `web-activity-tab.component.html`: Expand/collapse chevrons on parent rows, nested child domain rows with host, sessions, page views, new/returning users, session share bar

## Data Source

`ANALYTICS.PLATINUM_LFX_ONE.WEB_ACTIVITIES_BY_DOMAIN` — 74 rows, rolling 30-day snapshot, grouped by `LF_SUB_DOMAIN_CLASSIFICATION` + `FIRST_PAGE_URL_HOST`. Has `FOUNDATION_SLUG` for foundation-level filtering.

LFXV2-1973