### PR TITLE
fix(crowdfunding): fix activate initiative and archived initiatives not loading

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
@@ -105,3 +105,5 @@
     }
   </div>
 </lfx-card>
+
+<p-confirmDialog key="initiative-status" />

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -49,7 +49,7 @@ export class InitiativeDetailHeaderComponent {
         {
           label: 'Activate Initiative',
           icon: 'fa-solid fa-circle-check',
-          description: 'Make this initiative publicly visible and accept donations again.',
+          description: 'Re-submit this initiative for review. Once approved, it will be publicly visible and accept donations again.',
           command: () => this.confirmActivate(),
         },
       ];

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output, viewChild } from '@angular/core';
+import { Component, computed, inject, input, output, viewChild } from '@angular/core';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -16,14 +16,18 @@ import {
 } from '@lfx-one/shared/constants';
 import { CrowdfundingInitiativeStatus, InitiativeDetail, InitiativeMenuItem, TabOption } from '@lfx-one/shared/interfaces';
 import { environment } from '@environments/environment';
+import { ConfirmationService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 
 @Component({
   selector: 'lfx-initiative-detail-header',
-  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent, MarkdownRendererComponent],
+  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent, MarkdownRendererComponent, ConfirmDialogModule],
   templateUrl: './initiative-detail-header.component.html',
   styleUrl: './initiative-detail-header.component.scss',
 })
 export class InitiativeDetailHeaderComponent {
+  private readonly confirmationService = inject(ConfirmationService);
+
   public readonly initiative = input.required<InitiativeDetail>();
   public readonly activeTab = input.required<string>();
   public readonly tabChange = output<string>();
@@ -46,7 +50,7 @@ export class InitiativeDetailHeaderComponent {
           label: 'Activate Initiative',
           icon: 'fa-solid fa-circle-check',
           description: 'Make this initiative publicly visible and accept donations again.',
-          command: () => this.statusChange.emit('published'),
+          command: () => this.confirmActivate(),
         },
       ];
     }
@@ -55,7 +59,7 @@ export class InitiativeDetailHeaderComponent {
         label: 'Archive Initiative',
         icon: 'fa-solid fa-box-archive',
         description: 'Hide this initiative from public view. No new donations will be accepted while archived.',
-        command: () => this.statusChange.emit('hidden'),
+        command: () => this.confirmArchive(),
       },
     ];
   });
@@ -74,5 +78,31 @@ export class InitiativeDetailHeaderComponent {
 
   protected onMoreClick(event: Event): void {
     this.moreMenu()?.toggle(event);
+  }
+
+  private confirmActivate(): void {
+    this.confirmationService.confirm({
+      key: 'initiative-status',
+      header: 'Activate Initiative',
+      message: 'Are you sure you want to re-submit this initiative for review? Once approved, it will be publicly visible and accept donations again.',
+      acceptLabel: 'Activate',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-sm',
+      rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
+      accept: () => this.statusChange.emit('submitted'),
+    });
+  }
+
+  private confirmArchive(): void {
+    this.confirmationService.confirm({
+      key: 'initiative-status',
+      header: 'Archive Initiative',
+      message: 'Are you sure you want to archive this initiative? It will be hidden from public view and no new donations will be accepted while archived.',
+      acceptLabel: 'Archive',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
+      accept: () => this.statusChange.emit('hidden'),
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **Activate Initiative 403:** When an initiative is archived (`hidden`), clicking "Activate Initiative" was attempting to set `status: published` directly via `PATCH /v1/me/initiatives/{id}`. The CF API explicitly forbids this — `published` is exclusively managed by the approver workflow. As a workaround, the action now sets `status: submitted`, re-entering the initiative into the review queue for an approver to publish.
- **Confirmation dialogs:** Both "Activate Initiative" and "Archive Initiative" now show a `ConfirmationService` dialog before applying the status change.
- **Archived initiatives not visible:** The CF API's `GET /v1/me/initiatives` endpoint previously defaulted to `status=published` when no filter was passed, so the Archived and Pending tabs always showed empty. The fix (removing the default) depends on the upstream CF API change below.

## Notes

> ⚠️ **The archived initiatives fix requires [linuxfoundation/lfx-crowdfunding#183](https://github.com/linuxfoundation/lfx-crowdfunding/pull/183) to be merged and deployed first.** That PR changes the CF API so that omitting `?status=` returns all statuses instead of defaulting to `published`. No changes are needed in this repo once that PR is deployed — the LFX backend already calls the endpoint without a status filter.

> ⚠️ **The "Activate Initiative" flow is a workaround.** The CF API enforces that only approvers can set an initiative to `published` — initiative owners cannot do so directly. Setting `status: submitted` re-submits the initiative for review; an approver must then approve it before it becomes publicly visible again. A follow-up ticket should be filed if the requirement is truly to allow owners to publish directly, as that would require a CF API change.