### PR TITLE
fix(crowdfunding): append ?fundraise=true when redirecting to new initiative

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -43,7 +43,7 @@ export class MyDonationsComponent {
   private readonly messageService = inject(MessageService);
 
   // ─── Public Fields ────────────────────────────────────────────────────────
-  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly crowdfundingUrl = `${environment.urls.crowdfunding}initiatives`;
 
   // ─── Simple WritableSignals ───────────────────────────────────────────────
   // TODO: derive from API response once cancelled-recurring concept is implemented

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -26,7 +26,7 @@ export class MyInitiativesComponent {
   private readonly crowdfundingService = inject(CrowdfundingService);
 
   // ─── Public Fields ─────────────────────────────────────────────────────────
-  protected readonly crowdfundingUrl = environment.urls.crowdfunding;
+  protected readonly crowdfundingUrl = `${environment.urls.crowdfunding}?fundraise=true`;
 
   // ─── Simple WritableSignals ───────────────────────────────────────────────
   protected readonly loadingMore = signal(false);


### PR DESCRIPTION
## Summary

- Appends `?fundraise=true` to the Crowdfunding URL when the user clicks "New Initiative" in Self Serve
- The Crowdfunding side (https://github.com/linuxfoundation/lfx-crowdfunding/pull/185) intercepts this param and auto-opens the Start Fundraise drawer, then removes the param from the URL
- Fixes the "Explore Initiatives" button in My Donations redirecting to the main Crowdfunding page instead of `/initiatives` (LFXV2-2264)

## Notes

Fixes LFXV2-2262, LFXV2-2264. Depends on https://github.com/linuxfoundation/lfx-crowdfunding/pull/185 being merged and deployed first.