### PR TITLE
fix(crowdfunding): strip HTML tags from initiative description in card list

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.html
@@ -48,7 +48,7 @@
         }
       }
     </div>
-    <p class="text-xs text-gray-500 truncate">{{ initiative().description }}</p>
+    <p class="text-xs text-gray-500 truncate">{{ description() }}</p>
   </div>
 
   <!-- Metrics -->

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiative-card/initiative-card.component.ts
@@ -10,7 +10,7 @@ import {
   CROWDFUNDING_FUND_TYPE_LABELS,
 } from '@lfx-one/shared/constants';
 import { InitiativeBase } from '@lfx-one/shared/interfaces';
-import { formatCurrency } from '@lfx-one/shared/utils';
+import { formatCurrency, stripHtml } from '@lfx-one/shared/utils';
 import { environment } from '@environments/environment';
 
 @Component({
@@ -30,6 +30,7 @@ export class InitiativeCardComponent {
 
   protected readonly progressPercent = this.initProgressPercent();
 
+  protected readonly description = computed(() => stripHtml(this.initiative().description));
   protected readonly isClickable = computed(() => this.initiative().status !== 'declined');
   protected readonly publicPageUrl = computed(() => `${environment.urls.crowdfunding.replace(/\/+$/, '')}/initiatives/${this.initiative().slug}`);
 


### PR DESCRIPTION
## Summary

- Initiative descriptions in the My Initiatives card list were rendering raw HTML tags as visible text
- Added a `description` computed signal in `InitiativeCardComponent` that pipes the raw value through the existing `stripHtml` utility from `@lfx-one/shared/utils`