### PR TITLE
feat(crowdfunding): show canceled subscriptions in my donations

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -53,7 +53,7 @@
           </p>
           @if (entry.donation.status === 'active' && entry.donation.nextChargeDate) {
             <p class="text-xs text-gray-400">Next charge: {{ entry.donation.nextChargeDate | date: 'MMM d, y' : 'UTC' }}</p>
-          } @else if (entry.donation.status !== 'active' && entry.donation.pausedSince) {
+          } @else if (entry.donation.status === 'paused' && entry.donation.pausedSince) {
             <p class="text-xs text-gray-400">Paused since {{ entry.donation.pausedSince | date: 'MMM d, y' : 'UTC' }}</p>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -66,7 +66,7 @@
               severity="secondary"
               size="small"
               [attr.aria-label]="'More options for ' + entry.donation.name"
-              (click)="onMenuToggle($event, i)" />
+              (click)="onMenuToggle($event, menuIndexFor(i))" />
             <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
               <ng-template #item let-item>
                 <div

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.html
@@ -5,22 +5,13 @@
   <!-- Section header -->
   <div class="flex items-center justify-between" data-testid="recurring-donations-header">
     <h2 class="text-sm font-bold text-gray-900">Recurring Donations</h2>
-    @if (cancelledCount() > 0) {
-      <button
-        type="button"
-        class="text-xs font-medium text-gray-400 underline underline-offset-2 hover:text-gray-600 transition-colors"
-        (click)="viewCancelled.emit()"
-        data-testid="view-cancelled-btn">
-        Cancelled recurring donations ({{ cancelledCount() }})
-      </button>
-    }
   </div>
 
   <!-- Cards -->
-  <div class="flex flex-col gap-2" data-testid="recurring-cards">
+  <div class="flex flex-col border border-gray-200 rounded-lg" data-testid="recurring-cards">
     @for (entry of donationsWithMenuItems(); track entry.donation.id; let i = $index) {
       <div
-        class="flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-lg cursor-pointer hover:border-gray-300 hover:bg-gray-50 transition-colors"
+        class="recurring-card"
         [attr.data-testid]="'recurring-card-' + entry.donation.id"
         (click)="viewDetail.emit(entry.donation)"
         role="button"
@@ -43,10 +34,13 @@
             <span class="text-sm font-semibold text-gray-900">{{ entry.donation.name }}</span>
             @if (entry.donation.status === 'active') {
               <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700"> Active </span>
+            } @else if (entry.donation.status === 'canceled') {
+              <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-red-50 text-red-600"> Canceled </span>
             } @else {
               <span class="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500"> Paused </span>
             }
           </div>
+
           <p class="text-xs text-gray-400">
             Started {{ entry.donation.startDate | date: 'MMM d, y' : 'UTC' }} &middot; {{ entry.donation.billingDescription }}
           </p>
@@ -64,26 +58,28 @@
           }
         </div>
 
-        <!-- Ellipsis menu -->
-        <div class="flex-shrink-0" (click)="$event.stopPropagation()">
-          <lfx-button
-            icon="fa-solid fa-ellipsis"
-            severity="secondary"
-            size="small"
-            [attr.aria-label]="'More options for ' + entry.donation.name"
-            (click)="onMenuToggle($event, i)" />
-          <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
-            <ng-template #item let-item>
-              <div
-                class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
-                [class.text-red-600]="item.styleClass === 'text-red-600'"
-                [class.text-gray-700]="item.styleClass !== 'text-red-600'">
-                <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
-                {{ item.label }}
-              </div>
-            </ng-template>
-          </lfx-menu>
-        </div>
+        <!-- Ellipsis menu (hidden for canceled subscriptions) -->
+        @if (entry.menuItems.length > 0) {
+          <div class="flex-shrink-0" (click)="$event.stopPropagation()">
+            <lfx-button
+              icon="fa-solid fa-ellipsis"
+              severity="secondary"
+              size="small"
+              [attr.aria-label]="'More options for ' + entry.donation.name"
+              (click)="onMenuToggle($event, i)" />
+            <lfx-menu [model]="entry.menuItems" [popup]="true" appendTo="body">
+              <ng-template #item let-item>
+                <div
+                  class="flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors hover:bg-gray-50"
+                  [class.text-red-600]="item.styleClass === 'text-red-600'"
+                  [class.text-gray-700]="item.styleClass !== 'text-red-600'">
+                  <i [class]="item.icon + ' text-xs'" aria-hidden="true"></i>
+                  {{ item.label }}
+                </div>
+              </ng-template>
+            </lfx-menu>
+          </div>
+        }
       </div>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.scss
@@ -1,2 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
+
+.recurring-card {
+  @apply flex items-center gap-3 p-4 bg-white border-b border-gray-200 cursor-pointer hover:border-gray-300 hover:bg-gray-50 transition-colors;
+
+  &:first-child {
+    @apply rounded-t-lg;
+  }
+  &:last-child {
+    @apply border-b-0 rounded-b-lg;
+  }
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -35,7 +35,9 @@ export class RecurringDonationsListComponent {
   }
 
   protected menuIndexFor(donationIndex: number): number {
-    return this.donationsWithMenuItems().slice(0, donationIndex).filter((e) => e.menuItems.length > 0).length;
+    return this.donationsWithMenuItems()
+      .slice(0, donationIndex)
+      .filter((e) => e.menuItems.length > 0).length;
   }
 
   private initDonationsWithMenuItems(): Signal<{ donation: RecurringDonation; menuItems: MenuItem[] }[]> {

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -16,10 +16,8 @@ import { MenuItem } from 'primeng/api';
 })
 export class RecurringDonationsListComponent {
   public readonly donations = input.required<RecurringDonation[]>();
-  public readonly cancelledCount = input<number>(0);
 
   public readonly viewDetail = output<RecurringDonation>();
-  public readonly viewCancelled = output<void>();
   public readonly cancelDonation = output<RecurringDonation>();
 
   private readonly menus = viewChildren<MenuComponent>(MenuComponent);
@@ -46,6 +44,7 @@ export class RecurringDonationsListComponent {
   }
 
   private buildMenuItems(donation: RecurringDonation): MenuItem[] {
+    if (donation.status === 'canceled') return [];
     return [{ label: 'Cancel', icon: 'fa-solid fa-xmark', styleClass: 'text-red-600', command: () => this.cancelDonation.emit(donation) }];
   }
 }

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/components/recurring-donations-list/recurring-donations-list.component.ts
@@ -34,6 +34,10 @@ export class RecurringDonationsListComponent {
     this.menus()[index]?.toggle(event);
   }
 
+  protected menuIndexFor(donationIndex: number): number {
+    return this.donationsWithMenuItems().slice(0, donationIndex).filter((e) => e.menuItems.length > 0).length;
+  }
+
   private initDonationsWithMenuItems(): Signal<{ donation: RecurringDonation; menuItems: MenuItem[] }[]> {
     return computed(() =>
       this.donations().map((donation) => ({

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -27,13 +27,11 @@
     <!-- Stats -->
     <lfx-stat-card-grid [cards]="statCards()" data-testid="donations-me-stats" />
 
-    <!-- Recurring donations (hidden only when there are no active and no cancelled subscriptions) -->
-    @if (recurringDonations().length > 0 || cancelledCount() > 0) {
+    <!-- Recurring donations -->
+    @if (recurringDonations().length > 0) {
       <lfx-recurring-donations-list
         [donations]="recurringDonations()"
-        [cancelledCount]="cancelledCount()"
         (viewDetail)="onViewRecurringDetail($event)"
-        (viewCancelled)="onViewCancelled()"
         (cancelDonation)="onCancelDonation($event)" />
     }
 

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -46,8 +46,6 @@ export class MyDonationsComponent {
   protected readonly crowdfundingUrl = `${environment.urls.crowdfunding}initiatives`;
 
   // ─── Simple WritableSignals ───────────────────────────────────────────────
-  // TODO: derive from API response once cancelled-recurring concept is implemented
-  protected readonly cancelledCount = signal(0);
   protected readonly loadingMore = signal(false);
 
   // ─── Pagination Drivers ───────────────────────────────────────────────────
@@ -58,7 +56,7 @@ export class MyDonationsComponent {
   // ─── Complex Signals ──────────────────────────────────────────────────────
   protected readonly stats: Signal<DonationStats> = this.initStats();
   protected readonly statCards: Signal<StatCardItem[]> = this.initStatCards();
-  protected readonly recurringDonations: Signal<RecurringDonation[]> = this.initRecurringDonations();
+  protected readonly recurringDonations: Signal<RecurringDonation[]> = this.initAllRecurringDonations();
   private readonly paymentMethod: Signal<PaymentMethod | null> = this.initPaymentMethod();
   protected readonly paymentMethods = computed(() => (this.paymentMethod() ? [this.paymentMethod()!] : []));
   private readonly donationHistoryState: Signal<MyDonationsResponse> = this.initDonationHistory();
@@ -74,10 +72,6 @@ export class MyDonationsComponent {
 
   protected onViewRecurringDetail(donation: RecurringDonation): void {
     void this.router.navigate(['/crowdfunding/donations/recurring', donation.id]);
-  }
-
-  protected onViewCancelled(): void {
-    // TODO: navigate to cancelled donations view
   }
 
   protected onCancelDonation(donation: RecurringDonation): void {
@@ -160,7 +154,7 @@ export class MyDonationsComponent {
     });
   }
 
-  private initRecurringDonations(): Signal<RecurringDonation[]> {
+  private initAllRecurringDonations(): Signal<RecurringDonation[]> {
     return toSignal(
       this.recurringRefresh$.pipe(
         switchMap(() => this.crowdfundingService.getMyRecurringDonations()),

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -8,7 +8,7 @@ import { environment } from '@environments/environment';
 import { ButtonComponent } from '@components/button/button.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { MyDonationsResponse, DonationStats, PaymentMethod, RecurringDonation, RecurringDonationsResponse, StatCardItem } from '@lfx-one/shared/interfaces';
-import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_DONATION_STATS, EMPTY_MY_DONATIONS } from '@lfx-one/shared/constants';
+import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_DONATION_STATS, EMPTY_MY_DONATIONS, EMPTY_RECURRING_DONATION_LIST } from '@lfx-one/shared/constants';
 import { formatCurrency } from '@lfx-one/shared/utils';
 import { CrowdfundingService } from '@app/shared/services/crowdfunding.service';
 import { DonationHistoryTableComponent } from './components/donation-history-table/donation-history-table.component';
@@ -18,8 +18,6 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { BehaviorSubject } from 'rxjs';
 import { map, scan, switchMap, tap } from 'rxjs/operators';
-
-const EMPTY_RECURRING: RecurringDonation[] = [];
 
 @Component({
   selector: 'lfx-my-donations',
@@ -160,7 +158,7 @@ export class MyDonationsComponent {
         switchMap(() => this.crowdfundingService.getMyRecurringDonations()),
         map((res: RecurringDonationsResponse) => res.data)
       ),
-      { initialValue: EMPTY_RECURRING }
+      { initialValue: EMPTY_RECURRING_DONATION_LIST }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/components/recurring-donation-subscription-summary/recurring-donation-subscription-summary.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/components/recurring-donation-subscription-summary/recurring-donation-subscription-summary.component.html
@@ -14,6 +14,10 @@
         <span class="inline-flex items-center text-xs font-semibold px-2.5 py-1 rounded-full bg-emerald-50 text-emerald-700" data-testid="status-badge-active">
           Active
         </span>
+      } @else if (donation().status === 'canceled') {
+        <span class="inline-flex items-center text-xs font-semibold px-2.5 py-1 rounded-full bg-red-50 text-red-600" data-testid="status-badge-canceled">
+          Canceled
+        </span>
       } @else {
         <span class="inline-flex items-center text-xs font-semibold px-2.5 py-1 rounded-full bg-gray-100 text-gray-500" data-testid="status-badge-paused">
           Paused
@@ -21,17 +25,19 @@
       }
     </div>
 
-    <!-- Action buttons -->
-    <div class="flex items-center gap-2 flex-shrink-0" data-testid="action-buttons">
-      <lfx-button
-        label="Cancel"
-        icon="fa-solid fa-circle-xmark"
-        severity="danger"
-        size="small"
-        [outlined]="true"
-        data-testid="cancel-btn"
-        (click)="cancelDonation.emit()" />
-    </div>
+    <!-- Action buttons (hidden for canceled subscriptions) -->
+    @if (donation().status !== 'canceled') {
+      <div class="flex items-center gap-2 flex-shrink-0" data-testid="action-buttons">
+        <lfx-button
+          label="Cancel"
+          icon="fa-solid fa-circle-xmark"
+          severity="danger"
+          size="small"
+          [outlined]="true"
+          data-testid="cancel-btn"
+          (click)="cancelDonation.emit()" />
+      </div>
+    }
   </div>
 
   <!-- Billing note -->
@@ -51,6 +57,11 @@
       <div class="flex flex-col gap-0.5" data-testid="next-charge">
         <span class="text-xs font-medium text-gray-400 uppercase tracking-wide">Next Charge</span>
         <span class="text-sm font-semibold text-gray-800">{{ (donation().nextChargeDate | date: 'MMM d, y' : 'UTC') ?? '—' }}</span>
+      </div>
+    } @else if (donation().status === 'canceled') {
+      <div class="flex flex-col gap-0.5" data-testid="canceled-status">
+        <span class="text-xs font-medium text-gray-400 uppercase tracking-wide">Status</span>
+        <span class="text-sm font-semibold text-red-600">Canceled</span>
       </div>
     } @else {
       <div class="flex flex-col gap-0.5" data-testid="paused-since">

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -261,11 +261,9 @@ export class CrowdfundingService {
 
     const all = await cfFetchAllPages<BackendSubscription>(req, 'getMyRecurringDonations', '/v1/me/subscriptions');
 
-    // Exclude canceled subscriptions — the CF backend returns all statuses by default.
-    // Only active, incomplete, and past_due subscriptions represent active recurring commitments.
-    const active = all.filter((s) => s.status !== 'canceled');
-    logger.success(req, 'cf_get_my_recurring_donations', startTime, { total: all.length, active: active.length });
-    return { data: active.map(mapSubscriptionToRecurringDonation), total: active.length, pageSize: active.length, offset: 0 };
+    const canceled = all.filter((s) => s.status === 'canceled').length;
+    logger.success(req, 'cf_get_my_recurring_donations', startTime, { total: all.length, canceled });
+    return { data: all.map(mapSubscriptionToRecurringDonation), total: all.length, pageSize: all.length, offset: 0 };
   }
 
   public async getMyDonations(req: Request, pageSize?: number, offset?: number): Promise<MyDonationsResponse> {
@@ -287,8 +285,8 @@ export class CrowdfundingService {
     const startTime = logger.startOperation(req, 'cf_get_recurring_donation_by_id', { subscriptionId });
 
     const raw = await cfFetchNullable<BackendSubscription>(req, 'getRecurringDonationById', `/v1/me/subscriptions/${encodeURIComponent(subscriptionId)}`);
-    if (!raw || raw.status === 'canceled') {
-      logger.warning(req, 'cf_get_recurring_donation_by_id', 'Subscription not found', { subscriptionId, status: raw?.status });
+    if (!raw) {
+      logger.warning(req, 'cf_get_recurring_donation_by_id', 'Subscription not found', { subscriptionId });
       return null;
     }
 

--- a/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
+++ b/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
@@ -166,7 +166,7 @@ export function mapCfDonationToMyDonation(d: BackendDonation): MyDonation {
   };
 }
 
-const VALID_RECURRING_STATUSES: RecurringDonationStatus[] = ['active', 'paused'];
+const VALID_RECURRING_STATUSES: RecurringDonationStatus[] = ['active', 'paused', 'canceled'];
 
 function toValidRecurringStatus(value: unknown): RecurringDonationStatus {
   return VALID_RECURRING_STATUSES.includes(value as RecurringDonationStatus) ? (value as RecurringDonationStatus) : 'active';

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -10,6 +10,7 @@ import {
   FundDistributionItem,
   InitiativesResponse,
   MyDonationsResponse,
+  RecurringDonation,
   RecurringDonationsResponse,
   TopicOption,
 } from '../interfaces/crowdfunding.interface';
@@ -92,6 +93,7 @@ export const EMPTY_RECURRING_DONATIONS: RecurringDonationsResponse = {
   pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE,
   offset: 0,
 };
+export const EMPTY_RECURRING_DONATION_LIST: RecurringDonation[] = [];
 export const EMPTY_DONATION_STATS: DonationStats = {
   totalDonated: 0,
   initiativesSupported: 0,

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -230,7 +230,7 @@ export interface DonationStats {
   activeRecurringCount: number;
 }
 
-export type RecurringDonationStatus = 'active' | 'paused';
+export type RecurringDonationStatus = 'active' | 'paused' | 'canceled';
 export type DonationKind = 'one-time' | 'monthly';
 
 export interface RecurringDonation {


### PR DESCRIPTION
## Summary

- Canceled Stripe subscriptions are now returned by the server alongside active and paused ones
- Canceled subscriptions appear inline in the Recurring Donations list with a red "Canceled" badge and no ellipsis menu (no re-subscribe option)
- The subscription detail page shows a "Canceled" badge, hides the cancel button, and displays "Status: Canceled" in the meta grid

## Notes

- `RecurringDonationStatus` in the shared package now includes `'canceled'`
- Server `getMyRecurringDonations()` no longer filters out canceled subscriptions; `getRecurringDonationById()` now returns them instead of treating them as not found
- Donation stats (`getMyDonationStats`) are unchanged — still counts only active subscriptions