### PR TITLE
fix(crowdfunding): default to first non-empty tab when no active initiatives

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/components/initiatives-list/initiatives-list.component.ts
@@ -22,7 +22,16 @@ export class InitiativesListComponent {
   public readonly initiativeClick = output<string>();
   public readonly loadMore = output<void>();
 
-  protected readonly activeFilter = signal<'active' | 'pending' | 'archived'>('active');
+  private readonly userFilter = signal<'active' | 'pending' | 'archived' | null>(null);
+
+  protected readonly activeFilter = computed<'active' | 'pending' | 'archived'>(() => {
+    const pick = this.userFilter();
+    if (pick !== null) return pick;
+    const counts = this.statusCounts();
+    if (counts.active === 0 && counts.pending > 0) return 'pending';
+    if (counts.active === 0 && counts.pending === 0 && counts.archived > 0) return 'archived';
+    return 'active';
+  });
 
   protected readonly statusCounts = this.initStatusCounts();
   protected readonly filterOptions = this.initFilterOptions();
@@ -58,7 +67,7 @@ export class InitiativesListComponent {
 
   protected setFilter(value: string): void {
     if (value === 'active' || value === 'pending' || value === 'archived') {
-      this.activeFilter.set(value);
+      this.userFilter.set(value);
     }
   }
 


### PR DESCRIPTION
## Summary

- When the My Initiatives page loads with no active (published) initiatives, the filter now defaults to the first non-empty tab (Pending, then Archived) instead of always showing the empty Active tab
- Manual tab selection by the user always takes precedence over the computed default

Closes LFXV2-2366