### PR TITLE
feat(crowdfunding): loading state and silent CF token refresh

### DIFF
--- a/apps/lfx-one/public/assets/docs/search-index.json
+++ b/apps/lfx-one/public/assets/docs/search-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-17T11:30:12.302Z",
+  "generatedAt": "2026-06-16T04:48:15.796Z",
   "miniSearch": {
     "documentCount": 45,
     "nextId": 45,

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.html
@@ -12,7 +12,9 @@
     styleClass="self-start"
     data-testid="initiative-detail-back-btn" />
 
-  @if (initiative(); as detail) {
+  @if (isLoading()) {
+    <lfx-route-loading data-testid="initiative-detail-loading" />
+  } @else if (initiative(); as detail) {
     <lfx-initiative-detail-header
       [initiative]="detail"
       [activeTab]="activeTab()"

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -66,6 +66,7 @@ export class InitiativeDetailComponent {
     return toSignal(
       toObservable(this.initiativeSlug).pipe(
         filter((slug) => !!slug),
+        tap(() => this.isLoading.set(true)),
         switchMap((slug) => this.crowdfundingService.getInitiativeBySlug(slug).pipe(tap(() => this.isLoading.set(false))))
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/initiative-detail.component.ts
@@ -4,8 +4,9 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal, WritableSignal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { filter, firstValueFrom, map, switchMap } from 'rxjs';
+import { filter, firstValueFrom, map, switchMap, tap } from 'rxjs';
 import { ButtonComponent } from '@components/button/button.component';
+import { RouteLoadingComponent } from '@components/loading/route-loading.component';
 import { CrowdfundingInitiativeStatus, InitiativeDetail } from '@lfx-one/shared/interfaces';
 import { CrowdfundingService } from '@services/crowdfunding.service';
 import { InitiativeDetailHeaderComponent } from './components/initiative-detail-header/initiative-detail-header.component';
@@ -15,7 +16,14 @@ import { InitiativeSettingsDrawerComponent } from './components/initiative-setti
 
 @Component({
   selector: 'lfx-initiative-detail',
-  imports: [ButtonComponent, InitiativeDetailHeaderComponent, InitiativeOverviewComponent, InitiativeFinancialsComponent, InitiativeSettingsDrawerComponent],
+  imports: [
+    ButtonComponent,
+    RouteLoadingComponent,
+    InitiativeDetailHeaderComponent,
+    InitiativeOverviewComponent,
+    InitiativeFinancialsComponent,
+    InitiativeSettingsDrawerComponent,
+  ],
   templateUrl: './initiative-detail.component.html',
   styleUrl: './initiative-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -26,6 +34,7 @@ export class InitiativeDetailComponent {
   private readonly crowdfundingService = inject(CrowdfundingService);
 
   // ─── WritableSignals ───────────────────────────────────────────────────────
+  protected readonly isLoading = signal(true);
   protected readonly activeTab = signal<string>('overview');
   protected readonly settingsDrawerVisible = signal(false);
 
@@ -57,7 +66,7 @@ export class InitiativeDetailComponent {
     return toSignal(
       toObservable(this.initiativeSlug).pipe(
         filter((slug) => !!slug),
-        switchMap((slug) => this.crowdfundingService.getInitiativeBySlug(slug))
+        switchMap((slug) => this.crowdfundingService.getInitiativeBySlug(slug).pipe(tap(() => this.isLoading.set(false))))
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -1,54 +1,58 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-donations">
-  <div class="flex flex-col gap-6">
-    <!-- Page header -->
-    <div class="flex items-start justify-between mt-3" data-testid="my-donations-header">
-      <div>
-        <h1 class="font-display font-light text-2xl" data-testid="my-donations-title">My Donations</h1>
-        <p class="mt-1 text-sm text-gray-500" data-testid="my-donations-description">Your giving history across LFX Crowdfunding initiatives</p>
+@if (isLoading()) {
+  <lfx-route-loading data-testid="my-donations-loading" />
+} @else {
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-donations">
+    <div class="flex flex-col gap-6">
+      <!-- Page header -->
+      <div class="flex items-start justify-between mt-3" data-testid="my-donations-header">
+        <div>
+          <h1 class="font-display font-light text-2xl" data-testid="my-donations-title">My Donations</h1>
+          <p class="mt-1 text-sm text-gray-500" data-testid="my-donations-description">Your giving history across LFX Crowdfunding initiatives</p>
+        </div>
+        <div class="flex items-center gap-6">
+          <lfx-button
+            label="Explore Initiatives"
+            icon="fa-light fa-arrow-up-right-from-square"
+            iconPos="right"
+            severity="secondary"
+            [outlined]="true"
+            size="small"
+            [href]="crowdfundingUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="explore-initiatives-btn" />
+        </div>
       </div>
-      <div class="flex items-center gap-6">
-        <lfx-button
-          label="Explore Initiatives"
-          icon="fa-light fa-arrow-up-right-from-square"
-          iconPos="right"
-          severity="secondary"
-          [outlined]="true"
-          size="small"
-          [href]="crowdfundingUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="explore-initiatives-btn" />
+
+      <!-- Stats -->
+      <lfx-stat-card-grid [cards]="statCards()" data-testid="donations-me-stats" />
+
+      <!-- Recurring donations (hidden only when there are no active and no cancelled subscriptions) -->
+      @if (recurringDonations().length > 0 || cancelledCount() > 0) {
+        <lfx-recurring-donations-list
+          [donations]="recurringDonations()"
+          (viewDetail)="onViewRecurringDetail($event)"
+          (cancelDonation)="onCancelDonation($event)" />
+      }
+
+      <!-- Donation history -->
+      <div class="flex flex-col gap-3" data-testid="donation-history-section">
+        <h2 class="text-sm font-bold text-gray-900">Donation History</h2>
+        <lfx-donation-history-table
+          [items]="donationHistory()"
+          [hasMore]="donationHistoryHasMore()"
+          [loadingMore]="loadingMore()"
+          [exploreUrl]="crowdfundingUrl"
+          (loadMore)="onLoadMoreDonations()" />
       </div>
+
+      <!-- Payment methods -->
+      <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" (cardAdded)="onCardAdded()" />
     </div>
-
-    <!-- Stats -->
-    <lfx-stat-card-grid [cards]="statCards()" data-testid="donations-me-stats" />
-
-    <!-- Recurring donations -->
-    @if (recurringDonations().length > 0) {
-      <lfx-recurring-donations-list
-        [donations]="recurringDonations()"
-        (viewDetail)="onViewRecurringDetail($event)"
-        (cancelDonation)="onCancelDonation($event)" />
-    }
-
-    <!-- Donation history -->
-    <div class="flex flex-col gap-3" data-testid="donation-history-section">
-      <h2 class="text-sm font-bold text-gray-900">Donation History</h2>
-      <lfx-donation-history-table
-        [items]="donationHistory()"
-        [hasMore]="donationHistoryHasMore()"
-        [loadingMore]="loadingMore()"
-        [exploreUrl]="crowdfundingUrl"
-        (loadMore)="onLoadMoreDonations()" />
-    </div>
-
-    <!-- Payment methods -->
-    <lfx-payment-methods [methods]="paymentMethods()" (removeCard)="onRemoveCard($event)" (cardAdded)="onCardAdded()" />
   </div>
-</div>
+}
 
 <p-confirmDialog />

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -18,7 +18,7 @@ import { RecurringDonationsListComponent } from './components/recurring-donation
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { BehaviorSubject } from 'rxjs';
-import { map, scan, switchMap, tap } from 'rxjs/operators';
+import { defaultIfEmpty, map, scan, switchMap, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'lfx-my-donations',
@@ -170,7 +170,7 @@ export class MyDonationsComponent {
   private initDonationHistory(): Signal<MyDonationsResponse> {
     return toSignal(
       toObservable(this.donationHistoryOffset).pipe(
-        switchMap((offset) => this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset })),
+        switchMap((offset) => this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(defaultIfEmpty(EMPTY_MY_DONATIONS))),
         scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_MY_DONATIONS),
         tap(() => {
           this.isLoading.set(false);

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -170,7 +170,9 @@ export class MyDonationsComponent {
   private initDonationHistory(): Signal<MyDonationsResponse> {
     return toSignal(
       toObservable(this.donationHistoryOffset).pipe(
-        switchMap((offset) => this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(defaultIfEmpty(EMPTY_MY_DONATIONS))),
+        switchMap((offset) =>
+          this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(defaultIfEmpty(EMPTY_MY_DONATIONS))
+        ),
         scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_MY_DONATIONS),
         tap(() => {
           this.isLoading.set(false);

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { ButtonComponent } from '@components/button/button.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+import { RouteLoadingComponent } from '@components/loading/route-loading.component';
 import { MyDonationsResponse, DonationStats, PaymentMethod, RecurringDonation, RecurringDonationsResponse, StatCardItem } from '@lfx-one/shared/interfaces';
 import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_DONATION_STATS, EMPTY_MY_DONATIONS, EMPTY_RECURRING_DONATION_LIST } from '@lfx-one/shared/constants';
 import { formatCurrency } from '@lfx-one/shared/utils';
@@ -24,6 +25,7 @@ import { map, scan, switchMap, tap } from 'rxjs/operators';
   imports: [
     ButtonComponent,
     StatCardGridComponent,
+    RouteLoadingComponent,
     RecurringDonationsListComponent,
     DonationHistoryTableComponent,
     PaymentMethodsComponent,
@@ -44,6 +46,9 @@ export class MyDonationsComponent {
   protected readonly crowdfundingUrl = `${environment.urls.crowdfunding}initiatives`;
 
   // ─── Simple WritableSignals ───────────────────────────────────────────────
+  // TODO: derive from API response once cancelled-recurring concept is implemented
+  protected readonly cancelledCount = signal(0);
+  protected readonly isLoading = signal(true);
   protected readonly loadingMore = signal(false);
 
   // ─── Pagination Drivers ───────────────────────────────────────────────────
@@ -167,7 +172,10 @@ export class MyDonationsComponent {
       toObservable(this.donationHistoryOffset).pipe(
         switchMap((offset) => this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset })),
         scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_MY_DONATIONS),
-        tap(() => this.loadingMore.set(false))
+        tap(() => {
+          this.isLoading.set(false);
+          this.loadingMore.set(false);
+        })
       ),
       { initialValue: EMPTY_MY_DONATIONS }
     );

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -18,7 +18,7 @@ import { RecurringDonationsListComponent } from './components/recurring-donation
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { BehaviorSubject } from 'rxjs';
-import { defaultIfEmpty, map, scan, switchMap, tap } from 'rxjs/operators';
+import { finalize, map, scan, switchMap, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'lfx-my-donations',
@@ -171,13 +171,10 @@ export class MyDonationsComponent {
     return toSignal(
       toObservable(this.donationHistoryOffset).pipe(
         switchMap((offset) =>
-          this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(defaultIfEmpty(EMPTY_MY_DONATIONS))
+          this.crowdfundingService.getMyDonations({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(finalize(() => this.loadingMore.set(false)))
         ),
         scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_MY_DONATIONS),
-        tap(() => {
-          this.isLoading.set(false);
-          this.loadingMore.set(false);
-        })
+        tap(() => this.isLoading.set(false))
       ),
       { initialValue: EMPTY_MY_DONATIONS }
     );

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.html
@@ -1,38 +1,42 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-initiatives">
-  <div class="flex flex-col gap-6">
-    <!-- Page header -->
-    <div class="flex items-start justify-between mt-3">
-      <div>
-        <h1 class="font-display font-light text-2xl" data-testid="my-initiatives-title">My Initiatives</h1>
-        <p class="mt-1 text-sm text-gray-500" data-testid="my-initiatives-description">Fundraising initiatives you manage on LFX Crowdfunding</p>
+@if (isLoading()) {
+  <lfx-route-loading data-testid="my-initiatives-loading" />
+} @else {
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-initiatives">
+    <div class="flex flex-col gap-6">
+      <!-- Page header -->
+      <div class="flex items-start justify-between mt-3">
+        <div>
+          <h1 class="font-display font-light text-2xl" data-testid="my-initiatives-title">My Initiatives</h1>
+          <p class="mt-1 text-sm text-gray-500" data-testid="my-initiatives-description">Fundraising initiatives you manage on LFX Crowdfunding</p>
+        </div>
+        <div class="flex items-center gap-6">
+          <lfx-button
+            label="New Initiative"
+            icon="fa-light fa-arrow-up-right-from-square"
+            iconPos="right"
+            severity="secondary"
+            [outlined]="true"
+            size="small"
+            [href]="crowdfundingUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="new-initiative-button" />
+        </div>
       </div>
-      <div class="flex items-center gap-6">
-        <lfx-button
-          label="New Initiative"
-          icon="fa-light fa-arrow-up-right-from-square"
-          iconPos="right"
-          severity="secondary"
-          [outlined]="true"
-          size="small"
-          [href]="crowdfundingUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="new-initiative-button" />
-      </div>
+
+      <!-- Stats -->
+      <lfx-stat-card-grid [cards]="statCards()" [loading]="!stats()" data-testid="initiatives-me-stats" />
+
+      <!-- Initiatives list with filter pills -->
+      <lfx-initiatives-list
+        [initiatives]="initiatives()"
+        [hasMore]="initiativesHasMore()"
+        [loadingMore]="loadingMore()"
+        (loadMore)="onLoadMoreInitiatives()"
+        (initiativeClick)="onInitiativeClick($event)" />
     </div>
-
-    <!-- Stats -->
-    <lfx-stat-card-grid [cards]="statCards()" [loading]="!stats()" data-testid="initiatives-me-stats" />
-
-    <!-- Initiatives list with filter pills -->
-    <lfx-initiatives-list
-      [initiatives]="initiatives()"
-      [hasMore]="initiativesHasMore()"
-      [loadingMore]="loadingMore()"
-      (loadMore)="onLoadMoreInitiatives()"
-      (initiativeClick)="onInitiativeClick($event)" />
   </div>
-</div>
+}

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-initiatives/my-initiatives.component.ts
@@ -7,16 +7,17 @@ import { Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { ButtonComponent } from '@components/button/button.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+import { RouteLoadingComponent } from '@components/loading/route-loading.component';
 import { CrowdfundingInitiativesStats, InitiativesResponse, StatCardItem } from '@lfx-one/shared/interfaces';
 import { DEFAULT_CROWDFUNDING_PAGE_SIZE, EMPTY_INITIATIVES_RESPONSE } from '@lfx-one/shared/constants';
 import { formatCurrency } from '@lfx-one/shared/utils';
 import { CrowdfundingService } from '@services/crowdfunding.service';
-import { finalize, scan, switchMap } from 'rxjs/operators';
+import { finalize, scan, switchMap, tap } from 'rxjs/operators';
 import { InitiativesListComponent } from './components/initiatives-list/initiatives-list.component';
 
 @Component({
   selector: 'lfx-my-initiatives',
-  imports: [ButtonComponent, StatCardGridComponent, InitiativesListComponent],
+  imports: [ButtonComponent, StatCardGridComponent, RouteLoadingComponent, InitiativesListComponent],
   templateUrl: './my-initiatives.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -29,6 +30,7 @@ export class MyInitiativesComponent {
   protected readonly crowdfundingUrl = `${environment.urls.crowdfunding}?fundraise=true`;
 
   // ─── Simple WritableSignals ───────────────────────────────────────────────
+  protected readonly isLoading = signal(true);
   protected readonly loadingMore = signal(false);
 
   // ─── Pagination Driver ────────────────────────────────────────────────────
@@ -59,7 +61,8 @@ export class MyInitiativesComponent {
         switchMap((offset) =>
           this.crowdfundingService.getMyInitiatives({ pageSize: DEFAULT_CROWDFUNDING_PAGE_SIZE, offset }).pipe(finalize(() => this.loadingMore.set(false)))
         ),
-        scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_INITIATIVES_RESPONSE)
+        scan((acc, curr) => (curr.offset === 0 ? curr : { ...curr, data: [...acc.data, ...curr.data] }), EMPTY_INITIATIVES_RESPONSE),
+        tap(() => this.isLoading.set(false))
       ),
       { initialValue: EMPTY_INITIATIVES_RESPONSE }
     );

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -134,6 +134,7 @@ export class CrowdfundingService {
       if (err.status === 401 && (err.error as Record<string, unknown>)?.['code'] === 'CF_UNAUTHENTICATED') {
         if (isPlatformBrowser(this.platformId)) {
           this.redirectToCfAuth();
+          return EMPTY; // navigating away — don't emit fallback so loading state persists
         }
         return of(fallback);
       }

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -265,7 +265,7 @@ async function extractCrowdfundingToken(req: Request): Promise<void> {
     return;
   }
 
-  if (req.appSession?.crowdfundingRefreshToken) {
+  if (crowdfundingAuthService.isConfigured() && req.appSession?.crowdfundingRefreshToken) {
     const refreshed = await crowdfundingAuthService.tryRefreshToken(req);
     if (refreshed && req.appSession?.crowdfundingToken) {
       req.crowdfundingToken = req.appSession.crowdfundingToken;

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -5,9 +5,12 @@ import { AuthConfig, AuthDecision, AuthMiddlewareResult, RouteAuthConfig, TokenE
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
+import { CrowdfundingAuthService } from '../services/crowdfunding-auth.service';
 import { logger } from '../services/logger.service';
 import { clearImpersonationSession, decodeJwtPayload } from '../utils/auth-helper';
 import { exchangeRefreshTokenForAudience } from '../utils/refresh-token-exchange.util';
+
+const crowdfundingAuthService = new CrowdfundingAuthService();
 
 // OIDC middleware already provides req.oidc with authentication context
 
@@ -249,15 +252,25 @@ async function extractApiGatewayToken(req: Request): Promise<void> {
 }
 
 /**
- * Loads the LFX Crowdfunding API token from the session onto req.crowdfundingToken.
- * The token is obtained via the authorization_code flow in CrowdfundingAuthService
- * and stored in the session by the /crowdfunding/callback handler.
+ * Loads the LFX Crowdfunding API token onto req.crowdfundingToken.
+ * If the session token is valid, uses it directly. If it is expired or absent but a
+ * refresh token is stored, attempts a silent refresh before falling through — avoiding
+ * the auth-code redirect round-trip on token expiry.
  */
-function extractCrowdfundingToken(req: Request): void {
+async function extractCrowdfundingToken(req: Request): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   if (req.appSession?.crowdfundingToken && req.appSession.crowdfundingTokenExpiresAt && now < req.appSession.crowdfundingTokenExpiresAt) {
     req.crowdfundingToken = req.appSession.crowdfundingToken;
     logger.debug(req, 'crowdfunding_token', 'Using cached Crowdfunding token');
+    return;
+  }
+
+  if (req.appSession?.crowdfundingRefreshToken) {
+    const refreshed = await crowdfundingAuthService.tryRefreshToken(req);
+    if (refreshed && req.appSession?.crowdfundingToken) {
+      req.crowdfundingToken = req.appSession.crowdfundingToken;
+      logger.debug(req, 'crowdfunding_token', 'Crowdfunding token silently refreshed');
+    }
   }
 }
 
@@ -476,7 +489,7 @@ export function createAuthMiddleware(config: AuthConfig = DEFAULT_CONFIG) {
       // 4. Silently fetch secondary tokens when the user is authenticated
       if (hasToken) {
         await extractApiGatewayToken(req);
-        extractCrowdfundingToken(req);
+        await extractCrowdfundingToken(req);
       }
 
       // 5. Build result for decision making

--- a/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
@@ -203,7 +203,7 @@ export class CrowdfundingAuthService {
     const refreshToken = req.appSession?.crowdfundingRefreshToken;
     if (!refreshToken) return Promise.resolve(false);
 
-    const key = crypto.createHash('sha256').update(refreshToken).digest('hex').substring(0, 16);
+    const key = crypto.createHash('sha256').update(refreshToken).digest('hex');
     const inflight = this.pendingRefreshes.get(key);
     if (inflight) return inflight;
 

--- a/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
@@ -11,6 +11,7 @@ interface TokenResponse {
   token_type: string;
   scope: string;
   expires_in: number;
+  refresh_token?: string;
 }
 
 const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
@@ -90,7 +91,7 @@ export class CrowdfundingAuthService {
       response_type: 'code',
       client_id: this.clientId,
       redirect_uri: this.redirectUri,
-      scope: 'openid profile access:me',
+      scope: 'openid profile access:me offline_access',
       audience: this.audience,
       state,
     });
@@ -181,5 +182,59 @@ export class CrowdfundingAuthService {
 
     req.appSession.crowdfundingToken = tokenResponse.access_token;
     req.appSession.crowdfundingTokenExpiresAt = expiresAt;
+
+    if (tokenResponse.refresh_token) {
+      req.appSession.crowdfundingRefreshToken = tokenResponse.refresh_token;
+    }
+  }
+
+  /**
+   * Attempts to silently renew the CF access token using the stored refresh token.
+   * Returns true and updates the session on success; returns false (non-throwing)
+   * on any failure so callers can fall back to the auth-code redirect.
+   * Clears the stale refresh token on invalid_grant so we don't retry on every request.
+   */
+  public async tryRefreshToken(req: Request): Promise<boolean> {
+    const refreshToken = req.appSession?.crowdfundingRefreshToken;
+    if (!refreshToken) return false;
+
+    const startTime = logger.startOperation(req, 'crowdfunding_token_refresh', {});
+
+    try {
+      const response = await fetch(`${this.issuerBaseUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          audience: this.audience,
+        }).toString(),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => null);
+        logger.warning(req, 'crowdfunding_token_refresh', 'Token refresh returned non-OK status', {
+          status: response.status,
+          error: (errorBody as Record<string, unknown>)?.['error'],
+        });
+        if (req.appSession) delete req.appSession.crowdfundingRefreshToken;
+        return false;
+      }
+
+      const tokenResponse: TokenResponse = await response.json();
+      this.storeToken(req, tokenResponse);
+
+      logger.success(req, 'crowdfunding_token_refresh', startTime, { expires_in: tokenResponse.expires_in });
+
+      return true;
+    } catch (error) {
+      logger.warning(req, 'crowdfunding_token_refresh', 'Token refresh request failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return false;
+    }
   }
 }

--- a/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding-auth.service.ts
@@ -28,6 +28,8 @@ const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
  * has an Auth0 session — no second consent screen is shown.
  */
 export class CrowdfundingAuthService {
+  private readonly pendingRefreshes = new Map<string, Promise<boolean>>();
+
   private _clientId: string | undefined;
   private _clientSecret: string | undefined;
   private _audience: string | undefined;
@@ -192,12 +194,25 @@ export class CrowdfundingAuthService {
    * Attempts to silently renew the CF access token using the stored refresh token.
    * Returns true and updates the session on success; returns false (non-throwing)
    * on any failure so callers can fall back to the auth-code redirect.
-   * Clears the stale refresh token on invalid_grant so we don't retry on every request.
+   * Clears the stale refresh token only on invalid_grant (terminal error); transient
+   * failures (5xx, timeouts) leave the token in place for the next request to retry.
+   * Single-flight: concurrent requests sharing the same refresh token share one Promise
+   * so only one refresh attempt hits Auth0 per in-flight batch.
    */
-  public async tryRefreshToken(req: Request): Promise<boolean> {
+  public tryRefreshToken(req: Request): Promise<boolean> {
     const refreshToken = req.appSession?.crowdfundingRefreshToken;
-    if (!refreshToken) return false;
+    if (!refreshToken) return Promise.resolve(false);
 
+    const key = crypto.createHash('sha256').update(refreshToken).digest('hex').substring(0, 16);
+    const inflight = this.pendingRefreshes.get(key);
+    if (inflight) return inflight;
+
+    const promise = this.doRefreshToken(req, refreshToken).finally(() => this.pendingRefreshes.delete(key));
+    this.pendingRefreshes.set(key, promise);
+    return promise;
+  }
+
+  private async doRefreshToken(req: Request, refreshToken: string): Promise<boolean> {
     const startTime = logger.startOperation(req, 'crowdfunding_token_refresh', {});
 
     try {
@@ -216,11 +231,14 @@ export class CrowdfundingAuthService {
 
       if (!response.ok) {
         const errorBody = await response.json().catch(() => null);
+        const errorCode = (errorBody as Record<string, unknown>)?.['error'];
         logger.warning(req, 'crowdfunding_token_refresh', 'Token refresh returned non-OK status', {
           status: response.status,
-          error: (errorBody as Record<string, unknown>)?.['error'],
+          error: errorCode,
         });
-        if (req.appSession) delete req.appSession.crowdfundingRefreshToken;
+        if (errorCode === 'invalid_grant' && req.appSession) {
+          delete req.appSession.crowdfundingRefreshToken;
+        }
         return false;
       }
 

--- a/apps/lfx-one/src/types/express.d.ts
+++ b/apps/lfx-one/src/types/express.d.ts
@@ -21,6 +21,7 @@ declare global {
         apiGatewayTokenExpiresAt?: number;
         crowdfundingToken?: string;
         crowdfundingTokenExpiresAt?: number;
+        crowdfundingRefreshToken?: string;
         crowdfundingAuthState?: string;
         crowdfundingAuthReturnTo?: string;
         [key: string]: any;


### PR DESCRIPTION
## Summary

- Add skeleton loading state to my-donations, my-initiatives, and initiative-detail pages so users see a loading indicator instead of empty state while data or CF auth is pending
- Return `EMPTY` from `handleCfError` on browser redirect so the loading signal stays `true` during the CF auth redirect (previously the empty-state fallback was emitted before navigation completed)
- Add refresh token support to the CF auth flow: request `offline_access` scope, persist the refresh token in session, and silently renew the CF access token on expiry via `tryRefreshToken()` — eliminating the auth-code redirect round-trip for returning users

## Notes

- `auth.middleware.ts` is flagged as a protected file — the change is intentional and minimal: `extractCrowdfundingToken` is now `async` and awaited, with silent refresh attempted before falling through to the existing redirect path
- `offline_access` / silent refresh requires HTTPS. On localhost, Auth0 always prompts consent regardless of `skip_consent_for_verifiable_first_party_clients = true` — this is expected Auth0 behavior and will work silently on dev/staging/prod