### PR TITLE
feat(akrites): ossprey program dashboard triage board tab CM-1233

### DIFF
--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
@@ -31,6 +31,15 @@
       <i class="fa-light fa-box text-base" aria-hidden="true"></i>
       Packages
     </button>
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 px-4 py-3 text-sm border-b-2 -mb-px font-medium transition-colors"
+      [class]="activeTab() === 'triage' ? 'border-blue-500 text-slate-900' : 'border-transparent text-gray-500 hover:text-slate-700'"
+      (click)="setActiveTab('triage')"
+      data-testid="akrites-tab-triage">
+      <i class="fa-light fa-table-columns text-base" aria-hidden="true"></i>
+      Triage board
+    </button>
   </div>
 
   <!-- Overview Tab -->
@@ -71,6 +80,16 @@
         data-testid="akrites-packages-tab">
       </lfx-akrites-packages-tab>
     }
+  }
+
+  <!-- Triage Board Tab -->
+  @if (activeTab() === 'triage') {
+    <lfx-akrites-triage-tab
+      [reloadTrigger]="reloadTrigger()"
+      (packageClick)="onPackageClick($event)"
+      (stewardshipChanged)="onStewardshipChanged()"
+      data-testid="akrites-triage-tab">
+    </lfx-akrites-triage-tab>
   }
 
   <!-- Bulk Actions Bar -->

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -22,10 +22,11 @@ import { AkritesPackageDrawerComponent } from '../components/akrites-package-dra
 import { AkritesPackagesTabComponent } from '../components/akrites-packages-tab/akrites-packages-tab.component';
 import { AkritesEscalateModalComponent } from '../components/akrites-escalate-modal/akrites-escalate-modal.component';
 import { AkritesOverviewTabComponent } from '../components/akrites-overview-tab/akrites-overview-tab.component';
+import { AkritesTriageTabComponent } from '../components/akrites-triage-tab/akrites-triage-tab.component';
 
 @Component({
   selector: 'lfx-akrites-dashboard',
-  imports: [AkritesPackageDrawerComponent, AkritesPackagesTabComponent, AkritesEscalateModalComponent, AkritesOverviewTabComponent],
+  imports: [AkritesPackageDrawerComponent, AkritesPackagesTabComponent, AkritesEscalateModalComponent, AkritesOverviewTabComponent, AkritesTriageTabComponent],
   templateUrl: './akrites-dashboard.component.html',
 })
 export class AkritesDashboardComponent {

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-overview-tab/akrites-overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-overview-tab/akrites-overview-tab.component.html
@@ -91,19 +91,21 @@
                     </div>
                   </div>
 
-                  <!-- Action button -->
-                  @if (row.action; as action) {
-                    <button
-                      type="button"
-                      class="flex-shrink-0 h-8 px-3.5 rounded-full border text-[12.5px] font-medium transition-colors"
-                      [class]="{
-                        'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-400': action.variant === 'default',
-                        'border-blue-200 bg-white text-blue-600 hover:bg-blue-50 hover:border-blue-400': action.variant === 'blue',
-                        'border-red-200 bg-white text-red-600 hover:bg-red-50 hover:border-red-400': action.variant === 'red',
-                      }"
-                      (click)="$event.stopPropagation(); onActionButtonClick(row, action.variant)">
-                      {{ action.label }}
-                    </button>
+                  <!-- Action button — writer-only -->
+                  @if (canWrite()) {
+                    @if (row.action; as action) {
+                      <button
+                        type="button"
+                        class="flex-shrink-0 h-8 px-3.5 rounded-full border text-[12.5px] font-medium transition-colors"
+                        [class]="{
+                          'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-400': action.variant === 'default',
+                          'border-blue-200 bg-white text-blue-600 hover:bg-blue-50 hover:border-blue-400': action.variant === 'blue',
+                          'border-red-200 bg-white text-red-600 hover:bg-red-50 hover:border-red-400': action.variant === 'red',
+                        }"
+                        (click)="$event.stopPropagation(); onActionButtonClick(row, action.variant)">
+                        {{ action.label }}
+                      </button>
+                    }
                   }
                 </div>
               }

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-overview-tab/akrites-overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-overview-tab/akrites-overview-tab.component.ts
@@ -14,6 +14,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { catchError, of, switchMap, tap } from 'rxjs';
 import { AkritesService } from '@shared/services/akrites.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
 import { formatActivityType } from '../../akrites.utils';
 
 @Component({
@@ -23,7 +24,10 @@ import { formatActivityType } from '../../akrites.utils';
 })
 export class AkritesOverviewTabComponent {
   private readonly akritesService = inject(AkritesService);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly canWrite = this.projectContextService.canWrite;
 
   public readonly metrics = input<AkritesMetrics | undefined>(undefined);
   public readonly metricsLoading = input<boolean>(false);

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -34,92 +34,97 @@
   <div class="flex gap-3.5 overflow-x-auto pb-2" data-testid="akrites-triage-board">
     @for (col of TRIAGE_COLUMNS; track col.status) {
       @let state = getColumnState(col.status);
-      @if (state.total > 0 || state.error) {
-        <div
-          class="flex-1 min-w-[240px] max-w-[320px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
-          [style.background]="'linear-gradient(180deg, ' + col.color + '12 0%, #fff 38%)'"
-          [attr.data-testid]="'akrites-triage-col-' + col.status">
-          <!-- Column header -->
-          <div class="flex items-center justify-between py-1 px-0.5 pb-1.5">
-            <span class="flex items-center gap-2.5 text-[13.5px] font-semibold text-slate-900">
-              <span class="w-6 h-6 rounded-full flex items-center justify-center text-white flex-shrink-0" [style.background]="col.color">
-                <i [class]="getColumnIconClass(col.iconName)" aria-hidden="true"></i>
-              </span>
-              {{ col.label }}
+      <div
+        class="flex-1 min-w-[240px] max-w-[320px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
+        [style.background]="'linear-gradient(180deg, ' + col.color + '12 0%, #fff 38%)'"
+        [attr.data-testid]="'akrites-triage-col-' + col.status">
+        <!-- Column header -->
+        <div class="flex items-center justify-between py-1 px-0.5 pb-1.5">
+          <span class="flex items-center gap-2.5 text-[13.5px] font-semibold text-slate-900">
+            <span class="w-6 h-6 rounded-full flex items-center justify-center text-white flex-shrink-0" [style.background]="col.color">
+              <i [class]="getColumnIconClass(col.iconName)" aria-hidden="true"></i>
             </span>
-            <span class="text-[11px] font-bold text-gray-400">{{ state.total }}</span>
+            {{ col.label }}
+          </span>
+          <span class="text-[11px] font-bold text-gray-400">{{ state.total }}</span>
+        </div>
+
+        <!-- Error state -->
+        @if (state.error) {
+          <div class="flex flex-col items-center py-6 text-center" data-testid="akrites-triage-col-error">
+            <i class="fa-light fa-triangle-exclamation text-lg text-gray-400 mb-1" aria-hidden="true"></i>
+            <p class="text-xs text-gray-500">Failed to load</p>
           </div>
+        }
 
-          <!-- Error state -->
-          @if (state.error) {
-            <div class="flex flex-col items-center py-6 text-center" data-testid="akrites-triage-col-error">
-              <i class="fa-light fa-triangle-exclamation text-lg text-gray-400 mb-1" aria-hidden="true"></i>
-              <p class="text-xs text-gray-500">Failed to load</p>
-            </div>
-          }
+        <!-- Empty state -->
+        @if (!state.error && state.total === 0) {
+          <div class="flex flex-col items-center justify-center py-8 text-center" [attr.data-testid]="'akrites-triage-col-empty-' + col.status">
+            <i class="fa-light fa-circle-check text-xl text-gray-300 mb-1.5" aria-hidden="true"></i>
+            <p class="text-[11px] text-gray-400">No packages</p>
+          </div>
+        }
 
-          <!-- Package cards -->
-          @for (pkg of state.packages; track pkg.id) {
-            <div
-              class="bg-white border border-gray-200 rounded-[11px] p-[11px] cursor-pointer transition-all duration-100 hover:border-gray-300 hover:shadow-[0_3px_10px_rgba(2,39,65,0.08)]"
-              (click)="onCardClick(pkg)"
-              [attr.data-testid]="'akrites-triage-card-' + pkg.id">
-              <!-- Name + purl -->
-              <div class="text-[13px] font-semibold text-slate-900 truncate">{{ pkg.name }}</div>
-              <div class="text-[10.5px] text-gray-400 font-mono mt-px truncate">{{ pkg.purl }}</div>
+        <!-- Package cards -->
+        @for (pkg of state.packages; track pkg.id) {
+          <div
+            class="bg-white border border-gray-200 rounded-[11px] p-[11px] cursor-pointer transition-all duration-100 hover:border-gray-300 hover:shadow-[0_3px_10px_rgba(2,39,65,0.08)]"
+            (click)="onCardClick(pkg)"
+            [attr.data-testid]="'akrites-triage-card-' + pkg.id">
+            <!-- Name + purl -->
+            <div class="text-[13px] font-semibold text-slate-900 truncate">{{ pkg.name }}</div>
+            <div class="text-[10.5px] text-gray-400 font-mono mt-px truncate">{{ pkg.purl }}</div>
 
-              <!-- Chips -->
-              <div class="flex flex-wrap gap-1.5 mt-2.5">
-                @if (pkg.healthScore !== null) {
-                  <span
-                    class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
-                    <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getHealthColor(pkg.healthScore)"></span>
-                    {{ pkg.healthScore | number: '1.0-0' }} {{ getHealthLabel(pkg.healthScore) }}
-                  </span>
-                }
-                @if (pkg.impactScore !== null) {
-                  <span
-                    class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
-                    Impact {{ pkg.impactScore | number: '1.0-0' }}
-                  </span>
-                }
+            <!-- Chips -->
+            <div class="flex flex-wrap gap-1.5 mt-2.5">
+              @if (pkg.healthScore !== null) {
                 <span
                   class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
-                  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getVulnColor(pkg.vulnCount, pkg.vulnSeverity)"></span>
-                  @if (pkg.vulnCount > 0 && pkg.vulnSeverity) {
-                    {{ pkg.vulnCount }} {{ pkg.vulnSeverity | titlecase }}
-                  } @else {
-                    {{ pkg.vulnCount }} vulns
-                  }
+                  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getHealthColor(pkg.healthScore)"></span>
+                  {{ pkg.healthScore | number: '1.0-0' }} {{ getHealthLabel(pkg.healthScore) }}
                 </span>
-              </div>
-
-              <!-- Steward -->
-              @if (pkg.stewards.length > 0) {
-                <div class="flex items-center gap-2 mt-2.5 text-[11px] text-gray-500">
-                  <i class="fa-light fa-user text-xs text-gray-400 flex-shrink-0" aria-hidden="true"></i>
-                  @if (pkg.stewards[0].name) {
-                    <span class="truncate">{{ pkg.stewards[0].name }}</span>
-                  } @else {
-                    <span class="text-gray-400">Steward assigned</span>
-                  }
-                </div>
               }
-
-              <!-- Action button -->
-              <div class="mt-[18px]">
-                <button
-                  type="button"
-                  [class]="getActionButtonClass(col.actionVariant)"
-                  (click)="onAction($event, pkg, col)"
-                  [attr.data-testid]="'akrites-triage-action-' + pkg.id">
-                  {{ col.actionLabel }}
-                </button>
-              </div>
+              @if (pkg.impactScore !== null) {
+                <span
+                  class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
+                  Impact {{ pkg.impactScore | number: '1.0-0' }}
+                </span>
+              }
+              <span class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
+                <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getVulnColor(pkg.vulnCount, pkg.vulnSeverity)"></span>
+                @if (pkg.vulnCount > 0 && pkg.vulnSeverity) {
+                  {{ pkg.vulnCount }} {{ pkg.vulnSeverity | titlecase }}
+                } @else {
+                  {{ pkg.vulnCount }} vulns
+                }
+              </span>
             </div>
-          }
-        </div>
-      }
+
+            <!-- Steward -->
+            @if (pkg.stewards.length > 0) {
+              <div class="flex items-center gap-2 mt-2.5 text-[11px] text-gray-500">
+                <i class="fa-light fa-user text-xs text-gray-400 flex-shrink-0" aria-hidden="true"></i>
+                @if (pkg.stewards[0].name) {
+                  <span class="truncate">{{ pkg.stewards[0].name }}</span>
+                } @else {
+                  <span class="text-gray-400">Steward assigned</span>
+                }
+              </div>
+            }
+
+            <!-- Action button -->
+            <div class="mt-[18px]">
+              <button
+                type="button"
+                [class]="getActionButtonClass(col.actionVariant)"
+                (click)="onAction($event, pkg, col)"
+                [attr.data-testid]="'akrites-triage-action-' + pkg.id">
+                {{ col.actionLabel }}
+              </button>
+            </div>
+          </div>
+        }
+      </div>
     }
   </div>
 

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -1,0 +1,134 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Loading skeleton -->
+@if (loading()) {
+  <div class="flex gap-3.5 overflow-x-auto pb-2" data-testid="akrites-triage-loading">
+    @for (col of TRIAGE_COLUMNS; track col.status) {
+      <div class="flex-1 min-w-[240px] bg-gray-50 border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5">
+        <div class="flex items-center justify-between py-1 px-0.5 pb-1.5">
+          <div class="flex items-center gap-2.5">
+            <div class="w-6 h-6 rounded-full bg-gray-200 animate-pulse"></div>
+            <div class="w-24 h-3.5 rounded bg-gray-200 animate-pulse"></div>
+          </div>
+          <div class="w-4 h-3 rounded bg-gray-200 animate-pulse"></div>
+        </div>
+        @for (i of [1, 2, 3]; track i) {
+          <div class="bg-white border border-gray-200 rounded-[11px] p-3 flex flex-col gap-2">
+            <div class="w-20 h-3 rounded bg-gray-200 animate-pulse"></div>
+            <div class="w-32 h-2.5 rounded bg-gray-100 animate-pulse"></div>
+            <div class="flex gap-1.5 mt-1">
+              <div class="w-20 h-5 rounded-full bg-gray-100 animate-pulse"></div>
+              <div class="w-16 h-5 rounded-full bg-gray-100 animate-pulse"></div>
+            </div>
+            <div class="w-28 h-7 rounded-full bg-gray-100 animate-pulse mt-1"></div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+}
+
+<!-- Board -->
+@if (!loading() && boardData() !== undefined) {
+  <div class="flex gap-3.5 overflow-x-auto pb-2" data-testid="akrites-triage-board">
+    @for (col of TRIAGE_COLUMNS; track col.status) {
+      @let state = getColumnState(col.status);
+      @if (state.total > 0 || state.error) {
+        <div
+          class="flex-1 min-w-[240px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
+          [style.background]="'linear-gradient(180deg, ' + col.color + '12 0%, #fff 38%)'"
+          [attr.data-testid]="'akrites-triage-col-' + col.status">
+          <!-- Column header -->
+          <div class="flex items-center justify-between py-1 px-0.5 pb-1.5">
+            <span class="flex items-center gap-2.5 text-[13.5px] font-semibold text-slate-900">
+              <span class="w-6 h-6 rounded-full flex items-center justify-center text-white flex-shrink-0" [style.background]="col.color">
+                <i [class]="getColumnIconClass(col.iconName)" aria-hidden="true"></i>
+              </span>
+              {{ col.label }}
+            </span>
+            <span class="text-[11px] font-bold text-gray-400">{{ state.total }}</span>
+          </div>
+
+          <!-- Error state -->
+          @if (state.error) {
+            <div class="flex flex-col items-center py-6 text-center" data-testid="akrites-triage-col-error">
+              <i class="fa-light fa-triangle-exclamation text-lg text-gray-400 mb-1" aria-hidden="true"></i>
+              <p class="text-xs text-gray-500">Failed to load</p>
+            </div>
+          }
+
+          <!-- Package cards -->
+          @for (pkg of state.packages; track pkg.id) {
+            <div
+              class="bg-white border border-gray-200 rounded-[11px] p-[11px] cursor-pointer transition-all duration-100 hover:border-gray-300 hover:shadow-[0_3px_10px_rgba(2,39,65,0.08)]"
+              (click)="onCardClick(pkg)"
+              [attr.data-testid]="'akrites-triage-card-' + pkg.id">
+              <!-- Name + purl -->
+              <div class="text-[13px] font-semibold text-slate-900 truncate">{{ pkg.name }}</div>
+              <div class="text-[10.5px] text-gray-400 font-mono mt-px truncate">{{ pkg.purl }}</div>
+
+              <!-- Chips -->
+              <div class="flex flex-wrap gap-1.5 mt-2.5">
+                @if (pkg.healthScore !== null) {
+                  <span
+                    class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
+                    <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getHealthColor(pkg.healthScore)"></span>
+                    {{ pkg.healthScore | number: '1.0-0' }} {{ getHealthLabel(pkg.healthScore) }}
+                  </span>
+                }
+                @if (pkg.impactScore !== null) {
+                  <span
+                    class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
+                    Impact {{ pkg.impactScore | number: '1.0-0' }}
+                  </span>
+                }
+                <span
+                  class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
+                  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getVulnColor(pkg.vulnCount, pkg.vulnSeverity)"></span>
+                  @if (pkg.vulnCount > 0) {
+                    {{ pkg.vulnCount }} {{ pkg.vulnSeverity | titlecase }}
+                  } @else {
+                    0 vulns
+                  }
+                </span>
+              </div>
+
+              <!-- Steward -->
+              @if (pkg.stewards.length > 0) {
+                <div class="flex items-center gap-2 mt-2.5 text-[11px] text-gray-500">
+                  <i class="fa-light fa-user text-xs text-gray-400 flex-shrink-0" aria-hidden="true"></i>
+                  @if (pkg.stewards[0].name) {
+                    <span class="truncate">{{ pkg.stewards[0].name }}</span>
+                  } @else {
+                    <span class="text-gray-400">Steward assigned</span>
+                  }
+                </div>
+              }
+
+              <!-- Action button -->
+              <div class="mt-[18px]">
+                <button
+                  type="button"
+                  [class]="getActionButtonClass(col.actionVariant)"
+                  (click)="onAction($event, pkg, col)"
+                  [attr.data-testid]="'akrites-triage-action-' + pkg.id">
+                  {{ col.actionLabel }}
+                </button>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    }
+  </div>
+
+  <!-- All columns empty -->
+  @if (allColumnsEmpty()) {
+    <div class="flex flex-col items-center justify-center py-20 text-center" data-testid="akrites-triage-empty">
+      <i class="fa-light fa-circle-check text-3xl text-emerald-400 mb-3" aria-hidden="true"></i>
+      <p class="text-sm font-medium text-gray-700">All clear</p>
+      <p class="text-xs text-gray-500 mt-1">No packages require triage action right now.</p>
+    </div>
+  }
+}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -33,7 +33,7 @@
 @if (!loading() && boardData() !== undefined) {
   <div class="flex gap-3.5 overflow-x-auto pb-2" data-testid="akrites-triage-board">
     @for (col of TRIAGE_COLUMNS; track col.status) {
-      @let state = getColumnState(col.status);
+      @let state = columnStates()[col.status];
       <div
         class="flex-1 min-w-[240px] max-w-[320px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
         [style.background]="'linear-gradient(180deg, ' + col.color + '12 0%, #fff 38%)'"
@@ -42,7 +42,7 @@
         <div class="flex items-center justify-between py-1 px-0.5 pb-1.5">
           <span class="flex items-center gap-2.5 text-[13.5px] font-semibold text-slate-900">
             <span class="w-6 h-6 rounded-full flex items-center justify-center text-white flex-shrink-0" [style.background]="col.color">
-              <i [class]="getColumnIconClass(col.iconName)" aria-hidden="true"></i>
+              <i [class]="col.iconClass" aria-hidden="true"></i>
             </span>
             {{ col.label }}
           </span>
@@ -69,7 +69,12 @@
         @for (pkg of state.packages; track pkg.id) {
           <div
             class="bg-white border border-gray-200 rounded-[11px] p-[11px] cursor-pointer transition-all duration-100 hover:border-gray-300 hover:shadow-[0_3px_10px_rgba(2,39,65,0.08)]"
+            role="button"
+            tabindex="0"
+            [attr.aria-label]="'Open package details for ' + pkg.name"
             (click)="onCardClick(pkg)"
+            (keydown.enter)="onCardClick(pkg)"
+            (keydown.space)="$event.preventDefault(); onCardClick(pkg)"
             [attr.data-testid]="'akrites-triage-card-' + pkg.id">
             <!-- Name + purl -->
             <div class="text-[13px] font-semibold text-slate-900 truncate">{{ pkg.name }}</div>
@@ -80,8 +85,8 @@
               @if (pkg.healthScore !== null) {
                 <span
                   class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
-                  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getHealthColor(pkg.healthScore)"></span>
-                  {{ pkg.healthScore | number: '1.0-0' }} {{ getHealthLabel(pkg.healthScore) }}
+                  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="pkg.healthColor"></span>
+                  {{ pkg.healthScore | number: '1.0-0' }} {{ pkg.healthLabel }}
                 </span>
               }
               @if (pkg.impactScore !== null) {
@@ -91,7 +96,7 @@
                 </span>
               }
               <span class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
-                <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getVulnColor(pkg.vulnCount, pkg.vulnSeverity)"></span>
+                <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="pkg.vulnColor"></span>
                 @if (pkg.vulnCount > 0 && pkg.vulnSeverity) {
                   {{ pkg.vulnCount }} {{ pkg.vulnSeverity | titlecase }}
                 } @else {
@@ -117,7 +122,7 @@
               <div class="mt-[18px]">
                 <button
                   type="button"
-                  [class]="getActionButtonClass(col.actionVariant)"
+                  [class]="col.actionButtonClass"
                   (click)="onAction($event, pkg, col)"
                   [attr.data-testid]="'akrites-triage-action-' + pkg.id">
                   {{ col.actionLabel }}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -112,8 +112,8 @@
               </div>
             }
 
-            <!-- Action button -->
-            @if (col.status !== 'unassigned') {
+            <!-- Action button — writer-only, not shown for unassigned -->
+            @if (canWrite() && col.status !== 'unassigned') {
               <div class="mt-[18px]">
                 <button
                   type="button"

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -36,7 +36,7 @@
       @let state = getColumnState(col.status);
       @if (state.total > 0 || state.error) {
         <div
-          class="flex-1 min-w-[240px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
+          class="flex-1 min-w-[240px] max-w-[320px] border border-gray-200 rounded-[14px] p-3 flex flex-col gap-2.5"
           [style.background]="'linear-gradient(180deg, ' + col.color + '12 0%, #fff 38%)'"
           [attr.data-testid]="'akrites-triage-col-' + col.status">
           <!-- Column header -->
@@ -86,10 +86,10 @@
                 <span
                   class="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded-full py-0.5 px-2.5 text-[11px] font-semibold text-gray-700">
                   <span class="w-1.5 h-1.5 rounded-full flex-shrink-0" [style.background]="getVulnColor(pkg.vulnCount, pkg.vulnSeverity)"></span>
-                  @if (pkg.vulnCount > 0) {
+                  @if (pkg.vulnCount > 0 && pkg.vulnSeverity) {
                     {{ pkg.vulnCount }} {{ pkg.vulnSeverity | titlecase }}
                   } @else {
-                    0 vulns
+                    {{ pkg.vulnCount }} vulns
                   }
                 </span>
               </div>

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.html
@@ -113,15 +113,17 @@
             }
 
             <!-- Action button -->
-            <div class="mt-[18px]">
-              <button
-                type="button"
-                [class]="getActionButtonClass(col.actionVariant)"
-                (click)="onAction($event, pkg, col)"
-                [attr.data-testid]="'akrites-triage-action-' + pkg.id">
-                {{ col.actionLabel }}
-              </button>
-            </div>
+            @if (col.status !== 'unassigned') {
+              <div class="mt-[18px]">
+                <button
+                  type="button"
+                  [class]="getActionButtonClass(col.actionVariant)"
+                  (click)="onAction($event, pkg, col)"
+                  [attr.data-testid]="'akrites-triage-action-' + pkg.id">
+                  {{ col.actionLabel }}
+                </button>
+              </div>
+            }
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { DecimalPipe, TitleCasePipe } from '@angular/common';
-import { Component, DestroyRef, computed, inject, input, output, signal } from '@angular/core';
+import { Component, DestroyRef, Signal, computed, inject, input, output, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { AKRITES_TRIAGE_COLUMNS } from '@lfx-one/shared/constants';
+import { AKRITES_TRIAGE_COLUMNS, lfxColors } from '@lfx-one/shared/constants';
 import {
   AkritesPackage,
   AkritesTriageBoardColumnConfig,
@@ -103,20 +103,25 @@ export class AkritesTriageTabComponent {
   }
 
   private healthColor(score: number | null): string {
-    if (score === null) return '#9ca3af';
-    if (score >= 70) return '#22c55e';
-    if (score >= 50) return '#f59e0b';
-    if (score >= 30) return '#f97316';
-    return '#ef4444';
+    if (score === null) return lfxColors.gray[400];
+    if (score >= 70) return lfxColors.emerald[500];
+    if (score >= 50) return lfxColors.amber[500];
+    if (score >= 30) return lfxColors.amber[600];
+    return lfxColors.red[500];
   }
 
   private vulnColor(vulnCount: number, vulnSeverity: string | null): string {
-    if (vulnCount === 0) return '#22c55e';
-    const colors: Record<string, string> = { critical: '#ef4444', high: '#f97316', medium: '#f59e0b', low: '#3b82f6' };
-    return vulnSeverity ? (colors[vulnSeverity] ?? '#9ca3af') : '#9ca3af';
+    if (vulnCount === 0) return lfxColors.emerald[500];
+    const colors: Record<string, string> = {
+      critical: lfxColors.red[500],
+      high: lfxColors.amber[600],
+      medium: lfxColors.amber[500],
+      low: lfxColors.blue[500],
+    };
+    return vulnSeverity ? (colors[vulnSeverity] ?? lfxColors.gray[400]) : lfxColors.gray[400];
   }
 
-  private initBoardData() {
+  private initBoardData(): Signal<Record<AkritesTriageStatus, AkritesTriageColumnState> | undefined> {
     return toSignal(
       toObservable(this.reloadTrigger).pipe(
         tap(() => this.loading.set(true)),

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
@@ -7,6 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { AKRITES_TRIAGE_COLUMNS } from '@lfx-one/shared/constants';
 import { AkritesPackage, AkritesTriageBoardColumnConfig, AkritesTriageColumnState, AkritesTriageStatus } from '@lfx-one/shared/interfaces';
 import { AkritesService } from '@shared/services/akrites.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { catchError, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
 
@@ -17,8 +18,11 @@ import { catchError, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
 })
 export class AkritesTriageTabComponent {
   private readonly akritesService = inject(AkritesService);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly canWrite = this.projectContextService.canWrite;
 
   public readonly reloadTrigger = input<number>(0);
 

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
@@ -1,0 +1,134 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe, TitleCasePipe } from '@angular/common';
+import { Component, DestroyRef, computed, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { AKRITES_TRIAGE_COLUMNS } from '@lfx-one/shared/constants';
+import { AkritesPackage, AkritesTriageBoardColumnConfig, AkritesTriageColumnState, AkritesTriageStatus } from '@lfx-one/shared/interfaces';
+import { AkritesService } from '@shared/services/akrites.service';
+import { MessageService } from 'primeng/api';
+import { catchError, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-akrites-triage-tab',
+  imports: [DecimalPipe, TitleCasePipe],
+  templateUrl: './akrites-triage-tab.component.html',
+})
+export class AkritesTriageTabComponent {
+  private readonly akritesService = inject(AkritesService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public readonly reloadTrigger = input<number>(0);
+
+  public readonly packageClick = output<string>();
+  public readonly stewardshipChanged = output<void>();
+
+  protected readonly TRIAGE_COLUMNS = AKRITES_TRIAGE_COLUMNS;
+  protected readonly loading = signal(true);
+
+  protected readonly boardData = this.initBoardData();
+
+  protected readonly allColumnsEmpty = computed(() => {
+    const data = this.boardData();
+    if (data === undefined) return false;
+    return AKRITES_TRIAGE_COLUMNS.every((col) => (data[col.status]?.total ?? 0) === 0);
+  });
+
+  protected getColumnState(status: AkritesTriageStatus): AkritesTriageColumnState {
+    return this.boardData()?.[status] ?? { packages: [], total: 0, loading: true, error: false };
+  }
+
+  protected getHealthLabel(score: number | null): string {
+    if (score === null) return '';
+    if (score >= 70) return 'Healthy';
+    if (score >= 50) return 'Fair';
+    if (score >= 30) return 'Concerning';
+    return 'Critical';
+  }
+
+  protected getHealthColor(score: number | null): string {
+    if (score === null) return '#9ca3af';
+    if (score >= 70) return '#22c55e';
+    if (score >= 50) return '#f59e0b';
+    if (score >= 30) return '#f97316';
+    return '#ef4444';
+  }
+
+  protected getVulnColor(vulnCount: number, vulnSeverity: string | null): string {
+    if (vulnCount === 0) return '#22c55e';
+    const colors: Record<string, string> = {
+      critical: '#ef4444',
+      high: '#f97316',
+      medium: '#f59e0b',
+      low: '#3b82f6',
+    };
+    return vulnSeverity ? (colors[vulnSeverity] ?? '#9ca3af') : '#9ca3af';
+  }
+
+  protected getColumnIconClass(iconName: string): string {
+    return `fa-light fa-${iconName} text-[11px]`;
+  }
+
+  protected getActionButtonClass(variant: 'blue' | 'red' | 'default'): string {
+    const base = 'h-8 px-3.5 rounded-full border bg-white text-[12.5px] font-medium cursor-pointer transition-colors';
+    if (variant === 'blue') return `${base} border-blue-200 text-blue-600 hover:bg-blue-50 hover:border-blue-400`;
+    if (variant === 'red') return `${base} border-red-200 text-red-600 hover:bg-red-50 hover:border-red-400`;
+    return `${base} border-gray-300 text-gray-700 hover:bg-gray-50`;
+  }
+
+  protected onCardClick(pkg: AkritesPackage): void {
+    this.packageClick.emit(pkg.id);
+  }
+
+  protected onAction(event: Event, pkg: AkritesPackage, column: AkritesTriageBoardColumnConfig): void {
+    event.stopPropagation();
+    if ((column.status === 'escalated' || column.status === 'blocked') && pkg.stewardshipId) {
+      this.resolvePackage(pkg);
+    } else {
+      this.packageClick.emit(pkg.id);
+    }
+  }
+
+  private resolvePackage(pkg: AkritesPackage): void {
+    this.akritesService
+      .updateStewardshipStatus(pkg.stewardshipId!, { status: 'active' })
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.messageService.add({ severity: 'success', summary: 'Resolved', detail: `${pkg.name} has been resolved.` });
+          this.stewardshipChanged.emit();
+        },
+        error: () => {
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not resolve. Please try again.' });
+        },
+      });
+  }
+
+  private initBoardData() {
+    return toSignal(
+      toObservable(this.reloadTrigger).pipe(
+        tap(() => this.loading.set(true)),
+        switchMap(() => {
+          const requests = AKRITES_TRIAGE_COLUMNS.map((col) =>
+            this.akritesService.getPackages({ status: col.status, pageSize: 50, sortBy: 'risk' }).pipe(
+              map((res) => ({ status: col.status, packages: res.packages ?? [], total: res.total ?? 0, error: false })),
+              catchError(() => of({ status: col.status, packages: [] as AkritesPackage[], total: 0, error: true }))
+            )
+          );
+          return forkJoin(requests);
+        }),
+        map((results) => {
+          const data: Partial<Record<AkritesTriageStatus, AkritesTriageColumnState>> = {};
+          for (const r of results) {
+            data[r.status as AkritesTriageStatus] = { packages: r.packages, total: r.total, loading: false, error: r.error };
+          }
+          return data as Record<AkritesTriageStatus, AkritesTriageColumnState>;
+        }),
+        tap(() => this.loading.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-triage-tab/akrites-triage-tab.component.ts
@@ -5,7 +5,13 @@ import { DecimalPipe, TitleCasePipe } from '@angular/common';
 import { Component, DestroyRef, computed, inject, input, output, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AKRITES_TRIAGE_COLUMNS } from '@lfx-one/shared/constants';
-import { AkritesPackage, AkritesTriageBoardColumnConfig, AkritesTriageColumnState, AkritesTriageStatus } from '@lfx-one/shared/interfaces';
+import {
+  AkritesPackage,
+  AkritesTriageBoardColumnConfig,
+  AkritesTriageColumnState,
+  AkritesTriagePackageVM,
+  AkritesTriageStatus,
+} from '@lfx-one/shared/interfaces';
 import { AkritesService } from '@shared/services/akrites.service';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -22,8 +28,6 @@ export class AkritesTriageTabComponent {
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
 
-  protected readonly canWrite = this.projectContextService.canWrite;
-
   public readonly reloadTrigger = input<number>(0);
 
   public readonly packageClick = output<string>();
@@ -31,56 +35,27 @@ export class AkritesTriageTabComponent {
 
   protected readonly TRIAGE_COLUMNS = AKRITES_TRIAGE_COLUMNS;
   protected readonly loading = signal(true);
+  protected readonly canWrite = this.projectContextService.canWrite;
 
   protected readonly boardData = this.initBoardData();
+
+  /** Keyed lookup so the template avoids per-cycle method calls. */
+  protected readonly columnStates = computed<Record<AkritesTriageStatus, AkritesTriageColumnState>>(() => {
+    const empty: AkritesTriageColumnState = { packages: [], total: 0, loading: true, error: false };
+    const data = this.boardData();
+    if (!data) return Object.fromEntries(AKRITES_TRIAGE_COLUMNS.map((c) => [c.status, empty])) as Record<AkritesTriageStatus, AkritesTriageColumnState>;
+    return data;
+  });
 
   protected readonly allColumnsEmpty = computed(() => {
     const data = this.boardData();
     if (data === undefined) return false;
-    return AKRITES_TRIAGE_COLUMNS.every((col) => (data[col.status]?.total ?? 0) === 0);
+    return AKRITES_TRIAGE_COLUMNS.every((col) => {
+      const state = data[col.status];
+      if (!state || state.error) return false;
+      return state.total === 0;
+    });
   });
-
-  protected getColumnState(status: AkritesTriageStatus): AkritesTriageColumnState {
-    return this.boardData()?.[status] ?? { packages: [], total: 0, loading: true, error: false };
-  }
-
-  protected getHealthLabel(score: number | null): string {
-    if (score === null) return '';
-    if (score >= 70) return 'Healthy';
-    if (score >= 50) return 'Fair';
-    if (score >= 30) return 'Concerning';
-    return 'Critical';
-  }
-
-  protected getHealthColor(score: number | null): string {
-    if (score === null) return '#9ca3af';
-    if (score >= 70) return '#22c55e';
-    if (score >= 50) return '#f59e0b';
-    if (score >= 30) return '#f97316';
-    return '#ef4444';
-  }
-
-  protected getVulnColor(vulnCount: number, vulnSeverity: string | null): string {
-    if (vulnCount === 0) return '#22c55e';
-    const colors: Record<string, string> = {
-      critical: '#ef4444',
-      high: '#f97316',
-      medium: '#f59e0b',
-      low: '#3b82f6',
-    };
-    return vulnSeverity ? (colors[vulnSeverity] ?? '#9ca3af') : '#9ca3af';
-  }
-
-  protected getColumnIconClass(iconName: string): string {
-    return `fa-light fa-${iconName} text-[11px]`;
-  }
-
-  protected getActionButtonClass(variant: 'blue' | 'red' | 'default'): string {
-    const base = 'h-8 px-3.5 rounded-full border bg-white text-[12.5px] font-medium cursor-pointer transition-colors';
-    if (variant === 'blue') return `${base} border-blue-200 text-blue-600 hover:bg-blue-50 hover:border-blue-400`;
-    if (variant === 'red') return `${base} border-red-200 text-red-600 hover:bg-red-50 hover:border-red-400`;
-    return `${base} border-gray-300 text-gray-700 hover:bg-gray-50`;
-  }
 
   protected onCardClick(pkg: AkritesPackage): void {
     this.packageClick.emit(pkg.id);
@@ -110,6 +85,37 @@ export class AkritesTriageTabComponent {
       });
   }
 
+  private toVM(pkg: AkritesPackage): AkritesTriagePackageVM {
+    return {
+      ...pkg,
+      healthColor: this.healthColor(pkg.healthScore),
+      healthLabel: this.healthLabel(pkg.healthScore),
+      vulnColor: this.vulnColor(pkg.vulnCount, pkg.vulnSeverity),
+    };
+  }
+
+  private healthLabel(score: number | null): string {
+    if (score === null) return '';
+    if (score >= 70) return 'Healthy';
+    if (score >= 50) return 'Fair';
+    if (score >= 30) return 'Concerning';
+    return 'Critical';
+  }
+
+  private healthColor(score: number | null): string {
+    if (score === null) return '#9ca3af';
+    if (score >= 70) return '#22c55e';
+    if (score >= 50) return '#f59e0b';
+    if (score >= 30) return '#f97316';
+    return '#ef4444';
+  }
+
+  private vulnColor(vulnCount: number, vulnSeverity: string | null): string {
+    if (vulnCount === 0) return '#22c55e';
+    const colors: Record<string, string> = { critical: '#ef4444', high: '#f97316', medium: '#f59e0b', low: '#3b82f6' };
+    return vulnSeverity ? (colors[vulnSeverity] ?? '#9ca3af') : '#9ca3af';
+  }
+
   private initBoardData() {
     return toSignal(
       toObservable(this.reloadTrigger).pipe(
@@ -117,8 +123,8 @@ export class AkritesTriageTabComponent {
         switchMap(() => {
           const requests = AKRITES_TRIAGE_COLUMNS.map((col) =>
             this.akritesService.getPackages({ status: col.status, pageSize: 50, sortBy: 'risk' }).pipe(
-              map((res) => ({ status: col.status, packages: res.packages ?? [], total: res.total ?? 0, error: false })),
-              catchError(() => of({ status: col.status, packages: [] as AkritesPackage[], total: 0, error: true }))
+              map((res) => ({ status: col.status, packages: (res.packages ?? []).map((p) => this.toVM(p)), total: res.total ?? 0, error: false })),
+              catchError(() => of({ status: col.status, packages: [] as AkritesTriagePackageVM[], total: 0, error: true }))
             )
           );
           return forkJoin(requests);

--- a/packages/shared/src/constants/akrites.constants.ts
+++ b/packages/shared/src/constants/akrites.constants.ts
@@ -11,6 +11,7 @@ import {
   AkritesInactiveReason,
   AkritesStewardRole,
   AkritesUpdatableStatus,
+  AkritesTriageBoardColumnConfig,
 } from '../interfaces';
 
 /** Status pills shown above the Akrites package queue, in display order. */
@@ -106,4 +107,13 @@ export const AKRITES_UPDATABLE_STATUS_OPTIONS: Array<{ value: AkritesUpdatableSt
   { value: 'needs_attention', label: 'Needs attention' },
   { value: 'blocked', label: 'Blocked' },
   { value: 'inactive', label: 'Inactive' },
+];
+
+/** Columns shown on the Triage board tab, in display order. Only non-zero columns are rendered. */
+export const AKRITES_TRIAGE_COLUMNS: AkritesTriageBoardColumnConfig[] = [
+  { status: 'unassigned', label: 'Unassigned', color: '#62748e', iconName: 'user-xmark', actionLabel: 'Assign steward', actionVariant: 'blue' },
+  { status: 'needs_attention', label: 'Needs attention', color: '#f97316', iconName: 'binoculars', actionLabel: 'Review', actionVariant: 'default' },
+  { status: 'escalated', label: 'Escalated', color: '#e5484d', iconName: 'arrow-up', actionLabel: 'Resolve', actionVariant: 'red' },
+  { status: 'blocked', label: 'Blocked', color: '#e5484d', iconName: 'circle-info', actionLabel: 'Resolve blocker', actionVariant: 'red' },
+  { status: 'inactive', label: 'Inactive', color: '#90a1b9', iconName: 'clock', actionLabel: 'Reassign', actionVariant: 'default' },
 ];

--- a/packages/shared/src/constants/akrites.constants.ts
+++ b/packages/shared/src/constants/akrites.constants.ts
@@ -109,11 +109,53 @@ export const AKRITES_UPDATABLE_STATUS_OPTIONS: Array<{ value: AkritesUpdatableSt
   { value: 'inactive', label: 'Inactive' },
 ];
 
+const _BTN_BASE = 'h-8 px-3.5 rounded-full border bg-white text-[12.5px] font-medium cursor-pointer transition-colors';
+
 /** Columns shown on the Triage board tab, in display order. All columns are always rendered. */
 export const AKRITES_TRIAGE_COLUMNS: AkritesTriageBoardColumnConfig[] = [
-  { status: 'unassigned', label: 'Unassigned', color: '#62748e', iconName: 'user-xmark', actionLabel: 'Assign steward', actionVariant: 'blue' },
-  { status: 'needs_attention', label: 'Needs attention', color: '#f97316', iconName: 'binoculars', actionLabel: 'Review', actionVariant: 'default' },
-  { status: 'escalated', label: 'Escalated', color: '#e5484d', iconName: 'arrow-up', actionLabel: 'Resolve', actionVariant: 'red' },
-  { status: 'blocked', label: 'Blocked', color: '#e5484d', iconName: 'circle-info', actionLabel: 'Resolve blocker', actionVariant: 'red' },
-  { status: 'inactive', label: 'Inactive', color: '#90a1b9', iconName: 'clock', actionLabel: 'Reassign', actionVariant: 'default' },
+  {
+    status: 'unassigned',
+    label: 'Unassigned',
+    color: '#62748e',
+    iconClass: 'fa-light fa-user-xmark text-[11px]',
+    actionLabel: 'Assign steward',
+    actionVariant: 'blue',
+    actionButtonClass: `${_BTN_BASE} border-blue-200 text-blue-600 hover:bg-blue-50 hover:border-blue-400`,
+  },
+  {
+    status: 'needs_attention',
+    label: 'Needs attention',
+    color: '#f97316',
+    iconClass: 'fa-light fa-binoculars text-[11px]',
+    actionLabel: 'Review',
+    actionVariant: 'default',
+    actionButtonClass: `${_BTN_BASE} border-gray-300 text-gray-700 hover:bg-gray-50`,
+  },
+  {
+    status: 'escalated',
+    label: 'Escalated',
+    color: '#e5484d',
+    iconClass: 'fa-light fa-arrow-up text-[11px]',
+    actionLabel: 'Resolve',
+    actionVariant: 'red',
+    actionButtonClass: `${_BTN_BASE} border-red-200 text-red-600 hover:bg-red-50 hover:border-red-400`,
+  },
+  {
+    status: 'blocked',
+    label: 'Blocked',
+    color: '#e5484d',
+    iconClass: 'fa-light fa-circle-info text-[11px]',
+    actionLabel: 'Resolve blocker',
+    actionVariant: 'red',
+    actionButtonClass: `${_BTN_BASE} border-red-200 text-red-600 hover:bg-red-50 hover:border-red-400`,
+  },
+  {
+    status: 'inactive',
+    label: 'Inactive',
+    color: '#90a1b9',
+    iconClass: 'fa-light fa-clock text-[11px]',
+    actionLabel: 'Reassign',
+    actionVariant: 'default',
+    actionButtonClass: `${_BTN_BASE} border-gray-300 text-gray-700 hover:bg-gray-50`,
+  },
 ];

--- a/packages/shared/src/constants/akrites.constants.ts
+++ b/packages/shared/src/constants/akrites.constants.ts
@@ -109,7 +109,7 @@ export const AKRITES_UPDATABLE_STATUS_OPTIONS: Array<{ value: AkritesUpdatableSt
   { value: 'inactive', label: 'Inactive' },
 ];
 
-/** Columns shown on the Triage board tab, in display order. Only non-zero columns are rendered. */
+/** Columns shown on the Triage board tab, in display order. All columns are always rendered. */
 export const AKRITES_TRIAGE_COLUMNS: AkritesTriageBoardColumnConfig[] = [
   { status: 'unassigned', label: 'Unassigned', color: '#62748e', iconName: 'user-xmark', actionLabel: 'Assign steward', actionVariant: 'blue' },
   { status: 'needs_attention', label: 'Needs attention', color: '#f97316', iconName: 'binoculars', actionLabel: 'Review', actionVariant: 'default' },

--- a/packages/shared/src/interfaces/akrites.interface.ts
+++ b/packages/shared/src/interfaces/akrites.interface.ts
@@ -425,4 +425,26 @@ export interface AkritesActivityDayGroup {
   rows: AkritesActivityRowVM[];
 }
 
-export type AkritesDashboardTab = 'overview' | 'packages';
+export type AkritesDashboardTab = 'overview' | 'packages' | 'triage';
+
+// ===== Triage Board =====
+
+export type AkritesTriageStatus = Extract<AkritesStatus, 'unassigned' | 'needs_attention' | 'escalated' | 'blocked' | 'inactive'>;
+
+export interface AkritesTriageBoardColumnConfig {
+  status: AkritesTriageStatus;
+  label: string;
+  /** Hex color for the column icon circle and gradient tint. */
+  color: string;
+  /** FontAwesome icon name without the `fa-` prefix (e.g. `user-xmark`). */
+  iconName: string;
+  actionLabel: string;
+  actionVariant: 'blue' | 'red' | 'default';
+}
+
+export interface AkritesTriageColumnState {
+  packages: AkritesPackage[];
+  total: number;
+  loading: boolean;
+  error: boolean;
+}

--- a/packages/shared/src/interfaces/akrites.interface.ts
+++ b/packages/shared/src/interfaces/akrites.interface.ts
@@ -436,14 +436,23 @@ export interface AkritesTriageBoardColumnConfig {
   label: string;
   /** Hex color for the column icon circle and gradient tint. */
   color: string;
-  /** FontAwesome icon name without the `fa-` prefix (e.g. `user-xmark`). */
-  iconName: string;
+  /** Pre-computed FontAwesome class string bound directly in the template. */
+  iconClass: string;
   actionLabel: string;
   actionVariant: 'blue' | 'red' | 'default';
+  /** Pre-computed Tailwind class string for the action button. */
+  actionButtonClass: string;
+}
+
+/** `AkritesPackage` extended with pre-computed display values to avoid method calls in bindings. */
+export interface AkritesTriagePackageVM extends AkritesPackage {
+  healthColor: string;
+  healthLabel: string;
+  vulnColor: string;
 }
 
 export interface AkritesTriageColumnState {
-  packages: AkritesPackage[];
+  packages: AkritesTriagePackageVM[];
   total: number;
   loading: boolean;
   error: boolean;


### PR DESCRIPTION
## Summary

- Adds a Triage Board tab to the OSSPREY (Akrites) Program dashboard as a Kanban-style board
- Five columns, one per stewardship status: Unassigned, Needs attention, Escalated, Blocked, Inactive
- Each column fetches its packages in parallel (`forkJoin`) via `GET /api/akrites/packages?status=<status>&pageSize=50&sortBy=risk`
- Cards show package name, purl, health/impact/vulnerability chips, and assigned steward (if any)
- Per-column action buttons (Review, Resolve, Resolve blocker, Reassign) are gated behind `canWrite()` — same criteria as the overview activity list
- Assign steward action omitted from the Unassigned column (endpoint not yet available)
- Empty columns always render with a "No packages" empty state; columns are never hidden
- Also gates overview activity list action buttons behind `canWrite()` for consistency

## Changes

- `packages/shared/src/interfaces/akrites.interface.ts` — adds `'triage'` to `AkritessDashboardTab`, `AkritesTriageStatus`, `AkritesTriageBoardColumnConfig`, `AkritesTriageColumnState`
- `packages/shared/src/constants/akrites.constants.ts` — adds `AKRITES_TRIAGE_COLUMNS` config array
- `akrites-triage-tab` — new standalone component (TS + HTML) implementing the board
- `akrites-dashboard` — wires in the new tab and `lfx-akrites-triage-tab`
- `akrites-overview-tab` — gates action buttons on `canWrite()`

## JIRA

CM-1233