### PR TITLE
fix: use full Datadog env tag names for lfx-one RUM

### DIFF
--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -22,6 +22,6 @@ export const environment = {
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',
-    env: 'dev',
+    env: 'development',
   },
 };

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -21,7 +21,7 @@ export const environment = {
   },
   datadog: {
     site: 'datadoghq.com',
-    service: 'lfx-one',
+    service: 'lfx-self-serve',
     env: 'development',
   },
 };

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -22,6 +22,6 @@ export const environment = {
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',
-    env: 'prod',
+    env: 'production',
   },
 };

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -21,7 +21,7 @@ export const environment = {
   },
   datadog: {
     site: 'datadoghq.com',
-    service: 'lfx-one',
+    service: 'lfx-self-serve',
     env: 'production',
   },
 };

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -21,7 +21,7 @@ export const environment = {
   },
   datadog: {
     site: 'datadoghq.com',
-    service: 'lfx-one',
+    service: 'lfx-self-serve',
     env: 'staging',
   },
 };

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -21,7 +21,7 @@ export const environment = {
   },
   datadog: {
     site: 'datadoghq.com',
-    service: 'lfx-one',
+    service: 'lfx-self-serve',
     env: '', // temporarily set to 'local' to test RUM locally
   },
 };


### PR DESCRIPTION
## Summary

- Change `datadog.env` from `'prod'` to `'production'` in `environment.prod.ts`
- Change `datadog.env` from `'dev'` to `'development'` in `environment.dev.ts`
- Rename `datadog.service` from `'lfx-one'` to `'lfx-self-serve'` in all environment files

## Why

Two issues in the Datadog RUM configuration for `lfx-one`:

1. **Fragmented env tags** — RUM was reporting `env:prod`/`env:dev` instead of the standard `env:production`/`env:development`, splitting dashboards and APM correlation.
2. **Mismatched service name** — RUM reported under `lfx-one` while the server-side OTEL tracer (`server-tracer.ts`) defaults to `lfx-self-serve`. This prevented RUM↔APM trace correlation in Datadog.

## Safety

- `datadog.env` is only used as a label in `datadogRum.init()` and as a truthy/falsy toggle. No code compares against `'prod'`/`'dev'` literally.
- `datadog.service` is only passed to `datadogRum.init()` as a label. No code branches on the service name value.

## Test plan

- [ ] After deploy, confirm RUM explorer shows `lfx-self-serve` under `env:production` and `env:development`
- [ ] Confirm `env:(dev OR prod)` query returns no results for `lfx-self-serve`
- [ ] Confirm RUM sessions correlate with APM traces under the `lfx-self-serve` service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue: LFXV2-2401