### PR TITLE
fix(meetings): grant registered participants access to private meeting details

### DIFF
--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -142,6 +142,10 @@ export class PublicMeetingController {
       // Authenticated registered participants and organizers can access private/restricted
       // meeting details without a password in the URL — their registrant record is the gate.
       if (meeting.invited || meeting.organizer) {
+        // host_key grants Zoom host privileges — only organizers should receive it.
+        if (!meeting.organizer) {
+          delete (meeting as Partial<Meeting>).host_key;
+        }
         res.json({
           meeting,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
@@ -154,13 +158,22 @@ export class PublicMeetingController {
       if (isAuthenticated) {
         const userEmail = getEffectiveEmail(req);
         if (userEmail) {
-          const registrantsByEmail = await this.meetingService.getMeetingRegistrantsByEmail(req, id, userEmail, m2mToken);
-          if (registrantsByEmail.length > 0) {
-            res.json({
-              meeting,
-              project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+          try {
+            const registrantsByEmail = await this.meetingService.getMeetingRegistrantsByEmail(req, id, userEmail, m2mToken);
+            if (registrantsByEmail.length > 0) {
+              meeting.invited = true;
+              delete (meeting as Partial<Meeting>).host_key;
+              res.json({
+                meeting,
+                project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+              });
+              return;
+            }
+          } catch (fallbackError) {
+            logger.warning(req, 'get_public_meeting_by_id', 'Email registrant fallback check failed, continuing to password gate', {
+              meeting_id: id,
+              err: fallbackError,
             });
-            return;
           }
         }
       }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -161,6 +161,10 @@ export class PublicMeetingController {
           try {
             const registrantsByEmail = await this.meetingService.getMeetingRegistrantsByEmail(req, id, userEmail, m2mToken);
             if (registrantsByEmail.length > 0) {
+              logger.warning(req, 'get_public_meeting_by_id', 'invited flag was false negative; email fallback succeeded', {
+                meeting_id: id,
+                email: userEmail,
+              });
               meeting.invited = true;
               delete (meeting as Partial<Meeting>).host_key;
               res.json({

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -149,6 +149,22 @@ export class PublicMeetingController {
         return;
       }
 
+      // Fallback for authenticated users: the invited flag can miss someone if the query
+      // service OR lookup had a false negative. Re-check directly by email with M2M.
+      if (isAuthenticated) {
+        const userEmail = getEffectiveEmail(req);
+        if (userEmail) {
+          const registrantsByEmail = await this.meetingService.getMeetingRegistrantsByEmail(req, id, userEmail, m2mToken);
+          if (registrantsByEmail.length > 0) {
+            res.json({
+              meeting,
+              project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+            });
+            return;
+          }
+        }
+      }
+
       // Check if the user has passed in a password, if so, check if it's correct
       const { password } = req.query;
       if (!this.validateMeetingPassword(password as string, meeting.password as string, 'get_public_meeting_by_id', req, next)) {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -139,6 +139,16 @@ export class PublicMeetingController {
         return;
       }
 
+      // Authenticated registered participants and organizers can access private/restricted
+      // meeting details without a password in the URL — their registrant record is the gate.
+      if (meeting.invited || meeting.organizer) {
+        res.json({
+          meeting,
+          project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+        });
+        return;
+      }
+
       // Check if the user has passed in a password, if so, check if it's correct
       const { password } = req.query;
       if (!this.validateMeetingPassword(password as string, meeting.password as string, 'get_public_meeting_by_id', req, next)) {


### PR DESCRIPTION
## Summary

- Authenticated users registered for a private/restricted meeting were blocked by the password gate in `getMeetingById`
- `meeting.invited` was correctly set to `true` from their registrant record, but was never checked before requiring a password in the URL
- Users arriving from their self-serve profile (no `?password=` in the URL) saw a password prompt instead of meeting details

## Root Cause

In `public-meeting.controller.ts`, the flow for private/restricted meetings was:
1. Meeting is public → return immediately ✓
2. Check `?password=` → none present → return password error ✗

The `meeting.invited` flag (set by `addInvitedStatusToMeeting` from DynamoDB registrant records) was never used as an access gate.

## Fix

Added a check for `meeting.invited || meeting.organizer` between steps 1 and 2, so registered participants bypass the password requirement. The registrant record in DynamoDB is the access gate.

## Evidence

Confirmed via DynamoDB query: affected users (`thilaknath.ashok.kumar@sap.com`, `sesergee@cisco.com`) both have registrant records for the relevant meetings (`last_invite_delivery_successful: true`) — they are properly registered, just incorrectly blocked by the password check.

## Test plan

- [ ] Log in as a user registered for a private meeting and navigate to it from the self-serve profile (no `?password=` in URL) — should see meeting details and join link
- [ ] Log in as an unregistered user and attempt to access the same meeting — should still see password prompt
- [ ] Verify organizer access is unchanged
- [ ] Verify public meetings are unaffected

Fixes LFXV2-2438