### PR TITLE
fix(crowdfunding): return null instead of 404 when user has no payment method

### DIFF
--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -83,13 +83,9 @@ export class CrowdfundingController {
 
       const paymentMethod = await this.crowdfundingService.getMyPaymentMethod(req);
 
-      if (!paymentMethod) {
-        res.status(404).json({ message: 'No payment method found' });
-        return;
-      }
-
       logger.success(req, 'get_my_payment_method', startTime);
 
+      // null when the user has no payment method — not a 404, just an empty state
       res.json(paymentMethod);
     } catch (error) {
       next(error);


### PR DESCRIPTION
## Summary

- When a user has no saved payment method, `GET /api/crowdfunding/payment-method` was returning a 404 instead of a graceful null/empty response
- Root cause: the service (`cfFetchNullable`) already absorbed the upstream CF API 404 and returned `null`, but the controller re-converted that `null` into a `404`
- Fix: removed the spurious `if (!paymentMethod)` 404 guard; `res.json(paymentMethod)` now returns `200` with `null` body for the no-payment-method case, which the Angular frontend already handles correctly (`Observable<PaymentMethod | null>`)

## Notes

- No frontend changes needed — `CrowdfundingService.getMyPaymentMethod()` is already typed as `Observable<PaymentMethod | null>` and `handleCfError` already handles the null case
- Other CF controller endpoints (initiative-by-slug, recurring-donation-by-id) are genuine "not found" lookups where 404 remains semantically correct and were left unchanged

Fixes LFXV2-2261