### PR TITLE
feat(org-lens): send invite when adding or replacing a key contact

### DIFF
--- a/apps/lfx-one/src/server/services/org-lens-key-contacts.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-key-contacts.service.ts
@@ -252,6 +252,7 @@ export class OrgLensKeyContactsService {
         status: 'Active',
         primary_contact: body.contactType === KEY_CONTACT_PRIMARY_CONTACT_TYPE,
         board_member: false,
+        send_invite: true,
       }
     );
     return this.toPerson(created);
@@ -266,6 +267,7 @@ export class OrgLensKeyContactsService {
       primary_contact: body.contactType === KEY_CONTACT_PRIMARY_CONTACT_TYPE,
       board_member: false,
       ...(title ? { title } : {}),
+      send_invite: true,
     };
   }
 


### PR DESCRIPTION
## Summary
- Set `send_invite: true` when writing key contacts to the member-service so a newly added or replaced key contact receives an invitation to claim their LFID and access the project membership, instead of being created as a silent record.
- Applied to both the create key-contact `POST` body and the replace key-contact update body.

## Out of scope (intentionally)
- No UI changes — the invite is dispatched server-side by member-service on contact write.


[LFXV2-2461]: https://linuxfoundation.atlassian.net/browse/LFXV2-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ