### PR TITLE
fix(committees): use invite fields for org-required check

### DIFF
--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -5,7 +5,8 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HeaderComponent } from '@components/header/header.component';
-import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
+import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
+import { InvitationAcceptFlowService } from '@services/invitation-accept-flow.service';
 import { InviteService } from '@services/invite.service';
 import { take } from 'rxjs';
 
@@ -18,6 +19,7 @@ export class InviteComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly inviteService = inject(InviteService);
+  private readonly invitationAcceptFlow = inject(InvitationAcceptFlowService);
   private readonly platformId = inject(PLATFORM_ID);
 
   protected readonly isProcessing = signal(true);
@@ -43,7 +45,11 @@ export class InviteComponent implements OnInit {
       .pipe(take(1))
       .subscribe({
         next: (res) => {
-          window.location.href = res.return_url;
+          if (res.pending_committee_invite) {
+            this.collectOrgAndAccept(res.pending_committee_invite, res.return_url);
+          } else {
+            window.location.href = res.return_url;
+          }
         },
         error: (err) => {
           const code = err?.error?.code as string;
@@ -56,6 +62,28 @@ export class InviteComponent implements OnInit {
             reason = 'failed';
           }
           this.redirectToError(reason);
+        },
+      });
+  }
+
+  private collectOrgAndAccept(invite: PendingCommitteeInviteForOrg, returnUrl: string): void {
+    this.isProcessing.set(false);
+    this.invitationAcceptFlow
+      .accept({
+        committeeUid: invite.committee_uid,
+        inviteUid: invite.invite_uid,
+        committeeName: invite.committee_name,
+        organization: invite.organization,
+        organization_required: true,
+      })
+      .pipe(take(1))
+      .subscribe({
+        // Redirect whether the user confirmed or cancelled — the LFID accept already succeeded.
+        complete: () => {
+          window.location.href = returnUrl;
+        },
+        error: () => {
+          window.location.href = returnUrl;
         },
       });
   }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -13,7 +13,7 @@ import {
   CreateCommitteeJoinApplicationRequest,
   UploadCommitteeDocumentRequest,
 } from '@lfx-one/shared/interfaces';
-import { invitationRequiresOrganization, isFileTypeAllowed } from '@lfx-one/shared/utils';
+import { isFileTypeAllowed } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { Readable } from 'node:stream';
 import { ReadableStream as NodeReadableStream } from 'node:stream/web';
@@ -725,7 +725,11 @@ export class CommitteeController {
       // Build an explicit allowlist payload — never forward unknown client-supplied fields upstream.
       const acceptData: AcceptCommitteeInviteRequest = {};
 
-      if (invitationRequiresOrganization({ organization_required: pendingInvite.organization_required })) {
+      // Only pre-validate org when organization_required is explicitly true. When it is
+      // null/undefined (invite pre-dates committee-service v1.1), skip the BFF check and let
+      // the upstream accept endpoint be authoritative — avoid blocking valid accepts with a
+      // spurious 400 due to the fail-closed fallback in invitationRequiresOrganization.
+      if (pendingInvite.organization_required === true) {
         const body = (req.body ?? {}) as AcceptCommitteeInviteRequest;
         const orgName = typeof body.organization?.name === 'string' ? body.organization.name.trim() : '';
         if (!orgName) {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -13,7 +13,7 @@ import {
   CreateCommitteeJoinApplicationRequest,
   UploadCommitteeDocumentRequest,
 } from '@lfx-one/shared/interfaces';
-import { committeeRequiresOrganization, isFileTypeAllowed } from '@lfx-one/shared/utils';
+import { invitationRequiresOrganization, isFileTypeAllowed } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { Readable } from 'node:stream';
 import { ReadableStream as NodeReadableStream } from 'node:stream/web';
@@ -24,6 +24,7 @@ import { contentDispositionAttachment } from '../helpers/content-disposition.hel
 import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
 import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
 import { CommitteeService } from '../services/committee.service';
 import { MeetingService } from '../services/meeting.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
@@ -693,14 +694,38 @@ export class CommitteeController {
         return;
       }
 
-      // Fetch with throwOnSettingsError so a settings-service outage fails the accept
-      // (returns 503) rather than silently treating business_email_required as false.
-      const committee = await this.committeeService.getCommitteeById(req, id, { throwOnSettingsError: true });
+      // Determine org-required using the invite's own organization_required field — accessible
+      // to the invitee via the email-scoped query index regardless of committee-viewer status.
+      // This replaces the previous getCommitteeById + getCommitteeSettings fetch which failed
+      // the access check for invitees who are not yet committee viewers (LFXV2-2453).
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        next(
+          ServiceValidationError.forField('email', 'User email not found in authentication context', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      const pendingInvite = await this.committeeService.getPendingInviteForUser(req, userEmail, id, inviteId);
+      if (!pendingInvite) {
+        next(
+          ServiceValidationError.forField('inviteId', 'No matching pending invite found for this user', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
 
       // Build an explicit allowlist payload — never forward unknown client-supplied fields upstream.
       const acceptData: AcceptCommitteeInviteRequest = {};
 
-      if (committeeRequiresOrganization(committee)) {
+      if (invitationRequiresOrganization({ organization_required: pendingInvite.organization_required })) {
         const body = (req.body ?? {}) as AcceptCommitteeInviteRequest;
         const orgName = typeof body.organization?.name === 'string' ? body.organization.name.trim() : '';
         if (!orgName) {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -98,7 +98,7 @@ export class InviteController {
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
-      let pendingCommitteeInvite = undefined;
+      let pendingCommitteeInvite: PendingCommitteeInviteForOrg | undefined;
       try {
         pendingCommitteeInvite = (await this.autoAcceptPendingCommitteeInvites(req, payload)) ?? undefined;
       } catch (error) {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
+import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 import { errors as JoseErrors, JWK, JWT } from 'jose';
 
@@ -98,8 +98,9 @@ export class InviteController {
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
+      let pendingCommitteeInvite = undefined;
       try {
-        await this.autoAcceptPendingCommitteeInvites(req, payload);
+        pendingCommitteeInvite = (await this.autoAcceptPendingCommitteeInvites(req, payload)) ?? undefined;
       } catch (error) {
         // Best-effort — committee auto-accept failures must not block LFID invite acceptance.
         logger.warning(req, 'accept_invite', 'Committee invite auto-accept failed; LFID accept continues', {
@@ -114,7 +115,7 @@ export class InviteController {
         resource_uid: payload.resource_uid,
       });
 
-      res.json({ return_url: safeReturnUrl });
+      res.json({ return_url: safeReturnUrl, ...(pendingCommitteeInvite && { pending_committee_invite: pendingCommitteeInvite }) });
     } catch (error) {
       next(error);
     }
@@ -146,8 +147,12 @@ export class InviteController {
    * When an LFID invite is accepted for a committee invitee, accept any matching pending
    * committee_invite so a committee_member is created with the session username. Requires
    * the authenticated user's email to match the email embedded in the LFID invite JWT.
+   *
+   * Returns a {@link PendingCommitteeInviteForOrg} when an invite requires an organization
+   * that was not pre-filled — the caller should surface this to the client for manual org
+   * collection. Returns null when all invites were handled or the flow was skipped.
    */
-  private async autoAcceptPendingCommitteeInvites(req: Request, payload: InviteTokenPayload): Promise<void> {
+  private async autoAcceptPendingCommitteeInvites(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
     const sessionEmail = getEffectiveEmail(req)?.trim() ?? null;
 
@@ -155,24 +160,24 @@ export class InviteController {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — LFID invite token has no email claim', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
     if (!sessionEmail) {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — session email unavailable', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
     if (invitedEmail !== sessionEmail) {
       logger.info(req, 'accept_invite', 'Skipping committee invite auto-accept — session email does not match LFID invite token email', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
-    await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
+    return this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
       invitedEmail,
       resourceUid: payload.resource_uid,
     });

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -25,7 +25,7 @@ import {
   QueryServiceResponse,
   UploadCommitteeDocumentRequest,
 } from '@lfx-one/shared/interfaces';
-import { committeeRequiresOrganization } from '@lfx-one/shared/utils';
+import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -661,8 +661,11 @@ export class CommitteeService {
       pending_count: pendingInvites.length,
     });
 
-    // Enrich committee context (name, category, project) for the distinct committees once.
-    // Best-effort: a failed lookup degrades to a UID fallback rather than dropping the list.
+    // Enrich committee context (category, project_name) for the distinct committees once.
+    // committee_name and organization_required are sourced directly from the invite itself
+    // (committee-service ≥ v1.1) so no committee/settings fetch is required to decide org
+    // requirement — those endpoints fail the access check for invitees who are not yet viewers.
+    // Best-effort: a failed lookup degrades gracefully; category/project_name become null.
     const committeeUids = Array.from(new Set(pendingInvites.map((invite) => invite.committee_uid).filter(Boolean)));
     const committeeContext = new Map<
       string,
@@ -670,8 +673,6 @@ export class CommitteeService {
         committee_name: string;
         category?: string | null;
         project_name?: string | null;
-        enable_voting?: boolean;
-        business_email_required?: boolean;
       }
     >();
 
@@ -680,28 +681,6 @@ export class CommitteeService {
       const enriched = await this.projectService.enrichWithProjectData(req, Array.from(committees.values()));
       const projectNameByCommittee = new Map(enriched.map((committee) => [committee.uid, committee.project_name]));
 
-      // business_email_required is a settings-only field not present in the query-service
-      // committee index (which only stores CommitteeBase). Fetch settings in parallel so the
-      // invitationRequiresOrganization guard is accurate for business-email-only committees.
-      // throwOnError: true so a transient outage throws and is caught below, where we fail
-      // closed (true) rather than leaving business_email_required undefined — enable_voting
-      // is always defined from the index, so the both-undefined guard in
-      // invitationRequiresOrganization never fires here; without this, a settings outage
-      // would silently skip the org dialog and cause a server 400 on accept.
-      const settingsByUid = new Map<string, boolean | undefined>();
-      await Promise.all(
-        committeeUids.map(async (uid) => {
-          try {
-            const settings = await this.getCommitteeSettings(req, uid, { throwOnError: true });
-            settingsByUid.set(uid, settings.business_email_required);
-          } catch {
-            // Settings unavailable — fail closed: assume org is required so the dialog
-            // appears and the server's authoritative check can decide.
-            settingsByUid.set(uid, true);
-          }
-        })
-      );
-
       for (const uid of committeeUids) {
         const committee = committees.get(uid);
         if (committee) {
@@ -709,8 +688,6 @@ export class CommitteeService {
             committee_name: committee.name || uid,
             category: committee.category ?? null,
             project_name: projectNameByCommittee.get(uid) || null,
-            enable_voting: committee.enable_voting,
-            business_email_required: settingsByUid.get(uid),
           });
         }
       }
@@ -723,10 +700,13 @@ export class CommitteeService {
 
     return pendingInvites.map((invite) => {
       const context = committeeContext.get(invite.committee_uid);
+      // Prefer the invite's own committee_name (access-safe, set at invite-creation time),
+      // fall back to the enriched committee resource name, then the UID.
+      const committeeName = invite.committee_name?.trim() || context?.committee_name || invite.committee_uid;
       return {
         uid: invite.uid,
         committee_uid: invite.committee_uid,
-        committee_name: context?.committee_name || invite.committee_uid,
+        committee_name: committeeName,
         project_name: context?.project_name ?? null,
         category: context?.category ?? null,
         role: invite.role ?? null,
@@ -734,8 +714,7 @@ export class CommitteeService {
         status: invite.status,
         created_at: invite.created_at,
         organization: invite.organization ?? null,
-        enable_voting: context?.enable_voting,
-        business_email_required: context?.business_email_required,
+        organization_required: invite.organization_required ?? null,
         // inviter_name / expires_at are intentionally omitted (left undefined) — they're reserved
         // optional fields not in the committee-service contract yet, so JSON drops them rather than
         // sending an explicit null that consumers would have to disambiguate from "set".
@@ -776,23 +755,11 @@ export class CommitteeService {
 
     for (const invite of toAccept) {
       try {
-        // Default to true (org required) so a fetch failure is fail-closed — we skip rather
-        // than auto-accept when we cannot determine the committee's requirements.
-        let requiresOrganization = true;
-
-        try {
-          const committee = await this.getCommitteeById(req, invite.committee_uid, { throwOnSettingsError: true });
-          requiresOrganization = committeeRequiresOrganization({
-            enable_voting: committee.enable_voting,
-            business_email_required: committee.business_email_required,
-          });
-        } catch (settingsError) {
-          logger.warning(req, 'accept_invite', 'Unable to fetch committee settings; treating as org-required (fail-closed)', {
-            committee_uid: invite.committee_uid,
-            invite_uid: invite.uid,
-            err: settingsError,
-          });
-        }
+        // organization_required is carried on the invite itself (committee-service ≥ v1.1) so no
+        // committee/settings fetch is needed — those fail the access check for non-viewer invitees.
+        // Fail-closed when the field is absent: treat as org-required so we skip rather than
+        // auto-accept without the required organization.
+        const requiresOrganization = invitationRequiresOrganization({ organization_required: invite.organization_required });
 
         if (requiresOrganization) {
           const orgName = invite.organization?.name?.trim() || null;
@@ -848,6 +815,18 @@ export class CommitteeService {
       committee_uid: committeeId,
       invite_uid: inviteId,
     });
+  }
+
+  /**
+   * Returns the specific pending committee invite for {@link email} that matches
+   * {@link committeeUid} + {@link inviteUid}, or `null` when not found.
+   *
+   * Uses the email-scoped query index — accessible to the invitee regardless of whether they
+   * are a committee viewer — so this is safe to call before the invite is accepted.
+   */
+  public async getPendingInviteForUser(req: Request, email: string, committeeUid: string, inviteUid: string): Promise<CommitteeInvite | null> {
+    const pending = await this.fetchPendingCommitteeInvitesByEmail(req, email);
+    return pending.find((invite) => invite.committee_uid === committeeUid && invite.uid === inviteUid) ?? null;
   }
 
   // ── Persona Helper ──────────────────────────────────────────────────────

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -18,6 +18,7 @@ import {
   CreateCommitteeJoinApplicationRequest,
   CreateCommitteeMemberRequest,
   MyCommittee,
+  PendingCommitteeInviteForOrg,
   PendingInvitation,
   Project,
   ProjectSettings,
@@ -729,14 +730,20 @@ export class CommitteeService {
    * when multiple pending invites exist — matched against committee_invite UID first, then
    * committee UID; if no match and exactly one pending invite remains, that one is accepted.
    *
-   * Failures are logged and swallowed so LFID acceptance still succeeds — the user can
-   * accept manually from pending-actions / My Groups.
+   * Returns the first invite that requires an organization but had none pre-filled — the
+   * caller must surface this to the user to collect their organization and complete acceptance.
+   * Other invites (those that can be auto-accepted) are still processed before returning.
+   *
+   * Other failures are logged and swallowed so LFID acceptance still succeeds.
    */
-  public async acceptPendingCommitteeInvitesAfterLfidAccept(req: Request, params: { invitedEmail: string; resourceUid?: string }): Promise<void> {
+  public async acceptPendingCommitteeInvitesAfterLfidAccept(
+    req: Request,
+    params: { invitedEmail: string; resourceUid?: string }
+  ): Promise<PendingCommitteeInviteForOrg | null> {
     const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
     if (pendingInvites.length === 0) {
       logger.debug(req, 'accept_invite', 'No pending committee invitations to auto-accept after LFID invite');
-      return;
+      return null;
     }
 
     const toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
@@ -745,13 +752,15 @@ export class CommitteeService {
         pending_count: pendingInvites.length,
         resource_uid: params.resourceUid,
       });
-      return;
+      return null;
     }
 
     logger.info(req, 'accept_invite', 'Auto-accepting committee invitations after LFID invite', {
       accept_count: toAccept.length,
       resource_uid: params.resourceUid,
     });
+
+    let pendingForOrg: PendingCommitteeInviteForOrg | null = null;
 
     for (const invite of toAccept) {
       try {
@@ -764,10 +773,20 @@ export class CommitteeService {
         if (requiresOrganization) {
           const orgName = invite.organization?.name?.trim() || null;
           if (!orgName) {
-            logger.warning(req, 'accept_invite', 'Skipping auto-accept — committee requires organization but invite has none; user must accept manually', {
-              committee_uid: invite.committee_uid,
-              invite_uid: invite.uid,
-            });
+            // Return the first such invite so the client can collect the org and complete acceptance.
+            // Keep processing other invites — those that don't need org can still be auto-accepted.
+            if (!pendingForOrg) {
+              logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
+                committee_uid: invite.committee_uid,
+                invite_uid: invite.uid,
+              });
+              pendingForOrg = {
+                committee_uid: invite.committee_uid,
+                invite_uid: invite.uid,
+                committee_name: invite.committee_name?.trim() || invite.committee_uid,
+                organization: invite.organization ?? null,
+              };
+            }
             continue;
           }
           // Build an explicit allowlist payload — trim fields and coerce empty strings to null
@@ -789,6 +808,8 @@ export class CommitteeService {
         });
       }
     }
+
+    return pendingForOrg;
   }
 
   /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -95,6 +95,15 @@ export interface CommitteeInvite {
   created_at: string;
   /** Suggested organization for the invitee (optional) */
   organization?: CommitteeOrganizationReference | null;
+  /** Committee display name captured at invite-creation time (committee-service ≥ v1.1) */
+  committee_name?: string | null;
+  /**
+   * Whether the invitee must supply an organization when accepting. True when the committee
+   * has voting enabled or requires a business email (committee-service ≥ v1.1). Carried on
+   * the invite so the accept flow does not need to fetch the access-controlled committee/settings
+   * endpoints — those fail for invitees who are not yet committee viewers.
+   */
+  organization_required?: boolean | null;
 }
 
 /**
@@ -103,18 +112,21 @@ export interface CommitteeInvite {
  * committee-service `committee_invite` resource with its `committee` resource for
  * display context (committee name, project name, category).
  *
- * The underlying `committee_invite` resource carries ONLY: uid, committee_uid,
- * invitee_email, role, status, created_at. There is NO inviter name and NO expiry in
- * the current committee-service contract — so {@link inviter_name} and
- * {@link expires_at} are reserved, optional fields that stay `undefined` until/unless
- * the committee-service starts emitting them. Do NOT fabricate either on the BFF.
+ * `committee_name` is sourced from the invite's own `committee_name` field when
+ * available (committee-service ≥ v1.1), falling back to the enriched committee resource
+ * name, then the committee UID. `organization_required` is sourced from the invite's own
+ * field when available; legacy `enable_voting` / `business_email_required` are kept for
+ * backwards compat but are no longer fetched in the accept path.
+ *
+ * `inviter_name` / `expires_at` are reserved, optional fields that stay `undefined`
+ * until/unless the committee-service starts emitting them. Do NOT fabricate either on the BFF.
  */
 export interface PendingInvitation {
   /** committee_invite UID — used for accept/decline */
   uid: string;
   /** Committee this invitation is for */
   committee_uid: string;
-  /** Committee display name — enriched from the committee resource */
+  /** Committee display name */
   committee_name: string;
   /** Project display name — enriched (optional) */
   project_name?: string | null;
@@ -140,9 +152,15 @@ export interface PendingInvitation {
   expires_at?: string | null;
   /** Suggested organization from the invite (pre-fills the accept modal) */
   organization?: CommitteeOrganizationReference | null;
-  /** Whether the committee has voting enabled — enriched from the committee resource */
+  /**
+   * Whether the invitee must supply an organization when accepting. Sourced from the
+   * invite's own `organization_required` field (committee-service ≥ v1.1) so the accept
+   * flow does not require committee-viewer access.
+   */
+  organization_required?: boolean | null;
+  /** Whether the committee has voting enabled — enriched from the committee resource (legacy) */
   enable_voting?: boolean;
-  /** Whether the committee requires a business email — enriched from the committee resource */
+  /** Whether the committee requires a business email — enriched from the committee resource (legacy) */
   business_email_required?: boolean;
 }
 
@@ -203,6 +221,7 @@ export interface InvitationAcceptContext {
   inviteUid: string;
   committeeName: string;
   organization?: CommitteeOrganizationReference | null;
+  organization_required?: boolean | null;
   enable_voting?: boolean;
   business_email_required?: boolean;
   inviteRequiresOrganization?: boolean;

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CommitteeOrganizationReference } from './committee.interface';
+
 export interface InviteTokenPayload {
   email: string;
   exp: number;
@@ -12,6 +14,26 @@ export interface InviteTokenPayload {
   role: string;
 }
 
+/**
+ * A committee invite that could not be auto-accepted during the LFID invite flow because
+ * the committee requires an organization but none was pre-filled on the invite. The client
+ * must collect the organization from the user and accept the invite manually.
+ */
+export interface PendingCommitteeInviteForOrg {
+  committee_uid: string;
+  invite_uid: string;
+  /** Committee display name for the org dialog header */
+  committee_name: string;
+  /** Pre-fill value if the invite already carries a suggested organization */
+  organization?: CommitteeOrganizationReference | null;
+}
+
 export interface AcceptInviteResponse {
   return_url: string;
+  /**
+   * Present when a committee invite requires an organization on acceptance but none was
+   * pre-filled on the invite. The client should collect the org from the user and call
+   * POST /api/committees/:committee_uid/invites/:invite_uid/accept before redirecting.
+   */
+  pending_committee_invite?: PendingCommitteeInviteForOrg;
 }

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -121,6 +121,26 @@ describe('committeeRequiresOrganization', () => {
 });
 
 describe('invitationRequiresOrganization', () => {
+  // organization_required precedence (committee-service ≥ v1.1)
+  it('returns false when organization_required is false, even if legacy flags are true', () => {
+    expect(invitationRequiresOrganization({ organization_required: false, enable_voting: true, business_email_required: true })).toBe(false);
+  });
+
+  it('returns true when organization_required is true, even if inviteRequiresOrganization is false', () => {
+    expect(invitationRequiresOrganization({ organization_required: true, inviteRequiresOrganization: false })).toBe(true);
+  });
+
+  it('falls through when organization_required is null — checks inviteRequiresOrganization next', () => {
+    expect(invitationRequiresOrganization({ organization_required: null, inviteRequiresOrganization: false })).toBe(false);
+    expect(invitationRequiresOrganization({ organization_required: null, inviteRequiresOrganization: true })).toBe(true);
+  });
+
+  it('falls through when organization_required is undefined — checks legacy flags', () => {
+    expect(invitationRequiresOrganization({ organization_required: undefined, enable_voting: false, business_email_required: false })).toBe(false);
+    expect(invitationRequiresOrganization({ organization_required: undefined, enable_voting: true })).toBe(true);
+  });
+
+  // legacy precedence (pre-v1.1 invites without organization_required)
   it('prefers the precomputed inviteRequiresOrganization flag when set', () => {
     expect(invitationRequiresOrganization({ inviteRequiresOrganization: false, enable_voting: true })).toBe(false);
   });

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -13,14 +13,25 @@ export function committeeRequiresOrganization(flags: { enable_voting?: boolean; 
 }
 
 /**
- * Resolves whether an invitation accept flow must collect organization, preferring a
- * precomputed dashboard flag when present.
+ * Resolves whether an invitation accept flow must collect organization.
+ *
+ * Precedence (highest first):
+ * 1. `organization_required` — authoritative field on the invite itself (committee-service ≥ v1.1).
+ *    Preferred because it is access-safe: the invitee can read their own invite without being a
+ *    committee viewer, whereas the committee/settings endpoints fail the access check for non-members.
+ * 2. `inviteRequiresOrganization` — precomputed flag carried through the accept context.
+ * 3. `enable_voting` / `business_email_required` — legacy enriched flags; fail-closed to `true`
+ *    when both are undefined (unknown committee settings).
  */
 export function invitationRequiresOrganization(flags: {
+  organization_required?: boolean | null;
   enable_voting?: boolean;
   business_email_required?: boolean;
   inviteRequiresOrganization?: boolean;
 }): boolean {
+  if (flags.organization_required != null) {
+    return flags.organization_required;
+  }
   if (flags.inviteRequiresOrganization !== undefined) {
     return flags.inviteRequiresOrganization;
   }


### PR DESCRIPTION
## Summary

- Non-viewer invitees could never accept a committee invite because the BFF called the access-controlled \`GET /committees/:id\` + \`GET /committees/:id/settings\` endpoints to determine whether an organization is required on accept — those endpoints fail for users who are not yet committee members
- The committee-service now carries \`committee_name\` and \`organization_required\` directly on the \`committee_invite\` resource (readable via the email-scoped query index, no committee-viewer access needed)
- Replace all access-failing committee/settings fetches in the accept flow with the invite's own fields

## Changes

- **\`CommitteeInvite\` / \`PendingInvitation\` interfaces** — add \`committee_name?\` and \`organization_required?\`
- **\`invitationRequiresOrganization\`** — prefer \`organization_required\` (authoritative, access-safe) before the legacy \`enable_voting\` / \`business_email_required\` fallback chain
- **\`getMyPendingInvitations\`** — source \`committee_name\` and \`organization_required\` from the invite directly; remove the per-committee \`getCommitteeSettings\` fetch loop
- **New \`getPendingInviteForUser\`** — access-safe invite lookup via email-scoped query index
- **\`acceptCommitteeInvite\` controller** — replace \`getCommitteeById\` + settings fetch with \`getPendingInviteForUser\` to drive org-required check
- **\`acceptPendingCommitteeInvitesAfterLfidAccept\`** — use \`invite.organization_required\` directly instead of fetching the committee; returns the first invite that requires an org the user must supply manually, so the invite page can open the org dialog before redirecting

## Known edge cases

**Multiple org-required invites:** If a user has more than one pending invite that requires an organization but has none pre-filled, only the **first** such invite is returned to the client for manual collection. Remaining invites remain pending and can be accepted from the My Groups / pending-actions surface after the user becomes a committee member. This is a deliberate single-invite-at-a-time flow.

**Pre-v1.1 invites (legacy):** Invites created before committee-service v1.1 will have \`organization_required: null\`. In that case \`invitationRequiresOrganization\` falls through to the legacy \`enable_voting\` / \`business_email_required\` chain, which itself fails closed (\`true\`) when both fields are absent. This means the accept endpoint may return a 400 asking for an org for committees that don't actually require one, until all open invites are re-created by the committee-service after the v1.1 deploy. Acceptable transitional behaviour — the invite list is short-lived.

## Ticket

[LFXV2-2453](https://linuxfoundation.atlassian.net/browse/LFXV2-2453)

## Related

Depends on upstream: https://github.com/linuxfoundation/lfx-v2-committee-service/pull/135

## Test plan

- [ ] As a user **not yet a viewer** of a committee, accept a pending invite for a **non-org-required** committee — should accept directly without 403
- [ ] As a user **not yet a viewer**, accept a pending invite for an **org-required** committee — org dialog should appear, and accept should succeed after filling it in
- [ ] As a user with an org-required invite that has no pre-filled org, accept via LFID invite link — org dialog should appear after LFID accept succeeds, redirect to committee page after org is supplied
- [ ] Invite surfaces (dashboard pending-actions, My Groups, committee banner) show the real committee name instead of a UID
- [ ] Existing member accepts flow (user already a viewer) still works unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2453]: https://linuxfoundation.atlassian.net/browse/LFXV2-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ