### PR TITLE
fix(committees): accept committee invite org collection and forwarding

### DIFF
--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -68,6 +68,7 @@ export class InviteComponent implements OnInit {
 
   private collectOrgAndAccept(invite: PendingCommitteeInviteForOrg, returnUrl: string): void {
     this.isProcessing.set(false);
+    let accepted = false;
     this.invitationAcceptFlow
       .accept({
         committeeUid: invite.committee_uid,
@@ -78,12 +79,23 @@ export class InviteComponent implements OnInit {
       })
       .pipe(take(1))
       .subscribe({
-        // Redirect whether the user confirmed or cancelled — the LFID accept already succeeded.
-        complete: () => {
+        next: () => {
+          // Committee invite accepted with org — redirect to the group page now that the user is a member.
+          accepted = true;
           window.location.href = returnUrl;
         },
         error: () => {
+          // Committee accept failed; LFID accept already succeeded. Redirect anyway — the user can
+          // retry accepting the committee invite from My Groups.
           window.location.href = returnUrl;
+        },
+        complete: () => {
+          if (!accepted) {
+            // User dismissed the org dialog without confirming. The LFID accept already succeeded
+            // but the committee invite is still pending. Navigate home so the user isn't left on a
+            // blank page — they can accept the invite from My Groups.
+            void this.router.navigate(['/']);
+          }
         },
       });
   }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -725,23 +725,27 @@ export class CommitteeController {
       // Build an explicit allowlist payload — never forward unknown client-supplied fields upstream.
       const acceptData: AcceptCommitteeInviteRequest = {};
 
-      // Only pre-validate org when organization_required is explicitly true. When it is
-      // null/undefined (invite pre-dates committee-service v1.1), skip the BFF check and let
-      // the upstream accept endpoint be authoritative — avoid blocking valid accepts with a
-      // spurious 400 due to the fail-closed fallback in invitationRequiresOrganization.
-      if (pendingInvite.organization_required === true) {
-        const body = (req.body ?? {}) as AcceptCommitteeInviteRequest;
-        const orgName = typeof body.organization?.name === 'string' ? body.organization.name.trim() : '';
-        if (!orgName) {
-          next(
-            ServiceValidationError.forField('organization.name', 'Organization is required for this group', {
-              operation: 'accept_committee_invite',
-              service: 'committee_controller',
-              path: req.path,
-            })
-          );
-          return;
-        }
+      const body = (req.body ?? {}) as AcceptCommitteeInviteRequest;
+      const orgName = typeof body.organization?.name === 'string' ? body.organization.name.trim() : '';
+
+      // Only enforce org as required when organization_required is explicitly true. When it is
+      // null/undefined (invite pre-dates committee-service v1.1), skip the mandatory check and
+      // let the upstream accept endpoint be authoritative.
+      if (pendingInvite.organization_required === true && !orgName) {
+        next(
+          ServiceValidationError.forField('organization.name', 'Organization is required for this group', {
+            operation: 'accept_committee_invite',
+            service: 'committee_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      // Always forward the organization when the user supplied one — the upstream committee-service
+      // is authoritative on org requirements and must receive the value regardless of whether the
+      // invite's organization_required field is populated (it is absent on pre-v1.1 invites).
+      if (orgName) {
         acceptData.organization = {
           name: orgName,
           id: typeof body.organization?.id === 'string' ? body.organization.id.trim() || null : null,

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -727,11 +727,15 @@ export class CommitteeController {
 
       const body = (req.body ?? {}) as AcceptCommitteeInviteRequest;
       const orgName = typeof body.organization?.name === 'string' ? body.organization.name.trim() : '';
+      const orgId = typeof body.organization?.id === 'string' ? body.organization.id.trim() : '';
+
+      // Upstream accepts "organization id OR (organization name + domain)" — treat either as present.
+      const hasOrg = !!(orgName || orgId);
 
       // Only enforce org as required when organization_required is explicitly true. When it is
       // null/undefined (invite pre-dates committee-service v1.1), skip the mandatory check and
       // let the upstream accept endpoint be authoritative.
-      if (pendingInvite.organization_required === true && !orgName) {
+      if (pendingInvite.organization_required === true && !hasOrg) {
         next(
           ServiceValidationError.forField('organization.name', 'Organization is required for this group', {
             operation: 'accept_committee_invite',
@@ -745,10 +749,10 @@ export class CommitteeController {
       // Always forward the organization when the user supplied one — the upstream committee-service
       // is authoritative on org requirements and must receive the value regardless of whether the
       // invite's organization_required field is populated (it is absent on pre-v1.1 invites).
-      if (orgName) {
+      if (hasOrg) {
         acceptData.organization = {
           name: orgName,
-          id: typeof body.organization?.id === 'string' ? body.organization.id.trim() || null : null,
+          id: orgId || null,
           website: typeof body.organization?.website === 'string' ? body.organization.website.trim() || null : null,
         };
       }


### PR DESCRIPTION
## Summary

- **BAD_REQUEST on pre-v1.1 invites**: The BFF controller only forwarded the user's org to the upstream committee-service when `organization_required === true`. For older invites where the field is `null`/`undefined`, the org payload was silently dropped — the upstream service rejected with `BAD_REQUEST` ("organization id or organization name and domain are required").
- **"Not found" after LFID invite accept with org prompt**: The `collectOrgAndAccept` subscriber used `complete` for the redirect. `Observable#complete` fires for both the success path (after `acceptInvitation` emits) and for `EMPTY` (user dismissed the org dialog without confirming). The result was an immediate redirect to the committee group page before the invite was accepted, producing a "not found" error.

## Changes

**`committee.controller.ts`** — Decouple "enforce org required" from "forward org to upstream":
- The `=== true` guard now only gates the 400 response when org is absent and explicitly required.
- A separate `if (orgName)` block always forwards the org when the user supplied one, regardless of whether `organization_required` is populated on the invite.

**`invite.component.ts`** — Fix redirect timing in `collectOrgAndAccept`:
- Move redirect from `complete` to `next` — only fires when `acceptInvitation` actually emits (invite accepted with org).
- `complete` with `!accepted` guard navigates to `/` when the user dismisses the dialog, so they are not left on a blank page — they can accept the committee invite from My Groups.

## Ticket

[LFXV2-2453](https://linuxfoundation.atlassian.net/browse/LFXV2-2453)

## Test plan

- [ ] Accept a committee invite via the regular flow (org required, `organization_required === true`): org dialog appears, confirm — verify accept succeeds and committee page loads
- [ ] Accept a committee invite on a pre-v1.1 invite (`organization_required` is null): org dialog appears, confirm — verify no BAD_REQUEST and committee page loads
- [ ] Accept an LFID invite where committee requires org (no pre-filled org): after LFID accept, org dialog appears, confirm — verify redirect to committee page succeeds (user is now a member)
- [ ] Same as above but dismiss the org dialog: verify redirect goes to `/` (home) rather than the committee page

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2453]: https://linuxfoundation.atlassian.net/browse/LFXV2-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ