### PR TITLE
feat(campaigns): add program type selector for events and education

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -4,14 +4,14 @@
 <div class="flex flex-col gap-6 p-6" data-testid="campaigns-page">
   <!-- Header -->
   <div class="flex flex-col gap-3">
-    <h1 class="sr-only">Events Campaigns</h1>
+    <h1 class="sr-only">{{ activeProgramTypeConfig().breadcrumbLabel }}</h1>
     <!-- Breadcrumb -->
     <nav class="flex items-center gap-2 text-sm" aria-label="Breadcrumb" data-testid="campaigns-breadcrumb">
       <span class="text-gray-400">Campaigns</span>
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
       <span class="text-gray-400">Paid Performance</span>
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
-      <span class="font-semibold text-gray-900" aria-current="page">Events Campaigns</span>
+      <span class="font-semibold text-gray-900" aria-current="page">{{ activeProgramTypeConfig().breadcrumbLabel }}</span>
     </nav>
 
     <!-- Platform & Use Case Selectors -->
@@ -24,11 +24,14 @@
         <option>Paid Performance</option>
       </select>
       <select
-        class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
-        disabled
-        aria-label="Campaign use case"
+        class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        [value]="selectedProgramType()"
+        (change)="onProgramTypeChange($event)"
+        aria-label="Campaign program type"
         data-testid="campaigns-usecase-select">
-        <option>Events Campaigns</option>
+        @for (pt of programTypes; track pt.id) {
+          <option [value]="pt.id">{{ pt.label }}</option>
+        }
       </select>
     </div>
   </div>
@@ -63,7 +66,10 @@
   @switch (selectedTab()) {
     @case ('planning') {
       <div role="tabpanel" id="panel-planning" aria-labelledby="tab-planning" data-testid="campaigns-planning-panel">
-        <lfx-planning-tab (proceedToImplementation)="onProceedToImplementation($event)" data-testid="campaigns-planning-tab" />
+        <lfx-planning-tab
+          [programTypeConfig]="activeProgramTypeConfig()"
+          (proceedToImplementation)="onProceedToImplementation($event)"
+          data-testid="campaigns-planning-tab" />
       </div>
     }
     @case ('implementation') {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -57,8 +57,10 @@ export class CampaignsComponent {
   }
 
   protected onProgramTypeChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value as CampaignProgramType;
-    this.selectedProgramType.set(value);
+    const value = (event.target as HTMLSelectElement).value;
+    if (this.programTypes.some((pt) => pt.id === value)) {
+      this.selectedProgramType.set(value as CampaignProgramType);
+    }
   }
 
   protected onProceedToImplementation(brief: CampaignBriefOutput): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, inject, PLATFORM_ID, signal } from '@angular/core';
+import { Component, computed, inject, PLATFORM_ID, signal } from '@angular/core';
 
-import { CAMPAIGN_TABS } from '@lfx-one/shared/constants';
-import type { CampaignBriefOutput, CampaignTab } from '@lfx-one/shared/interfaces';
+import { CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS } from '@lfx-one/shared/constants';
+import type { CampaignBriefOutput, CampaignProgramType, CampaignTab } from '@lfx-one/shared/interfaces';
 
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
 import { MonitoringTabComponent } from './components/monitoring-tab/monitoring-tab.component';
@@ -22,8 +22,12 @@ export class CampaignsComponent {
   private readonly platformId = inject(PLATFORM_ID);
 
   protected readonly tabs = CAMPAIGN_TABS;
+  protected readonly programTypes = CAMPAIGN_PROGRAM_TYPES;
   protected readonly selectedTab = signal<CampaignTab>('planning');
+  protected readonly selectedProgramType = signal<CampaignProgramType>('events');
   protected readonly briefOutput = signal<CampaignBriefOutput | null>(null);
+
+  protected readonly activeProgramTypeConfig = computed(() => this.programTypes.find((pt) => pt.id === this.selectedProgramType()) ?? this.programTypes[0]);
 
   protected selectTab(tab: CampaignTab): void {
     this.selectedTab.set(tab);
@@ -50,6 +54,11 @@ export class CampaignsComponent {
         target?.focus();
       }
     }
+  }
+
+  protected onProgramTypeChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value as CampaignProgramType;
+    this.selectedProgramType.set(value);
   }
 
   protected onProceedToImplementation(brief: CampaignBriefOutput): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -60,6 +60,8 @@ export class CampaignsComponent {
     const value = (event.target as HTMLSelectElement).value;
     if (this.programTypes.some((pt) => pt.id === value)) {
       this.selectedProgramType.set(value as CampaignProgramType);
+      this.briefOutput.set(null);
+      this.selectedTab.set('planning');
     }
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -93,7 +93,7 @@
               formControlName="campaignGoal"
               class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               data-testid="planning-goal-select">
-              @for (goal of goals; track goal.id) {
+              @for (goal of goals(); track goal.id) {
                 <option [value]="goal.id">{{ goal.label }}</option>
               }
             </select>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -7,17 +7,17 @@
     <form [formGroup]="briefForm" class="flex flex-col gap-6">
       <!-- Event URL Card -->
       <div class="rounded-lg border border-gray-200 bg-white p-5" data-testid="planning-url-section">
-        <h3 class="mb-4 text-sm font-semibold text-gray-900">Event Page URL</h3>
+        <h3 class="mb-4 text-sm font-semibold text-gray-900">{{ programTypeConfig().urlLabel }}</h3>
         <div class="flex flex-col gap-4">
           <div class="flex flex-col gap-1">
             <input
               type="url"
               formControlName="url"
-              placeholder="https://events.linuxfoundation.org/your-event/"
+              [placeholder]="programTypeConfig().urlPlaceholder"
               (input)="onUrlInput()"
               class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               data-testid="planning-url-input" />
-            <p class="text-xs text-gray-500">Paste any LF event page — dates and details are scraped live, not from AI memory.</p>
+            <p class="text-xs text-gray-500">{{ programTypeConfig().urlHelp }}</p>
           </div>
 
           <!-- HubSpot UTM Token -->
@@ -103,7 +103,7 @@
             <input
               type="text"
               formControlName="targetAudience"
-              placeholder="e.g., Cloud-native developers, DevOps engineers"
+              [placeholder]="programTypeConfig().audiencePlaceholder"
               class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               data-testid="planning-audience-input" />
           </div>
@@ -112,7 +112,7 @@
             <textarea
               formControlName="valueProp"
               rows="3"
-              placeholder="e.g., Free registration, 200+ sessions, hands-on labs with industry experts"
+              [placeholder]="programTypeConfig().valuePropPlaceholder"
               class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               data-testid="planning-valueprop-input"></textarea>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser, NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
@@ -19,6 +19,7 @@ import type {
   CampaignKeyword,
   CampaignPlatform,
   CampaignPlatformOption,
+  CampaignProgramTypeOption,
   CampaignSSEEventType,
   HubSpotUtmLookupResult,
   LinkedInBriefCopy,
@@ -43,6 +44,9 @@ export class PlanningTabComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly destroyRef = inject(DestroyRef);
+
+  // === Inputs ===
+  public readonly programTypeConfig = input.required<CampaignProgramTypeOption>();
 
   // === Outputs ===
   public readonly proceedToImplementation = output<CampaignBriefOutput>();
@@ -218,6 +222,7 @@ export class PlanningTabComponent implements OnInit {
       targetAudience: this.briefForm.controls.targetAudience.value.trim() || undefined,
       valueProp: this.briefForm.controls.valueProp.value.trim() || undefined,
       totalBudget: budgetStr && Number.isFinite(Number(budgetStr)) ? Number(budgetStr) : undefined,
+      programType: this.programTypeConfig().id,
     };
 
     this.briefSubscription = this.campaignService
@@ -268,6 +273,7 @@ export class PlanningTabComponent implements OnInit {
       campaignGoal: (this.briefForm.controls.campaignGoal.value as CampaignGoal) || null,
       selectedPlatforms: [...this.selectedPlatforms()],
       linkedInCopy: this.getLinkedInCopy(),
+      programType: this.programTypeConfig().id,
     });
   }
 
@@ -413,6 +419,7 @@ export class PlanningTabComponent implements OnInit {
       feedback: capturedFeedback,
       eventDetails: this.eventDetails(),
       platforms: [...this.selectedPlatforms()],
+      programType: this.programTypeConfig().id,
     };
 
     this.briefSubscription?.unsubscribe();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -15,7 +15,6 @@ import type {
   CampaignBriefRefineRequest,
   CampaignEventDetails,
   CampaignGoal,
-  CampaignGoalOption,
   CampaignKeyword,
   CampaignPlatform,
   CampaignPlatformOption,
@@ -53,7 +52,10 @@ export class PlanningTabComponent implements OnInit {
 
   // === Constants ===
   protected readonly platforms: CampaignPlatformOption[] = [...CAMPAIGN_PLATFORMS];
-  protected readonly goals: CampaignGoalOption[] = [...CAMPAIGN_GOALS];
+  protected readonly goals = computed(() => {
+    const goalLabel = this.programTypeConfig().goalLabel;
+    return CAMPAIGN_GOALS.map((g) => (g.id === 'conversions' ? { ...g, label: goalLabel } : g));
+  });
 
   // === Forms ===
   protected readonly briefForm = this.fb.nonNullable.group({

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -482,6 +482,13 @@ function getExtractionPrompt(programType?: CampaignProgramType): string {
 }
 
 // ---------------------------------------------------------------------------
+// Validation constants
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_PLATFORMS: ReadonlySet<string> = new Set(['google-ads', 'linkedin-ads', 'reddit-ads', 'meta-ads']);
+const SUPPORTED_PROGRAM_TYPES: ReadonlySet<CampaignProgramType> = new Set<CampaignProgramType>(['events', 'education']);
+
+// ---------------------------------------------------------------------------
 // Background job management
 // ---------------------------------------------------------------------------
 
@@ -585,15 +592,13 @@ export class CampaignProxyService {
   public async *streamBrief(req: Request, body: CampaignBriefRequest, signal: AbortSignal): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
-    const supportedPlatforms = new Set(['google-ads', 'linkedin-ads', 'reddit-ads', 'meta-ads']);
-    const unsupported = (body.platforms ?? []).filter((p) => !supportedPlatforms.has(p));
+    const unsupported = (body.platforms ?? []).filter((p) => !SUPPORTED_PLATFORMS.has(p));
     if (unsupported.length > 0) {
       yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Supported: google-ads, linkedin-ads, reddit-ads, meta-ads.` };
       return;
     }
 
-    const supportedProgramTypes = new Set<CampaignProgramType>(['events', 'education']);
-    if (body.programType !== undefined && !supportedProgramTypes.has(body.programType)) {
+    if (body.programType !== undefined && !SUPPORTED_PROGRAM_TYPES.has(body.programType)) {
       yield { type: 'error', data: `Unsupported programType. Supported: events, education.` };
       return;
     }
@@ -772,15 +777,13 @@ export class CampaignProxyService {
   ): AsyncGenerator<{ type: CampaignSSEEventType; data: unknown }> {
     checkRequiredEnv(req);
 
-    const supportedPlatforms = new Set(['google-ads', 'linkedin-ads', 'reddit-ads', 'meta-ads']);
-    const unsupported = (body.platforms ?? []).filter((p) => !supportedPlatforms.has(p));
+    const unsupported = (body.platforms ?? []).filter((p) => !SUPPORTED_PLATFORMS.has(p));
     if (unsupported.length > 0) {
       yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Supported: google-ads, linkedin-ads, reddit-ads, meta-ads.` };
       return;
     }
 
-    const supportedProgramTypes = new Set<CampaignProgramType>(['events', 'education']);
-    if (body.programType !== undefined && !supportedProgramTypes.has(body.programType)) {
+    if (body.programType !== undefined && !SUPPORTED_PROGRAM_TYPES.has(body.programType)) {
       yield { type: 'error', data: `Unsupported programType. Supported: events, education.` };
       return;
     }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -640,7 +640,21 @@ export class CampaignProxyService {
       try {
         const extraction = await aiChat(getExtractionPrompt(body.programType), `URL: ${body.url}\n\nHTML:\n${html.slice(0, 30_000)}`);
         eventDetails = JSON.parse(extraction) as Record<string, unknown>;
-        yield { type: 'event', data: eventDetails };
+        yield {
+          type: 'event',
+          data: {
+            name: eventDetails['name'] ?? '',
+            dates: eventDetails['dates'] ?? '',
+            city: eventDetails['city'] ?? '',
+            countryCode: eventDetails['country_code'] ?? '',
+            audience: eventDetails['audience'] ?? '',
+            themes: Array.isArray(eventDetails['themes']) ? eventDetails['themes'] : [],
+            registrationUrl: eventDetails['registration_url'] ?? '',
+            speakers: Array.isArray(eventDetails['speakers']) ? eventDetails['speakers'] : [],
+            slug: eventDetails['slug'] ?? '',
+            formatNotes: eventDetails['format_notes'] ?? '',
+          },
+        };
       } catch (error) {
         logger.warning(req, 'campaign_brief_extract', `${isEducation ? 'Course' : 'Event'} extraction failed, continuing with URL only`, { err: error });
         yield { type: 'status', data: `Could not extract structured ${extractLabel}, generating copy from URL...` };

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -328,8 +328,15 @@ async function* aiChatStream(systemPrompt: string, userPrompt: string, signal: A
 // AI prompts
 // ---------------------------------------------------------------------------
 
-const COPY_SYSTEM_PROMPT_BASE = `You are an expert digital marketer specialising in developer events and open-source conferences.
+const COPY_SYSTEM_PROMPT_EVENTS = `You are an expert digital marketer specialising in developer events and open-source conferences.
 Generate high-quality, conversion-focused ad copy for the Linux Foundation's LFX events.`;
+
+const COPY_SYSTEM_PROMPT_EDUCATION = `You are an expert digital marketer specialising in professional training, certifications, and online education for software developers and IT professionals.
+Generate high-quality, conversion-focused ad copy for the Linux Foundation's training and certification programs.`;
+
+function getCopySystemPromptBase(programType?: string): string {
+  return programType === 'education' ? COPY_SYSTEM_PROMPT_EDUCATION : COPY_SYSTEM_PROMPT_EVENTS;
+}
 
 const COPY_GOOGLE_SECTION = `
 GOOGLE SEARCH (RSA):
@@ -398,13 +405,13 @@ IMPORTANT RULES:
 4. NEVER use em-dashes (—) or en-dashes (–) in ad copy. Use commas, periods, or colons instead.
 5. Demand Gen headlines are 40 chars max (not 30) — use the extra space for better copy.`;
 
-function buildCopySystemPrompt(platforms: string[]): string {
+function buildCopySystemPrompt(platforms: string[], programType?: string): string {
   const includeGoogle = platforms.includes('google-ads');
   const includeLinkedIn = platforms.includes('linkedin-ads');
   const includeReddit = platforms.includes('reddit-ads');
   const includeMeta = platforms.includes('meta-ads');
 
-  let prompt = COPY_SYSTEM_PROMPT_BASE + '\n\nPLATFORM SPECIFICATIONS (hard limits — never exceed):\n';
+  let prompt = getCopySystemPromptBase(programType) + '\n\nPLATFORM SPECIFICATIONS (hard limits — never exceed):\n';
 
   if (includeGoogle) prompt += COPY_GOOGLE_SECTION;
   if (includeLinkedIn) prompt += COPY_LINKEDIN_SECTION;
@@ -424,9 +431,17 @@ function buildCopySystemPrompt(platforms: string[]): string {
 
 const KEYWORD_SYSTEM_PROMPT = `You are a Google Ads keyword strategist. Return only a valid JSON array. No markdown fences, no explanation.`;
 
-const LINKEDIN_STRATEGY_SYSTEM_PROMPT = `You are a LinkedIn Ads strategist specializing in developer and open-source technology events.
+const LINKEDIN_STRATEGY_SYSTEM_PROMPT_EVENTS = `You are a LinkedIn Ads strategist specializing in developer and open-source technology events.
 Analyze the event details and generate a comprehensive targeting strategy for LinkedIn Sponsored Content campaigns.
 Return only valid JSON. No markdown fences, no explanation.`;
+
+const LINKEDIN_STRATEGY_SYSTEM_PROMPT_EDUCATION = `You are a LinkedIn Ads strategist specializing in professional training, certifications, and career development for software developers and IT professionals.
+Analyze the course/certification details and generate a comprehensive targeting strategy for LinkedIn Sponsored Content campaigns.
+Return only valid JSON. No markdown fences, no explanation.`;
+
+function getLinkedInStrategySystemPrompt(programType?: string): string {
+  return programType === 'education' ? LINKEDIN_STRATEGY_SYSTEM_PROMPT_EDUCATION : LINKEDIN_STRATEGY_SYSTEM_PROMPT_EVENTS;
+}
 
 const EVENT_EXTRACTION_PROMPT = `Extract structured event details from this HTML. Return valid JSON:
 {
@@ -442,6 +457,28 @@ const EVENT_EXTRACTION_PROMPT = `Extract structured event details from this HTML
 }
 
 If a field cannot be determined, use null.`;
+
+const EDUCATION_EXTRACTION_PROMPT = `Extract structured course/certification details from this HTML. Return valid JSON:
+{
+  "name": "course or certification name",
+  "dates": "duration (e.g. Self-paced, 3 days, 40 hours)",
+  "city": "Online",
+  "country_code": "US",
+  "audience": "target audience description",
+  "themes": ["technology1", "skill1"],
+  "registration_url": "enrollment URL",
+  "slug": "url-friendly-slug",
+  "format_notes": "self-paced/instructor-led/hybrid",
+  "price": "price or price range if found",
+  "certification_code": "e.g. CKA, LFCS, CKAD if applicable",
+  "prerequisites": "prerequisites if listed"
+}
+
+If a field cannot be determined, use null.`;
+
+function getExtractionPrompt(programType?: string): string {
+  return programType === 'education' ? EDUCATION_EXTRACTION_PROMPT : EVENT_EXTRACTION_PROMPT;
+}
 
 // ---------------------------------------------------------------------------
 // Background job management
@@ -581,18 +618,20 @@ export class CampaignProxyService {
       }
     }
 
-    yield { type: 'status', data: isRefinement ? 'Refining brief...' : 'Extracting event details...' };
+    const isEducation = body.programType === 'education';
+    const extractLabel = isEducation ? 'course details' : 'event details';
+    yield { type: 'status', data: isRefinement ? 'Refining brief...' : `Extracting ${extractLabel}...` };
 
     let eventDetails: Record<string, unknown> | null = null;
 
     if (!isRefinement) {
       try {
-        const extraction = await aiChat(EVENT_EXTRACTION_PROMPT, `URL: ${body.url}\n\nHTML:\n${html.slice(0, 30_000)}`);
+        const extraction = await aiChat(getExtractionPrompt(body.programType), `URL: ${body.url}\n\nHTML:\n${html.slice(0, 30_000)}`);
         eventDetails = JSON.parse(extraction) as Record<string, unknown>;
         yield { type: 'event', data: eventDetails };
       } catch (error) {
-        logger.warning(req, 'campaign_brief_extract', 'Event extraction failed, continuing with URL only', { err: error });
-        yield { type: 'status', data: 'Could not extract structured event details, generating copy from URL...' };
+        logger.warning(req, 'campaign_brief_extract', `${isEducation ? 'Course' : 'Event'} extraction failed, continuing with URL only`, { err: error });
+        yield { type: 'status', data: `Could not extract structured ${extractLabel}, generating copy from URL...` };
       }
 
       const eventName = (eventDetails?.['name'] as string) || extractEventNameFromUrl(body.url);
@@ -616,7 +655,7 @@ export class CampaignProxyService {
     const platformList = selectedPlatforms.join(', ');
     yield { type: 'status', data: `Generating copy for ${platformList}...` };
 
-    const copySystemPrompt = buildCopySystemPrompt(selectedPlatforms);
+    const copySystemPrompt = buildCopySystemPrompt(selectedPlatforms, body.programType);
     const userPrompt = buildCopyPrompt(body, eventDetails);
     let fullCopy = '';
 
@@ -698,7 +737,7 @@ export class CampaignProxyService {
       yield { type: 'status', data: 'Generating LinkedIn targeting strategy...' };
       try {
         const strategyPrompt = buildLinkedInStrategyPrompt(body, eventDetails);
-        let strategyText = (await aiChat(LINKEDIN_STRATEGY_SYSTEM_PROMPT, strategyPrompt)).trim();
+        let strategyText = (await aiChat(getLinkedInStrategySystemPrompt(body.programType), strategyPrompt)).trim();
         if (strategyText.startsWith('```')) {
           const firstNl = strategyText.indexOf('\n');
           if (firstNl !== -1) strategyText = strategyText.slice(firstNl + 1);
@@ -740,7 +779,7 @@ export class CampaignProxyService {
     const refinePlatforms = body.platforms?.length ? body.platforms : ['google-ads'];
 
     try {
-      for await (const token of aiChatStream(buildCopySystemPrompt(refinePlatforms), userPrompt, signal)) {
+      for await (const token of aiChatStream(buildCopySystemPrompt(refinePlatforms, body.programType), userPrompt, signal)) {
         yield { type: 'copy_token', data: token };
         fullCopy += token;
       }
@@ -1420,27 +1459,31 @@ function buildCopyPrompt(body: CampaignBriefRequest, eventDetails: Record<string
       ? `\n\nREFINEMENT REQUEST — do not generate from scratch. Revise the previous copy below based on the user's feedback.\n\nUSER FEEDBACK:\n${body.refineFeedback}\n\nPREVIOUS COPY:\n${serializedPreviousCopy}`
       : '';
 
+  const isEducation = body.programType === 'education';
+  const contentLabel = isEducation ? 'training/certification program' : 'event';
+  const ctaVerb = isEducation ? 'Enroll Now' : 'Register Now';
+
   if (eventDetails) {
     const e = eventDetails;
     const themes = Array.isArray(e['themes']) ? (e['themes'] as string[]).join(', ') : '';
     const speakers = Array.isArray(e['speakers']) ? (e['speakers'] as string[]).slice(0, 5).join(', ') : '';
-    return `Generate ad copy for this LF event across the requested platforms.
+    const educationNote = isEducation
+      ? `\n\nEDUCATION CAMPAIGN NOTES:\n- This is a training/certification campaign, NOT an event. Do not reference venues, travel, or in-person attendance.\n- Focus on career advancement, skill-building, and certification value.\n- Primary CTA should be "${ctaVerb}" or "Start Learning" — never "Register Now" or "Join Us in [City]".\n- Highlight self-paced learning, exam prep, industry recognition, and bundle discounts where relevant.\n- Sitelink ideas: course curriculum, exam details, certification paths, student testimonials, pricing/bundles.`
+      : '';
+    return `Generate ad copy for this LF ${contentLabel} across the requested platforms.
 
-EVENT DATA:
+${isEducation ? 'COURSE' : 'EVENT'} DATA:
 Name: ${e['name'] || ''}
-Dates: ${e['dates'] || ''}
-City: ${e['city'] || ''}
-Country: ${e['country_code'] || ''}
-Audience: ${e['audience'] || ''}
+${isEducation ? 'Duration' : 'Dates'}: ${e['dates'] || ''}
+${isEducation ? '' : `City: ${e['city'] || ''}\nCountry: ${e['country_code'] || ''}\n`}Audience: ${e['audience'] || ''}
 Themes: ${themes}
-Registration URL: ${e['registration_url'] || body.url}
-Speakers: ${speakers}
-Format: ${e['format_notes'] || ''}${extraBlock}${refinementBlock}
+${isEducation ? 'Enrollment' : 'Registration'} URL: ${e['registration_url'] || body.url}
+${isEducation ? '' : `Speakers: ${speakers}\nFormat: ${e['format_notes'] || ''}\n`}${extraBlock}${educationNote}${refinementBlock}
 
 ${platformInstruction}`;
   }
 
-  return `Generate ad copy for: ${body.url}${extraBlock}${refinementBlock}
+  return `Generate ad copy for this ${contentLabel}: ${body.url}${extraBlock}${refinementBlock}
 
 ${platformInstruction}`;
 }
@@ -1452,6 +1495,7 @@ function buildKeywordPrompt(body: CampaignBriefRequest, eventDetails: Record<str
   if (body.valueProp) extraParts.push(`Key Value Prop / Offer: ${body.valueProp}`);
   const extraBlock = extraParts.length > 0 ? `\n\nADDITIONAL CAMPAIGN CONTEXT:\n${extraParts.join('\n')}` : '';
 
+  const isEducation = body.programType === 'education';
   const e = eventDetails || {};
   const name = (e['name'] as string) || '';
   const dates = (e['dates'] as string) || '';
@@ -1460,6 +1504,33 @@ function buildKeywordPrompt(body: CampaignBriefRequest, eventDetails: Record<str
   const city = (e['city'] as string) || '';
   const yearMatch = dates.match(/20\d{2}/);
   const eventYear = yearMatch ? yearMatch[0] : new Date().getFullYear().toString();
+
+  if (isEducation) {
+    return `Generate 25-40 high-intent Google Search keywords for this training/certification program.
+
+COURSE: ${name || body.url}
+Themes: ${themes}
+Audience: ${audience}${extraBlock}
+
+Keyword categories to cover:
+1. Course/certification name exact: e.g. "${name}", "${name} certification"
+2. Certification acronyms: e.g. "CKA", "LFCS", "CKS" and their full names + "certification"/"exam"/"training"
+3. Topic training: "[technology] training", "[technology] certification", "[technology] course"
+4. Career/role: "[role] certification", "become a [role]", "[role] training"
+5. Competitor/adjacent: alternative certifications, "best [topic] certification ${eventYear}"
+
+Return a JSON array where each object has EXACTLY these keys:
+- "term": the keyword string
+- "match_type": "Exact", "Phrase", or "Broad"
+- "intent_level": "High" (direct course/cert search), "Medium" (related topic), "Low" (broad)
+- "notes": any flag (e.g. "evergreen term", "seasonal spike")
+
+CRITICAL RULES:
+- Focus on certification and training intent, NOT event/conference keywords.
+- Prefer HIGH INTENT — keywords that indicate someone actively looking to learn or get certified.
+- Include "linux foundation" branded terms where relevant.
+- Avoid generic broad terms that waste budget (e.g. "training" alone).`;
+  }
 
   return `Generate 25-40 high-intent Google Search keywords for this event.
 
@@ -1488,7 +1559,10 @@ CRITICAL RULES:
 }
 
 function buildRefinePrompt(body: CampaignBriefRefineRequest): string {
-  const eventBlock = body.eventDetails ? `\nEVENT: ${body.eventDetails.name}\nDates: ${body.eventDetails.dates}\nCity: ${body.eventDetails.city}\n` : '';
+  const isEducation = body.programType === 'education';
+  const eventBlock = body.eventDetails
+    ? `\n${isEducation ? 'COURSE' : 'EVENT'}: ${body.eventDetails.name}\n${isEducation ? 'Duration' : 'Dates'}: ${body.eventDetails.dates}\n${isEducation ? '' : `City: ${body.eventDetails.city}\n`}`
+    : '';
   const platforms = body.platforms?.length ? body.platforms : ['google-ads'];
   const hasGoogle = platforms.includes('google-ads');
   const hasLinkedIn = platforms.includes('linkedin-ads');
@@ -1517,10 +1591,13 @@ Respect all character limits from the system prompt. Return the same JSON format
 function buildRefineKeywordPrompt(body: CampaignBriefRefineRequest): string {
   const currentKws = (body.currentKeywords ?? []).map((kw) => kw.term).join(', ');
   const eventName = body.eventDetails?.name || '';
+  const isEducation = body.programType === 'education';
+  const contentLabel = isEducation ? 'course/certification' : 'event';
+  const intentLabel = isEducation ? 'direct course/cert search' : 'direct event search';
 
-  return `Regenerate keywords for this event based on user feedback.
+  return `Regenerate keywords for this ${contentLabel} based on user feedback.
 
-EVENT: ${eventName}
+${isEducation ? 'COURSE' : 'EVENT'}: ${eventName}
 CURRENT KEYWORDS: ${currentKws}
 
 USER FEEDBACK: ${body.feedback}
@@ -1530,13 +1607,14 @@ Based on the feedback, generate 25-40 refined Google Search keywords.
 Return a JSON array where each object has EXACTLY these keys:
 - "term": the keyword string
 - "match_type": "Exact", "Phrase", or "Broad"
-- "intent_level": "High" (direct event search), "Medium" (related topic), "Low" (broad)
+- "intent_level": "High" (${intentLabel}), "Medium" (related topic), "Low" (broad)
 - "notes": any flag (e.g. "added per user feedback")
 
 Prefer HIGH INTENT keywords. Incorporate the user's feedback to improve the keyword list.`;
 }
 
 function buildLinkedInStrategyPrompt(body: CampaignBriefRequest, eventDetails: Record<string, unknown> | null): string {
+  const isEducation = body.programType === 'education';
   const e = eventDetails || {};
   const name = (e['name'] as string) || '';
   const dates = (e['dates'] as string) || '';
@@ -1544,21 +1622,23 @@ function buildLinkedInStrategyPrompt(body: CampaignBriefRequest, eventDetails: R
   const audience = (e['audience'] as string) || '';
   const themes = Array.isArray(e['themes']) ? (e['themes'] as string[]).join(', ') : '';
 
-  return `Generate a LinkedIn Ads targeting strategy for this event.
+  const contentLabel = isEducation ? 'training/certification program' : 'event';
+  const dataHeader = isEducation ? 'COURSE' : 'EVENT';
+  const locationLine = isEducation ? '' : `Location: ${city}\n`;
 
-EVENT:
+  return `Generate a LinkedIn Ads targeting strategy for this ${contentLabel}.
+
+${dataHeader}:
 Name: ${name || body.url}
-Dates: ${dates}
-Location: ${city}
-Audience: ${audience}
+${isEducation ? '' : `Dates: ${dates}\n`}${locationLine}Audience: ${audience}
 Themes: ${themes}
 ${body.campaignGoal ? `Campaign Goal: ${body.campaignGoal}` : ''}
 ${body.totalBudget ? `Total Budget: $${body.totalBudget}` : ''}
 
 Return a JSON object with these keys:
 {
-  "targeting_profile": "cloud-native" or "mcp" (select based on event topics),
-  "targeting_rationale": "why this profile fits the event",
+  "targeting_profile": "cloud-native" or "mcp" (select based on ${isEducation ? 'course' : 'event'} topics),
+  "targeting_rationale": "why this profile fits the ${contentLabel}",
   "recommended_skills": ["skill names relevant to the audience"],
   "recommended_groups": ["LinkedIn group names relevant to the audience"],
   "recommended_job_functions": ["job functions to target, e.g. Engineering, IT, Product"],
@@ -1573,10 +1653,10 @@ Return a JSON object with these keys:
 }
 
 RULES:
-- Select 3-8 geo targets based on event location, audience, and topic relevance
+- Select 3-8 geo targets based on ${isEducation ? 'audience demographics and course topic relevance (education campaigns are always-on and global)' : 'event location, audience, and topic relevance'}
 - Budget should be realistic for LinkedIn CPMs ($8-15 range)
-- Skills and groups should be specific to the event's technology focus
-- Job functions should target decision-makers and practitioners`;
+- Skills and groups should be specific to the ${isEducation ? "course's" : "event's"} technology focus
+- Job functions should target ${isEducation ? 'career-changers, practitioners seeking certification, and hiring managers who value certified professionals' : 'decision-makers and practitioners'}`;
 }
 
 const REGION_MAP: Record<string, string> = {

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -14,6 +14,7 @@ import type {
   CampaignJobStatus,
   CampaignKeyword,
   CampaignPlatform,
+  CampaignProgramType,
   CampaignSSEEventType,
   KeywordActionResponse,
   LinkedInCampaignCreateResult,
@@ -334,7 +335,7 @@ Generate high-quality, conversion-focused ad copy for the Linux Foundation's LFX
 const COPY_SYSTEM_PROMPT_EDUCATION = `You are an expert digital marketer specialising in professional training, certifications, and online education for software developers and IT professionals.
 Generate high-quality, conversion-focused ad copy for the Linux Foundation's training and certification programs.`;
 
-function getCopySystemPromptBase(programType?: string): string {
+function getCopySystemPromptBase(programType?: CampaignProgramType): string {
   return programType === 'education' ? COPY_SYSTEM_PROMPT_EDUCATION : COPY_SYSTEM_PROMPT_EVENTS;
 }
 
@@ -342,7 +343,7 @@ const COPY_GOOGLE_SECTION = `
 GOOGLE SEARCH (RSA):
 - Headlines: 15 total, each ≤ 30 characters (STRICT — Google rejects longer)
 - Descriptions: 4 total, each ≤ 90 characters (STRICT)
-- Tone: direct, benefit-led, include CTA ("Register Now", "Join Today", "Secure Your Spot")
+- Tone: direct, benefit-led, include CTA (e.g. "Register Now", "Enroll Now", "Learn More")
 
 GOOGLE DEMAND GEN (key: "google_display" — runs on YouTube, Discover, Gmail, Display):
 - headlines: 5 variations, each ≤ 40 characters (STRICT — Demand Gen limit is 40, not 30)
@@ -399,13 +400,13 @@ META COPY RULES:
 
 const COPY_RULES_SECTION = `
 IMPORTANT RULES:
-1. Dates must come ONLY from the event data provided — never use training-data memory
+1. Dates and details must come ONLY from the data provided — never use training-data memory.
 2. CHARACTER LIMITS ARE HARD — platforms REJECT copy that exceeds them. Verify EVERY line.
-3. NEVER abbreviate month names, city names, or event names unless required to fit character limits
+3. NEVER abbreviate month names, city names, or proper nouns unless required to fit character limits.
 4. NEVER use em-dashes (—) or en-dashes (–) in ad copy. Use commas, periods, or colons instead.
 5. Demand Gen headlines are 40 chars max (not 30) — use the extra space for better copy.`;
 
-function buildCopySystemPrompt(platforms: string[], programType?: string): string {
+function buildCopySystemPrompt(platforms: string[], programType?: CampaignProgramType): string {
   const includeGoogle = platforms.includes('google-ads');
   const includeLinkedIn = platforms.includes('linkedin-ads');
   const includeReddit = platforms.includes('reddit-ads');
@@ -439,7 +440,7 @@ const LINKEDIN_STRATEGY_SYSTEM_PROMPT_EDUCATION = `You are a LinkedIn Ads strate
 Analyze the course/certification details and generate a comprehensive targeting strategy for LinkedIn Sponsored Content campaigns.
 Return only valid JSON. No markdown fences, no explanation.`;
 
-function getLinkedInStrategySystemPrompt(programType?: string): string {
+function getLinkedInStrategySystemPrompt(programType?: CampaignProgramType): string {
   return programType === 'education' ? LINKEDIN_STRATEGY_SYSTEM_PROMPT_EDUCATION : LINKEDIN_STRATEGY_SYSTEM_PROMPT_EVENTS;
 }
 
@@ -462,8 +463,8 @@ const EDUCATION_EXTRACTION_PROMPT = `Extract structured course/certification det
 {
   "name": "course or certification name",
   "dates": "duration (e.g. Self-paced, 3 days, 40 hours)",
-  "city": "Online",
-  "country_code": "US",
+  "city": "delivery location or null if online-only",
+  "country_code": "ISO country code or null if online-only",
   "audience": "target audience description",
   "themes": ["technology1", "skill1"],
   "registration_url": "enrollment URL",
@@ -476,7 +477,7 @@ const EDUCATION_EXTRACTION_PROMPT = `Extract structured course/certification det
 
 If a field cannot be determined, use null.`;
 
-function getExtractionPrompt(programType?: string): string {
+function getExtractionPrompt(programType?: CampaignProgramType): string {
   return programType === 'education' ? EDUCATION_EXTRACTION_PROMPT : EVENT_EXTRACTION_PROMPT;
 }
 
@@ -591,7 +592,15 @@ export class CampaignProxyService {
       return;
     }
 
+    const supportedProgramTypes = new Set<CampaignProgramType>(['events', 'education']);
+    if (body.programType !== undefined && !supportedProgramTypes.has(body.programType)) {
+      yield { type: 'error', data: `Unsupported programType. Supported: events, education.` };
+      return;
+    }
+
     const isRefinement = !!body.refineFeedback && !!body.previousCopy;
+    const isEducation = body.programType === 'education';
+    const pageLabel = isEducation ? 'course page' : 'event page';
     let html = '';
 
     if (!isRefinement) {
@@ -608,17 +617,15 @@ export class CampaignProxyService {
       try {
         const { html: scrapedHtml, ok, status } = await fetchSafeUrl(safeUrl, signal);
         if (!ok) {
-          yield { type: 'error', data: `Event page returned HTTP ${status}` };
+          yield { type: 'error', data: `Page returned HTTP ${status}` };
           return;
         }
         html = scrapedHtml;
       } catch (error) {
-        yield { type: 'error', data: `Failed to fetch event page: ${error instanceof Error ? error.message : 'Unknown error'}` };
+        yield { type: 'error', data: `Failed to fetch ${pageLabel}: ${error instanceof Error ? error.message : 'Unknown error'}` };
         return;
       }
     }
-
-    const isEducation = body.programType === 'education';
     const extractLabel = isEducation ? 'course details' : 'event details';
     yield { type: 'status', data: isRefinement ? 'Refining brief...' : `Extracting ${extractLabel}...` };
 
@@ -769,6 +776,12 @@ export class CampaignProxyService {
     const unsupported = (body.platforms ?? []).filter((p) => !supportedPlatforms.has(p));
     if (unsupported.length > 0) {
       yield { type: 'error', data: `Unsupported platforms: ${unsupported.join(', ')}. Supported: google-ads, linkedin-ads, reddit-ads, meta-ads.` };
+      return;
+    }
+
+    const supportedProgramTypes = new Set<CampaignProgramType>(['events', 'education']);
+    if (body.programType !== undefined && !supportedProgramTypes.has(body.programType)) {
+      yield { type: 'error', data: `Unsupported programType. Supported: events, education.` };
       return;
     }
 

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -5,6 +5,7 @@ import type {
   CampaignGoalOption,
   CampaignPlatform,
   CampaignPlatformOption,
+  CampaignProgramTypeOption,
   CampaignStatus,
   CampaignTabOption,
   LinkedInGeoTarget,
@@ -28,6 +29,31 @@ export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield', disabled: true },
   { id: 'feathr', label: 'Feathr', icon: 'fa-light fa-bullseye-arrow', disabled: true },
   { id: 'twitter-ads', label: 'X / Twitter Ads', icon: 'fa-brands fa-x-twitter', disabled: true },
+] as const;
+
+export const CAMPAIGN_PROGRAM_TYPES: readonly CampaignProgramTypeOption[] = [
+  {
+    id: 'events',
+    label: 'Events Campaigns',
+    breadcrumbLabel: 'Events Campaigns',
+    urlLabel: 'Event Page URL',
+    urlPlaceholder: 'https://events.linuxfoundation.org/your-event/',
+    urlHelp: 'Paste any LF event page — dates and details are scraped live, not from AI memory.',
+    goalLabel: 'Conversions / Registrations',
+    audiencePlaceholder: 'e.g., Cloud-native developers, DevOps engineers',
+    valuePropPlaceholder: 'e.g., Free registration, 200+ sessions, hands-on labs with industry experts',
+  },
+  {
+    id: 'education',
+    label: 'Education Campaigns',
+    breadcrumbLabel: 'Education Campaigns',
+    urlLabel: 'Course / Training Page URL',
+    urlPlaceholder: 'https://training.linuxfoundation.org/training/your-course/',
+    urlHelp: 'Paste any LF Training page — course details are scraped live, not from AI memory.',
+    goalLabel: 'Conversions / Enrollments',
+    audiencePlaceholder: 'e.g., IT professionals seeking certifications, career changers',
+    valuePropPlaceholder: 'e.g., Industry-recognized certification, self-paced learning, exam bundle discounts',
+  },
 ] as const;
 
 export const CAMPAIGN_GOALS: readonly CampaignGoalOption[] = [

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -26,6 +26,20 @@ export type DateRangeOption = 7 | 14 | 30;
 
 export type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead-generation' | 'engagement';
 
+export type CampaignProgramType = 'events' | 'education';
+
+export interface CampaignProgramTypeOption {
+  id: CampaignProgramType;
+  label: string;
+  breadcrumbLabel: string;
+  urlLabel: string;
+  urlPlaceholder: string;
+  urlHelp: string;
+  goalLabel: string;
+  audiencePlaceholder: string;
+  valuePropPlaceholder: string;
+}
+
 export type CampaignTab = CampaignPhase;
 
 export interface CampaignTabOption {
@@ -83,6 +97,7 @@ export type CampaignSSEEventType =
 export interface CampaignBriefRequest {
   url: string;
   platforms?: CampaignPlatform[];
+  programType?: CampaignProgramType;
   campaignGoal?: CampaignGoal;
   targetAudience?: string;
   valueProp?: string;
@@ -119,6 +134,7 @@ export interface CampaignBriefOutput {
   totalBudget: number | null;
   driveFolderUrl: string;
   campaignGoal: CampaignGoal | null;
+  programType?: CampaignProgramType;
   selectedPlatforms?: CampaignPlatform[];
   linkedInCopy?: LinkedInBriefCopy;
   redditCopy?: RedditBriefCopy;
@@ -372,6 +388,7 @@ export interface CampaignBriefRefineRequest {
   feedback: string;
   eventDetails?: CampaignEventDetails | null;
   platforms?: CampaignPlatform[];
+  programType?: CampaignProgramType;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a functional program type dropdown to the Campaigns page with two options: Events Campaigns and Education Campaigns
- Planning tab UI adapts dynamically: URL card heading, input placeholder, help text, audience placeholder, and value prop placeholder all change based on selected program type
- Backend AI prompts branch by program type: system prompts, copy generation, keyword strategy, LinkedIn targeting, page extraction, and refinement prompts all produce education-specific output when Education is selected
- Shared types and constants updated: `CampaignProgramType` union type, `CampaignProgramTypeOption` interface, `CAMPAIGN_PROGRAM_TYPES` constant, and `programType` field threaded through `CampaignBriefRequest`, `CampaignBriefOutput`, and `CampaignBriefRefineRequest`

LFXV2-2474