### PR TITLE
feat(dashboards): add social media monthly growth table

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
@@ -95,8 +95,16 @@
       </div>
     } @else if (hasMonthlyData()) {
       <div class="flex flex-col gap-0" role="table" aria-label="Monthly growth by platform" data-testid="social-monthly-table">
+        <!-- Column headers -->
+        <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+          <span class="w-6" role="columnheader" aria-hidden="true"></span>
+          <span class="w-36 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PLATFORM</span>
+          <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">FOLLOWERS</span>
+          <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">MOM %</span>
+        </div>
+
         @for (platform of monthlyPlatforms(); track platform.platform) {
-          <!-- Platform header row (expandable) -->
+          <!-- Platform row (expandable) -->
           <div
             class="flex cursor-pointer items-center gap-3 border-b border-gray-200 py-2.5 hover:bg-gray-50"
             role="row"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
@@ -70,4 +70,78 @@
       }
     </div>
   }
+
+  <!-- Monthly growth by platform -->
+  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="social-monthly-growth">
+    <div class="flex items-center justify-between">
+      <h4 class="text-sm font-semibold text-gray-900">Monthly growth by platform</h4>
+      <select
+        class="rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        [value]="selectedYear()"
+        (change)="onYearChange($event)"
+        data-testid="social-monthly-year-selector"
+        aria-label="Select year">
+        @for (yr of availableYears(); track yr) {
+          <option [value]="yr">{{ yr }}</option>
+        }
+      </select>
+    </div>
+
+    @if (monthlyLoading()) {
+      <div class="flex flex-col gap-2" data-testid="social-monthly-skeleton">
+        @for (i of [1, 2, 3]; track i) {
+          <div class="h-10 w-full animate-pulse rounded bg-gray-100"></div>
+        }
+      </div>
+    } @else if (hasMonthlyData()) {
+      <div class="flex flex-col gap-0" role="table" aria-label="Monthly growth by platform" data-testid="social-monthly-table">
+        @for (platform of monthlyPlatforms(); track platform.platform) {
+          <!-- Platform header row (expandable) -->
+          <div
+            class="flex cursor-pointer items-center gap-3 border-b border-gray-200 py-2.5 hover:bg-gray-50"
+            role="row"
+            (click)="togglePlatform(platform.platform)"
+            [attr.data-testid]="'social-monthly-platform-' + platform.platform">
+            <span class="w-6 text-center text-gray-400">
+              <i class="fa-light fa-chevron-right text-xs transition-transform duration-200" [class.rotate-90]="isPlatformExpanded(platform.platform)"></i>
+            </span>
+            <span class="w-36 text-xs font-medium text-gray-700" role="cell">{{ platform.platform }}</span>
+            <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ platform.latestFollowers }}</span>
+            <span class="flex-1 text-right text-xs" [ngClass]="platform.latestMomChangeClass" role="cell">{{ platform.latestMomChange }}</span>
+          </div>
+
+          <!-- Expanded monthly rows -->
+          @if (isPlatformExpanded(platform.platform)) {
+            <!-- Sub-header -->
+            <div class="flex items-center gap-3 border-b border-gray-100 bg-gray-50 py-1.5 pl-9" role="row">
+              <span class="w-36 text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">MONTH</span>
+              <span class="w-24 text-right text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+              <span class="w-24 text-right text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">ENG. RATE</span>
+              <span class="w-24 text-right text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">FOLLOWERS</span>
+              <span class="w-24 text-right text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">NEW</span>
+              <span class="flex-1 text-right text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">MOM % (FOLLOWERS)</span>
+            </div>
+
+            @for (month of platform.months; track month.month) {
+              <div
+                class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-9"
+                role="row"
+                [attr.data-testid]="'social-monthly-row-' + platform.platform + '-' + month.month">
+                <span class="w-36 text-xs text-gray-600" role="cell">{{ month.month }}</span>
+                <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ month.impressions }}</span>
+                <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ month.engagementRate }}</span>
+                <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ month.followers }}</span>
+                <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ month.newFollowers }}</span>
+                <span class="flex-1 text-right text-xs" [ngClass]="month.momChangeClass" role="cell">{{ month.momChange }}</span>
+              </div>
+            }
+          }
+        }
+      </div>
+    } @else {
+      <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="social-monthly-empty">
+        <p class="text-sm text-gray-500">No monthly growth data available.</p>
+      </div>
+    }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.html
@@ -100,10 +100,14 @@
           <div
             class="flex cursor-pointer items-center gap-3 border-b border-gray-200 py-2.5 hover:bg-gray-50"
             role="row"
+            tabindex="0"
+            [attr.aria-expanded]="platform.expanded"
             (click)="togglePlatform(platform.platform)"
+            (keydown.enter)="togglePlatform(platform.platform)"
+            (keydown.space)="$event.preventDefault(); togglePlatform(platform.platform)"
             [attr.data-testid]="'social-monthly-platform-' + platform.platform">
-            <span class="w-6 text-center text-gray-400">
-              <i class="fa-light fa-chevron-right text-xs transition-transform duration-200" [class.rotate-90]="isPlatformExpanded(platform.platform)"></i>
+            <span class="w-6 text-center text-gray-400" aria-hidden="true">
+              <i class="fa-light fa-chevron-right text-xs transition-transform duration-200" [class.rotate-90]="platform.expanded"></i>
             </span>
             <span class="w-36 text-xs font-medium text-gray-700" role="cell">{{ platform.platform }}</span>
             <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ platform.latestFollowers }}</span>
@@ -111,7 +115,7 @@
           </div>
 
           <!-- Expanded monthly rows -->
-          @if (isPlatformExpanded(platform.platform)) {
+          @if (platform.expanded) {
             <!-- Sub-header -->
             <div class="flex items-center gap-3 border-b border-gray-100 bg-gray-50 py-1.5 pl-9" role="row">
               <span class="w-36 text-[10px] font-semibold tracking-wide text-gray-400" role="columnheader">MONTH</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -41,7 +41,7 @@ export class SocialAccountsTabComponent {
   protected readonly loading = signal(false);
   protected readonly monthlyLoading = signal(false);
   protected readonly expandedPlatforms = signal<Set<string>>(new Set());
-  protected readonly selectedYear = signal(new Date().getFullYear());
+  protected readonly selectedYear = signal(new Date().getUTCFullYear());
 
   // === Computed Signals ===
   protected readonly socialData: Signal<SocialMediaResponse | null> = this.initSocialData();
@@ -52,7 +52,7 @@ export class SocialAccountsTabComponent {
   protected readonly monthlyPlatforms: Signal<SocialMonthlyPlatform[]> = this.initMonthlyPlatforms();
   protected readonly hasMonthlyData = computed(() => this.monthlyPlatforms().length > 0);
   protected readonly availableYears = computed(() => {
-    const current = new Date().getFullYear();
+    const current = new Date().getUTCFullYear();
     return [current, current - 1];
   });
 
@@ -70,7 +70,10 @@ export class SocialAccountsTabComponent {
 
   protected onYearChange(event: Event): void {
     const target = event.target as HTMLSelectElement;
-    this.selectedYear.set(parseInt(target.value, 10));
+    const parsed = parseInt(target.value, 10);
+    if (Number.isFinite(parsed) && this.availableYears().includes(parsed)) {
+      this.selectedYear.set(parsed);
+    }
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -4,6 +4,7 @@
 import { NgClass } from '@angular/common';
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { MONTH_NAMES } from '@lfx-one/shared/constants';
 import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -19,8 +20,6 @@ import type {
 } from '@lfx-one/shared/interfaces';
 
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
-
-const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 @Component({
   selector: 'lfx-social-accounts-tab',
@@ -57,7 +56,7 @@ export class SocialAccountsTabComponent {
     return [current, current - 1, current - 2];
   });
 
-  // === Public Methods ===
+  // === Protected Methods ===
   protected togglePlatform(platform: string): void {
     const current = this.expandedPlatforms();
     const next = new Set(current);
@@ -67,10 +66,6 @@ export class SocialAccountsTabComponent {
       next.add(platform);
     }
     this.expandedPlatforms.set(next);
-  }
-
-  protected isPlatformExpanded(platform: string): boolean {
-    return this.expandedPlatforms().has(platform);
   }
 
   protected onYearChange(event: Event): void {
@@ -218,6 +213,8 @@ export class SocialAccountsTabComponent {
       const data = this.monthlyData();
       if (!data?.platforms?.length) return [];
 
+      const expanded = this.expandedPlatforms();
+
       return data.platforms.map((p) => {
         const allMonths: SocialMonthlyRow[] = MONTH_NAMES.map((name, i) => {
           const monthStr = `${data.year}-${String(i + 1).padStart(2, '0')}`;
@@ -248,6 +245,7 @@ export class SocialAccountsTabComponent {
 
         return {
           platform: p.platform,
+          expanded: expanded.has(p.platform),
           latestFollowers: latestRow ? formatNumber(latestRow.followers) : '—',
           latestMomChange: latestRow ? this.formatMomChange(latestRow.momChangeFollowers) : '—',
           latestMomChangeClass: latestRow ? this.getMomChangeClass(latestRow.momChangeFollowers) : 'text-gray-400',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -1,19 +1,30 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgClass } from '@angular/common';
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
-import type { MarketingImpactFocusProgram, PerformanceSummaryKpi, SocialAccountRow, SocialMediaResponse } from '@lfx-one/shared/interfaces';
+import type {
+  MarketingImpactFocusProgram,
+  PerformanceSummaryKpi,
+  SocialAccountRow,
+  SocialMediaMonthlyResponse,
+  SocialMediaResponse,
+  SocialMonthlyPlatform,
+  SocialMonthlyRow,
+} from '@lfx-one/shared/interfaces';
 
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
+const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
 @Component({
   selector: 'lfx-social-accounts-tab',
-  imports: [SparklineKpiCardComponent],
+  imports: [SparklineKpiCardComponent, NgClass],
   templateUrl: './social-accounts-tab.component.html',
   styleUrl: './social-accounts-tab.component.scss',
 })
@@ -29,12 +40,43 @@ export class SocialAccountsTabComponent {
 
   // === WritableSignals ===
   protected readonly loading = signal(false);
+  protected readonly monthlyLoading = signal(false);
+  protected readonly expandedPlatforms = signal<Set<string>>(new Set());
+  protected readonly selectedYear = signal(new Date().getFullYear());
 
   // === Computed Signals ===
   protected readonly socialData: Signal<SocialMediaResponse | null> = this.initSocialData();
   protected readonly kpiCards: Signal<PerformanceSummaryKpi[]> = this.initKpiCards();
   protected readonly platformRows: Signal<SocialAccountRow[]> = this.initPlatformRows();
   protected readonly hasPlatforms = computed(() => this.platformRows().length > 0);
+  protected readonly monthlyData: Signal<SocialMediaMonthlyResponse | null> = this.initMonthlyData();
+  protected readonly monthlyPlatforms: Signal<SocialMonthlyPlatform[]> = this.initMonthlyPlatforms();
+  protected readonly hasMonthlyData = computed(() => this.monthlyPlatforms().length > 0);
+  protected readonly availableYears = computed(() => {
+    const current = new Date().getFullYear();
+    return [current, current - 1, current - 2];
+  });
+
+  // === Public Methods ===
+  protected togglePlatform(platform: string): void {
+    const current = this.expandedPlatforms();
+    const next = new Set(current);
+    if (next.has(platform)) {
+      next.delete(platform);
+    } else {
+      next.add(platform);
+    }
+    this.expandedPlatforms.set(next);
+  }
+
+  protected isPlatformExpanded(platform: string): boolean {
+    return this.expandedPlatforms().has(platform);
+  }
+
+  protected onYearChange(event: Event): void {
+    const target = event.target as HTMLSelectElement;
+    this.selectedYear.set(parseInt(target.value, 10));
+  }
 
   // === Private Initializers ===
   private initSocialData(): Signal<SocialMediaResponse | null> {
@@ -147,5 +189,84 @@ export class SocialAccountsTabComponent {
           })
         );
     });
+  }
+
+  private initMonthlyData(): Signal<SocialMediaMonthlyResponse | null> {
+    const slug$ = toObservable(this.foundationSlug);
+    const year$ = toObservable(this.selectedYear);
+
+    return toSignal(
+      combineLatest([slug$, year$]).pipe(
+        switchMap(([slug, year]) => {
+          if (!slug) {
+            this.monthlyLoading.set(false);
+            return of(null);
+          }
+          this.monthlyLoading.set(true);
+          return this.analyticsService.getSocialMediaMonthly(slug, year).pipe(
+            finalize(() => this.monthlyLoading.set(false)),
+            catchError(() => of(null))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initMonthlyPlatforms(): Signal<SocialMonthlyPlatform[]> {
+    return computed(() => {
+      const data = this.monthlyData();
+      if (!data?.platforms?.length) return [];
+
+      return data.platforms.map((p) => {
+        const allMonths: SocialMonthlyRow[] = MONTH_NAMES.map((name, i) => {
+          const monthStr = `${data.year}-${String(i + 1).padStart(2, '0')}`;
+          const row = p.months.find((m) => m.month === monthStr);
+          if (!row) {
+            return {
+              month: name,
+              impressions: '—',
+              engagementRate: '—',
+              followers: '—',
+              newFollowers: '—',
+              momChange: '—',
+              momChangeClass: 'text-gray-400',
+            };
+          }
+          return {
+            month: name,
+            impressions: formatNumber(row.impressions),
+            engagementRate: `${row.engagementRate.toFixed(2)}%`,
+            followers: formatNumber(row.followers),
+            newFollowers: formatNumber(row.newFollowers),
+            momChange: this.formatMomChange(row.momChangeFollowers),
+            momChangeClass: this.getMomChangeClass(row.momChangeFollowers),
+          };
+        });
+
+        const latestRow = p.months.length > 0 ? p.months[p.months.length - 1] : null;
+
+        return {
+          platform: p.platform,
+          latestFollowers: latestRow ? formatNumber(latestRow.followers) : '—',
+          latestMomChange: latestRow ? this.formatMomChange(latestRow.momChangeFollowers) : '—',
+          latestMomChangeClass: latestRow ? this.getMomChangeClass(latestRow.momChangeFollowers) : 'text-gray-400',
+          months: allMonths,
+        };
+      });
+    });
+  }
+
+  private formatMomChange(value: number | null): string {
+    if (value === null) return '—';
+    const sign = value >= 0 ? '+' : '';
+    return `${sign}${value.toFixed(1)}%`;
+  }
+
+  private getMomChangeClass(value: number | null): string {
+    if (value === null) return 'text-gray-400';
+    if (value > 0) return 'text-green-600';
+    if (value < 0) return 'text-red-600';
+    return 'text-gray-500';
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/social-accounts-tab/social-accounts-tab.component.ts
@@ -53,7 +53,7 @@ export class SocialAccountsTabComponent {
   protected readonly hasMonthlyData = computed(() => this.monthlyPlatforms().length > 0);
   protected readonly availableYears = computed(() => {
     const current = new Date().getFullYear();
-    return [current, current - 1, current - 2];
+    return [current, current - 1];
   });
 
   // === Protected Methods ===
@@ -216,9 +216,12 @@ export class SocialAccountsTabComponent {
       const expanded = this.expandedPlatforms();
 
       return data.platforms.map((p) => {
+        const rowsByMonth = new Map(p.months.map((m) => [m.month, m]));
+        const latestRow = p.months.length > 0 ? p.months.reduce((latest, row) => (row.month > latest.month ? row : latest)) : null;
+
         const allMonths: SocialMonthlyRow[] = MONTH_NAMES.map((name, i) => {
           const monthStr = `${data.year}-${String(i + 1).padStart(2, '0')}`;
-          const row = p.months.find((m) => m.month === monthStr);
+          const row = rowsByMonth.get(monthStr);
           if (!row) {
             return {
               month: name,
@@ -240,8 +243,6 @@ export class SocialAccountsTabComponent {
             momChangeClass: this.getMomChangeClass(row.momChangeFollowers),
           };
         });
-
-        const latestRow = p.months.length > 0 ? p.months[p.months.length - 1] : null;
 
         return {
           platform: p.platform,

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -907,7 +907,7 @@ export class AnalyticsService {
     }
     return this.http
       .get<SocialMediaMonthlyResponse>('/api/analytics/social-media/monthly', { params })
-      .pipe(catchError(() => of({ year: Number.isFinite(year) ? year! : new Date().getFullYear(), platforms: [] })));
+      .pipe(catchError(() => of({ year: Number.isFinite(year) ? year! : new Date().getUTCFullYear(), platforms: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import {
   OrgLensAccountContextResponse,
@@ -62,6 +62,7 @@ import {
   CodeContributionSummaryResponse,
   BoardMeetingParticipationSummaryResponse,
   KeywordPerformanceResponse,
+  SocialMediaMonthlyResponse,
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
@@ -896,6 +897,16 @@ export class AnalyticsService {
         });
       })
     );
+  }
+
+  public getSocialMediaMonthly(foundationSlug: string, year?: number): Observable<SocialMediaMonthlyResponse> {
+    let params = new HttpParams().set('foundationSlug', foundationSlug);
+    if (year) {
+      params = params.set('year', year.toString());
+    }
+    return this.http
+      .get<SocialMediaMonthlyResponse>('/api/analytics/social-media/monthly', { params })
+      .pipe(catchError(() => of({ year: year ?? new Date().getFullYear(), platforms: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -899,14 +899,15 @@ export class AnalyticsService {
     );
   }
 
+  /** Fetch monthly social media metrics by platform for the selected year. */
   public getSocialMediaMonthly(foundationSlug: string, year?: number): Observable<SocialMediaMonthlyResponse> {
     let params = new HttpParams().set('foundationSlug', foundationSlug);
-    if (year) {
-      params = params.set('year', year.toString());
+    if (Number.isFinite(year)) {
+      params = params.set('year', String(year));
     }
     return this.http
       .get<SocialMediaMonthlyResponse>('/api/analytics/social-media/monthly', { params })
-      .pipe(catchError(() => of({ year: year ?? new Date().getFullYear(), platforms: [] })));
+      .pipe(catchError(() => of({ year: Number.isFinite(year) ? year! : new Date().getFullYear(), platforms: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2169,9 +2169,14 @@ export class AnalyticsController {
       }
 
       const yearParam = getStringQueryParam(req, 'year');
-      const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+      if (yearParam && !/^\d{4}$/.test(yearParam)) {
+        throw ServiceValidationError.forField('year', 'year must be a 4-digit number', {
+          operation: 'get_social_media_monthly',
+        });
+      }
+      const year = yearParam ? Number(yearParam) : new Date().getFullYear();
 
-      if (isNaN(year) || year < 2020 || year > 2100) {
+      if (!Number.isInteger(year) || year < 2020 || year > 2100) {
         throw ServiceValidationError.forField('year', 'year must be between 2020 and 2100', {
           operation: 'get_social_media_monthly',
         });

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2174,7 +2174,7 @@ export class AnalyticsController {
           operation: 'get_social_media_monthly',
         });
       }
-      const year = yearParam ? Number(yearParam) : new Date().getFullYear();
+      const year = yearParam ? Number(yearParam) : new Date().getUTCFullYear();
 
       if (!Number.isInteger(year) || year < 2020 || year > 2100) {
         throw ServiceValidationError.forField('year', 'year must be between 2020 and 2100', {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2140,6 +2140,57 @@ export class AnalyticsController {
     }
   }
 
+  /**
+   * GET /api/analytics/social-media/monthly
+   * Get per-platform monthly social media growth data
+   */
+  public async getSocialMediaMonthly(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_social_media_monthly');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_social_media_monthly',
+        });
+      }
+
+      if (foundationSlug.length > NAME_MAX_LENGTH) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug exceeds maximum length', {
+          operation: 'get_social_media_monthly',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_social_media_monthly',
+        });
+      }
+
+      const yearParam = getStringQueryParam(req, 'year');
+      const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+
+      if (isNaN(year) || year < 2020 || year > 2100) {
+        throw ServiceValidationError.forField('year', 'year must be between 2020 and 2100', {
+          operation: 'get_social_media_monthly',
+        });
+      }
+
+      const response = await this.projectService.getSocialMediaMonthly(foundationSlug, year);
+
+      logger.success(req, 'get_social_media_monthly', startTime, {
+        foundation_slug: foundationSlug,
+        year,
+        platforms_count: response.platforms.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   // North Star Metrics Endpoints
   // All North Star views use `foundationSlug` (FOUNDATION_SLUG column in NORTH_STAR_* tables)
 

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -152,6 +152,9 @@ router.get('/keyword-performance', (req, res, next) => analyticsController.getKe
 // Social media endpoint (marketing dashboard)
 router.get('/social-media', (req, res, next) => analyticsController.getSocialMedia(req, res, next));
 
+// Social media monthly growth endpoint (marketing dashboard)
+router.get('/social-media/monthly', (req, res, next) => analyticsController.getSocialMediaMonthly(req, res, next));
+
 // North Star metrics endpoints (executive director dashboard)
 router.get('/member-retention', (req, res, next) => analyticsController.getMemberRetention(req, res, next));
 router.get('/member-acquisition', (req, res, next) => analyticsController.getMemberAcquisition(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3343,7 +3343,7 @@ export class ProjectService {
     }
   }
 
-  // TODO: Replace dummy data with Snowflake view SOCIAL_MEDIA_PLATFORM_MONTHLY once data team creates it
+  /** Returns monthly social-media metrics by platform. Temporary dummy data until SOCIAL_MEDIA_PLATFORM_MONTHLY is available. */
   public async getSocialMediaMonthly(_foundationSlug: string, year: number): Promise<SocialMediaMonthlyResponse> {
     logger.warning(undefined, 'get_social_media_monthly', 'Returning dummy data — Snowflake view not yet implemented', {
       foundation_slug: _foundationSlug,
@@ -3358,22 +3358,26 @@ export class ProjectService {
       { name: 'Instagram', baseFollowers: 32000, basePosts: 25, baseImpressions: 280000, baseEngagement: 5.6 },
     ];
 
-    const platforms = platformSeeds.map((seed) => {
+    const currentYear = new Date().getUTCFullYear();
+    const monthCount = year === currentYear ? new Date().getUTCMonth() + 1 : 12;
+
+    const platforms = platformSeeds.map((seed, platformIndex) => {
       const makeRow = (monthIndex: number): Omit<SocialMediaPlatformMonthlyRow, 'momChangeFollowers'> => {
         const growth = 1 + monthIndex * 0.012;
+        const jitter = 0.9 + (((platformIndex + 1) * 37 + (monthIndex + 1) * 17) % 21) / 100;
         const followers = Math.round(seed.baseFollowers * growth);
         const prevFollowers = monthIndex === 0 ? 0 : Math.round(seed.baseFollowers * (1 + (monthIndex - 1) * 0.012));
         return {
           month: `${year}-${String(monthIndex + 1).padStart(2, '0')}`,
           followers,
           newFollowers: monthIndex === 0 ? 0 : followers - prevFollowers,
-          impressions: Math.round(seed.baseImpressions * growth * (0.9 + monthIndex * 0.02)),
-          engagementRate: Math.round(seed.baseEngagement * (0.95 + monthIndex * 0.01) * 100) / 100,
-          posts: Math.round(seed.basePosts * (0.85 + monthIndex * 0.03)),
+          impressions: Math.round(seed.baseImpressions * growth * jitter),
+          engagementRate: Math.round(seed.baseEngagement * (0.95 + (jitter - 0.9) / 2) * 100) / 100,
+          posts: Math.round(seed.basePosts * (0.8 + (jitter - 0.9) * 2)),
         };
       };
 
-      const rawRows = Array.from({ length: 5 }, (_, i) => makeRow(i));
+      const rawRows = Array.from({ length: monthCount }, (_, i) => makeRow(i));
       const months: SocialMediaPlatformMonthlyRow[] = rawRows.map((row, i) => ({
         ...row,
         momChangeFollowers: this.computeMomChange(i, rawRows),

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3345,7 +3345,10 @@ export class ProjectService {
 
   // TODO: Replace dummy data with Snowflake view SOCIAL_MEDIA_PLATFORM_MONTHLY once data team creates it
   public async getSocialMediaMonthly(_foundationSlug: string, year: number): Promise<SocialMediaMonthlyResponse> {
-    logger.debug(undefined, 'get_social_media_monthly', 'Returning dummy social media monthly data', { year });
+    logger.warning(undefined, 'get_social_media_monthly', 'Returning dummy data — Snowflake view not yet implemented', {
+      foundation_slug: _foundationSlug,
+      year,
+    });
 
     const platformSeeds: { name: string; baseFollowers: number; basePosts: number; baseImpressions: number; baseEngagement: number }[] = [
       { name: 'LinkedIn', baseFollowers: 125000, basePosts: 45, baseImpressions: 890000, baseEngagement: 3.2 },

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3344,9 +3344,9 @@ export class ProjectService {
   }
 
   /** Returns monthly social-media metrics by platform. Temporary dummy data until SOCIAL_MEDIA_PLATFORM_MONTHLY is available. */
-  public async getSocialMediaMonthly(_foundationSlug: string, year: number): Promise<SocialMediaMonthlyResponse> {
-    logger.warning(undefined, 'get_social_media_monthly', 'Returning dummy data — Snowflake view not yet implemented', {
-      foundation_slug: _foundationSlug,
+  public async getSocialMediaMonthly(foundationSlug: string, year: number): Promise<SocialMediaMonthlyResponse> {
+    logger.debug(undefined, 'get_social_media_monthly', 'Returning dummy data — Snowflake view not yet implemented', {
+      foundation_slug: foundationSlug,
       year,
     });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3362,14 +3362,14 @@ export class ProjectService {
       const makeRow = (monthIndex: number): Omit<SocialMediaPlatformMonthlyRow, 'momChangeFollowers'> => {
         const growth = 1 + monthIndex * 0.012;
         const followers = Math.round(seed.baseFollowers * growth);
-        const prevFollowers = monthIndex === 0 ? Math.round(seed.baseFollowers * 0.988) : Math.round(seed.baseFollowers * (1 + (monthIndex - 1) * 0.012));
+        const prevFollowers = monthIndex === 0 ? 0 : Math.round(seed.baseFollowers * (1 + (monthIndex - 1) * 0.012));
         return {
           month: `${year}-${String(monthIndex + 1).padStart(2, '0')}`,
           followers,
-          newFollowers: followers - prevFollowers,
-          impressions: Math.round(seed.baseImpressions * growth * (0.9 + Math.random() * 0.2)),
-          engagementRate: Math.round(seed.baseEngagement * (0.95 + Math.random() * 0.1) * 100) / 100,
-          posts: Math.round(seed.basePosts * (0.8 + Math.random() * 0.4)),
+          newFollowers: monthIndex === 0 ? 0 : followers - prevFollowers,
+          impressions: Math.round(seed.baseImpressions * growth * (0.9 + monthIndex * 0.02)),
+          engagementRate: Math.round(seed.baseEngagement * (0.95 + monthIndex * 0.01) * 100) / 100,
+          posts: Math.round(seed.basePosts * (0.85 + monthIndex * 0.03)),
         };
       };
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -105,6 +105,8 @@ import {
   ProjectUniqueContributorsDailyRow,
   QueryServiceResponse,
   RevenueImpactResponse,
+  SocialMediaMonthlyResponse,
+  SocialMediaPlatformMonthlyRow,
   SocialMediaResponse,
   SocialReachResponse,
   TrainingCertificationSummaryResponse,
@@ -3339,6 +3341,45 @@ export class ProjectService {
         monthlyData: [],
       };
     }
+  }
+
+  // TODO: Replace dummy data with Snowflake view SOCIAL_MEDIA_PLATFORM_MONTHLY once data team creates it
+  public async getSocialMediaMonthly(_foundationSlug: string, year: number): Promise<SocialMediaMonthlyResponse> {
+    logger.debug(undefined, 'get_social_media_monthly', 'Returning dummy social media monthly data', { year });
+
+    const platformSeeds: { name: string; baseFollowers: number; basePosts: number; baseImpressions: number; baseEngagement: number }[] = [
+      { name: 'LinkedIn', baseFollowers: 125000, basePosts: 45, baseImpressions: 890000, baseEngagement: 3.2 },
+      { name: 'YouTube', baseFollowers: 48000, basePosts: 12, baseImpressions: 520000, baseEngagement: 4.1 },
+      { name: 'Twitter/X', baseFollowers: 210000, basePosts: 120, baseImpressions: 1200000, baseEngagement: 1.8 },
+      { name: 'Facebook', baseFollowers: 67000, basePosts: 30, baseImpressions: 340000, baseEngagement: 2.5 },
+      { name: 'Instagram', baseFollowers: 32000, basePosts: 25, baseImpressions: 280000, baseEngagement: 5.6 },
+    ];
+
+    const platforms = platformSeeds.map((seed) => {
+      const makeRow = (monthIndex: number): Omit<SocialMediaPlatformMonthlyRow, 'momChangeFollowers'> => {
+        const growth = 1 + monthIndex * 0.012;
+        const followers = Math.round(seed.baseFollowers * growth);
+        const prevFollowers = monthIndex === 0 ? Math.round(seed.baseFollowers * 0.988) : Math.round(seed.baseFollowers * (1 + (monthIndex - 1) * 0.012));
+        return {
+          month: `${year}-${String(monthIndex + 1).padStart(2, '0')}`,
+          followers,
+          newFollowers: followers - prevFollowers,
+          impressions: Math.round(seed.baseImpressions * growth * (0.9 + Math.random() * 0.2)),
+          engagementRate: Math.round(seed.baseEngagement * (0.95 + Math.random() * 0.1) * 100) / 100,
+          posts: Math.round(seed.basePosts * (0.8 + Math.random() * 0.4)),
+        };
+      };
+
+      const rawRows = Array.from({ length: 5 }, (_, i) => makeRow(i));
+      const months: SocialMediaPlatformMonthlyRow[] = rawRows.map((row, i) => ({
+        ...row,
+        momChangeFollowers: this.computeMomChange(i, rawRows),
+      }));
+
+      return { platform: seed.name, months };
+    });
+
+    return { year, platforms };
   }
 
   // North Star Metrics Queries (ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_* views)
@@ -6598,5 +6639,12 @@ export class ProjectService {
     }
     const date = value instanceof Date ? value : new Date(String(value));
     return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+  }
+
+  private computeMomChange(index: number, data: { followers: number }[]): number | null {
+    if (index === 0) return null;
+    const prev = data[index - 1].followers;
+    if (prev === 0) return null;
+    return Math.round(((data[index].followers - prev) / prev) * 1000) / 10;
   }
 }

--- a/docs/proposals/social-media-platform-monthly-view.md
+++ b/docs/proposals/social-media-platform-monthly-view.md
@@ -84,7 +84,7 @@ Plus any additional platforms tracked for foundations (Bluesky, Mastodon are use
 
 The Express backend will run a single query against this view and return the results grouped by platform:
 
-```
+```text
 GET /api/analytics/social-media/monthly?foundationSlug=tlf&year=2026
 ```
 

--- a/docs/proposals/social-media-platform-monthly-view.md
+++ b/docs/proposals/social-media-platform-monthly-view.md
@@ -1,0 +1,161 @@
+# Data Requirement: SOCIAL_MEDIA_PLATFORM_MONTHLY Snowflake View
+
+## Context
+
+The LFX Marketing Impact dashboard has a **Social Accounts** tab that shows aggregate social media metrics (total followers, impressions, engagement rate, posts) with a per-platform breakdown table. The data comes from three existing Platinum views:
+
+| View                              | Purpose                                                                | Temporal?                                                   |
+| --------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `SOCIAL_MEDIA_OVERVIEW`           | Aggregate KPIs (total followers, growth %)                             | No — latest snapshot                                        |
+| `SOCIAL_MEDIA_PLATFORM_BREAKDOWN` | Per-platform snapshot (followers, impressions, engagements, posts_30d) | No — latest snapshot                                        |
+| `SOCIAL_MEDIA_FOLLOWER_TREND`     | Monthly follower totals                                                | Yes — `SNAPSHOT_MONTH`, but aggregated across all platforms |
+
+We need to add a **Monthly Growth Table** that shows per-platform, per-month metrics (matching the AAIF Growth Tracker spreadsheet format). None of the existing views provide per-platform monthly breakdowns.
+
+## Requested View
+
+**Name:** `ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_PLATFORM_MONTHLY`
+
+**Purpose:** Monthly time-series of social media metrics broken down by platform and foundation. Powers the "Monthly Growth" section of the Social Accounts tab, showing month-over-month trends per platform.
+
+## Required Columns
+
+| Column            | Type      | Description                                                                                                                                                                           |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SNAPSHOT_MONTH`  | `DATE`    | First day of the month (e.g., `2026-01-01`, `2026-02-01`). Same convention as `SOCIAL_MEDIA_FOLLOWER_TREND`.                                                                          |
+| `PLATFORM_NAME`   | `VARCHAR` | Platform identifier. Must match values in `SOCIAL_MEDIA_PLATFORM_BREAKDOWN.PLATFORM_NAME` (e.g., `LinkedIn`, `Twitter/X`, `YouTube`, `Facebook`, `Instagram`, `Bluesky`, `Mastodon`). |
+| `FOUNDATION_SLUG` | `VARCHAR` | Foundation slug for filtering. Same convention as existing social media views.                                                                                                        |
+| `FOLLOWERS`       | `NUMBER`  | Total followers/subscribers at end of month.                                                                                                                                          |
+| `NEW_FOLLOWERS`   | `NUMBER`  | Net new followers gained during the month. Can be computed as `FOLLOWERS - LAG(FOLLOWERS)` over the platform+foundation partition if raw deltas aren't available.                     |
+| `IMPRESSIONS`     | `NUMBER`  | Total impressions during the month.                                                                                                                                                   |
+| `ENGAGEMENTS`     | `NUMBER`  | Total engagements during the month (likes, comments, shares, clicks). Raw count — the UI computes engagement rate as `ENGAGEMENTS / IMPRESSIONS * 100`.                               |
+| `POSTS`           | `NUMBER`  | Total posts/videos published during the month.                                                                                                                                        |
+
+## Filtering & Aggregation Contract
+
+The UI queries this view the same way it queries existing social media views:
+
+```sql
+-- For a specific foundation:
+SELECT *
+FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_PLATFORM_MONTHLY
+WHERE FOUNDATION_SLUG = 'linux-foundation'
+  AND SNAPSHOT_MONTH >= '2026-01-01'
+  AND SNAPSHOT_MONTH < '2027-01-01'
+ORDER BY PLATFORM_NAME, SNAPSHOT_MONTH ASC;
+
+-- For TLF (umbrella — all foundations aggregated):
+SELECT
+  SNAPSHOT_MONTH,
+  PLATFORM_NAME,
+  SUM(FOLLOWERS) AS FOLLOWERS,
+  SUM(NEW_FOLLOWERS) AS NEW_FOLLOWERS,
+  SUM(IMPRESSIONS) AS IMPRESSIONS,
+  SUM(ENGAGEMENTS) AS ENGAGEMENTS,
+  SUM(POSTS) AS POSTS
+FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_PLATFORM_MONTHLY
+GROUP BY SNAPSHOT_MONTH, PLATFORM_NAME
+ORDER BY PLATFORM_NAME, SNAPSHOT_MONTH ASC;
+```
+
+The UI handles the `tlf` umbrella aggregation in app code (same pattern as existing social media queries — no foundation filter for TLF, `SUM()` + `GROUP BY` across all foundations).
+
+## Data Expectations
+
+- **Backfill:** At minimum from January 2026 forward. Older data (2025) is nice-to-have for year-over-year comparison but not required for launch.
+- **Refresh cadence:** Monthly (end of each month or first few days of the following month). The data doesn't need to be real-time — a 1-3 day lag is acceptable.
+- **Null handling:** Months with no data for a platform should either be absent (no row) or have `0` values. The UI handles both cases. Do NOT insert rows with `NULL` numeric values — use `0` if the platform existed but had no activity.
+- **Platform consistency:** `PLATFORM_NAME` values must exactly match what's in `SOCIAL_MEDIA_PLATFORM_BREAKDOWN`. If a platform appears in the breakdown view, it should appear in the monthly view (and vice versa). This is critical for the UI to join/correlate data.
+- **NEW_FOLLOWERS accuracy:** If raw follower-delta data isn't available from the source APIs, computing as `FOLLOWERS(month N) - FOLLOWERS(month N-1)` using a window function is acceptable. The first month of data can have `NEW_FOLLOWERS = 0` or `NULL` (UI shows "N/A" for the first month).
+
+## Platforms to Include
+
+All platforms currently in `SOCIAL_MEDIA_PLATFORM_BREAKDOWN`, which today includes:
+
+- LinkedIn
+- Twitter/X
+- YouTube
+- Facebook
+- Instagram
+
+Plus any additional platforms tracked for foundations (Bluesky, Mastodon are used by TLF — see `SOCIAL_MEDIA_PLATFORM_BREAKDOWN` for the authoritative list).
+
+## How the UI Will Consume This
+
+The Express backend will run a single query against this view and return the results grouped by platform:
+
+```
+GET /api/analytics/social-media/monthly?foundationSlug=tlf&year=2026
+```
+
+Response shape the UI expects:
+
+```json
+{
+  "year": 2026,
+  "platforms": [
+    {
+      "platform": "LinkedIn",
+      "months": [
+        {
+          "month": "2026-01",
+          "followers": 1077,
+          "newFollowers": 0,
+          "impressions": 16886,
+          "engagementRate": 5.2,
+          "posts": 42,
+          "momChangeFollowers": null
+        },
+        {
+          "month": "2026-02",
+          "followers": 2093,
+          "newFollowers": 1008,
+          "impressions": 24308,
+          "engagementRate": 5.3,
+          "posts": 58,
+          "momChangeFollowers": 94.34
+        }
+      ]
+    },
+    {
+      "platform": "YouTube",
+      "months": [
+        {
+          "month": "2026-01",
+          "followers": 7584,
+          "newFollowers": 163,
+          "impressions": 0,
+          "engagementRate": 0,
+          "posts": 12,
+          "momChangeFollowers": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+The backend computes `engagementRate` (from `ENGAGEMENTS / IMPRESSIONS * 100`) and `momChangeFollowers` (from consecutive months' `FOLLOWERS` values) — these do NOT need to be in the Snowflake view.
+
+## Relationship to Existing Views
+
+This view complements (does not replace) the existing three views:
+
+- `SOCIAL_MEDIA_OVERVIEW` — still used for aggregate KPI cards (snapshot)
+- `SOCIAL_MEDIA_PLATFORM_BREAKDOWN` — still used for the platform summary table (snapshot)
+- `SOCIAL_MEDIA_FOLLOWER_TREND` — still used for the aggregate follower sparkline (monthly, all platforms combined)
+- **`SOCIAL_MEDIA_PLATFORM_MONTHLY` (new)** — used for the monthly growth table (monthly, per platform)
+
+## Acceptance Criteria
+
+1. View exists at `ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_PLATFORM_MONTHLY`
+2. Contains all columns listed above with correct types
+3. Has data for at least January–May 2026 for TLF foundation
+4. `PLATFORM_NAME` values match `SOCIAL_MEDIA_PLATFORM_BREAKDOWN` exactly
+5. `FOUNDATION_SLUG` values match existing social media views exactly
+6. Query returns results in under 3 seconds for a single foundation + full year
+7. Numeric values are `0` (not `NULL`) for months where a platform had no activity
+
+## Timeline
+
+This view is a prerequisite for the "Social Accounts — Monthly Growth Table" UI work. The UI and backend code can be built in parallel (with mock data), but end-to-end testing requires the view to be live.

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -9,6 +9,8 @@ import type {
   MarketingImpactTabOption,
 } from '../interfaces/marketing-impact.interface';
 
+export const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'] as const;
+
 /** Focus program filter options for the Marketing Impact FOCUS bar. Labels match Snowflake LF_SUB_DOMAIN_CLASSIFICATION values. */
 export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
   { id: 'all', label: 'All programs' },

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2745,6 +2745,29 @@ export interface SocialMediaResponse {
   monthlyData: SocialMediaMonthlyData[];
 }
 
+/** Per-platform monthly row for the social media monthly growth table. */
+export interface SocialMediaPlatformMonthlyRow {
+  month: string;
+  followers: number;
+  newFollowers: number;
+  impressions: number;
+  engagementRate: number;
+  posts: number;
+  momChangeFollowers: number | null;
+}
+
+/** A single platform's monthly breakdown for the social media monthly growth table. */
+export interface SocialMediaPlatformMonthly {
+  platform: string;
+  months: SocialMediaPlatformMonthlyRow[];
+}
+
+/** API response for the social media monthly growth endpoint. */
+export interface SocialMediaMonthlyResponse {
+  year: number;
+  platforms: SocialMediaPlatformMonthly[];
+}
+
 // ============================================
 // Email CTR (Marketing Dashboard)
 // ============================================

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -135,6 +135,26 @@ export interface SocialAccountRow {
   posts: string;
 }
 
+/** View-model row for a single month inside a social monthly platform. */
+export interface SocialMonthlyRow {
+  month: string;
+  impressions: string;
+  engagementRate: string;
+  followers: string;
+  newFollowers: string;
+  momChange: string;
+  momChangeClass: string;
+}
+
+/** View-model for an expandable social platform with monthly data. */
+export interface SocialMonthlyPlatform {
+  platform: string;
+  latestFollowers: string;
+  latestMomChange: string;
+  latestMomChangeClass: string;
+  months: SocialMonthlyRow[];
+}
+
 /** Segment data for the sentiment breakdown horizontal bar chart. */
 export interface SentimentBar {
   positive: number;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -149,6 +149,7 @@ export interface SocialMonthlyRow {
 /** View-model for an expandable social platform with monthly data. */
 export interface SocialMonthlyPlatform {
   platform: string;
+  expanded: boolean;
   latestFollowers: string;
   latestMomChange: string;
   latestMomChangeClass: string;


### PR DESCRIPTION
## Summary
- Add expandable per-platform monthly growth table to the Social Accounts tab on the Marketing Impact dashboard
- New backend endpoint `GET /api/analytics/social-media/monthly` with dummy data (pending Snowflake view)
- Year selector for switching between current and previous years
- Keyboard-accessible expandable rows with `aria-expanded`, Enter/Space handlers

## JIRA
LFXV2-2398

## Changes
### Shared package
- `analytics-data.interface.ts` — 3 new interfaces: `SocialMediaPlatformMonthlyRow`, `SocialMediaPlatformMonthly`, `SocialMediaMonthlyResponse`
- `marketing-impact.interface.ts` — 2 view-model interfaces: `SocialMonthlyRow`, `SocialMonthlyPlatform`
- `marketing-impact.constants.ts` — `MONTH_NAMES` constant

### Backend
- `analytics.route.ts` — new `/social-media/monthly` route
- `analytics.controller.ts` — `getSocialMediaMonthly` with foundationSlug + year validation
- `project.service.ts` — dummy data for 5 platforms, `computeMomChange` helper

### Frontend
- `analytics.service.ts` — `getSocialMediaMonthly()` method
- `social-accounts-tab.component.ts` — monthly data signals, expand/collapse, year selection
- `social-accounts-tab.component.html` — expandable platform rows with monthly metrics

### Documentation
- `docs/proposals/social-media-platform-monthly-view.md` — Snowflake view specification for data team