### PR TITLE
fix(dashboards): correct code contribution explore-more link

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/code-contribution-card/code-contribution-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/code-contribution-card/code-contribution-card.component.ts
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, i
 import { SkeletonModule } from 'primeng/skeleton';
 import { HealthMetricsCardEmptyStateComponent } from '../health-metrics-card-empty-state/health-metrics-card-empty-state.component';
 import { HEALTH_METRICS_CODE_CONTRIBUTION_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
+import { buildLensAwareInsightsUrl } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
@@ -122,7 +122,9 @@ export class CodeContributionCardComponent {
   protected readonly exploreMoreUrl = computed(() => {
     const slug = this.summaryData().projectSlug;
     if (!slug) return '';
-    return buildInsightsUrl(`/project/${slug}/contributors`);
+    return buildLensAwareInsightsUrl(slug, this.projectContextService.isFoundationContext(), {
+      projectSubPath: 'contributors',
+    });
   });
 
   public constructor() {


### PR DESCRIPTION
## Summary

- Fixes the Code Contribution card's "Explore more →" link on `/foundation/health-metrics`, which was silently redirecting to the generic Insights homepage
- Foundation lens now links to `https://insights.linuxfoundation.org/collection/details/{foundation_slug}` instead of the broken `/project/{foundation_slug}` path
- Reuses the existing `buildLensAwareInsightsUrl` helper from `@lfx-one/shared/utils`, consistent with all sibling dashboard drawers

Closes LFXV2-1624

## Test plan

- [ ] Impersonate AAIF Executive Director
- [ ] Navigate to `/foundation/health-metrics`
- [ ] Click "Explore more →" on the Code Contribution card
- [ ] Verify landing page is `https://insights.linuxfoundation.org/collection/details/agentic-ai-foundation` with foundation context, not the generic Insights homepage
- [ ] Confirm link is hidden when no foundation slug is available (empty state)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)