### PR TITLE
fix: force google ads api to use gaxios fetch

### DIFF
--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -70,6 +70,7 @@
     "express-openid-connect": "^2.19.2",
     "express-rate-limit": "^8.3.2",
     "form-data": "^4.0.4",
+    "gaxios": "^6.1.1",
     "google-ads-api": "^23.0.0",
     "html-to-image": "^1.11.13",
     "ioredis": "^5.11.1",

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -37,8 +37,12 @@ import { executeRedditCampaignCreation, updateRedditCampaignStatus } from './red
 // ---------------------------------------------------------------------------
 
 import { GoogleAdsApi, enums } from 'google-ads-api';
+import { instance as gaxiosInstance } from 'gaxios';
 
 import type { Customer } from 'google-ads-api';
+
+// Use Node.js native fetch instead of node-fetch
+gaxiosInstance.defaults.fetchImplementation = globalThis.fetch;
 
 // ---------------------------------------------------------------------------
 // Required environment variables — log warnings on first use for missing ones

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -41,7 +41,9 @@ import { instance as gaxiosInstance } from 'gaxios';
 
 import type { Customer } from 'google-ads-api';
 
-// Use Node.js native fetch instead of node-fetch
+// Override gaxios's bundled node-fetch with Node's built-in fetch (undici).
+// node-fetch fails with ERR_STREAM_PREMATURE_CLOSE when handling gzip-encoded
+// responses from oauth2.googleapis.com in the cluster environment.
 gaxiosInstance.defaults.fetchImplementation = globalThis.fetch;
 
 // ---------------------------------------------------------------------------

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -24,6 +24,9 @@ import type {
   RedditCampaignCreateResult,
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
+import { instance as gaxiosInstance } from 'gaxios';
+import { GoogleAdsApi, enums } from 'google-ads-api';
+import type { Customer } from 'google-ads-api';
 
 import { ServiceValidationError } from '../errors/service-validation.error';
 import { validateScrapeUrl, fetchSafeUrl } from '../helpers/url-validation';
@@ -32,19 +35,17 @@ import { logger } from './logger.service';
 import { executeMetaCampaignCreation, updateMetaCampaignStatus } from './meta-ads.service';
 import { executeRedditCampaignCreation, updateRedditCampaignStatus } from './reddit-ads.service';
 
-// ---------------------------------------------------------------------------
-// Google Ads gRPC client (via google-ads-api)
-// ---------------------------------------------------------------------------
-
-import { GoogleAdsApi, enums } from 'google-ads-api';
-import { instance as gaxiosInstance } from 'gaxios';
-
-import type { Customer } from 'google-ads-api';
-
-// Override gaxios's bundled node-fetch with Node's built-in fetch (undici).
+// Override gaxios@6's bundled node-fetch with Node's built-in fetch (undici).
 // node-fetch fails with ERR_STREAM_PREMATURE_CLOSE when handling gzip-encoded
 // responses from oauth2.googleapis.com in the cluster environment.
-gaxiosInstance.defaults.fetchImplementation = globalThis.fetch;
+//
+// NOTE: this mutates the process-global gaxios@6 singleton, so it also
+// changes the default fetch for every other gaxios@6 consumer in this
+// process (@google-cloud/storage, gcp-metadata, gtoken, google-auth-library).
+// That's intentional — undici is the desired transport everywhere in Node 22+.
+if (globalThis.fetch) {
+  gaxiosInstance.defaults.fetchImplementation = globalThis.fetch as typeof gaxiosInstance.defaults.fetchImplementation;
+}
 
 // ---------------------------------------------------------------------------
 // Required environment variables — log warnings on first use for missing ones

--- a/yarn.lock
+++ b/yarn.lock
@@ -13552,6 +13552,7 @@ __metadata:
     express-openid-connect: "npm:^2.19.2"
     express-rate-limit: "npm:^8.3.2"
     form-data: "npm:^4.0.4"
+    gaxios: "npm:^6.1.1"
     google-ads-api: "npm:^23.0.0"
     gray-matter: "npm:^4.0.3"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
Google Ads API was returning a `GaxiosError`: `ERR_STREAM_PREMATURE_CLOSE`. Based on [this](https://station.railway.com/questions/outbound-https-to-oauth2-googleapis-com-086171e4) thread of the same error, this PR forces the use of `gaxios` global fetch, instead of inherently using `node-fetch`.