### PR TITLE
fix(committees): show invite accept ui when org-required group returns 403

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -42,7 +42,7 @@
     <!-- Error State -->
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center max-w-md">
-        @if (errorType() === 'not-found') {
+        @if (errorType() === 'access-denied') {
           @if (pendingInvitationFromRoute(); as invite) {
             <div class="w-16 h-16 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-4">
               <i class="fa-light fa-user-plus text-2xl text-blue-600"></i>
@@ -55,13 +55,13 @@
                 severity="info"
                 icon="fa-light fa-check"
                 (onClick)="onAcceptInvite(invite)"
-                data-testid="committee-view-error-invite-accept" />
+                data-testid="committee-view-invitation-error-accept" />
               <lfx-button
                 label="Decline"
                 severity="secondary"
                 [outlined]="true"
                 (onClick)="onDeclineInvite(invite)"
-                data-testid="committee-view-error-invite-decline" />
+                data-testid="committee-view-invitation-error-decline" />
             </div>
           } @else {
             <div class="w-16 h-16 rounded-full bg-red-50 flex items-center justify-center mx-auto mb-4">
@@ -71,6 +71,13 @@
             <p class="text-sm text-gray-500 mb-6">The group you're looking for doesn't exist, has been removed, or you may not have permission to view it.</p>
             <lfx-button label="Back to Groups" severity="secondary" [outlined]="true" icon="fa-light fa-arrow-left" (onClick)="goBack()"></lfx-button>
           }
+        } @else if (errorType() === 'not-found') {
+          <div class="w-16 h-16 rounded-full bg-red-50 flex items-center justify-center mx-auto mb-4">
+            <i class="fa-light fa-exclamation-triangle text-2xl text-red-500"></i>
+          </div>
+          <h2 class="text-lg font-semibold text-gray-900 mb-2">Group Not Found</h2>
+          <p class="text-sm text-gray-500 mb-6">The group you're looking for doesn't exist, has been removed, or you may not have permission to view it.</p>
+          <lfx-button label="Back to Groups" severity="secondary" [outlined]="true" icon="fa-light fa-arrow-left" (onClick)="goBack()"></lfx-button>
         } @else {
           <div class="w-16 h-16 rounded-full bg-amber-50 flex items-center justify-center mx-auto mb-4">
             <i class="fa-light fa-cloud-exclamation text-2xl text-amber-500"></i>

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -43,12 +43,34 @@
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center max-w-md">
         @if (errorType() === 'not-found') {
-          <div class="w-16 h-16 rounded-full bg-red-50 flex items-center justify-center mx-auto mb-4">
-            <i class="fa-light fa-exclamation-triangle text-2xl text-red-500"></i>
-          </div>
-          <h2 class="text-lg font-semibold text-gray-900 mb-2">Group Not Found</h2>
-          <p class="text-sm text-gray-500 mb-6">The group you're looking for doesn't exist, has been removed, or you may not have permission to view it.</p>
-          <lfx-button label="Back to Groups" severity="secondary" [outlined]="true" icon="fa-light fa-arrow-left" (onClick)="goBack()"></lfx-button>
+          @if (pendingInvitationFromRoute(); as invite) {
+            <div class="w-16 h-16 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-4">
+              <i class="fa-light fa-user-plus text-2xl text-blue-600"></i>
+            </div>
+            <h2 class="text-lg font-semibold text-gray-900 mb-2">You've been invited to {{ invite.committee_name }}</h2>
+            <p class="text-sm text-gray-500 mb-6">Accept the invitation to join and view this group.</p>
+            <div class="flex items-center justify-center gap-3">
+              <lfx-button
+                label="Accept Invitation"
+                severity="info"
+                icon="fa-light fa-check"
+                (onClick)="onAcceptInvite(invite)"
+                data-testid="committee-view-error-invite-accept" />
+              <lfx-button
+                label="Decline"
+                severity="secondary"
+                [outlined]="true"
+                (onClick)="onDeclineInvite(invite)"
+                data-testid="committee-view-error-invite-decline" />
+            </div>
+          } @else {
+            <div class="w-16 h-16 rounded-full bg-red-50 flex items-center justify-center mx-auto mb-4">
+              <i class="fa-light fa-exclamation-triangle text-2xl text-red-500"></i>
+            </div>
+            <h2 class="text-lg font-semibold text-gray-900 mb-2">Group Not Found</h2>
+            <p class="text-sm text-gray-500 mb-6">The group you're looking for doesn't exist, has been removed, or you may not have permission to view it.</p>
+            <lfx-button label="Back to Groups" severity="secondary" [outlined]="true" icon="fa-light fa-arrow-left" (onClick)="goBack()"></lfx-button>
+          }
         } @else {
           <div class="w-16 h-16 rounded-full bg-amber-50 flex items-center justify-center mx-auto mb-4">
             <i class="fa-light fa-cloud-exclamation text-2xl text-amber-500"></i>

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -167,6 +167,16 @@ export class CommitteeViewComponent {
     return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), committee.uid);
   });
 
+  // When the committee 403s and committee() is null, pendingInvitation() returns null because it
+  // requires committee.uid. This signal resolves the same invite using the route :id directly so
+  // the error state can surface the accept flow without a loaded committee record.
+  public pendingInvitationFromRoute: Signal<PendingInvitation | null> = computed(() => {
+    if (!this.error()) {
+      return null;
+    }
+    return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), this.committeeId());
+  });
+
   // Deferred-decline timers keyed by invite UID (committee UID stored alongside since the invite is
   // out of the cache by the time the timer/destroy flush fires). Mirrors the dashboard/My Groups UX.
   private readonly pendingDeclines = new Map<string, { committeeUid: string; timerId: ReturnType<typeof setTimeout> }>();

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -131,7 +131,7 @@ export class CommitteeViewComponent {
   // `loading`, which only gates the full-page spinner on the initial fetch.
   public committeeRefreshing = signal<boolean>(false);
   public error = signal<boolean>(false);
-  public errorType = signal<'not-found' | 'server-error' | null>(null);
+  public errorType = signal<'not-found' | 'access-denied' | 'server-error' | null>(null);
   public refresh = signal(0);
   public membersRefresh = signal(0);
   public membersLoading = signal<boolean>(true);
@@ -170,12 +170,7 @@ export class CommitteeViewComponent {
   // When the committee 403s and committee() is null, pendingInvitation() returns null because it
   // requires committee.uid. This signal resolves the same invite using the route :id directly so
   // the error state can surface the accept flow without a loaded committee record.
-  public pendingInvitationFromRoute: Signal<PendingInvitation | null> = computed(() => {
-    if (!this.error()) {
-      return null;
-    }
-    return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), this.committeeId());
-  });
+  public pendingInvitationFromRoute: Signal<PendingInvitation | null> = this.initPendingInvitationFromRoute();
 
   // Deferred-decline timers keyed by invite UID (committee UID stored alongside since the invite is
   // out of the cache by the time the timer/destroy flush fires). Mirrors the dashboard/My Groups UX.
@@ -648,6 +643,15 @@ export class CommitteeViewComponent {
   }
 
   // -- Private initializer functions --
+  private initPendingInvitationFromRoute(): Signal<PendingInvitation | null> {
+    return computed(() => {
+      if (this.errorType() !== 'access-denied') {
+        return null;
+      }
+      return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), this.committeeId());
+    });
+  }
+
   private initCommitteeId(): Signal<string | null> {
     return toSignal(this.route.paramMap.pipe(map((params) => params.get('id'))), { requireSync: true });
   }
@@ -715,7 +719,9 @@ export class CommitteeViewComponent {
           return this.committeeService.getCommittee(committeeId).pipe(
             catchError((err) => {
               const status = err?.status;
-              if (status === 404 || status === 403) {
+              if (status === 403) {
+                this.errorType.set('access-denied');
+              } else if (status === 404) {
                 this.errorType.set('not-found');
               } else {
                 this.errorType.set('server-error');


### PR DESCRIPTION
## Summary

- Invitees to org-required committees (voting/business-email rules) land on `/project/groups/:id` after accepting their email invite. Because `autoAcceptPendingCommitteeInvitesAfterLfidAccept` skips membership creation when the invite carries no org name (PR #965, fail-closed), the committee fetch returns 403. The page mapped 403 to "Group Not Found" with no path to accept — a catch-22.
- Added `pendingInvitationFromRoute` computed signal that resolves a pending invite using the route `:id` directly, bypassing the null `committee()` problem on 403.
- When the error state renders and a matching pending invite is found, the "Group Not Found" block is replaced with an invite accept UI ("You've been invited to {name}" + Accept/Decline). On accept, the existing `refreshCommitteeAfterMembershipChange` polls until membership propagates, then reloads the committee — clearing the error state and letting `syncEntityProjectContext` switch the active project to the correct one.

## Test plan

- [ ] Accept an email invite for an org-required committee (one with `enable_voting` or `business_email_required`) while not already a member
- [ ] Confirm the group detail page shows "You've been invited to {group name}" with Accept/Decline instead of "Group Not Found"
- [ ] Accept → org dialog appears → confirm → page transitions to the loaded committee view on the correct project
- [ ] Decline → "Group Not Found" state is shown (invite resolved, no access)
- [ ] Non-invited user landing on a restricted group UID still sees "Group Not Found" (no invite in cache)
- [ ] Normal invite banner on a successfully-loaded group is unaffected

Fixes: https://linuxfoundation.atlassian.net/browse/LFXV2-2507

🤖 Generated with [Claude Code](https://claude.com/claude-code)