### PR TITLE
fix(meetings): pass project+committee_uid queryParams on meeting edit navigation

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -60,7 +60,8 @@
             severity="secondary"
             data-testid="edit-meeting-button"
             tooltip="Edit Meeting"
-            [routerLink]="['/meetings', meeting().id, 'edit']"></lfx-button>
+            [routerLink]="['/meetings', meeting().id, 'edit']"
+            [queryParams]="editQueryParams()"></lfx-button>
         }
         @if (meeting().organizer) {
           <lfx-button

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -187,6 +187,14 @@ export class MeetingCardComponent implements OnInit {
   public readonly showTranscriptBadge: Signal<boolean> = computed(() => (this.pastMeeting() ? this.hasTranscript() : !!this.meeting().transcript_enabled));
   public readonly showAiSummaryBadge: Signal<boolean> = computed(() => (this.pastMeeting() ? this.hasSummary() : this.hasAiCompanion()));
   public readonly joinQueryParams: Signal<Record<string, string>> = this.initJoinQueryParams();
+  public readonly editQueryParams: Signal<Record<string, string>> = computed(() => {
+    const meeting = this.meeting() as Meeting;
+    const params: Record<string, string> = {};
+    if (meeting.project_slug) params['project'] = meeting.project_slug;
+    const committeeUid = meeting.committees?.[0]?.uid;
+    if (committeeUid) params['committee_uid'] = committeeUid;
+    return params;
+  });
 
   public readonly meetingDeleted = output<void>();
   public readonly project = this.projectService.project;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -188,7 +188,7 @@ export class MeetingCardComponent implements OnInit {
   public readonly showAiSummaryBadge: Signal<boolean> = computed(() => (this.pastMeeting() ? this.hasSummary() : this.hasAiCompanion()));
   public readonly joinQueryParams: Signal<Record<string, string>> = this.initJoinQueryParams();
   public readonly editQueryParams: Signal<Record<string, string>> = computed(() => {
-    const meeting = this.meeting() as Meeting;
+    const meeting = this.meeting();
     const params: Record<string, string> = {};
     if (meeting.project_slug) params['project'] = meeting.project_slug;
     const committeeUid = meeting.committees?.[0]?.uid;


### PR DESCRIPTION
## Problem

Committee Managers (users with `committee.writer === true` but no `project.writer` or `meetingCoordinator` role) were seeing "Access Denied — You don't have permission to schedule meetings for this project" when clicking the **Edit** button on any meeting, even though they can successfully schedule new meetings.

**Root cause:** The edit button in `meeting-card.component.html` navigated to `/meetings/:id/edit` with no query params. `writerGuard` reads `?committee_uid` and `?project` from the route query params to run the committee-writer check. Without them, it falls straight to the deny path on line 99.

By contrast, the "Schedule Meeting" CTA in `committee-meetings.component.ts` passes `committee_uid` via `buildCommitteeCreateQueryParams()`, so the guard finds it and checks `committee.writer` correctly.

## Fix

Add a computed signal `editQueryParams` to `meeting-card.component.ts` that extracts:
- `project`: from `meeting.project_slug` (always present on `Meeting`)
- `committee_uid`: from `meeting.committees[0].uid` (when the meeting has a committee association)

Wire it to `[queryParams]` on the edit button so `writerGuard` can reach the committee.writer check.

## Test plan
- [ ] As a committee Manager (no project.writer), click Edit on a meeting associated with the committee → should open the edit form without "Access Denied"
- [ ] As a regular member (no committee.writer), click Edit → should still see "Access Denied" toast and redirect to overview
- [ ] Project-level writer editing still works unchanged

## Related
Reported by Junjie Bu (Google) via Keiran McDermott. Meeting: `97227615758`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)