### PR TITLE
feat(mktg-os): scaffold flag-gated marketplace nav, route, env

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -171,3 +171,9 @@ LINKEDIN_ORG_ID=your-linkedin-org-id
 # This value can be obtained from our AWS Systems Manager Parameter Store:
 # aws ssm get-parameters-by-path --region us-east-1 --path / --recursive --query "Parameters[?contains(Name, 'stripe')].Name" --output text
 STRIPE_PUBLISHABLE_KEY=pk_test
+
+# Guild AI Integration — server-side secrets for the Marketing OS agents proxy (LFXAI-97).
+GUILD_API_URL=https://app.guild.ai
+GUILD_API_KEY=your-guild-api-key
+GUILD_WORKSPACE_OWNER=your-guild-workspace-owner
+GUILD_WORKSPACE_NAME=your-guild-workspace-name

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { MKTG_OS_AGENTS_ROUTE_SEGMENT } from '@lfx-one/shared/constants';
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
@@ -212,7 +213,7 @@ export const routes: Routes = [
       },
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
       {
-        path: 'foundation/mktg-os-agents',
+        path: `foundation/${MKTG_OS_AGENTS_ROUTE_SEGMENT}`,
         data: { lens: 'foundation' },
         canMatch: [mktgOsAgentsEnabledGuard],
         canActivate: [projectQueryParamGuard],
@@ -269,7 +270,7 @@ export const routes: Routes = [
       },
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
       {
-        path: 'project/mktg-os-agents',
+        path: `project/${MKTG_OS_AGENTS_ROUTE_SEGMENT}`,
         data: { lens: 'project' },
         canMatch: [mktgOsAgentsEnabledGuard],
         canActivate: [projectQueryParamGuard],

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { akritesEnabledGuard } from './shared/guards/akrites-enabled.guard';
+import { mktgOsAgentsEnabledGuard } from './shared/guards/mktg-os-agents-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
 
 const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
@@ -209,6 +210,14 @@ export const routes: Routes = [
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
       },
+      // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
+      {
+        path: 'foundation/mktg-os-agents',
+        data: { lens: 'foundation' },
+        canMatch: [mktgOsAgentsEnabledGuard],
+        canActivate: [projectQueryParamGuard],
+        loadChildren: () => import('./modules/mktg-os-agents/mktg-os-agents.routes').then((m) => m.MKTG_OS_AGENTS_ROUTES),
+      },
       {
         path: 'foundation/votes',
         data: { lens: 'foundation' },
@@ -257,6 +266,14 @@ export const routes: Routes = [
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
+      },
+      // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
+      {
+        path: 'project/mktg-os-agents',
+        data: { lens: 'project' },
+        canMatch: [mktgOsAgentsEnabledGuard],
+        canActivate: [projectQueryParamGuard],
+        loadChildren: () => import('./modules/mktg-os-agents/mktg-os-agents.routes').then((m) => m.MKTG_OS_AGENTS_ROUTES),
       },
       {
         path: 'project/votes',

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -13,6 +13,8 @@ import {
   CROWDFUNDING_ENABLED_FLAG,
   DOCUMENT_LABEL,
   MAILING_LIST_LABEL,
+  MKTG_OS_AGENTS_ENABLED_FLAG,
+  MKTG_OS_AGENTS_LABEL,
   ORG_LENS_ENABLED_FLAG,
   AKRITES_ENABLED_FLAG,
   SURVEY_LABEL,
@@ -59,6 +61,8 @@ export class MainLayoutComponent {
   private readonly isCrowdfundingEnabled = this.featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false);
   /** Dark-launch gate for the Akrites admin dashboard; hides the Security nav section when off. */
   private readonly isAkritesEnabled = this.featureFlagService.getBooleanFlag(AKRITES_ENABLED_FLAG, false);
+  /** Dark-launch gate for the Marketing OS agents marketplace; hides the project-lens nav entry when off. */
+  private readonly isMktgOsAgentsEnabled = this.featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false);
 
   // Expose mobile sidebar state from service (writable for two-way binding with p-drawer)
   protected readonly showMobileSidebar = this.appService.showMobileSidebar;
@@ -84,7 +88,10 @@ export class MainLayoutComponent {
         // matching Foundation lens behavior. Authorization for write actions (add user,
         // edit role, remove, etc.) is enforced server-side and by per-page UI gating where
         // implemented; pre-existing gaps in those gates are tracked separately.
-        const base = this.projectLensItemsWithGovernance;
+        // Mktg OS agents is dark-launched: when its flag is on, the entry is inserted between
+        // Documents (last of projectLensItems) and the Governance section in the project sidebar.
+        const mktgOsItems = this.isMktgOsAgentsEnabled() ? [this.mktgOsAgentsNavItem] : [];
+        const base = [...this.projectLensItems, ...mktgOsItems, this.projectGovernanceSection];
         return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
       }
       case 'org':
@@ -439,32 +446,37 @@ export class MainLayoutComponent {
     },
   ];
 
-  // --- Project Lens Items with Governance (for non-board personas) ---
-  private readonly projectLensItemsWithGovernance: SidebarMenuItem[] = [
-    ...this.projectLensItems,
-    {
-      label: 'Governance',
-      isSection: true,
-      expanded: true,
-      items: [
-        {
-          label: VOTE_LABEL.plural,
-          icon: 'fa-light fa-check-to-slot',
-          routerLink: '/project/votes',
-        },
-        {
-          label: SURVEY_LABEL.plural,
-          icon: 'fa-light fa-clipboard-list',
-          routerLink: '/project/surveys',
-        },
-        {
-          label: 'Permissions',
-          icon: 'fa-light fa-shield',
-          routerLink: '/project/settings',
-        },
-      ],
-    },
-  ];
+  // --- Project Lens — Mktg OS agents (dark-launched; inserted directly under Documents in sidebarItems()) ---
+  private readonly mktgOsAgentsNavItem: SidebarMenuItem = {
+    label: MKTG_OS_AGENTS_LABEL.nav,
+    icon: 'fa-light fa-robot',
+    routerLink: '/project/mktg-os-agents',
+    testId: 'sidebar-project-mktg-os-agents',
+  };
+
+  // --- Project Lens — Governance section (for non-board personas) ---
+  private readonly projectGovernanceSection: SidebarMenuItem = {
+    label: 'Governance',
+    isSection: true,
+    expanded: true,
+    items: [
+      {
+        label: VOTE_LABEL.plural,
+        icon: 'fa-light fa-check-to-slot',
+        routerLink: '/project/votes',
+      },
+      {
+        label: SURVEY_LABEL.plural,
+        icon: 'fa-light fa-clipboard-list',
+        routerLink: '/project/surveys',
+      },
+      {
+        label: 'Permissions',
+        icon: 'fa-light fa-shield',
+        routerLink: '/project/settings',
+      },
+    ],
+  };
 
   // Project-lens Communications section (ED-only); appended dynamically in sidebarItems().
   private readonly projectCommunicationsSection: SidebarMenuItem = {

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents.routes.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents.routes.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Routes } from '@angular/router';
+import { authGuard } from '@shared/guards/auth.guard';
+
+export const MKTG_OS_AGENTS_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./mktg-os-agents/mktg-os-agents.component').then((m) => m.MktgOsAgentsComponent),
+    canActivate: [authGuard],
+  },
+];

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.html
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.html
@@ -1,0 +1,22 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="mktg-os-agents-page">
+  <div class="flex flex-col gap-6">
+    <!-- Page Header -->
+    <div class="flex items-start justify-between mt-3">
+      <div>
+        <h1 class="font-display font-light text-2xl" data-testid="mktg-os-agents-title">{{ labels.marketplaceTitle }}</h1>
+        <p class="mt-1 text-sm text-gray-500" data-testid="mktg-os-agents-description">{{ labels.marketplaceDescription }}</p>
+      </div>
+    </div>
+
+    <!-- Placeholder body — marketplace UI lands in LFXAI-98 -->
+    <lfx-card data-testid="mktg-os-agents-card">
+      <div class="flex flex-col items-center justify-center gap-2 py-12 text-center">
+        <i class="fa-light fa-robot text-3xl text-gray-400" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">The marketing agents marketplace is coming soon.</p>
+      </div>
+    </lfx-card>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { MKTG_OS_AGENTS_LABEL } from '@lfx-one/shared/constants';
+
+// Placeholder landing for the dark-launched Marketing OS marketplace (LFXAI-96).
+// The marketplace UI and per-agent chat land in later stories (LFXAI-98 / LFXAI-99).
+@Component({
+  selector: 'lfx-mktg-os-agents',
+  imports: [CardComponent],
+  templateUrl: './mktg-os-agents.component.html',
+})
+export class MktgOsAgentsComponent {
+  // === Constants ===
+  protected readonly labels = MKTG_OS_AGENTS_LABEL;
+}

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { CanMatchFn, Router } from '@angular/router';
+import { MKTG_OS_AGENTS_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
+
+import { FeatureFlagService } from '../services/feature-flag.service';
+
+/** CanMatch guard for /project|foundation/mktg-os-agents gating the dark-launched Marketing OS marketplace behind the `mktg-os-agents-enabled` flag; SSR defers to browser, browser waits for provider READY then fails closed. */
+export const mktgOsAgentsEnabledGuard: CanMatchFn = async () => {
+  const platformId = inject(PLATFORM_ID);
+
+  // On the server LaunchDarkly is unavailable — let the route match and let the
+  // browser-side run of this guard make the real decision after hydration.
+  if (!isPlatformBrowser(platformId)) {
+    return true;
+  }
+
+  const featureFlagService = inject(FeatureFlagService);
+  const router = inject(Router);
+
+  if (!featureFlagService.providerReady()) {
+    const ready = await firstValueFrom(
+      toObservable(featureFlagService.providerReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(5000),
+        catchError(() => of(false))
+      )
+    );
+    // Provider never became ready (no client id / LD unreachable) → fail closed.
+    if (!ready) {
+      return router.parseUrl('/');
+    }
+  }
+
+  return featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false)() ? true : router.parseUrl('/');
+};

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -185,6 +185,17 @@ environment:
 | `environment.AI_PROXY_URL` | AI service proxy URL (OpenAI compatible) | **Yes**  | -       |
 | `environment.AI_API_KEY`   | API key for AI service                   | **Yes**  | -       |
 
+#### Guild AI Integration
+
+Server-side credentials for the Marketing OS agents proxy. Consumed only by the SSR server — never exposed to the browser.
+
+| Parameter                           | Description                            | Required | Default                |
+| ----------------------------------- | -------------------------------------- | -------- | ---------------------- |
+| `environment.GUILD_API_URL`         | Guild API base URL                     | No       | `https://app.guild.ai` |
+| `environment.GUILD_API_KEY`         | API key for Guild workspace operations | **Yes**  | -                      |
+| `environment.GUILD_WORKSPACE_OWNER` | Guild workspace owner identifier       | **Yes**  | -                      |
+| `environment.GUILD_WORKSPACE_NAME`  | Guild workspace name                   | **Yes**  | -                      |
+
 #### Runtime Client Configuration
 
 | Parameter                     | Description                                                                                                                                                             | Required | Default           |

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -346,6 +346,19 @@ environment:
   AI_API_KEY:
     value:
 
+  # Guild AI Integration — server-side credentials for the Marketing OS agents proxy.
+  GUILD_API_URL:
+    value: "https://app.guild.ai"
+
+  GUILD_API_KEY:
+    value:
+
+  GUILD_WORKSPACE_OWNER:
+    value:
+
+  GUILD_WORKSPACE_NAME:
+    value:
+
   # Public Intercom Messenger workspace App ID. Identity verification rides on the
   # `http://lfx.dev/claims/intercom` Auth0 claim — not on this value.
   INTERCOM_APP_ID:

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -4,3 +4,4 @@
 export const ORG_LENS_ENABLED_FLAG = 'org-lens-enabled';
 export const AKRITES_ENABLED_FLAG = 'akrites-enabled';
 export const CROWDFUNDING_ENABLED_FLAG = 'crowdfunding-enabled';
+export const MKTG_OS_AGENTS_ENABLED_FLAG = 'mktg-os-agents-enabled';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -75,5 +75,6 @@ export * from './rich-editor.constants';
 export * from './due-date.constants';
 export * from './akrites.constants';
 export * from './crowdfunding.constants';
+export * from './mktg-os-agents.constants';
 
 export * from './project-context.constants';

--- a/packages/shared/src/constants/mktg-os-agents.constants.ts
+++ b/packages/shared/src/constants/mktg-os-agents.constants.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Shared labels for the Marketing OS Agents marketplace (LFXAI-95 workstream).
+// Centralized so the nav item, route, and landing page stay in sync.
+// The nav reads "Marketing OS"; the landing title matches the mockup ("LFX Mktg OS Marketplace").
+export const MKTG_OS_AGENTS_LABEL = {
+  /** Sidebar nav entry, placed directly under Documents. */
+  nav: 'Marketing OS',
+  /** Marketplace landing page title (mockup). */
+  marketplaceTitle: 'LFX Mktg OS Marketplace',
+  /** Short description shown under the landing page title. */
+  marketplaceDescription: 'Browse and chat with LFX marketing agents.',
+} as const;
+
+/** Route segment (lens-prefixed at the route layer, e.g. /project/mktg-os-agents). */
+export const MKTG_OS_AGENTS_ROUTE_SEGMENT = 'mktg-os-agents';


### PR DESCRIPTION
## Summary

Story 1 of 4 of the Marketing OS agents epic (**LFXAI-95**). Dark-launches the
"LFX Mktg OS Marketplace" surface behind the `mktg-os-agents-enabled` LaunchDarkly
flag — flag, nav entry, gated placeholder page, and env scaffolding. No real Guild
integration yet (that's LFXAI-97+).

- `MKTG_OS_AGENTS_ENABLED_FLAG` (`mktg-os-agents-enabled`) + shared `MKTG_OS_AGENTS_LABEL` constant
- `mktgOsAgentsEnabledGuard` — `CanMatch`, SSR-safe, waits for the LD provider then **fails closed**
- Lazy `mktg-os-agents` module + placeholder landing page (LFX wrappers, `data-testid`s, SSR-safe)
- `project/` + `foundation/` routes gated by the flag (`canMatch`)
- Project-lens nav item **"Marketing OS"** directly under Documents (reactive to the flag signal)
- `GUILD_*` server-side secret scaffolding (`.env.example`, `values.yaml`, chart README)

**Behavior:** flag **off** → nav hidden + route redirects to `/`. Flag **on** → nav shows under Documents, placeholder renders.

## Jira

LFXAI-96 (epic LFXAI-95)

## External dependencies (not in this PR)

- **LaunchDarkly:** create flag `mktg-os-agents-enabled` (boolean, default off), enable **client-side availability**, add targeting rule `email is <user> → true`. Code only *reads* the flag.
- `GUILD_*` real values are provisioned later (consumed in LFXAI-97); only scaffolded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
