### PR TITLE
fix(committees): default member visibility to hidden when unset

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -223,7 +223,9 @@ export class CommitteeViewComponent {
   public parentGroup: Signal<Committee | null> = this.initParentGroup();
 
   // -- Tab visibility signals --
-  public isMembersTabVisible: Signal<boolean> = computed(() => this.committee()?.member_visibility !== CommitteeMemberVisibility.HIDDEN || this.canEdit());
+  public isMembersTabVisible: Signal<boolean> = computed(
+    () => this.committee()?.member_visibility === CommitteeMemberVisibility.BASIC_PROFILE || this.canEdit()
+  );
   public isVotesTabVisible: Signal<boolean> = computed(() => !!this.committee()?.enable_voting);
 
   // -- Visitor gating --

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -15,7 +15,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
-import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
+import { CommitteeMemberRole, CommitteeMemberVotingStatus, CommitteeMemberVisibility } from '@lfx-one/shared/enums';
 import {
   Committee,
   CommitteeInvite,
@@ -92,11 +92,13 @@ export class CommitteeMembersComponent implements OnInit {
   // `writer from project`). No separate inherited check is needed here — a foundation-level
   // manager's `writer` flag is already true (LFXV2-2059).
   public readonly canManageMembers = computed(() => canManageCommitteeMembers(this.committee()));
-  // Default to hidden while committee is loading (fail closed for privacy)
+  // Fail-closed: only show members when visibility is explicitly set to basic_profile.
+  // Undefined/null/unknown values default to hidden so committees without a persisted
+  // setting don't inadvertently expose the member list.
   public readonly isMembersVisible = computed(() => {
     const committee = this.committee();
     if (!committee) return false;
-    return committee.member_visibility !== 'hidden' || this.canManageMembers();
+    return committee.member_visibility === CommitteeMemberVisibility.BASIC_PROFILE || this.canManageMembers();
   });
   public readonly votingRepCount: Signal<number> = computed(
     () => this.members().filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length


### PR DESCRIPTION
## Summary

- Fixes a fail-open bug where committees without a persisted `member_visibility` setting (e.g. created before this field existed) would expose the full member list including email addresses to all users
- Flips both visibility guards from `!== 'hidden'` to `=== 'basic_profile'` so `undefined`/`null`/unknown values default to hidden rather than visible
- Affects `isMembersVisible` in `committee-members.component.ts` and `isMembersTabVisible` in `committee-view.component.ts`

Closes LFXV2-2520