### PR TITLE
fix(cdp): drop empty domain from org create payload

### DIFF
--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -24,6 +24,25 @@
       <p class="text-xs text-red-600">Organization is required for this group</p>
     }
   </div>
+
+  @if (isNewOrg()) {
+    <div class="flex w-full flex-col gap-1">
+      <label class="block text-sm font-medium text-gray-700"> Organization Website <span class="text-red-500">*</span> </label>
+      <lfx-input-text
+        [form]="form"
+        control="organization_url"
+        placeholder="https://example.com"
+        styleClass="w-full text-sm"
+        dataTest="accept-invite-organization-url">
+      </lfx-input-text>
+      @if (urlControl.errors?.['trimmedRequired'] && urlControl.touched) {
+        <p class="text-xs text-red-600">Website is required for new organizations</p>
+      }
+      @if (urlControl.errors?.['httpsUrl'] && urlControl.touched) {
+        <p class="text-xs text-red-600">Website must be a valid https:// URL</p>
+      }
+    </div>
+  }
 </div>
 
 <div class="flex justify-end gap-2 mt-4">

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -13,6 +13,7 @@
       [form]="form"
       nameControl="organization"
       domainControl="organization_url"
+      [domainRequired]="isNewOrg()"
       placeholder="Search for organization..."
       styleClass="w-full"
       inputStyleClass="text-sm w-full"
@@ -24,25 +25,6 @@
       <p class="text-xs text-red-600">Organization is required for this group</p>
     }
   </div>
-
-  @if (isNewOrg()) {
-    <div class="flex w-full flex-col gap-1">
-      <label class="block text-sm font-medium text-gray-700"> Organization Website <span class="text-red-500">*</span> </label>
-      <lfx-input-text
-        [form]="form"
-        control="organization_url"
-        placeholder="https://example.com"
-        styleClass="w-full text-sm"
-        dataTest="accept-invite-organization-url">
-      </lfx-input-text>
-      @if (urlControl.errors?.['trimmedRequired'] && urlControl.touched) {
-        <p class="text-xs text-red-600">Website is required for new organizations</p>
-      }
-      @if (urlControl.errors?.['httpsUrl'] && urlControl.touched) {
-        <p class="text-xs text-red-600">Website must be a valid https:// URL</p>
-      }
-    </div>
-  }
 </div>
 
 <div class="flex justify-end gap-2 mt-4">

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -1,21 +1,22 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject, signal, viewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { AcceptInviteOrganizationDialogData, AcceptInviteOrganizationDialogResult, OrganizationResolveResult } from '@lfx-one/shared/interfaces';
 import { buildCommitteeOrganizationPayload } from '@lfx-one/shared/utils';
-import { trimmedRequired } from '@lfx-one/shared/validators';
+import { httpsUrlValidator, trimmedRequired } from '@lfx-one/shared/validators';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { take } from 'rxjs';
+import { startWith, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-accept-invite-organization-dialog',
   standalone: true,
-  imports: [ReactiveFormsModule, ButtonComponent, OrganizationSearchComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, OrganizationSearchComponent, InputTextComponent],
   templateUrl: './accept-invite-organization-dialog.component.html',
 })
 export class AcceptInviteOrganizationDialogComponent {
@@ -33,8 +34,16 @@ export class AcceptInviteOrganizationDialogComponent {
   });
 
   protected readonly organizationControl = this.form.get('organization') as FormControl;
+  protected readonly urlControl = this.form.get('organization_url') as FormControl;
 
   public readonly submitting = signal(false);
+
+  private readonly formValue = this.initFormValue();
+
+  protected readonly isNewOrg = computed(() => {
+    const value = this.formValue();
+    return !value?.organization_id && !!value?.organization?.trim();
+  });
 
   public constructor() {
     this.organizationControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((name) => {
@@ -42,6 +51,15 @@ export class AcceptInviteOrganizationDialogComponent {
       if (!normalizedName || normalizedName !== this.resolvedOrganizationName) {
         this.form.patchValue({ organization_id: null }, { emitEvent: false });
       }
+    });
+
+    effect(() => {
+      if (this.isNewOrg()) {
+        this.urlControl.setValidators([trimmedRequired(), httpsUrlValidator()]);
+      } else {
+        this.urlControl.clearValidators();
+      }
+      this.urlControl.updateValueAndValidity({ emitEvent: false });
     });
   }
 
@@ -56,6 +74,9 @@ export class AcceptInviteOrganizationDialogComponent {
 
   public onConfirm(): void {
     this.organizationControl.markAsTouched();
+    if (this.isNewOrg()) {
+      this.urlControl.markAsTouched();
+    }
     if (!this.form.valid) {
       return;
     }
@@ -95,5 +116,9 @@ export class AcceptInviteOrganizationDialogComponent {
     }
 
     finish();
+  }
+
+  private initFormValue() {
+    return toSignal(this.form.valueChanges.pipe(startWith(this.form.value)));
   }
 }

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -5,7 +5,6 @@ import { Component, computed, effect, inject, signal, viewChild } from '@angular
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { AcceptInviteOrganizationDialogData, AcceptInviteOrganizationDialogResult, OrganizationResolveResult } from '@lfx-one/shared/interfaces';
 import { buildCommitteeOrganizationPayload } from '@lfx-one/shared/utils';
@@ -16,7 +15,7 @@ import { startWith, take } from 'rxjs';
 @Component({
   selector: 'lfx-accept-invite-organization-dialog',
   standalone: true,
-  imports: [ReactiveFormsModule, ButtonComponent, OrganizationSearchComponent, InputTextComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, OrganizationSearchComponent],
   templateUrl: './accept-invite-organization-dialog.component.html',
 })
 export class AcceptInviteOrganizationDialogComponent {

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.html
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.html
@@ -77,12 +77,22 @@
       }
 
       @if (domainControl()) {
-        <lfx-input-text
-          [form]="form()"
-          [control]="domainControl()!"
-          placeholder="Enter website (e.g., example.com or https://example.com)"
-          styleClass="w-full"
-          size="small" />
+        @let ctrl = form().get(domainControl()!);
+        <div class="flex flex-col gap-1">
+          <label class="block text-sm font-medium text-gray-700">
+            Organization Website
+            @if (domainRequired()) {
+              <span class="text-red-500"> *</span>
+            }
+          </label>
+          <lfx-input-text [form]="form()" [control]="domainControl()!" placeholder="https://example.com" styleClass="w-full" size="small" />
+          @if (ctrl?.errors?.['trimmedRequired'] && ctrl?.touched) {
+            <p class="text-xs text-red-600">Website is required for new organizations</p>
+          }
+          @if (ctrl?.errors?.['httpsUrl'] && ctrl?.touched) {
+            <p class="text-xs text-red-600">Website must be a valid https:// URL</p>
+          }
+        </div>
       }
 
       <button type="button" class="text-xs text-primary hover:underline" (click)="switchToSearchMode()">← Back to search</button>

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.html
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.html
@@ -79,13 +79,19 @@
       @if (domainControl()) {
         @let ctrl = form().get(domainControl()!);
         <div class="flex flex-col gap-1">
-          <label class="block text-sm font-medium text-gray-700">
+          <label [for]="domainControl()! + '-input'" class="block text-sm font-medium text-gray-700">
             Organization Website
             @if (domainRequired()) {
               <span class="text-red-500"> *</span>
             }
           </label>
-          <lfx-input-text [form]="form()" [control]="domainControl()!" placeholder="https://example.com" styleClass="w-full" size="small" />
+          <lfx-input-text
+            [form]="form()"
+            [control]="domainControl()!"
+            [id]="domainControl()! + '-input'"
+            placeholder="https://example.com"
+            styleClass="w-full"
+            size="small" />
           @if (ctrl?.errors?.['trimmedRequired'] && ctrl?.touched) {
             <p class="text-xs text-red-600">Website is required for new organizations</p>
           }

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -33,6 +33,8 @@ export class OrganizationSearchComponent {
    *  CDP canonical name returned by /api/organizations/resolve. Defaults to true for backward
    *  compatibility with forms where canonical normalization is desired. */
   public resolveToCdpName = input<boolean>(true);
+  /** When true, marks the domain/website field as required (shows asterisk and validation errors). */
+  public domainRequired = input<boolean>(false);
 
   public readonly onOrganizationSelect = output<OrganizationSuggestion>();
   public readonly onOrganizationResolved = output<OrganizationResolveResult>();

--- a/apps/lfx-one/src/server/controllers/organization.controller.ts
+++ b/apps/lfx-one/src/server/controllers/organization.controller.ts
@@ -78,6 +78,17 @@ export class OrganizationController {
         return;
       }
 
+      if (!domain || typeof domain !== 'string') {
+        const validationError = ServiceValidationError.forField('domain', 'Organization domain is required and must be a string', {
+          operation: 'resolve_organization',
+          service: 'organization_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
       if (logo !== undefined && (typeof logo !== 'string' || !logo.startsWith('https://'))) {
         const validationError = ServiceValidationError.forField('logo', 'Organization logo must be an https URL', {
           operation: 'resolve_organization',

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -821,8 +821,8 @@ export class CdpService {
         Authorization: `Bearer ${token}`,
         'X-LFX-Request-ID': requestId,
       },
-      // Drop empty-string logos — they're not meaningful URLs
-      body: JSON.stringify({ name, domain, source, ...(logo ? { logo } : {}) }),
+      // Drop empty-string domains and logos — they're not meaningful values
+      body: JSON.stringify({ name, source, ...(domain ? { domain } : {}), ...(logo ? { logo } : {}) }),
       signal: AbortSignal.timeout(10000),
     });
 

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -821,8 +821,8 @@ export class CdpService {
         Authorization: `Bearer ${token}`,
         'X-LFX-Request-ID': requestId,
       },
-      // Drop empty-string logos — they're not meaningful URLs
-      body: JSON.stringify({ name, domain, source, ...(logo ? { logo } : {}) }),
+      // Drop empty-string domains and logos — CDP rejects them with 400
+      body: JSON.stringify({ name, ...(domain ? { domain } : {}), source, ...(logo ? { logo } : {}) }),
       signal: AbortSignal.timeout(10000),
     });
 
@@ -853,14 +853,18 @@ export class CdpService {
       });
     }
 
-    const existing = await this.findOrganizationByDomain(req, domain);
+    // Normalize full URLs (e.g. "https://example.com") to bare hostname ("example.com")
+    // so the CDP API stores and looks up consistent domain identity values.
+    const normalizedDomain = domain.includes('://') ? new URL(domain).hostname : domain;
+
+    const existing = await this.findOrganizationByDomain(req, normalizedDomain);
     if (existing) {
       logger.debug(req, 'resolve_cdp_organization', 'Found existing CDP organization', { id: existing.id, name: existing.name });
       return existing;
     }
 
-    const created = await this.createOrganization(req, name, domain, undefined, logo);
-    logger.info(req, 'resolve_cdp_organization', 'Created new CDP organization', { id: created.id, name: created.name, domain });
+    const created = await this.createOrganization(req, name, normalizedDomain, undefined, logo);
+    logger.info(req, 'resolve_cdp_organization', 'Created new CDP organization', { id: created.id, name: created.name, domain: normalizedDomain });
     return created;
   }
 

--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -821,8 +821,8 @@ export class CdpService {
         Authorization: `Bearer ${token}`,
         'X-LFX-Request-ID': requestId,
       },
-      // Drop empty-string domains and logos — they're not meaningful values
-      body: JSON.stringify({ name, source, ...(domain ? { domain } : {}), ...(logo ? { logo } : {}) }),
+      // Drop empty-string logos — they're not meaningful URLs
+      body: JSON.stringify({ name, domain, source, ...(logo ? { logo } : {}) }),
       signal: AbortSignal.timeout(10000),
     });
 
@@ -839,18 +839,24 @@ export class CdpService {
   }
 
   /**
-   * Find or create an organization in CDP by domain
-   * Tries to find first, creates if not found
+   * Find or create an organization in CDP by domain.
+   * The CDP API requires domain for both lookup and creation — callers must
+   * validate that domain is present before calling this method.
    */
   public async resolveOrganization(req: Request | undefined, name: string, domain: string, logo?: string): Promise<CdpOrganization> {
     logger.debug(req, 'resolve_cdp_organization', 'Resolving CDP organization', { name, domain });
 
-    if (domain) {
-      const existing = await this.findOrganizationByDomain(req, domain);
-      if (existing) {
-        logger.debug(req, 'resolve_cdp_organization', 'Found existing CDP organization', { id: existing.id, name: existing.name });
-        return existing;
-      }
+    if (!domain) {
+      throw ServiceValidationError.forField('domain', 'domain is required to resolve or create a CDP organization', {
+        operation: 'resolve_cdp_organization',
+        service: 'cdp_service',
+      });
+    }
+
+    const existing = await this.findOrganizationByDomain(req, domain);
+    if (existing) {
+      logger.debug(req, 'resolve_cdp_organization', 'Found existing CDP organization', { id: existing.id, name: existing.name });
+      return existing;
     }
 
     const created = await this.createOrganization(req, name, domain, undefined, logo);


### PR DESCRIPTION
## Summary

Fixes the "CDP organization create failed: Bad Request" error that users hit when accepting a committee invite and creating a new organization by typing its name manually (rather than selecting from the autocomplete).

**Root cause:** The CDP API (crowd.dev) enforces `domain: z.string().trim().min(1)` in its Zod validation schema for both `GET /v1/organizations` (lookup by domain) and `POST /v1/organizations` (create). The invite acceptance dialog had no input for the organization website/domain in manual entry mode, and the server sent an empty `domain` field, which always caused a CDP 400.

## Changes

**Frontend**
- `organization-search.component.html/ts`: Added an "Organization Website" input to the manual entry mode, visible and required only when `[domainRequired]="true"` is passed (via a new `domainRequired = input<boolean>(false)` signal). Label/input are accessibility-associated via `[for]`/`[id]`.
- `accept-invite-organization-dialog.component.ts/html`: Passes `[domainRequired]="isNewOrg()"` to `lfx-organization-search`. When the user types a new org name (no `organization_id` selected), `trimmedRequired()` + `httpsUrlValidator()` are dynamically applied to the `organization_url` control via a reactive `effect()`.

**Backend**
- `cdp.service.ts resolveOrganization`: Throws a `ServiceValidationError` when `domain` is falsy (returns a structured 400 before hitting CDP). Strips the URL protocol (`new URL(domain).hostname`) before forwarding bare hostname to CDP.
- `cdp.service.ts createOrganization`: Guards `domain` in the POST body (`domain ? { domain } : {}`) so an empty string is never serialized.
- `organization.controller.ts`: Validates domain presence at the HTTP boundary, returning a clear error before reaching the service layer.

## Ticket

[LFXV2-2527](https://linuxfoundation.atlassian.net/browse/LFXV2-2527)

## Test Plan

1. Accept a committee invite as a user who has no existing organization affiliation
2. In the "Confirm Organization" dialog, click "I want to create '...'" to enter manual mode
3. Fill in the organization name but leave the website blank → "Website is required" error appears; form does not submit
4. Enter an invalid URL (e.g. `not-a-url`) → "Website must be a valid https:// URL" error appears
5. Enter a valid `https://` URL → form submits successfully, organization is created in CDP with the bare hostname as domain
6. Select an existing organization from the autocomplete → website field is not shown; submission succeeds without requiring a URL

[LFXV2-2527]: https://linuxfoundation.atlassian.net/browse/LFXV2-2527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ