### PR TITLE
fix(invite): pre-fill org dialog from user profile when invite has none

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -129,6 +129,7 @@
         <label class="block text-sm font-medium text-gray-700">Organization <span class="text-gray-400 font-normal">(optional)</span></label>
         <p class="text-xs text-gray-500">
           Invitees must confirm their organization when accepting. Optionally set a suggested default here — it pre-fills the accept flow but is not required.
+          If you select an existing user above, this will auto-populate from their profile.
         </p>
         <lfx-organization-search
           [form]="form"

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -159,16 +159,21 @@ export class AddMemberDialogComponent {
     // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
     // Uses the same work-experience endpoint and employer-selection logic as the invite accept flow.
     // DEBUG — remove before merging
-    console.log('[add-member] selected user:', { username: user.username, email: user.email, showOrgField: this.showOrganizationField(), currentOrg: this.form.get('organization')!.value });
+    console.info('[add-member] selected user:', {
+      username: user.username,
+      email: user.email,
+      showOrgField: this.showOrganizationField(),
+      currentOrg: this.form.get('organization')!.value,
+    });
     if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
       this.searchService
         .getUserWorkExperiences(user.username)
         .pipe(take(1), takeUntilDestroyed(this.destroyRef))
         .subscribe((experiences) => {
           // DEBUG — remove before merging
-          console.log('[add-member] work experiences:', experiences);
+          console.info('[add-member] work experiences:', experiences);
           const employer = currentEmployerFromWorkExperiences(experiences);
-          console.log('[add-member] resolved employer:', employer);
+          console.info('[add-member] resolved employer:', employer);
           if (employer?.name && !this.form.get('organization')!.value?.trim()) {
             this.form.patchValue({ organization: employer.name });
           }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -24,7 +24,14 @@ import {
   OrganizationResolveResult,
   CommitteeOrganizationReference,
 } from '@lfx-one/shared/interfaces';
-import { buildCommitteeOrganizationPayload, committeeRequiresOrganization, hasLfAccount, parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
+import {
+  buildCommitteeOrganizationPayload,
+  committeeRequiresOrganization,
+  currentEmployerFromWorkExperiences,
+  hasLfAccount,
+  parseEmailList,
+  rankUserSearchResults,
+} from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
@@ -149,9 +156,18 @@ export class AddMemberDialogComponent {
     this.form.get('emails')!.setValue(current ? `${current}\n${email}` : email);
     this.searchForm.get('query')!.setValue('');
 
-    // Pre-fill the org field from the selected user's known org (only when shown and currently blank).
-    if (this.showOrganizationField() && user.organization && !this.form.get('organization')!.value?.trim()) {
-      this.form.patchValue({ organization: user.organization.name });
+    // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
+    // Uses the same work-experience endpoint and employer-selection logic as the invite accept flow.
+    if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
+      this.searchService
+        .getUserWorkExperiences(user.username)
+        .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe((experiences) => {
+          const employer = currentEmployerFromWorkExperiences(experiences);
+          if (employer?.name && !this.form.get('organization')!.value?.trim()) {
+            this.form.patchValue({ organization: employer.name });
+          }
+        });
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -24,14 +24,7 @@ import {
   OrganizationResolveResult,
   CommitteeOrganizationReference,
 } from '@lfx-one/shared/interfaces';
-import {
-  buildCommitteeOrganizationPayload,
-  committeeRequiresOrganization,
-  currentEmployerFromWorkExperiences,
-  hasLfAccount,
-  parseEmailList,
-  rankUserSearchResults,
-} from '@lfx-one/shared/utils';
+import { buildCommitteeOrganizationPayload, committeeRequiresOrganization, hasLfAccount, parseEmailList, rankUserSearchResults } from '@lfx-one/shared/utils';
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
@@ -156,15 +149,12 @@ export class AddMemberDialogComponent {
     this.form.get('emails')!.setValue(current ? `${current}\n${email}` : email);
     this.searchForm.get('query')!.setValue('');
 
-    // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
-    // Uses the same employer-selection logic as the invite accept flow (currentEmployerFromWorkExperiences),
-    // but via a separate endpoint (/api/search/users/:lfid/work-experiences) that accepts any LFID.
+    // Pre-fill the org field from the selected user's current employer when shown and blank.
     if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
       this.searchService
-        .getUserWorkExperiences(user.username)
+        .getUserCurrentEmployer(user.username)
         .pipe(take(1), takeUntilDestroyed(this.destroyRef))
-        .subscribe((experiences) => {
-          const employer = currentEmployerFromWorkExperiences(experiences);
+        .subscribe((employer) => {
           if (employer?.name && !this.form.get('organization')!.value?.trim()) {
             this.form.patchValue({ organization: employer.name });
           }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -158,22 +158,12 @@ export class AddMemberDialogComponent {
 
     // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
     // Uses the same work-experience endpoint and employer-selection logic as the invite accept flow.
-    // DEBUG — remove before merging
-    console.info('[add-member] selected user:', {
-      username: user.username,
-      email: user.email,
-      showOrgField: this.showOrganizationField(),
-      currentOrg: this.form.get('organization')!.value,
-    });
     if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
       this.searchService
         .getUserWorkExperiences(user.username)
         .pipe(take(1), takeUntilDestroyed(this.destroyRef))
         .subscribe((experiences) => {
-          // DEBUG — remove before merging
-          console.info('[add-member] work experiences:', experiences);
           const employer = currentEmployerFromWorkExperiences(experiences);
-          console.info('[add-member] resolved employer:', employer);
           if (employer?.name && !this.form.get('organization')!.value?.trim()) {
             this.form.patchValue({ organization: employer.name });
           }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -157,7 +157,8 @@ export class AddMemberDialogComponent {
     this.searchForm.get('query')!.setValue('');
 
     // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
-    // Uses the same work-experience endpoint and employer-selection logic as the invite accept flow.
+    // Uses the same employer-selection logic as the invite accept flow (currentEmployerFromWorkExperiences),
+    // but via a separate endpoint (/api/search/users/:lfid/work-experiences) that accepts any LFID.
     if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
       this.searchService
         .getUserWorkExperiences(user.username)

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -148,6 +148,14 @@ export class AddMemberDialogComponent {
     const current = this.form.get('emails')!.value.trim();
     this.form.get('emails')!.setValue(current ? `${current}\n${email}` : email);
     this.searchForm.get('query')!.setValue('');
+
+    // Pre-fill the org field from the selected user's known org (only when shown and currently blank).
+    if (this.showOrganizationField() && user.organization && !this.form.get('organization')!.value?.trim()) {
+      this.form.patchValue({
+        organization: user.organization.name,
+        organization_url: user.organization.website ?? '',
+      });
+    }
   }
 
   public onOrgResolved(result: OrganizationResolveResult): void {

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -151,10 +151,7 @@ export class AddMemberDialogComponent {
 
     // Pre-fill the org field from the selected user's known org (only when shown and currently blank).
     if (this.showOrganizationField() && user.organization && !this.form.get('organization')!.value?.trim()) {
-      this.form.patchValue({
-        organization: user.organization.name,
-        organization_url: user.organization.website ?? '',
-      });
+      this.form.patchValue({ organization: user.organization.name });
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -158,12 +158,17 @@ export class AddMemberDialogComponent {
 
     // Pre-fill the org field from the selected user's CDP work experience when shown and blank.
     // Uses the same work-experience endpoint and employer-selection logic as the invite accept flow.
+    // DEBUG — remove before merging
+    console.log('[add-member] selected user:', { username: user.username, email: user.email, showOrgField: this.showOrganizationField(), currentOrg: this.form.get('organization')!.value });
     if (this.showOrganizationField() && user.username && !this.form.get('organization')!.value?.trim()) {
       this.searchService
         .getUserWorkExperiences(user.username)
         .pipe(take(1), takeUntilDestroyed(this.destroyRef))
         .subscribe((experiences) => {
+          // DEBUG — remove before merging
+          console.log('[add-member] work experiences:', experiences);
           const employer = currentEmployerFromWorkExperiences(experiences);
+          console.log('[add-member] resolved employer:', employer);
           if (employer?.name && !this.form.get('organization')!.value?.trim()) {
             this.form.patchValue({ organization: employer.name });
           }

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -103,10 +103,7 @@ export class OrganizationSearchComponent {
           }
 
           const sub = nameControl.valueChanges.subscribe((value: string | null) => {
-            const trimmed = (value ?? '').trim();
-            if (trimmed) {
-              searchControl.setValue(trimmed, { emitEvent: false });
-            }
+            searchControl.setValue((value ?? '').trim(), { emitEvent: false });
           });
 
           onCleanup(() => sub.unsubscribe());

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -85,16 +85,29 @@ export class OrganizationSearchComponent {
       initialValue: [],
     });
 
-    // Effect to sync the search input with the parent form's name control
-    effect(() => {
+    // Effect to sync the search input with the parent form's name control — both on
+    // initial render and whenever the control's value changes programmatically (e.g. patchValue).
+    // onCleanup tears down the valueChanges subscription if the form/nameControl inputs change.
+    effect((onCleanup) => {
       const parentForm = this.form();
       const nameControlName = this.nameControl();
 
       if (parentForm && nameControlName) {
-        const nameControlValue = parentForm.get(nameControlName)?.value;
+        const nameControl = parentForm.get(nameControlName);
+        if (nameControl) {
+          const currentValue = nameControl.value;
+          if (currentValue?.trim()) {
+            searchControl.setValue(currentValue, { emitEvent: false });
+          }
 
-        if (nameControlValue && nameControlValue.trim()) {
-          searchControl.setValue(nameControlValue, { emitEvent: false });
+          const sub = nameControl.valueChanges.subscribe((value: string | null) => {
+            const trimmed = (value ?? '').trim();
+            if (trimmed) {
+              searchControl.setValue(trimmed, { emitEvent: false });
+            }
+          });
+
+          onCleanup(() => sub.unsubscribe());
         }
       }
     });

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { normalizeToUrl, OrganizationResolveResult, OrganizationSuggestion } from '@lfx-one/shared';
 import { OrganizationService } from '@services/organization.service';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
-import { catchError, debounceTime, distinctUntilChanged, EMPTY, map, merge, Observable, of, startWith, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, EMPTY, map, merge, Observable, of, startWith, switchMap, take } from 'rxjs';
 
 import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
 import { InputTextComponent } from '../input-text/input-text.component';
@@ -88,12 +88,11 @@ export class OrganizationSearchComponent {
     });
 
     // Sync the internal search input with the parent form's name control — both on initial render
-    // and on any programmatic patchValue(). Uses toObservable + switchMap so the inner subscription
-    // is automatically cancelled and re-created whenever the form() or nameControl() inputs change.
-    toObservable(this.form)
+    // and on any programmatic patchValue(). combineLatest re-subscribes whenever either form()
+    // or nameControl() changes so the inner subscription always tracks the live control.
+    combineLatest([toObservable(this.form), toObservable(this.nameControl)])
       .pipe(
-        switchMap((parentForm) => {
-          const nameControlName = this.nameControl();
+        switchMap(([parentForm, nameControlName]) => {
           if (!parentForm || !nameControlName) return EMPTY;
           const ctrl = parentForm.get(nameControlName);
           if (!ctrl) return EMPTY;

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -1,13 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, effect, inject, input, output, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, inject, input, output, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { normalizeToUrl, OrganizationResolveResult, OrganizationSuggestion } from '@lfx-one/shared';
 import { OrganizationService } from '@services/organization.service';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
-import { catchError, debounceTime, distinctUntilChanged, map, Observable, of, startWith, switchMap, take } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, EMPTY, map, merge, Observable, of, startWith, switchMap, take } from 'rxjs';
 
 import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
 import { InputTextComponent } from '../input-text/input-text.component';
@@ -87,29 +87,23 @@ export class OrganizationSearchComponent {
       initialValue: [],
     });
 
-    // Effect to sync the search input with the parent form's name control — both on
-    // initial render and whenever the control's value changes programmatically (e.g. patchValue).
-    // onCleanup tears down the valueChanges subscription if the form/nameControl inputs change.
-    effect((onCleanup) => {
-      const parentForm = this.form();
-      const nameControlName = this.nameControl();
-
-      if (parentForm && nameControlName) {
-        const nameControl = parentForm.get(nameControlName);
-        if (nameControl) {
-          const currentValue = nameControl.value;
-          if (currentValue?.trim()) {
-            searchControl.setValue(currentValue, { emitEvent: false });
-          }
-
-          const sub = nameControl.valueChanges.subscribe((value: string | null) => {
-            searchControl.setValue((value ?? '').trim(), { emitEvent: false });
-          });
-
-          onCleanup(() => sub.unsubscribe());
-        }
-      }
-    });
+    // Sync the internal search input with the parent form's name control — both on initial render
+    // and on any programmatic patchValue(). Uses toObservable + switchMap so the inner subscription
+    // is automatically cancelled and re-created whenever the form() or nameControl() inputs change.
+    toObservable(this.form)
+      .pipe(
+        switchMap((parentForm) => {
+          const nameControlName = this.nameControl();
+          if (!parentForm || !nameControlName) return EMPTY;
+          const ctrl = parentForm.get(nameControlName);
+          if (!ctrl) return EMPTY;
+          return merge(of(ctrl.value as string | null), ctrl.valueChanges);
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((value) => {
+        searchControl.setValue((value ?? '').trim(), { emitEvent: false });
+      });
   }
 
   public onSearchComplete(event: AutoCompleteCompleteEvent): void {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -63,8 +63,18 @@ export class InvitationAcceptFlowService {
   private currentEmployerFromProfile(experiences: WorkExperienceEntry[]): CommitteeOrganizationReference | null {
     if (!experiences.length) return null;
     const current =
-      experiences.find((e) => !e.endDate) ?? [...experiences].sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime())[0];
+      experiences.find((e) => !e.endDate) ?? [...experiences].sort((a, b) => this.monthYearToOrdinal(b.startDate) - this.monthYearToOrdinal(a.startDate))[0];
     return { name: current.organization, id: current.organizationId ?? null };
+  }
+
+  // Converts "MMM YYYY" (BFF date format) to a sortable ordinal. Avoids new Date() on
+  // non-ISO strings, which is unreliable in Safari.
+  private monthYearToOrdinal(monthYear: string): number {
+    const MONTHS: Record<string, number> = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+    const [mon, yr] = monthYear.split(' ');
+    const month = MONTHS[mon] ?? 0;
+    const year = parseInt(yr, 10);
+    return isNaN(year) ? 0 : year * 12 + month;
   }
 
   private openOrganizationDialog(context: InvitationAcceptContext): Promise<AcceptInviteOrganizationDialogResult | null> {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -3,11 +3,18 @@
 
 import { inject, Injectable } from '@angular/core';
 import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invite-organization-dialog/accept-invite-organization-dialog.component';
-import { AcceptInviteOrganizationDialogData, AcceptInviteOrganizationDialogResult, InvitationAcceptContext } from '@lfx-one/shared/interfaces';
+import {
+  AcceptInviteOrganizationDialogData,
+  AcceptInviteOrganizationDialogResult,
+  CommitteeOrganizationReference,
+  InvitationAcceptContext,
+  WorkExperience,
+} from '@lfx-one/shared/interfaces';
 import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationService } from '@services/invitation.service';
+import { UserService } from '@services/user.service';
 import { DialogService } from 'primeng/dynamicdialog';
-import { EMPTY, Observable, from, switchMap, take } from 'rxjs';
+import { EMPTY, Observable, from, map, of, switchMap, take } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -15,10 +22,15 @@ import { EMPTY, Observable, from, switchMap, take } from 'rxjs';
 export class InvitationAcceptFlowService {
   private readonly dialogService = inject(DialogService);
   private readonly invitationService = inject(InvitationService);
+  private readonly userService = inject(UserService);
 
   /**
    * Accepts a committee invitation, opening the organization dialog when the committee
    * requires it. Emits nothing when the user cancels the dialog.
+   *
+   * When the invite has no pre-filled organization, the user's current employer from
+   * their work experience is used to pre-fill the dialog so they don't have to re-enter
+   * an org they've already associated with their profile.
    */
   public accept(context: InvitationAcceptContext): Observable<void> {
     const requiresOrganization = invitationRequiresOrganization(context);
@@ -27,7 +39,17 @@ export class InvitationAcceptFlowService {
       return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid);
     }
 
-    return from(this.openOrganizationDialog(context)).pipe(
+    // Resolve the pre-fill org: use the invite's org when present, otherwise fall back to
+    // the user's current employer from their profile (fails silently — dialog opens blank).
+    const contextReady$: Observable<InvitationAcceptContext> = context.organization
+      ? of(context)
+      : this.userService.getWorkExperience().pipe(
+          take(1),
+          map((experiences) => ({ ...context, organization: this.currentEmployerFromProfile(experiences) }))
+        );
+
+    return contextReady$.pipe(
+      switchMap((ctx) => from(this.openOrganizationDialog(ctx))),
       switchMap((result) => {
         if (!result?.organization) {
           return EMPTY;
@@ -35,6 +57,12 @@ export class InvitationAcceptFlowService {
         return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization);
       })
     );
+  }
+
+  private currentEmployerFromProfile(experiences: WorkExperience[]): CommitteeOrganizationReference | null {
+    if (!experiences.length) return null;
+    const current = experiences.find((e) => !e.endDate) ?? experiences[0];
+    return { name: current.organization, id: current.organizationId ?? null };
   }
 
   private openOrganizationDialog(context: InvitationAcceptContext): Promise<AcceptInviteOrganizationDialogResult | null> {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -7,11 +7,10 @@ import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invi
 import {
   AcceptInviteOrganizationDialogData,
   AcceptInviteOrganizationDialogResult,
-  CommitteeOrganizationReference,
   InvitationAcceptContext,
   WorkExperienceEntry,
 } from '@lfx-one/shared/interfaces';
-import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import { currentEmployerFromWorkExperiences, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationService } from '@services/invitation.service';
 import { DialogService } from 'primeng/dynamicdialog';
 import { EMPTY, Observable, catchError, from, map, of, switchMap, take } from 'rxjs';
@@ -45,7 +44,7 @@ export class InvitationAcceptFlowService {
       ? of(context)
       : this.http.get<WorkExperienceEntry[]>('/api/profile/work-experiences').pipe(
           take(1),
-          map((experiences) => ({ ...context, organization: this.currentEmployerFromProfile(experiences) })),
+          map((experiences) => ({ ...context, organization: currentEmployerFromWorkExperiences(experiences) })),
           catchError(() => of(context))
         );
 
@@ -58,23 +57,6 @@ export class InvitationAcceptFlowService {
         return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization);
       })
     );
-  }
-
-  private currentEmployerFromProfile(experiences: WorkExperienceEntry[]): CommitteeOrganizationReference | null {
-    if (!experiences.length) return null;
-    const current =
-      experiences.find((e) => !e.endDate) ?? [...experiences].sort((a, b) => this.monthYearToOrdinal(b.startDate) - this.monthYearToOrdinal(a.startDate))[0];
-    return { name: current.organization, id: current.organizationId ?? null };
-  }
-
-  // Converts "MMM YYYY" (BFF date format) to a sortable ordinal. Avoids new Date() on
-  // non-ISO strings, which is unreliable in Safari.
-  private monthYearToOrdinal(monthYear: string): number {
-    const MONTHS: Record<string, number> = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
-    const [mon, yr] = monthYear.split(' ');
-    const month = MONTHS[mon] ?? 0;
-    const year = parseInt(yr, 10);
-    return isNaN(year) ? 0 : year * 12 + month;
   }
 
   private openOrganizationDialog(context: InvitationAcceptContext): Promise<AcceptInviteOrganizationDialogResult | null> {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invite-organization-dialog/accept-invite-organization-dialog.component';
 import {
@@ -8,13 +9,12 @@ import {
   AcceptInviteOrganizationDialogResult,
   CommitteeOrganizationReference,
   InvitationAcceptContext,
-  WorkExperience,
+  WorkExperienceEntry,
 } from '@lfx-one/shared/interfaces';
 import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationService } from '@services/invitation.service';
-import { UserService } from '@services/user.service';
 import { DialogService } from 'primeng/dynamicdialog';
-import { EMPTY, Observable, from, map, of, switchMap, take } from 'rxjs';
+import { EMPTY, Observable, catchError, from, map, of, switchMap, take } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -22,7 +22,7 @@ import { EMPTY, Observable, from, map, of, switchMap, take } from 'rxjs';
 export class InvitationAcceptFlowService {
   private readonly dialogService = inject(DialogService);
   private readonly invitationService = inject(InvitationService);
-  private readonly userService = inject(UserService);
+  private readonly http = inject(HttpClient);
 
   /**
    * Accepts a committee invitation, opening the organization dialog when the committee
@@ -43,9 +43,10 @@ export class InvitationAcceptFlowService {
     // the user's current employer from their profile (fails silently — dialog opens blank).
     const contextReady$: Observable<InvitationAcceptContext> = context.organization
       ? of(context)
-      : this.userService.getWorkExperience().pipe(
+      : this.http.get<WorkExperienceEntry[]>('/api/profile/work-experiences').pipe(
           take(1),
-          map((experiences) => ({ ...context, organization: this.currentEmployerFromProfile(experiences) }))
+          map((experiences) => ({ ...context, organization: this.currentEmployerFromProfile(experiences) })),
+          catchError(() => of(context))
         );
 
     return contextReady$.pipe(
@@ -59,9 +60,10 @@ export class InvitationAcceptFlowService {
     );
   }
 
-  private currentEmployerFromProfile(experiences: WorkExperience[]): CommitteeOrganizationReference | null {
+  private currentEmployerFromProfile(experiences: WorkExperienceEntry[]): CommitteeOrganizationReference | null {
     if (!experiences.length) return null;
-    const current = experiences.find((e) => !e.endDate) ?? experiences[0];
+    const current =
+      experiences.find((e) => !e.endDate) ?? [...experiences].sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime())[0];
     return { name: current.organization, id: current.organizationId ?? null };
   }
 

--- a/apps/lfx-one/src/app/shared/services/search.service.ts
+++ b/apps/lfx-one/src/app/shared/services/search.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { UserSearchResponse, UserSearchResult, WorkExperienceEntry } from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -36,5 +36,12 @@ export class SearchService {
         return of([]);
       })
     );
+  }
+
+  /** Fetch work experiences for any user by LFID — used to pre-fill org fields. Fails silently. */
+  public getUserWorkExperiences(lfid: string): Observable<WorkExperienceEntry[]> {
+    return this.http
+      .get<WorkExperienceEntry[]>(`/api/search/users/${encodeURIComponent(lfid)}/work-experiences`)
+      .pipe(catchError(() => of([] as WorkExperienceEntry[])));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/search.service.ts
+++ b/apps/lfx-one/src/app/shared/services/search.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { UserSearchResponse, UserSearchResult, WorkExperienceEntry } from '@lfx-one/shared/interfaces';
+import { CommitteeOrganizationReference, UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -38,10 +38,10 @@ export class SearchService {
     );
   }
 
-  /** Fetch work experiences for any user by LFID — used to pre-fill org fields. Fails silently. */
-  public getUserWorkExperiences(lfid: string): Observable<WorkExperienceEntry[]> {
+  /** Fetch the current employer for any user by LFID — used to pre-fill org fields. Fails silently. */
+  public getUserCurrentEmployer(lfid: string): Observable<CommitteeOrganizationReference | null> {
     return this.http
-      .get<WorkExperienceEntry[]>(`/api/search/users/${encodeURIComponent(lfid)}/work-experiences`)
-      .pipe(catchError(() => of([] as WorkExperienceEntry[])));
+      .get<CommitteeOrganizationReference | null>(`/api/search/users/${encodeURIComponent(lfid)}/work-experiences`)
+      .pipe(catchError(() => of(null)));
   }
 }

--- a/apps/lfx-one/src/server/controllers/search.controller.ts
+++ b/apps/lfx-one/src/server/controllers/search.controller.ts
@@ -6,6 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
+import { CdpService } from '../services/cdp.service';
 import { SearchService } from '../services/search.service';
 
 /**
@@ -13,6 +14,7 @@ import { SearchService } from '../services/search.service';
  */
 export class SearchController {
   private searchService: SearchService = new SearchService();
+  private cdpService: CdpService = new CdpService();
 
   /**
    * GET /search/users
@@ -78,6 +80,36 @@ export class SearchController {
       });
 
       res.json(results);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /search/users/:lfid/work-experiences
+   * Returns the CDP work-experience list for any user by LFID.
+   * Used to pre-fill the organization field in the add-member dialog.
+   */
+  public async getUserWorkExperiences(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { lfid } = req.params;
+    const startTime = logger.startOperation(req, 'get_user_work_experiences', { lfid });
+
+    try {
+      if (!lfid || typeof lfid !== 'string') {
+        return next(
+          ServiceValidationError.forField('lfid', 'lfid path parameter is required', {
+            operation: 'get_user_work_experiences',
+            service: 'search_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const workExperiences = await this.cdpService.getWorkExperiencesForUser(req, lfid);
+
+      logger.success(req, 'get_user_work_experiences', startTime, { lfid, count: workExperiences.length });
+
+      res.json(workExperiences);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/search.controller.ts
+++ b/apps/lfx-one/src/server/controllers/search.controller.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { UserSearchParams } from '@lfx-one/shared/interfaces';
+import { CommitteeOrganizationReference, UserSearchParams } from '@lfx-one/shared/interfaces';
+import { currentEmployerFromWorkExperiences } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -87,12 +88,12 @@ export class SearchController {
 
   /**
    * GET /search/users/:lfid/work-experiences
-   * Returns org-prefill fields (organization, organizationId, startDate, endDate) for any user by LFID.
+   * Returns the computed current employer ({name, id}) for any user by LFID, or null.
    * Used to pre-fill the organization field in the add-member dialog.
    *
    * Auth: requires a valid session (authMiddleware, applied globally). Any authenticated user can
    * query any LFID — a committee-admin role guard is not yet implemented in this BFF. The response
-   * is intentionally minimised to org-prefill fields only to limit PII exposure.
+   * is a single computed org reference (no employment dates or job titles) to limit PII exposure.
    * TODO(LFXV2-2531): add a committee-admin/manager role check once the BFF has that middleware.
    */
   public async getUserWorkExperiences(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -111,19 +112,11 @@ export class SearchController {
       }
 
       const workExperiences = await this.cdpService.getWorkExperiencesForUser(req, lfid);
+      const employer: CommitteeOrganizationReference | null = currentEmployerFromWorkExperiences(workExperiences);
 
-      logger.success(req, 'get_user_work_experiences', startTime, { lfid, count: workExperiences.length });
+      logger.success(req, 'get_user_work_experiences', startTime, { lfid, found: !!employer });
 
-      // Return only the fields required for org pre-fill — job titles, source, and verification
-      // metadata are not needed and would unnecessarily expose other users' profile data.
-      res.json(
-        workExperiences.map(({ organization, organizationId, startDate, endDate }) => ({
-          organization,
-          organizationId: organizationId ?? null,
-          startDate,
-          endDate: endDate ?? null,
-        }))
-      );
+      res.json(employer);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/search.controller.ts
+++ b/apps/lfx-one/src/server/controllers/search.controller.ts
@@ -109,7 +109,16 @@ export class SearchController {
 
       logger.success(req, 'get_user_work_experiences', startTime, { lfid, count: workExperiences.length });
 
-      res.json(workExperiences);
+      // Return only the fields required for org pre-fill — job titles, source, and verification
+      // metadata are not needed and would unnecessarily expose other users' profile data.
+      res.json(
+        workExperiences.map(({ organization, organizationId, startDate, endDate }) => ({
+          organization,
+          organizationId: organizationId ?? null,
+          startDate,
+          endDate: endDate ?? null,
+        }))
+      );
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/search.controller.ts
+++ b/apps/lfx-one/src/server/controllers/search.controller.ts
@@ -87,8 +87,13 @@ export class SearchController {
 
   /**
    * GET /search/users/:lfid/work-experiences
-   * Returns the CDP work-experience list for any user by LFID.
+   * Returns org-prefill fields (organization, organizationId, startDate, endDate) for any user by LFID.
    * Used to pre-fill the organization field in the add-member dialog.
+   *
+   * Auth: requires a valid session (authMiddleware, applied globally). Any authenticated user can
+   * query any LFID — a committee-admin role guard is not yet implemented in this BFF. The response
+   * is intentionally minimised to org-prefill fields only to limit PII exposure.
+   * TODO(LFXV2-2531): add a committee-admin/manager role check once the BFF has that middleware.
    */
   public async getUserWorkExperiences(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { lfid } = req.params;

--- a/apps/lfx-one/src/server/routes/search.route.ts
+++ b/apps/lfx-one/src/server/routes/search.route.ts
@@ -11,4 +11,7 @@ const searchController = new SearchController();
 // User search route
 router.get('/users', (req, res, next) => searchController.searchUsers(req, res, next));
 
+// GET /api/search/users/:lfid/work-experiences — work-experience lookup for any user by LFID
+router.get('/users/:lfid/work-experiences', (req, res, next) => searchController.getUserWorkExperiences(req, res, next));
+
 export default router;

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -16,6 +16,7 @@ import {
   buildInvitationActions,
   buildInvitationSubtext,
   committeeRequiresOrganization,
+  currentEmployerFromWorkExperiences,
   findPendingInvitationForCommittee,
   formatInviteExpiry,
   invitationRequiresOrganization,
@@ -246,6 +247,55 @@ describe('findPendingInvitationForCommittee', () => {
 
   it('excludes an invite already resolved this session', () => {
     expect(findPendingInvitationForCommittee(invites, new Set(['i1']), 'c1')).toBeNull();
+  });
+});
+
+describe('currentEmployerFromWorkExperiences', () => {
+  it('returns null for an empty array', () => {
+    expect(currentEmployerFromWorkExperiences([])).toBeNull();
+  });
+
+  it('prefers the entry without an endDate (current job)', () => {
+    const result = currentEmployerFromWorkExperiences([
+      { organization: 'Old Corp', organizationId: 'org-old', startDate: 'Jan 2020', endDate: 'Dec 2022' },
+      { organization: 'Current Corp', organizationId: 'org-cur', startDate: 'Jan 2023', endDate: null },
+      { organization: 'Older Corp', organizationId: 'org-older', startDate: 'Jan 2018', endDate: 'Dec 2019' },
+    ]);
+    expect(result).toEqual({ name: 'Current Corp', id: 'org-cur' });
+  });
+
+  it('picks the first entry without endDate when multiple are current', () => {
+    const result = currentEmployerFromWorkExperiences([
+      { organization: 'Corp A', organizationId: 'a', startDate: 'Jan 2021', endDate: null },
+      { organization: 'Corp B', organizationId: 'b', startDate: 'Jan 2022', endDate: null },
+    ]);
+    expect(result?.name).toBe('Corp A');
+  });
+
+  it('falls back to the most recent by startDate when all entries have endDates', () => {
+    const result = currentEmployerFromWorkExperiences([
+      { organization: 'Older Corp', organizationId: 'org-older', startDate: 'Mar 2019', endDate: 'Dec 2020' },
+      { organization: 'Newest Corp', organizationId: 'org-new', startDate: 'Jan 2023', endDate: 'Jun 2024' },
+      { organization: 'Middle Corp', organizationId: 'org-mid', startDate: 'Jan 2021', endDate: 'Dec 2022' },
+    ]);
+    expect(result).toEqual({ name: 'Newest Corp', id: 'org-new' });
+  });
+
+  it('handles a missing organizationId by returning id: null', () => {
+    const result = currentEmployerFromWorkExperiences([{ organization: 'No ID Corp', organizationId: undefined, startDate: 'Jan 2023', endDate: null }]);
+    expect(result).toEqual({ name: 'No ID Corp', id: null });
+  });
+
+  it('correctly orders months within the same year (Dec > Jan)', () => {
+    const result = currentEmployerFromWorkExperiences([
+      { organization: 'Jan Corp', organizationId: 'jan', startDate: 'Jan 2023', endDate: 'Feb 2023' },
+      { organization: 'Dec Corp', organizationId: 'dec', startDate: 'Dec 2023', endDate: 'Jan 2024' },
+    ]);
+    expect(result?.name).toBe('Dec Corp');
+  });
+
+  it('handles an invalid startDate without throwing (treats as ordinal 0)', () => {
+    expect(() => currentEmployerFromWorkExperiences([{ organization: 'Corp', organizationId: null, startDate: 'invalid', endDate: 'Dec 2020' }])).not.toThrow();
   });
 });
 

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -4,12 +4,35 @@
 import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_SEVERITY } from '../constants/pending-action.constants';
 import { PendingActionItem } from '../interfaces/components.interface';
 import type { CommitteeOrganizationFormValue, CommitteeOrganizationReference, PendingInvitation } from '../interfaces/committee.interface';
+import type { WorkExperienceEntry } from '../interfaces/profile.interface';
 
 /**
  * Returns true when a committee requires organization on invite create/accept.
  */
 export function committeeRequiresOrganization(flags: { enable_voting?: boolean; business_email_required?: boolean }): boolean {
   return !!flags.enable_voting || !!flags.business_email_required;
+}
+
+/**
+ * Picks the current employer from a CDP work-experience array.
+ * Prefers an entry without an endDate; falls back to the most recent by startDate.
+ * Returns null when the array is empty.
+ *
+ * startDate is formatted as "MMM YYYY" by the BFF — parsed deterministically to
+ * avoid relying on new Date() with non-ISO strings, which is unreliable in Safari.
+ */
+export function currentEmployerFromWorkExperiences(experiences: WorkExperienceEntry[]): CommitteeOrganizationReference | null {
+  if (!experiences.length) return null;
+  const current = experiences.find((e) => !e.endDate) ?? [...experiences].sort((a, b) => monthYearToOrdinal(b.startDate) - monthYearToOrdinal(a.startDate))[0];
+  return { name: current.organization, id: current.organizationId ?? null };
+}
+
+function monthYearToOrdinal(monthYear: string): number {
+  const MONTHS: Record<string, number> = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+  const [mon, yr] = monthYear.split(' ');
+  const month = MONTHS[mon] ?? 0;
+  const year = parseInt(yr, 10);
+  return isNaN(year) ? 0 : year * 12 + month;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Invite accept flow**: when a pending invite requires organization and the invite itself carries no pre-set org, the accept flow now fetches the invitee's current employer from their CDP work-experience profile (`/api/profile/work-experiences`) and pre-fills the org dialog instead of opening it blank. Falls back gracefully to blank when CDP returns no data.

- **Add-member dialog**: when a committee admin selects an existing user from the search results in the Add Member dialog, the optional Organization field auto-populates from that user's CDP work-experience history. A new BFF endpoint (`GET /api/search/users/:lfid/work-experiences`) is added for this purpose; it returns only the org-prefill fields (name, id, startDate, endDate) to minimise data exposure. The hint text under the Organization label is updated to communicate the auto-populate behaviour.

- **Shared utility**: `currentEmployerFromWorkExperiences()` is extracted into `@lfx-one/shared/utils` so both flows use the same employer-selection logic. Prefers an entry without an `endDate` (current job), falls back to most-recent by `startDate` using a Safari-safe "MMM YYYY" parser. Unit tests added in `invitation.utils.spec.ts`.

- **`OrganizationSearchComponent`**: fixed the parent→search-input sync `effect()` so it reacts to programmatic `patchValue()` calls (not just the initial render), and also clears the search input when the parent control is cleared.

## Ticket

[LFXV2-2528](https://jira.linuxfoundation.org/browse/LFXV2-2528) / [LFXV2-2531](https://jira.linuxfoundation.org/browse/LFXV2-2531)

## Test plan

- [ ] Accept a pending committee invite that requires org and has no pre-set org — org dialog should open pre-filled with current employer from CDP profile, or blank if no work history
- [ ] Accept a pending committee invite that already carries an org — dialog skips CDP fetch, shows the invite org
- [ ] Add member to an org-requiring committee: search for a user with known work history, select them — Organization field should auto-populate; hint text mentions auto-populate
- [ ] Add member: selecting a user with no CDP work history leaves the org field blank (no error)
- [ ] Add member: org field is blank before selecting a user; after selecting, auto-populates; manually typing in the field is still possible and overrides the auto-fill
- [ ] `GET /api/profile/work-experiences` (plural) — confirm endpoint exists and returns work experiences for the authenticated user
- [ ] `GET /api/search/users/:lfid/work-experiences` — confirm returns only `{ organization, organizationId, startDate, endDate }` per entry (no job title, source, or verification fields)

[LFXV2-2528]: https://linuxfoundation.atlassian.net/browse/LFXV2-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ