### PR TITLE
feat(mktg-os): add per-agent chat panel with polling

### DIFF
--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.html
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.html
@@ -1,0 +1,143 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col h-[32rem] bg-white border border-gray-200 rounded-lg overflow-hidden" data-testid="mktg-chat-panel">
+  <!-- Header -->
+  <div class="flex items-center justify-between gap-3 px-4 py-3 border-b border-gray-200">
+    <div class="flex items-center gap-3 min-w-0">
+      <lfx-button
+        icon="fa-light fa-arrow-left"
+        [text]="true"
+        size="small"
+        ariaLabel="Back to the marketplace"
+        data-testid="mktg-chat-back"
+        (onClick)="onBack()" />
+      <span class="flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 text-gray-500 shrink-0">
+        <i [class]="agent().icon + ' text-base'" aria-hidden="true"></i>
+      </span>
+      <div class="flex flex-col min-w-0">
+        <span class="font-medium text-sm text-gray-900 truncate">{{ agent().number }}. {{ agent().name }}</span>
+        @if (agent().tags.length > 0) {
+          <span class="text-xs text-gray-500 truncate">{{ agent().tags.join(' · ') }}</span>
+        }
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 shrink-0">
+      <lfx-button
+        icon="fa-light fa-clock-rotate-left"
+        [text]="true"
+        size="small"
+        [ariaLabel]="showSessions() ? 'Hide past chats' : 'Show past chats'"
+        data-testid="mktg-chat-toggle-sessions"
+        (onClick)="onToggleSessions()" />
+      <lfx-button
+        label="New Chat"
+        icon="fa-light fa-plus"
+        severity="secondary"
+        [outlined]="true"
+        size="small"
+        ariaLabel="Start a new chat"
+        data-testid="mktg-chat-new"
+        (onClick)="onNewChat()" />
+    </div>
+  </div>
+
+  <!-- Body -->
+  <div class="flex flex-1 min-h-0">
+    <!-- Past Chats drawer -->
+    @if (showSessions()) {
+      <aside class="flex flex-col gap-2 w-56 shrink-0 border-r border-gray-200 p-3 overflow-y-auto" data-testid="mktg-chat-sessions">
+        <span class="text-xs font-medium uppercase tracking-wide text-gray-500">Past Chats</span>
+        @if (sessions().length === 0) {
+          <p class="text-xs text-gray-400">No past chats yet. Send a message to start one.</p>
+        } @else {
+          <ul class="flex flex-col gap-1">
+            @for (session of sessions(); track session.sessionId) {
+              <li class="flex items-center gap-1 rounded-md" [class.bg-gray-100]="session.sessionId === activeSessionId()">
+                <button
+                  type="button"
+                  class="flex-1 min-w-0 px-2 py-1.5 text-left rounded-md hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                  [attr.data-testid]="'mktg-chat-session-' + session.sessionId"
+                  (click)="onSelectSession(session.sessionId)">
+                  <span class="block text-xs font-medium text-gray-800 truncate">{{ session.title }}</span>
+                </button>
+                <button
+                  type="button"
+                  class="px-1.5 py-1 rounded text-gray-400 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                  [attr.data-testid]="'mktg-chat-delete-' + session.sessionId"
+                  aria-label="Delete chat"
+                  (click)="onDeleteSession(session.sessionId)">
+                  <i class="fa-light fa-trash-can text-xs" aria-hidden="true"></i>
+                </button>
+              </li>
+            }
+          </ul>
+        }
+      </aside>
+    }
+
+    <!-- Chat main -->
+    <div class="flex flex-col flex-1 min-w-0">
+      <!-- Intro banner -->
+      <p class="px-4 py-2 text-xs text-gray-500 border-b border-gray-100">{{ agent().description }}</p>
+
+      @if (isHistoryLoading()) {
+        <div class="flex flex-1 items-center justify-center gap-2 text-sm text-gray-500" data-testid="mktg-chat-loading">
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          <span>Loading chat history…</span>
+        </div>
+      } @else {
+        <!-- Messages -->
+        <div class="flex flex-col flex-1 gap-3 p-4 overflow-y-auto" data-testid="mktg-chat-messages">
+          @for (message of messages(); track message.id) {
+            <div
+              class="flex flex-col max-w-[80%]"
+              [class.self-end]="message.sender === 'user'"
+              [class.items-end]="message.sender === 'user'"
+              [attr.data-testid]="'mktg-chat-message-' + message.sender">
+              <div
+                class="px-3 py-2 rounded-lg text-sm break-words whitespace-pre-wrap"
+                [ngClass]="message.sender === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-800'">
+                {{ message.text }}
+              </div>
+              @if (message.timestamp) {
+                <span class="mt-1 text-[10px] text-gray-400">{{ message.timestamp }}</span>
+              }
+            </div>
+          } @empty {
+            @if (!isTyping()) {
+              <div class="flex flex-1 items-center justify-center text-sm text-gray-400 text-center" data-testid="mktg-chat-empty">
+                Send a message to start chatting with {{ agent().name }}.
+              </div>
+            }
+          }
+
+          @if (isTyping()) {
+            <div class="flex items-center gap-1 self-start px-3 py-2 rounded-lg bg-gray-100" data-testid="mktg-chat-typing" aria-label="Agent is responding">
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"></span>
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce [animation-delay:0.15s]"></span>
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce [animation-delay:0.3s]"></span>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- Input -->
+      <form class="flex items-center gap-2 p-3 border-t border-gray-200" [formGroup]="chatForm" (ngSubmit)="onSubmit()">
+        <div class="flex-1">
+          <lfx-input-text [form]="chatForm" control="message" [placeholder]="'Message ' + agent().name + '…'" dataTest="mktg-chat-input" />
+        </div>
+        <lfx-button
+          type="button"
+          label="Send"
+          icon="fa-light fa-paper-plane"
+          size="small"
+          [disabled]="isTyping() || isHistoryLoading()"
+          ariaLabel="Send message"
+          data-testid="mktg-chat-send"
+          (onClick)="onSubmit()" />
+      </form>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.html
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.html
@@ -18,7 +18,7 @@
       <div class="flex flex-col min-w-0">
         <span class="font-medium text-sm text-gray-900 truncate">{{ agent().number }}. {{ agent().name }}</span>
         @if (agent().tags.length > 0) {
-          <span class="text-xs text-gray-500 truncate">{{ agent().tags.join(' · ') }}</span>
+          <span class="text-xs text-gray-500 truncate">{{ tagsLabel() }}</span>
         }
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -47,10 +47,6 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   public readonly agent = input.required<MktgAgent>();
   public readonly back = output<void>();
 
-  // === Computed ===
-  // Header tag list joined once per agent change — keeps `join()` out of the template.
-  protected readonly tagsLabel = computed(() => this.agent().tags.join(' · '));
-
   // === Forms ===
   protected readonly chatForm = new FormGroup({
     message: new FormControl('', { nonNullable: true }),
@@ -63,6 +59,10 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   protected readonly isTyping = signal(false);
   protected readonly isHistoryLoading = signal(false);
   protected readonly showSessions = signal(true);
+
+  // === Computed ===
+  // Header tag list joined once per agent change — keeps `join()` out of the template.
+  protected readonly tagsLabel = computed(() => this.agent().tags.join(' · '));
 
   // In-flight history fetch (load or poll) and the in-flight send POST. Both are
   // cancelled on agent/session switch and on destroy (via cancelInFlight) so a
@@ -105,8 +105,9 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     const sessionId = this.activeSessionId();
 
     // Optimistic user bubble — replaced by the canonical server copy once the
-    // agent replies and the full history is reloaded.
-    this.messages.update((list) => [...list, this.buildMessage('user', text)]);
+    // agent replies and the full history is reloaded, or rolled back on failure.
+    const optimistic = this.buildMessage('user', text);
+    this.messages.update((list) => [...list, optimistic]);
     this.isTyping.set(true);
 
     const agentMessageBaseline = this.countAgentMessages();
@@ -125,10 +126,10 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
             // New-session request but the server returned the follow-up shape:
             // there is no sessionId to poll, so fail soft instead of leaving the
             // input wedged with `isTyping` stuck on.
-            this.handleSendError('unexpected follow-up response for a new session');
+            this.handleSendError('unexpected follow-up response for a new session', text, optimistic.id);
           }
         },
-        error: (error) => this.handleSendError(error),
+        error: (error) => this.handleSendError(error, text, optimistic.id),
       });
   }
 
@@ -279,9 +280,17 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     this.sendSub = null;
   }
 
-  private handleSendError(error: unknown): void {
+  /**
+   * Recover from a failed send: roll back the optimistic bubble (the server never
+   * received it), restore the user's draft so they can resend without retyping,
+   * and surface an inline error. The input is disabled while sending, so the
+   * field is guaranteed empty here — restoring the draft can't clobber new input.
+   */
+  private handleSendError(error: unknown, draft: string, optimisticId: string): void {
     console.error('[mktg-chat] failed to send message', error);
     this.isTyping.set(false);
+    this.messages.update((list) => list.filter((message) => message.id !== optimisticId));
+    this.chatForm.controls.message.setValue(draft);
     this.messages.update((list) => [...list, this.buildMessage('agent', 'Sorry — that message could not be sent. Please try again.')]);
   }
 

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser, NgClass } from '@angular/common';
-import { Component, computed, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, effect, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -71,6 +72,22 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   private historySub: Subscription | null = null;
   private sendSub: Subscription | null = null;
   private optimisticCounter = 0;
+
+  public constructor() {
+    // Lock the message input in lockstep with the Send button while sending or
+    // loading. `lfx-input-text` has no `disabled` input, so toggle the control
+    // directly — this makes "the input is disabled while sending" a real
+    // invariant the draft-restore in handleSendError depends on.
+    effect(() => {
+      const locked = this.isTyping() || this.isHistoryLoading();
+      const control = this.chatForm.controls.message;
+      if (locked && control.enabled) {
+        control.disable({ emitEvent: false });
+      } else if (!locked && control.disabled) {
+        control.enable({ emitEvent: false });
+      }
+    });
+  }
 
   // === Lifecycle ===
   public ngOnInit(): void {
@@ -209,7 +226,17 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
       error: (error) => {
         console.error('[mktg-chat] failed to load session history', error);
         this.isHistoryLoading.set(false);
-        this.handleExpiredSession(sessionId);
+        if (isSessionGoneError(error)) {
+          // Genuinely missing/expired upstream — safe to drop locally.
+          this.handleExpiredSession(sessionId);
+        } else {
+          // Transient or server error: keep the session (and its ownerToken)
+          // intact so the user can still post follow-ups; show a non-destructive
+          // notice instead of silently deleting a valid conversation.
+          this.messages.set([
+            this.buildMessage('agent', 'Couldn’t load this conversation right now. It’s still saved — reopen it or send a message to try again.'),
+          ]);
+        }
       },
     });
   }
@@ -283,8 +310,9 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   /**
    * Recover from a failed send: roll back the optimistic bubble (the server never
    * received it), restore the user's draft so they can resend without retyping,
-   * and surface an inline error. The input is disabled while sending, so the
-   * field is guaranteed empty here — restoring the draft can't clobber new input.
+   * and surface an inline error. The message control is locked while sending (see
+   * the constructor effect), so no new input can have accumulated — restoring the
+   * draft can't clobber anything the user typed.
    */
   private handleSendError(error: unknown, draft: string, optimisticId: string): void {
     console.error('[mktg-chat] failed to send message', error);
@@ -312,4 +340,12 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     const now = new Date();
     return `${String(now.getUTCHours()).padStart(2, '0')}:${String(now.getUTCMinutes()).padStart(2, '0')}`;
   }
+}
+
+/**
+ * True only when the upstream genuinely reports the session as gone (404/410),
+ * so a transient network/5xx error never triggers destructive local cleanup.
+ */
+function isSessionGoneError(error: unknown): boolean {
+  return error instanceof HttpErrorResponse && (error.status === 404 || error.status === 410);
 }

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -1,0 +1,274 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser, NgClass } from '@angular/common';
+import { Component, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { MktgAgent, MktgChatMessage, MktgChatSession } from '@lfx-one/shared/interfaces';
+import { catchError, of, Subscription, switchMap, takeUntil, timer } from 'rxjs';
+
+import { MktgAgentsService } from '../../../shared/services/mktg-agents.service';
+import { MktgChatSessionService } from '../../../shared/services/mktg-chat-session.service';
+
+// Poll the history endpoint while waiting for the agent to reply (MVP substitute
+// for streaming — see LFXAI-99). Cadence is a balance between responsiveness and
+// load on the Guild proxy; the deadline caps a single send's wait.
+const POLL_INTERVAL_MS = 1500;
+const POLL_TIMEOUT_MS = 60_000;
+
+// Max length of the first user message used as a session's drawer title.
+const SESSION_TITLE_MAX_LENGTH = 28;
+
+/**
+ * Per-agent chat surface for the Marketing OS marketplace (LFXAI-99).
+ *
+ * Opened in place of the marketplace grid for a single `active` agent. Talks to
+ * the BFF Guild proxy via `MktgAgentsService` and waits for replies by polling
+ * the history endpoint (no SSE/WebSocket in the MVP). Sessions persist in
+ * localStorage through `MktgChatSessionService`; all browser access is guarded
+ * so the panel renders inert under SSR.
+ */
+@Component({
+  selector: 'lfx-mktg-chat-panel',
+  imports: [NgClass, ReactiveFormsModule, ButtonComponent, InputTextComponent],
+  templateUrl: './mktg-chat-panel.component.html',
+})
+export class MktgChatPanelComponent implements OnInit, OnDestroy {
+  // === Injections ===
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly mktgAgents = inject(MktgAgentsService);
+  private readonly sessionStore = inject(MktgChatSessionService);
+
+  // === Inputs / Outputs ===
+  // Only `active` agents are routable; the marketplace never opens a panel for
+  // a `coming-soon` tile, so the chat handle is guaranteed server-side.
+  public readonly agent = input.required<MktgAgent>();
+  public readonly back = output<void>();
+
+  // === Forms ===
+  protected readonly chatForm = new FormGroup({
+    message: new FormControl('', { nonNullable: true }),
+  });
+
+  // === Signals ===
+  protected readonly messages = signal<MktgChatMessage[]>([]);
+  protected readonly sessions = signal<MktgChatSession[]>([]);
+  protected readonly activeSessionId = signal<string | null>(null);
+  protected readonly isTyping = signal(false);
+  protected readonly isHistoryLoading = signal(false);
+  protected readonly showSessions = signal(true);
+
+  // In-flight history fetch (load or poll); cancelled on agent/session switch so
+  // a stale response can never overwrite a newer conversation.
+  private historySub: Subscription | null = null;
+  private optimisticCounter = 0;
+
+  // === Lifecycle ===
+  public ngOnInit(): void {
+    // SSR renders an empty panel — no localStorage, no network.
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    const agentId = this.agent().id;
+    this.sessions.set(this.sessionStore.getSessions(agentId));
+
+    const savedSessionId = this.sessionStore.getActiveSessionId(agentId);
+    if (savedSessionId) {
+      this.activeSessionId.set(savedSessionId);
+      this.loadHistory(savedSessionId);
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.cancelInFlight();
+  }
+
+  // === Protected actions (template) ===
+  protected onSubmit(): void {
+    const text = this.chatForm.controls.message.value.trim();
+    if (!text || this.isTyping() || this.isHistoryLoading()) {
+      return;
+    }
+
+    this.chatForm.controls.message.setValue('');
+    const agentId = this.agent().id;
+    const sessionId = this.activeSessionId();
+
+    // Optimistic user bubble — replaced by the canonical server copy once the
+    // agent replies and the full history is reloaded.
+    this.messages.update((list) => [...list, this.buildMessage('user', text)]);
+    this.isTyping.set(true);
+
+    const agentMessageBaseline = this.countAgentMessages();
+    const ownerToken = sessionId ? this.sessionStore.getSession(agentId, sessionId)?.ownerToken : undefined;
+
+    this.mktgAgents.sendMessage({ agentId, message: text, sessionId: sessionId ?? null, ownerToken }).subscribe({
+      next: (response) => {
+        if ('sessionId' in response) {
+          this.onSessionCreated(agentId, response.sessionId, response.ownerToken, text, agentMessageBaseline);
+        } else if (sessionId) {
+          this.pollForReply(sessionId, agentMessageBaseline);
+        }
+      },
+      error: () => {
+        this.isTyping.set(false);
+        this.messages.update((list) => [...list, this.buildMessage('agent', 'Sorry — that message could not be sent. Please try again.')]);
+      },
+    });
+  }
+
+  protected onSelectSession(sessionId: string): void {
+    if (sessionId === this.activeSessionId()) {
+      return;
+    }
+    this.cancelInFlight();
+    this.isTyping.set(false);
+    this.activeSessionId.set(sessionId);
+    this.sessionStore.setActiveSessionId(this.agent().id, sessionId);
+    this.loadHistory(sessionId);
+  }
+
+  protected onNewChat(): void {
+    this.cancelInFlight();
+    this.isTyping.set(false);
+    this.activeSessionId.set(null);
+    this.messages.set([]);
+    this.sessionStore.setActiveSessionId(this.agent().id, null);
+  }
+
+  protected onDeleteSession(sessionId: string): void {
+    const agentId = this.agent().id;
+    this.sessionStore.removeSession(agentId, sessionId);
+    this.sessions.update((list) => list.filter((session) => session.sessionId !== sessionId));
+
+    if (this.activeSessionId() !== sessionId) {
+      return;
+    }
+
+    // Deleting the open session: fall back to the most recent remaining one.
+    this.cancelInFlight();
+    this.isTyping.set(false);
+    const next = this.sessions()[0]?.sessionId ?? null;
+    this.activeSessionId.set(next);
+    this.sessionStore.setActiveSessionId(agentId, next);
+    if (next) {
+      this.loadHistory(next);
+    } else {
+      this.messages.set([]);
+    }
+  }
+
+  protected onToggleSessions(): void {
+    this.showSessions.update((shown) => !shown);
+  }
+
+  protected onBack(): void {
+    this.back.emit();
+  }
+
+  // === Private helpers ===
+  private onSessionCreated(agentId: string, sessionId: string, ownerToken: string, firstMessage: string, agentMessageBaseline: number): void {
+    const session: MktgChatSession = {
+      sessionId,
+      ownerToken,
+      title: this.toTitle(firstMessage),
+      createdAt: new Date().toISOString(),
+    };
+    this.sessionStore.addSession(agentId, session);
+    this.sessionStore.setActiveSessionId(agentId, sessionId);
+    this.sessions.update((list) => [session, ...list.filter((existing) => existing.sessionId !== sessionId)]);
+    this.activeSessionId.set(sessionId);
+    this.pollForReply(sessionId, agentMessageBaseline);
+  }
+
+  /** Load and display a session's full history; recover gracefully if it expired. */
+  private loadHistory(sessionId: string): void {
+    this.cancelInFlight();
+    this.isHistoryLoading.set(true);
+    this.historySub = this.mktgAgents.getHistory(sessionId).subscribe({
+      next: (messages) => {
+        this.isHistoryLoading.set(false);
+        this.messages.set(messages);
+      },
+      error: () => {
+        this.isHistoryLoading.set(false);
+        this.handleExpiredSession(sessionId);
+      },
+    });
+  }
+
+  /**
+   * Poll history until a new agent message lands (or the deadline passes), then
+   * swap in the canonical server history. A transient fetch error is swallowed
+   * so a single hiccup doesn't abort the wait.
+   */
+  private pollForReply(sessionId: string, agentMessageBaseline: number): void {
+    this.cancelInFlight();
+    const deadline$ = timer(POLL_TIMEOUT_MS);
+
+    this.historySub = timer(POLL_INTERVAL_MS, POLL_INTERVAL_MS)
+      .pipe(
+        switchMap(() => this.mktgAgents.getHistory(sessionId).pipe(catchError(() => of(null)))),
+        takeUntil(deadline$)
+      )
+      .subscribe({
+        next: (messages) => {
+          if (!messages) {
+            return;
+          }
+          const agentMessages = messages.filter((message) => message.sender === 'agent').length;
+          if (agentMessages > agentMessageBaseline) {
+            this.messages.set(messages);
+            this.isTyping.set(false);
+            this.cancelInFlight();
+          }
+        },
+        complete: () => {
+          // Reached only when the deadline fires first — a reply unsubscribes via
+          // cancelInFlight() before the timer can complete.
+          if (this.isTyping()) {
+            this.isTyping.set(false);
+            this.messages.update((list) => [
+              ...list,
+              this.buildMessage('agent', 'The agent is taking longer than usual to respond. Your message was sent — check back shortly.'),
+            ]);
+          }
+        },
+      });
+  }
+
+  private handleExpiredSession(sessionId: string): void {
+    const agentId = this.agent().id;
+    this.sessionStore.removeSession(agentId, sessionId);
+    this.sessions.update((list) => list.filter((session) => session.sessionId !== sessionId));
+    this.activeSessionId.set(null);
+    this.messages.set([this.buildMessage('agent', 'This conversation could not be found — it may have expired. Send a message to start a new one.')]);
+  }
+
+  private cancelInFlight(): void {
+    this.historySub?.unsubscribe();
+    this.historySub = null;
+  }
+
+  private countAgentMessages(): number {
+    return this.messages().filter((message) => message.sender === 'agent').length;
+  }
+
+  private buildMessage(sender: MktgChatMessage['sender'], text: string): MktgChatMessage {
+    this.optimisticCounter += 1;
+    return { id: `local-${sender}-${this.optimisticCounter}`, sender, text, timestamp: this.nowUtcHhMm() };
+  }
+
+  private toTitle(message: string): string {
+    return message.length > SESSION_TITLE_MAX_LENGTH ? `${message.slice(0, SESSION_TITLE_MAX_LENGTH)}…` : message;
+  }
+
+  /** UTC `HH:MM`, matching the server-side timestamp format for mapped history. */
+  private nowUtcHhMm(): string {
+    const now = new Date();
+    return `${String(now.getUTCHours()).padStart(2, '0')}:${String(now.getUTCMinutes()).padStart(2, '0')}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -3,7 +3,7 @@
 
 import { isPlatformBrowser, NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, effect, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
+import { Component, computed, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -73,22 +73,6 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   private sendSub: Subscription | null = null;
   private optimisticCounter = 0;
 
-  public constructor() {
-    // Lock the message input in lockstep with the Send button while sending or
-    // loading. `lfx-input-text` has no `disabled` input, so toggle the control
-    // directly — this makes "the input is disabled while sending" a real
-    // invariant the draft-restore in handleSendError depends on.
-    effect(() => {
-      const locked = this.isTyping() || this.isHistoryLoading();
-      const control = this.chatForm.controls.message;
-      if (locked && control.enabled) {
-        control.disable({ emitEvent: false });
-      } else if (!locked && control.disabled) {
-        control.enable({ emitEvent: false });
-      }
-    });
-  }
-
   // === Lifecycle ===
   public ngOnInit(): void {
     // SSR renders an empty panel — no localStorage, no network.
@@ -125,7 +109,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     // agent replies and the full history is reloaded, or rolled back on failure.
     const optimistic = this.buildMessage('user', text);
     this.messages.update((list) => [...list, optimistic]);
-    this.isTyping.set(true);
+    this.setTyping(true);
 
     const agentMessageBaseline = this.countAgentMessages();
     const ownerToken = sessionId ? this.sessionStore.getSession(agentId, sessionId)?.ownerToken : undefined;
@@ -155,7 +139,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
       return;
     }
     this.cancelInFlight();
-    this.isTyping.set(false);
+    this.setTyping(false);
     this.activeSessionId.set(sessionId);
     this.sessionStore.setActiveSessionId(this.agent().id, sessionId);
     this.loadHistory(sessionId);
@@ -163,7 +147,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
 
   protected onNewChat(): void {
     this.cancelInFlight();
-    this.isTyping.set(false);
+    this.setTyping(false);
     this.activeSessionId.set(null);
     this.messages.set([]);
     this.sessionStore.setActiveSessionId(this.agent().id, null);
@@ -180,7 +164,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
 
     // Deleting the open session: fall back to the most recent remaining one.
     this.cancelInFlight();
-    this.isTyping.set(false);
+    this.setTyping(false);
     const next = this.sessions()[0]?.sessionId ?? null;
     this.activeSessionId.set(next);
     this.sessionStore.setActiveSessionId(agentId, next);
@@ -217,15 +201,15 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   /** Load and display a session's full history; recover gracefully if it expired. */
   private loadHistory(sessionId: string): void {
     this.cancelInFlight();
-    this.isHistoryLoading.set(true);
+    this.setHistoryLoading(true);
     this.historySub = this.mktgAgents.getHistory(sessionId).subscribe({
       next: (messages) => {
-        this.isHistoryLoading.set(false);
+        this.setHistoryLoading(false);
         this.messages.set(messages);
       },
       error: (error) => {
         console.error('[mktg-chat] failed to load session history', error);
-        this.isHistoryLoading.set(false);
+        this.setHistoryLoading(false);
         if (isSessionGoneError(error)) {
           // Genuinely missing/expired upstream — safe to drop locally.
           this.handleExpiredSession(sessionId);
@@ -272,7 +256,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
           const agentMessages = messages.filter((message) => message.sender === 'agent').length;
           if (agentMessages > agentMessageBaseline) {
             this.messages.set(messages);
-            this.isTyping.set(false);
+            this.setTyping(false);
             this.cancelInFlight();
           }
         },
@@ -280,7 +264,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
           // Reached only when the deadline fires first — a reply unsubscribes via
           // cancelInFlight() before the timer can complete.
           if (this.isTyping()) {
-            this.isTyping.set(false);
+            this.setTyping(false);
             this.messages.update((list) => [
               ...list,
               this.buildMessage('agent', 'The agent is taking longer than usual to respond. Your message was sent — check back shortly.'),
@@ -307,6 +291,34 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     this.sendSub = null;
   }
 
+  // The "busy" signals and the input lock are written together so the message
+  // control is always disabled exactly when the Send button is. Done in these
+  // setters (not an effect) per the repo's no-effect()-for-side-effects rule.
+  private setTyping(value: boolean): void {
+    this.isTyping.set(value);
+    this.syncInputLock();
+  }
+
+  private setHistoryLoading(value: boolean): void {
+    this.isHistoryLoading.set(value);
+    this.syncInputLock();
+  }
+
+  /**
+   * Lock the message control while sending or loading. `lfx-input-text` exposes
+   * no `disabled` input, so toggle the FormControl directly — this makes the
+   * "input is disabled while sending" invariant the draft-restore relies on real.
+   */
+  private syncInputLock(): void {
+    const locked = this.isTyping() || this.isHistoryLoading();
+    const control = this.chatForm.controls.message;
+    if (locked && control.enabled) {
+      control.disable({ emitEvent: false });
+    } else if (!locked && control.disabled) {
+      control.enable({ emitEvent: false });
+    }
+  }
+
   /**
    * Recover from a failed send: roll back the optimistic bubble (the server never
    * received it), restore the user's draft so they can resend without retyping,
@@ -316,7 +328,7 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
    */
   private handleSendError(error: unknown, draft: string, optimisticId: string): void {
     console.error('[mktg-chat] failed to send message', error);
-    this.isTyping.set(false);
+    this.setTyping(false);
     this.messages.update((list) => list.filter((message) => message.id !== optimisticId));
     this.chatForm.controls.message.setValue(draft);
     this.messages.update((list) => [...list, this.buildMessage('agent', 'Sorry — that message could not be sent. Please try again.')]);

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser, NgClass } from '@angular/common';
-import { Component, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
+import { Component, computed, inject, input, OnDestroy, OnInit, output, PLATFORM_ID, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MktgAgent, MktgChatMessage, MktgChatSession } from '@lfx-one/shared/interfaces';
-import { catchError, of, Subscription, switchMap, takeUntil, timer } from 'rxjs';
+import { catchError, of, Subscription, switchMap, take, takeUntil, timer } from 'rxjs';
 
 import { MktgAgentsService } from '../../../shared/services/mktg-agents.service';
 import { MktgChatSessionService } from '../../../shared/services/mktg-chat-session.service';
@@ -47,6 +47,10 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   public readonly agent = input.required<MktgAgent>();
   public readonly back = output<void>();
 
+  // === Computed ===
+  // Header tag list joined once per agent change — keeps `join()` out of the template.
+  protected readonly tagsLabel = computed(() => this.agent().tags.join(' · '));
+
   // === Forms ===
   protected readonly chatForm = new FormGroup({
     message: new FormControl('', { nonNullable: true }),
@@ -60,9 +64,12 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   protected readonly isHistoryLoading = signal(false);
   protected readonly showSessions = signal(true);
 
-  // In-flight history fetch (load or poll); cancelled on agent/session switch so
-  // a stale response can never overwrite a newer conversation.
+  // In-flight history fetch (load or poll) and the in-flight send POST. Both are
+  // cancelled on agent/session switch and on destroy (via cancelInFlight) so a
+  // stale response can never overwrite a newer conversation or write to a
+  // destroyed component.
   private historySub: Subscription | null = null;
+  private sendSub: Subscription | null = null;
   private optimisticCounter = 0;
 
   // === Lifecycle ===
@@ -105,19 +112,24 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
     const agentMessageBaseline = this.countAgentMessages();
     const ownerToken = sessionId ? this.sessionStore.getSession(agentId, sessionId)?.ownerToken : undefined;
 
-    this.mktgAgents.sendMessage({ agentId, message: text, sessionId: sessionId ?? null, ownerToken }).subscribe({
-      next: (response) => {
-        if ('sessionId' in response) {
-          this.onSessionCreated(agentId, response.sessionId, response.ownerToken, text, agentMessageBaseline);
-        } else if (sessionId) {
-          this.pollForReply(sessionId, agentMessageBaseline);
-        }
-      },
-      error: () => {
-        this.isTyping.set(false);
-        this.messages.update((list) => [...list, this.buildMessage('agent', 'Sorry — that message could not be sent. Please try again.')]);
-      },
-    });
+    this.sendSub = this.mktgAgents
+      .sendMessage({ agentId, message: text, sessionId: sessionId ?? null, ownerToken })
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          if ('sessionId' in response) {
+            this.onSessionCreated(agentId, response.sessionId, response.ownerToken, text, agentMessageBaseline);
+          } else if (sessionId) {
+            this.pollForReply(sessionId, agentMessageBaseline);
+          } else {
+            // New-session request but the server returned the follow-up shape:
+            // there is no sessionId to poll, so fail soft instead of leaving the
+            // input wedged with `isTyping` stuck on.
+            this.handleSendError('unexpected follow-up response for a new session');
+          }
+        },
+        error: (error) => this.handleSendError(error),
+      });
   }
 
   protected onSelectSession(sessionId: string): void {
@@ -193,7 +205,8 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
         this.isHistoryLoading.set(false);
         this.messages.set(messages);
       },
-      error: () => {
+      error: (error) => {
+        console.error('[mktg-chat] failed to load session history', error);
         this.isHistoryLoading.set(false);
         this.handleExpiredSession(sessionId);
       },
@@ -211,7 +224,16 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
 
     this.historySub = timer(POLL_INTERVAL_MS, POLL_INTERVAL_MS)
       .pipe(
-        switchMap(() => this.mktgAgents.getHistory(sessionId).pipe(catchError(() => of(null)))),
+        switchMap(() =>
+          this.mktgAgents.getHistory(sessionId).pipe(
+            catchError((error) => {
+              // Swallow transient poll errors so a single hiccup doesn't abort the
+              // wait; the loop retries on the next tick.
+              console.warn('[mktg-chat] history poll failed, retrying', error);
+              return of(null);
+            })
+          )
+        ),
         takeUntil(deadline$)
       )
       .subscribe({
@@ -251,6 +273,16 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   private cancelInFlight(): void {
     this.historySub?.unsubscribe();
     this.historySub = null;
+    // Abandon any in-flight send so its continuation can't poll/swap into the
+    // wrong session (switch) or write after teardown (destroy).
+    this.sendSub?.unsubscribe();
+    this.sendSub = null;
+  }
+
+  private handleSendError(error: unknown): void {
+    console.error('[mktg-chat] failed to send message', error);
+    this.isTyping.set(false);
+    this.messages.update((list) => [...list, this.buildMessage('agent', 'Sorry — that message could not be sent. Please try again.')]);
   }
 
   private countAgentMessages(): number {

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-chat-panel/mktg-chat-panel.component.ts
@@ -322,9 +322,9 @@ export class MktgChatPanelComponent implements OnInit, OnDestroy {
   /**
    * Recover from a failed send: roll back the optimistic bubble (the server never
    * received it), restore the user's draft so they can resend without retyping,
-   * and surface an inline error. The message control is locked while sending (see
-   * the constructor effect), so no new input can have accumulated — restoring the
-   * draft can't clobber anything the user typed.
+   * and surface an inline error. The message control is locked while sending
+   * (`setTyping` → `syncInputLock`), so no new input can have accumulated —
+   * restoring the draft can't clobber anything the user typed.
    */
   private handleSendError(error: unknown, draft: string, optimisticId: string): void {
     console.error('[mktg-chat] failed to send message', error);

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.html
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.html
@@ -50,29 +50,9 @@
       </div>
     </div>
 
-    <!-- Chat surface (stub until LFXAI-99) -->
+    <!-- Per-agent chat surface (LFXAI-99) -->
     @if (selectedAgent(); as agent) {
-      <lfx-card data-testid="mktg-os-agents-chat-stub">
-        <div class="flex items-start justify-between gap-4">
-          <div class="flex items-center gap-3">
-            <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-gray-100 text-gray-500">
-              <i [class]="agent.icon + ' text-lg'" aria-hidden="true"></i>
-            </span>
-            <div class="flex flex-col">
-              <span class="font-medium text-sm text-gray-900">{{ agent.name }}</span>
-              <span class="text-xs text-gray-500">Chat with this agent opens here in a future update.</span>
-            </div>
-          </div>
-          <lfx-button
-            label="Back to marketplace"
-            icon="fa-light fa-arrow-left"
-            [text]="true"
-            size="small"
-            ariaLabel="Back to the marketplace"
-            data-testid="mktg-os-agents-chat-back-button"
-            (onClick)="clearSelection()" />
-        </div>
-      </lfx-card>
+      <lfx-mktg-chat-panel [agent]="agent" (back)="clearSelection()" />
     }
 
     <!-- Filtered Results — hidden while a chat surface is open -->

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents/mktg-os-agents.component.ts
@@ -5,13 +5,14 @@ import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MKTG_AGENTS, MKTG_OS_AGENTS_LABEL } from '@lfx-one/shared/constants';
 import { MktgAgent, MktgAgentAccent } from '@lfx-one/shared/interfaces';
+
+import { MktgChatPanelComponent } from '../mktg-chat-panel/mktg-chat-panel.component';
 
 // Marketplace landing for the Marketing OS marketplace (LFXAI-98). Renders the
 // catalog tiles, client-side search, and the placeholder Alerts / Agents-in-Process
@@ -20,7 +21,7 @@ import { MktgAgent, MktgAgentAccent } from '@lfx-one/shared/interfaces';
 // because the chat panel (LFXAI-99) is an in-page side panel, not a separate page.
 @Component({
   selector: 'lfx-mktg-os-agents',
-  imports: [NgClass, ReactiveFormsModule, ButtonComponent, CardComponent, InputTextComponent, TagComponent, EmptyStateComponent],
+  imports: [NgClass, ReactiveFormsModule, CardComponent, InputTextComponent, TagComponent, EmptyStateComponent, MktgChatPanelComponent],
   templateUrl: './mktg-os-agents.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/shared/services/mktg-agents.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mktg-agents.service.ts
@@ -1,0 +1,30 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { MktgChatMessage, MktgChatRequest, MktgChatResponse, MktgHistoryResponse } from '@lfx-one/shared/interfaces';
+import { map, Observable } from 'rxjs';
+
+// Frontend client for the Marketing OS Agents Guild proxy (LFXAI-99). Thin
+// wrapper over the BFF endpoints mounted at /api/mktg-agents — the Guild
+// credentials and routing live entirely server-side.
+@Injectable({ providedIn: 'root' })
+export class MktgAgentsService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Create a Guild session (no `sessionId`) or post a follow-up (with
+   * `sessionId` + `ownerToken`). A new session resolves to
+   * `{ sessionId, ownerToken }`; a follow-up resolves to `{ success: true }`.
+   */
+  public sendMessage(payload: MktgChatRequest): Observable<MktgChatResponse> {
+    return this.http.post<MktgChatResponse>('/api/mktg-agents/chat', payload);
+  }
+
+  /** Fetch a session's mapped chat history (oldest first). */
+  public getHistory(sessionId: string): Observable<MktgChatMessage[]> {
+    const params = new HttpParams().set('sessionId', sessionId);
+    return this.http.get<MktgHistoryResponse>('/api/mktg-agents/history', { params }).pipe(map((response) => response.messages));
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/mktg-agents.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mktg-agents.service.ts
@@ -22,7 +22,15 @@ export class MktgAgentsService {
     return this.http.post<MktgChatResponse>('/api/mktg-agents/chat', payload);
   }
 
-  /** Fetch a session's mapped chat history (oldest first). */
+  /**
+   * Fetch a session's mapped chat history (oldest first).
+   *
+   * Errors are intentionally NOT swallowed with a `catchError(() => of([]))`
+   * fallback: the caller distinguishes an expired/missing session (which it
+   * recovers from via `handleExpiredSession`) from a transient poll hiccup
+   * (which it retries). A service-level fallback would mask both and make that
+   * recovery path dead code.
+   */
   public getHistory(sessionId: string): Observable<MktgChatMessage[]> {
     const params = new HttpParams().set('sessionId', sessionId);
     return this.http.get<MktgHistoryResponse>('/api/mktg-agents/history', { params }).pipe(map((response) => response.messages));

--- a/apps/lfx-one/src/app/shared/services/mktg-chat-session.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mktg-chat-session.service.ts
@@ -1,0 +1,97 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { MktgChatSession } from '@lfx-one/shared/interfaces';
+
+// localStorage keys for the Marketing OS chat panel (LFXAI-99). Names ported
+// from the guild_embed prototype so existing local sessions keep working.
+const ACTIVE_SESSION_IDS_KEY = 'guild_active_session_ids';
+const AGENT_SESSIONS_KEY = 'guild_agent_sessions';
+
+/**
+ * Browser-only persistence for Marketing OS chat sessions.
+ *
+ * Sessions are a UX convenience (the "Past Chats" drawer) and a place to keep
+ * each session's `ownerToken` for follow-ups — they are NOT a security boundary
+ * (the server independently verifies the owner token on every write). All access
+ * is guarded by `isPlatformBrowser` so SSR renders an empty, side-effect-free
+ * panel. A corrupt/unreadable store degrades to empty rather than throwing.
+ */
+@Injectable({ providedIn: 'root' })
+export class MktgChatSessionService {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /** The active session id for an agent, or null when none is selected. */
+  public getActiveSessionId(agentId: string): string | null {
+    return this.readMap(ACTIVE_SESSION_IDS_KEY)[agentId] ?? null;
+  }
+
+  /** Set (or clear, when `sessionId` is null) the active session for an agent. */
+  public setActiveSessionId(agentId: string, sessionId: string | null): void {
+    const map = this.readMap(ACTIVE_SESSION_IDS_KEY);
+    if (sessionId) {
+      map[agentId] = sessionId;
+    } else {
+      delete map[agentId];
+    }
+    this.writeJson(ACTIVE_SESSION_IDS_KEY, map);
+  }
+
+  /** All persisted sessions for an agent (most recent first). */
+  public getSessions(agentId: string): MktgChatSession[] {
+    return this.readSessions()[agentId] ?? [];
+  }
+
+  /** A single session by id, used to recover its `ownerToken` for follow-ups. */
+  public getSession(agentId: string, sessionId: string): MktgChatSession | undefined {
+    return this.getSessions(agentId).find((session) => session.sessionId === sessionId);
+  }
+
+  /** Prepend a newly created session to an agent's list. */
+  public addSession(agentId: string, session: MktgChatSession): void {
+    const all = this.readSessions();
+    all[agentId] = [session, ...(all[agentId] ?? []).filter((existing) => existing.sessionId !== session.sessionId)];
+    this.writeJson(AGENT_SESSIONS_KEY, all);
+  }
+
+  /** Remove a session from an agent's list; clears the active id if it matched. */
+  public removeSession(agentId: string, sessionId: string): void {
+    const all = this.readSessions();
+    all[agentId] = (all[agentId] ?? []).filter((existing) => existing.sessionId !== sessionId);
+    this.writeJson(AGENT_SESSIONS_KEY, all);
+
+    if (this.getActiveSessionId(agentId) === sessionId) {
+      this.setActiveSessionId(agentId, null);
+    }
+  }
+
+  private readSessions(): Record<string, MktgChatSession[]> {
+    return this.readMap<MktgChatSession[]>(AGENT_SESSIONS_KEY);
+  }
+
+  private readMap<T = string>(key: string): Record<string, T> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return {};
+    }
+    try {
+      const raw = localStorage.getItem(key);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, T>) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeJson(key: string, value: unknown): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Quota exceeded or storage unavailable — sessions are best-effort.
+    }
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/mktg-chat-session.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mktg-chat-session.service.ts
@@ -78,7 +78,9 @@ export class MktgChatSessionService {
     try {
       const raw = localStorage.getItem(key);
       const parsed = raw ? (JSON.parse(raw) as unknown) : null;
-      return parsed && typeof parsed === 'object' ? (parsed as Record<string, T>) : {};
+      // Arrays are objects too, but keyed writes on an array are dropped by
+      // JSON.stringify — treat a corrupted array value as an empty map.
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, T>) : {};
     } catch {
       return {};
     }

--- a/packages/shared/src/interfaces/mktg-chat.interface.ts
+++ b/packages/shared/src/interfaces/mktg-chat.interface.ts
@@ -35,6 +35,23 @@ export interface MktgSessionInfo {
 }
 
 /**
+ * A chat session as persisted client-side (localStorage) for the "Past Chats"
+ * drawer. Carries the `ownerToken` needed to post follow-ups plus presentation
+ * metadata (`title`, `createdAt`) that the server history endpoint does not
+ * return. Stored per-agent: `Record<agentId, MktgChatSession[]>`.
+ */
+export interface MktgChatSession {
+  /** Guild session id returned on session creation. */
+  sessionId: string;
+  /** Owner token from the create response; required to post follow-ups. */
+  ownerToken: string;
+  /** Display label for the drawer — derived from the first user message. */
+  title: string;
+  /** ISO-8601 creation timestamp, used to order and label sessions. */
+  createdAt: string;
+}
+
+/**
  * Request body for `POST /api/mktg-agents/chat`.
  * Omit/null `sessionId` to create a new session; provide it to post a follow-up.
  */


### PR DESCRIPTION
## Summary

Implements **LFXAI-99** — the final story of the LFX Marketing OS Marketplace epic (LFXAI-95). Ports the `guild_embed` chat UX into an Angular per-agent chat panel, wired to the existing `/api/mktg-agents` Guild proxy (shipped in #1032) with **REST polling** instead of streaming (MVP, no `ws` dependency). Replaces the marketplace chat stub.

## What's included

- **`MktgChatPanelComponent`** — per-agent chat surface: optimistic send, history polling until a new agent reply (~1.5s cadence, ~60s deadline), typing indicator, Past Chats drawer (select/delete), New Chat, back-to-grid, draft-restore + optimistic rollback on send failure, and non-destructive recovery (drops a session only on a genuine 404/410, not on a transient error).
- **`MktgAgentsService`** — thin HTTP client for chat (create/follow-up) + history.
- **`MktgChatSessionService`** — SSR-safe `localStorage` persistence (`guild_active_session_ids` / `guild_agent_sessions`), retaining each session's owner token for follow-ups; a corrupt store degrades to empty.
- **`MktgChatSession`** added to the shared chat contract.
- Marketplace stub replaced with `<lfx-mktg-chat-panel>`.

## Testing

- `yarn check-types`, `yarn lint`, `yarn build` (SSR) all green; license headers pass.
- Verified locally against the live `linux-foundation/marketing-os` Guild workspace (agent `foundation-message`, `READY` / published `v1.0.4`): create → poll → reply round-trip, follow-ups, session switch, new chat, delete, and expired-session recovery. First replies take ~15–25s (well within the 60s poll deadline).

## Documented trade-offs

- **No unit/e2e specs.** This app has no component/service unit-test convention (Playwright e2e only), and the chat surface is LaunchDarkly-gated + requires a live Guild backend, so a meaningful e2e cannot run green in CI yet — consistent with LFXAI-98, which shipped the marketplace without e2e. To be added when the flag goes GA. `data-testid`s are in place throughout.
- **`getHistory` intentionally omits a `catchError` fallback** — the component distinguishes an expired session (recover) from a transient poll error (retry); a service-level fallback would make that recovery path dead code.
- **Branch / JIRA key uses LFXAI, not LFXV2** — this workstream is tracked on the LFXAI board (matches PRs #1029 / #1032).

## Not included (stays dark-launched)

The local-dev flag-bypass (`MKTG_OS_FORCE_ENABLED`) is intentionally **not** committed — Marketing OS stays gated behind the `mktg-os-agents-enabled` LaunchDarkly flag (default off; visible only via the targeting rule).

Relates to: LFXAI-99 · epic LFXAI-95.
