### PR TITLE
docs(crowdfunding): improve in-app documentation with Fin structure and FAQ (LFXV2-2532)

### DIFF
--- a/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/components/docs-topic-card/docs-topic-card.component.ts
@@ -48,6 +48,7 @@ export class DocsTopicCardComponent {
     profile: { icon: 'fa-light fa-user', container: 'bg-gray-200 text-gray-900' },
     settings: { icon: 'fa-light fa-gear', container: 'bg-gray-200 text-gray-900' },
     transactions: { icon: 'fa-light fa-receipt', container: 'bg-gray-200 text-gray-900' },
+    crowdfunding: { icon: 'fa-solid fa-box-dollar', container: 'bg-blue-500 text-white' },
   };
 
   protected readonly articleCountLabel = computed(() => {

--- a/docs/user/crowdfunding/faq/index.md
+++ b/docs/user/crowdfunding/faq/index.md
@@ -1,0 +1,43 @@
+---
+title: Crowdfunding FAQ
+description: Frequently asked questions about crowdfunding initiatives and donations in LFX Self Serve.
+audience: [all]
+product_area: Crowdfunding
+tags: [crowdfunding, faq, initiatives, donations, recurring, refunds]
+last_generated: 2026-06-29
+last_updated: 2026-06-29
+intercom_collection: Crowdfunding
+---
+
+## Why can't I see my initiative on the crowdfunding site?
+
+Your initiative may not be publicly visible if its status is Pending, Submitted, Hidden, or Declined. Only Published initiatives appear on the public crowdfunding site and accept donations. Check your initiative status under **Crowdfunding → My Initiatives** in LFX Self Serve. If your initiative is Pending or Submitted, it is still under review by the Linux Foundation team.
+
+## How do I submit a new crowdfunding initiative?
+
+New initiatives are submitted through the public crowdfunding site at [crowdfunding.linuxfoundation.org](https://crowdfunding.linuxfoundation.org), not through LFX Self Serve. Once your initiative is reviewed and approved, it will appear in the **My Initiatives** section of LFX Self Serve where you can manage it.
+
+## What types of crowdfunding initiatives are supported?
+
+LFX Crowdfunding supports four fund types:
+
+- **General Fund** — supports a project's general development and operating expenses
+- **Security Audit** — funds a third-party security review or penetration test of the project's code
+- **Mentorship** — funds a mentorship program that trains new contributors to the project
+- **Event** — funds a conference, summit, or community event organized around the project
+
+## What happens to my recurring donors when I archive an initiative?
+
+Archiving an initiative stops the initiative from accepting new donations, but it does not automatically cancel existing recurring subscriptions. Donors who have active recurring donations to the initiative will continue to be charged on their billing cycle until they manually cancel their subscriptions. If you archive an initiative, notify your recurring donors so they can cancel their subscriptions through [Manage Recurring Donations](../manage-recurring-donations/).
+
+## How do I cancel a recurring donation I made?
+
+To cancel a recurring donation, go to **Crowdfunding → My Donations** in LFX Self Serve, find the donation in the recurring donations list, open its detail page, and select **Cancel Recurring Donation**. Cancellation stops all future charges immediately. Past charges are not refunded. See [Manage Recurring Donations](../manage-recurring-donations/) for full steps.
+
+## Why is a charge on my recurring donation showing as Failed?
+
+A charge fails when the linked payment method cannot be processed — for example, because the card is expired, declined, or has been removed from your account. To resolve it, check that your saved payment method is valid and up to date under **Crowdfunding → My Donations → Payment Methods**. See [Manage Payment Methods](../manage-payment-methods/) for steps to add or update a card.
+
+## Can I get a refund for a crowdfunding donation?
+
+Crowdfunding donations are contributions to open-source project funds and are generally non-refundable. If you believe a charge was made in error, contact LFX support through the Help Center with the donation date, amount, and initiative name so the support team can investigate.

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, donations, funding, sponsors]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 
@@ -43,5 +43,6 @@ Go to **app.lfx.dev** and select **Crowdfunding** from the left navigation sideb
 
 ## Related sections
 
+- [Crowdfunding FAQ](./faq/) — answers to common questions about initiatives and donations
 - [Transactions](../transactions/) — view purchase and billing history across all LFX products
 - [Profile](../profile/) — manage your account details associated with your donations

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -9,9 +9,12 @@ last_updated: 2026-06-16
 intercom_collection: Crowdfunding
 ---
 
-These steps apply to users who have created crowdfunding initiatives. If you have not created any initiatives, this section does not apply to your account.
+This article explains how to edit, archive, and activate crowdfunding initiatives you own in LFX Self Serve. Select an initiative from the [View Initiatives](../view-initiatives/) page to open its detail page, where you can review financials, edit settings, and change the initiative's status.
 
-Select an initiative from the [View Initiatives](../view-initiatives/) page to open its detail page. From the detail page you can review financials, edit initiative settings, and change the initiative's status.
+## Before you begin
+
+- Sign in to LFX Self Serve at [app.lfx.dev](https://app.lfx.dev) with your Linux Foundation account.
+- You must have created at least one crowdfunding initiative. These steps apply to initiative owners only.
 
 ## Initiative detail page
 

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, manage, edit, archive, activate]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -11,6 +11,11 @@ intercom_collection: Crowdfunding
 
 Your saved payment methods are listed at the bottom of the My Donations page. Each entry shows the card brand, the last four digits, and the expiry date. You can add a new card or remove an existing one at any time.
 
+## Before you begin
+
+- Sign in to LFX Self Serve at [app.lfx.dev](https://app.lfx.dev) with your Linux Foundation account.
+- Before deleting a card: check whether it is linked to any active recurring donations. Deleting it will cause those donations to fail on the next billing cycle. To avoid missed charges, cancel the recurring donation first — see [Manage Recurring Donations](../manage-recurring-donations/).
+
 ## Add a payment method
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
@@ -20,7 +25,9 @@ Your saved payment methods are listed at the bottom of the My Donations page. Ea
 5. Enter your card number, expiry date, and CVC (the 3-digit security code on the back of the card) in the dialog that appears.
 6. Confirm to save the card.
 
-The new card appears in your payment methods list and can be used for future donations.
+## After completing (add)
+
+The new card appears in your payment methods list immediately and can be used for future donations.
 
 ## Delete a payment method
 
@@ -32,7 +39,9 @@ The new card appears in your payment methods list and can be used for future don
 4. Select **Delete** next to the card you want to remove.
 5. Confirm the deletion.
 
-The card is removed from your account.
+## After completing (delete)
+
+The card is removed from your account immediately. Any active recurring donations linked to that card will fail on their next billing cycle — cancel them before removing the card if you want to stop future charges cleanly.
 
 ## Frequently asked
 

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, payment methods, add, delete, credit card]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 

--- a/docs/user/crowdfunding/manage-recurring-donations/index.md
+++ b/docs/user/crowdfunding/manage-recurring-donations/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, recurring donations, cancel, subscription, manage]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 

--- a/docs/user/crowdfunding/manage-recurring-donations/index.md
+++ b/docs/user/crowdfunding/manage-recurring-donations/index.md
@@ -9,7 +9,12 @@ last_updated: 2026-06-16
 intercom_collection: Crowdfunding
 ---
 
-A recurring donation is a monthly subscription that automatically charges your saved payment method each billing cycle. You can view the details of a recurring donation and cancel it at any time from the recurring donation detail page.
+This article explains how to view your recurring donation details and how to cancel a recurring donation subscription in LFX Self Serve. A recurring donation is a monthly subscription that automatically charges your saved payment method each billing cycle. You can view the details of a recurring donation and cancel it at any time from the recurring donation detail page.
+
+## Before you begin
+
+- Sign in to LFX Self Serve at [app.lfx.dev](https://app.lfx.dev) with your Linux Foundation account.
+- You must have at least one active recurring donation. If your recurring donations list is empty, you have no active subscriptions.
 
 ## View recurring donation details
 

--- a/docs/user/crowdfunding/view-donations/index.md
+++ b/docs/user/crowdfunding/view-donations/index.md
@@ -34,6 +34,11 @@ A paginated table lists all your donations in chronological order, including bot
 - Donation kind (Monthly or One-time)
 - Amount
 
+## Before you begin
+
+- Sign in to LFX Self Serve at [app.lfx.dev](https://app.lfx.dev) with your Linux Foundation account.
+- You must have made at least one donation. If the page shows no history, you have not donated to any initiative yet. Donations are made on the public crowdfunding site at [crowdfunding.linuxfoundation.org](https://crowdfunding.linuxfoundation.org).
+
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
@@ -42,6 +47,10 @@ A paginated table lists all your donations in chronological order, including bot
 4. Scroll down to the recurring donations list to see your active subscriptions.
 5. Scroll further to the donation history table to see all past contributions.
 6. Select a recurring donation to open its detail page.
+
+## After completing
+
+Your full donation history is visible in the table. Selecting a recurring donation opens its detail page where you can review charge history or cancel the subscription — see [Manage Recurring Donations](../manage-recurring-donations/).
 
 ## Related
 

--- a/docs/user/crowdfunding/view-donations/index.md
+++ b/docs/user/crowdfunding/view-donations/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, donations, view, history, recurring, one-time]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 

--- a/docs/user/crowdfunding/view-initiatives/index.md
+++ b/docs/user/crowdfunding/view-initiatives/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, view, status, list]
 last_generated: 2026-06-16
-last_updated: 2026-06-16
+last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---
 

--- a/docs/user/crowdfunding/view-initiatives/index.md
+++ b/docs/user/crowdfunding/view-initiatives/index.md
@@ -31,6 +31,11 @@ Below the stats bar, your initiatives are displayed as cards. Use the status fil
 
 Each filter pill shows the count of initiatives in that group. The list supports pagination with a load-more button.
 
+## Before you begin
+
+- Sign in to LFX Self Serve at [app.lfx.dev](https://app.lfx.dev) with your Linux Foundation account.
+- You must have created at least one crowdfunding initiative. If the My Initiatives section is empty, you have not created any initiatives yet — new initiatives are submitted at [crowdfunding.linuxfoundation.org](https://crowdfunding.linuxfoundation.org).
+
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
@@ -39,14 +44,9 @@ Each filter pill shows the count of initiatives in that group. The list supports
 4. Select a status filter pill (**Active**, **Pending**, or **Archived**) to narrow the list.
 5. Select an initiative card to open its detail page.
 
-## Fund types
+## After completing
 
-Each initiative has a fund type that describes its purpose:
-
-- **General Fund** — supports the project's general development and operating expenses
-- **Security Audit** — funds a third-party security review or penetration test of the project's code
-- **Mentorship** — funds a mentorship program that trains new contributors to the project
-- **Event** — funds a conference, summit, or community event organized around the project
+The initiative detail page opens, where you can review financials and manage the initiative. See [Manage Initiatives](../manage-initiatives/) for available actions.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add `docs/user/crowdfunding/faq/index.md` — standalone FAQ article (7 questions) covering initiative status, fund types, archiving donors, cancelling subscriptions, failed charges, and refunds; crowdfunding was the only docs section missing a top-level FAQ
- Add `Before you begin` and `After completing` sections to all procedural articles (`view-initiatives`, `view-donations`, `manage-initiatives`, `manage-recurring-donations`, `manage-payment-methods`) per Fin/Intercom best-practice structure
- Fix two misplaced `After completing` sections introduced during drafting — removed from `manage-initiatives` (was before the steps) and `manage-recurring-donations` (was between unrelated action sections); inline confirmation text already covered both cases
- Improve `manage-initiatives` intro to be Fin-surfaceable: now states the article covers edit, archive, and activate rather than starting with a navigation instruction
- Add explicit topic sentence to `manage-recurring-donations` intro so Fin can surface the article without relying on the title
- Replace `LF SSO` jargon with `Linux Foundation account` across all Before you begin sections (Fin/Intercom Pillar 8: defined terms)
- Add crowdfunding FAQ link to the landing `index.md` Related sections
- Add `crowdfunding` entry to `topicVisuals` in `docs-topic-card.component.ts`: icon `fa-solid fa-box-dollar` (matches My Initiatives sidebar entry) with `bg-blue-500 text-white` style (matches Surveys section)

## Notes

Screenshots are required by LFXV2-2532 but are not part of this PR — they need manual capture from the production UI at `app.lfx.dev/crowdfunding` and will be handled separately. The `lfx-intercom` skill's `fin-best-practices.md` does not itself mandate screenshots; the requirement is ticket-specific.