### PR TITLE
fix(akrites): add assign stewardship action to packages list

### DIFF
--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
@@ -139,7 +139,17 @@
         [disabled]="bulkActionLoading()"
         (click)="onBulkOpen()"
         data-testid="akrites-bulk-open">
+        <i class="fa-light fa-folder-open" aria-hidden="true"></i>
         Open for stewardship
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        [disabled]="bulkActionLoading()"
+        (click)="onBulkAssignSteward()"
+        data-testid="akrites-bulk-assign-steward">
+        <i class="fa-light fa-user-group" aria-hidden="true"></i>
+        Assign steward
       </button>
       <button
         type="button"
@@ -147,6 +157,7 @@
         [disabled]="bulkActionLoading()"
         (click)="onBulkEscalate()"
         data-testid="akrites-bulk-escalate">
+        <i class="fa-light fa-paper-plane" aria-hidden="true"></i>
         Escalate
       </button>
     </div>
@@ -164,3 +175,10 @@
 
 <!-- Bulk Escalate Modal -->
 <lfx-akrites-escalate-modal [(visible)]="bulkEscalateVisible" [packageName]="null" [loading]="bulkActionLoading()" (confirm)="onBulkEscalateConfirm($event)" />
+
+<!-- Bulk Assign Steward Modal -->
+<lfx-akrites-assign-steward-modal
+  [(visible)]="bulkAssignStewardVisible"
+  [packageName]="null"
+  [loading]="bulkActionLoading()"
+  (confirm)="onBulkAssignStewardConfirm($event)" />

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
@@ -135,7 +135,7 @@
       <div class="w-px h-6 bg-gray-300"></div>
       <button
         type="button"
-        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
         [disabled]="bulkActionLoading()"
         (click)="onBulkOpen()"
         data-testid="akrites-bulk-open">
@@ -153,7 +153,7 @@
       </button>
       <button
         type="button"
-        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
         [disabled]="bulkActionLoading()"
         (click)="onBulkEscalate()"
         data-testid="akrites-bulk-escalate">

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
@@ -89,6 +89,7 @@
         (toggleAll)="onToggleAll($event)"
         (clearFilters)="onClearFilters()"
         (pageChange)="onPageChange($event)"
+        (stewardshipChanged)="onStewardshipChanged()"
         data-testid="akrites-packages-tab">
       </lfx-akrites-packages-tab>
     }

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html
@@ -121,7 +121,7 @@
   <!-- Bulk Actions Bar -->
   @if (showBulkActions()) {
     <div
-      class="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white border border-gray-300 rounded-xl shadow-lg px-4 py-3 flex items-center gap-3 z-40"
+      class="fixed bottom-6 left-1/2 lg:left-[calc(50%+172px)] -translate-x-1/2 bg-white border border-gray-300 rounded-xl shadow-lg px-4 py-3 flex items-center gap-3 z-40"
       data-testid="akrites-bulk-actions-bar">
       <button
         type="button"

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -275,7 +275,7 @@ export class AkritesDashboardComponent {
 
   protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
     const selected = this.selectedPackages();
-    const eligible = this.packages().filter((p) => selected.has(p.id) && p.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(p.status));
+    const eligible = this.packages().filter((p) => selected.has(p.id) && AKRITES_ASSIGNABLE_STATUSES.has(p.status));
     if (this.bulkActionLoading()) return;
     if (!eligible.length) {
       this.bulkAssignStewardVisible.set(false);

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -4,7 +4,13 @@
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AKRITES_VALID_TABS, AKRITES_DEFAULT_TAB, AKRITES_DEFAULT_VISIBLE_STATUSES, AKRITES_TOTAL_STATUSES } from '@lfx-one/shared/constants';
+import {
+  AKRITES_ASSIGNABLE_STATUSES,
+  AKRITES_VALID_TABS,
+  AKRITES_DEFAULT_TAB,
+  AKRITES_DEFAULT_VISIBLE_STATUSES,
+  AKRITES_TOTAL_STATUSES,
+} from '@lfx-one/shared/constants';
 import {
   AkritesAssignStewardRequest,
   AkritesFilterState,
@@ -269,14 +275,16 @@ export class AkritesDashboardComponent {
 
   protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
     const selected = this.selectedPackages();
-    const eligible = this.packages().filter((p) => selected.has(p.id) && p.stewardshipId !== null);
+    const eligible = this.packages().filter(
+      (p) => selected.has(p.id) && p.stewardshipId !== null && p.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(p.status)
+    );
     if (this.bulkActionLoading()) return;
     if (!eligible.length) {
       this.bulkAssignStewardVisible.set(false);
       this.messageService.add({
         severity: 'info',
         summary: 'No eligible packages',
-        detail: 'None of the selected packages have an open stewardship record to assign.',
+        detail: 'None of the selected packages are eligible for steward assignment.',
       });
       return;
     }

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -6,6 +6,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ActivatedRoute, Router } from '@angular/router';
 import { AKRITES_VALID_TABS, AKRITES_DEFAULT_TAB, AKRITES_DEFAULT_VISIBLE_STATUSES, AKRITES_TOTAL_STATUSES } from '@lfx-one/shared/constants';
 import {
+  AkritesAssignStewardRequest,
   AkritesFilterState,
   AkritesListParams,
   AkritesLoadResult,
@@ -24,6 +25,7 @@ import { AkritesService } from '@shared/services/akrites.service';
 import { AkritesPackageDrawerComponent } from '../components/akrites-package-drawer/akrites-package-drawer.component';
 import { AkritesPackagesTabComponent } from '../components/akrites-packages-tab/akrites-packages-tab.component';
 import { AkritesEscalateModalComponent } from '../components/akrites-escalate-modal/akrites-escalate-modal.component';
+import { AkritesAssignStewardModalComponent } from '../components/akrites-assign-steward-modal/akrites-assign-steward-modal.component';
 import { AkritesOverviewTabComponent } from '../components/akrites-overview-tab/akrites-overview-tab.component';
 import { AkritesTriageTabComponent } from '../components/akrites-triage-tab/akrites-triage-tab.component';
 import { AkritesRiskMatrixTabComponent } from '../components/akrites-risk-matrix-tab/akrites-risk-matrix-tab.component';
@@ -34,6 +36,7 @@ import { AkritesRiskMatrixTabComponent } from '../components/akrites-risk-matrix
     AkritesPackageDrawerComponent,
     AkritesPackagesTabComponent,
     AkritesEscalateModalComponent,
+    AkritesAssignStewardModalComponent,
     AkritesOverviewTabComponent,
     AkritesTriageTabComponent,
     AkritesRiskMatrixTabComponent,
@@ -53,6 +56,7 @@ export class AkritesDashboardComponent {
   protected readonly selectedPackages = signal<Set<string>>(new Set());
   protected readonly showBulkActions = computed(() => this.selectedPackages().size > 0);
   protected readonly bulkEscalateVisible = signal(false);
+  protected readonly bulkAssignStewardVisible = signal(false);
   protected readonly bulkActionLoading = signal(false);
 
   // Bumped after a steward admin action to force the package list and activity feed to re-fetch.
@@ -255,6 +259,58 @@ export class AkritesDashboardComponent {
         error: () => {
           this.bulkActionLoading.set(false);
           this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Some packages could not be opened. Please try again.' });
+        },
+      });
+  }
+
+  protected onBulkAssignSteward(): void {
+    this.bulkAssignStewardVisible.set(true);
+  }
+
+  protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
+    const selected = this.selectedPackages();
+    const eligible = this.packages().filter((p) => selected.has(p.id) && p.stewardshipId !== null);
+    if (this.bulkActionLoading()) return;
+    if (!eligible.length) {
+      this.bulkAssignStewardVisible.set(false);
+      this.messageService.add({
+        severity: 'info',
+        summary: 'No eligible packages',
+        detail: 'None of the selected packages have an open stewardship record to assign.',
+      });
+      return;
+    }
+    this.bulkAssignStewardVisible.set(false);
+    this.bulkActionLoading.set(true);
+    forkJoin(
+      eligible.map((p) =>
+        this.akritesService.assignSteward(String(p.stewardshipId!), body).pipe(
+          map(() => true),
+          catchError(() => of(false))
+        )
+      )
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (results) => {
+          const succeeded = results.filter(Boolean).length;
+          const failed = results.length - succeeded;
+          this.bulkActionLoading.set(false);
+          if (succeeded > 0) {
+            this.messageService.add({
+              severity: failed > 0 ? 'warn' : 'success',
+              summary: failed > 0 ? 'Partial success' : 'Success',
+              detail: failed > 0 ? `${succeeded} assigned, ${failed} failed.` : `Steward assigned to ${succeeded} package(s).`,
+            });
+            this.clearSelection();
+            this.reloadTrigger.update((n) => n + 1);
+          } else {
+            this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No packages could be assigned. Please try again.' });
+          }
+        },
+        error: () => {
+          this.bulkActionLoading.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Assignment failed. Please try again.' });
         },
       });
   }

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -28,7 +28,6 @@ import {
 import { switchMap, catchError, of, map, debounceTime, tap, forkJoin, take, filter } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { AkritesService } from '@shared/services/akrites.service';
-import { ProjectContextService } from '@shared/services/project-context.service';
 import { AkritesPackageDrawerComponent } from '../components/akrites-package-drawer/akrites-package-drawer.component';
 import { AkritesPackagesTabComponent } from '../components/akrites-packages-tab/akrites-packages-tab.component';
 import { AkritesEscalateModalComponent } from '../components/akrites-escalate-modal/akrites-escalate-modal.component';
@@ -56,14 +55,11 @@ export class AkritesDashboardComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  private readonly projectContextService = inject(ProjectContextService);
-
   protected readonly activeTab = this.initActiveTab();
   protected readonly selectedPackageId = signal<string | null>(null);
   protected readonly drawerVisible = signal(false);
   protected readonly selectedPackages = signal<Set<string>>(new Set());
-  protected readonly canWrite = computed(() => this.projectContextService.canWrite());
-  protected readonly showBulkActions = computed(() => this.canWrite() && this.selectedPackages().size > 0);
+  protected readonly showBulkActions = computed(() => this.selectedPackages().size > 0);
   protected readonly bulkEscalateVisible = signal(false);
   protected readonly bulkAssignStewardVisible = signal(false);
   protected readonly bulkActionLoading = signal(false);
@@ -231,7 +227,6 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkOpen(): void {
-    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const unassigned = this.packages().filter((p) => selected.has(p.id) && p.status === 'unassigned');
     if (this.bulkActionLoading()) return;
@@ -278,7 +273,6 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
-    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const eligible = this.packages().filter((p) => selected.has(p.id) && AKRITES_ASSIGNABLE_STATUSES.has(p.status));
     if (this.bulkActionLoading()) return;
@@ -330,7 +324,6 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkEscalateConfirm(body: AkritesEscalateRequest): void {
-    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const eligible = this.packages().filter((p) => selected.has(p.id) && p.stewardshipId !== null);
     if (this.bulkActionLoading()) return;

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -275,9 +275,7 @@ export class AkritesDashboardComponent {
 
   protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
     const selected = this.selectedPackages();
-    const eligible = this.packages().filter(
-      (p) => selected.has(p.id) && p.stewardshipId !== null && p.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(p.status)
-    );
+    const eligible = this.packages().filter((p) => selected.has(p.id) && p.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(p.status));
     if (this.bulkActionLoading()) return;
     if (!eligible.length) {
       this.bulkAssignStewardVisible.set(false);
@@ -291,12 +289,15 @@ export class AkritesDashboardComponent {
     this.bulkAssignStewardVisible.set(false);
     this.bulkActionLoading.set(true);
     forkJoin(
-      eligible.map((p) =>
-        this.akritesService.assignSteward(String(p.stewardshipId!), body).pipe(
+      eligible.map((p) => {
+        const stewardshipId$ =
+          p.stewardshipId !== null ? of(String(p.stewardshipId)) : this.akritesService.openStewardship(p.purl).pipe(map((res) => res.stewardship.id));
+        return stewardshipId$.pipe(
+          switchMap((id) => this.akritesService.assignSteward(id, body)),
           map(() => true),
           catchError(() => of(false))
-        )
-      )
+        );
+      })
     )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -317,10 +317,6 @@ export class AkritesDashboardComponent {
             this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No packages could be assigned. Please try again.' });
           }
         },
-        error: () => {
-          this.bulkActionLoading.set(false);
-          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Assignment failed. Please try again.' });
-        },
       });
   }
 

--- a/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts
@@ -28,6 +28,7 @@ import {
 import { switchMap, catchError, of, map, debounceTime, tap, forkJoin, take, filter } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { AkritesService } from '@shared/services/akrites.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
 import { AkritesPackageDrawerComponent } from '../components/akrites-package-drawer/akrites-package-drawer.component';
 import { AkritesPackagesTabComponent } from '../components/akrites-packages-tab/akrites-packages-tab.component';
 import { AkritesEscalateModalComponent } from '../components/akrites-escalate-modal/akrites-escalate-modal.component';
@@ -55,12 +56,14 @@ export class AkritesDashboardComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly projectContextService = inject(ProjectContextService);
 
   protected readonly activeTab = this.initActiveTab();
   protected readonly selectedPackageId = signal<string | null>(null);
   protected readonly drawerVisible = signal(false);
   protected readonly selectedPackages = signal<Set<string>>(new Set());
-  protected readonly showBulkActions = computed(() => this.selectedPackages().size > 0);
+  protected readonly canWrite = computed(() => this.projectContextService.canWrite());
+  protected readonly showBulkActions = computed(() => this.canWrite() && this.selectedPackages().size > 0);
   protected readonly bulkEscalateVisible = signal(false);
   protected readonly bulkAssignStewardVisible = signal(false);
   protected readonly bulkActionLoading = signal(false);
@@ -228,6 +231,7 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkOpen(): void {
+    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const unassigned = this.packages().filter((p) => selected.has(p.id) && p.status === 'unassigned');
     if (this.bulkActionLoading()) return;
@@ -274,6 +278,7 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
+    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const eligible = this.packages().filter((p) => selected.has(p.id) && AKRITES_ASSIGNABLE_STATUSES.has(p.status));
     if (this.bulkActionLoading()) return;
@@ -325,6 +330,7 @@ export class AkritesDashboardComponent {
   }
 
   protected onBulkEscalateConfirm(body: AkritesEscalateRequest): void {
+    if (!this.canWrite()) return;
     const selected = this.selectedPackages();
     const eligible = this.packages().filter((p) => selected.has(p.id) && p.stewardshipId !== null);
     if (this.bulkActionLoading()) return;

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -219,7 +219,7 @@
         <th>Steward</th>
         <th>Last activity</th>
         <th>Stewardship</th>
-        <th class="w-12"></th>
+        <th class="w-12"><span class="sr-only">Row actions</span></th>
       </tr>
     </ng-template>
     <ng-template #loadingbody let-rowData>

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -387,7 +387,7 @@
         </td>
         <td><lfx-tag [value]="formatStatus(pkg.status)" [severity]="getStatusTagSeverity(pkg.status)" [rounded]="true" /></td>
         <td (click)="$event.stopPropagation()" class="text-right">
-          @if (canWrite() && assignablePackageIds().has(pkg.id)) {
+          @if (assignablePackageIds().has(pkg.id)) {
             <lfx-button
               icon="fa-solid fa-ellipsis-vertical"
               [text]="true"

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -387,7 +387,7 @@
         </td>
         <td><lfx-tag [value]="formatStatus(pkg.status)" [severity]="getStatusTagSeverity(pkg.status)" [rounded]="true" /></td>
         <td (click)="$event.stopPropagation()" class="text-right">
-          @if (canWrite() && canAssignSteward(pkg)) {
+          @if (canWrite() && assignablePackageIds().has(pkg.id)) {
             <lfx-button
               icon="fa-solid fa-ellipsis-vertical"
               [text]="true"

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -393,6 +393,7 @@
               [text]="true"
               [rounded]="true"
               size="small"
+              ariaLabel="Package actions"
               styleClass="!text-slate-400 hover:!text-slate-600 hover:!bg-slate-100"
               (onClick)="onRowMenuOpen($event, pkg, rowActionMenu)"
               [attr.data-testid]="'akrites-row-action-' + pkg.id" />

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -219,6 +219,7 @@
         <th>Steward</th>
         <th>Last activity</th>
         <th>Stewardship</th>
+        <th class="w-12"></th>
       </tr>
     </ng-template>
     <ng-template #loadingbody let-rowData>
@@ -243,6 +244,7 @@
           </div>
         </td>
         <td><div class="lfx-skeleton-bar w-16"></div></td>
+        <td></td>
       </tr>
     </ng-template>
     <ng-template #body let-pkg>
@@ -384,12 +386,31 @@
           }
         </td>
         <td><lfx-tag [value]="formatStatus(pkg.status)" [severity]="getStatusTagSeverity(pkg.status)" [rounded]="true" /></td>
+        <td (click)="$event.stopPropagation()" class="text-right">
+          @if (canWrite() && canAssignSteward(pkg)) {
+            <lfx-button
+              icon="fa-solid fa-ellipsis-vertical"
+              [text]="true"
+              [rounded]="true"
+              size="small"
+              styleClass="!text-slate-400 hover:!text-slate-600 hover:!bg-slate-100"
+              (onClick)="onRowMenuOpen($event, pkg, rowActionMenu)"
+              [attr.data-testid]="'akrites-row-action-' + pkg.id" />
+            <lfx-menu #rowActionMenu [model]="rowActionItems()" [popup]="true" appendTo="body" />
+          }
+        </td>
       </tr>
     </ng-template>
     <ng-template #emptymessage>
       <tr>
-        <td colspan="10" class="text-center py-8 text-sm text-gray-500">No packages match the current filters.</td>
+        <td colspan="11" class="text-center py-8 text-sm text-gray-500">No packages match the current filters.</td>
       </tr>
     </ng-template>
   </lfx-table>
 </div>
+
+<lfx-akrites-assign-steward-modal
+  [(visible)]="assignModalVisible"
+  [packageName]="assignTargetPackage()?.name ?? null"
+  [loading]="actionLoading()"
+  (confirm)="onAssignStewardConfirm($event)" />

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -232,7 +232,7 @@ export class AkritesPackagesTabComponent {
   }
 
   protected canAssignSteward(pkg: AkritesPackage): boolean {
-    return pkg.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(pkg.status);
+    return AKRITES_ASSIGNABLE_STATUSES.has(pkg.status);
   }
 
   protected onRowMenuOpen(event: Event, pkg: AkritesPackage, menu: { toggle: (e: Event) => void }): void {

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -15,7 +15,6 @@ import {
 } from '@lfx-one/shared/constants';
 import { AkritesAssignStewardRequest, AkritesFilterChip, AkritesFilterState, AkritesPackage, AkritesStatusCounts } from '@lfx-one/shared/interfaces';
 import { AkritesService } from '@shared/services/akrites.service';
-import { ProjectContextService } from '@shared/services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { map, of, switchMap, take } from 'rxjs';
 import { ButtonComponent } from '@components/button/button.component';
@@ -54,7 +53,6 @@ export class AkritesPackagesTabComponent {
   private readonly akritesService = inject(AkritesService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly projectContextService = inject(ProjectContextService);
   private readonly formBuilder = inject(FormBuilder);
 
   public readonly packages = input<AkritesPackage[]>([]);
@@ -102,7 +100,6 @@ export class AkritesPackagesTabComponent {
   protected readonly assignModalVisible = signal(false);
   protected readonly assignTargetPackage = signal<AkritesPackage | null>(null);
   protected readonly actionLoading = signal(false);
-  protected readonly canWrite = computed(() => this.projectContextService.canWrite());
   protected readonly assignablePackageIds = computed(
     () =>
       new Set(
@@ -247,8 +244,8 @@ export class AkritesPackagesTabComponent {
   protected onAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
     const pkg = this.assignTargetPackage();
     if (!pkg || this.actionLoading()) return;
-    if (!this.canWrite() || !this.assignablePackageIds().has(pkg.id)) {
-      this.messageService.add({ severity: 'error', summary: 'Not allowed', detail: 'You do not have permission to assign a steward to this package.' });
+    if (!this.assignablePackageIds().has(pkg.id)) {
+      this.messageService.add({ severity: 'error', summary: 'Not allowed', detail: 'This package is not eligible for steward assignment.' });
       return;
     }
     this.actionLoading.set(true);

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -247,6 +247,10 @@ export class AkritesPackagesTabComponent {
   protected onAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
     const pkg = this.assignTargetPackage();
     if (!pkg || this.actionLoading()) return;
+    if (!this.canWrite() || !this.assignablePackageIds().has(pkg.id)) {
+      this.messageService.add({ severity: 'error', summary: 'Not allowed', detail: 'You do not have permission to assign a steward to this package.' });
+      return;
+    }
     this.actionLoading.set(true);
 
     const stewardshipId$ =

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, output, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder } from '@angular/forms';
 import {
   AKRITES_ECOSYSTEM_OPTIONS,
@@ -11,12 +12,18 @@ import {
   AKRITES_STATUS_PILLS,
   AKRITES_VULN_OPTIONS,
 } from '@lfx-one/shared/constants';
-import { AkritesFilterChip, AkritesFilterState, AkritesPackage, AkritesStatusCounts } from '@lfx-one/shared/interfaces';
+import { AkritesAssignStewardRequest, AkritesFilterChip, AkritesFilterState, AkritesPackage, AkritesStatusCounts } from '@lfx-one/shared/interfaces';
+import { AkritesService } from '@shared/services/akrites.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { map, of, switchMap, take } from 'rxjs';
 import { ButtonComponent } from '@components/button/button.component';
 import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { AkritesAssignStewardModalComponent } from '../akrites-assign-steward-modal/akrites-assign-steward-modal.component';
 import { StewardInitialsPipe } from '../../pipes/steward-initials.pipe';
 import {
   formatStatus,
@@ -28,12 +35,27 @@ import {
   getStatusTagSeverity,
 } from '../../akrites.utils';
 
+const ASSIGNABLE_STATUSES = new Set(['unassigned', 'open', 'assessing', 'escalated', 'inactive']);
+
 @Component({
   selector: 'lfx-akrites-packages-tab',
-  imports: [ButtonComponent, CheckboxComponent, SelectComponent, StewardInitialsPipe, TableComponent, TagComponent],
+  imports: [
+    AkritesAssignStewardModalComponent,
+    ButtonComponent,
+    CheckboxComponent,
+    MenuComponent,
+    SelectComponent,
+    StewardInitialsPipe,
+    TableComponent,
+    TagComponent,
+  ],
   templateUrl: './akrites-packages-tab.component.html',
 })
 export class AkritesPackagesTabComponent {
+  private readonly akritesService = inject(AkritesService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly formBuilder = inject(FormBuilder);
 
   public readonly packages = input<AkritesPackage[]>([]);
@@ -74,9 +96,14 @@ export class AkritesPackagesTabComponent {
   public readonly toggleAll = output<{ checked: boolean }>();
   public readonly clearFilters = output<void>();
   public readonly pageChange = output<{ page: number; pageSize: number }>();
+  public readonly stewardshipChanged = output<void>();
 
   protected readonly sortMenuOpen = signal(false);
   protected readonly filterPanelOpen = signal(false);
+  protected readonly assignModalVisible = signal(false);
+  protected readonly assignTargetPackage = signal<AkritesPackage | null>(null);
+  protected readonly actionLoading = signal(false);
+  protected readonly canWrite = computed(() => this.projectContextService.canWrite());
 
   protected readonly statusPills = AKRITES_STATUS_PILLS;
   protected readonly sortOptions = AKRITES_SORT_OPTIONS;
@@ -124,6 +151,16 @@ export class AkritesPackagesTabComponent {
   protected readonly getHealthTagSeverity = getHealthTagSeverity;
   protected readonly getHealthLabel = getHealthLabel;
   protected readonly getAdvisoryTagSeverity = getAdvisoryTagSeverity;
+
+  protected readonly rowActionItems = computed(() => [
+    {
+      label: 'Assign stewardship',
+      icon: 'fa-light fa-user-plus',
+      command: () => {
+        this.assignModalVisible.set(true);
+      },
+    },
+  ]);
 
   protected isPackageSelected(id: string): boolean {
     return this.selectedPackages().has(id);
@@ -193,5 +230,43 @@ export class AkritesPackagesTabComponent {
   protected onTablePage(event: { first: number; rows: number }): void {
     const page = Math.floor(event.first / event.rows) + 1;
     this.pageChange.emit({ page, pageSize: event.rows });
+  }
+
+  protected canAssignSteward(pkg: AkritesPackage): boolean {
+    return pkg.status !== null && ASSIGNABLE_STATUSES.has(pkg.status);
+  }
+
+  protected onRowMenuOpen(event: Event, pkg: AkritesPackage, menu: { toggle: (e: Event) => void }): void {
+    this.assignTargetPackage.set(pkg);
+    menu.toggle(event);
+  }
+
+  protected onAssignStewardConfirm(body: AkritesAssignStewardRequest): void {
+    const pkg = this.assignTargetPackage();
+    if (!pkg || this.actionLoading()) return;
+    this.actionLoading.set(true);
+
+    const stewardshipId$ =
+      pkg.stewardshipId !== null ? of(String(pkg.stewardshipId)) : this.akritesService.openStewardship(pkg.purl).pipe(map((res) => res.stewardship.id));
+
+    stewardshipId$
+      .pipe(
+        switchMap((id) => this.akritesService.assignSteward(id, body)),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: () => {
+          this.assignModalVisible.set(false);
+          this.assignTargetPackage.set(null);
+          this.actionLoading.set(false);
+          this.messageService.add({ severity: 'success', summary: 'Assigned', detail: `Steward assigned to ${pkg.name}.` });
+          this.stewardshipChanged.emit();
+        },
+        error: () => {
+          this.actionLoading.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not assign steward. Please try again.' });
+        },
+      });
   }
 }

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -103,6 +103,14 @@ export class AkritesPackagesTabComponent {
   protected readonly assignTargetPackage = signal<AkritesPackage | null>(null);
   protected readonly actionLoading = signal(false);
   protected readonly canWrite = computed(() => this.projectContextService.canWrite());
+  protected readonly assignablePackageIds = computed(
+    () =>
+      new Set(
+        this.packages()
+          .filter((p) => AKRITES_ASSIGNABLE_STATUSES.has(p.status))
+          .map((p) => p.id)
+      )
+  );
 
   protected readonly statusPills = AKRITES_STATUS_PILLS;
   protected readonly sortOptions = AKRITES_SORT_OPTIONS;
@@ -229,10 +237,6 @@ export class AkritesPackagesTabComponent {
   protected onTablePage(event: { first: number; rows: number }): void {
     const page = Math.floor(event.first / event.rows) + 1;
     this.pageChange.emit({ page, pageSize: event.rows });
-  }
-
-  protected canAssignSteward(pkg: AkritesPackage): boolean {
-    return AKRITES_ASSIGNABLE_STATUSES.has(pkg.status);
   }
 
   protected onRowMenuOpen(event: Event, pkg: AkritesPackage, menu: { toggle: (e: Event) => void }): void {

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -5,6 +5,7 @@ import { Component, DestroyRef, computed, inject, input, output, signal } from '
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder } from '@angular/forms';
 import {
+  AKRITES_ASSIGNABLE_STATUSES,
   AKRITES_ECOSYSTEM_OPTIONS,
   AKRITES_HEALTH_OPTIONS,
   AKRITES_LIFECYCLE_OPTIONS,
@@ -34,8 +35,6 @@ import {
   getLifecycleTagSeverity,
   getStatusTagSeverity,
 } from '../../akrites.utils';
-
-const ASSIGNABLE_STATUSES = new Set(['unassigned', 'open', 'assessing', 'escalated', 'inactive']);
 
 @Component({
   selector: 'lfx-akrites-packages-tab',
@@ -233,7 +232,7 @@ export class AkritesPackagesTabComponent {
   }
 
   protected canAssignSteward(pkg: AkritesPackage): boolean {
-    return pkg.status !== null && ASSIGNABLE_STATUSES.has(pkg.status);
+    return pkg.status !== null && AKRITES_ASSIGNABLE_STATUSES.has(pkg.status);
   }
 
   protected onRowMenuOpen(event: Event, pkg: AkritesPackage, menu: { toggle: (e: Event) => void }): void {

--- a/packages/shared/src/constants/akrites.constants.ts
+++ b/packages/shared/src/constants/akrites.constants.ts
@@ -112,6 +112,9 @@ export const AKRITES_UPDATABLE_STATUS_OPTIONS: Array<{ value: AkritesUpdatableSt
   { value: 'inactive', label: 'Inactive' },
 ];
 
+/** Stewardship statuses for which assigning a steward is permitted. */
+export const AKRITES_ASSIGNABLE_STATUSES = new Set<AkritesStatus>(['unassigned', 'open', 'assessing', 'escalated', 'inactive']);
+
 /** Valid dashboard tabs for the Akrites module. */
 export const AKRITES_VALID_TABS = new Set<AkritesDashboardTab>(['overview', 'packages', 'triage', 'risk-matrix']);
 


### PR DESCRIPTION
## Summary

- Adds a row-level "Assign stewardship" ellipsis menu to each package row in the Packages tab list, gated on `canWrite()` and the package's assignable status
- Adds a "Assign steward" bulk action button (between "Open for stewardship" and "Escalate") in the bulk actions bar that opens `AkritesAssignStewardModalComponent` for selected packages
- Adds Font Awesome icons to all three bulk action buttons (folder-open, user-group, paper-plane)
- Centers the bulk actions bar horizontally relative to the main content area (accounting for the 344px sidebar offset)

## Ticket

CM-1288

## Files Changed

- `apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts` — injected `AkritesService`, `MessageService`, `ProjectContextService`; added `assignModalVisible`, `assignTargetPackage`, `actionLoading`, `canWrite` signals; added `rowActionItems` computed; added `canAssignSteward()`, `onRowMenuOpen()`, `onAssignStewardConfirm()` methods
- `apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html` — added action column with `lfx-button` + `lfx-menu` per row; added `lfx-akrites-assign-steward-modal`
- `apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.ts` — added `bulkAssignStewardVisible` signal; added `onBulkAssignSteward()` and `onBulkAssignStewardConfirm()` methods; imported `AkritesAssignStewardModalComponent`
- `apps/lfx-one/src/app/modules/akrites/akrites-dashboard/akrites-dashboard.component.html` — added "Assign steward" bulk action button with icon; added icons to all bulk action buttons; added `lfx-akrites-assign-steward-modal`; fixed bulk bar horizontal centering for sidebar offset
