### PR TITLE
fix(meetings): allow single-character names when adding meeting guests

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.html
@@ -18,6 +18,13 @@
         placeholder="Enter first name"
         data-testid="public-registration-firstname-input">
       </lfx-input-text>
+      @if (
+        (form.get('first_name')?.errors?.['required'] || form.get('first_name')?.errors?.['pattern']) &&
+        form.get('first_name')?.touched &&
+        form.get('first_name')?.dirty
+      ) {
+        <p class="text-sm text-red-500" role="alert" data-testid="public-registration-firstname-error">First name cannot be empty</p>
+      }
     </div>
 
     <!-- Last Name -->
@@ -31,6 +38,13 @@
         placeholder="Enter last name"
         data-testid="public-registration-lastname-input">
       </lfx-input-text>
+      @if (
+        (form.get('last_name')?.errors?.['required'] || form.get('last_name')?.errors?.['pattern']) &&
+        form.get('last_name')?.touched &&
+        form.get('last_name')?.dirty
+      ) {
+        <p class="text-sm text-red-500" role="alert" data-testid="public-registration-lastname-error">Last name cannot be empty</p>
+      }
     </div>
 
     <!-- Email -->

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -32,8 +32,8 @@ export class PublicRegistrationModalComponent {
 
   public constructor() {
     this.form = new FormGroup({
-      first_name: new FormControl('', [Validators.required, Validators.minLength(2)]),
-      last_name: new FormControl('', [Validators.required, Validators.minLength(2)]),
+      first_name: new FormControl('', [Validators.required, Validators.pattern(/\S/)]),
+      last_name: new FormControl('', [Validators.required, Validators.pattern(/\S/)]),
       email: new FormControl('', [Validators.required, Validators.email]),
       job_title: new FormControl(''),
       org_name: new FormControl(''),

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
@@ -70,7 +70,7 @@
             form().get('first_name')?.touched &&
             form().get('first_name')?.dirty
           ) {
-            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-firstname-error">First name is required</p>
+            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-firstname-error">First name cannot be empty</p>
           }
         </div>
 
@@ -90,7 +90,7 @@
             form().get('last_name')?.touched &&
             form().get('last_name')?.dirty
           ) {
-            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-lastname-error">Last name is required</p>
+            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-lastname-error">Last name cannot be empty</p>
           }
         </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
@@ -24,6 +24,12 @@
             (onUserSelect)="handleUserSelection()"
             (onManualEntry)="switchToManualEntry()">
           </lfx-user-search>
+          @if (searchSelectionError()) {
+            <p class="mt-2 text-sm text-red-500 flex items-center gap-1" data-testid="registrant-form-search-selection-error">
+              <i class="fa-light fa-circle-exclamation"></i>
+              {{ searchSelectionError() }}
+            </p>
+          }
         </div>
         <div class="flex items-center justify-center gap-3 mt-3">
           <span class="flex-1 border-t border-gray-200"></span>
@@ -59,6 +65,9 @@
             placeholder="Enter first name"
             data-testid="registrant-form-firstname-input">
           </lfx-input-text>
+          @if (form().get('first_name')?.errors?.['required'] && form().get('first_name')?.touched) {
+            <p class="text-sm text-red-500" data-testid="registrant-form-firstname-error">First name is required</p>
+          }
         </div>
 
         <!-- Last Name -->
@@ -72,6 +81,9 @@
             placeholder="Enter last name"
             data-testid="registrant-form-lastname-input">
           </lfx-input-text>
+          @if (form().get('last_name')?.errors?.['required'] && form().get('last_name')?.touched) {
+            <p class="text-sm text-red-500" data-testid="registrant-form-lastname-error">Last name is required</p>
+          }
         </div>
 
         <!-- Email -->

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
@@ -26,7 +26,7 @@
           </lfx-user-search>
           @if (searchSelectionError()) {
             <p class="mt-2 text-sm text-red-500 flex items-center gap-1" role="alert" data-testid="registrant-form-search-selection-error">
-              <i class="fa-light fa-circle-exclamation"></i>
+              <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
               {{ searchSelectionError() }}
             </p>
           }
@@ -65,7 +65,11 @@
             placeholder="Enter first name"
             data-testid="registrant-form-firstname-input">
           </lfx-input-text>
-          @if (form().get('first_name')?.errors?.['required'] && form().get('first_name')?.touched && form().get('first_name')?.dirty) {
+          @if (
+            (form().get('first_name')?.errors?.['required'] || form().get('first_name')?.errors?.['pattern']) &&
+            form().get('first_name')?.touched &&
+            form().get('first_name')?.dirty
+          ) {
             <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-firstname-error">First name is required</p>
           }
         </div>
@@ -81,7 +85,11 @@
             placeholder="Enter last name"
             data-testid="registrant-form-lastname-input">
           </lfx-input-text>
-          @if (form().get('last_name')?.errors?.['required'] && form().get('last_name')?.touched && form().get('last_name')?.dirty) {
+          @if (
+            (form().get('last_name')?.errors?.['required'] || form().get('last_name')?.errors?.['pattern']) &&
+            form().get('last_name')?.touched &&
+            form().get('last_name')?.dirty
+          ) {
             <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-lastname-error">Last name is required</p>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
@@ -24,12 +24,6 @@
             (onUserSelect)="handleUserSelection()"
             (onManualEntry)="switchToManualEntry()">
           </lfx-user-search>
-          @if (searchSelectionError()) {
-            <p class="mt-2 text-sm text-red-500 flex items-center gap-1" role="alert" data-testid="registrant-form-search-selection-error">
-              <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
-              {{ searchSelectionError() }}
-            </p>
-          }
         </div>
         <div class="flex items-center justify-center gap-3 mt-3">
           <span class="flex-1 border-t border-gray-200"></span>

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html
@@ -25,7 +25,7 @@
             (onManualEntry)="switchToManualEntry()">
           </lfx-user-search>
           @if (searchSelectionError()) {
-            <p class="mt-2 text-sm text-red-500 flex items-center gap-1" data-testid="registrant-form-search-selection-error">
+            <p class="mt-2 text-sm text-red-500 flex items-center gap-1" role="alert" data-testid="registrant-form-search-selection-error">
               <i class="fa-light fa-circle-exclamation"></i>
               {{ searchSelectionError() }}
             </p>
@@ -65,8 +65,8 @@
             placeholder="Enter first name"
             data-testid="registrant-form-firstname-input">
           </lfx-input-text>
-          @if (form().get('first_name')?.errors?.['required'] && form().get('first_name')?.touched) {
-            <p class="text-sm text-red-500" data-testid="registrant-form-firstname-error">First name is required</p>
+          @if (form().get('first_name')?.errors?.['required'] && form().get('first_name')?.touched && form().get('first_name')?.dirty) {
+            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-firstname-error">First name is required</p>
           }
         </div>
 
@@ -81,8 +81,8 @@
             placeholder="Enter last name"
             data-testid="registrant-form-lastname-input">
           </lfx-input-text>
-          @if (form().get('last_name')?.errors?.['required'] && form().get('last_name')?.touched) {
-            <p class="text-sm text-red-500" data-testid="registrant-form-lastname-error">Last name is required</p>
+          @if (form().get('last_name')?.errors?.['required'] && form().get('last_name')?.touched && form().get('last_name')?.dirty) {
+            <p class="text-sm text-red-500" role="alert" data-testid="registrant-form-lastname-error">Last name is required</p>
           }
         </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
@@ -26,7 +26,6 @@ export class RegistrantFormComponent {
 
   // State to track whether we're showing search or individual fields
   public showIndividualFields = signal(false);
-  public searchSelectionError = signal<string | null>(null);
 
   public constructor() {
     // If we have an existing registrant, show individual fields immediately
@@ -48,7 +47,6 @@ export class RegistrantFormComponent {
    */
   public handleUserSelection(): void {
     this.form().markAsDirty();
-    this.searchSelectionError.set(null);
 
     const firstName = this.form().get('first_name')?.value?.trim();
     const lastName = this.form().get('last_name')?.value?.trim();
@@ -80,7 +78,6 @@ export class RegistrantFormComponent {
     const hostValue = this.form().get('host')?.value;
     this.form().reset();
     this.form().get('host')?.setValue(hostValue);
-    this.searchSelectionError.set(null);
     this.showIndividualFields.set(true);
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
@@ -26,6 +26,7 @@ export class RegistrantFormComponent {
 
   // State to track whether we're showing search or individual fields
   public showIndividualFields = signal(false);
+  public searchSelectionError = signal<string | null>(null);
 
   public constructor() {
     // If we have an existing registrant, show individual fields immediately
@@ -46,9 +47,25 @@ export class RegistrantFormComponent {
    * Emit event for parent to add the user directly to the guest list
    */
   public handleUserSelection(): void {
-    // The search component has already populated the form controls
-    // Emit event so parent can add the user directly
     this.form().markAsDirty();
+    this.searchSelectionError.set(null);
+
+    const firstName = this.form().get('first_name')?.value?.trim();
+    const lastName = this.form().get('last_name')?.value?.trim();
+
+    if (!firstName && !lastName) {
+      this.searchSelectionError.set("This user's profile is missing a first and last name. Please enter their details manually.");
+      return;
+    }
+    if (!firstName) {
+      this.searchSelectionError.set("This user's profile is missing a first name. Please enter their details manually.");
+      return;
+    }
+    if (!lastName) {
+      this.searchSelectionError.set("This user's profile is missing a last name. Please enter their details manually.");
+      return;
+    }
+
     this.onUserSelected.emit();
   }
 
@@ -56,12 +73,10 @@ export class RegistrantFormComponent {
    * Switch to manual entry mode when user clicks "Enter details manually"
    */
   public switchToManualEntry(): void {
-    // Clear the form for manual entry
-    const hostValue = this.form().get('host')?.value; // Preserve host checkbox state
+    const hostValue = this.form().get('host')?.value;
     this.form().reset();
     this.form().get('host')?.setValue(hostValue);
-
-    // Show individual fields for manual entry
+    this.searchSelectionError.set(null);
     this.showIndividualFields.set(true);
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts
@@ -53,19 +53,23 @@ export class RegistrantFormComponent {
     const firstName = this.form().get('first_name')?.value?.trim();
     const lastName = this.form().get('last_name')?.value?.trim();
 
-    if (!firstName && !lastName) {
-      this.searchSelectionError.set("This user's profile is missing a first and last name. Please enter their details manually.");
-      return;
-    }
-    if (!firstName) {
-      this.searchSelectionError.set("This user's profile is missing a first name. Please enter their details manually.");
-      return;
-    }
-    if (!lastName) {
-      this.searchSelectionError.set("This user's profile is missing a last name. Please enter their details manually.");
+    if (!firstName || !lastName) {
+      // Auto-switch to individual fields, preserving all populated controls,
+      // and mark the missing field(s) as touched+dirty so validation renders.
+      this.showIndividualFields.set(true);
+      if (!firstName) {
+        this.form().get('first_name')?.markAsTouched();
+        this.form().get('first_name')?.markAsDirty();
+      }
+      if (!lastName) {
+        this.form().get('last_name')?.markAsTouched();
+        this.form().get('last_name')?.markAsDirty();
+      }
       return;
     }
 
+    this.form().get('first_name')?.setValue(firstName);
+    this.form().get('last_name')?.setValue(lastName);
     this.onUserSelected.emit();
   }
 

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -491,8 +491,8 @@ export class MeetingService {
    */
   public createRegistrantFormGroup(includeAddMore: boolean = false): FormGroup {
     const controls: any = {
-      first_name: new FormControl('', [Validators.required, Validators.minLength(2)]),
-      last_name: new FormControl('', [Validators.required, Validators.minLength(2)]),
+      first_name: new FormControl('', [Validators.required, Validators.minLength(1)]),
+      last_name: new FormControl('', [Validators.required, Validators.minLength(1)]),
       email: new FormControl('', [Validators.required, Validators.email]),
       job_title: new FormControl(''),
       org_name: new FormControl(''),

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -491,8 +491,8 @@ export class MeetingService {
    */
   public createRegistrantFormGroup(includeAddMore: boolean = false): FormGroup {
     const controls: any = {
-      first_name: new FormControl('', [Validators.required, Validators.minLength(1)]),
-      last_name: new FormControl('', [Validators.required, Validators.minLength(1)]),
+      first_name: new FormControl('', [Validators.required, Validators.minLength(1), Validators.pattern(/\S/)]),
+      last_name: new FormControl('', [Validators.required, Validators.minLength(1), Validators.pattern(/\S/)]),
       email: new FormControl('', [Validators.required, Validators.email]),
       job_title: new FormControl(''),
       org_name: new FormControl(''),

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -491,8 +491,8 @@ export class MeetingService {
    */
   public createRegistrantFormGroup(includeAddMore: boolean = false): FormGroup {
     const controls: any = {
-      first_name: new FormControl('', [Validators.required, Validators.minLength(1), Validators.pattern(/\S/)]),
-      last_name: new FormControl('', [Validators.required, Validators.minLength(1), Validators.pattern(/\S/)]),
+      first_name: new FormControl('', [Validators.required, Validators.pattern(/\S/)]),
+      last_name: new FormControl('', [Validators.required, Validators.pattern(/\S/)]),
       email: new FormControl('', [Validators.required, Validators.email]),
       job_title: new FormControl(''),
       org_name: new FormControl(''),


### PR DESCRIPTION
## Summary

- **Root cause:** `Validators.minLength(2)` on `first_name` and `last_name` in `MeetingService.createRegistrantFormGroup()` and `PublicRegistrationModalComponent` silently blocked guests with single-character names (e.g. `last_name: 'S'`). The form was invalid so the add action no-opped with no user feedback.
- **Fix:** Replace `minLength(2)` with `[Validators.required, Validators.pattern(/\S/)]` — `required` rejects empty strings, `pattern` rejects whitespace-only input, and real single-character names pass correctly. Applied consistently to both the shared form group (`MeetingService.createRegistrantFormGroup()`) and the public registration modal.
- **UX improvement — missing name on search selection:** When a selected user profile is missing a first or last name, `handleUserSelection()` auto-switches to individual fields (`showIndividualFields.set(true)`) and marks the missing control(s) as `touched` + `dirty` so inline validation renders immediately. All other populated fields (email, org_name, etc.) are preserved — no form reset.
- **Name normalization:** Trimmed first/last name values are written back via `setValue()` before `onUserSelected.emit()`, so downstream consumers always receive clean data.
- **Manual entry errors:** Inline "cannot be empty" error messages under `first_name` and `last_name` fire on both `required` and `pattern` errors (gated by `touched && dirty`, consistent with the email error pattern). All error nodes carry `role="alert"` for screen reader announcement; decorative icons carry `aria-hidden="true"`.
- **Public registration modal errors:** Inline "cannot be empty" error messages added for `first_name` and `last_name` in the public registration modal, matching the same `required || pattern`, `touched && dirty`, `role="alert"` pattern used in the registrant form.

## Affected files

- `apps/lfx-one/src/app/shared/services/meeting.service.ts` — validator stack updated to `[Validators.required, Validators.pattern(/\S/)]` on `first_name` and `last_name` controls
- `apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.ts` — `handleUserSelection()` auto-expands individual fields on missing name, normalizes trimmed values before emit
- `apps/lfx-one/src/app/modules/meetings/components/registrant-form/registrant-form.component.html` — "cannot be empty" error messages for manual-entry first/last name with `role="alert"` and `touched && dirty` gating
- `apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts` — validators aligned to `[Validators.required, Validators.pattern(/\S/)]` to match the shared form group
- `apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.html` — inline "cannot be empty" error messages for `first_name` and `last_name` with `role="alert"` and `touched && dirty` gating

## Test plan

- [ ] Search for `yskumar@contractor.linuxfoundation.org` (last_name: "S") when editing a meeting's Invite Guests step — confirm they can be added successfully
- [ ] Search for a user with no first_name or last_name — confirm the form auto-expands to individual fields, the missing field(s) show inline validation errors, and other populated fields (email, org_name) are preserved
- [ ] Enter a single-character first or last name manually — confirm form accepts it
- [ ] Enter only whitespace in first_name or last_name manually and blur the field — confirm "cannot be empty" error appears
- [ ] Leave first_name or last_name empty in manual-entry mode and blur the field — confirm "cannot be empty" error appears
- [ ] Register via the public meeting registration modal with a single-character first or last name — confirm it is accepted
- [ ] Leave first_name or last_name empty in the public registration modal and submit — confirm "cannot be empty" error appears inline
- [ ] Normal guests (full names) still add without any change in behavior