### PR TITLE
fix(committees): align onScheduleMeeting with surveys/votes permission-check pattern

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.html
@@ -94,7 +94,8 @@
             severity="info"
             size="small"
             [class]="isCalendarView() ? 'md:ml-auto' : ''"
-            (click)="onScheduleMeeting()"
+            [loading]="creating()"
+            (onClick)="onScheduleMeeting()"
             data-testid="committee-meetings-create-btn"></lfx-button>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -178,6 +178,7 @@ export class CommitteeMeetingsComponent {
   }
 
   protected onScheduleMeeting(): void {
+    if (this.creating()) return;
     const committee = this.committee();
     const overviewPath = this.lensService.activeLens() === 'foundation' ? '/foundation/overview' : '/project/overview';
     const denyParams: Record<string, string> = { _notice: 'meetings' };

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -17,12 +17,13 @@ import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS, SURVEY_COLO
 import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
 import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
+import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
 import { VoteService } from '@services/vote.service';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, debounceTime, distinctUntilChanged, filter, finalize, forkJoin, map, of, startWith, switchMap, take, tap } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, finalize, forkJoin, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { IcalSubscribeDialogComponent } from '../ical-subscribe-dialog/ical-subscribe-dialog.component';
 
@@ -45,6 +46,7 @@ import { IcalSubscribeDialogComponent } from '../ical-subscribe-dialog/ical-subs
 })
 export class CommitteeMeetingsComponent {
   private readonly committeeService = inject(CommitteeService);
+  private readonly lensService = inject(LensService);
   private readonly meetingService = inject(MeetingService);
   private readonly voteService = inject(VoteService);
   private readonly surveyService = inject(SurveyService);
@@ -94,6 +96,7 @@ export class CommitteeMeetingsComponent {
   public meetingsLoading = signal(true);
   public pastMeetingsLoading = signal(false);
   public calendarLoading = signal(false);
+  public creating = signal(false);
 
   // Data — upcoming meetings
   public upcomingMeetings: Signal<Meeting[]> = this.initUpcomingMeetings();
@@ -174,20 +177,20 @@ export class CommitteeMeetingsComponent {
     }
   }
 
-  /** Checks committee write permission fresh before navigating to the create-meeting route.
-   * If the permission has been revoked since the page loaded (e.g. Manager demoted to Member),
-   * redirects to the project overview with _notice=meetings so AppComponent shows the toast —
-   * consistent with the writerGuard denial flow. */
-  public onScheduleMeeting(): void {
+  protected onScheduleMeeting(): void {
     const committee = this.committee();
-    const slug = committee.project_slug;
+    const overviewPath = this.lensService.activeLens() === 'foundation' ? '/foundation/overview' : '/project/overview';
     const denyParams: Record<string, string> = { _notice: 'meetings' };
-    if (slug) denyParams['project'] = slug;
-    const deny = () => void this.router.navigate(['/project/overview'], { queryParams: denyParams });
+    if (committee.project_slug) denyParams['project'] = committee.project_slug;
+    const deny = () => void this.router.navigate([overviewPath], { queryParams: denyParams });
 
+    this.creating.set(true);
     this.committeeService
-      .getCommittee(committee.uid)
-      .pipe(take(1))
+      .fetchCommittee(committee.uid)
+      .pipe(
+        finalize(() => this.creating.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe({
         next: (fresh) => {
           if (fresh?.writer !== true) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -177,6 +177,7 @@ export class CommitteeMeetingsComponent {
     }
   }
 
+  /** Checks writer permission fresh before navigating — prevents a demoted member from reaching /meetings/create. */
   protected onScheduleMeeting(): void {
     if (this.creating()) return;
     const committee = this.committee();


### PR DESCRIPTION
## Summary

Brings `CommitteeMeetingsComponent.onScheduleMeeting()` to full parity with the pattern established in the parallel PRs for surveys (#1000), votes (#997), and mailing-list (#1016).

Five changes — all identified during review of those sibling PRs:

- **`fetchCommittee()` over `getCommittee()`** — avoids the `tap()` side-effect that mutates the shared `CommitteeService.committee` signal during a permission-only check; matches the surveys/votes approach
- **Lens-aware redirect** — injects `LensService` and uses `activeLens()` to select `/foundation/overview` vs `/project/overview`; meetings was the only committee tab still using a hardcoded `/project/overview`
- **`creating = signal(false)` double-click guard** — set before `fetchCommittee()`, cleared in `finalize()`, bound as `[loading]="creating()"` on the Schedule Meeting button; prevents rapid double-clicks queuing multiple in-flight permission checks
- **`(onClick)` over `(click)`** — `ButtonComponent` emits `(onClick)`, not a native click event; the previous `(click)` binding was silently a no-op on the async check (the `routerLink` still navigated, bypassing the guard)
- **`protected` visibility on `onScheduleMeeting()`** — template-only method; `protected` makes intent clear and matches the surveys/votes convention

## Related PRs
- #1000 — surveys permission check (same pattern, origin)
- #997 — votes permission check (same pattern)
- #1016 — mailing-list permission check (same pattern)

## Test plan
- [ ] Schedule Meeting button navigates to `/meetings/create` for a committee writer
- [ ] Access-denied toast appears (with correct overview path) when permission revoked mid-session
- [ ] Button shows spinner and is disabled during the in-flight `fetchCommittee()` call — rapid double-clicks are blocked
- [ ] Foundation-lens committee redirects to `/foundation/overview` on denial; project-lens redirects to `/project/overview`
- [ ] `yarn build` passes (SSR safety)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)