### PR TITLE
feat(meetings): show impersonation banner on meeting join page

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -2,18 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- Impersonation Banner -->
-@if (userService.impersonating()) {
-  <div
-    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
-    data-testid="impersonation-banner">
-    <i class="fa-light fa-eye text-sm"></i>
-    <span
-      >Viewing as <strong>{{ userService.user()?.email }}</strong></span
-    >
-    <span class="text-black/60">— by {{ userService.impersonator()?.name }}</span>
-    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
-  </div>
-}
+<lfx-impersonation-banner />
 
 <div class="flex min-h-screen" [ngClass]="{ 'pt-12': userService.impersonating() }">
   <!-- Sidebar - Desktop: lens switcher (64px) + nav panel (280px) = 344px -->

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -24,21 +24,20 @@ import { Lens, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { AnalyticsService } from '@services/analytics.service';
 import { AppService } from '@services/app.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
-import { ImpersonationService } from '@services/impersonation.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
-import { filter, map, of, startWith, switchMap, take } from 'rxjs';
+import { filter, map, of, startWith, switchMap } from 'rxjs';
 
 import { environment } from '@environments/environment';
 
-import { ButtonComponent } from '@components/button/button.component';
+import { ImpersonationBannerComponent } from '@components/impersonation-banner/impersonation-banner.component';
 
 @Component({
   selector: 'lfx-main-layout',
-  imports: [NgClass, RouterModule, SidebarComponent, DrawerModule, LensSwitcherComponent, ButtonComponent],
+  imports: [NgClass, RouterModule, SidebarComponent, DrawerModule, LensSwitcherComponent, ImpersonationBannerComponent],
   templateUrl: './main-layout.component.html',
   styleUrl: './main-layout.component.scss',
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -49,7 +48,6 @@ export class MainLayoutComponent {
   private readonly appService = inject(AppService);
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
-  private readonly impersonationService = inject(ImpersonationService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
   private readonly featureFlagService = inject(FeatureFlagService);
@@ -589,15 +587,6 @@ export class MainLayoutComponent {
     if (!visible) {
       this.appService.closeMobileSidebar();
     }
-  }
-
-  protected stopImpersonation(): void {
-    this.impersonationService
-      .stopImpersonation()
-      .pipe(take(1))
-      .subscribe(() => {
-        window.location.reload();
-      });
   }
 
   private initCanSeeNewsletters(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -2,18 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- Impersonation Banner -->
-@if (impersonating()) {
-  <div
-    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
-    data-testid="impersonation-banner">
-    <i class="fa-light fa-eye text-sm"></i>
-    <span
-      >Viewing as <strong>{{ user()?.email }}</strong></span
-    >
-    <span class="text-black/60">— by {{ impersonator()?.name }}</span>
-    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
-  </div>
-}
+<lfx-impersonation-banner />
 
 <div [ngClass]="{ 'pt-12': impersonating() }">
   <lfx-header></lfx-header>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -4,7 +4,7 @@
 <!-- Impersonation Banner -->
 <lfx-impersonation-banner />
 
-<div [ngClass]="{ 'pt-12': impersonating() }">
+<div [ngClass]="{ 'pt-12': userService.impersonating() }">
   <lfx-header></lfx-header>
 
   @if (meeting()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -1,792 +1,813 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
-<lfx-header></lfx-header>
 
-@if (meeting()) {
-  <div class="bg-gray-50 min-h-screen">
-    <!-- Main Content Container -->
-    <div class="container mx-auto py-6 px-8">
-      <div class="max-w-[900px] mx-auto flex flex-col">
-        <!-- Project Logo (fallback to LFX logo) -->
-        <div class="flex items-center justify-center mb-6">
-          @if (project()?.logo_url) {
-            <img [src]="project()?.logo_url" [alt]="project()?.name" class="w-auto h-10 md:h-14" />
-          } @else {
-            <img src="/images/logo_lfx.svg" alt="LFX Logo" class="w-auto h-10 md:h-14" />
-          }
-        </div>
-
-        <!-- Main Meeting Card -->
-        <lfx-card class="rounded-[12.75px] mb-6" [attr.data-testid]="'meeting-info-card'">
-          <!-- Header Section: Badges + Copy Link -->
-          <div class="flex justify-between items-start mb-4">
-            <!-- Left: Badges + View Guests Button -->
-            <div class="flex items-center gap-2 flex-wrap">
-              <!-- Ended Badge -->
-              @if (isPastMeeting()) {
-                <lfx-tag value="Ended" severity="warn" icon="fa-light fa-check" styleClass="tag-ended" [attr.data-testid]="'meeting-badge-ended'"></lfx-tag>
-              }
-
-              <!-- Private Badge -->
-              @if (meeting().visibility === 'private') {
-                <lfx-tag
-                  value="Private"
-                  severity="danger"
-                  icon="fa-light fa-shield"
-                  styleClass="tag-private"
-                  [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
-              }
-
-              <!-- Meeting Type Badge -->
-              @if (meetingTypeBadge(); as badge) {
-                <lfx-tag
-                  [value]="badge.text"
-                  [severity]="badge.severity"
-                  [icon]="badge.icon"
-                  [styleClass]="badge.styleClass"
-                  [attr.data-testid]="'meeting-badge-type'"></lfx-tag>
-              }
-
-              <!-- Recurring Badge -->
-              @if (displayRecurrence(); as recurrence) {
-                <lfx-tag
-                  [value]="recurrence | recurrenceSummary"
-                  severity="secondary"
-                  icon="fa-light fa-repeat"
-                  styleClass="tag-recurring"
-                  pTooltip="This is a recurring meeting"
-                  data-testid="recurring-badge"></lfx-tag>
-              }
-
-              <!-- View Guests Button -->
-              @if (authenticated() && (meeting().organizer || meeting().invited)) {
-                <lfx-button
-                  label="Show Members"
-                  icon="fa-light fa-users"
-                  [outlined]="true"
-                  severity="primary"
-                  (onClick)="onRegistrantsToggle()"
-                  styleClass="py-[0.15rem] text-xs"
-                  data-testid="view-members-button">
-                </lfx-button>
-              } @else if (meeting().show_meeting_attendees) {
-                <lfx-button
-                  label="Show Members"
-                  icon="fa-light fa-users"
-                  [outlined]="true"
-                  severity="secondary"
-                  (onClick)="onShowMembersPlaceholder()"
-                  styleClass="py-[0.15rem] text-xs"
-                  data-testid="view-members-button-placeholder">
-                </lfx-button>
-              }
-            </div>
-
-            <!-- Right: Copy Link Button -->
-            <lfx-button
-              [icon]="'fa-light fa-copy'"
-              [rounded]="true"
-              size="small"
-              severity="secondary"
-              [text]="true"
-              (onClick)="handleCopyLink()"
-              [attr.data-testid]="'meeting-copy-link-button'"
-              [pTooltip]="'Copy meeting link'">
-            </lfx-button>
-          </div>
-
-          <!-- Content Row: Title/Details + Join Button (if immediate) -->
-          <div class="flex flex-col md:flex-row justify-between items-start gap-6 mb-4">
-            <!-- Left Column: Title + Details -->
-            <div class="flex-1 flex flex-col gap-4 justify-between h-full">
-              <div class="flex flex-col gap-4 h-full">
-                <!-- Meeting Title -->
-                <h1 [attr.data-testid]="'meeting-title'">
-                  {{ meetingTitle() }}
-                </h1>
-
-                <!-- Foundation / Project / Committee Context Chips -->
-                @if (parentProject()?.name || project()?.name || meeting().project_name || (meeting().committees && meeting().committees.length > 0)) {
-                  <div class="flex flex-wrap items-center gap-2" data-testid="meeting-context">
-                    @if (parentProject()?.name; as foundationName) {
-                      <button
-                        type="button"
-                        class="cursor-pointer hover:opacity-70 transition-opacity"
-                        (click)="navigateToFoundation()"
-                        data-testid="meeting-context-foundation">
-                        <lfx-tag [value]="foundationName" severity="secondary" icon="fa-light fa-landmark" styleClass="cursor-pointer"></lfx-tag>
-                      </button>
-                    }
-                    @if (project()?.name || meeting().project_name; as projectName) {
-                      <button
-                        type="button"
-                        class="cursor-pointer hover:opacity-70 transition-opacity"
-                        (click)="navigateToFoundation()"
-                        data-testid="meeting-context-project">
-                        <lfx-tag
-                          [value]="projectName"
-                          severity="secondary"
-                          icon="fa-light fa-cube"
-                          styleClass="!text-teal-700 !bg-teal-50 !border-teal-200 cursor-pointer"></lfx-tag>
-                      </button>
-                    }
-                    @for (committee of meeting().committees; track committee.uid) {
-                      @if (committee.name && committee.uid) {
-                        <a
-                          [href]="'/groups/' + committee.uid"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="no-underline hover:opacity-70 transition-opacity"
-                          [attr.data-testid]="'meeting-context-committee-' + committee.uid">
-                          <lfx-tag
-                            [value]="committee.name"
-                            severity="secondary"
-                            icon="fa-light fa-users-rectangle"
-                            styleClass="!text-blue-700 !bg-blue-50 !border-blue-200 cursor-pointer"></lfx-tag>
-                        </a>
-                      }
-                    }
-                  </div>
-                }
-
-                <!-- Date/Time Badge -->
-                @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
-                  <div class="flex items-center gap-3">
-                    <lfx-tag
-                      [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact'"
-                      severity="secondary"
-                      icon="fa-light fa-calendar-days"
-                      [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
-                  </div>
-                }
-
-                <!-- Occurrence Navigation (recurring meetings only) -->
-                @if (meeting().recurrence && occurrenceLabel()) {
-                  <div class="flex items-center gap-3" data-testid="occurrence-navigation">
-                    @if (previousOccurrenceUrl(); as prevUrl) {
-                      <a
-                        [href]="prevUrl"
-                        class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
-                        data-testid="occurrence-nav-prev">
-                        <i class="fa-light fa-chevron-left text-xs"></i>
-                        <span>Previous</span>
-                      </a>
-                    } @else {
-                      <span class="flex items-center gap-1 text-sm text-gray-300">
-                        <i class="fa-light fa-chevron-left text-xs"></i>
-                        <span>Previous</span>
-                      </span>
-                    }
-                    <span class="text-sm text-gray-500 font-medium" data-testid="occurrence-counter">{{ occurrenceLabel() }}</span>
-                    @if (nextOccurrenceUrl(); as nextUrl) {
-                      <a
-                        [href]="nextUrl"
-                        class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
-                        data-testid="occurrence-nav-next">
-                        <span>Next</span>
-                        <i class="fa-light fa-chevron-right text-xs"></i>
-                      </a>
-                    } @else {
-                      <span class="flex items-center gap-1 text-sm text-gray-300">
-                        <span>Next</span>
-                        <i class="fa-light fa-chevron-right text-xs"></i>
-                      </span>
-                    }
-                  </div>
-                }
-
-                <!-- Feature Badges Row -->
-                <div class="flex flex-wrap gap-2 items-center">
-                  <!-- Recording Badge -->
-                  @if (meeting().recording_enabled) {
-                    <lfx-tag
-                      value="Recording"
-                      severity="secondary"
-                      icon="fa-light fa-video"
-                      styleClass="!text-red-500"
-                      data-testid="meeting-badge-recording"></lfx-tag>
-                  }
-
-                  <!-- Transcripts Badge -->
-                  @if (meeting().transcript_enabled) {
-                    <lfx-tag
-                      value="Transcripts"
-                      severity="secondary"
-                      icon="fa-light fa-file-lines"
-                      styleClass="!text-teal-600"
-                      data-testid="meeting-badge-transcripts"></lfx-tag>
-                  }
-
-                  <!-- YouTube Upload Badge -->
-                  @if (meeting().youtube_upload_enabled) {
-                    <lfx-tag
-                      value="YouTube Upload"
-                      severity="secondary"
-                      icon="fa-light fa-upload"
-                      styleClass="!text-amber-600"
-                      data-testid="meeting-badge-youtube"></lfx-tag>
-                  }
-
-                  <!-- AI Summary Badge -->
-                  @if (hasAiCompanion()) {
-                    <lfx-tag
-                      value="AI Summary"
-                      severity="secondary"
-                      icon="fa-light fa-sparkles"
-                      styleClass="!text-purple-500"
-                      data-testid="meeting-badge-ai-summary"></lfx-tag>
-                  }
-                </div>
-
-                <!-- RSVP Summary -->
-                @if (hasRsvpData()) {
-                  <div class="flex items-center gap-4 text-xs" data-testid="rsvp-summary">
-                    <div class="inline-flex items-center gap-1">
-                      <i class="fa-light fa-circle-check text-emerald-500"></i>
-                      <span class="text-gray-600">{{ rsvpAcceptedCount() }} accepted</span>
-                    </div>
-                    <div class="inline-flex items-center gap-1">
-                      <i class="fa-light fa-circle-xmark text-red-500"></i>
-                      <span class="text-gray-600">{{ rsvpDeclinedCount() }} declined</span>
-                    </div>
-                    <div class="inline-flex items-center gap-1">
-                      <i class="fa-light fa-clock text-gray-400"></i>
-                      <span class="text-gray-600">{{ rsvpPendingCount() }} pending</span>
-                    </div>
-                  </div>
-                }
-
-                <!-- Total Invitees -->
-                @if (registrants().length > 0 && !isPastMeeting()) {
-                  <div class="inline-flex items-center gap-1 text-sm text-gray-500" data-testid="total-invitees">
-                    <i class="fa-light fa-users"></i>
-                    <span>{{ totalInvitees() }} invited</span>
-                  </div>
-                }
-              </div>
-
-              <!-- Attendance Stats (past meetings) -->
-              @if (hasAttendanceData()) {
-                <div class="flex items-center gap-4" data-testid="attendance-summary">
-                  <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
-                    <i class="fa-light fa-circle-check text-emerald-500 text-sm"></i>
-                    <span class="text-sm font-semibold text-emerald-600">{{ attendedCount() }}</span>
-                    <span class="text-sm text-gray-500">attended</span>
-                  </div>
-                  <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
-                    <i class="fa-light fa-circle-xmark text-gray-400 text-sm"></i>
-                    <span class="text-sm font-semibold text-gray-500">{{ absentCount() }}</span>
-                    <span class="text-sm text-gray-500">absent</span>
-                  </div>
-                  <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
-                    <i class="fa-light fa-chart-pie text-blue-500 text-sm"></i>
-                    <span class="text-sm font-semibold text-gray-700">{{ attendancePercentage() }}%</span>
-                    <span class="text-sm text-gray-500">rate</span>
-                  </div>
-                </div>
-              }
-
-              <!-- Alert Banner -->
-              @if (isPastMeeting()) {
-                <div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-past'">
-                  <i class="fa-light fa-clock-rotate-left text-gray-500 text-base"></i>
-                  <p class="text-sm text-gray-700">This meeting has ended.</p>
-                </div>
-              } @else if (messageSeverity() === 'warn') {
-                <div class="bg-amber-50 border border-amber-500/50 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-warn'">
-                  <i class="fa-light fa-clock text-amber-500 text-base"></i>
-                  <p class="text-sm text-amber-900">{{ alertMessage() }}</p>
-                </div>
-              } @else if (messageSeverity() === 'info' && canJoinMeeting()) {
-                <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-info'">
-                  <i class="fa-light fa-calendar text-blue-500 text-base"></i>
-                  <p class="text-sm text-blue-900">{{ alertMessage() }}</p>
-                </div>
-              }
-            </div>
-
-            <!-- Right Column: Join Button (immediate meetings) or RSVP (future meetings) -->
-            @if (canJoinMeeting() && authenticated()) {
-              @if (fetchedJoinUrl() && !showGuestForm()) {
-                <div class="w-full md:w-[296px]">
-                  <lfx-button
-                    styleClass="w-full h-[40px]"
-                    label="Join Meeting"
-                    icon="fa-light fa-video"
-                    severity="success"
-                    size="large"
-                    [href]="fetchedJoinUrl()"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    [attr.data-testid]="'join-meeting-button-immediate'">
-                  </lfx-button>
-                </div>
-              } @else if (joinUrlError() !== null && !showGuestForm()) {
-                <div class="w-full md:w-[296px] flex flex-col gap-2">
-                  <lfx-button
-                    label="Join Meeting"
-                    icon="fa-light fa-video"
-                    [disabled]="true"
-                    size="large"
-                    styleClass="w-full h-[40px] bg-gray-300 text-gray-500 border-none cursor-not-allowed"
-                    rel="noopener noreferrer"
-                    [attr.data-testid]="'join-meeting-button-error'">
-                  </lfx-button>
-                  <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2">
-                    <span>{{ joinUrlError() }}</span
-                    >.
-                    @if (emailError()) {
-                      <span><a class="text-primary cursor-pointer" (click)="onEmailErrorClick()">Click here</a> to join using a different email address.</span>
-                    }
-                  </div>
-                </div>
-              } @else if (!showGuestForm()) {
-                <!-- Disabled+loading is the default while the join URL is resolving.
-                     Placed last so it renders at SSR first paint (no join URL or error yet)
-                     rather than depending on the client-only isLoadingJoinUrl signal. -->
-                <div class="w-full md:w-[296px]">
-                  <lfx-button
-                    styleClass="w-full h-[40px]"
-                    label="Join Meeting"
-                    icon="fa-light fa-video"
-                    severity="success"
-                    size="large"
-                    [loading]="true"
-                    [disabled]="true"
-                    [attr.data-testid]="'join-meeting-button-loading'">
-                  </lfx-button>
-                </div>
-              }
-            } @else if (authenticated() && !isPastMeeting() && meeting().organizer) {
-              <!-- RSVP Section - Future Meeting (Authenticated Organizers) -->
-              <div class="w-full md:w-[296px] flex flex-col gap-2">
-                @if (canToggleRsvpView() && showMyRsvp()) {
-                  <!-- Show RSVP Button Group when organizer toggles to set their own RSVP -->
-                  <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id" (rsvpChanged)="onRsvpChanged($event)">
-                  </lfx-rsvp-button-group>
-                } @else {
-                  <!-- Show RSVP Details for organizers (default view) -->
-                  <lfx-meeting-rsvp-details
-                    [meeting]="meeting()"
-                    [project]="project()"
-                    [currentOccurrence]="currentOccurrence()"
-                    [pastMeeting]="isPastMeeting()"
-                    [showAddButton]="!!meeting().organizer && !isPastMeeting()"
-                    [additionalRegistrantsCount]="additionalRegistrantsCount()"
-                    backgroundColor="bg-gray-50"
-                    borderColor="border-gray-200"
-                    (addClicked)="showRegistrants.set(true)">
-                  </lfx-meeting-rsvp-details>
-                }
-                @if (canToggleRsvpView()) {
-                  @if (!showMyRsvp() && currentUserRsvpLabel(); as rsvpLabel) {
-                    <div
-                      class="flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-50 border border-gray-200 text-xs"
-                      data-testid="current-user-rsvp-status">
-                      @if (currentUserRsvpIcon(); as iconClass) {
-                        <i [class]="iconClass" aria-hidden="true"></i>
-                      }
-                      <span class="text-gray-600">Your RSVP:</span>
-                      <span class="font-medium text-gray-900">{{ rsvpLabel }}</span>
-                    </div>
-                  }
-                  <lfx-button
-                    class="w-full"
-                    styleClass="w-full"
-                    [icon]="showMyRsvp() ? 'fa-light fa-users' : 'fa-light fa-hand'"
-                    [label]="rsvpToggleLabel()"
-                    size="small"
-                    severity="secondary"
-                    (onClick)="onRsvpViewToggle()"
-                    data-testid="toggle-rsvp-view-button">
-                  </lfx-button>
-                }
-              </div>
-            } @else if (authenticated() && !isPastMeeting()) {
-              <!-- RSVP Container - Future Meeting (Authenticated Non-Organizers) -->
-              <div class="w-full md:w-[296px]">
-                @if (isInvited()) {
-                  @defer (when meeting()) {
-                    <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id"> </lfx-rsvp-button-group>
-                  }
-                } @else if (canRegisterForMeeting()) {
-                  <lfx-button
-                    class="w-full"
-                    styleClass="w-full"
-                    icon="fa-light fa-user-plus"
-                    label="Register for Meeting"
-                    size="small"
-                    severity="secondary"
-                    (onClick)="registerForMeeting()"
-                    data-testid="register-meeting-button">
-                  </lfx-button>
-                }
-              </div>
-            } @else if (isPastMeeting() && authenticated() && pastMeetingFullAccess()) {
-              <!-- Meeting Tools — Past Meeting (right column) -->
-              <div class="w-full md:w-[296px]" data-testid="meeting-tools">
-                <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                  <div class="flex flex-col gap-1 mb-3">
-                    <h3 class="text-gray-700 text-sm font-medium">Meeting Tools</h3>
-                    <p class="text-xs text-gray-400">Tools are provided for accessibility and reference.</p>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <!-- See Recording -->
-                    @if (primaryRecordingUrl()) {
-                      <a
-                        [href]="primaryRecordingUrl()"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer"
-                        data-testid="view-recording-link">
-                        <i class="fa-light fa-play text-sm"></i>
-                        <span>See Recording</span>
-                      </a>
-                    } @else {
-                      <div
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
-                        data-testid="recording-unavailable">
-                        <i class="fa-light fa-play text-sm"></i>
-                        <span>See Recording</span>
-                      </div>
-                    }
-
-                    <!-- AI Summary -->
-                    @if (hasSummaryContent()) {
-                      <button
-                        type="button"
-                        (click)="openSummaryModal()"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer w-full"
-                        data-testid="past-meeting-summary">
-                        <i class="fa-light fa-sparkles text-sm"></i>
-                        <span>AI Summary</span>
-                        @if (pastMeetingSummary()?.approved) {
-                          <span class="text-xs font-medium text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded-full">Approved</span>
-                        } @else if (summaryAwaitingApproval()) {
-                          <span class="text-xs font-medium text-amber-600 bg-amber-100 px-1.5 py-0.5 rounded-full">Pending</span>
-                        }
-                      </button>
-                    } @else {
-                      <div
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
-                        data-testid="summary-unavailable">
-                        <i class="fa-light fa-sparkles text-sm"></i>
-                        <span>AI Summary Not Available</span>
-                      </div>
-                    }
-
-                    <!-- Transcript -->
-                    @if (transcriptUrl()) {
-                      <button
-                        type="button"
-                        (click)="openTranscriptModal()"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer w-full"
-                        data-testid="view-transcript-button">
-                        <i class="fa-light fa-file-lines text-sm"></i>
-                        <span>View Transcript</span>
-                      </button>
-                    } @else {
-                      <div
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
-                        data-testid="transcript-unavailable">
-                        <i class="fa-light fa-file-lines text-sm"></i>
-                        <span>Transcript Unavailable</span>
-                      </div>
-                    }
-                  </div>
-                </div>
-              </div>
-            }
-          </div>
-
-          @if (!(isPastMeeting() && !pastMeetingFullAccess())) {
-            <!-- Divider -->
-            <hr class="border-gray-200 my-4" />
-
-            <!-- Agenda + Resources Row (2-column) -->
-            <div class="flex flex-col md:flex-row gap-6">
-              <!-- Left: Agenda Section (flex-1) -->
-              <div class="flex-1 flex flex-col gap-2">
-                <!-- Agenda Header -->
-                <div class="flex items-center gap-2">
-                  <i class="fa-light fa-list text-gray-500 text-xs"></i>
-                  <h3 class="text-gray-600 text-sm font-normal">Agenda</h3>
-                </div>
-
-                <!-- Description -->
-                @if (meetingDescription(); as description) {
-                  <div class="text-gray-600 text-xs leading-relaxed" [attr.data-testid]="'meeting-description'">
-                    <lfx-expandable-text [maxHeight]="200">
-                      <div [innerHTML]="description | linkify" class="text-sm leading-relaxed"></div>
-                    </lfx-expandable-text>
-                  </div>
-                }
-              </div>
-
-              <!-- Right: Meeting Materials Card (fixed width) -->
-              <div class="w-full md:w-[296px]" data-testid="meeting-materials">
-                @defer (on idle) {
-                  <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                    <!-- Header -->
-                    <div class="flex items-center gap-2 mb-1">
-                      <i class="fa-light fa-folder-open text-gray-500 text-sm"></i>
-                      <h3 class="text-gray-700 text-sm font-medium flex-1">Meeting Materials</h3>
-                      @if (hasRecentlyUpdatedMaterials()) {
-                        <span class="text-xs font-medium text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded-full">Updated</span>
-                      }
-                      @if (meeting().organizer && !isPastMeeting()) {
-                        <button
-                          type="button"
-                          (click)="openMaterialsDrawer()"
-                          class="text-xs text-blue-600 hover:text-blue-800 font-medium transition-colors"
-                          data-testid="manage-materials-btn">
-                          Manage
-                        </button>
-                      }
-                    </div>
-                    <p class="text-xs text-gray-400 mb-3">Documents provided to support meeting preparation, discussion, and governance record.</p>
-
-                    <div class="flex flex-col gap-4">
-                      <!-- PRIMARY MATERIALS -->
-                      <div class="flex flex-col gap-2">
-                        <span class="text-xs font-semibold uppercase tracking-wider text-gray-400">Primary Materials</span>
-                        <p class="text-xs text-gray-400">Materials intended for review before the meeting.</p>
-                        @if (materialFiles().length > 0) {
-                          @for (attachment of visibleFiles(); track attachment.uid; let i = $index) {
-                            @let fileType = attachment | fileTypeDisplay;
-                            <button
-                              type="button"
-                              (click)="downloadAttachment(attachment)"
-                              class="bg-white border border-gray-200 hover:border-gray-300 rounded-lg p-3 flex items-center gap-3 transition-colors cursor-pointer w-full text-left"
-                              [attr.data-testid]="'meeting-material-file-' + i">
-                              <div class="w-9 h-9 rounded flex items-center justify-center flex-shrink-0" [ngClass]="[fileType.bgColor]">
-                                <i [ngClass]="[fileType.icon, fileType.textColor]" class="text-base"></i>
-                              </div>
-                              <div class="flex flex-col flex-1 overflow-hidden gap-0.5">
-                                <span class="text-sm text-gray-900 overflow-ellipsis overflow-hidden whitespace-nowrap font-inter">{{ attachment.name }}</span>
-                                <div class="flex items-center gap-2">
-                                  <span class="text-xs uppercase tracking-wide text-gray-500 bg-gray-200 px-1.5 py-0.5 rounded">{{ fileType.label }}</span>
-                                  @if (attachment.updated_at || attachment.created_at) {
-                                    <span class="text-xs text-gray-400">{{ attachment.updated_at || attachment.created_at | date: 'MMM d, yyyy' }}</span>
-                                  }
-                                </div>
-                              </div>
-                              <i class="fa-light fa-arrow-up-right-from-square text-gray-400 text-xs flex-shrink-0"></i>
-                            </button>
-                          }
-                          @if (hasMoreFiles()) {
-                            <button
-                              type="button"
-                              (click)="showAllFiles.set(!showAllFiles())"
-                              class="text-xs text-blue-600 hover:text-blue-800 font-medium py-1 transition-colors"
-                              data-testid="toggle-more-files">
-                              {{ showAllFiles() ? 'Show less' : 'Show ' + (materialFiles().length - 5) + ' more' }}
-                            </button>
-                          }
-                        } @else {
-                          @if (!authenticated() && meeting().visibility === 'private') {
-                            <p class="text-xs text-gray-400 italic">Sign in to view materials for this meeting.</p>
-                          } @else {
-                            <p class="text-xs text-gray-400 italic">No primary materials available.</p>
-                          }
-                        }
-                      </div>
-
-                      <!-- SUPPORTING MATERIALS -->
-                      <div class="flex flex-col gap-2">
-                        <span class="text-xs font-semibold uppercase tracking-wider text-gray-400">Supporting Materials</span>
-                        @if (materialLinks().length > 0) {
-                          @for (attachment of materialLinks(); track attachment.uid; let i = $index) {
-                            <div class="flex items-center gap-3 py-1.5" [attr.data-testid]="'meeting-material-link-' + i">
-                              <i class="fa-light fa-link text-gray-400 text-sm flex-shrink-0"></i>
-                              <span class="text-sm text-gray-700 overflow-ellipsis overflow-hidden whitespace-nowrap flex-1 font-inter">{{
-                                attachment.name
-                              }}</span>
-                              <a
-                                [href]="attachment.link"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="text-xs border border-gray-300 text-gray-600 rounded px-2 py-0.5 hover:bg-gray-100 transition-colors flex-shrink-0">
-                                Open
-                              </a>
-                            </div>
-                          }
-                        } @else {
-                          <p class="text-xs text-gray-400 italic">No supporting materials available.</p>
-                        }
-                      </div>
-                    </div>
-                  </div>
-                } @placeholder {
-                  <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 animate-pulse">
-                    <div class="h-4 bg-gray-200 rounded w-2/3 mb-3"></div>
-                    <div class="h-3 bg-gray-200 rounded w-full mb-4"></div>
-                    <div class="flex flex-col gap-3">
-                      <div class="h-12 bg-gray-200 rounded"></div>
-                      <div class="h-12 bg-gray-200 rounded"></div>
-                    </div>
-                  </div>
-                }
-              </div>
-            </div>
-          }
-
-          <!-- Footer Divider -->
-          <hr class="border-gray-200 my-4" />
-
-          <!-- Authentication Section -->
-          @if (authenticated() && user(); as user) {
-            <!-- Signed In State -->
-            <div class="flex flex-col gap-6">
-              <div class="flex flex-col gap-3">
-                <p class="text-sm text-gray-950">You are signed in as:</p>
-
-                <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center gap-3">
-                  <!-- Avatar -->
-                  <div class="hidden md:flex w-12 h-12 bg-blue-600 rounded-full items-center justify-center">
-                    <span class="text-white text-2xl font-medium">{{ userInitials() }}</span>
-                  </div>
-
-                  <!-- User Info -->
-                  <div class="flex-1">
-                    <p class="font-semibold text-sm text-blue-900">{{ user.name }}</p>
-                    <p class="text-sm text-blue-900">{{ user.email }}</p>
-                  </div>
-                </div>
-              </div>
-
-              @if (isPastMeeting() && !pastMeetingFullAccess()) {
-                <div class="bg-amber-50 border border-amber-300 rounded px-3 py-3 flex items-start gap-3">
-                  <i class="fa-light fa-lock text-amber-600 text-base mt-0.5"></i>
-                  <div>
-                    <p class="font-semibold text-sm text-amber-900">This is a private meeting</p>
-                    <p class="text-xs text-gray-600">
-                      Meeting details, recordings, and summaries are only available to meeting participants and committee members. If you believe you should
-                      have access, please contact the meeting organizer.
-                    </p>
-                  </div>
-                </div>
-              }
-
-              <!-- Guest Form for authenticated users -->
-              @if (showGuestForm() && !isPastMeeting()) {
-                <!-- OR Divider -->
-                <div class="relative h-px bg-gray-200">
-                  <span class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white px-3 text-xs text-gray-600">OR</span>
-                </div>
-
-                <lfx-guest-form [form]="joinForm" [joinUrl]="fetchedJoinUrl()" [isLoading]="isLoadingJoinUrl()"> </lfx-guest-form>
-                @if (joinUrlError() !== null) {
-                  <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2 text-center">
-                    <span>{{ joinUrlError() }}. Please contact the meeting organizer or support team if you believe this is an error.</span>
-                  </div>
-                }
-              }
-            </div>
-          } @else {
-            <!-- Signed Out State -->
-            <div class="flex flex-col gap-6">
-              <!-- Sign In CTA -->
-              <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center justify-between gap-3">
-                <div class="flex items-center gap-3">
-                  <i class="fa-light fa-arrow-right-to-bracket text-blue-600 text-2xl"></i>
-                  <div>
-                    @if (isPastMeeting()) {
-                      <p class="font-semibold text-sm text-blue-900">Sign in to view meeting details</p>
-                      <p class="text-xs text-gray-600">Access the agenda, recordings, summaries, and resources</p>
-                    } @else {
-                      <p class="font-semibold text-sm text-blue-900">Sign in with your LFX account</p>
-                      <p class="text-xs text-gray-600">Join quickly with your saved information</p>
-                    }
-                  </div>
-                </div>
-
-                <lfx-button
-                  class="w-full md:w-auto"
-                  styleClass="w-full md:w-auto"
-                  size="small"
-                  label="Sign In"
-                  icon="fa-light fa-arrow-right-to-bracket"
-                  severity="info"
-                  [href]="'/login?returnTo=' + returnTo()">
-                </lfx-button>
-              </div>
-
-              @if (!isPastMeeting()) {
-                <!-- OR Divider -->
-                <div class="relative h-px bg-gray-200">
-                  <span class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white px-3 text-xs text-gray-600">OR</span>
-                </div>
-
-                <!-- Guest Form -->
-                <lfx-guest-form [form]="joinForm" [joinUrl]="fetchedJoinUrl()" [isLoading]="isLoadingJoinUrl()"> </lfx-guest-form>
-                @if (joinUrlError() !== null) {
-                  <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2 text-center">
-                    <span>{{ joinUrlError() }}. Please contact the meeting organizer or support team if you believe this is an error.</span>
-                  </div>
-                }
-              }
-            </div>
-          }
-        </lfx-card>
-      </div>
-    </div>
-
-    <!-- Meeting Registrants Drawer (rendered outside the card so PrimeNG's overlay/mask isn't
-         re-parented under lfx-card's content tree, which causes the drawer to close itself
-         when the opening click bubbles back through that subtree). -->
-    <p-drawer
-      [(visible)]="showRegistrants"
-      [position]="drawerPosition()"
-      styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
-      [modal]="true"
-      [showCloseIcon]="false"
-      data-testid="meeting-registrants-drawer">
-      <ng-template #header>
-        <div class="flex items-center justify-between w-full">
-          <div class="flex items-center gap-3">
-            <div class="bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center">
-              <i class="fa-light fa-user-group text-white text-2xl"></i>
-            </div>
-            @if (isPastMeeting()) {
-              <div class="flex flex-col">
-                <h1>Meeting Participants</h1>
-                <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ invitedCount() }} invited</span>
-              </div>
-            } @else if (meeting().committees && meeting().committees.length) {
-              <div class="flex flex-col">
-                <h1>Meeting Members</h1>
-                <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>
-              </div>
-            } @else {
-              <div class="flex flex-col">
-                <h1>Meeting Guests</h1>
-                <span class="text-base text-gray-500">{{ totalInvitees() }} guests</span>
-              </div>
-            }
-          </div>
-          <button type="button" class="text-gray-400 hover:text-gray-600 p-2 cursor-pointer" (click)="onDrawerHide()" aria-label="Close panel">
-            <i class="fa-light fa-xmark text-xl"></i>
-          </button>
-        </div>
-      </ng-template>
-      <lfx-meeting-registrants-display
-        [meeting]="meeting()"
-        [pastMeeting]="isPastMeeting()"
-        [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
-        [myMeetingRegistrants]="true"
-        [initialRegistrants]="registrants()"
-        [initialRegistrantsLoading]="registrantsLoading()"
-        [visible]="showRegistrants()"
-        (refreshRequested)="onRegistrantsRefreshRequested($event)">
-      </lfx-meeting-registrants-display>
-    </p-drawer>
-
-    <!-- Meeting Materials Drawer -->
-    @if (meeting().organizer && !isPastMeeting()) {
-      <lfx-meeting-materials-drawer [(visible)]="materialsDrawerVisible" [meetingId]="meeting().id" (materialsChanged)="onMaterialsChanged()">
-      </lfx-meeting-materials-drawer>
-    }
+<!-- Impersonation Banner -->
+@if (impersonating()) {
+  <div
+    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
+    data-testid="impersonation-banner">
+    <i class="fa-light fa-eye text-sm"></i>
+    <span
+      >Viewing as <strong>{{ user()?.email }}</strong></span
+    >
+    <span class="text-black/60">— by {{ impersonator()?.name }}</span>
+    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
   </div>
 }
+
+<div [ngClass]="{ 'pt-12': impersonating() }">
+  <lfx-header></lfx-header>
+
+  @if (meeting()) {
+    <div class="bg-gray-50 min-h-screen">
+      <!-- Main Content Container -->
+      <div class="container mx-auto py-6 px-8">
+        <div class="max-w-[900px] mx-auto flex flex-col">
+          <!-- Project Logo (fallback to LFX logo) -->
+          <div class="flex items-center justify-center mb-6">
+            @if (project()?.logo_url) {
+              <img [src]="project()?.logo_url" [alt]="project()?.name" class="w-auto h-10 md:h-14" />
+            } @else {
+              <img src="/images/logo_lfx.svg" alt="LFX Logo" class="w-auto h-10 md:h-14" />
+            }
+          </div>
+
+          <!-- Main Meeting Card -->
+          <lfx-card class="rounded-[12.75px] mb-6" [attr.data-testid]="'meeting-info-card'">
+            <!-- Header Section: Badges + Copy Link -->
+            <div class="flex justify-between items-start mb-4">
+              <!-- Left: Badges + View Guests Button -->
+              <div class="flex items-center gap-2 flex-wrap">
+                <!-- Ended Badge -->
+                @if (isPastMeeting()) {
+                  <lfx-tag value="Ended" severity="warn" icon="fa-light fa-check" styleClass="tag-ended" [attr.data-testid]="'meeting-badge-ended'"></lfx-tag>
+                }
+
+                <!-- Private Badge -->
+                @if (meeting().visibility === 'private') {
+                  <lfx-tag
+                    value="Private"
+                    severity="danger"
+                    icon="fa-light fa-shield"
+                    styleClass="tag-private"
+                    [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
+                }
+
+                <!-- Meeting Type Badge -->
+                @if (meetingTypeBadge(); as badge) {
+                  <lfx-tag
+                    [value]="badge.text"
+                    [severity]="badge.severity"
+                    [icon]="badge.icon"
+                    [styleClass]="badge.styleClass"
+                    [attr.data-testid]="'meeting-badge-type'"></lfx-tag>
+                }
+
+                <!-- Recurring Badge -->
+                @if (displayRecurrence(); as recurrence) {
+                  <lfx-tag
+                    [value]="recurrence | recurrenceSummary"
+                    severity="secondary"
+                    icon="fa-light fa-repeat"
+                    styleClass="tag-recurring"
+                    pTooltip="This is a recurring meeting"
+                    data-testid="recurring-badge"></lfx-tag>
+                }
+
+                <!-- View Guests Button -->
+                @if (authenticated() && (meeting().organizer || meeting().invited)) {
+                  <lfx-button
+                    label="Show Members"
+                    icon="fa-light fa-users"
+                    [outlined]="true"
+                    severity="primary"
+                    (onClick)="onRegistrantsToggle()"
+                    styleClass="py-[0.15rem] text-xs"
+                    data-testid="view-members-button">
+                  </lfx-button>
+                } @else if (meeting().show_meeting_attendees) {
+                  <lfx-button
+                    label="Show Members"
+                    icon="fa-light fa-users"
+                    [outlined]="true"
+                    severity="secondary"
+                    (onClick)="onShowMembersPlaceholder()"
+                    styleClass="py-[0.15rem] text-xs"
+                    data-testid="view-members-button-placeholder">
+                  </lfx-button>
+                }
+              </div>
+
+              <!-- Right: Copy Link Button -->
+              <lfx-button
+                [icon]="'fa-light fa-copy'"
+                [rounded]="true"
+                size="small"
+                severity="secondary"
+                [text]="true"
+                (onClick)="handleCopyLink()"
+                [attr.data-testid]="'meeting-copy-link-button'"
+                [pTooltip]="'Copy meeting link'">
+              </lfx-button>
+            </div>
+
+            <!-- Content Row: Title/Details + Join Button (if immediate) -->
+            <div class="flex flex-col md:flex-row justify-between items-start gap-6 mb-4">
+              <!-- Left Column: Title + Details -->
+              <div class="flex-1 flex flex-col gap-4 justify-between h-full">
+                <div class="flex flex-col gap-4 h-full">
+                  <!-- Meeting Title -->
+                  <h1 [attr.data-testid]="'meeting-title'">
+                    {{ meetingTitle() }}
+                  </h1>
+
+                  <!-- Foundation / Project / Committee Context Chips -->
+                  @if (parentProject()?.name || project()?.name || meeting().project_name || (meeting().committees && meeting().committees.length > 0)) {
+                    <div class="flex flex-wrap items-center gap-2" data-testid="meeting-context">
+                      @if (parentProject()?.name; as foundationName) {
+                        <button
+                          type="button"
+                          class="cursor-pointer hover:opacity-70 transition-opacity"
+                          (click)="navigateToFoundation()"
+                          data-testid="meeting-context-foundation">
+                          <lfx-tag [value]="foundationName" severity="secondary" icon="fa-light fa-landmark" styleClass="cursor-pointer"></lfx-tag>
+                        </button>
+                      }
+                      @if (project()?.name || meeting().project_name; as projectName) {
+                        <button
+                          type="button"
+                          class="cursor-pointer hover:opacity-70 transition-opacity"
+                          (click)="navigateToFoundation()"
+                          data-testid="meeting-context-project">
+                          <lfx-tag
+                            [value]="projectName"
+                            severity="secondary"
+                            icon="fa-light fa-cube"
+                            styleClass="!text-teal-700 !bg-teal-50 !border-teal-200 cursor-pointer"></lfx-tag>
+                        </button>
+                      }
+                      @for (committee of meeting().committees; track committee.uid) {
+                        @if (committee.name && committee.uid) {
+                          <a
+                            [href]="'/groups/' + committee.uid"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="no-underline hover:opacity-70 transition-opacity"
+                            [attr.data-testid]="'meeting-context-committee-' + committee.uid">
+                            <lfx-tag
+                              [value]="committee.name"
+                              severity="secondary"
+                              icon="fa-light fa-users-rectangle"
+                              styleClass="!text-blue-700 !bg-blue-50 !border-blue-200 cursor-pointer"></lfx-tag>
+                          </a>
+                        }
+                      }
+                    </div>
+                  }
+
+                  <!-- Date/Time Badge -->
+                  @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
+                    <div class="flex items-center gap-3">
+                      <lfx-tag
+                        [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact'"
+                        severity="secondary"
+                        icon="fa-light fa-calendar-days"
+                        [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                    </div>
+                  }
+
+                  <!-- Occurrence Navigation (recurring meetings only) -->
+                  @if (meeting().recurrence && occurrenceLabel()) {
+                    <div class="flex items-center gap-3" data-testid="occurrence-navigation">
+                      @if (previousOccurrenceUrl(); as prevUrl) {
+                        <a
+                          [href]="prevUrl"
+                          class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                          data-testid="occurrence-nav-prev">
+                          <i class="fa-light fa-chevron-left text-xs"></i>
+                          <span>Previous</span>
+                        </a>
+                      } @else {
+                        <span class="flex items-center gap-1 text-sm text-gray-300">
+                          <i class="fa-light fa-chevron-left text-xs"></i>
+                          <span>Previous</span>
+                        </span>
+                      }
+                      <span class="text-sm text-gray-500 font-medium" data-testid="occurrence-counter">{{ occurrenceLabel() }}</span>
+                      @if (nextOccurrenceUrl(); as nextUrl) {
+                        <a
+                          [href]="nextUrl"
+                          class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                          data-testid="occurrence-nav-next">
+                          <span>Next</span>
+                          <i class="fa-light fa-chevron-right text-xs"></i>
+                        </a>
+                      } @else {
+                        <span class="flex items-center gap-1 text-sm text-gray-300">
+                          <span>Next</span>
+                          <i class="fa-light fa-chevron-right text-xs"></i>
+                        </span>
+                      }
+                    </div>
+                  }
+
+                  <!-- Feature Badges Row -->
+                  <div class="flex flex-wrap gap-2 items-center">
+                    <!-- Recording Badge -->
+                    @if (meeting().recording_enabled) {
+                      <lfx-tag
+                        value="Recording"
+                        severity="secondary"
+                        icon="fa-light fa-video"
+                        styleClass="!text-red-500"
+                        data-testid="meeting-badge-recording"></lfx-tag>
+                    }
+
+                    <!-- Transcripts Badge -->
+                    @if (meeting().transcript_enabled) {
+                      <lfx-tag
+                        value="Transcripts"
+                        severity="secondary"
+                        icon="fa-light fa-file-lines"
+                        styleClass="!text-teal-600"
+                        data-testid="meeting-badge-transcripts"></lfx-tag>
+                    }
+
+                    <!-- YouTube Upload Badge -->
+                    @if (meeting().youtube_upload_enabled) {
+                      <lfx-tag
+                        value="YouTube Upload"
+                        severity="secondary"
+                        icon="fa-light fa-upload"
+                        styleClass="!text-amber-600"
+                        data-testid="meeting-badge-youtube"></lfx-tag>
+                    }
+
+                    <!-- AI Summary Badge -->
+                    @if (hasAiCompanion()) {
+                      <lfx-tag
+                        value="AI Summary"
+                        severity="secondary"
+                        icon="fa-light fa-sparkles"
+                        styleClass="!text-purple-500"
+                        data-testid="meeting-badge-ai-summary"></lfx-tag>
+                    }
+                  </div>
+
+                  <!-- RSVP Summary -->
+                  @if (hasRsvpData()) {
+                    <div class="flex items-center gap-4 text-xs" data-testid="rsvp-summary">
+                      <div class="inline-flex items-center gap-1">
+                        <i class="fa-light fa-circle-check text-emerald-500"></i>
+                        <span class="text-gray-600">{{ rsvpAcceptedCount() }} accepted</span>
+                      </div>
+                      <div class="inline-flex items-center gap-1">
+                        <i class="fa-light fa-circle-xmark text-red-500"></i>
+                        <span class="text-gray-600">{{ rsvpDeclinedCount() }} declined</span>
+                      </div>
+                      <div class="inline-flex items-center gap-1">
+                        <i class="fa-light fa-clock text-gray-400"></i>
+                        <span class="text-gray-600">{{ rsvpPendingCount() }} pending</span>
+                      </div>
+                    </div>
+                  }
+
+                  <!-- Total Invitees -->
+                  @if (registrants().length > 0 && !isPastMeeting()) {
+                    <div class="inline-flex items-center gap-1 text-sm text-gray-500" data-testid="total-invitees">
+                      <i class="fa-light fa-users"></i>
+                      <span>{{ totalInvitees() }} invited</span>
+                    </div>
+                  }
+                </div>
+
+                <!-- Attendance Stats (past meetings) -->
+                @if (hasAttendanceData()) {
+                  <div class="flex items-center gap-4" data-testid="attendance-summary">
+                    <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
+                      <i class="fa-light fa-circle-check text-emerald-500 text-sm"></i>
+                      <span class="text-sm font-semibold text-emerald-600">{{ attendedCount() }}</span>
+                      <span class="text-sm text-gray-500">attended</span>
+                    </div>
+                    <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
+                      <i class="fa-light fa-circle-xmark text-gray-400 text-sm"></i>
+                      <span class="text-sm font-semibold text-gray-500">{{ absentCount() }}</span>
+                      <span class="text-sm text-gray-500">absent</span>
+                    </div>
+                    <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2">
+                      <i class="fa-light fa-chart-pie text-blue-500 text-sm"></i>
+                      <span class="text-sm font-semibold text-gray-700">{{ attendancePercentage() }}%</span>
+                      <span class="text-sm text-gray-500">rate</span>
+                    </div>
+                  </div>
+                }
+
+                <!-- Alert Banner -->
+                @if (isPastMeeting()) {
+                  <div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-past'">
+                    <i class="fa-light fa-clock-rotate-left text-gray-500 text-base"></i>
+                    <p class="text-sm text-gray-700">This meeting has ended.</p>
+                  </div>
+                } @else if (messageSeverity() === 'warn') {
+                  <div class="bg-amber-50 border border-amber-500/50 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-warn'">
+                    <i class="fa-light fa-clock text-amber-500 text-base"></i>
+                    <p class="text-sm text-amber-900">{{ alertMessage() }}</p>
+                  </div>
+                } @else if (messageSeverity() === 'info' && canJoinMeeting()) {
+                  <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex items-center gap-2" [attr.data-testid]="'meeting-alert-info'">
+                    <i class="fa-light fa-calendar text-blue-500 text-base"></i>
+                    <p class="text-sm text-blue-900">{{ alertMessage() }}</p>
+                  </div>
+                }
+              </div>
+
+              <!-- Right Column: Join Button (immediate meetings) or RSVP (future meetings) -->
+              @if (canJoinMeeting() && authenticated()) {
+                @if (fetchedJoinUrl() && !showGuestForm()) {
+                  <div class="w-full md:w-[296px]">
+                    <lfx-button
+                      styleClass="w-full h-[40px]"
+                      label="Join Meeting"
+                      icon="fa-light fa-video"
+                      severity="success"
+                      size="large"
+                      [href]="fetchedJoinUrl()"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      [attr.data-testid]="'join-meeting-button-immediate'">
+                    </lfx-button>
+                  </div>
+                } @else if (joinUrlError() !== null && !showGuestForm()) {
+                  <div class="w-full md:w-[296px] flex flex-col gap-2">
+                    <lfx-button
+                      label="Join Meeting"
+                      icon="fa-light fa-video"
+                      [disabled]="true"
+                      size="large"
+                      styleClass="w-full h-[40px] bg-gray-300 text-gray-500 border-none cursor-not-allowed"
+                      rel="noopener noreferrer"
+                      [attr.data-testid]="'join-meeting-button-error'">
+                    </lfx-button>
+                    <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2">
+                      <span>{{ joinUrlError() }}</span
+                      >.
+                      @if (emailError()) {
+                        <span
+                          ><a class="text-primary cursor-pointer" (click)="onEmailErrorClick()">Click here</a> to join using a different email address.</span
+                        >
+                      }
+                    </div>
+                  </div>
+                } @else if (!showGuestForm()) {
+                  <!-- Disabled+loading is the default while the join URL is resolving.
+                     Placed last so it renders at SSR first paint (no join URL or error yet)
+                     rather than depending on the client-only isLoadingJoinUrl signal. -->
+                  <div class="w-full md:w-[296px]">
+                    <lfx-button
+                      styleClass="w-full h-[40px]"
+                      label="Join Meeting"
+                      icon="fa-light fa-video"
+                      severity="success"
+                      size="large"
+                      [loading]="true"
+                      [disabled]="true"
+                      [attr.data-testid]="'join-meeting-button-loading'">
+                    </lfx-button>
+                  </div>
+                }
+              } @else if (authenticated() && !isPastMeeting() && meeting().organizer) {
+                <!-- RSVP Section - Future Meeting (Authenticated Organizers) -->
+                <div class="w-full md:w-[296px] flex flex-col gap-2">
+                  @if (canToggleRsvpView() && showMyRsvp()) {
+                    <!-- Show RSVP Button Group when organizer toggles to set their own RSVP -->
+                    <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id" (rsvpChanged)="onRsvpChanged($event)">
+                    </lfx-rsvp-button-group>
+                  } @else {
+                    <!-- Show RSVP Details for organizers (default view) -->
+                    <lfx-meeting-rsvp-details
+                      [meeting]="meeting()"
+                      [project]="project()"
+                      [currentOccurrence]="currentOccurrence()"
+                      [pastMeeting]="isPastMeeting()"
+                      [showAddButton]="!!meeting().organizer && !isPastMeeting()"
+                      [additionalRegistrantsCount]="additionalRegistrantsCount()"
+                      backgroundColor="bg-gray-50"
+                      borderColor="border-gray-200"
+                      (addClicked)="showRegistrants.set(true)">
+                    </lfx-meeting-rsvp-details>
+                  }
+                  @if (canToggleRsvpView()) {
+                    @if (!showMyRsvp() && currentUserRsvpLabel(); as rsvpLabel) {
+                      <div
+                        class="flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-50 border border-gray-200 text-xs"
+                        data-testid="current-user-rsvp-status">
+                        @if (currentUserRsvpIcon(); as iconClass) {
+                          <i [class]="iconClass" aria-hidden="true"></i>
+                        }
+                        <span class="text-gray-600">Your RSVP:</span>
+                        <span class="font-medium text-gray-900">{{ rsvpLabel }}</span>
+                      </div>
+                    }
+                    <lfx-button
+                      class="w-full"
+                      styleClass="w-full"
+                      [icon]="showMyRsvp() ? 'fa-light fa-users' : 'fa-light fa-hand'"
+                      [label]="rsvpToggleLabel()"
+                      size="small"
+                      severity="secondary"
+                      (onClick)="onRsvpViewToggle()"
+                      data-testid="toggle-rsvp-view-button">
+                    </lfx-button>
+                  }
+                </div>
+              } @else if (authenticated() && !isPastMeeting()) {
+                <!-- RSVP Container - Future Meeting (Authenticated Non-Organizers) -->
+                <div class="w-full md:w-[296px]">
+                  @if (isInvited()) {
+                    @defer (when meeting()) {
+                      <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id"> </lfx-rsvp-button-group>
+                    }
+                  } @else if (canRegisterForMeeting()) {
+                    <lfx-button
+                      class="w-full"
+                      styleClass="w-full"
+                      icon="fa-light fa-user-plus"
+                      label="Register for Meeting"
+                      size="small"
+                      severity="secondary"
+                      (onClick)="registerForMeeting()"
+                      data-testid="register-meeting-button">
+                    </lfx-button>
+                  }
+                </div>
+              } @else if (isPastMeeting() && authenticated() && pastMeetingFullAccess()) {
+                <!-- Meeting Tools — Past Meeting (right column) -->
+                <div class="w-full md:w-[296px]" data-testid="meeting-tools">
+                  <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                    <div class="flex flex-col gap-1 mb-3">
+                      <h3 class="text-gray-700 text-sm font-medium">Meeting Tools</h3>
+                      <p class="text-xs text-gray-400">Tools are provided for accessibility and reference.</p>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                      <!-- See Recording -->
+                      @if (primaryRecordingUrl()) {
+                        <a
+                          [href]="primaryRecordingUrl()"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer"
+                          data-testid="view-recording-link">
+                          <i class="fa-light fa-play text-sm"></i>
+                          <span>See Recording</span>
+                        </a>
+                      } @else {
+                        <div
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
+                          data-testid="recording-unavailable">
+                          <i class="fa-light fa-play text-sm"></i>
+                          <span>See Recording</span>
+                        </div>
+                      }
+
+                      <!-- AI Summary -->
+                      @if (hasSummaryContent()) {
+                        <button
+                          type="button"
+                          (click)="openSummaryModal()"
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer w-full"
+                          data-testid="past-meeting-summary">
+                          <i class="fa-light fa-sparkles text-sm"></i>
+                          <span>AI Summary</span>
+                          @if (pastMeetingSummary()?.approved) {
+                            <span class="text-xs font-medium text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded-full">Approved</span>
+                          } @else if (summaryAwaitingApproval()) {
+                            <span class="text-xs font-medium text-amber-600 bg-amber-100 px-1.5 py-0.5 rounded-full">Pending</span>
+                          }
+                        </button>
+                      } @else {
+                        <div
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
+                          data-testid="summary-unavailable">
+                          <i class="fa-light fa-sparkles text-sm"></i>
+                          <span>AI Summary Not Available</span>
+                        </div>
+                      }
+
+                      <!-- Transcript -->
+                      @if (transcriptUrl()) {
+                        <button
+                          type="button"
+                          (click)="openTranscriptModal()"
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer w-full"
+                          data-testid="view-transcript-button">
+                          <i class="fa-light fa-file-lines text-sm"></i>
+                          <span>View Transcript</span>
+                        </button>
+                      } @else {
+                        <div
+                          class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-300"
+                          data-testid="transcript-unavailable">
+                          <i class="fa-light fa-file-lines text-sm"></i>
+                          <span>Transcript Unavailable</span>
+                        </div>
+                      }
+                    </div>
+                  </div>
+                </div>
+              }
+            </div>
+
+            @if (!(isPastMeeting() && !pastMeetingFullAccess())) {
+              <!-- Divider -->
+              <hr class="border-gray-200 my-4" />
+
+              <!-- Agenda + Resources Row (2-column) -->
+              <div class="flex flex-col md:flex-row gap-6">
+                <!-- Left: Agenda Section (flex-1) -->
+                <div class="flex-1 flex flex-col gap-2">
+                  <!-- Agenda Header -->
+                  <div class="flex items-center gap-2">
+                    <i class="fa-light fa-list text-gray-500 text-xs"></i>
+                    <h3 class="text-gray-600 text-sm font-normal">Agenda</h3>
+                  </div>
+
+                  <!-- Description -->
+                  @if (meetingDescription(); as description) {
+                    <div class="text-gray-600 text-xs leading-relaxed" [attr.data-testid]="'meeting-description'">
+                      <lfx-expandable-text [maxHeight]="200">
+                        <div [innerHTML]="description | linkify" class="text-sm leading-relaxed"></div>
+                      </lfx-expandable-text>
+                    </div>
+                  }
+                </div>
+
+                <!-- Right: Meeting Materials Card (fixed width) -->
+                <div class="w-full md:w-[296px]" data-testid="meeting-materials">
+                  @defer (on idle) {
+                    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                      <!-- Header -->
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="fa-light fa-folder-open text-gray-500 text-sm"></i>
+                        <h3 class="text-gray-700 text-sm font-medium flex-1">Meeting Materials</h3>
+                        @if (hasRecentlyUpdatedMaterials()) {
+                          <span class="text-xs font-medium text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded-full">Updated</span>
+                        }
+                        @if (meeting().organizer && !isPastMeeting()) {
+                          <button
+                            type="button"
+                            (click)="openMaterialsDrawer()"
+                            class="text-xs text-blue-600 hover:text-blue-800 font-medium transition-colors"
+                            data-testid="manage-materials-btn">
+                            Manage
+                          </button>
+                        }
+                      </div>
+                      <p class="text-xs text-gray-400 mb-3">Documents provided to support meeting preparation, discussion, and governance record.</p>
+
+                      <div class="flex flex-col gap-4">
+                        <!-- PRIMARY MATERIALS -->
+                        <div class="flex flex-col gap-2">
+                          <span class="text-xs font-semibold uppercase tracking-wider text-gray-400">Primary Materials</span>
+                          <p class="text-xs text-gray-400">Materials intended for review before the meeting.</p>
+                          @if (materialFiles().length > 0) {
+                            @for (attachment of visibleFiles(); track attachment.uid; let i = $index) {
+                              @let fileType = attachment | fileTypeDisplay;
+                              <button
+                                type="button"
+                                (click)="downloadAttachment(attachment)"
+                                class="bg-white border border-gray-200 hover:border-gray-300 rounded-lg p-3 flex items-center gap-3 transition-colors cursor-pointer w-full text-left"
+                                [attr.data-testid]="'meeting-material-file-' + i">
+                                <div class="w-9 h-9 rounded flex items-center justify-center flex-shrink-0" [ngClass]="[fileType.bgColor]">
+                                  <i [ngClass]="[fileType.icon, fileType.textColor]" class="text-base"></i>
+                                </div>
+                                <div class="flex flex-col flex-1 overflow-hidden gap-0.5">
+                                  <span class="text-sm text-gray-900 overflow-ellipsis overflow-hidden whitespace-nowrap font-inter">{{
+                                    attachment.name
+                                  }}</span>
+                                  <div class="flex items-center gap-2">
+                                    <span class="text-xs uppercase tracking-wide text-gray-500 bg-gray-200 px-1.5 py-0.5 rounded">{{ fileType.label }}</span>
+                                    @if (attachment.updated_at || attachment.created_at) {
+                                      <span class="text-xs text-gray-400">{{ attachment.updated_at || attachment.created_at | date: 'MMM d, yyyy' }}</span>
+                                    }
+                                  </div>
+                                </div>
+                                <i class="fa-light fa-arrow-up-right-from-square text-gray-400 text-xs flex-shrink-0"></i>
+                              </button>
+                            }
+                            @if (hasMoreFiles()) {
+                              <button
+                                type="button"
+                                (click)="showAllFiles.set(!showAllFiles())"
+                                class="text-xs text-blue-600 hover:text-blue-800 font-medium py-1 transition-colors"
+                                data-testid="toggle-more-files">
+                                {{ showAllFiles() ? 'Show less' : 'Show ' + (materialFiles().length - 5) + ' more' }}
+                              </button>
+                            }
+                          } @else {
+                            @if (!authenticated() && meeting().visibility === 'private') {
+                              <p class="text-xs text-gray-400 italic">Sign in to view materials for this meeting.</p>
+                            } @else {
+                              <p class="text-xs text-gray-400 italic">No primary materials available.</p>
+                            }
+                          }
+                        </div>
+
+                        <!-- SUPPORTING MATERIALS -->
+                        <div class="flex flex-col gap-2">
+                          <span class="text-xs font-semibold uppercase tracking-wider text-gray-400">Supporting Materials</span>
+                          @if (materialLinks().length > 0) {
+                            @for (attachment of materialLinks(); track attachment.uid; let i = $index) {
+                              <div class="flex items-center gap-3 py-1.5" [attr.data-testid]="'meeting-material-link-' + i">
+                                <i class="fa-light fa-link text-gray-400 text-sm flex-shrink-0"></i>
+                                <span class="text-sm text-gray-700 overflow-ellipsis overflow-hidden whitespace-nowrap flex-1 font-inter">{{
+                                  attachment.name
+                                }}</span>
+                                <a
+                                  [href]="attachment.link"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  class="text-xs border border-gray-300 text-gray-600 rounded px-2 py-0.5 hover:bg-gray-100 transition-colors flex-shrink-0">
+                                  Open
+                                </a>
+                              </div>
+                            }
+                          } @else {
+                            <p class="text-xs text-gray-400 italic">No supporting materials available.</p>
+                          }
+                        </div>
+                      </div>
+                    </div>
+                  } @placeholder {
+                    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 animate-pulse">
+                      <div class="h-4 bg-gray-200 rounded w-2/3 mb-3"></div>
+                      <div class="h-3 bg-gray-200 rounded w-full mb-4"></div>
+                      <div class="flex flex-col gap-3">
+                        <div class="h-12 bg-gray-200 rounded"></div>
+                        <div class="h-12 bg-gray-200 rounded"></div>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+
+            <!-- Footer Divider -->
+            <hr class="border-gray-200 my-4" />
+
+            <!-- Authentication Section -->
+            @if (authenticated() && user(); as user) {
+              <!-- Signed In State -->
+              <div class="flex flex-col gap-6">
+                <div class="flex flex-col gap-3">
+                  <p class="text-sm text-gray-950">You are signed in as:</p>
+
+                  <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center gap-3">
+                    <!-- Avatar -->
+                    <div class="hidden md:flex w-12 h-12 bg-blue-600 rounded-full items-center justify-center">
+                      <span class="text-white text-2xl font-medium">{{ userInitials() }}</span>
+                    </div>
+
+                    <!-- User Info -->
+                    <div class="flex-1">
+                      <p class="font-semibold text-sm text-blue-900">{{ user.name }}</p>
+                      <p class="text-sm text-blue-900">{{ user.email }}</p>
+                    </div>
+                  </div>
+                </div>
+
+                @if (isPastMeeting() && !pastMeetingFullAccess()) {
+                  <div class="bg-amber-50 border border-amber-300 rounded px-3 py-3 flex items-start gap-3">
+                    <i class="fa-light fa-lock text-amber-600 text-base mt-0.5"></i>
+                    <div>
+                      <p class="font-semibold text-sm text-amber-900">This is a private meeting</p>
+                      <p class="text-xs text-gray-600">
+                        Meeting details, recordings, and summaries are only available to meeting participants and committee members. If you believe you should
+                        have access, please contact the meeting organizer.
+                      </p>
+                    </div>
+                  </div>
+                }
+
+                <!-- Guest Form for authenticated users -->
+                @if (showGuestForm() && !isPastMeeting()) {
+                  <!-- OR Divider -->
+                  <div class="relative h-px bg-gray-200">
+                    <span class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white px-3 text-xs text-gray-600">OR</span>
+                  </div>
+
+                  <lfx-guest-form [form]="joinForm" [joinUrl]="fetchedJoinUrl()" [isLoading]="isLoadingJoinUrl()"> </lfx-guest-form>
+                  @if (joinUrlError() !== null) {
+                    <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2 text-center">
+                      <span>{{ joinUrlError() }}. Please contact the meeting organizer or support team if you believe this is an error.</span>
+                    </div>
+                  }
+                }
+              </div>
+            } @else {
+              <!-- Signed Out State -->
+              <div class="flex flex-col gap-6">
+                <!-- Sign In CTA -->
+                <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center justify-between gap-3">
+                  <div class="flex items-center gap-3">
+                    <i class="fa-light fa-arrow-right-to-bracket text-blue-600 text-2xl"></i>
+                    <div>
+                      @if (isPastMeeting()) {
+                        <p class="font-semibold text-sm text-blue-900">Sign in to view meeting details</p>
+                        <p class="text-xs text-gray-600">Access the agenda, recordings, summaries, and resources</p>
+                      } @else {
+                        <p class="font-semibold text-sm text-blue-900">Sign in with your LFX account</p>
+                        <p class="text-xs text-gray-600">Join quickly with your saved information</p>
+                      }
+                    </div>
+                  </div>
+
+                  <lfx-button
+                    class="w-full md:w-auto"
+                    styleClass="w-full md:w-auto"
+                    size="small"
+                    label="Sign In"
+                    icon="fa-light fa-arrow-right-to-bracket"
+                    severity="info"
+                    [href]="'/login?returnTo=' + returnTo()">
+                  </lfx-button>
+                </div>
+
+                @if (!isPastMeeting()) {
+                  <!-- OR Divider -->
+                  <div class="relative h-px bg-gray-200">
+                    <span class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white px-3 text-xs text-gray-600">OR</span>
+                  </div>
+
+                  <!-- Guest Form -->
+                  <lfx-guest-form [form]="joinForm" [joinUrl]="fetchedJoinUrl()" [isLoading]="isLoadingJoinUrl()"> </lfx-guest-form>
+                  @if (joinUrlError() !== null) {
+                    <div class="text-xs text-red-500 bg-red-50 border border-red-500/50 rounded px-3 py-2 text-center">
+                      <span>{{ joinUrlError() }}. Please contact the meeting organizer or support team if you believe this is an error.</span>
+                    </div>
+                  }
+                }
+              </div>
+            }
+          </lfx-card>
+        </div>
+      </div>
+
+      <!-- Meeting Registrants Drawer (rendered outside the card so PrimeNG's overlay/mask isn't
+         re-parented under lfx-card's content tree, which causes the drawer to close itself
+         when the opening click bubbles back through that subtree). -->
+      <p-drawer
+        [(visible)]="showRegistrants"
+        [position]="drawerPosition()"
+        styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+        [modal]="true"
+        [showCloseIcon]="false"
+        data-testid="meeting-registrants-drawer">
+        <ng-template #header>
+          <div class="flex items-center justify-between w-full">
+            <div class="flex items-center gap-3">
+              <div class="bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center">
+                <i class="fa-light fa-user-group text-white text-2xl"></i>
+              </div>
+              @if (isPastMeeting()) {
+                <div class="flex flex-col">
+                  <h1>Meeting Participants</h1>
+                  <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ invitedCount() }} invited</span>
+                </div>
+              } @else if (meeting().committees && meeting().committees.length) {
+                <div class="flex flex-col">
+                  <h1>Meeting Members</h1>
+                  <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>
+                </div>
+              } @else {
+                <div class="flex flex-col">
+                  <h1>Meeting Guests</h1>
+                  <span class="text-base text-gray-500">{{ totalInvitees() }} guests</span>
+                </div>
+              }
+            </div>
+            <button type="button" class="text-gray-400 hover:text-gray-600 p-2 cursor-pointer" (click)="onDrawerHide()" aria-label="Close panel">
+              <i class="fa-light fa-xmark text-xl"></i>
+            </button>
+          </div>
+        </ng-template>
+        <lfx-meeting-registrants-display
+          [meeting]="meeting()"
+          [pastMeeting]="isPastMeeting()"
+          [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
+          [myMeetingRegistrants]="true"
+          [initialRegistrants]="registrants()"
+          [initialRegistrantsLoading]="registrantsLoading()"
+          [visible]="showRegistrants()"
+          (refreshRequested)="onRegistrantsRefreshRequested($event)">
+        </lfx-meeting-registrants-display>
+      </p-drawer>
+
+      <!-- Meeting Materials Drawer -->
+      @if (meeting().organizer && !isPastMeeting()) {
+        <lfx-meeting-materials-drawer [(visible)]="materialsDrawerVisible" [meetingId]="meeting().id" (materialsChanged)="onMaterialsChanged()">
+        </lfx-meeting-materials-drawer>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -120,7 +120,7 @@ export class MeetingJoinComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly meetingService = inject(MeetingService);
   private readonly projectService = inject(ProjectService);
-  private readonly userService = inject(UserService);
+  protected readonly userService = inject(UserService);
   private readonly clipboard = inject(Clipboard);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly plausibleService = inject(PlausibleService);
@@ -131,7 +131,6 @@ export class MeetingJoinComponent implements OnInit {
   // Class variables with types
   public authenticated: WritableSignal<boolean>;
   public user: Signal<User | null> = this.userService.user;
-  public readonly impersonating: Signal<boolean> = this.userService.impersonating;
   public joinForm: FormGroup;
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> }>;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -21,6 +21,7 @@ import {
   buildJoinUrlWithParams,
   canJoinMeeting,
   DEFAULT_MEETING_TYPE_CONFIG,
+  Impersonator,
   getActiveOccurrences,
   getCurrentOrNextOccurrence,
   hasMeetingEnded,
@@ -51,6 +52,7 @@ import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
 import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { ImpersonationService } from '@services/impersonation.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -119,6 +121,7 @@ export class MeetingJoinComponent implements OnInit {
   private readonly meetingService = inject(MeetingService);
   private readonly projectService = inject(ProjectService);
   private readonly userService = inject(UserService);
+  private readonly impersonationService = inject(ImpersonationService);
   private readonly clipboard = inject(Clipboard);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly plausibleService = inject(PlausibleService);
@@ -129,6 +132,8 @@ export class MeetingJoinComponent implements OnInit {
   // Class variables with types
   public authenticated: WritableSignal<boolean>;
   public user: Signal<User | null> = this.userService.user;
+  public readonly impersonating: Signal<boolean> = this.userService.impersonating;
+  public readonly impersonator: Signal<Impersonator | null> = this.userService.impersonator;
   public joinForm: FormGroup;
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> }>;
@@ -322,6 +327,15 @@ export class MeetingJoinComponent implements OnInit {
       mql.addEventListener('change', handler);
       this.destroyRef.onDestroy(() => mql.removeEventListener('change', handler));
     }
+  }
+
+  public stopImpersonation(): void {
+    this.impersonationService
+      .stopImpersonation()
+      .pipe(take(1))
+      .subscribe(() => {
+        window.location.reload();
+      });
   }
 
   public handleCopyLink(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -12,6 +12,7 @@ import { MeetingSummaryModalComponent } from '@app/modules/meetings/components/m
 import { TranscriptModalComponent } from '@app/modules/meetings/components/transcript-modal/transcript-modal.component';
 import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component';
 import { ButtonComponent } from '@components/button/button.component';
+import { ImpersonationBannerComponent } from '@components/impersonation-banner/impersonation-banner.component';
 import { CardComponent } from '@components/card/card.component';
 import { ExpandableTextComponent } from '@components/expandable-text/expandable-text.component';
 import { HeaderComponent } from '@components/header/header.component';
@@ -21,7 +22,6 @@ import {
   buildJoinUrlWithParams,
   canJoinMeeting,
   DEFAULT_MEETING_TYPE_CONFIG,
-  Impersonator,
   getActiveOccurrences,
   getCurrentOrNextOccurrence,
   hasMeetingEnded,
@@ -52,7 +52,6 @@ import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
 import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { ImpersonationService } from '@services/impersonation.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -109,6 +108,7 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     FileTypeDisplayPipe,
     DynamicDialogModule,
     MeetingMaterialsDrawerComponent,
+    ImpersonationBannerComponent,
   ],
   providers: [DialogService],
   templateUrl: './meeting-join.component.html',
@@ -121,7 +121,6 @@ export class MeetingJoinComponent implements OnInit {
   private readonly meetingService = inject(MeetingService);
   private readonly projectService = inject(ProjectService);
   private readonly userService = inject(UserService);
-  private readonly impersonationService = inject(ImpersonationService);
   private readonly clipboard = inject(Clipboard);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly plausibleService = inject(PlausibleService);
@@ -133,7 +132,6 @@ export class MeetingJoinComponent implements OnInit {
   public authenticated: WritableSignal<boolean>;
   public user: Signal<User | null> = this.userService.user;
   public readonly impersonating: Signal<boolean> = this.userService.impersonating;
-  public readonly impersonator: Signal<Impersonator | null> = this.userService.impersonator;
   public joinForm: FormGroup;
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> }>;
@@ -327,15 +325,6 @@ export class MeetingJoinComponent implements OnInit {
       mql.addEventListener('change', handler);
       this.destroyRef.onDestroy(() => mql.removeEventListener('change', handler));
     }
-  }
-
-  public stopImpersonation(): void {
-    this.impersonationService
-      .stopImpersonation()
-      .pipe(take(1))
-      .subscribe(() => {
-        window.location.reload();
-      });
   }
 
   public handleCopyLink(): void {

--- a/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.html
@@ -1,0 +1,15 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (userService.impersonating()) {
+  <div
+    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
+    data-testid="impersonation-banner">
+    <i class="fa-light fa-eye text-sm" aria-hidden="true"></i>
+    <span
+      >Viewing as <strong>{{ userService.user()?.email }}</strong></span
+    >
+    <span class="text-black/60">— by {{ userService.impersonator()?.name }}</span>
+    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
+  </div>
+}

--- a/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.html
@@ -3,13 +3,23 @@
 
 @if (userService.impersonating()) {
   <div
-    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
+    role="status"
+    aria-live="polite"
+    aria-label="Impersonation active"
+    class="fixed top-0 left-0 right-0 z-[60] flex min-h-12 items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
     data-testid="impersonation-banner">
     <i class="fa-light fa-eye text-sm" aria-hidden="true"></i>
     <span
       >Viewing as <strong>{{ userService.user()?.email }}</strong></span
     >
     <span class="text-black/60">— by {{ userService.impersonator()?.name }}</span>
-    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
+    <lfx-button
+      label="Stop Impersonating"
+      severity="contrast"
+      size="small"
+      [disabled]="stoppingImpersonation()"
+      [loading]="stoppingImpersonation()"
+      (onClick)="stopImpersonation()"
+      data-testid="stop-impersonation-button" />
   </div>
 }

--- a/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { ImpersonationService } from '@services/impersonation.service';
+import { UserService } from '@services/user.service';
+import { take } from 'rxjs';
+
+@Component({
+  selector: 'lfx-impersonation-banner',
+  imports: [ButtonComponent],
+  templateUrl: './impersonation-banner.component.html',
+})
+export class ImpersonationBannerComponent {
+  private readonly impersonationService = inject(ImpersonationService);
+  protected readonly userService = inject(UserService);
+
+  protected stopImpersonation(): void {
+    this.impersonationService
+      .stopImpersonation()
+      .pipe(take(1))
+      .subscribe(() => {
+        window.location.reload();
+      });
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
@@ -35,8 +35,6 @@ export class ImpersonationBannerComponent {
             window.location.reload();
           }
         },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        error: () => {},
       });
   }
 }

--- a/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-banner/impersonation-banner.component.ts
@@ -1,11 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { ImpersonationService } from '@services/impersonation.service';
 import { UserService } from '@services/user.service';
-import { take } from 'rxjs';
+import { finalize, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-impersonation-banner',
@@ -15,13 +15,28 @@ import { take } from 'rxjs';
 export class ImpersonationBannerComponent {
   private readonly impersonationService = inject(ImpersonationService);
   protected readonly userService = inject(UserService);
+  protected readonly stoppingImpersonation = signal(false);
 
   protected stopImpersonation(): void {
+    if (this.stoppingImpersonation()) {
+      return;
+    }
+
+    this.stoppingImpersonation.set(true);
     this.impersonationService
       .stopImpersonation()
-      .pipe(take(1))
-      .subscribe(() => {
-        window.location.reload();
+      .pipe(
+        take(1),
+        finalize(() => this.stoppingImpersonation.set(false))
+      )
+      .subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.location.reload();
+          }
+        },
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        error: () => {},
       });
   }
 }


### PR DESCRIPTION
## Summary

The meeting join page had no impersonation indicator. Staff members could unknowingly join meetings as an impersonated user with no way to return to their own identity.

- Added the same impersonation banner shown in the main app (`main-layout.component.html`) to the meeting join page: fixed yellow bar at `z-[60]`, showing the impersonated user's email, the impersonator's name, and a **Stop Impersonating** CTA
- Wrapped page content in a `pt-12` container (active when impersonating) so the banner does not overlap the header or content on load
- Exposed `impersonating`/`impersonator` signals from `UserService` as public class members on `MeetingJoinComponent`; injected `ImpersonationService` for `stopImpersonation()`

## Test plan

- [ ] Sign in as a staff member, impersonate another user, navigate to any meeting join page — confirm the yellow impersonation banner appears at the top with the correct email and impersonator name
- [ ] Click **Stop Impersonating** — confirm the page reloads and the banner disappears
- [ ] Verify the banner does not overlap the header or page content
- [ ] Verify the page looks normal (no banner) when not impersonating

Fixes LFXV2-2541

🤖 Generated with [Claude Code](https://claude.com/claude-code)