### PR TITLE
fix(impersonation): prevent CF auth loop and add target user CF token

### DIFF
--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -65,15 +65,15 @@ export class ImpersonationController {
         throw new Error('Failed to decode target user claims from CTE response');
       }
 
-      // Attempt a CF-audience CTE so the impersonated session can access the target user's
-      // Crowdfunding data. This is best-effort: if the exchange fails (e.g. the target user
-      // has no CF account or Auth0 denies the audience), impersonation still starts and CF
-      // sections fall back to empty state (Phase 1 behaviour).
-      const cfAudience = process.env['CROWDFUNDING_API_AUDIENCE'];
+      // Attempt a CF-scoped CTE so the impersonated session can access the target user's
+      // Crowdfunding data. The admin's CF token is used as the subject_token so the auth
+      // service can extract the CF audience from it. Best-effort: if the exchange fails
+      // (e.g. admin has no CF token, or auth service rejects it), impersonation still
+      // starts and CF sections fall back to empty state.
       let cfTokenResponse: M2MTokenResponse | undefined;
-      if (cfAudience) {
+      if (req.crowdfundingToken) {
         try {
-          cfTokenResponse = await this.impersonationService.exchangeToken(req, targetUser.trim(), cfAudience);
+          cfTokenResponse = await this.impersonationService.exchangeToken(req, targetUser.trim(), req.crowdfundingToken);
           logger.debug(req, 'start_impersonation', 'CF CTE exchange succeeded for target user');
         } catch (cfErr) {
           logger.warning(req, 'start_impersonation', 'CF CTE exchange failed — CF will show empty state during impersonation', {

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PersonaType, VALID_PERSONAS } from '@lfx-one/shared/interfaces';
+import { M2MTokenResponse, PersonaType, VALID_PERSONAS } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
@@ -65,8 +65,25 @@ export class ImpersonationController {
         throw new Error('Failed to decode target user claims from CTE response');
       }
 
+      // Attempt a CF-audience CTE so the impersonated session can access the target user's
+      // Crowdfunding data. This is best-effort: if the exchange fails (e.g. the target user
+      // has no CF account or Auth0 denies the audience), impersonation still starts and CF
+      // sections fall back to empty state (Phase 1 behaviour).
+      const cfAudience = process.env['CROWDFUNDING_API_AUDIENCE'];
+      let cfTokenResponse: M2MTokenResponse | undefined;
+      if (cfAudience) {
+        try {
+          cfTokenResponse = await this.impersonationService.exchangeToken(req, targetUser.trim(), cfAudience);
+          logger.debug(req, 'start_impersonation', 'CF CTE exchange succeeded for target user');
+        } catch (cfErr) {
+          logger.warning(req, 'start_impersonation', 'CF CTE exchange failed — CF will show empty state during impersonation', {
+            error: cfErr instanceof Error ? cfErr.message : String(cfErr),
+          });
+        }
+      }
+
       const profile = await this.impersonationService.fetchTargetUserProfile(req, targetClaims['sub']);
-      this.impersonationService.startImpersonation(req, res, tokenResponse, targetClaims, profile, personaContext);
+      this.impersonationService.startImpersonation(req, res, tokenResponse, targetClaims, profile, personaContext, cfTokenResponse);
 
       logger.success(req, 'start_impersonation', startTime, {
         target_sub: targetClaims['sub'],

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -256,8 +256,32 @@ async function extractApiGatewayToken(req: Request): Promise<void> {
  * If the session token is valid, uses it directly. If it is expired or absent but a
  * refresh token is stored, attempts a silent refresh before falling through — avoiding
  * the auth-code redirect round-trip on token expiry.
+ *
+ * During impersonation the normal (admin's) CF token is never used — it would return
+ * the admin's data under the target user's session. Instead, a CF-audience CTE token
+ * for the target user is stored at impersonation start and loaded here. If no such
+ * token exists (CTE failed or Auth0 cross-audience not configured), req.crowdfundingToken
+ * is left undefined and cfFetch() falls back to an empty-state 503 response.
  */
 async function extractCrowdfundingToken(req: Request): Promise<void> {
+  // During impersonation: use the target user's CF token obtained via audience-scoped CTE.
+  // If we don't have one (CF CTE failed or CROWDFUNDING_API_AUDIENCE is not set), leave
+  // req.crowdfundingToken undefined — cfFetch() handles the 503 fallback to empty state.
+  // Always return early here to prevent the admin's own CF token from being loaded.
+  if (req.appSession?.['impersonationToken']) {
+    const impersonationCfToken = req.appSession['impersonationCrowdfundingToken'];
+    const impersonationCfExpiresAt = req.appSession['impersonationCrowdfundingExpiresAt'];
+    const nowSecs = Math.floor(Date.now() / 1000);
+
+    if (impersonationCfToken && impersonationCfExpiresAt && nowSecs < impersonationCfExpiresAt) {
+      req.crowdfundingToken = impersonationCfToken;
+      logger.debug(req, 'crowdfunding_token', 'Using impersonation CF token for target user');
+    } else {
+      logger.debug(req, 'crowdfunding_token', 'No valid CF token for impersonated user — CF will show empty state');
+    }
+    return;
+  }
+
   const now = Math.floor(Date.now() / 1000);
   if (req.appSession?.crowdfundingToken && req.appSession.crowdfundingTokenExpiresAt && now < req.appSession.crowdfundingTokenExpiresAt) {
     req.crowdfundingToken = req.appSession.crowdfundingToken;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -301,10 +301,9 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     }
   }
 
-  // CF auth redirect is skipped during impersonation — the target user's CF token is
-  // obtained via CTE at session start (see impersonation.controller.ts). Allowing the
-  // auth-code redirect here would kick off a new CF auth flow for the admin before
-  // Angular boots, producing a redirect loop and discarding the impersonation session.
+  // CF auth redirect is skipped during impersonation — allowing it would kick off a new
+  // CF auth flow for the admin before Angular boots, producing a redirect loop and
+  // discarding the impersonation session. CF falls back to empty state during impersonation.
   const isImpersonating = !!(req.appSession?.['impersonationToken'] && req.appSession?.['impersonationUser']);
   if (
     auth.authenticated &&

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -301,8 +301,14 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     }
   }
 
+  // CF auth redirect is skipped during impersonation — the target user's CF token is
+  // obtained via CTE at session start (see impersonation.controller.ts). Allowing the
+  // auth-code redirect here would kick off a new CF auth flow for the admin before
+  // Angular boots, producing a redirect loop and discarding the impersonation session.
+  const isImpersonating = !!(req.appSession?.['impersonationToken'] && req.appSession?.['impersonationUser']);
   if (
     auth.authenticated &&
+    !isImpersonating &&
     req.originalUrl.startsWith('/crowdfunding') &&
     !req.query['error'] &&
     crowdfundingAuthService.isConfigured() &&
@@ -459,7 +465,6 @@ async function gracefulShutdown(signal: string): Promise<void> {
   if (!httpServer) {
     logger.success(undefined, 'graceful_shutdown', startTime, { reason: 'no_http_server' });
     process.exit(0);
-    return;
   }
 
   // Stop accepting new connections and drain in-flight requests (25s window).

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -56,6 +56,16 @@ function throwCfNetworkError(operation: string, error: unknown): never {
 async function cfFetch<T>(req: Request, operation: string, path: string, options: { method?: string; body?: unknown; noBody?: boolean } = {}): Promise<T> {
   const token = req.crowdfundingToken;
   if (!token) {
+    // During impersonation, a CF-audience CTE is attempted at session start but may
+    // fail (e.g. Auth0 not configured for cross-audience exchange, or target user has
+    // no CF account). Use 503 so the client falls through to the empty-state fallback
+    // rather than triggering the CF auth-code redirect loop.
+    if (req.appSession?.['impersonationToken']) {
+      throw new MicroserviceError('Crowdfunding is unavailable during impersonation', 503, 'CF_UNAVAILABLE_DURING_IMPERSONATION', {
+        operation,
+        service: 'crowdfunding',
+      });
+    }
     throw new MicroserviceError(`No crowdfunding token available for ${operation}`, 401, 'CF_UNAUTHENTICATED', { operation, service: 'crowdfunding' });
   }
 
@@ -122,6 +132,12 @@ async function cfFetchAllPages<T>(req: Request, operation: string, basePath: str
 async function cfFetchNullable<T>(req: Request, operation: string, path: string): Promise<T | null> {
   const token = req.crowdfundingToken;
   if (!token) {
+    if (req.appSession?.['impersonationToken']) {
+      throw new MicroserviceError('Crowdfunding is unavailable during impersonation', 503, 'CF_UNAVAILABLE_DURING_IMPERSONATION', {
+        operation,
+        service: 'crowdfunding',
+      });
+    }
     throw new MicroserviceError(`No crowdfunding token available for ${operation}`, 401, 'CF_UNAUTHENTICATED', { operation, service: 'crowdfunding' });
   }
 

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -56,10 +56,10 @@ function throwCfNetworkError(operation: string, error: unknown): never {
 async function cfFetch<T>(req: Request, operation: string, path: string, options: { method?: string; body?: unknown; noBody?: boolean } = {}): Promise<T> {
   const token = req.crowdfundingToken;
   if (!token) {
-    // During impersonation, a CF-audience CTE is attempted at session start but may
-    // fail (e.g. Auth0 not configured for cross-audience exchange, or target user has
-    // no CF account). Use 503 so the client falls through to the empty-state fallback
-    // rather than triggering the CF auth-code redirect loop.
+    // During impersonation the CF token should be present (set from the CTE token at
+    // session start). If it's missing the session is in an unexpected state — 503 so
+    // the client falls through to empty state rather than triggering the CF auth-code
+    // redirect loop.
     if (req.appSession?.['impersonationToken']) {
       throw new MicroserviceError('Crowdfunding is unavailable during impersonation', 503, 'CF_UNAVAILABLE_DURING_IMPERSONATION', {
         operation,

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -29,14 +29,13 @@ export class ImpersonationService {
     this.natsService = new NatsService();
   }
 
-  public async exchangeToken(req: Request, targetUser: string, audience?: string): Promise<M2MTokenResponse> {
-    logger.debug(req, 'cte_token_exchange', 'Starting CTE token exchange via NATS', { target_user: targetUser, ...(audience ? { audience } : {}) });
+  public async exchangeToken(req: Request, targetUser: string, subjectToken?: string): Promise<M2MTokenResponse> {
+    logger.debug(req, 'cte_token_exchange', 'Starting CTE token exchange via NATS', { target_user: targetUser, subject_token_type: subjectToken ? 'cf' : 'oidc' });
 
     const codec = this.natsService.getCodec();
     const payload = JSON.stringify({
-      subject_token: req.bearerToken || '',
+      subject_token: subjectToken || req.bearerToken || '',
       target_user: targetUser,
-      ...(audience ? { audience } : {}),
     });
 
     try {
@@ -163,8 +162,9 @@ export class ImpersonationService {
     req.appSession['impersonationUser'] = targetUser;
     req.appSession['impersonator'] = impersonator;
 
-    // Store target user's CF token when we obtained one via audience-scoped CTE.
-    // Stored in Unix seconds to match the pattern of crowdfundingTokenExpiresAt.
+    // Store the CF-scoped CTE token so extractCrowdfundingToken can load it for
+    // crowdfunding requests under impersonation. Stored in Unix seconds to match
+    // the crowdfundingTokenExpiresAt pattern.
     if (cfTokenResponse) {
       const cfSafetyBuffer = cfTokenResponse.expires_in > TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS ? TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS : 0;
       req.appSession['impersonationCrowdfundingToken'] = cfTokenResponse.access_token;

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -19,6 +19,9 @@ import { clearImpersonationSession, decodeJwtPayload } from '../utils/auth-helpe
 import { logger } from './logger.service';
 import { NatsService } from './nats.service';
 
+/** Safety buffer subtracted from token expiry to avoid using near-expired tokens (5 min). */
+const TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS = 300;
+
 export class ImpersonationService {
   private readonly natsService: NatsService;
 
@@ -26,13 +29,14 @@ export class ImpersonationService {
     this.natsService = new NatsService();
   }
 
-  public async exchangeToken(req: Request, targetUser: string): Promise<M2MTokenResponse> {
-    logger.debug(req, 'cte_token_exchange', 'Starting CTE token exchange via NATS', { target_user: targetUser });
+  public async exchangeToken(req: Request, targetUser: string, audience?: string): Promise<M2MTokenResponse> {
+    logger.debug(req, 'cte_token_exchange', 'Starting CTE token exchange via NATS', { target_user: targetUser, ...(audience ? { audience } : {}) });
 
     const codec = this.natsService.getCodec();
     const payload = JSON.stringify({
       subject_token: req.bearerToken || '',
       target_user: targetUser,
+      ...(audience ? { audience } : {}),
     });
 
     try {
@@ -131,7 +135,8 @@ export class ImpersonationService {
     tokenResponse: M2MTokenResponse,
     targetClaims: LfxAccessTokenClaims,
     profile?: { name?: string; picture?: string },
-    personaContext?: PersonaType
+    personaContext?: PersonaType,
+    cfTokenResponse?: M2MTokenResponse
   ): void {
     if (!req.appSession) {
       req.appSession = {};
@@ -153,10 +158,18 @@ export class ImpersonationService {
     };
 
     req.appSession['impersonationToken'] = tokenResponse.access_token;
-    const safetyBufferSeconds = tokenResponse.expires_in > 300 ? 300 : 0;
+    const safetyBufferSeconds = tokenResponse.expires_in > TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS ? TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS : 0;
     req.appSession['impersonationExpiresAt'] = Date.now() + (tokenResponse.expires_in - safetyBufferSeconds) * 1000;
     req.appSession['impersonationUser'] = targetUser;
     req.appSession['impersonator'] = impersonator;
+
+    // Store target user's CF token when we obtained one via audience-scoped CTE.
+    // Stored in Unix seconds to match the pattern of crowdfundingTokenExpiresAt.
+    if (cfTokenResponse) {
+      const cfSafetyBuffer = cfTokenResponse.expires_in > TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS ? TOKEN_EXPIRY_SAFETY_BUFFER_SECONDS : 0;
+      req.appSession['impersonationCrowdfundingToken'] = cfTokenResponse.access_token;
+      req.appSession['impersonationCrowdfundingExpiresAt'] = Math.floor(Date.now() / 1000) + cfTokenResponse.expires_in - cfSafetyBuffer;
+    }
 
     if (personaContext) {
       req.appSession['impersonationPersonaContext'] = personaContext;

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -137,4 +137,6 @@ export function clearImpersonationSession(req: Request): void {
   delete req.appSession['impersonationUser'];
   delete req.appSession['impersonator'];
   delete req.appSession['impersonationPersonaContext'];
+  delete req.appSession['impersonationCrowdfundingToken'];
+  delete req.appSession['impersonationCrowdfundingExpiresAt'];
 }

--- a/apps/lfx-one/src/types/express.d.ts
+++ b/apps/lfx-one/src/types/express.d.ts
@@ -24,6 +24,8 @@ declare global {
         crowdfundingRefreshToken?: string;
         crowdfundingAuthState?: string;
         crowdfundingAuthReturnTo?: string;
+        impersonationCrowdfundingToken?: string;
+        impersonationCrowdfundingExpiresAt?: number;
         [key: string]: any;
       };
     }


### PR DESCRIPTION
## Summary

Fixes an auth redirect loop that occurred when an admin impersonated a user and navigated to `/crowdfunding` pages. The error presented was:

```json
{"error": "Authentication required to access this resource", "code": "AUTHENTICATION_REQUIRED"}
```

### Root Causes (three simultaneous)

1. **SSR redirect triggered before Angular booted** — the catch-all handler called the CF auth-code redirect on every `/crowdfunding` page load during impersonation, before Angular had a chance to render anything.
2. **Admin's CF token loaded under impersonation** — `extractCrowdfundingToken` loaded the real (admin's) CF token into the impersonation session, returning the wrong user's data or triggering a confusing upstream 401.
3. **401 CF_UNAUTHENTICATED triggered Angular redirect loop** — `cfFetch` returned `401 CF_UNAUTHENTICATED` which is the exact condition the Angular `handleCfError` handler uses to call `redirectToCfAuth()`, creating a loop.

### Fix

**Phase 1 (no Auth0 changes required — ships immediately):**
- Guard the SSR CF auth-code redirect with `!isImpersonating`
- Return `503 CF_UNAVAILABLE_DURING_IMPERSONATION` from `cfFetch`/`cfFetchNullable` when no CF token is available during impersonation — Angular's `handleCfError` falls through to `of(fallback)` (empty state) instead of redirecting
- `extractCrowdfundingToken` returns early during impersonation, never loading the admin's CF token

**Phase 2 (best-effort — shows target user's real CF data when Auth0 is configured):**
- During `startImpersonation`, attempt a second audience-scoped CTE for `CROWDFUNDING_API_AUDIENCE` using the same NATS subject
- If Auth0 is configured to allow cross-audience exchange, the target user's CF token is stored in the session (`impersonationCrowdfundingToken` / `impersonationCrowdfundingExpiresAt`)
- If Auth0 returns `access_denied` (not yet configured), the `try/catch` logs a warning, impersonation still starts, and CF shows empty state (Phase 1 fallback)

### Auth Service Dependency

The Phase 2 CTE requires `lfx-v2-auth-service` to accept an optional `audience` field on `lfx.auth-service.impersonation.token_exchange`. That change has been implemented in a separate PR in that repo. If the auth service is deployed without that change, the CF CTE NATS call will still succeed (the auth service silently ignores unknown fields) but will issue a primary LFX V2 token scoped to the wrong audience — the token will be rejected by the CF API and the BFF will fall through to Phase 1 empty state. No breakage.

### Auth0 Tenant Configuration (for Phase 2 to show live CF data)

See `cf-impersonation-solution.md` §9 for the two Auth0 tenant changes needed:
1. Authorize `AUTH0_M2M_CLIENT_ID` for the CF API with scopes `openid profile access:me offline_access`
2. Add a CF audience branch to the CTE Action

## Testing

- [ ] Admin impersonates user → navigates to `/crowdfunding` → no redirect loop, no console auth errors
- [ ] CF sections show empty state (Phase 1) or target user's CF data (Phase 2)
- [ ] Admin stops impersonation → own CF data returns normally
- [ ] Non-impersonating user with no CF token still gets redirected to CF auth (no regression)

## Related

- JIRA: [LFXV2-2367](https://linuxfoundation.atlassian.net/browse/LFXV2-2367)
- Auth service PR: _(link once open)_

[LFXV2-2367]: https://linuxfoundation.atlassian.net/browse/LFXV2-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ