### PR TITLE
docs(shared): document type-alias placement convention

### DIFF
--- a/.claude/rules/development-rules.md
+++ b/.claude/rules/development-rules.md
@@ -24,6 +24,7 @@ If you already have a working branch, ensure it's rebased on the latest `main` b
 - Use TypeScript interfaces instead of union types for better maintainability
 - Shared package uses direct source imports during development for hot reloading
 - All interfaces, reusable constants, and enums should live in the shared package
+- Types live in `interfaces/`, values live in `constants/`: `export type` (including derived aliases like `type Foo = (typeof BAR)[keyof typeof BAR]`) belongs in a `.interface.ts`; constants files export runtime values only. A derived alias goes in the interface file even when its source constant lives in `constants/` (import the constant to derive it)
 
 ## AI Service
 

--- a/.claude/skills/self-serve-dev/references/shared-types.md
+++ b/.claude/skills/self-serve-dev/references/shared-types.md
@@ -4,3 +4,20 @@
 # Shared Types Reference
 
 Canonical shared-package conventions (location, naming, barrel exports, when to share vs keep local, import aliases) live in [`docs/architecture/shared/package-architecture.md`](../../../docs/architecture/shared/package-architecture.md). Use that doc as the source of truth.
+
+## Quick placement rules
+
+- **Interfaces and type aliases** → `packages/shared/src/interfaces/<name>.interface.ts`.
+- **Runtime values** (`const`, `as const` objects, `Set`s, arrays) → `packages/shared/src/constants/<name>.constants.ts`. Constants files export **values only — no `export type` / `export interface`**.
+- **Derived type aliases belong with the interfaces, not the constant.** When you write `export type Foo = (typeof BAR)[keyof typeof BAR]`, define it in the matching `.interface.ts` and import the `BAR` constant into that file — even though `BAR` itself lives in `constants/`.
+- Export every new file from its directory `index.ts` barrel, and import via the category path (`@lfx-one/shared/interfaces`, `@lfx-one/shared/constants`).
+
+```typescript
+// constants/events.constants.ts — value only
+export const MY_EVENT_STATUS = { ATTENDED: 'Attended', REGISTERED: 'Registered' } as const;
+
+// interfaces/events.interface.ts — derived alias
+import { MY_EVENT_STATUS } from '../constants/events.constants';
+
+export type MyEventStatus = (typeof MY_EVENT_STATUS)[keyof typeof MY_EVENT_STATUS];
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ For missing sign-off recovery (single-commit amend, or older commits / cherry-pi
 - Never nest ternary expressions.
 - Use `flex + flex-col + gap-*`, not `space-y-*`, for vertical stacking.
 - All shared constants and interfaces live in `@lfx-one/shared` — no module-level consts or local `interface Foo {}` inside `apps/lfx-one/`.
+- Within `@lfx-one/shared`, types live in `interfaces/` and values live in `constants/`: `export type` (including derived aliases like `(typeof CONST)[keyof typeof CONST]`) belongs in a `.interface.ts`; constants files export runtime values only.
 
 ### Architecture
 

--- a/docs/architecture/placement.md
+++ b/docs/architecture/placement.md
@@ -44,9 +44,13 @@ Is it a type alias / interface (not a runtime value)?
                  (Includes derived aliases: `type Foo = (typeof BAR)[keyof typeof BAR]`.
                   The alias goes here even if BAR lives in constants/ — import the
                   constant into the .interface.ts to derive it.)
+  NO (it's a runtime value, enum, or utility)
+       -> constants: packages/shared/src/constants/<name>.constants.ts (values only — no export type)
+       -> enums:     packages/shared/src/enums/<name>.enum.ts
+       -> utils:     packages/shared/src/utils/<name>.utils.ts
 ```
 
-Enums go in `packages/shared/src/enums/<name>.enum.ts`; constants in `packages/shared/src/constants/<name>.constants.ts` (**runtime values only — no `export type`**). Each directory has a barrel `index.ts` — every new file must be exported there.
+Each directory has a barrel `index.ts` — every new file must be exported there.
 
 See `docs/architecture/shared/package-architecture.md` for full naming, exports, and import-alias rules.
 

--- a/docs/architecture/placement.md
+++ b/docs/architecture/placement.md
@@ -37,14 +37,16 @@ Current modules: `badges`, `committees`, `dashboards`, `documents`, `events`, `m
 ## Where does my type go?
 
 ```text
-Is it used across modules or between frontend and backend?
-  YES -> packages/shared/src/interfaces/<name>.interface.ts
-  NO  -> Is it purely component-internal state?
+Is it a type alias / interface (not a runtime value)?
+  YES -> Is it purely component-internal state?
           YES -> Define locally in the component file.
           NO  -> packages/shared/src/interfaces/<name>.interface.ts (default to shared)
+                 (Includes derived aliases: `type Foo = (typeof BAR)[keyof typeof BAR]`.
+                  The alias goes here even if BAR lives in constants/ — import the
+                  constant into the .interface.ts to derive it.)
 ```
 
-Enums go in `packages/shared/src/enums/<name>.enum.ts`; constants in `packages/shared/src/constants/<name>.constants.ts`. Each directory has a barrel `index.ts` — every new file must be exported there.
+Enums go in `packages/shared/src/enums/<name>.enum.ts`; constants in `packages/shared/src/constants/<name>.constants.ts` (**runtime values only — no `export type`**). Each directory has a barrel `index.ts` — every new file must be exported there.
 
 See `docs/architecture/shared/package-architecture.md` for full naming, exports, and import-alias rules.
 

--- a/docs/architecture/shared/package-architecture.md
+++ b/docs/architecture/shared/package-architecture.md
@@ -39,17 +39,19 @@ During development, TypeScript path mappings resolve `@lfx-one/shared/*` directl
 
 ### Interfaces (`interfaces/`)
 
-All TypeScript interfaces live in this package — **including component-specific prop interfaces** — so types are discoverable from one place and reusable without refactoring.
+All TypeScript interfaces **and type aliases** live in this package — **including component-specific prop interfaces** — so types are discoverable from one place and reusable without refactoring.
 
 - File suffix: `.interface.ts`; one domain per file (e.g. `meeting.interface.ts` owns all meeting-shaped types).
 - Prefer `interface` over union types where it makes the shape extensible.
 - Add JSDoc for non-obvious fields (especially ones that mirror upstream Go/Goa API shapes).
+- **Type aliases live here too, including derived aliases** such as `type Foo = (typeof BAR)[keyof typeof BAR]`. The alias belongs in the interface file even when the `BAR` constant it derives from lives in a constants file — import the constant into the `.interface.ts` to derive the alias. (This is a type-only import in a values-only file, so it introduces no runtime cycle.)
 
 ### Constants (`constants/`)
 
 Design tokens, API endpoint config, and static lookup data (countries, timezones, t-shirt sizes, etc.).
 
 - Use `as const` assertions for immutable values.
+- Export **runtime values only** — `const`, `as const` objects, `Set`s, arrays. No `export type` / `export interface`; a type derived from a constant goes in the matching `.interface.ts` (see Interfaces above).
 - Group by domain file. Subdirectories are allowed for large groupings (e.g. `meeting-templates/`).
 
 ### Enums (`enums/`)
@@ -121,6 +123,7 @@ Keep runtime deps minimal. Prefer peer dependencies for framework-specific types
 
 - **File naming**: Use the canonical suffix (`.interface.ts`, `.constants.ts`, `.enum.ts`, `.utils.ts`, `.validators.ts`) so tooling and grep work consistently.
 - **Interfaces everywhere**: Even component-specific prop types live here — no local `interface Foo {}` declarations inside `apps/lfx-one/`.
+- **Types in `interfaces/`, values in `constants/`**: `export type` (including derived aliases like `(typeof CONST)[keyof typeof CONST]`) belongs in a `.interface.ts`; constants files export runtime values only.
 - **Prefer `interface` over union types** for shapes you might extend.
 - **Optional properties**: Use `?` for fields that may be undefined rather than `| undefined` in unions.
 - **Pure utils**: Utilities should not import from `apps/lfx-one/` — the dependency direction is one-way (app depends on shared, not vice versa).

--- a/docs/architecture/shared/package-architecture.md
+++ b/docs/architecture/shared/package-architecture.md
@@ -44,7 +44,7 @@ All TypeScript interfaces **and type aliases** live in this package — **includ
 - File suffix: `.interface.ts`; one domain per file (e.g. `meeting.interface.ts` owns all meeting-shaped types).
 - Prefer `interface` over union types where it makes the shape extensible.
 - Add JSDoc for non-obvious fields (especially ones that mirror upstream Go/Goa API shapes).
-- **Type aliases live here too, including derived aliases** such as `type Foo = (typeof BAR)[keyof typeof BAR]`. The alias belongs in the interface file even when the `BAR` constant it derives from lives in a constants file — import the constant into the `.interface.ts` to derive the alias. (This is a type-only import in a values-only file, so it introduces no runtime cycle.)
+- **Type aliases live here too, including derived aliases** such as `type Foo = (typeof BAR)[keyof typeof BAR]`. The alias belongs in the interface file even when the `BAR` constant it derives from lives in a constants file — import the constant into the `.interface.ts` to derive the alias. (The constant is used only in a type position via `typeof`, so the import is erased at compile time and creates no runtime dependency cycle.)
 
 ### Constants (`constants/`)
 

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -6,9 +6,11 @@ Standards for the shared package (`@lfx-one/shared`) and Snowflake SQL queries.
 
 ## Shared Package
 
-### 1. Interfaces in shared (SHOULD FIX)
+### 1. Interfaces and type aliases in shared (SHOULD FIX)
 
-Prefer defining reusable interfaces in `packages/shared/src/interfaces/<name>.interface.ts`. Truly local UI-only types with no reuse potential may remain local in a component, but shared or reusable interfaces should not be defined there.
+Prefer defining reusable interfaces **and type aliases** in `packages/shared/src/interfaces/<name>.interface.ts`. Truly local UI-only types with no reuse potential may remain local in a component, but shared or reusable types should not be defined there.
+
+This includes **derived type aliases** such as `type Foo = (typeof BAR)[keyof typeof BAR]`: the alias lives in the interface file even when the `BAR` constant it derives from lives in a constants file. Import the constant into the interface file to derive the alias.
 
 **Violation:**
 
@@ -35,11 +37,37 @@ export interface MeetingDetails {
 import { MeetingDetails } from '@lfx-one/shared/interfaces';
 ```
 
+**Violation (derived alias in a constants file):**
+
+```typescript
+// packages/shared/src/constants/events.constants.ts
+export const MY_EVENT_STATUS = { ATTENDED: 'Attended', REGISTERED: 'Registered' } as const;
+export type MyEventStatus = (typeof MY_EVENT_STATUS)[keyof typeof MY_EVENT_STATUS]; // ❌ type in constants file
+```
+
+**Fix (constant stays; alias moves to the interface file):**
+
+```typescript
+// packages/shared/src/constants/events.constants.ts — value only
+export const MY_EVENT_STATUS = { ATTENDED: 'Attended', REGISTERED: 'Registered' } as const;
+
+// packages/shared/src/interfaces/events.interface.ts — derived alias
+import { MY_EVENT_STATUS } from '../constants/events.constants';
+
+export type MyEventStatus = (typeof MY_EVENT_STATUS)[keyof typeof MY_EVENT_STATUS];
+
+// Consumers import the value and the type from their respective barrels
+import { MY_EVENT_STATUS } from '@lfx-one/shared/constants';
+import { MyEventStatus } from '@lfx-one/shared/interfaces';
+```
+
 ---
 
 ### 2. Constants in shared (SHOULD FIX)
 
 All constants belong in `packages/shared/src/constants/<name>.constants.ts`. Use `as const` for constant objects.
+
+Constants files export **runtime values only** (`const`, `as const` objects, `Set`, arrays) — no `export type` or `export interface`. Types and derived aliases belong in the matching `.interface.ts` (see item 1).
 
 **Violation:**
 


### PR DESCRIPTION
## Summary

Documents the previously-implicit convention that shared TypeScript **type aliases** — including derived aliases like `type Foo = (typeof BAR)[keyof typeof BAR]` — belong in `packages/shared/src/interfaces/`, and that `constants/` files export **runtime values only**.

### Why

During LFXV2-2566 (PR #1053), a reviewer flagged `MyEventStatus` being exported from `events.constants.ts` instead of `events.interface.ts`. An audit found the rule was a reasonable maintainer expectation that was **never documented** — the docs gave parallel "interfaces → `interfaces/`, constants → `constants/`" guidance but never forbade `export type` in a constants file or addressed the derived-alias pattern. As a result neither the pre-PR reviewer trio nor CodeRabbit/Copilot flagged it. This PR closes that documentation gap.

## Changes

- **`docs/reviews/shared-and-sql-checklist.md`** — item 1 now explicitly covers type aliases with a derived-alias violation/fix example; item 2 states constants files are values-only. (This is the surface the reviewer trio enforces.)
- **`docs/architecture/shared/package-architecture.md`** — Interfaces/Constants sections + Best Practices updated.
- **`docs/architecture/placement.md`** — derived-alias branch added to "Where does my type go?".
- **`.claude/skills/self-serve-dev/references/shared-types.md`** — added a Quick placement rules section with the pattern.
- **`.claude/rules/development-rules.md`** — one bullet in the Shared Package section.
- **`CLAUDE.md`** — one bullet in Source hygiene. ⚠️ **`CLAUDE.md` is a preflight-protected file — needs code-owner review.**

## Out of scope (separate follow-up)

Migrating the 6 existing counterexample type aliases (`CountryCode`, `USState`, `TShirtSize`, `ProductType`, `CombinedSurveyStatus`, `AllowedLogoMimeType`) from constants files into interface files is a cross-cutting code refactor and will be handled in its own PR.

## Validation

`prettier --check`, `markdownlint-cli2`, and `./check-headers.sh` all pass. Documentation-only — no code, SQL, or API changes.

Refs: LFXV2-2570
