### PR TITLE
refactor(shared): migrate type/value placement to LFXV2-2570 convention

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-branding-tab/settings-branding-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-branding-tab/settings-branding-tab.component.ts
@@ -6,8 +6,8 @@ import { Component, ElementRef, inject, input, signal, viewChild, PLATFORM_ID } 
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { filter, firstValueFrom } from 'rxjs';
 import { ButtonComponent } from '@components/button/button.component';
-import { ALLOWED_LOGO_MIME_TYPES, AllowedLogoMimeType, MAX_LOGO_SIZE_BYTES } from '@lfx-one/shared/constants';
-import { InitiativeDetail } from '@lfx-one/shared/interfaces';
+import { ALLOWED_LOGO_MIME_TYPES, MAX_LOGO_SIZE_BYTES } from '@lfx-one/shared/constants';
+import { AllowedLogoMimeType, InitiativeDetail } from '@lfx-one/shared/interfaces';
 import { CrowdfundingService } from '@services/crowdfunding.service';
 
 @Component({

--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { afterNextRender, Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { isBoardScopedPersona } from '@lfx-one/shared/interfaces';
+import { isBoardScopedPersona } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
@@ -3,7 +3,8 @@
 
 import { Component, computed, inject, Signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { isBoardScopedPersona, PendingActionItem } from '@lfx-one/shared/interfaces';
+import { PendingActionItem } from '@lfx-one/shared/interfaces';
+import { isBoardScopedPersona } from '@lfx-one/shared/utils';
 import { PersonaService } from '@services/persona.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -3,19 +3,17 @@
 
 import { HttpClient } from '@angular/common/http';
 import { afterNextRender, computed, inject, Injectable, makeStateKey, Signal, signal, TransferState, WritableSignal } from '@angular/core';
-import { PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { PERSONA_COOKIE_KEY, VALID_PERSONAS } from '@lfx-one/shared/constants';
 import {
   Account,
   AuthContext,
   EnrichedPersonaProject,
-  isBoardScopedPersona,
-  isProjectScopedPersona,
   PersistedPersonaState,
   PersonaApiResponse,
   PersonaProject,
   PersonaType,
-  VALID_PERSONAS,
 } from '@lfx-one/shared/interfaces';
+import { isBoardScopedPersona, isProjectScopedPersona } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, Observable, of, take, tap } from 'rxjs';
 

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -6,8 +6,8 @@ import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@a
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
-import { isBoardScopedPersona, ProjectContext } from '@lfx-one/shared/interfaces';
-import { isSameProjectContext } from '@lfx-one/shared/utils';
+import { ProjectContext } from '@lfx-one/shared/interfaces';
+import { isBoardScopedPersona, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, map, of, startWith, switchMap } from 'rxjs';
 

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PersonaType, VALID_PERSONAS } from '@lfx-one/shared/interfaces';
+import { VALID_PERSONAS } from '@lfx-one/shared/constants';
+import { PersonaType } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -8,6 +8,7 @@ import {
   PERSONAS_CACHE_TTL_MS,
   ROOT_PROJECT_SLUG,
   ROOT_PROJECT_UID_CACHE_TTL_MS,
+  VALID_PERSONAS,
 } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
@@ -20,7 +21,6 @@ import {
   PersonaDetections,
   PersonaProject,
   PersonaType,
-  VALID_PERSONAS,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 

--- a/apps/lfx-one/src/server/services/rewards.service.ts
+++ b/apps/lfx-one/src/server/services/rewards.service.ts
@@ -1,9 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { REWARD_STEP_SIZE } from '@lfx-one/shared/constants';
+import { REWARD_CATEGORIES, REWARD_STEP_SIZE } from '@lfx-one/shared/constants';
 import {
-  REWARD_CATEGORIES,
   RewardCouponGenerationResponse,
   RewardPromotion,
   RewardPromotionCategory,

--- a/apps/lfx-one/src/server/utils/persona-helper.ts
+++ b/apps/lfx-one/src/server/utils/persona-helper.ts
@@ -1,9 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { PERSONA_COOKIE_KEY, VALID_PERSONAS } from '@lfx-one/shared/constants';
 import type { PersistedPersonaState, PersonaType, SsrPersonaResult } from '@lfx-one/shared/interfaces';
-import { VALID_PERSONAS } from '@lfx-one/shared/interfaces';
 import { Request, Response } from 'express';
 
 import { logger } from '../services/logger.service';

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberAppointedBy, CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { BehavioralClassDisplayConfig, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
+import { BehavioralClassDisplayConfig, CommitteeCategoryInfo, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
 import { lfxColors } from './colors.constants';
 
 // Re-export helper functions from utils for backward compatibility
@@ -37,17 +37,6 @@ export const COMMITTEE_LABEL = {
   singular: 'Group',
   plural: 'Groups',
 } as const;
-
-/**
- * Committee category info for card-based selection
- * @description Defines icons, descriptions, and colors for each committee category
- */
-export interface CommitteeCategoryInfo {
-  icon: string;
-  description: string;
-  examples: string;
-  color: string;
-}
 
 /**
  * Committee category configurations with visual styling

--- a/packages/shared/src/constants/countries.constants.ts
+++ b/packages/shared/src/constants/countries.constants.ts
@@ -97,11 +97,6 @@ export const COUNTRIES = [
 ] as const;
 
 /**
- * Type for country codes
- */
-export type CountryCode = (typeof COUNTRIES)[number]['value'];
-
-/**
  * Helper function to get country name by code
  */
 export function getCountryByCode(code: string): string {

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -3,6 +3,7 @@
 
 import { FundType } from '../enums/crowdfunding.enum';
 import {
+  AllowedLogoMimeType,
   CrowdfundingInitiativesStats,
   CrowdfundingTransaction,
   CrowdfundingTransactionList,
@@ -101,7 +102,6 @@ export const EMPTY_DONATION_STATS: DonationStats = {
   activeRecurringCount: 0,
 };
 
-export type AllowedLogoMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
 export const ALLOWED_LOGO_MIME_TYPES: AllowedLogoMimeType[] = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 export const MAX_LOGO_SIZE_BYTES = 2 * 1024 * 1024;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ArtifactVisibility } from '../enums';
-import { TagSeverity } from '../interfaces';
+import type { MeetingTypeConfig } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 
 /**
@@ -94,41 +94,6 @@ export const ARTIFACT_VISIBILITY_OPTIONS = [
   { label: 'Meeting Guests', value: ArtifactVisibility.MEETING_PARTICIPANTS },
   { label: 'Public', value: ArtifactVisibility.PUBLIC },
 ];
-
-/**
- * Meeting type color configuration
- * @description Defines colors, icons, and styling for meeting type badges and borders
- */
-export interface MeetingTypeConfig {
-  /** Display label for the meeting type */
-  label: string;
-  /** Background color class (e.g., bg-violet-100) */
-  bgColor: string;
-  /** Text color class - 600 shade (e.g., text-violet-600) */
-  textColor: string;
-  /** Text color class - 500 shade (e.g., text-violet-500) for alternate styling */
-  textColorAlt: string;
-  /** Border color class - 500 shade (e.g., border-violet-500) */
-  borderColor: string;
-  /** Border color class - 300 shade (e.g., border-violet-300) for lighter borders */
-  borderColorLight: string;
-  /** Font Awesome icon class */
-  icon: string;
-  /** CSS class for tag badge color override (e.g., tag-meeting-board) */
-  tagStyleClass: string;
-}
-
-/**
- * Meeting type badge interface
- * @description Structure for meeting type badge display
- */
-export interface MeetingTypeBadge {
-  label: string;
-  className: string;
-  severity?: TagSeverity;
-  styleClass?: string;
-  icon?: string;
-}
 
 /**
  * Meeting type color mappings

--- a/packages/shared/src/constants/persona.constants.ts
+++ b/packages/shared/src/constants/persona.constants.ts
@@ -1,7 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { BOARD_SCOPED_PERSONAS, DevPersonaPreset, PersonaOption, PersonaType, PROJECT_SCOPED_PERSONAS } from '../interfaces';
+import type { DevPersonaPreset, PersonaOption, PersonaType } from '../interfaces';
+
+export const VALID_PERSONAS: ReadonlySet<string> = new Set<string>(['contributor', 'maintainer', 'board-member', 'executive-director']);
+
+export const BOARD_SCOPED_PERSONAS: ReadonlySet<PersonaType> = new Set(['board-member', 'executive-director']);
+
+export const PROJECT_SCOPED_PERSONAS: ReadonlySet<PersonaType> = new Set(['maintainer', 'contributor']);
 
 export const PERSONA_COOKIE_KEY = 'lfx-active-persona-preset';
 

--- a/packages/shared/src/constants/rewards.constants.ts
+++ b/packages/shared/src/constants/rewards.constants.ts
@@ -7,3 +7,9 @@
  * - the points granularity for the "next reward" threshold calculation.
  */
 export const REWARD_STEP_SIZE = 500;
+
+// Single source of truth for reward categories. The `RewardPromotionCategory`
+// union in rewards.interface.ts is derived from this tuple, and
+// `RewardPromotionGroups` keys off that union — adding a new category requires
+// editing only this array.
+export const REWARD_CATEGORIES = ['Event', 'Training', 'Certification'] as const;

--- a/packages/shared/src/constants/states.constants.ts
+++ b/packages/shared/src/constants/states.constants.ts
@@ -57,8 +57,3 @@ export const US_STATES = [
   { label: 'Wyoming', value: 'WY' },
   { label: 'District of Columbia', value: 'DC' },
 ] as const;
-
-/**
- * Type for US state values
- */
-export type USState = (typeof US_STATES)[number]['value'];

--- a/packages/shared/src/constants/survey.constants.ts
+++ b/packages/shared/src/constants/survey.constants.ts
@@ -3,6 +3,7 @@
 
 import { SurveyResponseStatus, SurveyStatus } from '../enums/survey.enum';
 import { TagSeverity } from '../interfaces/components.interface';
+import type { CombinedSurveyStatus } from '../interfaces/survey.interface';
 
 /**
  * Configurable labels for surveys displayed throughout the UI
@@ -60,12 +61,6 @@ export const SURVEY_RESPONSE_STATUS_SEVERITY: Record<SurveyResponseStatus, TagSe
   [SurveyResponseStatus.RESPONDED]: 'success',
   [SurveyResponseStatus.NOT_RESPONDED]: 'info',
 } as const;
-
-/**
- * Combined survey status type
- * @description Represents the combined state of survey status and response status
- */
-export type CombinedSurveyStatus = 'open' | 'submitted' | 'closed';
 
 /**
  * Combined survey status values

--- a/packages/shared/src/constants/tag.constants.ts
+++ b/packages/shared/src/constants/tag.constants.ts
@@ -1,18 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { TagProps, TagSeverity } from '../interfaces/components.interface';
-
-/**
- * Tag type configuration
- * @description Centralized tag styling configuration for common use cases
- */
-export interface TagTypeConfig {
-  severity: TagProps['severity'];
-  icon?: string;
-  rounded?: boolean;
-  styleClass?: string;
-}
+import { TagSeverity } from '../interfaces/components.interface';
+import type { TagTypeConfig } from '../interfaces/tag.interface';
 
 /**
  * Centralized tag type configurations

--- a/packages/shared/src/constants/timezones.constants.ts
+++ b/packages/shared/src/constants/timezones.constants.ts
@@ -1,18 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * Timezone option interface for dropdown components
- * @description Structured timezone data with human-readable labels and IANA identifiers
- */
-export interface TimezoneOption {
-  /** Human-readable timezone label */
-  label: string;
-  /** IANA timezone identifier value */
-  value: string;
-  /** UTC offset string representation */
-  offset: string;
-}
+import type { TimezoneOption } from '../interfaces/timezones.interface';
 
 /**
  * Comprehensive list of timezone options for global meeting scheduling

--- a/packages/shared/src/constants/training.constants.ts
+++ b/packages/shared/src/constants/training.constants.ts
@@ -80,7 +80,6 @@ export const DESCENDING_DEFAULT_ORG_TRAINING_SORT_FIELDS: ReadonlySet<string> = 
 
 export const TRAINING_PRODUCT_TYPE = 'Training' as const;
 export const CERTIFICATION_PRODUCT_TYPE = 'Certification' as const;
-export type ProductType = typeof TRAINING_PRODUCT_TYPE | typeof CERTIFICATION_PRODUCT_TYPE;
 
 export const CONTINUE_LEARNING_URL = 'https://trainingportal.linuxfoundation.org/learn/dashboard';
 export const COURSE_URL_PREFIX = 'https://trainingportal.linuxfoundation.org/learn/course/';

--- a/packages/shared/src/constants/tshirt-sizes.constants.ts
+++ b/packages/shared/src/constants/tshirt-sizes.constants.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { TShirtSize } from '../interfaces/tshirt-sizes.interface';
+
 /**
  * T-shirt size options for profile forms and swag distribution.
  * Values mirror the v1 Salesforce picklist so v2→v1 sync round-trips cleanly.
@@ -18,11 +20,6 @@ export const TSHIRT_SIZES = [
   { label: 'Straight-Cut 2XL', value: 'Straight-Cut 2XL' },
   { label: 'Straight-Cut 3XL', value: 'Straight-Cut 3XL' },
 ] as const;
-
-/**
- * Type for T-shirt size values
- */
-export type TShirtSize = (typeof TSHIRT_SIZES)[number]['value'];
 
 /**
  * Coerce a stored t-shirt size into one of the current valid options.

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -944,3 +944,14 @@ export interface CommitteeMemberPermissionInfo {
   /** True when `level` comes only from an inherited (project/foundation) grant, not a committee-scoped role. */
   inherited: boolean;
 }
+
+/**
+ * Committee category info for card-based selection
+ * @description Defines icons, descriptions, and colors for each committee category
+ */
+export interface CommitteeCategoryInfo {
+  icon: string;
+  description: string;
+  examples: string;
+  color: string;
+}

--- a/packages/shared/src/interfaces/countries.interface.ts
+++ b/packages/shared/src/interfaces/countries.interface.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { COUNTRIES } from '../constants/countries.constants';
+
+/**
+ * Type for country codes
+ */
+export type CountryCode = (typeof COUNTRIES)[number]['value'];

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -359,3 +359,5 @@ export interface InitiativeMenuItem {
   danger?: boolean;
   command?: (event: unknown) => void;
 }
+
+export type AllowedLogoMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -247,6 +247,9 @@ export * from './linux-email.interface';
 
 // Crowdfunding interfaces
 export * from './crowdfunding.interface';
+export * from './countries.interface';
+export * from './states.interface';
+export * from './tshirt-sizes.interface';
 
 // Donut chart interfaces
 export * from './donut-chart.interface';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -250,6 +250,8 @@ export * from './crowdfunding.interface';
 export * from './countries.interface';
 export * from './states.interface';
 export * from './tshirt-sizes.interface';
+export * from './tag.interface';
+export * from './timezones.interface';
 
 // Donut chart interfaces
 export * from './donut-chart.interface';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -247,6 +247,8 @@ export * from './linux-email.interface';
 
 // Crowdfunding interfaces
 export * from './crowdfunding.interface';
+
+// Country, state, t-shirt size, tag, and timezone interfaces
 export * from './countries.interface';
 export * from './states.interface';
 export * from './tshirt-sizes.interface';

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
+import { TagSeverity } from './components.interface';
 
 // ============================================================================
 // V1 Legacy Summary Interfaces (still used by transformV1SummaryToV2)
@@ -1156,4 +1157,39 @@ export interface SummarySection {
   borderColor: string;
   /** Tailwind text color class for the icon */
   iconColor: string;
+}
+
+/**
+ * Meeting type color configuration
+ * @description Defines colors, icons, and styling for meeting type badges and borders
+ */
+export interface MeetingTypeConfig {
+  /** Display label for the meeting type */
+  label: string;
+  /** Background color class (e.g., bg-violet-100) */
+  bgColor: string;
+  /** Text color class - 600 shade (e.g., text-violet-600) */
+  textColor: string;
+  /** Text color class - 500 shade (e.g., text-violet-500) for alternate styling */
+  textColorAlt: string;
+  /** Border color class - 500 shade (e.g., border-violet-500) */
+  borderColor: string;
+  /** Border color class - 300 shade (e.g., border-violet-300) for lighter borders */
+  borderColorLight: string;
+  /** Font Awesome icon class */
+  icon: string;
+  /** CSS class for tag badge color override (e.g., tag-meeting-board) */
+  tagStyleClass: string;
+}
+
+/**
+ * Meeting type badge interface
+ * @description Structure for meeting type badge display
+ */
+export interface MeetingTypeBadge {
+  label: string;
+  className: string;
+  severity?: TagSeverity;
+  styleClass?: string;
+  icon?: string;
 }

--- a/packages/shared/src/interfaces/persona.interface.ts
+++ b/packages/shared/src/interfaces/persona.interface.ts
@@ -5,20 +5,6 @@ import type { Account } from './account.interface';
 
 export type PersonaType = 'contributor' | 'maintainer' | 'board-member' | 'executive-director';
 
-export const VALID_PERSONAS: ReadonlySet<string> = new Set<string>(['contributor', 'maintainer', 'board-member', 'executive-director']);
-
-export const BOARD_SCOPED_PERSONAS: ReadonlySet<PersonaType> = new Set(['board-member', 'executive-director']);
-
-export function isBoardScopedPersona(persona: PersonaType): boolean {
-  return BOARD_SCOPED_PERSONAS.has(persona);
-}
-
-export const PROJECT_SCOPED_PERSONAS: ReadonlySet<PersonaType> = new Set(['maintainer', 'contributor']);
-
-export function isProjectScopedPersona(persona: PersonaType): boolean {
-  return PROJECT_SCOPED_PERSONAS.has(persona);
-}
-
 export interface PersistedPersonaState {
   primary: PersonaType;
   all: PersonaType[];

--- a/packages/shared/src/interfaces/rewards.interface.ts
+++ b/packages/shared/src/interfaces/rewards.interface.ts
@@ -1,10 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Single source of truth for reward categories. The union type below is derived
-// from this tuple, and `RewardPromotionGroups` keys off the union — adding a
-// new category requires editing only this array.
-export const REWARD_CATEGORIES = ['Event', 'Training', 'Certification'] as const;
+import type { REWARD_CATEGORIES } from '../constants/rewards.constants';
 
 export type RewardPromotionCategory = (typeof REWARD_CATEGORIES)[number];
 

--- a/packages/shared/src/interfaces/states.interface.ts
+++ b/packages/shared/src/interfaces/states.interface.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { US_STATES } from '../constants/states.constants';
+
+/**
+ * Type for US state values
+ */
+export type USState = (typeof US_STATES)[number]['value'];

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -554,3 +554,9 @@ export interface SurveyReviewData {
   /** Email body preview */
   emailBodyPreview: string;
 }
+
+/**
+ * Combined survey status type
+ * @description Represents the combined state of survey status and response status
+ */
+export type CombinedSurveyStatus = 'open' | 'submitted' | 'closed';

--- a/packages/shared/src/interfaces/tag.interface.ts
+++ b/packages/shared/src/interfaces/tag.interface.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TagProps } from './components.interface';
+
+/**
+ * Tag type configuration
+ * @description Centralized tag styling configuration for common use cases
+ */
+export interface TagTypeConfig {
+  severity: TagProps['severity'];
+  icon?: string;
+  rounded?: boolean;
+  styleClass?: string;
+}

--- a/packages/shared/src/interfaces/timezones.interface.ts
+++ b/packages/shared/src/interfaces/timezones.interface.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Timezone option interface for dropdown components
+ * @description Structured timezone data with human-readable labels and IANA identifiers
+ */
+export interface TimezoneOption {
+  /** Human-readable timezone label */
+  label: string;
+  /** IANA timezone identifier value */
+  value: string;
+  /** UTC offset string representation */
+  offset: string;
+}

--- a/packages/shared/src/interfaces/training.interface.ts
+++ b/packages/shared/src/interfaces/training.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CERTIFICATION_PRODUCT_TYPE, TRAINING_PRODUCT_TYPE } from '../constants/training.constants';
+
 import type { OffsetPaginatedResponse } from './api.interface';
 
 /** Active tab on the org training & certifications page */
@@ -306,3 +308,5 @@ export interface TrainingEnrollment {
   /** Whether the enrollment is currently active */
   isActiveEnrollment: boolean;
 }
+
+export type ProductType = typeof TRAINING_PRODUCT_TYPE | typeof CERTIFICATION_PRODUCT_TYPE;

--- a/packages/shared/src/interfaces/training.interface.ts
+++ b/packages/shared/src/interfaces/training.interface.ts
@@ -309,4 +309,7 @@ export interface TrainingEnrollment {
   isActiveEnrollment: boolean;
 }
 
+/**
+ * Type for training/certification product types
+ */
 export type ProductType = typeof TRAINING_PRODUCT_TYPE | typeof CERTIFICATION_PRODUCT_TYPE;

--- a/packages/shared/src/interfaces/tshirt-sizes.interface.ts
+++ b/packages/shared/src/interfaces/tshirt-sizes.interface.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { TSHIRT_SIZES } from '../constants/tshirt-sizes.constants';
+
+/**
+ * Type for T-shirt size values
+ */
+export type TShirtSize = (typeof TSHIRT_SIZES)[number]['value'];

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -3,18 +3,9 @@
 
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 
-import {
-  DAYS_IN_WEEK,
-  DEFAULT_REPEAT_INTERVAL,
-  MINUTES_IN_HOUR,
-  MS_IN_DAY,
-  TIME_ROUNDING_MINUTES,
-  TimezoneOption,
-  TIMEZONES,
-  WEEKDAY_CODES,
-} from '../constants';
+import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, TIMEZONES, WEEKDAY_CODES } from '../constants';
 import { RecurrenceType } from '../enums';
-import { MeetingRecurrence } from '../interfaces';
+import { MeetingRecurrence, TimezoneOption } from '../interfaces';
 
 // ============================================================================
 // Date Formatting and Parsing Utilities

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -37,3 +37,4 @@ export * from './search.utils';
 export * from './email.utils';
 export * from './invitation.utils';
 export * from './crowdfunding.utils';
+export * from './persona.utils';

--- a/packages/shared/src/utils/persona.utils.ts
+++ b/packages/shared/src/utils/persona.utils.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { BOARD_SCOPED_PERSONAS, PROJECT_SCOPED_PERSONAS } from '../constants/persona.constants';
+import type { PersonaType } from '../interfaces/persona.interface';
+
+export function isBoardScopedPersona(persona: PersonaType): boolean {
+  return BOARD_SCOPED_PERSONAS.has(persona);
+}
+
+export function isProjectScopedPersona(persona: PersonaType): boolean {
+  return PROJECT_SCOPED_PERSONAS.has(persona);
+}

--- a/packages/shared/src/utils/survey.utils.ts
+++ b/packages/shared/src/utils/survey.utils.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { COMBINED_SURVEY_STATUS, type CombinedSurveyStatus } from '../constants/survey.constants';
+import { COMBINED_SURVEY_STATUS } from '../constants/survey.constants';
 import { SurveyResponseStatus, SurveyStatus } from '../enums/survey.enum';
-import type { NpsBand, SurveyDisplayStatusInput, SurveyResponseItem, SurveyStatusInput } from '../interfaces/survey.interface';
+import type { CombinedSurveyStatus, NpsBand, SurveyDisplayStatusInput, SurveyResponseItem, SurveyStatusInput } from '../interfaces/survey.interface';
 
 /**
  * Sentinel value the API uses on `response_status` to signal that responses


### PR DESCRIPTION
## Summary

Migrates the `@lfx-one/shared` package counterexamples onto the type-alias/value
placement convention documented in LFXV2-2570 (PR #1054): **types (including
derived aliases) live in `interfaces/`, runtime values live in `constants/`, and
pure functions live in `utils/`.** Behavior-preserving refactor — no runtime logic
changes.

Split into three reviewable commits:

- **Phase A** — move 6 `export type` aliases out of constants files into the
  matching `.interface.ts`: `CountryCode`, `USState`, `TShirtSize` (new
  `countries`/`states`/`tshirt-sizes` interface files), `AllowedLogoMimeType`
  (crowdfunding), `CombinedSurveyStatus` (survey), `ProductType` (training).
- **Phase B** — move 5 `export interface` definitions out of constants files:
  `CommitteeCategoryInfo` (committee), `MeetingTypeConfig` + `MeetingTypeBadge`
  (meeting), `TagTypeConfig` (new `tag` interface file), `TimezoneOption` (new
  `timezones` interface file).
- **Phase C** — move runtime values + helpers out of interface files:
  `VALID_PERSONAS` / `BOARD_SCOPED_PERSONAS` / `PROJECT_SCOPED_PERSONAS` →
  `persona.constants.ts`; `isBoardScopedPersona` / `isProjectScopedPersona` → new
  `persona.utils.ts`; `REWARD_CATEGORIES` → `rewards.constants.ts`
  (`RewardPromotionCategory` stays and derives from it).

Derived aliases import their source constant type-only (`import type` + `typeof`),
so the binding is erased at compile time and introduces no runtime import cycle.
Consumer imports are split so values resolve from `@lfx-one/shared/constants`,
functions from `@lfx-one/shared/utils`, and types from `@lfx-one/shared/interfaces`.
Notably, `persona.constants.ts` previously imported the persona value-sets *from*
`interfaces` — that cross-layer import is now removed since the values live
alongside it.

## Validation

`yarn check-types`, `yarn lint:check`, `yarn format:check`, `./check-headers.sh`,
and `yarn build` all pass on the final branch state. Pre-PR full-branch reviewer
trio (general, self-serve conventions, empirical learnings) returned clean.
No behavior change, no API/SQL/endpoint changes.

Refs: LFXV2-2573
