### PR TITLE
fix(profile): safely handle already-linked identity conflicts

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
@@ -92,6 +92,10 @@
       }
     </div>
 
+    @if (!codeSent() && verificationError()) {
+      <p class="text-sm text-red-600" data-testid="add-account-send-error">{{ verificationError() }}</p>
+    }
+
     @if (!codeSent()) {
       <lfx-button
         severity="primary"

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
@@ -86,14 +86,14 @@
             styleClass="w-full gap-3 [&_.p-inputtext]:flex-1"
             data-testid="add-account-otp" />
           @if (verificationError()) {
-            <p class="text-center text-sm text-red-600" data-testid="add-account-otp-error">{{ verificationError() }}</p>
+            <p class="text-center text-sm text-red-600" role="alert" data-testid="add-account-otp-error">{{ verificationError() }}</p>
           }
         </div>
       }
     </div>
 
     @if (!codeSent() && verificationError()) {
-      <p class="text-sm text-red-600" data-testid="add-account-send-error">{{ verificationError() }}</p>
+      <p class="text-sm text-red-600" role="alert" data-testid="add-account-send-error">{{ verificationError() }}</p>
     }
 
     @if (!codeSent()) {

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
@@ -70,7 +70,7 @@ export class AddAccountDialogComponent {
           this.form.controls.email.disable();
           this.resendCooldownUtil.start();
         } else {
-          this.verificationError.set(response.error || response.message || 'Failed to send verification code');
+          this.verificationError.set(response.message || response.error || 'Failed to send verification code');
         }
         this.isConnecting.set(false);
       },
@@ -101,7 +101,7 @@ export class AddAccountDialogComponent {
           };
           this.ref.close(result);
         } else {
-          this.verificationError.set(response.error || response.message || 'Verification failed');
+          this.verificationError.set(response.message || response.error || 'Verification failed');
           this.isVerifying.set(false);
         }
       },
@@ -130,7 +130,7 @@ export class AddAccountDialogComponent {
     this.userService.sendEmailVerificationCode(email).subscribe({
       next: (response) => {
         if (!response.success) {
-          this.verificationError.set(response.error || response.message || 'Failed to resend code');
+          this.verificationError.set(response.message || response.error || 'Failed to resend code');
         }
         this.isConnecting.set(false);
         this.resendCooldownUtil.start();

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -7,6 +7,7 @@ import {
   CDP_PLATFORM_ICONS,
   CDP_PLATFORM_TO_TYPE_MAP,
   CDP_TO_AUTH0_PROVIDER_MAP,
+  EMAIL_ALREADY_LINKED_MESSAGE,
   EMAIL_REGEX,
   PURCHASE_LINUX_URL,
 } from '@lfx-one/shared/constants';
@@ -1804,7 +1805,7 @@ export class ProfileController {
             linked_to: linkedTo,
           });
 
-          res.status(409).json({ success: false, error: response.error, message: 'This email is already linked to another account' });
+          res.status(409).json({ success: false, error: response.error, message: EMAIL_ALREADY_LINKED_MESSAGE });
         } else if (response.error === 'Service temporarily unavailable') {
           res.status(503).json({ success: false, error: response.error, message: response.message });
         } else {
@@ -1922,7 +1923,7 @@ export class ProfileController {
       if (!linkResponse.success) {
         if (linkResponse.error?.includes('already linked')) {
           // Never forward the upstream message here — it could name the owning account.
-          res.status(409).json({ success: false, error: linkResponse.error, message: 'This email is already linked to another account' });
+          res.status(409).json({ success: false, error: linkResponse.error, message: EMAIL_ALREADY_LINKED_MESSAGE });
         } else if (linkResponse.error === 'Service temporarily unavailable') {
           res.status(503).json({ success: false, error: linkResponse.error, message: linkResponse.message });
         } else {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1923,6 +1923,15 @@ export class ProfileController {
 
       if (!linkResponse.success) {
         if (isIdentityAlreadyLinkedError(linkResponse.error, linkResponse.message)) {
+          // Resolve the owning account for support/debugging only — never returned to the client.
+          const linkedTo =
+            (await this.emailVerificationService.resolveEmailToUsername(req, email)) || (await this.emailVerificationService.resolveEmailToSub(req, email));
+
+          logger.warning(req, 'verify_and_link_email', 'Email already linked to another account', {
+            email,
+            linked_to: linkedTo,
+          });
+
           // Never forward the upstream message here — it could name the owning account.
           res.status(409).json({ success: false, error: linkResponse.error, message: EMAIL_ALREADY_LINKED_MESSAGE });
         } else if (linkResponse.error === 'Service temporarily unavailable') {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1794,14 +1794,17 @@ export class ProfileController {
         if (response.error?.includes('already linked')) {
           // Upstream auth-service emits the "already linked" error without identifying the
           // owning account, so resolve it here via EMAIL_TO_USERNAME → EMAIL_TO_SUB lookups.
+          // The resolved account is logged for support/debugging only — never returned to the
+          // client, so we don't expose another user's LFID.
           const linkedTo =
             (await this.emailVerificationService.resolveEmailToUsername(req, email)) || (await this.emailVerificationService.resolveEmailToSub(req, email));
 
-          const message = linkedTo
-            ? `This email is already linked to account: ${linkedTo}`
-            : response.message || 'This email is already linked to another account';
+          logger.warning(req, 'send_email_verification', 'Email already linked to another account', {
+            email,
+            linked_to: linkedTo,
+          });
 
-          res.status(409).json({ success: false, error: response.error, message, linkedTo });
+          res.status(409).json({ success: false, error: response.error, message: 'This email is already linked to another account' });
         } else if (response.error === 'Service temporarily unavailable') {
           res.status(503).json({ success: false, error: response.error, message: response.message });
         } else {
@@ -1918,7 +1921,8 @@ export class ProfileController {
 
       if (!linkResponse.success) {
         if (linkResponse.error?.includes('already linked')) {
-          res.status(409).json({ success: false, error: linkResponse.error, message: linkResponse.message });
+          // Never forward the upstream message here — it could name the owning account.
+          res.status(409).json({ success: false, error: linkResponse.error, message: 'This email is already linked to another account' });
         } else if (linkResponse.error === 'Service temporarily unavailable') {
           res.status(503).json({ success: false, error: linkResponse.error, message: linkResponse.message });
         } else {

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -31,6 +31,7 @@ import {
   UserProfile,
   WorkExperienceCreateUpdateBody,
 } from '@lfx-one/shared/interfaces';
+import { isIdentityAlreadyLinkedError } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, AuthorizationError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -1686,7 +1687,7 @@ export class ProfileController {
       const linkResponse = await this.emailVerificationService.linkIdentity(req, mgmtToken, tokenResponse.id_token);
 
       if (!linkResponse.success) {
-        const isAlreadyLinked = linkResponse.error?.includes('already') || linkResponse.message?.includes('already');
+        const isAlreadyLinked = isIdentityAlreadyLinkedError(linkResponse.error, linkResponse.message);
         logger.error(req, 'social_auth_callback', startTime, new Error('Identity link failed'), {
           error: linkResponse.error,
           message: linkResponse.message,
@@ -1792,7 +1793,7 @@ export class ProfileController {
           message: response.message,
         });
 
-        if (response.error?.includes('already linked')) {
+        if (isIdentityAlreadyLinkedError(response.error, response.message)) {
           // Upstream auth-service emits the "already linked" error without identifying the
           // owning account, so resolve it here via EMAIL_TO_USERNAME → EMAIL_TO_SUB lookups.
           // The resolved account is logged for support/debugging only — never returned to the
@@ -1921,7 +1922,7 @@ export class ProfileController {
       const linkResponse = await this.emailVerificationService.linkIdentity(req, authToken, identityToken);
 
       if (!linkResponse.success) {
-        if (linkResponse.error?.includes('already linked')) {
+        if (isIdentityAlreadyLinkedError(linkResponse.error, linkResponse.message)) {
           // Never forward the upstream message here — it could name the owning account.
           res.status(409).json({ success: false, error: linkResponse.error, message: EMAIL_ALREADY_LINKED_MESSAGE });
         } else if (linkResponse.error === 'Service temporarily unavailable') {

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -144,3 +144,10 @@ export const IDENTITY_PROVIDER_LABELS: Record<IdentityProvider, string> = {
  * Source identifier for work experiences created via LFX One UI
  */
 export const LFX_ONE_WORK_EXPERIENCE_SOURCE = 'lfxOne';
+
+/**
+ * Generic, non-identifying message returned when an email is already linked to
+ * another account. Intentionally never names the owning account — surfacing the
+ * owning LFID would enable account enumeration.
+ */
+export const EMAIL_ALREADY_LINKED_MESSAGE = 'This email is already linked to another account';

--- a/packages/shared/src/utils/identity.utils.spec.ts
+++ b/packages/shared/src/utils/identity.utils.spec.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { isEmailShape, isIdentityAlreadyLinkedError } from './identity.utils';
+
+describe('isEmailShape', () => {
+  it('accepts a well-formed address', () => {
+    expect(isEmailShape('alice@example.com')).toBe(true);
+  });
+
+  it.each([['no-at'], ['missing@tld'], ['@example.com'], ['alice@'], ['']])('rejects %p', (value) => {
+    expect(isEmailShape(value)).toBe(false);
+  });
+});
+
+describe('isIdentityAlreadyLinkedError', () => {
+  it('matches the email send-code phrasing', () => {
+    expect(isIdentityAlreadyLinkedError('email already linked')).toBe(true);
+  });
+
+  it('matches the identity-link phrasing returned for social conflicts', () => {
+    // Exact string returned by the auth-service USER_IDENTITY_LINK call — note it
+    // contains no "already", which the previous substring check missed.
+    expect(isIdentityAlreadyLinkedError('the provided identity token belongs to an existing LFID account and cannot be linked')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isIdentityAlreadyLinkedError('Belongs To An Existing LFID Account')).toBe(true);
+  });
+
+  it('checks every provided text and short-circuits on a match in message', () => {
+    expect(isIdentityAlreadyLinkedError('some_error_code', 'This email is already linked to another account')).toBe(true);
+  });
+
+  it('does not match unrelated / transient failures', () => {
+    expect(isIdentityAlreadyLinkedError('Service temporarily unavailable', 'Please try again later.')).toBe(false);
+    expect(isIdentityAlreadyLinkedError('Internal server error')).toBe(false);
+  });
+
+  it('ignores nullish inputs', () => {
+    expect(isIdentityAlreadyLinkedError(undefined, null, '')).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/identity.utils.ts
+++ b/packages/shared/src/utils/identity.utils.ts
@@ -24,3 +24,26 @@ export const EMAIL_SHAPE_REGEX = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
 export function isEmailShape(value: string): boolean {
   return EMAIL_SHAPE_REGEX.test(value.trim());
 }
+
+/**
+ * Case-insensitive substrings that mark an upstream identity-link / email
+ * verification failure caused by the identity already belonging to another
+ * account. The auth-service phrases this conflict differently per endpoint —
+ * "email already linked" from the email send-code check, and "the provided
+ * identity token belongs to an existing LFID account and cannot be linked" from
+ * the identity-link call — so we match on any known marker rather than a single
+ * word (grepping for "already" alone misses the social/link phrasing).
+ */
+const IDENTITY_ALREADY_LINKED_MARKERS = ['already linked', 'belongs to an existing', 'existing lfid account'];
+
+/**
+ * Returns true if any of the provided upstream error/message strings indicate the
+ * identity (email or social) is already linked to another account.
+ */
+export function isIdentityAlreadyLinkedError(...texts: (string | undefined | null)[]): boolean {
+  return texts.some((text) => {
+    if (!text) return false;
+    const lower = text.toLowerCase();
+    return IDENTITY_ALREADY_LINKED_MARKERS.some((marker) => lower.includes(marker));
+  });
+}


### PR DESCRIPTION
## Summary

- Return a generic, non-identifying message when an email is already linked to another account (send-code + verify), and log the resolved account server-side for support.
- Surface the failure in the add-account dialog's email-entry step (previously silent).
- Fix social (GitHub/Google) already-linked detection so the conflict banner shows instead of a misleading generic "try again" toast.
- Centralize conflict detection in the shared `isIdentityAlreadyLinkedError` util (with unit tests) and reuse a shared `EMAIL_ALREADY_LINKED_MESSAGE` constant across paths.

Fixes LFXV2-2569

🤖 Generated with Claude Code
