### PR TITLE
fix(nav): stabilize sidebar @for track keys for me-lens menu

### DIFF
--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -83,7 +83,15 @@
       <!-- Hidden on foundation/project lens until nav API responds, since items are lens-scoped. -->
       @if (lensLoaded()) {
         <div class="flex flex-col gap-2 items-start px-4 w-full">
-          @for (item of itemsWithTestIds(); track trackNavItem(item)) {
+          <!--
+            Track by stable per-destination key (routerLink/url, falling back to the unique label for
+            sections and command-only items). Labels are not unique across the lens/flag reshape that
+            runs after first paint, so tracking by label made Angular reuse/mis-map DOM nodes — items
+            rendered under the wrong section and, because Font Awesome's kit JS bakes an <svg> into
+            each <i> on first render, reused nodes kept a stale icon. The same track key is applied to
+            all four @for loops below.
+          -->
+          @for (item of itemsWithTestIds(); track (item.routerLink ?? item.url ?? item.label)) {
             @if (item.isGroup) {
               <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: item }"></ng-container>
             } @else if (item.isSection) {
@@ -95,7 +103,7 @@
 
                 @if (item.items?.length) {
                   <div class="flex flex-col gap-1 mt-2">
-                    @for (childItem of item.items; track trackNavItem(childItem)) {
+                    @for (childItem of item.items; track (childItem.routerLink ?? childItem.url ?? childItem.label)) {
                       @if (childItem.isGroup) {
                         <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: childItem }"></ng-container>
                       } @else {
@@ -164,7 +172,7 @@
 
     <div class="flex flex-col gap-2 items-start px-4 w-full mt-auto pt-4">
       @if (footerItems().length > 0) {
-        @for (item of footerItemsWithTestIds(); track trackNavItem(item)) {
+        @for (item of footerItemsWithTestIds(); track (item.routerLink ?? item.url ?? item.label)) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: item }"></ng-container>
         }
       }
@@ -190,7 +198,7 @@
     </button>
     @if (expandedGroupStates()[item.label] && item.items?.length) {
       <div class="flex flex-col gap-1 mt-1 pl-6">
-        @for (childItem of item.items; track trackNavItem(childItem)) {
+        @for (childItem of item.items; track (childItem.routerLink ?? childItem.url ?? childItem.label)) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
         }
       </div>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -91,7 +91,7 @@
             each <i> on first render, reused nodes kept a stale icon. The same track key is applied to
             all four @for loops below.
           -->
-          @for (item of itemsWithTestIds(); track (item.routerLink ?? item.url ?? item.label)) {
+          @for (item of itemsWithTestIds(); track item.routerLink ?? item.url ?? item.label) {
             @if (item.isGroup) {
               <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: item }"></ng-container>
             } @else if (item.isSection) {
@@ -103,7 +103,7 @@
 
                 @if (item.items?.length) {
                   <div class="flex flex-col gap-1 mt-2">
-                    @for (childItem of item.items; track (childItem.routerLink ?? childItem.url ?? childItem.label)) {
+                    @for (childItem of item.items; track childItem.routerLink ?? childItem.url ?? childItem.label) {
                       @if (childItem.isGroup) {
                         <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: childItem }"></ng-container>
                       } @else {
@@ -172,7 +172,7 @@
 
     <div class="flex flex-col gap-2 items-start px-4 w-full mt-auto pt-4">
       @if (footerItems().length > 0) {
-        @for (item of footerItemsWithTestIds(); track (item.routerLink ?? item.url ?? item.label)) {
+        @for (item of footerItemsWithTestIds(); track item.routerLink ?? item.url ?? item.label) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: item }"></ng-container>
         }
       }
@@ -198,7 +198,7 @@
     </button>
     @if (expandedGroupStates()[item.label] && item.items?.length) {
       <div class="flex flex-col gap-1 mt-1 pl-6">
-        @for (childItem of item.items; track (childItem.routerLink ?? childItem.url ?? childItem.label)) {
+        @for (childItem of item.items; track childItem.routerLink ?? childItem.url ?? childItem.label) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
         }
       </div>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -83,7 +83,7 @@
       <!-- Hidden on foundation/project lens until nav API responds, since items are lens-scoped. -->
       @if (lensLoaded()) {
         <div class="flex flex-col gap-2 items-start px-4 w-full">
-          @for (item of itemsWithTestIds(); track item.label) {
+          @for (item of itemsWithTestIds(); track trackNavItem(item)) {
             @if (item.isGroup) {
               <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: item }"></ng-container>
             } @else if (item.isSection) {
@@ -95,7 +95,7 @@
 
                 @if (item.items?.length) {
                   <div class="flex flex-col gap-1 mt-2">
-                    @for (childItem of item.items; track childItem.label) {
+                    @for (childItem of item.items; track trackNavItem(childItem)) {
                       @if (childItem.isGroup) {
                         <ng-container *ngTemplateOutlet="groupItem; context: { $implicit: childItem }"></ng-container>
                       } @else {
@@ -164,7 +164,7 @@
 
     <div class="flex flex-col gap-2 items-start px-4 w-full mt-auto pt-4">
       @if (footerItems().length > 0) {
-        @for (item of footerItemsWithTestIds(); track item.label) {
+        @for (item of footerItemsWithTestIds(); track trackNavItem(item)) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: item }"></ng-container>
         }
       }
@@ -190,7 +190,7 @@
     </button>
     @if (expandedGroupStates()[item.label] && item.items?.length) {
       <div class="flex flex-col gap-1 mt-1 pl-6">
-        @for (childItem of item.items; track childItem.label) {
+        @for (childItem of item.items; track trackNavItem(childItem)) {
           <ng-container *ngTemplateOutlet="menuItem; context: { $implicit: childItem }"></ng-container>
         }
       </div>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -130,16 +130,6 @@ export class SidebarComponent {
     return states;
   });
 
-  // Stable identity for @for tracking. Labels are not unique across the full lens/flag reshape, so
-  // tracking by label made Angular reuse/mis-map DOM nodes when the menu recomputed (once feature
-  // flags and persona data resolve after first paint) — items rendered under the wrong section and,
-  // because Font Awesome's kit JS bakes an <svg> into each <i> on first render, reused nodes kept a
-  // stale icon. routerLink/url is unique per destination; sections and command-only items fall back
-  // to their (unique) label.
-  protected trackNavItem(item: SidebarMenuItem): string {
-    return item.routerLink ?? item.url ?? item.label;
-  }
-
   protected toggleGroup(label: string): void {
     const items = this.items();
     const current = this.expandedGroupStates()[label] ?? true;

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -130,6 +130,16 @@ export class SidebarComponent {
     return states;
   });
 
+  // Stable identity for @for tracking. Labels are not unique across the full lens/flag reshape, so
+  // tracking by label made Angular reuse/mis-map DOM nodes when the menu recomputed (once feature
+  // flags and persona data resolve after first paint) — items rendered under the wrong section and,
+  // because Font Awesome's kit JS bakes an <svg> into each <i> on first render, reused nodes kept a
+  // stale icon. routerLink/url is unique per destination; sections and command-only items fall back
+  // to their (unique) label.
+  protected trackNavItem(item: SidebarMenuItem): string {
+    return item.routerLink ?? item.url ?? item.label;
+  }
+
   protected toggleGroup(label: string): void {
     const items = this.items();
     const current = this.expandedGroupStates()[label] ?? true;


### PR DESCRIPTION
## What

Fixes the Me-lens sidebar rendering in a garbled state on load — menu items appearing under the wrong section headers (e.g. Mentorships / Badges under **Security** instead of **My Growth**), then re-shuffling into the correct layout a few seconds later, with some icons (Training & Certifications, Badges) staying wrong even after it settled.

## Why

The sidebar menu is built from `computed` signals that depend on data resolving **after** first paint — feature flags (default `false`, real values arrive when LaunchDarkly reaches READY) and persona/lens roles (cookie defaults, then `/api/user/personas`). So the menu paints once, then recomputes into a different shape.

Two things turned that clean recompute into a garbled one:

1. **Unstable `@for` track keys.** Every loop in `sidebar.component.html` tracked by `item.label` / `childItem.label`. Labels are not a stable identity across the reshape, so Angular reused and mis-mapped DOM nodes → items rendered under the wrong section header.
2. **Font Awesome kit JS.** Icons load via the SVG+JS kit, which replaces each `<i class="fa-…">` with a baked-in `<svg>` on first render. When a node was reused (because of the label-based track) and its `[ngClass]="item.icon"` changed, FA had already converted the node and didn't re-render it → the wrong icon stuck permanently.

## How

Track menu items by a stable per-destination key instead of by label, using an inline `track` expression (the repo convention — no functions in templates):

```html
@for (item of itemsWithTestIds(); track item.routerLink ?? item.url ?? item.label) {
```

Applied to all four `@for` loops (top-level items, section children, group children, footer items), with the `childItem` equivalent in the nested loops. Each leaf item has a unique `routerLink`/`url`; sections and command-only items fall back to their (unique) label. A condensed HTML comment above the first loop documents the root cause. Because icons are static per destination, retained nodes never need an icon swap and genuinely new items get a fresh `<i>` that FA renders correctly — fixing both the misplacement and the stale icons.

## Verification

- `yarn check-types`, `yarn lint:check`, and `yarn build` all pass.
- Live visual verification was blocked in this environment: the app's Auth0 `redirect_uri` is pinned to `localhost:4200` and that port was held by another process, so an authenticated Me-lens render couldn't be captured. The change is a mechanical control-flow track-key fix with no behavioral or styling change; `data-testid` output is unchanged.

## Notes

- No JIRA ticket associated with this branch.
- The in-flight `feat/navigation-improvements` refactor moves this menu into `SidebarNavService` and carries the same four label-tracked loops; the same inline `track item.routerLink ?? item.url ?? item.label` key should be applied there when it rebases/merges.