### PR TITLE
fix(committees): hide join CTA for invite-only groups (LFXV2-2577)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -152,8 +152,8 @@
               <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
             }
             <!-- Join / Request to Join / Contact Admin / Leave actions.
-                 Suppressed for an invited visitor — the Accept/Decline banner above is the action,
-                 so a "Request Access" CTA here would be redundant and contradictory. -->
+                 Suppressed for an invited visitor — the Accept/Decline banner above is the action.
+                 Suppressed for invite-only groups — visitors must wait for an invitation. -->
             <div class="ml-auto flex items-center gap-2">
               @if (isVisitor() && !pendingInvitation()) {
                 @if (committee()?.join_mode === 'open') {
@@ -175,17 +175,7 @@
                     [loading]="joiningOrLeaving()"
                     (onClick)="handleJoinRequest()"
                     data-testid="committee-view-request-to-join-btn" />
-                } @else if (committee()?.join_mode === 'invite_only') {
-                  <lfx-button
-                    label="Request Access"
-                    icon="fa-light fa-paper-plane"
-                    severity="secondary"
-                    [outlined]="true"
-                    size="small"
-                    [loading]="joiningOrLeaving()"
-                    (onClick)="handleJoinRequest()"
-                    data-testid="committee-view-request-access-btn" />
-                } @else {
+                } @else if (committee()?.join_mode !== 'invite_only') {
                   <lfx-button
                     label="Contact Admin"
                     icon="fa-light fa-envelope"

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -175,7 +175,7 @@
                     [loading]="joiningOrLeaving()"
                     (onClick)="handleJoinRequest()"
                     data-testid="committee-view-request-to-join-btn" />
-                } @else if (committee()?.join_mode !== 'invite_only') {
+                } @else if (committee()?.join_mode === 'closed') {
                   <lfx-button
                     label="Contact Admin"
                     icon="fa-light fa-envelope"

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -384,8 +384,8 @@ export class CommitteeViewComponent {
             this.messageService.add({ severity: 'error', summary: 'Unable to Join', detail, life: 6000 });
           },
         });
-    } else if (joinMode === 'application' || joinMode === 'invite_only') {
-      this.openApplicationDialog(committee.uid, committee.name, joinMode);
+    } else if (joinMode === 'application') {
+      this.openApplicationDialog(committee.uid, committee.name);
     } else {
       // closed — no self-service action available
       this.messageService.add({ severity: 'info', summary: 'Contact Admin', detail: 'Contact a group admin to request membership.' });
@@ -597,16 +597,14 @@ export class CommitteeViewComponent {
       });
   }
 
-  private openApplicationDialog(committeeUid: string, committeeName: string, mode: 'application' | 'invite_only'): void {
-    const isApplication = mode === 'application';
-
+  private openApplicationDialog(committeeUid: string, committeeName: string): void {
     const ref = this.dialogService.open(JoinApplicationDialogComponent, {
-      header: mode === 'invite_only' ? 'Request Access' : 'Request to Join',
+      header: 'Request to Join',
       width: '520px',
       modal: true,
       closable: true,
       dismissableMask: false,
-      data: { committeeName, mode },
+      data: { committeeName },
     }) as DynamicDialogRef;
 
     ref.onClose.pipe(take(1)).subscribe((result: JoinApplicationDialogResult | null) => {
@@ -620,10 +618,8 @@ export class CommitteeViewComponent {
           next: () => {
             this.messageService.add({
               severity: 'success',
-              summary: isApplication ? 'Application Submitted' : 'Request Submitted',
-              detail: isApplication
-                ? `Your request to join "${committeeName}" has been submitted. An admin will review it shortly.`
-                : `Your access request for "${committeeName}" has been submitted. An admin will review and send you an invitation if approved.`,
+              summary: 'Application Submitted',
+              detail: `Your request to join "${committeeName}" has been submitted. An admin will review it shortly.`,
               life: 8000,
             });
           },
@@ -631,12 +627,9 @@ export class CommitteeViewComponent {
             const upstream = err.error?.message as string | undefined;
             let detail: string;
             if (err.status === 409) {
-              detail = isApplication ? 'You already have a pending application for this group.' : 'You already have a pending request for this group.';
+              detail = 'You already have a pending application for this group.';
             } else {
-              const fallback = isApplication
-                ? `Failed to submit your request for "${committeeName}". Please try again.`
-                : `Failed to submit your access request for "${committeeName}". Please try again.`;
-              detail = upstream ?? fallback;
+              detail = upstream ?? `Failed to submit your request for "${committeeName}". Please try again.`;
             }
             this.messageService.add({ severity: 'error', summary: 'Unable to Submit', detail, life: 6000 });
           },

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -251,7 +251,7 @@
         <!-- Invite-only groups: informational only — visitors must wait for an invitation -->
         <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 text-center" role="status" data-testid="committee-overview-invite-only-notice">
           <div class="flex flex-col gap-3 items-center">
-            <i class="fa-light fa-envelope-open-text text-2xl text-gray-500"></i>
+            <i class="fa-light fa-envelope-open-text text-2xl text-gray-500" aria-hidden="true"></i>
             <h3 class="text-base font-semibold text-gray-900">{{ inviteOnlyTitle() }}</h3>
             <p class="text-sm text-gray-600 max-w-md">{{ inviteOnlyDescription() }}</p>
           </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -249,7 +249,7 @@
         </div>
       } @else if (showInviteOnlyNotice()) {
         <!-- Invite-only groups: informational only — visitors must wait for an invitation -->
-        <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 text-center" data-testid="committee-overview-invite-only-notice">
+        <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 text-center" role="status" data-testid="committee-overview-invite-only-notice">
           <div class="flex flex-col gap-3 items-center">
             <i class="fa-light fa-envelope-open-text text-2xl text-gray-500"></i>
             <h3 class="text-base font-semibold text-gray-900">{{ inviteOnlyTitle() }}</h3>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -247,6 +247,15 @@
             <lfx-button [label]="joinButtonLabel()" severity="info" size="small" [icon]="joinButtonIcon()" (onClick)="onJoinClick()"></lfx-button>
           </div>
         </div>
+      } @else if (showInviteOnlyNotice()) {
+        <!-- Invite-only groups: informational only — visitors must wait for an invitation -->
+        <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 text-center" data-testid="committee-overview-invite-only-notice">
+          <div class="flex flex-col gap-3 items-center">
+            <i class="fa-light fa-envelope-open-text text-2xl text-gray-500"></i>
+            <h3 class="text-base font-semibold text-gray-900">{{ inviteOnlyTitle() }}</h3>
+            <p class="text-sm text-gray-600 max-w-md">{{ inviteOnlyDescription() }}</p>
+          </div>
+        </div>
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -131,13 +131,17 @@ export class CommitteeOverviewComponent {
     return 'member';
   });
 
-  public canJoin: Signal<boolean> = computed(() => this.isVisitor() && this.committee().join_mode !== 'closed' && !this.hasPendingInvite());
+  public canJoin: Signal<boolean> = computed(() => {
+    const mode = this.committee().join_mode;
+    return this.isVisitor() && (mode === 'open' || mode === 'application') && !this.hasPendingInvite();
+  });
+
+  public showInviteOnlyNotice: Signal<boolean> = computed(() => this.isVisitor() && this.committee().join_mode === 'invite_only' && !this.hasPendingInvite());
 
   public joinButtonLabel: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;
     if (mode === 'open') return 'Join Group';
     if (mode === 'application') return 'Request to Join';
-    if (mode === 'invite_only') return 'Request Access';
     return 'Contact Admin';
   });
 
@@ -145,14 +149,14 @@ export class CommitteeOverviewComponent {
   public joinButtonIcon: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;
     if (mode === 'open') return 'fa-light fa-user-plus';
-    if (mode === 'invite_only' || mode === 'application') return 'fa-light fa-paper-plane';
+    if (mode === 'application') return 'fa-light fa-paper-plane';
     return 'fa-light fa-envelope';
   });
 
   /** Large illustrative icon above the CTA card title */
   public joinCtaIcon: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;
-    if (mode === 'application' || mode === 'invite_only') return 'fa-light fa-paper-plane';
+    if (mode === 'application') return 'fa-light fa-paper-plane';
     return 'fa-light fa-users';
   });
 
@@ -161,7 +165,6 @@ export class CommitteeOverviewComponent {
     const name = this.committee().name;
     if (mode === 'open') return `Interested in ${name}? Click Join Group above to become a member.`;
     if (mode === 'application') return `Interested in ${name}? Click Request to Join above to submit your application for admin review.`;
-    if (mode === 'invite_only') return `Interested in ${name}? Click Request Access above to submit a membership request for admin review.`;
     return `${name} is closed to new members. Contact a group admin for access.`;
   });
 
@@ -170,8 +173,14 @@ export class CommitteeOverviewComponent {
   public joinCtaDescription: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;
     if (mode === 'application') return 'Submit a request and a group admin will review your application.';
-    if (mode === 'invite_only') return 'Submit a request and a group admin will review and send you an invitation if approved.';
     return 'Participate in meetings, vote on proposals, access resources, and collaborate with the group.';
+  });
+
+  public inviteOnlyTitle: Signal<string> = computed(() => 'Membership is by invitation only');
+
+  public inviteOnlyDescription: Signal<string> = computed(() => {
+    const name = this.committee().name;
+    return `${name} is invite only. A group admin or member must send you an invitation before you can join.`;
   });
 
   public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -136,7 +136,10 @@ export class CommitteeOverviewComponent {
     return this.isVisitor() && (mode === 'open' || mode === 'application') && !this.hasPendingInvite();
   });
 
-  public showInviteOnlyNotice: Signal<boolean> = computed(() => this.isVisitor() && this.committee().join_mode === 'invite_only' && !this.hasPendingInvite());
+  public showInviteOnlyNotice: Signal<boolean> = computed(() => {
+    const mode = this.committee().join_mode;
+    return this.isVisitor() && (mode === 'invite_only' || !mode) && !this.hasPendingInvite();
+  });
 
   public joinButtonLabel: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -183,7 +183,7 @@ export class CommitteeOverviewComponent {
 
   public inviteOnlyDescription: Signal<string> = computed(() => {
     const name = this.committee().name;
-    return `${name} is invite only. A group admin or member must send you an invitation before you can join.`;
+    return `${name} is invite only. A group admin must send you an invitation before you can join.`;
   });
 
   public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));

--- a/apps/lfx-one/src/app/modules/committees/components/join-application-dialog/join-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/join-application-dialog/join-application-dialog.component.html
@@ -3,15 +3,9 @@
 
 <div class="flex flex-col gap-4" data-testid="join-application-dialog">
   <p class="text-sm text-gray-500">
-    @if (mode === 'invite_only') {
-      Provide a brief message to help admins understand why you need access to
-      <strong>{{ committeeName }}</strong
-      >.
-    } @else {
-      Optionally include a message to introduce yourself or explain why you'd like to join
-      <strong>{{ committeeName }}</strong
-      >.
-    }
+    Optionally include a message to introduce yourself or explain why you'd like to join
+    <strong>{{ committeeName }}</strong
+    >.
   </p>
   <lfx-textarea
     [form]="applicationForm"
@@ -25,10 +19,5 @@
 </div>
 <div class="flex justify-end gap-2 mt-4">
   <lfx-button label="Cancel" severity="secondary" [outlined]="true" size="small" (onClick)="cancel()" data-testid="join-application-cancel-btn"></lfx-button>
-  <lfx-button
-    [label]="mode === 'invite_only' ? 'Submit Request' : 'Submit Application'"
-    severity="info"
-    size="small"
-    (onClick)="submit()"
-    data-testid="join-application-submit-btn"></lfx-button>
+  <lfx-button label="Submit Application" severity="info" size="small" (onClick)="submit()" data-testid="join-application-submit-btn"></lfx-button>
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/join-application-dialog/join-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/join-application-dialog/join-application-dialog.component.ts
@@ -18,7 +18,6 @@ export class JoinApplicationDialogComponent {
   private readonly dialogRef = inject(DynamicDialogRef);
 
   public readonly committeeName: string = this.config.data.committeeName;
-  public readonly mode: 'application' | 'invite_only' = this.config.data.mode;
 
   public applicationForm = new FormGroup({
     message: new FormControl(''),

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -137,7 +137,7 @@ export class CommitteeService {
     return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(take(1));
   }
 
-  /** Submit a join application for a group with join_mode 'application' or 'invite_only' */
+  /** Submit a join application for a group with join_mode 'application' */
   public submitApplication(committeeId: string, message?: string): Observable<CommitteeJoinApplication> {
     const body: CreateCommitteeJoinApplicationRequest = { message: message || '' };
     return this.http.post<CommitteeJoinApplication>(`/api/committees/${committeeId}/applications`, body).pipe(take(1));

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -890,7 +890,6 @@ export interface CommitteeUser {
 
 export interface JoinApplicationDialogData {
   committeeName: string;
-  mode: 'application' | 'invite_only';
 }
 
 export interface JoinApplicationDialogResult {


### PR DESCRIPTION
## Summary
- Remove the **Request Access** button and application flow for groups with `join_mode: invite_only`, since the committee service rejects those submissions with `committee does not accept applications`.
- Show an informational notice on the overview tab explaining that membership is by invitation only.
- Limit the join-application dialog to `application` join mode only.

## Test plan
- [x] Open an invite-only group as a non-member (e.g. AAIF WG Workflows & Process Integration on dev)
- [x] Confirm no **Request Access** button appears in the group header
- [x] Confirm the overview tab shows the invite-only notice instead of the join CTA
- [x] Confirm `application` groups still show **Request to Join** and can submit successfully
- [x] Confirm `open` groups still show **Join Group** and self-join works


Made with [Cursor](https://cursor.com)