### PR TITLE
fix(votes): keep early close tooltip for auto-ended polls (LFXV2-2574)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -17,7 +17,7 @@ import {
   VoteResultsQuestion,
   VoteResultsResponse,
 } from '@lfx-one/shared/interfaces';
-import { getVoteEndedEarlyDetailTooltip, isVoteEndedEarly } from '@lfx-one/shared/utils';
+import { getVoteEndedEarlyDetailTooltip } from '@lfx-one/shared/utils';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { VoteService } from '@services/vote.service';
@@ -416,12 +416,12 @@ export class VoteResultsDrawerComponent {
 
   private initVoteEndedEarlyTooltip(): Signal<string | null> {
     return computed(() => {
-      const voteData = this.vote();
-      if (!voteData || !isVoteEndedEarly(voteData) || !voteData.early_end_time) {
+      const earlyEndTime = this.vote()?.early_end_time;
+      if (!earlyEndTime) {
         return null;
       }
 
-      const formattedEarlyClose = formatDate(voteData.early_end_time, 'MMM d, y', 'en-US');
+      const formattedEarlyClose = formatDate(earlyEndTime, 'MMM d, y', 'en-US');
       return getVoteEndedEarlyDetailTooltip(formattedEarlyClose);
     });
   }

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -17,7 +17,7 @@ import {
   VoteResultsQuestion,
   VoteResultsResponse,
 } from '@lfx-one/shared/interfaces';
-import { getVoteEndedEarlyDetailTooltip } from '@lfx-one/shared/utils';
+import { getVoteEndedEarlyDetailTooltip, isVoteEndedEarly } from '@lfx-one/shared/utils';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { VoteService } from '@services/vote.service';
@@ -416,12 +416,12 @@ export class VoteResultsDrawerComponent {
 
   private initVoteEndedEarlyTooltip(): Signal<string | null> {
     return computed(() => {
-      const earlyEndTime = this.vote()?.early_end_time;
-      if (!earlyEndTime) {
+      const vote = this.vote();
+      if (!vote || !isVoteEndedEarly(vote)) {
         return null;
       }
 
-      const formattedEarlyClose = formatDate(earlyEndTime, 'MMM d, y', 'en-US');
+      const formattedEarlyClose = formatDate(vote.early_end_time!, 'MMM d, y', 'en-US');
       return getVoteEndedEarlyDetailTooltip(formattedEarlyClose);
     });
   }

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -15,7 +15,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
 import { FilterPillOption, Vote, VoteFilterState, VoteTableRow } from '@lfx-one/shared/interfaces';
-import { getVoteEndedEarlyDetailTooltip } from '@lfx-one/shared/utils';
+import { getVoteEndedEarlyDetailTooltip, isVoteEndedEarly } from '@lfx-one/shared/utils';
 import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
@@ -271,9 +271,8 @@ export class VotesTableComponent {
   private toVoteTableRow(vote: Vote): VoteTableRow {
     let endedEarlyTooltip: string | null = null;
 
-    const earlyEndTime = vote.early_end_time;
-    if (earlyEndTime) {
-      const formattedEarlyClose = formatDate(earlyEndTime, 'MMM d, y', 'en-US');
+    if (isVoteEndedEarly(vote)) {
+      const formattedEarlyClose = formatDate(vote.early_end_time!, 'MMM d, y', 'en-US');
       endedEarlyTooltip = getVoteEndedEarlyDetailTooltip(formattedEarlyClose);
     }
 

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -15,7 +15,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
 import { FilterPillOption, Vote, VoteFilterState, VoteTableRow } from '@lfx-one/shared/interfaces';
-import { getVoteEndedEarlyDetailTooltip, isVoteEndedEarly } from '@lfx-one/shared/utils';
+import { getVoteEndedEarlyDetailTooltip } from '@lfx-one/shared/utils';
 import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
@@ -271,8 +271,9 @@ export class VotesTableComponent {
   private toVoteTableRow(vote: Vote): VoteTableRow {
     let endedEarlyTooltip: string | null = null;
 
-    if (isVoteEndedEarly(vote) && vote.early_end_time) {
-      const formattedEarlyClose = formatDate(vote.early_end_time, 'MMM d, y', 'en-US');
+    const earlyEndTime = vote.early_end_time;
+    if (earlyEndTime) {
+      const formattedEarlyClose = formatDate(earlyEndTime, 'MMM d, y', 'en-US');
       endedEarlyTooltip = getVoteEndedEarlyDetailTooltip(formattedEarlyClose);
     }
 

--- a/packages/shared/src/utils/poll.utils.ts
+++ b/packages/shared/src/utils/poll.utils.ts
@@ -31,16 +31,12 @@ export function getCombinedVoteStatus(vote: UserVote): CombinedVoteStatus {
   return 'closed';
 }
 
-/** Tooltip copy when the scheduled close date differs from the actual early close. */
+/** Tooltip copy when a vote auto-ended because all eligible voters responded. */
 export function getVoteEndedEarlyDetailTooltip(earlyEndTimeFormatted: string): string {
   return `Vote closed early on ${earlyEndTimeFormatted}. All voters have responded.`;
 }
 
-/** True when the poll closed before its scheduled end_time (ITX auto-end). */
-export function isVoteEndedEarly(vote: Pick<Vote, 'end_time' | 'early_end_time'>): boolean {
-  if (!vote.early_end_time || !vote.end_time) {
-    return false;
-  }
-
-  return new Date(vote.early_end_time).getTime() < new Date(vote.end_time).getTime();
+/** True when ITX auto-ended the poll because all eligible voters responded. */
+export function isVoteEndedEarly(vote: Pick<Vote, 'early_end_time'>): boolean {
+  return Boolean(vote.early_end_time);
 }


### PR DESCRIPTION
# Summary

When ITX auto-ends a poll because all eligible voters have responded, the votes table and results drawer now show the early-close tooltip whenever `early_end_time` is present. Detection no longer compares `early_end_time` to the scheduled `end_time`, which could miss valid auto-ended polls.

