### PR TITLE
feat(akrites): add nuget, packagist, rubygems ecosystem support

### DIFF
--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-ecosystem-badge/akrites-ecosystem-badge.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-ecosystem-badge/akrites-ecosystem-badge.component.html
@@ -1,0 +1,56 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<span class="inline-flex items-center gap-2 text-gray-600 font-medium whitespace-nowrap">
+  @switch (ecosystem()) {
+    @case ('npm') {
+      <span
+        class="inline-flex items-center justify-center bg-[#cb3837] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
+        style="font-size: 9px"
+        aria-hidden="true"
+        >npm</span
+      >
+      npm
+    }
+    @case ('maven') {
+      <svg viewBox="0 0 24 24" width="16" height="16" class="flex-shrink-0" aria-hidden="true">
+        <path d="M4 21C4 12 9.5 4.5 18 2c-1.7 9-7.5 15.5-14 19z" fill="#69a2d0" />
+        <path d="M4 21c4.2-1 8-3.4 11-7.6C14 18.7 9.2 21 4 21z" fill="#cf2b58" />
+      </svg>
+      Maven
+    }
+    @case ('pypi') {
+      <i [class]="'fa-brands fa-python text-[#3776ab] flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      PyPI
+    }
+    @case ('go') {
+      <i [class]="'fa-brands fa-golang text-[#00ADD8] flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      Go
+    }
+    @case ('cargo') {
+      <i [class]="'fa-brands fa-rust text-[#CE422B] flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      Cargo
+    }
+    @case ('nuget') {
+      <span
+        class="inline-flex items-center justify-center bg-[#004880] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
+        style="font-size: 9px"
+        aria-hidden="true"
+        >Nu</span
+      >
+      NuGet
+    }
+    @case ('packagist') {
+      <i [class]="'fa-brands fa-php text-[#f28d1a] flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      Packagist
+    }
+    @case ('rubygems') {
+      <i [class]="'fa-solid fa-gem text-[#c00] flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      RubyGems
+    }
+    @default {
+      <i [class]="'fa-light fa-cube text-gray-400 flex-shrink-0 ' + (size() === 'sm' ? 'text-sm' : 'text-base')" aria-hidden="true"></i>
+      {{ ecosystem() }}
+    }
+  }
+</span>

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-ecosystem-badge/akrites-ecosystem-badge.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-ecosystem-badge/akrites-ecosystem-badge.component.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+
+import { AkritesEcosystem } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-akrites-ecosystem-badge',
+  templateUrl: './akrites-ecosystem-badge.component.html',
+})
+export class AkritesEcosystemBadgeComponent {
+  public readonly ecosystem = input.required<AkritesEcosystem>();
+  public readonly size = input<'sm' | 'base'>('base');
+}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.html
@@ -46,6 +46,27 @@
                 <i class="fa-brands fa-golang text-[#00ADD8] text-sm flex-shrink-0" aria-hidden="true"></i>
                 Go
               }
+              @case ('cargo') {
+                <i class="fa-brands fa-rust text-[#CE422B] text-sm flex-shrink-0" aria-hidden="true"></i>
+                Cargo
+              }
+              @case ('nuget') {
+                <span
+                  class="inline-flex items-center justify-center bg-[#004880] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
+                  style="font-size: 9px"
+                  aria-hidden="true"
+                  >Nu</span
+                >
+                NuGet
+              }
+              @case ('packagist') {
+                <i class="fa-brands fa-php text-[#f28d1a] text-sm flex-shrink-0" aria-hidden="true"></i>
+                Packagist
+              }
+              @case ('rubygems') {
+                <i class="fa-solid fa-gem text-[#c00] text-sm flex-shrink-0" aria-hidden="true"></i>
+                RubyGems
+              }
               @default {
                 <i class="fa-light fa-cube text-gray-400 text-sm flex-shrink-0" aria-hidden="true"></i>
                 {{ pkg.ecosystem }}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.html
@@ -20,59 +20,7 @@
       @if (packageData(); as pkg) {
         <div class="flex items-center gap-2.5 flex-wrap text-xs text-gray-500">
           <code class="font-mono text-[11px] bg-gray-100 px-1.5 py-0.5 rounded">{{ pkg.purl }}</code>
-          <span class="inline-flex items-center gap-1.5 font-medium text-gray-600">
-            @switch (pkg.ecosystem) {
-              @case ('npm') {
-                <span
-                  class="inline-flex items-center justify-center bg-[#cb3837] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
-                  style="font-size: 9px"
-                  aria-hidden="true"
-                  >npm</span
-                >
-                npm
-              }
-              @case ('maven') {
-                <svg viewBox="0 0 24 24" width="16" height="16" class="flex-shrink-0" aria-hidden="true">
-                  <path d="M4 21C4 12 9.5 4.5 18 2c-1.7 9-7.5 15.5-14 19z" fill="#69a2d0" />
-                  <path d="M4 21c4.2-1 8-3.4 11-7.6C14 18.7 9.2 21 4 21z" fill="#cf2b58" />
-                </svg>
-                Maven
-              }
-              @case ('pypi') {
-                <i class="fa-brands fa-python text-[#3776ab] text-sm flex-shrink-0" aria-hidden="true"></i>
-                PyPI
-              }
-              @case ('go') {
-                <i class="fa-brands fa-golang text-[#00ADD8] text-sm flex-shrink-0" aria-hidden="true"></i>
-                Go
-              }
-              @case ('cargo') {
-                <i class="fa-brands fa-rust text-[#CE422B] text-sm flex-shrink-0" aria-hidden="true"></i>
-                Cargo
-              }
-              @case ('nuget') {
-                <span
-                  class="inline-flex items-center justify-center bg-[#004880] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
-                  style="font-size: 9px"
-                  aria-hidden="true"
-                  >Nu</span
-                >
-                NuGet
-              }
-              @case ('packagist') {
-                <i class="fa-brands fa-php text-[#f28d1a] text-sm flex-shrink-0" aria-hidden="true"></i>
-                Packagist
-              }
-              @case ('rubygems') {
-                <i class="fa-solid fa-gem text-[#c00] text-sm flex-shrink-0" aria-hidden="true"></i>
-                RubyGems
-              }
-              @default {
-                <i class="fa-light fa-cube text-gray-400 text-sm flex-shrink-0" aria-hidden="true"></i>
-                {{ pkg.ecosystem }}
-              }
-            }
-          </span>
+          <lfx-akrites-ecosystem-badge [ecosystem]="pkg.ecosystem" size="sm" />
         </div>
       }
 

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-package-drawer/akrites-package-drawer.component.ts
@@ -24,6 +24,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { AkritesAssignStewardModalComponent } from '../akrites-assign-steward-modal/akrites-assign-steward-modal.component';
+import { AkritesEcosystemBadgeComponent } from '../akrites-ecosystem-badge/akrites-ecosystem-badge.component';
 import { AkritesEscalateModalComponent } from '../akrites-escalate-modal/akrites-escalate-modal.component';
 import { AkritesStatusModalComponent } from '../akrites-status-modal/akrites-status-modal.component';
 import {
@@ -42,6 +43,7 @@ type DrawerTab = 'overview' | 'assessment' | 'security' | 'provenance' | 'histor
   selector: 'lfx-akrites-package-drawer',
   imports: [
     DrawerModule,
+    AkritesEcosystemBadgeComponent,
     ButtonComponent,
     EmptyStateComponent,
     TagComponent,

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -303,6 +303,23 @@
                 <i class="fa-brands fa-rust text-[#CE422B] text-base flex-shrink-0" aria-hidden="true"></i>
                 Cargo
               }
+              @case ('nuget') {
+                <span
+                  class="inline-flex items-center justify-center bg-[#004880] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
+                  style="font-size: 9px"
+                  aria-hidden="true"
+                  >Nu</span
+                >
+                NuGet
+              }
+              @case ('packagist') {
+                <i class="fa-brands fa-php text-[#f28d1a] text-base flex-shrink-0" aria-hidden="true"></i>
+                Packagist
+              }
+              @case ('rubygems') {
+                <i class="fa-solid fa-gem text-[#c00] text-base flex-shrink-0" aria-hidden="true"></i>
+                RubyGems
+              }
               @default {
                 <i class="fa-light fa-cube text-gray-400 text-base flex-shrink-0" aria-hidden="true"></i>
                 {{ pkg.ecosystem }}

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.html
@@ -273,59 +273,7 @@
           <div class="text-xs text-gray-500 font-mono max-w-64 truncate">{{ pkg.purl }}</div>
         </td>
         <td>
-          <span class="inline-flex items-center gap-2 text-gray-600 font-medium whitespace-nowrap">
-            @switch (pkg.ecosystem) {
-              @case ('npm') {
-                <span
-                  class="inline-flex items-center justify-center bg-[#cb3837] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
-                  style="font-size: 9px"
-                  aria-hidden="true"
-                  >npm</span
-                >
-                npm
-              }
-              @case ('maven') {
-                <svg viewBox="0 0 24 24" width="16" height="16" class="flex-shrink-0" aria-hidden="true">
-                  <path d="M4 21C4 12 9.5 4.5 18 2c-1.7 9-7.5 15.5-14 19z" fill="#69a2d0" />
-                  <path d="M4 21c4.2-1 8-3.4 11-7.6C14 18.7 9.2 21 4 21z" fill="#cf2b58" />
-                </svg>
-                Maven
-              }
-              @case ('pypi') {
-                <i class="fa-brands fa-python text-[#3776ab] text-base flex-shrink-0" aria-hidden="true"></i>
-                PyPI
-              }
-              @case ('go') {
-                <i class="fa-brands fa-golang text-[#00ADD8] text-base flex-shrink-0" aria-hidden="true"></i>
-                Go
-              }
-              @case ('cargo') {
-                <i class="fa-brands fa-rust text-[#CE422B] text-base flex-shrink-0" aria-hidden="true"></i>
-                Cargo
-              }
-              @case ('nuget') {
-                <span
-                  class="inline-flex items-center justify-center bg-[#004880] text-white font-bold rounded px-1 py-0.5 leading-none tracking-tight flex-shrink-0"
-                  style="font-size: 9px"
-                  aria-hidden="true"
-                  >Nu</span
-                >
-                NuGet
-              }
-              @case ('packagist') {
-                <i class="fa-brands fa-php text-[#f28d1a] text-base flex-shrink-0" aria-hidden="true"></i>
-                Packagist
-              }
-              @case ('rubygems') {
-                <i class="fa-solid fa-gem text-[#c00] text-base flex-shrink-0" aria-hidden="true"></i>
-                RubyGems
-              }
-              @default {
-                <i class="fa-light fa-cube text-gray-400 text-base flex-shrink-0" aria-hidden="true"></i>
-                {{ pkg.ecosystem }}
-              }
-            }
-          </span>
+          <lfx-akrites-ecosystem-badge [ecosystem]="pkg.ecosystem" />
         </td>
         <!-- TODO(v2): replace per-row template functions below with pure pipes or computed() maps to avoid per-cycle re-execution -->
         <td>

--- a/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/akrites/components/akrites-packages-tab/akrites-packages-tab.component.ts
@@ -24,6 +24,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { AkritesAssignStewardModalComponent } from '../akrites-assign-steward-modal/akrites-assign-steward-modal.component';
+import { AkritesEcosystemBadgeComponent } from '../akrites-ecosystem-badge/akrites-ecosystem-badge.component';
 import { StewardInitialsPipe } from '../../pipes/steward-initials.pipe';
 import {
   formatStatus,
@@ -39,6 +40,7 @@ import {
   selector: 'lfx-akrites-packages-tab',
   imports: [
     AkritesAssignStewardModalComponent,
+    AkritesEcosystemBadgeComponent,
     ButtonComponent,
     CheckboxComponent,
     MenuComponent,

--- a/packages/shared/src/constants/akrites.constants.ts
+++ b/packages/shared/src/constants/akrites.constants.ts
@@ -45,6 +45,9 @@ export const AKRITES_ECOSYSTEM_OPTIONS: Array<{ value: AkritesEcosystem | ''; la
   { value: 'pypi', label: 'PyPI' },
   { value: 'go', label: 'Go' },
   { value: 'cargo', label: 'Cargo' },
+  { value: 'nuget', label: 'NuGet' },
+  { value: 'packagist', label: 'Packagist' },
+  { value: 'rubygems', label: 'RubyGems' },
 ];
 
 /** Lifecycle options for the Akrites filter panel. */

--- a/packages/shared/src/interfaces/akrites.interface.ts
+++ b/packages/shared/src/interfaces/akrites.interface.ts
@@ -3,7 +3,7 @@
 
 export type AkritesStatus = 'unassigned' | 'open' | 'assessing' | 'active' | 'needs_attention' | 'escalated' | 'blocked' | 'inactive';
 export type AkritesLifecycle = 'active' | 'stable' | 'declining' | 'abandoned';
-export type AkritesEcosystem = 'npm' | 'maven' | 'pypi' | 'go' | 'cargo';
+export type AkritesEcosystem = 'npm' | 'maven' | 'pypi' | 'go' | 'cargo' | 'nuget' | 'packagist' | 'rubygems';
 export type AkritesHealthBand = 'healthy' | 'fair' | 'concerning' | 'critical';
 export type AkritesSeverity = 'critical' | 'high' | 'medium' | 'moderate' | 'low';
 /** Severities the advisories flow models. Narrower than AkritesSeverity — excludes the package-level `medium`. */


### PR DESCRIPTION
## Summary

- Extends \`AkritesEcosystem\` union to include \`nuget\`, \`packagist\`, \`rubygems\`
- Adds NuGet, Packagist, RubyGems options to \`AKRITES_ECOSYSTEM_OPTIONS\` filter dropdown
- Adds branded icon cases in the packages-tab and drawer; backfills missing \`cargo\` case in the drawer
- Extracts a standalone \`AkritesEcosystemBadgeComponent\` shared by both templates — eliminates switch duplication and drift risk

## Notes

- Tracked in [CM-1311](https://linuxfoundation.atlassian.net/browse/CM-1311) (Community Data Platform project) — deviates from the repo's default \`LFXV2\` convention; work originated in the CDP board by design
- Backend/CDP data pipeline changes for the new ecosystems are out of scope and tracked separately

## Test plan

- [ ] Ecosystem filter dropdown shows NuGet, Packagist, RubyGems as selectable options
- [ ] NuGet renders \`Nu\` badge (navy \`#004880\`), Packagist renders \`fa-brands fa-php\` (orange), RubyGems renders \`fa-solid fa-gem\` (red)
- [ ] Icons render correctly in both the packages table row and the package drawer header
- [ ] \`yarn check-types\`, \`yarn lint\`, \`yarn build\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CM-1311]: https://linuxfoundation.atlassian.net/browse/CM-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ