### PR TITLE
feat(org): org lens meetings upcoming list (LFXV2-1902)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 # Local env files
 .env
 .env.local
+.env.dev
 .env.development.local
 .env.test.local
 .env.production.local

--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -1,13 +1,70 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { expect, Page, test } from '@playwright/test';
+import { expect, Page, Route, test } from '@playwright/test';
 
 const ORG_MEETINGS_URL = '/org/meetings';
 const DATA_LOAD_TIMEOUT = 30_000;
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 
 test.setTimeout(120_000);
+
+interface StubInvitee {
+  name: string;
+  title: string;
+  avatarUrl: string | null;
+  rsvpStatus: 'yes' | 'maybe' | 'no' | null;
+}
+
+interface StubMeeting {
+  id: string;
+  title: string;
+  privacy: 'public' | 'private';
+  type: 'board' | 'working-group' | 'other';
+  recurrenceLabel: string | null;
+  startTime: string;
+  endTime: string;
+  foundation: string;
+  orgName: string;
+  project: string;
+  agenda: string | null;
+  resources: string[];
+  rsvpTally: { yes: number; maybe: number; no: number; noResponse: number };
+  orgInvitees: StubInvitee[];
+  guestCount: number;
+  joinUrl: string | null;
+  statusFlags: { recording: boolean; transcripts: boolean; aiSummary: boolean };
+}
+
+function makeMeeting(index: number, overrides: Partial<StubMeeting> = {}): StubMeeting {
+  return {
+    id: `mtg-${index}`,
+    title: `Governing Board Meeting ${index}`,
+    privacy: 'private',
+    type: 'board',
+    recurrenceLabel: 'Every week on Thu',
+    startTime: '2026-08-14T17:00:00.000Z',
+    endTime: '2026-08-14T18:00:00.000Z',
+    foundation: 'RISC-V International',
+    orgName: 'Red Hat, Inc.',
+    project: 'RISC-V International',
+    agenda: `Agenda for meeting ${index}`,
+    resources: [],
+    rsvpTally: { yes: 2, maybe: 1, no: 0, noResponse: 1 },
+    orgInvitees: [
+      { name: 'Jeffrey Osier-Mixon', title: 'Community Architect', avatarUrl: 'https://example.com/a.png', rsvpStatus: 'yes' },
+      { name: 'Ada Lovelace', title: 'Engineer', avatarUrl: null, rsvpStatus: null },
+    ],
+    guestCount: 2,
+    joinUrl: null,
+    statusFlags: { recording: true, transcripts: true, aiSummary: false },
+    ...overrides,
+  };
+}
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
 
 function skipWhenAuthMissing(page: Page): void {
   try {
@@ -31,114 +88,211 @@ async function seedSelectedOrgCookie(page: Page): Promise<void> {
   ]);
 }
 
-async function stubOrgMeetingsRoutes(page: Page): Promise<void> {
+async function stubOrgMeetingsRoutes(page: Page, listResponder: (route: Route, url: URL) => Promise<void>): Promise<void> {
   await page.route('**/api/user/personas*', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        personas: ['contributor'],
-        personaProjects: {},
-        projects: [],
-        organizations: [
-          {
-            accountId: MOCK_ACCOUNT_ID,
-            accountName: 'Red Hat LLC',
-            accountSlug: 'red-hat-llc',
-            membershipTier: '',
-            uid: MOCK_ACCOUNT_ID,
-          },
-        ],
-        isRootWriter: false,
-      }),
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }],
+      isRootWriter: false,
     })
   );
 
   await page.route('**/api/analytics/org-lens-account-context*', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([
-        {
-          accountId: MOCK_ACCOUNT_ID,
-          accountName: 'Red Hat LLC',
-          accountSlug: 'red-hat-llc',
-          membershipTier: 'Gold',
-        },
-      ]),
-    })
+    fulfillJson(route, [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }])
   );
+
+  await page.route('**/api/orgs/**/lens/meetings**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname.endsWith('/lens/meetings/summary')) {
+      await fulfillJson(route, { upcomingMeetings: 12, recurringSeries: 4, recurringFoundations: 3, nextMeeting: '2026-07-03T12:00:00.000Z' });
+      return;
+    }
+    if (url.pathname.endsWith('/lens/meetings/projects')) {
+      await fulfillJson(route, { projects: ['RISC-V International', 'Cloud Native Computing Foundation'] });
+      return;
+    }
+    await listResponder(route, url);
+  });
 }
 
 async function gotoOrgMeetingsPage(page: Page): Promise<void> {
   await seedSelectedOrgCookie(page);
-  await stubOrgMeetingsRoutes(page);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await page.reload({ waitUntil: 'domcontentloaded' });
   await page.goto(ORG_MEETINGS_URL, { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await expect(page).not.toHaveURL(/auth0\.com/);
-
   if (!page.url().includes('/org/meetings')) {
     test.skip(true, 'org-lens-enabled flag appears off — /org/meetings redirected away');
   }
 }
 
 test.describe('Org Meetings Dashboard', () => {
-  test('renders the meetings page with KPI strip and upcoming tab by default', async ({ page }) => {
+  test('renders KPI strip and real upcoming cards by default', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1), makeMeeting(2)], total: 2, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);
+
     await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('org-meetings-kpi-strip')).toBeVisible();
-    await expect(page.getByTestId('org-meetings-tab-bar')).toBeVisible();
     await expect(page.getByTestId('org-meetings-upcoming-tab')).toBeVisible();
-    await expect(page.getByTestId('org-upcoming-meetings-list')).toBeVisible();
+    const list = page.getByTestId('org-upcoming-meetings-list');
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+    await expect(list).toContainText('Governing Board Meeting 1');
   });
 
-  test('switches to past tab and renders past meeting list', async ({ page }) => {
+  test('KPI strip renders the Snowflake-backed summary counts', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);
-    await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-
-    await page.getByTestId('org-meetings-tab-past').click();
-    await expect(page).toHaveURL(/tab=past/);
-    await expect(page.getByTestId('org-meetings-past-tab')).toBeVisible();
-    await expect(page.getByTestId('org-past-meetings-list')).toBeVisible();
+    const strip = page.getByTestId('org-meetings-kpi-strip');
+    await expect(strip).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(strip).toContainText('Upcoming Meetings');
+    await expect(strip).toContainText('12');
+    await expect(strip).toContainText('Recurring Series');
   });
 
-  test('switching back to upcoming tab clears tab query param', async ({ page }) => {
+  test('card date/time shows a timezone abbreviation', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);
-    await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-
-    await page.getByTestId('org-meetings-tab-past').click();
-    await expect(page).toHaveURL(/tab=past/);
-
-    await page.getByTestId('org-meetings-tab-upcoming').click();
-    await expect(page).not.toHaveURL(/tab=/);
-    await expect(page.getByTestId('org-meetings-upcoming-tab')).toBeVisible();
+    const card = page.getByTestId('org-upcoming-meeting-card-mtg-1');
+    await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(card).toContainText('GMT');
   });
 
-  test('search narrows the upcoming meetings list', async ({ page }) => {
+  test('shows the empty state when the org has no upcoming meetings', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [], total: 0, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);
-    await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-upcoming-meetings-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-upcoming-meetings-error')).toHaveCount(0);
+  });
+
+  test('shows a distinct error state with retry that re-requests', async ({ page }) => {
+    let calls = 0;
+    await stubOrgMeetingsRoutes(page, async (route) => {
+      calls += 1;
+      if (calls === 1) {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await fulfillJson(route, { data: [makeMeeting(9)], total: 1, pageSize: 10, offset: 0 });
+    });
+    await gotoOrgMeetingsPage(page);
+
+    await expect(page.getByTestId('org-upcoming-meetings-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-upcoming-meetings-empty')).toHaveCount(0);
+
+    await page.getByTestId('org-upcoming-meetings-retry').click();
+    await expect(page.getByTestId('org-upcoming-meeting-card-mtg-9')).toBeVisible();
+    await expect(page.getByTestId('org-upcoming-meetings-error')).toHaveCount(0);
+  });
+
+  test('load more appends the next page', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, async (route, url) => {
+      const offset = Number(url.searchParams.get('offset') ?? '0');
+      if (offset === 0) {
+        await fulfillJson(route, { data: [makeMeeting(1), makeMeeting(2)], total: 3, pageSize: 10, offset: 0 });
+        return;
+      }
+      await fulfillJson(route, { data: [makeMeeting(3)], total: 3, pageSize: 10, offset });
+    });
+    await gotoOrgMeetingsPage(page);
 
     const list = page.getByTestId('org-upcoming-meetings-list');
-    const initialCount = await list.locator('[data-testid^="org-upcoming-meeting-card-"]').count();
-    expect(initialCount).toBeGreaterThan(1);
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+    await page.getByTestId('org-upcoming-meetings-load-more').click();
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(3);
+  });
 
-    await page.getByTestId('org-meetings-search').locator('input').fill('Security TAG');
+  test('a failed load more keeps the already-loaded cards visible', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, async (route, url) => {
+      const offset = Number(url.searchParams.get('offset') ?? '0');
+      if (offset === 0) {
+        await fulfillJson(route, { data: [makeMeeting(1), makeMeeting(2)], total: 3, pageSize: 10, offset: 0 });
+        return;
+      }
+      await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+    });
+    await gotoOrgMeetingsPage(page);
+
+    const list = page.getByTestId('org-upcoming-meetings-list');
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+
+    await page.getByTestId('org-upcoming-meetings-load-more').click();
+    await expect(page.getByTestId('org-upcoming-meetings-load-more-error')).toBeVisible();
+    await expect(page.getByTestId('org-upcoming-meetings-load-more')).toContainText('Retry');
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+    await expect(page.getByTestId('org-upcoming-meetings-error')).toHaveCount(0);
+
+    // Retry also fails: the loaded cards must still stay, never the full-page error.
+    await page.getByTestId('org-upcoming-meetings-load-more').click();
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+    await expect(page.getByTestId('org-upcoming-meetings-error')).toHaveCount(0);
+  });
+
+  test('renders org invitee rows and the reconciling attendance tally', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
+    await gotoOrgMeetingsPage(page);
+
+    const panel = page.getByTestId('org-upcoming-meeting-people-invited-mtg-1');
+    await expect(panel).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // rsvpTally 2/1/0/1 => 2 of 4 attending; orgInvitees(2) + guests(2) = total(4).
+    await expect(panel).toContainText('2 of 4 attending');
+    const firstInvitee = page.getByTestId('org-upcoming-meeting-invitee-mtg-1-0');
+    await expect(firstInvitee).toContainText('Jeffrey Osier-Mixon');
+    await expect(firstInvitee).toContainText('Community Architect');
+    await expect(page.getByTestId('org-upcoming-meeting-guests-mtg-1')).toContainText('2');
+  });
+
+  test('search re-fetches server-side with the searchQuery param', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, async (route, url) => {
+      const search = url.searchParams.get('searchQuery');
+      if (search) {
+        await fulfillJson(route, { data: [makeMeeting(7, { title: 'Security TAG Monthly' })], total: 1, pageSize: 10, offset: 0 });
+        return;
+      }
+      await fulfillJson(route, { data: [makeMeeting(1), makeMeeting(2), makeMeeting(3)], total: 3, pageSize: 10, offset: 0 });
+    });
+    await gotoOrgMeetingsPage(page);
+
+    const list = page.getByTestId('org-upcoming-meetings-list');
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(3);
+
+    const request = page.waitForRequest((req) => req.url().includes('/lens/meetings?') && req.url().includes('searchQuery=Security'));
+    await page.getByTestId('org-meetings-search').locator('input').fill('Security');
+    await request;
     await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(1);
     await expect(list).toContainText('Security TAG Monthly');
   });
 
-  test('pending RSVP toggle narrows the upcoming meetings list', async ({ page }) => {
+  test('pending RSVP toggle re-fetches with the pendingRsvpOnly param', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, async (route, url) => {
+      const pending = url.searchParams.get('pendingRsvpOnly') === 'true';
+      const data = pending ? [makeMeeting(1)] : [makeMeeting(1), makeMeeting(2)];
+      await fulfillJson(route, { data, total: data.length, pageSize: 10, offset: 0 });
+    });
+    await gotoOrgMeetingsPage(page);
+
+    const list = page.getByTestId('org-upcoming-meetings-list');
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(2);
+    const request = page.waitForRequest((req) => req.url().includes('/lens/meetings?') && req.url().includes('pendingRsvpOnly=true'));
+    await page.getByTestId('org-meetings-pending-rsvp-toggle').click();
+    await request;
+    await expect(list.locator('[data-testid^="org-upcoming-meeting-card-"]')).toHaveCount(1);
+  });
+
+  test('switches to the past tab and back, clearing the tab query param', async ({ page }) => {
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);
     await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
-    const list = page.getByTestId('org-upcoming-meetings-list');
-    const initialCount = await list.locator('[data-testid^="org-upcoming-meeting-card-"]').count();
+    await page.getByTestId('org-meetings-tab-past').click();
+    await expect(page).toHaveURL(/tab=past/);
+    await expect(page.getByTestId('org-past-meetings-list')).toBeVisible();
 
-    await page.getByTestId('org-meetings-pending-rsvp-toggle').click();
-    const filteredCount = await list.locator('[data-testid^="org-upcoming-meeting-card-"]').count();
-    expect(filteredCount).toBeLessThan(initialCount);
+    await page.getByTestId('org-meetings-tab-upcoming').click();
+    await expect(page).not.toHaveURL(/tab=/);
+    await expect(page.getByTestId('org-meetings-upcoming-tab')).toBeVisible();
   });
 });

--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -130,9 +130,14 @@ async function gotoOrgMeetingsPage(page: Page): Promise<void> {
   }
 }
 
+/** Stub a single-page meetings response (total = the given list length). */
+async function stubSinglePage(page: Page, meetings: StubMeeting[]): Promise<void> {
+  await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: meetings, total: meetings.length, pageSize: 10, offset: 0 }));
+}
+
 test.describe('Org Meetings Dashboard', () => {
   test('renders KPI strip and real upcoming cards by default', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1), makeMeeting(2)], total: 2, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1), makeMeeting(2)]);
     await gotoOrgMeetingsPage(page);
 
     await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
@@ -145,7 +150,7 @@ test.describe('Org Meetings Dashboard', () => {
 
   test('renders URLs in the agenda as clickable links', async ({ page }) => {
     const agenda = 'Planning doc: https://docs.google.com/document/d/abc123/edit';
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1, { agenda })], total: 1, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1, { agenda })]);
     await gotoOrgMeetingsPage(page);
 
     const card = page.getByTestId('org-upcoming-meeting-card-mtg-1');
@@ -157,7 +162,7 @@ test.describe('Org Meetings Dashboard', () => {
   });
 
   test('KPI strip renders the Snowflake-backed summary counts', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1)]);
     await gotoOrgMeetingsPage(page);
     const strip = page.getByTestId('org-meetings-kpi-strip');
     await expect(strip).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
@@ -167,7 +172,7 @@ test.describe('Org Meetings Dashboard', () => {
   });
 
   test('card date/time shows a timezone abbreviation', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1)]);
     await gotoOrgMeetingsPage(page);
     const card = page.getByTestId('org-upcoming-meeting-card-mtg-1');
     await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
@@ -175,7 +180,7 @@ test.describe('Org Meetings Dashboard', () => {
   });
 
   test('shows the empty state when the org has no upcoming meetings', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [], total: 0, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, []);
     await gotoOrgMeetingsPage(page);
     await expect(page.getByTestId('org-upcoming-meetings-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('org-upcoming-meetings-error')).toHaveCount(0);
@@ -245,7 +250,7 @@ test.describe('Org Meetings Dashboard', () => {
   });
 
   test('renders org invitee rows and the reconciling attendance tally', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1)]);
     await gotoOrgMeetingsPage(page);
 
     const panel = page.getByTestId('org-upcoming-meeting-people-invited-mtg-1');
@@ -296,7 +301,7 @@ test.describe('Org Meetings Dashboard', () => {
   });
 
   test('switches to the past tab and back, clearing the tab query param', async ({ page }) => {
-    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
+    await stubSinglePage(page, [makeMeeting(1)]);
     await gotoOrgMeetingsPage(page);
     await expect(page.getByTestId('org-meetings-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 

--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -143,6 +143,19 @@ test.describe('Org Meetings Dashboard', () => {
     await expect(list).toContainText('Governing Board Meeting 1');
   });
 
+  test('renders URLs in the agenda as clickable links', async ({ page }) => {
+    const agenda = 'Planning doc: https://docs.google.com/document/d/abc123/edit';
+    await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1, { agenda })], total: 1, pageSize: 10, offset: 0 }));
+    await gotoOrgMeetingsPage(page);
+
+    const card = page.getByTestId('org-upcoming-meeting-card-mtg-1');
+    await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    const link = card.locator('#org-upcoming-meeting-agenda-mtg-1 a[href="https://docs.google.com/document/d/abc123/edit"]');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   test('KPI strip renders the Snowflake-backed summary counts', async ({ page }) => {
     await stubOrgMeetingsRoutes(page, (route) => fulfillJson(route, { data: [makeMeeting(1)], total: 1, pageSize: 10, offset: 0 }));
     await gotoOrgMeetingsPage(page);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
@@ -11,7 +11,7 @@
   } @else if (error()) {
     <div class="flex flex-col items-center gap-3 py-16 text-center" data-testid="org-upcoming-meetings-error">
       <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400" aria-hidden="true"></i>
-      <p class="text-sm text-gray-500">We couldn't load meetings. Please try again.</p>
+      <p class="text-sm text-gray-500" role="alert">We couldn't load meetings. Please try again.</p>
       <button
         type="button"
         class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
@@ -158,7 +158,7 @@
               <div class="flex flex-col gap-3 rounded-lg border border-gray-100 bg-white p-3">
                 <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">{{ orgName() }} Invitees ({{ meeting.orgInvitees.length }})</p>
                 <div class="flex flex-col divide-y divide-gray-100">
-                  @for (invitee of meeting.orgInvitees; track invitee.name + '|' + invitee.title; let i = $index) {
+                  @for (invitee of meeting.orgInvitees; track $index; let i = $index) {
                     <div class="flex items-center gap-3 py-2 first:pt-0 last:pb-0" [attr.data-testid]="'org-upcoming-meeting-invitee-' + meeting.id + '-' + i">
                       <lfx-person-avatar [avatarUrl]="invitee.avatarUrl" [name]="invitee.name" [identity]="invitee.name" />
                       <div class="flex-1 min-w-0">
@@ -201,7 +201,7 @@
     @if (hasMore()) {
       <div class="flex flex-col items-center gap-2 pt-2">
         @if (loadMoreError()) {
-          <p class="text-sm text-red-500" role="alert" aria-live="polite" data-testid="org-upcoming-meetings-load-more-error">Couldn't load more meetings.</p>
+          <p class="text-sm text-red-500" role="status" data-testid="org-upcoming-meetings-load-more-error">Couldn't load more meetings.</p>
         }
         <button
           type="button"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
@@ -26,7 +26,7 @@
       <p class="text-sm text-gray-500">No upcoming meetings match these filters.</p>
     </div>
   } @else {
-    @for (meeting of meetings(); track meeting.id) {
+    @for (meeting of meetingVms(); track meeting.id) {
       <div class="flex flex-col gap-3 p-5 bg-white rounded-xl shadow-sm border border-gray-100" [attr.data-testid]="'org-upcoming-meeting-card-' + meeting.id">
         <div class="flex items-center justify-between gap-3">
           <div class="flex flex-wrap items-center gap-2">
@@ -59,7 +59,7 @@
             class="rounded p-1 text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 flex-shrink-0"
             aria-label="Copy meeting link"
             [attr.data-testid]="'org-upcoming-meeting-copy-' + meeting.id"
-            [cdkCopyToClipboard]="meetingLinkUrl(meeting.id)">
+            [cdkCopyToClipboard]="meeting.linkUrl">
             <i class="fa-light fa-copy text-sm" aria-hidden="true"></i>
           </button>
         </div>
@@ -131,17 +131,14 @@
             <p class="flex items-center gap-1.5 text-sm font-medium text-gray-700"><i class="fa-light fa-users" aria-hidden="true"></i> People Invited</p>
 
             <div class="flex items-center justify-between gap-3">
-              <p class="text-base font-semibold text-gray-900">{{ meeting.rsvpTally.yes }} of {{ totalInvited(meeting.rsvpTally) }} attending</p>
-              <span class="text-sm font-medium text-gray-500">{{ attendingPercent(meeting.rsvpTally) }}%</span>
+              <p class="text-base font-semibold text-gray-900">{{ meeting.rsvpTally.yes }} of {{ meeting.totalInvited }} attending</p>
+              <span class="text-sm font-medium text-gray-500">{{ meeting.attendingPercent }}%</span>
             </div>
 
-            <div
-              class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100"
-              role="img"
-              [attr.aria-label]="attendingPercent(meeting.rsvpTally) + '% attending'">
-              <div class="bg-blue-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.yes, meeting.rsvpTally)"></div>
-              <div class="bg-amber-400" [style.width.%]="rsvpPercent(meeting.rsvpTally.maybe, meeting.rsvpTally)"></div>
-              <div class="bg-red-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.no, meeting.rsvpTally)"></div>
+            <div class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100" role="img" [attr.aria-label]="meeting.attendingPercent + '% attending'">
+              <div class="bg-blue-500" [style.width.%]="meeting.yesPercent"></div>
+              <div class="bg-amber-400" [style.width.%]="meeting.maybePercent"></div>
+              <div class="bg-red-500" [style.width.%]="meeting.noPercent"></div>
             </div>
 
             <div class="flex flex-wrap items-center justify-between gap-4 text-sm">
@@ -156,11 +153,11 @@
               </span>
             </div>
 
-            @if (meeting.orgInvitees.length > 0) {
+            @if (meeting.inviteeVms.length > 0) {
               <div class="flex flex-col gap-3 rounded-lg border border-gray-100 bg-white p-3">
-                <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">{{ orgName() }} Invitees ({{ meeting.orgInvitees.length }})</p>
+                <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">{{ orgName() }} Invitees ({{ meeting.inviteeVms.length }})</p>
                 <div class="flex flex-col divide-y divide-gray-100">
-                  @for (invitee of meeting.orgInvitees; track $index; let i = $index) {
+                  @for (invitee of meeting.inviteeVms; track $index; let i = $index) {
                     <div class="flex items-center gap-3 py-2 first:pt-0 last:pb-0" [attr.data-testid]="'org-upcoming-meeting-invitee-' + meeting.id + '-' + i">
                       <lfx-person-avatar [avatarUrl]="invitee.avatarUrl" [name]="invitee.name" [identity]="invitee.name" />
                       <div class="flex-1 min-w-0">
@@ -169,8 +166,8 @@
                       </div>
                       <span
                         class="inline-flex flex-shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium"
-                        [class]="rsvpBadge(invitee.rsvpStatus).badgeClass">
-                        <i class="fa-light fa-circle-small text-[6px]" aria-hidden="true"></i> {{ rsvpBadge(invitee.rsvpStatus).label }}
+                        [class]="invitee.badge.badgeClass">
+                        <i class="fa-light fa-circle-small text-[6px]" aria-hidden="true"></i> {{ invitee.badge.label }}
                       </span>
                     </div>
                   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
@@ -8,6 +8,18 @@
         <div class="h-3 bg-gray-100 rounded w-2/3"></div>
       </div>
     }
+  } @else if (error()) {
+    <div class="flex flex-col items-center gap-3 py-16 text-center" data-testid="org-upcoming-meetings-error">
+      <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400" aria-hidden="true"></i>
+      <p class="text-sm text-gray-500">We couldn't load meetings. Please try again.</p>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        data-testid="org-upcoming-meetings-retry"
+        (click)="retry.emit()">
+        <i class="fa-light fa-rotate-right" aria-hidden="true"></i> Try again
+      </button>
+    </div>
   } @else if (meetings().length === 0) {
     <div class="flex flex-col items-center gap-3 py-16 text-center" data-testid="org-upcoming-meetings-empty">
       <i class="fa-light fa-calendar-xmark text-4xl text-gray-300" aria-hidden="true"></i>
@@ -16,7 +28,6 @@
   } @else {
     @for (meeting of meetings(); track meeting.id) {
       <div class="flex flex-col gap-3 p-5 bg-white rounded-xl shadow-sm border border-gray-100" [attr.data-testid]="'org-upcoming-meeting-card-' + meeting.id">
-        <!-- ── Header: privacy/type/recurrence badges | copy icon ── -->
         <div class="flex items-center justify-between gap-3">
           <div class="flex flex-wrap items-center gap-2">
             @if (meeting.privacy === 'private') {
@@ -43,26 +54,22 @@
               </span>
             }
           </div>
-          @defer (on idle) {
-            <button
-              type="button"
-              class="rounded p-1 text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 flex-shrink-0"
-              aria-label="Copy meeting link"
-              [attr.data-testid]="'org-upcoming-meeting-copy-' + meeting.id"
-              [cdkCopyToClipboard]="meetingLinkUrl(meeting.id)">
-              <i class="fa-light fa-copy text-sm" aria-hidden="true"></i>
-            </button>
-          }
+          <button
+            type="button"
+            class="rounded p-1 text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 flex-shrink-0"
+            aria-label="Copy meeting link"
+            [attr.data-testid]="'org-upcoming-meeting-copy-' + meeting.id"
+            [cdkCopyToClipboard]="meetingLinkUrl(meeting.id)">
+            <i class="fa-light fa-copy text-sm" aria-hidden="true"></i>
+          </button>
         </div>
 
-        <!-- ── Title ── -->
         <h3 class="text-base font-semibold text-gray-900">{{ meeting.title }}</h3>
 
-        <!-- ── Date + inline status artifacts ── -->
         <div class="flex flex-wrap items-center gap-2">
           <span class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1 text-sm text-gray-600">
             <i class="fa-light fa-calendar-day text-xs text-gray-400" aria-hidden="true"></i>
-            {{ meeting.startTime | date: 'EEEE, MMMM d, y' }} &bull; {{ meeting.startTime | date: 'h:mm a' }} &ndash; {{ meeting.endTime | date: 'h:mm a' }}
+            {{ meeting.startTime | date: 'EEEE, MMMM d, y' }} &bull; {{ meeting.startTime | date: 'h:mm a' }} &ndash; {{ meeting.endTime | date: 'h:mm a z' }}
           </span>
           @if (meeting.statusFlags.recording) {
             <span class="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-500">
@@ -81,7 +88,6 @@
           }
         </div>
 
-        <!-- ── Agenda with Show more/less ── -->
         @if (meeting.agenda) {
           @let expanded = expandedIds().has(meeting.id);
           <div class="flex flex-col gap-1">
@@ -100,9 +106,7 @@
           </div>
         }
 
-        <!-- ── Two-column: Resources | People Invited or Register ── -->
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <!-- LEFT: Resources -->
           <div class="flex flex-col gap-2 rounded-lg border border-gray-100 bg-gray-50 p-4">
             <p class="flex items-center gap-1.5 text-sm font-medium text-gray-500"><i class="fa-light fa-paperclip" aria-hidden="true"></i> Resources</p>
             @if (meeting.resources.length === 0) {
@@ -119,94 +123,97 @@
             }
           </div>
 
-          <!-- RIGHT: People Invited or Register -->
-          @if (meeting.privacy === 'private') {
-            <!-- People Invited (org-lens attendance summary; no personal RSVP actions here) -->
-            <div
-              class="flex flex-col gap-4 rounded-lg border border-gray-100 bg-gray-50 p-4"
-              [attr.data-testid]="'org-upcoming-meeting-people-invited-' + meeting.id">
-              <p class="flex items-center gap-1.5 text-sm font-medium text-gray-700"><i class="fa-light fa-users" aria-hidden="true"></i> People Invited</p>
+          <div
+            class="flex flex-col gap-4 rounded-lg border border-gray-100 bg-gray-50 p-4"
+            [attr.data-testid]="'org-upcoming-meeting-people-invited-' + meeting.id">
+            <p class="flex items-center gap-1.5 text-sm font-medium text-gray-700"><i class="fa-light fa-users" aria-hidden="true"></i> People Invited</p>
 
-              <div class="flex items-center justify-between gap-3">
-                <p class="text-base font-semibold text-gray-900">{{ meeting.rsvpTally.yes }} of {{ totalInvited(meeting.rsvpTally) }} attending</p>
-                <span class="text-sm font-medium text-gray-500">{{ attendingPercent(meeting.rsvpTally) }}%</span>
-              </div>
-
-              <div
-                class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100"
-                role="img"
-                [attr.aria-label]="attendingPercent(meeting.rsvpTally) + '% attending'">
-                <div class="bg-blue-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.yes, meeting.rsvpTally)"></div>
-                <div class="bg-amber-400" [style.width.%]="rsvpPercent(meeting.rsvpTally.maybe, meeting.rsvpTally)"></div>
-                <div class="bg-red-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.no, meeting.rsvpTally)"></div>
-              </div>
-
-              <div class="flex flex-wrap items-center justify-between gap-4 text-sm">
-                <span class="inline-flex items-center gap-1.5 text-blue-600">
-                  <i class="fa-light fa-circle-check text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.yes }} Yes
-                </span>
-                <span class="inline-flex items-center gap-1.5 text-amber-600">
-                  <i class="fa-light fa-circle-question text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.maybe }} Maybe
-                </span>
-                <span class="inline-flex items-center gap-1.5 text-red-500">
-                  <i class="fa-light fa-circle-xmark text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.no }} No
-                </span>
-              </div>
-
-              @if (meeting.orgInvitees.length > 0) {
-                <div class="flex flex-col gap-3 rounded-lg border border-gray-100 bg-white p-3">
-                  <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">{{ meeting.orgName }} Invitees ({{ meeting.orgInvitees.length }})</p>
-                  <div class="flex flex-col divide-y divide-gray-100">
-                    @for (invitee of meeting.orgInvitees; track invitee.name + '|' + invitee.title) {
-                      <div class="flex items-center gap-3 py-2 first:pt-0 last:pb-0">
-                        <lfx-person-avatar [avatarUrl]="invitee.avatarUrl" [name]="invitee.name" [identity]="invitee.name" />
-                        <div class="flex-1 min-w-0">
-                          <p class="truncate text-sm font-medium text-gray-900">{{ invitee.name }}</p>
-                          <p class="truncate text-sm text-gray-500">{{ invitee.title }}</p>
-                        </div>
-                        <span
-                          class="inline-flex flex-shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium"
-                          [class]="rsvpBadge(invitee.rsvpStatus).badgeClass">
-                          <i class="fa-light fa-circle-small text-[6px]" aria-hidden="true"></i> {{ rsvpBadge(invitee.rsvpStatus).label }}
-                        </span>
-                      </div>
-                    }
-                  </div>
-                </div>
-              }
-
-              <div class="grid grid-cols-2 gap-2">
-                <button
-                  type="button"
-                  disabled
-                  aria-disabled="true"
-                  class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
-                  [attr.data-testid]="'org-upcoming-meeting-guests-' + meeting.id">
-                  <i class="fa-light fa-user" aria-hidden="true"></i> Guests ({{ meeting.guestCount }})
-                </button>
-                <button
-                  type="button"
-                  disabled
-                  aria-disabled="true"
-                  class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
-                  [attr.data-testid]="'org-upcoming-meeting-details-' + meeting.id">
-                  <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i> See Details
-                </button>
-              </div>
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-base font-semibold text-gray-900">{{ meeting.rsvpTally.yes }} of {{ totalInvited(meeting.rsvpTally) }} attending</p>
+              <span class="text-sm font-medium text-gray-500">{{ attendingPercent(meeting.rsvpTally) }}%</span>
             </div>
-          } @else {
-            <div class="flex flex-col gap-2">
+
+            <div
+              class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100"
+              role="img"
+              [attr.aria-label]="attendingPercent(meeting.rsvpTally) + '% attending'">
+              <div class="bg-blue-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.yes, meeting.rsvpTally)"></div>
+              <div class="bg-amber-400" [style.width.%]="rsvpPercent(meeting.rsvpTally.maybe, meeting.rsvpTally)"></div>
+              <div class="bg-red-500" [style.width.%]="rsvpPercent(meeting.rsvpTally.no, meeting.rsvpTally)"></div>
+            </div>
+
+            <div class="flex flex-wrap items-center justify-between gap-4 text-sm">
+              <span class="inline-flex items-center gap-1.5 text-blue-600">
+                <i class="fa-light fa-circle-check text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.yes }} Yes
+              </span>
+              <span class="inline-flex items-center gap-1.5 text-amber-600">
+                <i class="fa-light fa-circle-question text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.maybe }} Maybe
+              </span>
+              <span class="inline-flex items-center gap-1.5 text-red-500">
+                <i class="fa-light fa-circle-xmark text-xs" aria-hidden="true"></i> {{ meeting.rsvpTally.no }} No
+              </span>
+            </div>
+
+            @if (meeting.orgInvitees.length > 0) {
+              <div class="flex flex-col gap-3 rounded-lg border border-gray-100 bg-white p-3">
+                <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">{{ orgName() }} Invitees ({{ meeting.orgInvitees.length }})</p>
+                <div class="flex flex-col divide-y divide-gray-100">
+                  @for (invitee of meeting.orgInvitees; track invitee.name + '|' + invitee.title; let i = $index) {
+                    <div class="flex items-center gap-3 py-2 first:pt-0 last:pb-0" [attr.data-testid]="'org-upcoming-meeting-invitee-' + meeting.id + '-' + i">
+                      <lfx-person-avatar [avatarUrl]="invitee.avatarUrl" [name]="invitee.name" [identity]="invitee.name" />
+                      <div class="flex-1 min-w-0">
+                        <p class="truncate text-sm font-medium text-gray-900">{{ invitee.name }}</p>
+                        <p class="truncate text-sm text-gray-500">{{ invitee.title }}</p>
+                      </div>
+                      <span
+                        class="inline-flex flex-shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium"
+                        [class]="rsvpBadge(invitee.rsvpStatus).badgeClass">
+                        <i class="fa-light fa-circle-small text-[6px]" aria-hidden="true"></i> {{ rsvpBadge(invitee.rsvpStatus).label }}
+                      </span>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+
+            <div class="grid grid-cols-2 gap-2">
               <button
                 type="button"
                 disabled
                 aria-disabled="true"
-                class="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
+                class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
+                [attr.data-testid]="'org-upcoming-meeting-guests-' + meeting.id">
+                <i class="fa-light fa-user" aria-hidden="true"></i> Guests ({{ meeting.guestCount }})
+              </button>
+              <button
+                type="button"
+                disabled
+                aria-disabled="true"
+                class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
                 [attr.data-testid]="'org-upcoming-meeting-details-' + meeting.id">
-                <i class="fa-light fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i> See Meeting Details
+                <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i> See Details
               </button>
             </div>
-          }
+          </div>
         </div>
+      </div>
+    }
+    @if (hasMore()) {
+      <div class="flex flex-col items-center gap-2 pt-2">
+        @if (loadMoreError()) {
+          <p class="text-sm text-red-500" role="alert" aria-live="polite" data-testid="org-upcoming-meetings-load-more-error">Couldn't load more meetings.</p>
+        }
+        <button
+          type="button"
+          [disabled]="loadingMore()"
+          class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+          data-testid="org-upcoming-meetings-load-more"
+          (click)="loadMore.emit()">
+          <i
+            [class]="loadingMore() ? 'fa-light fa-spinner-third fa-spin' : loadMoreError() ? 'fa-light fa-rotate-right' : 'fa-light fa-chevron-down'"
+            aria-hidden="true"></i>
+          {{ loadingMore() ? 'Loading…' : loadMoreError() ? 'Retry' : 'Load more' }}
+        </button>
       </div>
     }
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.html
@@ -91,9 +91,11 @@
         @if (meeting.agenda) {
           @let expanded = expandedIds().has(meeting.id);
           <div class="flex flex-col gap-1">
-            <p [attr.id]="'org-upcoming-meeting-agenda-' + meeting.id" class="text-sm text-gray-700" [class.line-clamp-3]="!expanded">
-              {{ meeting.agenda }}
-            </p>
+            <div
+              [attr.id]="'org-upcoming-meeting-agenda-' + meeting.id"
+              class="text-sm text-gray-700 whitespace-pre-line"
+              [class.line-clamp-3]="!expanded"
+              [innerHTML]="meeting.agenda | linkify"></div>
             <button
               type="button"
               class="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded w-fit"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
@@ -3,7 +3,7 @@
 
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { DatePipe, isPlatformBrowser } from '@angular/common';
-import { Component, inject, input, PLATFORM_ID, signal } from '@angular/core';
+import { Component, inject, input, output, PLATFORM_ID, signal } from '@angular/core';
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
 import { ORG_MEETINGS_NO_RESPONSE_BADGE, ORG_MEETINGS_RSVP_BADGES } from '@lfx-one/shared/constants';
 import type { OrgMeeting, OrgMeetingRsvpStatus, OrgMeetingRsvpTally } from '@lfx-one/shared/interfaces';
@@ -19,6 +19,13 @@ export class OrgUpcomingMeetingsComponent {
 
   public readonly meetings = input.required<readonly OrgMeeting[]>();
   public readonly loading = input<boolean>(false);
+  public readonly loadingMore = input<boolean>(false);
+  public readonly loadMoreError = input<boolean>(false);
+  public readonly error = input<boolean>(false);
+  public readonly orgName = input<string>('');
+  public readonly hasMore = input<boolean>(false);
+  public readonly retry = output<void>();
+  public readonly loadMore = output<void>();
 
   protected readonly expandedIds = signal<ReadonlySet<string>>(new Set());
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
@@ -8,10 +8,11 @@ import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.c
 import { ORG_MEETINGS_NO_RESPONSE_BADGE, ORG_MEETINGS_RSVP_BADGES } from '@lfx-one/shared/constants';
 import type { OrgMeeting, OrgMeetingRsvpStatus, OrgMeetingRsvpTally } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
+import { LinkifyPipe } from '@pipes/linkify.pipe';
 
 @Component({
   selector: 'lfx-org-upcoming-meetings',
-  imports: [DatePipe, PersonAvatarComponent, ClipboardModule],
+  imports: [DatePipe, PersonAvatarComponent, ClipboardModule, LinkifyPipe],
   templateUrl: './org-upcoming-meetings.component.html',
 })
 export class OrgUpcomingMeetingsComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-upcoming-meetings/org-upcoming-meetings.component.ts
@@ -3,10 +3,10 @@
 
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { DatePipe, isPlatformBrowser } from '@angular/common';
-import { Component, inject, input, output, PLATFORM_ID, signal } from '@angular/core';
+import { Component, computed, inject, input, output, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
 import { ORG_MEETINGS_NO_RESPONSE_BADGE, ORG_MEETINGS_RSVP_BADGES } from '@lfx-one/shared/constants';
-import type { OrgMeeting, OrgMeetingRsvpStatus, OrgMeetingRsvpTally } from '@lfx-one/shared/interfaces';
+import type { OrgMeeting, OrgMeetingRsvpTally, OrgMeetingVm } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 
@@ -30,6 +30,12 @@ export class OrgUpcomingMeetingsComponent {
 
   protected readonly expandedIds = signal<ReadonlySet<string>>(new Set());
 
+  // Pre-bake per-meeting presentation fields once per list change so the template's `@for` binds plain values (no method calls per change-detection).
+  protected readonly meetingVms: Signal<readonly OrgMeetingVm[]> = computed(() => {
+    const isBrowser = isPlatformBrowser(this.platformId);
+    return this.meetings().map((meeting) => this.toVm(meeting, isBrowser));
+  });
+
   protected toggleExpand(id: string): void {
     this.expandedIds.update((prev) => {
       const next = new Set(prev);
@@ -42,25 +48,29 @@ export class OrgUpcomingMeetingsComponent {
     });
   }
 
-  protected meetingLinkUrl(meetingId: string): string {
-    return toAbsoluteUrl(`/meetings/${meetingId}`, isPlatformBrowser(this.platformId));
+  private toVm(meeting: OrgMeeting, isBrowser: boolean): OrgMeetingVm {
+    const tally = meeting.rsvpTally;
+    const total = this.totalInvited(tally);
+    return {
+      ...meeting,
+      linkUrl: toAbsoluteUrl(`/meetings/${meeting.id}`, isBrowser),
+      totalInvited: total,
+      attendingPercent: total === 0 ? 0 : Math.round((tally.yes / total) * 100),
+      yesPercent: this.rsvpPercent(tally.yes, total),
+      maybePercent: this.rsvpPercent(tally.maybe, total),
+      noPercent: this.rsvpPercent(tally.no, total),
+      inviteeVms: meeting.orgInvitees.map((invitee) => ({
+        ...invitee,
+        badge: invitee.rsvpStatus ? ORG_MEETINGS_RSVP_BADGES[invitee.rsvpStatus] : ORG_MEETINGS_NO_RESPONSE_BADGE,
+      })),
+    };
   }
 
-  protected totalInvited(tally: OrgMeetingRsvpTally): number {
+  private totalInvited(tally: OrgMeetingRsvpTally): number {
     return tally.yes + tally.maybe + tally.no + tally.noResponse;
   }
 
-  protected attendingPercent(tally: OrgMeetingRsvpTally): number {
-    const total = this.totalInvited(tally);
-    return total === 0 ? 0 : Math.round((tally.yes / total) * 100);
-  }
-
-  protected rsvpPercent(count: number, tally: OrgMeetingRsvpTally): number {
-    const total = this.totalInvited(tally);
+  private rsvpPercent(count: number, total: number): number {
     return total === 0 ? 0 : (count / total) * 100;
-  }
-
-  protected rsvpBadge(status: OrgMeetingRsvpStatus): { label: string; badgeClass: string } {
-    return status ? ORG_MEETINGS_RSVP_BADGES[status] : ORG_MEETINGS_NO_RESPONSE_BADGE;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
@@ -1,19 +1,15 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 <main class="flex flex-col gap-6 p-6" data-testid="org-meetings-page">
-  <!-- Page header -->
   <header class="flex flex-col gap-1">
     <h1 class="text-2xl font-bold text-gray-900">Meetings</h1>
     <p class="text-sm text-gray-500">Coordinate decisions, align stakeholders, and maintain transparent governance across your foundations.</p>
   </header>
 
-  <!-- KPI strip -->
-  <lfx-stat-card-grid [cards]="kpiCards()" [loading]="loading()" [columns]="2" data-testid="org-meetings-kpi-strip" />
+  <lfx-stat-card-grid [cards]="kpiCards()" [loading]="summaryLoading()" [columns]="2" data-testid="org-meetings-kpi-strip" />
 
-  <!-- Filter bar — matches app.lfx.dev/meetings top-bar structure -->
   <div class="bg-white rounded-lg border border-gray-200 p-4 mb-8" data-testid="org-meetings-filter-bar">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
-      <!-- Tab pills (no counts — matches live site) -->
       <div class="flex flex-wrap items-center gap-2" data-testid="org-meetings-tab-bar">
         @for (tab of tabs; track tab.id) {
           <button
@@ -31,7 +27,6 @@
         }
       </div>
 
-      <!-- Pending RSVP toggle pill (Upcoming tab only) -->
       @if (activeTab() === 'upcoming') {
         <div class="flex flex-wrap items-center gap-2">
           <button
@@ -49,7 +44,6 @@
         </div>
       }
 
-      <!-- Search fills center, pushing filters to the right -->
       <div class="flex-1">
         <label for="org-meetings-search-id" class="sr-only">Search meetings</label>
         <lfx-input-text
@@ -63,13 +57,12 @@
           data-testid="org-meetings-search" />
       </div>
 
-      <!-- All Projects — right-aligned -->
       <div class="w-full sm:w-48">
         <label for="org-meetings-project-filter-id" class="sr-only">Filter by project</label>
         <lfx-select
           [form]="filterForm"
           control="project"
-          [options]="projectOptions"
+          [options]="projectOptions()"
           placeholder="All Projects"
           inputId="org-meetings-project-filter-id"
           ariaLabel="Filter by project"
@@ -78,7 +71,6 @@
           data-testid="org-meetings-project-filter" />
       </div>
 
-      <!-- All Types — right-aligned -->
       <div class="w-full sm:w-64">
         <label for="org-meetings-type-filter-id" class="sr-only">Filter by meeting type</label>
         <lfx-select
@@ -95,11 +87,20 @@
     </div>
   </div>
 
-  <!-- Tab content — each sub-component renders its own bordered cards with gap -->
   @if (activeTab() === 'upcoming') {
-    <lfx-org-upcoming-meetings [meetings]="filteredUpcoming()" [loading]="loading()" data-testid="org-meetings-upcoming-tab" />
+    <lfx-org-upcoming-meetings
+      [meetings]="upcomingMeetings()"
+      [loading]="listLoading()"
+      [loadingMore]="loadingMore()"
+      [loadMoreError]="loadMoreError()"
+      [error]="listError()"
+      [orgName]="orgName()"
+      [hasMore]="hasMore()"
+      (retry)="retryUpcoming()"
+      (loadMore)="loadMore()"
+      data-testid="org-meetings-upcoming-tab" />
   }
   @if (activeTab() === 'past') {
-    <lfx-org-past-meetings [meetings]="filteredPast()" [loading]="loading()" data-testid="org-meetings-past-tab" />
+    <lfx-org-past-meetings [meetings]="filteredPast()" [loading]="false" data-testid="org-meetings-past-tab" />
   }
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
@@ -90,6 +90,7 @@ export class OrgMeetingsComponent {
 
   public constructor() {
     this.initProjectOptions();
+    this.initResetFiltersOnAccountChange();
     this.initResetOnFilterChange();
     this.initUpcomingFetch();
   }
@@ -210,6 +211,16 @@ export class OrgMeetingsComponent {
         takeUntilDestroyed()
       )
       .subscribe((res) => this.projectOptions.set([{ label: 'All Projects', value: null }, ...res.projects.map((p) => ({ label: p, value: p }))]));
+  }
+
+  private initResetFiltersOnAccountChange(): void {
+    // Filters are org-scoped: a leftover project/type/search or pending-RSVP toggle would hide the new org's meetings.
+    toObservable(this.accountId)
+      .pipe(distinctUntilChanged(), skip(1), takeUntilDestroyed())
+      .subscribe(() => {
+        this.filterForm.reset({ search: '', type: null, project: null });
+        this.pendingRsvpOnly.set(false);
+      });
   }
 
   private initResetOnFilterChange(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DatePipe } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -38,6 +39,7 @@ import { OrgPastMeetingsComponent } from './components/org-past-meetings/org-pas
 @Component({
   selector: 'lfx-org-meetings',
   imports: [ReactiveFormsModule, StatCardGridComponent, InputTextComponent, SelectComponent, OrgUpcomingMeetingsComponent, OrgPastMeetingsComponent],
+  providers: [DatePipe],
   templateUrl: './org-meetings.component.html',
 })
 export class OrgMeetingsComponent {
@@ -46,6 +48,7 @@ export class OrgMeetingsComponent {
   private readonly router = inject(Router);
   private readonly accountContext = inject(AccountContextService);
   private readonly meetingService = inject(MeetingService);
+  private readonly datePipe = inject(DatePipe);
 
   // === Template constants ===
   protected readonly tabs = ORG_MEETINGS_TABS;
@@ -160,6 +163,7 @@ export class OrgMeetingsComponent {
       const nextDate = this.nextUpcomingMeetingDate();
       const summary = this.summary();
       const recurringProjects = summary?.recurringFoundations ?? 0;
+      const recurringProjectsLabel = recurringProjects === 1 ? 'project' : 'projects';
       return [
         {
           value: (summary?.upcomingMeetings ?? 0).toLocaleString(),
@@ -171,7 +175,7 @@ export class OrgMeetingsComponent {
         {
           value: (summary?.recurringSeries ?? 0).toLocaleString(),
           label: 'Recurring Series',
-          subLine: recurringProjects > 0 ? `Across ${recurringProjects} ${recurringProjects === 1 ? 'project' : 'projects'}` : undefined,
+          subLine: recurringProjects > 0 ? `Across ${recurringProjects} ${recurringProjectsLabel}` : undefined,
           icon: 'fa-light fa-repeat',
           iconContainerClass: 'bg-purple-100 text-purple-600',
         },
@@ -199,7 +203,8 @@ export class OrgMeetingsComponent {
     return computed(() => {
       const next = this.summary()?.nextMeeting;
       if (!next) return '';
-      return new Date(next).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      // Format via DatePipe (same engine as the meeting-card `| date` bindings) so the KPI date stays consistent with the cards.
+      return this.datePipe.transform(next, 'MMM d') ?? '';
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
@@ -4,25 +4,33 @@
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, finalize, map, of, skip, switchMap, tap } from 'rxjs';
 
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import {
+  DEFAULT_MEETINGS_PAGE_SIZE,
   DEFAULT_ORG_MEETINGS_TAB_ID,
   DEMO_PAST_MEETINGS,
-  DEMO_UPCOMING_MEETINGS,
   ORG_MEETINGS_KPI_RECORDINGS_COUNT,
-  ORG_MEETINGS_KPI_RECURRING_COUNT,
-  ORG_MEETINGS_KPI_RECURRING_PROJECTS,
-  ORG_MEETINGS_PROJECT_OPTIONS,
   ORG_MEETINGS_TABS,
   ORG_MEETINGS_TYPE_OPTIONS,
   VALID_ORG_MEETINGS_TAB_IDS,
 } from '@lfx-one/shared/constants';
-import type { FilterOption, OrgMeeting, OrgMeetingBase, OrgMeetingsTabId, OrgMeetingType, OrgPastMeeting, StatCardItem } from '@lfx-one/shared/interfaces';
+import type {
+  FilterOption,
+  OrgMeeting,
+  OrgMeetingBase,
+  OrgMeetingsSummary,
+  OrgMeetingsTabId,
+  OrgMeetingType,
+  OrgPastMeeting,
+  StatCardItem,
+} from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { MeetingService } from '@services/meeting.service';
 
 import { OrgUpcomingMeetingsComponent } from './components/org-upcoming-meetings/org-upcoming-meetings.component';
 import { OrgPastMeetingsComponent } from './components/org-past-meetings/org-past-meetings.component';
@@ -36,11 +44,13 @@ export class OrgMeetingsComponent {
   // === Private injections ===
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly accountContext = inject(AccountContextService);
+  private readonly meetingService = inject(MeetingService);
 
   // === Template constants ===
   protected readonly tabs = ORG_MEETINGS_TABS;
+  protected readonly pageSize = DEFAULT_MEETINGS_PAGE_SIZE;
   protected readonly typeOptions: FilterOption<OrgMeetingType | null>[] = ORG_MEETINGS_TYPE_OPTIONS;
-  protected readonly projectOptions: FilterOption[] = ORG_MEETINGS_PROJECT_OPTIONS;
 
   // === Forms ===
   protected readonly filterForm = new FormGroup({
@@ -50,20 +60,39 @@ export class OrgMeetingsComponent {
   });
 
   // === WritableSignals ===
-  protected readonly loading = signal(false);
+  protected readonly summaryLoading = signal(true);
   protected readonly pendingRsvpOnly = signal(false);
-  protected readonly upcomingMeetings = signal<readonly OrgMeeting[]>(DEMO_UPCOMING_MEETINGS);
+  protected readonly listLoading = signal(true);
+  protected readonly loadingMore = signal(false);
+  protected readonly listError = signal(false);
+  protected readonly loadMoreError = signal(false);
+  protected readonly offset = signal(0);
+  protected readonly total = signal(0);
+  protected readonly upcomingMeetings = signal<readonly OrgMeeting[]>([]);
+  protected readonly projectOptions = signal<FilterOption[]>([{ label: 'All Projects', value: null }]);
   protected readonly pastMeetings = signal<readonly OrgPastMeeting[]>(DEMO_PAST_MEETINGS);
+  private readonly refreshTick = signal(0);
 
   // === Computed signals ===
+  protected readonly accountId = computed(() => this.accountContext.selectedAccount().accountId);
+  protected readonly orgName = computed(() => this.accountContext.selectedAccount().accountName ?? '');
+  protected readonly summary: Signal<OrgMeetingsSummary | null> = this.initSummary();
   protected readonly activeTab: Signal<OrgMeetingsTabId> = this.initActiveTab();
   protected readonly kpiCards: Signal<StatCardItem[]> = this.initKpiCards();
   protected readonly nextUpcomingMeetingDate: Signal<string> = this.initNextUpcomingMeetingDate();
-  protected readonly filterSearch: Signal<string> = this.initFilterSearch();
-  protected readonly filterType: Signal<OrgMeetingType | null> = this.initFilterType();
-  protected readonly filterProject: Signal<string | null> = this.initFilterProject();
-  protected readonly filteredUpcoming: Signal<readonly OrgMeeting[]> = this.initFilteredUpcoming();
+  protected readonly filterSearch: Signal<string> = toSignal(this.filterForm.controls.search.valueChanges, { initialValue: '' });
+  protected readonly filterType: Signal<OrgMeetingType | null> = toSignal(this.filterForm.controls.type.valueChanges, { initialValue: null });
+  protected readonly filterProject: Signal<string | null> = toSignal(this.filterForm.controls.project.valueChanges, { initialValue: null });
+  protected readonly hasMore = computed(() => this.upcomingMeetings().length < this.total());
   protected readonly filteredPast: Signal<readonly OrgPastMeeting[]> = this.initFilteredPast();
+
+  private readonly debouncedSearch = toSignal(toObservable(this.filterSearch).pipe(debounceTime(300), distinctUntilChanged()), { initialValue: '' });
+
+  public constructor() {
+    this.initProjectOptions();
+    this.initResetOnFilterChange();
+    this.initUpcomingFetch();
+  }
 
   // === Protected methods ===
   protected switchTab(tabId: OrgMeetingsTabId): void {
@@ -81,6 +110,19 @@ export class OrgMeetingsComponent {
 
   protected togglePendingRsvpOnly(): void {
     this.pendingRsvpOnly.update((value) => !value);
+  }
+
+  protected loadMore(): void {
+    // offset tracks the loaded count (monotonic), so this advances on success and retries the same page after a failure.
+    this.loadMoreError.set(false);
+    this.offset.set(this.upcomingMeetings().length);
+    this.refreshTick.update((value) => value + 1);
+  }
+
+  protected retryUpcoming(): void {
+    this.listError.set(false);
+    this.offset.set(0);
+    this.refreshTick.update((value) => value + 1);
   }
 
   // === Private initializers ===
@@ -101,13 +143,13 @@ export class OrgMeetingsComponent {
       if (this.activeTab() === 'past') {
         return [
           {
-            value: String(this.filteredPast().length),
+            value: this.filteredPast().length.toLocaleString(),
             label: 'Past Meetings',
             icon: 'fa-light fa-clock-rotate-left',
             iconContainerClass: 'bg-gray-200 text-gray-500',
           },
           {
-            value: String(ORG_MEETINGS_KPI_RECORDINGS_COUNT),
+            value: ORG_MEETINGS_KPI_RECORDINGS_COUNT.toLocaleString(),
             label: 'Recordings Available',
             icon: 'fa-light fa-video',
             iconContainerClass: 'bg-red-100 text-red-600',
@@ -115,18 +157,20 @@ export class OrgMeetingsComponent {
         ];
       }
       const nextDate = this.nextUpcomingMeetingDate();
+      const summary = this.summary();
+      const recurringProjects = summary?.recurringFoundations ?? 0;
       return [
         {
-          value: String(this.filteredUpcoming().length),
+          value: (summary?.upcomingMeetings ?? 0).toLocaleString(),
           label: 'Upcoming Meetings',
           subLine: nextDate ? `Next: ${nextDate}` : undefined,
           icon: 'fa-light fa-calendar',
           iconContainerClass: 'bg-blue-100 text-blue-600',
         },
         {
-          value: String(ORG_MEETINGS_KPI_RECURRING_COUNT),
+          value: (summary?.recurringSeries ?? 0).toLocaleString(),
           label: 'Recurring Series',
-          subLine: `Across ${ORG_MEETINGS_KPI_RECURRING_PROJECTS} projects`,
+          subLine: recurringProjects > 0 ? `Across ${recurringProjects} ${recurringProjects === 1 ? 'project' : 'projects'}` : undefined,
           icon: 'fa-light fa-repeat',
           iconContainerClass: 'bg-purple-100 text-purple-600',
         },
@@ -134,39 +178,121 @@ export class OrgMeetingsComponent {
     });
   }
 
+  private initSummary(): Signal<OrgMeetingsSummary | null> {
+    return toSignal(
+      toObservable(this.accountId).pipe(
+        filter((id): id is string => !!id),
+        tap(() => this.summaryLoading.set(true)),
+        switchMap((id) =>
+          this.meetingService.getOrgMeetingsSummary(id).pipe(
+            catchError(() => of(null)),
+            finalize(() => this.summaryLoading.set(false))
+          )
+        )
+      ),
+      { initialValue: null }
+    );
+  }
+
   private initNextUpcomingMeetingDate(): Signal<string> {
     return computed(() => {
-      const now = Date.now();
-      const sorted = [...this.upcomingMeetings()]
-        .filter((m) => new Date(m.startTime).getTime() >= now)
-        .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-      const first = sorted[0];
-      if (!first) return '';
-      return new Date(first.startTime).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const next = this.summary()?.nextMeeting;
+      if (!next) return '';
+      return new Date(next).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     });
   }
 
-  private initFilterSearch(): Signal<string> {
-    return toSignal(this.filterForm.controls.search.valueChanges, { initialValue: '' });
+  private initProjectOptions(): void {
+    toObservable(this.accountId)
+      .pipe(
+        filter((id): id is string => !!id),
+        switchMap((id) => this.meetingService.getOrgMeetingProjects(id).pipe(catchError(() => of({ projects: [] as string[] })))),
+        takeUntilDestroyed()
+      )
+      .subscribe((res) => this.projectOptions.set([{ label: 'All Projects', value: null }, ...res.projects.map((p) => ({ label: p, value: p }))]));
   }
 
-  private initFilterType(): Signal<OrgMeetingType | null> {
-    return toSignal(this.filterForm.controls.type.valueChanges, { initialValue: null });
+  private initResetOnFilterChange(): void {
+    combineLatest([
+      toObservable(this.accountId),
+      toObservable(this.debouncedSearch),
+      toObservable(this.filterType),
+      toObservable(this.filterProject),
+      toObservable(this.pendingRsvpOnly),
+    ])
+      .pipe(skip(1), takeUntilDestroyed())
+      .subscribe(() => this.offset.set(0));
   }
 
-  private initFilterProject(): Signal<string | null> {
-    return toSignal(this.filterForm.controls.project.valueChanges, { initialValue: null });
-  }
+  private initUpcomingFetch(): void {
+    const params$ = toObservable(
+      computed(() => {
+        const accountId = this.accountId();
+        if (!accountId) return null;
+        return {
+          accountId,
+          searchQuery: this.debouncedSearch() || null,
+          project: this.filterProject(),
+          type: this.filterType(),
+          pendingRsvpOnly: this.pendingRsvpOnly(),
+          offset: this.offset(),
+          tick: this.refreshTick(),
+        };
+      })
+    );
 
-  private initFilteredUpcoming(): Signal<readonly OrgMeeting[]> {
-    return computed(() => {
-      const pendingRsvpOnly = this.pendingRsvpOnly();
-      const now = Date.now();
-      return this.upcomingMeetings()
-        .filter((m) => new Date(m.startTime).getTime() >= now)
-        .filter((m) => this.matchesFilters(m))
-        .filter((m) => !pendingRsvpOnly || m.orgInvitees.some((invitee) => invitee.rsvpStatus === null));
-    });
+    params$
+      .pipe(
+        debounceTime(0),
+        filter((p): p is NonNullable<typeof p> => p !== null),
+        distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+        tap((p) => {
+          if (p.offset === 0) {
+            this.listLoading.set(true);
+            this.listError.set(false);
+            this.loadMoreError.set(false);
+            this.loadingMore.set(false);
+          } else {
+            this.loadingMore.set(true);
+            this.loadMoreError.set(false);
+          }
+        }),
+        switchMap((p) =>
+          this.meetingService
+            .getOrgUpcomingMeetings(p.accountId, {
+              searchQuery: p.searchQuery,
+              project: p.project,
+              type: p.type,
+              pendingRsvpOnly: p.pendingRsvpOnly,
+              pageSize: this.pageSize,
+              offset: p.offset,
+            })
+            .pipe(
+              map((res) => ({ res, offset: p.offset })),
+              catchError(() => of({ res: null, offset: p.offset }))
+            )
+        ),
+        takeUntilDestroyed()
+      )
+      .subscribe(({ res, offset }) => {
+        if (!res) {
+          if (offset === 0) {
+            this.listError.set(true);
+            this.upcomingMeetings.set([]);
+            this.listLoading.set(false);
+          } else {
+            // Keep the loaded pages; the load-more button surfaces the error and retries the same offset.
+            this.loadMoreError.set(true);
+            this.loadingMore.set(false);
+          }
+          return;
+        }
+        this.total.set(res.total);
+        // Splice the page in at its offset so a re-fetch of the same page can't duplicate rows.
+        this.upcomingMeetings.set([...this.upcomingMeetings().slice(0, offset), ...res.data]);
+        this.listLoading.set(false);
+        this.loadingMore.set(false);
+      });
   }
 
   private initFilteredPast(): Signal<readonly OrgPastMeeting[]> {

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -20,6 +20,10 @@ import {
   MeetingRegistrant,
   MeetingRegistrantWithState,
   MeetingRsvp,
+  GetOrgUpcomingMeetingsOptions,
+  OrgMeetingsProjectsResponse,
+  OrgMeetingsSummary,
+  OrgUpcomingMeetingsResponse,
   PaginatedResponse,
   PastMeeting,
   PastMeetingAttachment,
@@ -55,6 +59,24 @@ export class MeetingService {
         return of({ data: [] as Meeting[], page_token: undefined });
       })
     );
+  }
+
+  /** Org Lens Meetings stat strip: upcoming + recurring counts (with foundation breadth) for the selected org, from Snowflake. */
+  public getOrgMeetingsSummary(accountId: string): Observable<OrgMeetingsSummary> {
+    return this.http.get<OrgMeetingsSummary>(`/api/orgs/${encodeURIComponent(accountId)}/lens/meetings/summary`);
+  }
+
+  public getOrgUpcomingMeetings(accountId: string, options: GetOrgUpcomingMeetingsOptions): Observable<OrgUpcomingMeetingsResponse> {
+    let params = new HttpParams().set('pageSize', String(options.pageSize)).set('offset', String(options.offset));
+    if (options.searchQuery) params = params.set('searchQuery', options.searchQuery);
+    if (options.project) params = params.set('project', options.project);
+    if (options.type) params = params.set('type', options.type);
+    if (options.pendingRsvpOnly) params = params.set('pendingRsvpOnly', 'true');
+    return this.http.get<OrgUpcomingMeetingsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/meetings`, { params });
+  }
+
+  public getOrgMeetingProjects(accountId: string): Observable<OrgMeetingsProjectsResponse> {
+    return this.http.get<OrgMeetingsProjectsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/meetings/projects`);
   }
 
   public getPastMeetings(params?: HttpParams): Observable<PaginatedResponse<PastMeeting>> {

--- a/apps/lfx-one/src/server/controllers/org-lens-meetings.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-meetings.controller.ts
@@ -1,0 +1,120 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DEFAULT_MEETINGS_PAGE_SIZE, MAX_MEETINGS_PAGE_SIZE, SALESFORCE_ACCOUNT_ID_PATTERN, VALID_ORG_MEETING_TYPE_VALUES } from '@lfx-one/shared/constants';
+import type { GetOrgUpcomingMeetingsOptions, OrgMeetingType } from '@lfx-one/shared/interfaces';
+import type { NextFunction, Request, Response } from 'express';
+
+import { AuthenticationError, ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
+import { logger } from '../services/logger.service';
+import { OrgLensMeetingsService } from '../services/org-lens-meetings.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
+
+/** HTTP boundary for the org-lens meetings endpoints (summary, list, projects). */
+export class OrgLensMeetingsController {
+  private readonly service: OrgLensMeetingsService;
+
+  public constructor() {
+    this.service = new OrgLensMeetingsService();
+  }
+
+  public async getOrgMeetingsSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_meetings_summary', { account_id: accountId });
+
+    try {
+      this.assertAccountId(accountId, 'get_org_lens_meetings_summary');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_meetings_summary' });
+      }
+
+      const summary = await this.service.getOrgMeetingsSummary(req, accountId);
+
+      logger.success(req, 'get_org_lens_meetings_summary', startTime, { account_id: accountId });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getOrgUpcomingMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_meetings', { account_id: accountId });
+
+    try {
+      this.assertAccountId(accountId, 'get_org_lens_meetings');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_meetings' });
+      }
+
+      const rawPageSize = Math.trunc(Number(req.query['pageSize'] ?? DEFAULT_MEETINGS_PAGE_SIZE));
+      const rawOffset = Math.trunc(Number(req.query['offset'] ?? 0));
+      const rawType = getStringQueryParam(req, 'type');
+
+      const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_MEETINGS_PAGE_SIZE ? rawPageSize : DEFAULT_MEETINGS_PAGE_SIZE;
+      const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+      const type = rawType && VALID_ORG_MEETING_TYPE_VALUES.has(rawType as OrgMeetingType) ? (rawType as OrgMeetingType) : null;
+
+      const options: GetOrgUpcomingMeetingsOptions = {
+        searchQuery: getStringQueryParam(req, 'searchQuery') ?? null,
+        project: getStringQueryParam(req, 'project') ?? null,
+        type,
+        pendingRsvpOnly: getStringQueryParam(req, 'pendingRsvpOnly') === 'true',
+        pageSize,
+        offset,
+      };
+
+      const response = await this.service.getOrgUpcomingMeetings(req, accountId, options);
+
+      logger.success(req, 'get_org_lens_meetings', startTime, {
+        account_id: accountId,
+        result_count: response.data.length,
+        total: response.total,
+      });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getMeetingProjects(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const accountId = req.params['accountId'];
+    const startTime = logger.startOperation(req, 'get_org_lens_meeting_projects', { account_id: accountId });
+
+    try {
+      this.assertAccountId(accountId, 'get_org_lens_meeting_projects');
+
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_lens_meeting_projects' });
+      }
+
+      const response = await this.service.getOrgMeetingProjects(req, accountId);
+
+      logger.success(req, 'get_org_lens_meeting_projects', startTime, { account_id: accountId, result_count: response.projects.length });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private assertAccountId(accountId: string | undefined, operation: string): asserts accountId is string {
+    if (!accountId || typeof accountId !== 'string') {
+      throw ServiceValidationError.forField('accountId', 'accountId path parameter is required', { operation });
+    }
+    if (!SALESFORCE_ACCOUNT_ID_PATTERN.test(accountId)) {
+      throw ServiceValidationError.forField('accountId', 'Invalid Salesforce accountId format', { operation });
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -11,6 +11,7 @@ import { OrgLensDocumentsController } from '../controllers/org-lens-documents.co
 import { OrgLensEventsController } from '../controllers/org-lens-events.controller';
 import { OrgLensFoundationsController } from '../controllers/org-lens-foundations.controller';
 import { OrgLensKeyContactsController } from '../controllers/org-lens-key-contacts.controller';
+import { OrgLensMeetingsController } from '../controllers/org-lens-meetings.controller';
 import { OrgLensMembershipsController } from '../controllers/org-lens-memberships.controller';
 import { OrgLensPeopleController } from '../controllers/org-lens-people.controller';
 import { OrgLensTrainingController } from '../controllers/org-lens-training.controller';
@@ -19,6 +20,7 @@ function buildOrgsRouter(): Router {
   const router = Router();
   const orgLensFoundationsController = new OrgLensFoundationsController();
   const orgLensEventsController = new OrgLensEventsController();
+  const orgLensMeetingsController = new OrgLensMeetingsController();
   const orgLensMembershipsController = new OrgLensMembershipsController();
   const orgLensBoardCommitteeController = new OrgLensBoardCommitteeController();
   const orgLensDocumentsController = new OrgLensDocumentsController();
@@ -45,6 +47,9 @@ function buildOrgsRouter(): Router {
   router.get('/:accountId/lens/events/:eventId/attendees', (req, res, next) => orgLensEventsController.getEventAttendees(req, res, next));
   router.get('/:accountId/lens/events/:eventId/speakers', (req, res, next) => orgLensEventsController.getEventSpeakers(req, res, next));
   router.get('/:accountId/lens/events', (req, res, next) => orgLensEventsController.getOrgEvents(req, res, next));
+  router.get('/:accountId/lens/meetings/summary', (req, res, next) => orgLensMeetingsController.getOrgMeetingsSummary(req, res, next));
+  router.get('/:accountId/lens/meetings/projects', (req, res, next) => orgLensMeetingsController.getMeetingProjects(req, res, next));
+  router.get('/:accountId/lens/meetings', (req, res, next) => orgLensMeetingsController.getOrgUpcomingMeetings(req, res, next));
   router.get('/:orgUid/lens/memberships/active', (req, res, next) => orgLensMembershipsController.getActiveMemberships(req, res, next));
   router.get('/:orgUid/lens/memberships/expired', (req, res, next) => orgLensMembershipsController.getExpiredMemberships(req, res, next));
   router.get('/:orgUid/lens/memberships/discover', (req, res, next) => orgLensMembershipsController.getDiscoverOpportunities(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-events.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-events.service.ts
@@ -16,7 +16,7 @@ import type {
   OrgEventsSummary,
   OrgEventsSummaryRow,
 } from '@lfx-one/shared/interfaces';
-import { formatDateToUTC, normalizeToUrl } from '@lfx-one/shared/utils';
+import { formatDateToUTC, isObjectRow, isObjectRowArray, normalizeToUrl } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -103,7 +103,7 @@ export class OrgLensEventsService {
       );
     } catch (error) {
       logger.warning(req, 'get_org_lens_events', 'Snowflake query failed, returning empty events', {
-        error: error instanceof Error ? error.message : String(error),
+        err: error,
         account_id: accountId,
       });
       return { data: [], total: 0, pageSize, offset };
@@ -141,7 +141,7 @@ export class OrgLensEventsService {
       );
     } catch (error) {
       logger.warning(req, 'get_org_lens_events_summary', 'Snowflake query failed, returning zero counts', {
-        error: error instanceof Error ? error.message : String(error),
+        err: error,
         account_id: accountId,
       });
       return { totalEvents: 0, pastEvents: 0, upcomingEvents: 0 };
@@ -197,7 +197,7 @@ export class OrgLensEventsService {
       );
     } catch (error) {
       logger.warning(req, 'get_event_attendees', 'Snowflake query failed, returning empty attendees', {
-        error: error instanceof Error ? error.message : String(error),
+        err: error,
         account_id: accountId,
         event_id: eventId,
       });
@@ -254,7 +254,7 @@ export class OrgLensEventsService {
       );
     } catch (error) {
       logger.warning(req, 'get_event_speakers', 'Snowflake query failed, returning empty speakers', {
-        error: error instanceof Error ? error.message : String(error),
+        err: error,
         account_id: accountId,
         event_id: eventId,
       });
@@ -322,15 +322,6 @@ export class OrgLensEventsService {
 /** Deterministic, key-safe sub-resource suffix for the result-changing query params (base64url → only `[A-Za-z0-9_-]`). */
 function paramSignature(parts: readonly (string | number | boolean | null)[]): string {
   return Buffer.from(JSON.stringify(parts), 'utf8').toString('base64url');
-}
-
-function isObjectRow(el: unknown): el is Record<string, unknown> {
-  return el !== null && typeof el === 'object' && !Array.isArray(el);
-}
-
-/** Summary rows expose no contract key replayed verbatim to the client (every field is read null-safe), so an object shape suffices. */
-function isObjectRowArray(value: unknown): boolean {
-  return Array.isArray(value) && value.every(isObjectRow);
 }
 
 /** Event-list rows reach the client through `mapRowToOrgEvent`, which reads `EVENT_ID` with no fallback — validate the contract key so a poisoned `[{}]` entry degrades to a miss. */

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -1,0 +1,323 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { VALKEY_CACHE } from '@lfx-one/shared/constants';
+import type {
+  GetOrgUpcomingMeetingsOptions,
+  OrgMeeting,
+  OrgMeetingInvitee,
+  OrgMeetingPrivacy,
+  OrgMeetingRsvpStatus,
+  OrgMeetingsProjectsResponse,
+  OrgMeetingsSummary,
+  OrgMeetingsSummaryRow,
+  OrgMeetingType,
+  OrgMeetingProjectRow,
+  OrgUpcomingMeetingInviteeRow,
+  OrgUpcomingMeetingRow,
+  OrgUpcomingMeetingsResponse,
+} from '@lfx-one/shared/interfaces';
+import { formatDateToUTC, isObjectRow, isObjectRowArray } from '@lfx-one/shared/utils';
+import type { Request } from 'express';
+
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+import { withOrgCache } from './valkey.service';
+
+/** Service for org-lens meeting endpoints — reads the org upcoming-meeting footprint from platinum ORG_UPCOMING_MEETINGS. */
+export class OrgLensMeetingsService {
+  private readonly snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  /** GET /api/orgs/:accountId/lens/meetings/summary — org upcoming + recurring counts (+ foundation breadth, next date); fail-soft to zeros. */
+  public async getOrgMeetingsSummary(req: Request, accountId: string): Promise<OrgMeetingsSummary> {
+    logger.debug(req, 'get_org_lens_meetings_summary', 'Building org meetings summary query', { account_id: accountId });
+
+    const sql = `
+      SELECT
+        COUNT(DISTINCT meeting_id)                                     AS UPCOMING_MEETINGS,
+        COUNT(DISTINCT CASE WHEN is_recurring THEN meeting_id END)     AS RECURRING_SERIES,
+        COUNT(DISTINCT CASE WHEN is_recurring THEN foundation_id END)  AS RECURRING_FOUNDATIONS,
+        MIN(next_occurrence_utc_ts)                                    AS NEXT_MEETING
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETINGS
+      WHERE account_id = ?
+    `;
+
+    let rows: OrgMeetingsSummaryRow[];
+    try {
+      rows = await withOrgCache(
+        accountId,
+        'meetings-summary',
+        VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+        () => this.fetchSummaryRows(accountId, sql),
+        isObjectRowArray
+      );
+    } catch (error) {
+      logger.warning(req, 'get_org_lens_meetings_summary', 'Snowflake query failed, returning zero counts', {
+        err: error,
+        account_id: accountId,
+      });
+      return { upcomingMeetings: 0, recurringSeries: 0, recurringFoundations: 0, nextMeeting: null };
+    }
+
+    const row = rows[0];
+    // Degrade an unparseable (e.g. corrupt-cache) NEXT_MEETING to null instead of throwing.
+    const nextRaw = row?.NEXT_MEETING;
+    const nextDate = nextRaw != null ? new Date(nextRaw as string | number | Date) : null;
+    const summary: OrgMeetingsSummary = {
+      upcomingMeetings: row?.UPCOMING_MEETINGS ?? 0,
+      recurringSeries: row?.RECURRING_SERIES ?? 0,
+      recurringFoundations: row?.RECURRING_FOUNDATIONS ?? 0,
+      nextMeeting: nextDate && !Number.isNaN(nextDate.getTime()) ? nextDate.toISOString() : null,
+    };
+
+    logger.debug(req, 'get_org_lens_meetings_summary', 'Fetched org meetings summary', { ...summary, account_id: accountId });
+
+    return summary;
+  }
+
+  public async getOrgUpcomingMeetings(req: Request, accountId: string, options: GetOrgUpcomingMeetingsOptions): Promise<OrgUpcomingMeetingsResponse> {
+    const { searchQuery, project, type, pendingRsvpOnly, pageSize, offset } = options;
+
+    logger.debug(req, 'get_org_lens_meetings', 'Building org meetings list query', {
+      account_id: accountId,
+      has_search: !!searchQuery,
+      project,
+      type,
+      pending_rsvp_only: pendingRsvpOnly,
+      page_size: pageSize,
+      offset,
+    });
+
+    const searchFilter = searchQuery ? 'AND (m.TOPIC ILIKE ? OR m.AGENDA ILIKE ?)' : '';
+    const projectFilter = project ? 'AND m.FOUNDATION_NAME = ?' : '';
+    const typeFilter = type ? 'AND m.MEETING_TYPE_BUCKET = ?' : '';
+    const pendingFilter = pendingRsvpOnly ? 'AND m.HAS_PENDING_ORG_RSVP = TRUE' : '';
+
+    const sql = `
+      SELECT
+        m.MEETING_ID,
+        m.TOPIC,
+        m.AGENDA,
+        m.VISIBILITY,
+        m.MEETING_TYPE_BUCKET,
+        m.RECURRENCE_LABEL,
+        m.NEXT_OCCURRENCE_UTC_TS,
+        m.MEETING_DURATION,
+        m.FOUNDATION_NAME,
+        m.RECORDING_ENABLED,
+        m.TRANSCRIPT_ENABLED,
+        m.AI_SUMMARY_ENABLED,
+        m.ATTENDING_COUNT,
+        m.MAYBE_COUNT,
+        m.NO_COUNT,
+        m.NO_RESPONSE_COUNT,
+        m.GUEST_COUNT,
+        COUNT(*) OVER() AS TOTAL_RECORDS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETINGS m
+      WHERE m.ACCOUNT_ID = ?
+        ${searchFilter}
+        ${projectFilter}
+        ${typeFilter}
+        ${pendingFilter}
+      ORDER BY m.NEXT_OCCURRENCE_UTC_TS ASC NULLS LAST
+      LIMIT ${pageSize} OFFSET ${offset}
+    `;
+
+    const binds: string[] = [accountId];
+    if (searchQuery) binds.push(`%${searchQuery}%`, `%${searchQuery}%`);
+    if (project) binds.push(project);
+    if (type) binds.push(type);
+
+    // Surface list errors (no fail-soft) so the client renders its distinct "couldn't load" state instead of an empty list.
+    const rows = await withOrgCache(
+      accountId,
+      `meetings:${paramSignature([searchQuery ?? null, project ?? null, type ?? null, pendingRsvpOnly, pageSize, offset])}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      () => this.fetchMeetingRows(sql, binds),
+      isMeetingRowArray
+    );
+
+    const total = rows.length > 0 ? rows[0].TOTAL_RECORDS : 0;
+    const meetingIds = rows.map((row) => row.MEETING_ID);
+    const inviteesByMeeting = await this.fetchInviteesByMeeting(req, accountId, meetingIds);
+    const data = rows.map((row) => this.mapRowToOrgMeeting(row, inviteesByMeeting.get(row.MEETING_ID) ?? []));
+
+    logger.debug(req, 'get_org_lens_meetings', 'Fetched org meetings', { count: data.length, total });
+
+    return { data, total, pageSize, offset };
+  }
+
+  public async getOrgMeetingProjects(req: Request, accountId: string): Promise<OrgMeetingsProjectsResponse> {
+    logger.debug(req, 'get_org_lens_meeting_projects', 'Building org meeting projects query', { account_id: accountId });
+
+    const sql = `
+      SELECT DISTINCT m.FOUNDATION_NAME AS PROJECT_NAME
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETINGS m
+      WHERE m.ACCOUNT_ID = ?
+        AND m.FOUNDATION_NAME IS NOT NULL
+      ORDER BY PROJECT_NAME ASC
+    `;
+
+    let rows: OrgMeetingProjectRow[];
+    try {
+      rows = await withOrgCache(
+        accountId,
+        'meetings-projects',
+        VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+        () => this.fetchProjectRows(accountId, sql),
+        isProjectRowArray
+      );
+    } catch (error) {
+      logger.warning(req, 'get_org_lens_meeting_projects', 'Snowflake query failed, returning empty projects', {
+        err: error,
+        account_id: accountId,
+      });
+      return { projects: [] };
+    }
+
+    const projects = rows.map((row) => row.PROJECT_NAME);
+
+    logger.debug(req, 'get_org_lens_meeting_projects', 'Fetched org meeting projects', { count: projects.length });
+
+    return { projects };
+  }
+
+  private async fetchSummaryRows(accountId: string, sql: string): Promise<OrgMeetingsSummaryRow[]> {
+    const result = await this.snowflakeService.execute<OrgMeetingsSummaryRow>(sql, [accountId]);
+    return result.rows;
+  }
+
+  private async fetchMeetingRows(sql: string, binds: string[]): Promise<OrgUpcomingMeetingRow[]> {
+    const result = await this.snowflakeService.execute<OrgUpcomingMeetingRow>(sql, binds);
+    return result.rows;
+  }
+
+  private async fetchProjectRows(accountId: string, sql: string): Promise<OrgMeetingProjectRow[]> {
+    const result = await this.snowflakeService.execute<OrgMeetingProjectRow>(sql, [accountId]);
+    return result.rows;
+  }
+
+  private async fetchInviteesByMeeting(req: Request, accountId: string, meetingIds: readonly string[]): Promise<Map<string, OrgMeetingInvitee[]>> {
+    const byMeeting = new Map<string, OrgMeetingInvitee[]>();
+    if (meetingIds.length === 0) return byMeeting;
+
+    const placeholders = meetingIds.map(() => '?').join(', ');
+    const sql = `
+      SELECT
+        i.MEETING_ID,
+        i.FULL_NAME,
+        i.JOB_TITLE,
+        i.AVATAR_URL,
+        i.RSVP_STATUS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETING_INVITEES i
+      WHERE i.ACCOUNT_ID = ?
+        AND i.MEETING_ID IN (${placeholders})
+    `;
+    const binds: string[] = [accountId, ...meetingIds];
+
+    let rows: OrgUpcomingMeetingInviteeRow[];
+    try {
+      rows = await withOrgCache(
+        accountId,
+        `meeting-invitees:${paramSignature([...meetingIds])}`,
+        VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+        () => this.fetchInviteeRows(sql, binds),
+        isInviteeRowArray
+      );
+    } catch (error) {
+      logger.warning(req, 'get_org_lens_meetings', 'Invitee query failed, returning meetings without invitees', {
+        err: error,
+        account_id: accountId,
+      });
+      return byMeeting;
+    }
+
+    for (const row of rows) {
+      const invitees = byMeeting.get(row.MEETING_ID) ?? [];
+      invitees.push({
+        name: row.FULL_NAME,
+        title: row.JOB_TITLE ?? '',
+        avatarUrl: row.AVATAR_URL ?? null,
+        rsvpStatus: mapRsvpStatus(row.RSVP_STATUS),
+      });
+      byMeeting.set(row.MEETING_ID, invitees);
+    }
+    return byMeeting;
+  }
+
+  private async fetchInviteeRows(sql: string, binds: string[]): Promise<OrgUpcomingMeetingInviteeRow[]> {
+    const result = await this.snowflakeService.execute<OrgUpcomingMeetingInviteeRow>(sql, binds);
+    return result.rows;
+  }
+
+  private mapRowToOrgMeeting(row: OrgUpcomingMeetingRow, orgInvitees: OrgMeetingInvitee[]): OrgMeeting {
+    const startTime = formatDateToUTC(row.NEXT_OCCURRENCE_UTC_TS) ?? '';
+    const durationMinutes = row.MEETING_DURATION ?? 0;
+    const startMs = startTime ? new Date(startTime).getTime() : Number.NaN;
+    const endTime = Number.isFinite(startMs) ? new Date(startMs + durationMinutes * 60_000).toISOString() : startTime;
+    const foundation = row.FOUNDATION_NAME ?? '';
+
+    return {
+      id: row.MEETING_ID,
+      title: row.TOPIC,
+      privacy: mapPrivacy(row.VISIBILITY),
+      type: mapMeetingType(row.MEETING_TYPE_BUCKET),
+      recurrenceLabel: row.RECURRENCE_LABEL ?? null,
+      startTime,
+      endTime,
+      foundation,
+      orgName: '',
+      project: foundation,
+      agenda: row.AGENDA ?? null,
+      resources: [],
+      rsvpTally: {
+        yes: row.ATTENDING_COUNT ?? 0,
+        maybe: row.MAYBE_COUNT ?? 0,
+        no: row.NO_COUNT ?? 0,
+        noResponse: row.NO_RESPONSE_COUNT ?? 0,
+      },
+      orgInvitees,
+      guestCount: row.GUEST_COUNT ?? 0,
+      joinUrl: null,
+      statusFlags: {
+        recording: !!row.RECORDING_ENABLED,
+        transcripts: !!row.TRANSCRIPT_ENABLED,
+        aiSummary: !!row.AI_SUMMARY_ENABLED,
+      },
+    };
+  }
+}
+
+/** Deterministic, key-safe sub-resource suffix for the result-changing query params (base64url → only `[A-Za-z0-9_-]`). */
+function paramSignature(parts: readonly (string | number | boolean | null)[]): string {
+  return Buffer.from(JSON.stringify(parts), 'utf8').toString('base64url');
+}
+
+function mapPrivacy(visibility: string | null): OrgMeetingPrivacy {
+  return visibility?.toLowerCase() === 'private' ? 'private' : 'public';
+}
+
+function mapMeetingType(bucket: string | null): OrgMeetingType {
+  return bucket === 'board' || bucket === 'working-group' ? bucket : 'other';
+}
+
+function mapRsvpStatus(status: string): OrgMeetingRsvpStatus {
+  return status === 'yes' || status === 'maybe' || status === 'no' ? status : null;
+}
+
+/** List rows reach the client through `mapRowToOrgMeeting`, which reads `MEETING_ID` with no fallback — validate the contract key so a poisoned `[{}]` entry degrades to a miss. */
+function isMeetingRowArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((el) => isObjectRow(el) && typeof el['MEETING_ID'] === 'string');
+}
+
+function isInviteeRowArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((el) => isObjectRow(el) && typeof el['MEETING_ID'] === 'string' && typeof el['FULL_NAME'] === 'string');
+}
+
+function isProjectRowArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((el) => isObjectRow(el) && typeof el['PROJECT_NAME'] === 'string');
+}

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -79,6 +79,7 @@ export class OrgLensMeetingsService {
     return summary;
   }
 
+  /** GET /api/orgs/:accountId/lens/meetings — paginated upcoming-meeting list (search/project/type/pending filters); surfaces errors so the client renders its "couldn't load" state. */
   public async getOrgUpcomingMeetings(req: Request, accountId: string, options: GetOrgUpcomingMeetingsOptions): Promise<OrgUpcomingMeetingsResponse> {
     const { searchQuery, project, type, pendingRsvpOnly, pageSize, offset } = options;
 
@@ -151,6 +152,7 @@ export class OrgLensMeetingsService {
     return { data, total, pageSize, offset };
   }
 
+  /** GET /api/orgs/:accountId/lens/meetings/projects — distinct foundation/project names for the meetings filter dropdown; fail-soft to empty. */
   public async getOrgMeetingProjects(req: Request, accountId: string): Promise<OrgMeetingsProjectsResponse> {
     logger.debug(req, 'get_org_lens_meeting_projects', 'Building org meeting projects query', { account_id: accountId });
 

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -125,13 +125,14 @@ export class OrgLensMeetingsService {
         ${typeFilter}
         ${pendingFilter}
       ORDER BY m.NEXT_OCCURRENCE_UTC_TS ASC NULLS LAST
-      LIMIT ${pageSize} OFFSET ${offset}
+      LIMIT ? OFFSET ?
     `;
 
-    const binds: string[] = [accountId];
+    const binds: (string | number)[] = [accountId];
     if (searchQuery) binds.push(`%${searchQuery}%`, `%${searchQuery}%`);
     if (project) binds.push(project);
     if (type) binds.push(type);
+    binds.push(pageSize, offset);
 
     // Surface list errors (no fail-soft) so the client renders its distinct "couldn't load" state instead of an empty list.
     const rows = await withOrgCache(
@@ -193,7 +194,7 @@ export class OrgLensMeetingsService {
     return result.rows;
   }
 
-  private async fetchMeetingRows(sql: string, binds: string[]): Promise<OrgUpcomingMeetingRow[]> {
+  private async fetchMeetingRows(sql: string, binds: (string | number)[]): Promise<OrgUpcomingMeetingRow[]> {
     const result = await this.snowflakeService.execute<OrgUpcomingMeetingRow>(sql, binds);
     return result.rows;
   }

--- a/apps/lfx-one/src/server/services/org-people-contributors.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-contributors.service.ts
@@ -12,6 +12,7 @@ import type {
   OrgContributorStatsBaseline,
   OrgContributorTimeRange,
 } from '@lfx-one/shared/interfaces';
+import { isObjectRowArray } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { SnowflakeService } from './snowflake.service';
@@ -74,10 +75,6 @@ export class OrgPeopleContributorsService {
     const result = await this.snowflakeService.execute<ContributorPersonProjectRow>(query, [accountId]);
     return result.rows;
   }
-}
-
-function isObjectRowArray(value: unknown): boolean {
-  return Array.isArray(value) && value.every((el) => el !== null && typeof el === 'object' && !Array.isArray(el));
 }
 
 /** Snowflake date-cutoff SQL fragment (inline, not bound) so the planner can fold it; null for 'all' (dbt caps at 3yr rolling). */

--- a/packages/shared/src/constants/org-meetings.constants.ts
+++ b/packages/shared/src/constants/org-meetings.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { FilterOption, OrgMeeting, OrgMeetingRsvpStatus, OrgMeetingsTabConfig, OrgMeetingsTabId, OrgMeetingType, OrgPastMeeting } from '../interfaces';
+import type { FilterOption, OrgMeetingRsvpStatus, OrgMeetingsTabConfig, OrgMeetingsTabId, OrgMeetingType, OrgPastMeeting } from '../interfaces';
 
 /** Org Meetings page tabs in visible order (`upcoming` is the default). */
 export const ORG_MEETINGS_TABS: readonly OrgMeetingsTabConfig[] = [
@@ -15,17 +15,12 @@ export const DEFAULT_ORG_MEETINGS_TAB_ID: OrgMeetingsTabId = 'upcoming';
 /** Derived from ORG_MEETINGS_TABS; used to validate `?tab=` query-param input. */
 export const VALID_ORG_MEETINGS_TAB_IDS: ReadonlySet<OrgMeetingsTabId> = new Set(ORG_MEETINGS_TABS.map((t) => t.id));
 
-/** KPI: total upcoming meetings count (demo). */
-export const ORG_MEETINGS_KPI_UPCOMING_COUNT = 12;
+/** Default / max page size for the server-paginated Upcoming meetings list. */
+export const DEFAULT_MEETINGS_PAGE_SIZE = 10;
+export const MAX_MEETINGS_PAGE_SIZE = 100;
 
-/** KPI: recurring series count (demo). */
-export const ORG_MEETINGS_KPI_RECURRING_COUNT = 4;
-
-/** KPI: recurring series project span (demo). */
-export const ORG_MEETINGS_KPI_RECURRING_PROJECTS = 3;
-
-/** KPI: total past meetings count (demo). */
-export const ORG_MEETINGS_KPI_PAST_COUNT = 15;
+/** Valid meeting-type filter values for server-side validation. */
+export const VALID_ORG_MEETING_TYPE_VALUES: ReadonlySet<OrgMeetingType> = new Set<OrgMeetingType>(['board', 'working-group', 'other']);
 
 /** KPI: recordings available from past 30 days (demo). */
 export const ORG_MEETINGS_KPI_RECORDINGS_COUNT = 3;
@@ -39,16 +34,6 @@ export const ORG_MEETINGS_RSVP_BADGES: Record<Exclude<OrgMeetingRsvpStatus, null
 
 /** RSVP badge shown when an invitee has not responded. */
 export const ORG_MEETINGS_NO_RESPONSE_BADGE = { label: 'No Response', badgeClass: 'bg-gray-100 text-gray-500' };
-
-/** Project filter options for the Org Meetings filter bar. */
-export const ORG_MEETINGS_PROJECT_OPTIONS: FilterOption[] = [
-  { label: 'All Projects', value: null },
-  { label: 'CNCF', value: 'CNCF' },
-  { label: 'Kubernetes', value: 'Kubernetes' },
-  { label: 'LF AI & Data Foundation', value: 'LF AI & Data Foundation' },
-  { label: 'OpenSSF', value: 'OpenSSF' },
-  { label: 'Security TAG', value: 'Security TAG' },
-];
 
 /** Type filter options for the Org Meetings filter bar. */
 export const ORG_MEETINGS_TYPE_OPTIONS: FilterOption<OrgMeetingType | null>[] = [
@@ -70,71 +55,6 @@ function demoMeetingTimes(offsetDays: number, hour: number, minute: number, dura
   const end = new Date(start.getTime() + durationMinutes * 60_000);
   return { startTime: start.toISOString(), endTime: end.toISOString() };
 }
-
-/** Demo upcoming meetings (3 records). */
-export const DEMO_UPCOMING_MEETINGS: readonly OrgMeeting[] = [
-  {
-    id: 'um-1',
-    title: 'CNCF Governing Board',
-    privacy: 'private',
-    type: 'board',
-    recurrenceLabel: 'Every week on Thu',
-    ...demoMeetingTimes(2, 1, 54, 60),
-    foundation: 'Cloud Native Computing Foundation',
-    orgName: 'CoreOS',
-    project: 'CNCF',
-    agenda: 'Review Q3 budget proposal. Approve new project sandbox applications. Open floor for governing board motions.',
-    resources: ['Q3 Budget Proposal.pdf', 'Board Meeting Agenda.docx'],
-    rsvpTally: { yes: 12, maybe: 2, no: 1, noResponse: 3 },
-    orgInvitees: [
-      { name: 'Sarah Chen', title: 'VP Engineering', avatarUrl: null, rsvpStatus: 'yes' },
-      { name: 'Marcus Williams', title: 'CTO', avatarUrl: null, rsvpStatus: 'yes' },
-      { name: 'Priya Sharma', title: 'Director of Open Source', avatarUrl: null, rsvpStatus: 'maybe' },
-    ],
-    guestCount: 8,
-    joinUrl: 'https://zoom.us/j/demo-cncf-board',
-    statusFlags: { recording: true, transcripts: true, aiSummary: true },
-  },
-  {
-    id: 'um-2',
-    title: 'Security TAG Monthly',
-    privacy: 'public',
-    type: 'working-group',
-    recurrenceLabel: 'Every month on the 3rd Wed',
-    ...demoMeetingTimes(17, 17, 0, 60),
-    foundation: 'Cloud Native Computing Foundation',
-    orgName: 'CoreOS',
-    project: 'Security TAG',
-    agenda: 'Security posture review. Vulnerability disclosure process update. New TAG member introductions.',
-    resources: ['Security TAG Charter.pdf'],
-    rsvpTally: { yes: 22, maybe: 5, no: 2, noResponse: 8 },
-    orgInvitees: [
-      { name: 'Marcus Williams', title: 'CTO', avatarUrl: null, rsvpStatus: 'yes' },
-      { name: 'Aisha Johnson', title: 'Security Architect', avatarUrl: null, rsvpStatus: null },
-    ],
-    guestCount: 15,
-    joinUrl: 'https://zoom.us/j/demo-security-tag',
-    statusFlags: { recording: true, transcripts: false, aiSummary: false },
-  },
-  {
-    id: 'um-3',
-    title: 'LF AI & Data Summit Planning',
-    privacy: 'public',
-    type: 'other',
-    recurrenceLabel: null,
-    ...demoMeetingTimes(34, 15, 0, 90),
-    foundation: 'LF AI & Data',
-    orgName: 'CoreOS',
-    project: 'LF AI & Data Foundation',
-    agenda: 'Summit logistics. Keynote speaker lineup. Sponsorship tier discussion.',
-    resources: [],
-    rsvpTally: { yes: 6, maybe: 1, no: 0, noResponse: 2 },
-    orgInvitees: [{ name: 'Sarah Chen', title: 'VP Engineering', avatarUrl: null, rsvpStatus: 'yes' }],
-    guestCount: 4,
-    joinUrl: 'https://zoom.us/j/demo-lfai-summit',
-    statusFlags: { recording: false, transcripts: false, aiSummary: false },
-  },
-];
 
 /** Demo past meetings (3 records). */
 export const DEMO_PAST_MEETINGS: readonly OrgPastMeeting[] = [

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -233,6 +233,9 @@ export * from './org-events.interface';
 // Org Events internal backend query-row shapes
 export * from './org-events-internal.interface';
 
+// Org Meetings internal backend query-row shapes
+export * from './org-meetings-internal.interface';
+
 // Newsletter interfaces
 export * from './newsletter.interface';
 

--- a/packages/shared/src/interfaces/org-meetings-internal.interface.ts
+++ b/packages/shared/src/interfaces/org-meetings-internal.interface.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Raw row returned by the org meetings summary (stat strip) Snowflake query. */
+export interface OrgMeetingsSummaryRow {
+  UPCOMING_MEETINGS: number;
+  RECURRING_SERIES: number;
+  RECURRING_FOUNDATIONS: number;
+  NEXT_MEETING: string | null;
+}
+
+/** Raw row from ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETINGS (page query). */
+export interface OrgUpcomingMeetingRow {
+  MEETING_ID: string;
+  TOPIC: string;
+  AGENDA: string | null;
+  VISIBILITY: string | null;
+  MEETING_TYPE_BUCKET: string | null;
+  RECURRENCE_LABEL: string | null;
+  NEXT_OCCURRENCE_UTC_TS: string | null;
+  MEETING_DURATION: number | null;
+  FOUNDATION_NAME: string | null;
+  RECORDING_ENABLED: boolean;
+  TRANSCRIPT_ENABLED: boolean;
+  AI_SUMMARY_ENABLED: boolean;
+  ATTENDING_COUNT: number;
+  MAYBE_COUNT: number;
+  NO_COUNT: number;
+  NO_RESPONSE_COUNT: number;
+  GUEST_COUNT: number;
+  TOTAL_RECORDS: number;
+}
+
+/** Raw row from ANALYTICS.PLATINUM_LFX_ONE.ORG_UPCOMING_MEETING_INVITEES (invitee query). */
+export interface OrgUpcomingMeetingInviteeRow {
+  MEETING_ID: string;
+  FULL_NAME: string;
+  JOB_TITLE: string | null;
+  AVATAR_URL: string | null;
+  RSVP_STATUS: string;
+}
+
+/** Raw row from the distinct org meeting projects (facets) query. */
+export interface OrgMeetingProjectRow {
+  PROJECT_NAME: string;
+}

--- a/packages/shared/src/interfaces/org-meetings.interface.ts
+++ b/packages/shared/src/interfaces/org-meetings.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { OffsetPaginatedResponse } from './api.interface';
+
 /** Tab identifier for the Org Meetings page tab strip. */
 export type OrgMeetingsTabId = 'upcoming' | 'past';
 
@@ -98,4 +100,30 @@ export interface OrgPastMeeting extends OrgMeetingBase {
   readonly artifact: OrgMeetingArtifact;
   readonly minutesUploaded: boolean;
   readonly orgPastInvitees: readonly OrgPastMeetingInvitee[];
+}
+
+/** Summary counts for the Org Meetings stat strip (Snowflake ORG_UPCOMING_MEETINGS; nextMeeting is ISO or null; foundation counts drive "Across N"). */
+export interface OrgMeetingsSummary {
+  readonly upcomingMeetings: number;
+  readonly recurringSeries: number;
+  readonly recurringFoundations: number;
+  readonly nextMeeting: string | null;
+}
+
+/** Server-side filter/pagination options for the Org Lens Upcoming Meetings list. */
+export interface GetOrgUpcomingMeetingsOptions {
+  readonly searchQuery: string | null;
+  readonly project: string | null;
+  readonly type: OrgMeetingType | null;
+  readonly pendingRsvpOnly: boolean;
+  readonly pageSize: number;
+  readonly offset: number;
+}
+
+/** Paginated response for the Org Lens Upcoming Meetings list. */
+export type OrgUpcomingMeetingsResponse = OffsetPaginatedResponse<OrgMeeting>;
+
+/** Distinct foundation/project names the selected org has upcoming meetings in (Project filter options). */
+export interface OrgMeetingsProjectsResponse {
+  readonly projects: readonly string[];
 }

--- a/packages/shared/src/interfaces/org-meetings.interface.ts
+++ b/packages/shared/src/interfaces/org-meetings.interface.ts
@@ -94,6 +94,28 @@ export interface OrgMeeting extends OrgMeetingBase {
   readonly statusFlags: OrgMeetingStatusFlags;
 }
 
+/** RSVP badge label + style for an invitee row. */
+export interface OrgMeetingRsvpBadge {
+  readonly label: string;
+  readonly badgeClass: string;
+}
+
+/** Org invitee with its RSVP badge pre-derived (avoids method calls in the template). */
+export interface OrgMeetingInviteeVm extends OrgMeetingInvitee {
+  readonly badge: OrgMeetingRsvpBadge;
+}
+
+/** Upcoming meeting with presentation fields pre-baked for template rendering (avoids method calls in the `@for`). */
+export interface OrgMeetingVm extends OrgMeeting {
+  readonly linkUrl: string;
+  readonly totalInvited: number;
+  readonly attendingPercent: number;
+  readonly yesPercent: number;
+  readonly maybePercent: number;
+  readonly noPercent: number;
+  readonly inviteeVms: readonly OrgMeetingInviteeVm[];
+}
+
 /** A past meeting in the Org Lens Meetings list. */
 export interface OrgPastMeeting extends OrgMeetingBase {
   readonly attendanceTally: OrgMeetingAttendanceTally;

--- a/packages/shared/src/utils/object.utils.ts
+++ b/packages/shared/src/utils/object.utils.ts
@@ -42,3 +42,13 @@ export function nullifyEmptyStrings<T>(value: T): NullifyEmptyStrings<T> {
   }
   return value as NullifyEmptyStrings<T>;
 }
+
+/** Type guard: a non-null, non-array object (one Snowflake result row). */
+export function isObjectRow(el: unknown): el is Record<string, unknown> {
+  return el !== null && typeof el === 'object' && !Array.isArray(el);
+}
+
+/** Shallow accept-guard for a read-through cache of object rows; a corrupt/foreign entry degrades to a miss, so callers reading a required contract key must validate it on top of this shape check. */
+export function isObjectRowArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every(isObjectRow);
+}


### PR DESCRIPTION
## Summary

Replace the hardcoded demo cards on `/org/meetings` (**Upcoming** tab) with a real, paginated, server-filtered list from Snowflake — cloning the shipped Org Events list lane. Depends on the paired **lf-dbt** PR (platinum models).

- **BFF**: `GET /:accountId/lens/meetings` (paginated; server-side search/project/type/pending-RSVP filters; fixed `next_occurrence` sort; `withOrgCache`) + `GET /:accountId/lens/meetings/projects` facets. List errors surface (no fail-soft) so the client shows a **distinct error state**; summary/projects fail-soft.
- **Client**: signal-driven fetch keyed on the selected org with distinct **loading / empty / error+retry / load-more(append)** states. The People Invited panel shows the meeting-wide RSVP tally, the org's invitee rows, and the guest count. Past tab stays demo; resources out of scope.
- **Shared**: reuse `OrgMeeting`/`OrgMeetingInvitee`; extract `isObjectRow`/`isObjectRowArray` to shared utils (events/contributors now reuse them).

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-1902

## Test plan

- [x] `yarn lint:check` + `check-types` + `format:check` + `build` (SSR + strict templates) — green
- [x] Playwright e2e (`org-meetings-dashboard.spec.ts`): real cards, empty state, error+retry, load-more(+retry keeps cards), invitee rows + tally reconciliation, server-side search / pending-RSVP re-fetch
- [x] Manual against dev: `/org/meetings` with Red Hat (106 meetings) + other orgs — real cards, filters, load-more, tz abbreviation
- [ ] Merge after the lf-dbt platinum models are materialized in prod

Made with [Cursor](https://cursor.com)