### PR TITLE
feat(surveys): show scheduled send date tooltip on Me lens status badge

### DIFF
--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -171,14 +171,13 @@
                 @let isResponded = survey.response_status?.toLowerCase() === 'responded';
                 @let openResponded = survey.displayStatus === SurveyStatus.OPEN && isResponded;
                 @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && !isResponded;
-                @let scheduledSendTooltip = survey.displayStatus === SurveyStatus.SCHEDULED ? getScheduledSendTooltip(survey) : '';
                 <span
                   class="inline-flex"
-                  [pTooltip]="scheduledSendTooltip"
-                  [tooltipDisabled]="!scheduledSendTooltip"
+                  [pTooltip]="survey | scheduledSendTooltip"
+                  [tooltipDisabled]="!(survey | scheduledSendTooltip)"
                   tooltipPosition="top"
-                  [attr.tabindex]="scheduledSendTooltip ? 0 : null"
-                  [attr.aria-label]="getScheduledStatusAriaLabel(survey, openResponded)">
+                  [attr.tabindex]="(survey | scheduledSendTooltip) ? 0 : null"
+                  [attr.aria-label]="survey | scheduledSendAriaLabel: openResponded">
                   <lfx-tag
                     [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
                     [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -171,13 +171,15 @@
                 @let isResponded = survey.response_status?.toLowerCase() === 'responded';
                 @let openResponded = survey.displayStatus === SurveyStatus.OPEN && isResponded;
                 @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && !isResponded;
+                @let scheduledSendTooltipValue = survey | scheduledSendTooltip;
+                @let scheduledSendAriaLabelValue = survey | scheduledSendAriaLabel;
                 <span
                   class="inline-flex"
-                  [pTooltip]="survey | scheduledSendTooltip"
-                  [tooltipDisabled]="!(survey | scheduledSendTooltip)"
+                  [pTooltip]="scheduledSendTooltipValue"
+                  [tooltipDisabled]="!scheduledSendTooltipValue"
                   tooltipPosition="top"
-                  [attr.tabindex]="(survey | scheduledSendTooltip) ? 0 : null"
-                  [attr.aria-label]="survey | scheduledSendAriaLabel: openResponded">
+                  [attr.tabindex]="scheduledSendTooltipValue ? 0 : null"
+                  [attr.aria-label]="scheduledSendAriaLabelValue">
                   <lfx-tag
                     [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
                     [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -171,9 +171,19 @@
                 @let isResponded = survey.response_status?.toLowerCase() === 'responded';
                 @let openResponded = survey.displayStatus === SurveyStatus.OPEN && isResponded;
                 @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && !isResponded;
-                <lfx-tag
-                  [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
-                  [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>
+                @let scheduledSendTooltip =
+                  survey.displayStatus === SurveyStatus.SCHEDULED ? getScheduledSendTooltip(survey) : '';
+                <span
+                  class="inline-flex"
+                  [pTooltip]="scheduledSendTooltip"
+                  [tooltipDisabled]="!scheduledSendTooltip"
+                  tooltipPosition="top"
+                  [attr.tabindex]="scheduledSendTooltip ? 0 : null"
+                  [attr.aria-label]="scheduledSendTooltip || null">
+                  <lfx-tag
+                    [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
+                    [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>
+                </span>
               </td>
 
               <td>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -171,15 +171,14 @@
                 @let isResponded = survey.response_status?.toLowerCase() === 'responded';
                 @let openResponded = survey.displayStatus === SurveyStatus.OPEN && isResponded;
                 @let openUnresponded = survey.displayStatus === SurveyStatus.OPEN && !isResponded;
-                @let scheduledSendTooltip =
-                  survey.displayStatus === SurveyStatus.SCHEDULED ? getScheduledSendTooltip(survey) : '';
+                @let scheduledSendTooltip = survey.displayStatus === SurveyStatus.SCHEDULED ? getScheduledSendTooltip(survey) : '';
                 <span
                   class="inline-flex"
                   [pTooltip]="scheduledSendTooltip"
                   [tooltipDisabled]="!scheduledSendTooltip"
                   tooltipPosition="top"
                   [attr.tabindex]="scheduledSendTooltip ? 0 : null"
-                  [attr.aria-label]="scheduledSendTooltip || null">
+                  [attr.aria-label]="getScheduledStatusAriaLabel(survey, openResponded)">
                   <lfx-tag
                     [value]="openResponded ? 'Submitted' : (survey | surveyStatusLabel)"
                     [severity]="openResponded ? 'success' : openUnresponded ? 'warn' : (survey | surveyStatusSeverity)"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -161,6 +161,18 @@ export class SurveysTableComponent {
     return `${responses} of ${total} responses (${percentage}%)`;
   }
 
+  protected getScheduledSendTooltip(survey: Survey): string {
+    if (!survey.survey_send_date) {
+      return '';
+    }
+    const sendDate = new Date(survey.survey_send_date);
+    if (Number.isNaN(sendDate.getTime())) {
+      return '';
+    }
+    const formatted = sendDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return `Sends on ${formatted}`;
+  }
+
   // === Private Initializers ===
   private initSearchTerm(): Signal<string> {
     const control = this.searchForm.controls.search;

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -13,7 +13,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
+import { SURVEY_LABEL, SURVEY_STATUS_LABELS, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
 import { FilterPillOption, Survey } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
@@ -171,6 +171,20 @@ export class SurveysTableComponent {
     }
     const formatted = sendDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
     return `Sends on ${formatted}`;
+  }
+
+  protected getScheduledStatusAriaLabel(survey: Survey, openResponded: boolean): string | null {
+    const tooltip = this.getScheduledSendTooltip(survey);
+    if (!tooltip) {
+      return null;
+    }
+    const statusLabel = openResponded ? 'Submitted' : this.getStatusLabel(survey);
+    return `${statusLabel}. ${tooltip}`;
+  }
+
+  private getStatusLabel(survey: Survey): string {
+    const displayStatus = getSurveyDisplayStatus(survey);
+    return SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus;
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -13,11 +13,12 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { SURVEY_LABEL, SURVEY_STATUS_LABELS, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
+import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
 import { FilterPillOption, Survey } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
+import { ScheduledSendAriaLabelPipe, ScheduledSendTooltipPipe } from '@pipes/scheduled-send-tooltip.pipe';
 import { SurveyStatusLabelPipe } from '@pipes/survey-status-label.pipe';
 import { SurveyStatusSeverityPipe } from '@pipes/survey-status-severity.pipe';
 import { ConfirmationService } from 'primeng/api';
@@ -41,6 +42,8 @@ import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
     SurveyStatusSeverityPipe,
     DueDateLabelPipe,
     DueDateLabelColorPipe,
+    ScheduledSendTooltipPipe,
+    ScheduledSendAriaLabelPipe,
     TooltipModule,
     ConfirmDialogModule,
     EmptyStateComponent,
@@ -159,32 +162,6 @@ export class SurveysTableComponent {
     const responses = survey.total_responses || 0;
     const percentage = total > 0 ? Math.round((responses / total) * 100) : 0;
     return `${responses} of ${total} responses (${percentage}%)`;
-  }
-
-  protected getScheduledSendTooltip(survey: Survey): string {
-    if (!survey.survey_send_date) {
-      return '';
-    }
-    const sendDate = new Date(survey.survey_send_date);
-    if (Number.isNaN(sendDate.getTime())) {
-      return '';
-    }
-    const formatted = sendDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    return `Sends on ${formatted}`;
-  }
-
-  protected getScheduledStatusAriaLabel(survey: Survey, openResponded: boolean): string | null {
-    const tooltip = this.getScheduledSendTooltip(survey);
-    if (!tooltip) {
-      return null;
-    }
-    const statusLabel = openResponded ? 'Submitted' : this.getStatusLabel(survey);
-    return `${statusLabel}. ${tooltip}`;
-  }
-
-  private getStatusLabel(survey: Survey): string {
-    const displayStatus = getSurveyDisplayStatus(survey);
-    return SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus;
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/shared/pipes/scheduled-send-tooltip.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/scheduled-send-tooltip.pipe.ts
@@ -35,7 +35,7 @@ export class ScheduledSendTooltipPipe implements PipeTransform {
   pure: true,
 })
 export class ScheduledSendAriaLabelPipe implements PipeTransform {
-  public transform(survey: Survey, openResponded: boolean): string | null {
+  public transform(survey: Survey): string | null {
     if (getSurveyDisplayStatus(survey) !== SurveyStatus.SCHEDULED) {
       return null;
     }
@@ -43,7 +43,8 @@ export class ScheduledSendAriaLabelPipe implements PipeTransform {
     if (!tooltip) {
       return null;
     }
-    const statusLabel = openResponded ? 'Submitted' : (SURVEY_STATUS_LABELS[getSurveyDisplayStatus(survey)] ?? getSurveyDisplayStatus(survey));
+    const displayStatus = getSurveyDisplayStatus(survey);
+    const statusLabel = SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus;
     return `${statusLabel}. ${tooltip}`;
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/scheduled-send-tooltip.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/scheduled-send-tooltip.pipe.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { Survey, SURVEY_STATUS_LABELS, SurveyStatus } from '@lfx-one/shared';
+import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+
+function formatScheduledSendTooltip(survey: Survey): string {
+  if (!survey.survey_send_date) {
+    return '';
+  }
+  const sendDate = new Date(survey.survey_send_date);
+  if (Number.isNaN(sendDate.getTime())) {
+    return '';
+  }
+  const formatted = sendDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return `Sends on ${formatted}`;
+}
+
+@Pipe({
+  name: 'scheduledSendTooltip',
+  pure: true,
+})
+export class ScheduledSendTooltipPipe implements PipeTransform {
+  public transform(survey: Survey): string {
+    if (getSurveyDisplayStatus(survey) !== SurveyStatus.SCHEDULED) {
+      return '';
+    }
+    return formatScheduledSendTooltip(survey);
+  }
+}
+
+@Pipe({
+  name: 'scheduledSendAriaLabel',
+  pure: true,
+})
+export class ScheduledSendAriaLabelPipe implements PipeTransform {
+  public transform(survey: Survey, openResponded: boolean): string | null {
+    if (getSurveyDisplayStatus(survey) !== SurveyStatus.SCHEDULED) {
+      return null;
+    }
+    const tooltip = formatScheduledSendTooltip(survey);
+    if (!tooltip) {
+      return null;
+    }
+    const statusLabel = openResponded ? 'Submitted' : (SURVEY_STATUS_LABELS[getSurveyDisplayStatus(survey)] ?? getSurveyDisplayStatus(survey));
+    return `${statusLabel}. ${tooltip}`;
+  }
+}

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -295,6 +295,7 @@ export class SurveyService {
         survey_status: r.survey_status || '',
         // Keep null (not empty string) when absent so Angular's DatePipe doesn't choke.
         survey_cutoff_date: r.survey_cutoff_date || null,
+        survey_send_date: r.survey_send_date || null,
         is_nps_survey: r.is_nps_survey ?? false,
         is_project_survey: r.is_project_survey ?? false,
         committees: r.committee_name

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -88,6 +88,8 @@ export interface Survey {
   /** Survey deadline/cutoff date. May be null when the upstream detail fetch
    * fails and the row is rendered from a stub (see getMySurveys fallback). */
   survey_cutoff_date: string | null;
+  /** Scheduled send date (denormalized from survey_response in Me lens) */
+  survey_send_date?: string | null;
   /** Whether this is an NPS survey */
   is_nps_survey: boolean;
   /** Whether this is a project-level survey */
@@ -182,6 +184,7 @@ export interface SurveyResponseRecord {
   survey_link?: string;
   survey_title: string;
   survey_status: string;
+  survey_send_date?: string;
   survey_cutoff_date?: string;
   is_nps_survey: boolean;
   is_project_survey: boolean;


### PR DESCRIPTION
## Summary

- Adds `survey_send_date` to `SurveyResponseRecord` and `Survey` interfaces
- Maps the field in `getMySurveys` from denormalized query-service data
- Shows a "Sends on {date}" tooltip on the status badge when `displayStatus === scheduled`

## Context

The Me lens builds survey rows exclusively from `survey_response` query data. Respondents cannot fetch parent survey details, so `survey_send_date` must be denormalized onto response records by the survey service (see linuxfoundation/lfx-v2-survey-service#33).

## Screenshot

<img width="1715" height="1036" alt="Screenshot 2026-07-06 at 10 44 02 AM" src="https://github.com/user-attachments/assets/21b84f33-bad2-4576-ad39-3ee07a8805b0" />

---
Issue: LFXV2-1847

Made with [Cursor](https://cursor.com)