### PR TITLE
fix(crowdfunding): wire sponsorship tiers to live backend contract

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.html
@@ -17,7 +17,7 @@
       data-testid="settings-donation-mode" />
   </div>
 
-  @if (donationMode() === 'tier') {
+  @if (donationMode() === 'tiers') {
     <div class="flex flex-col" formArrayName="tiers" data-testid="settings-sponsorship-tiers-list">
       @for (tierData of tiersData(); track $index; let i = $index; let last = $last) {
         <div

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.ts
@@ -27,7 +27,7 @@ export class SettingsSponsorshipTiersTabComponent {
   protected readonly donationModeOptions = SPONSORSHIP_DONATION_MODE_OPTIONS;
 
   public readonly form: FormGroup = new FormGroup({
-    donationMode: new FormControl<SponsorshipDonationMode>('tier', { nonNullable: true }),
+    donationMode: new FormControl<SponsorshipDonationMode>('tiers', { nonNullable: true }),
     tiers: new FormArray<FormGroup>(DEFAULT_SPONSORSHIP_TIERS.map((t) => this.makeTierGroup(t))),
   });
 
@@ -49,7 +49,7 @@ export class SettingsSponsorshipTiersTabComponent {
       .pipe(filter(Boolean), takeUntilDestroyed())
       .subscribe(() => {
         const init = this.initiative();
-        this.form.patchValue({ donationMode: init.donationMode ?? 'tier' }, { emitEvent: false });
+        this.form.patchValue({ donationMode: init.donationMode ?? 'tiers' }, { emitEvent: false });
 
         const tiersArray = this.form.get('tiers') as FormArray<FormGroup>;
         DEFAULT_SPONSORSHIP_TIERS.forEach((defaultTier, i) => {
@@ -65,10 +65,13 @@ export class SettingsSponsorshipTiersTabComponent {
           benefits.clear({ emitEvent: false });
           (saved?.benefits.length ? saved.benefits : ['']).forEach((b) => benefits.push(new FormControl(b, { nonNullable: true }), { emitEvent: false }));
         });
+
+        // Patches above are silent (emitEvent: false); force one emission so the valueChanges-driven signal picks up the loaded data.
+        this.form.updateValueAndValidity({ emitEvent: true });
       });
   }
 
-  // By design, both donation modes ship the full tier set (including disabled/hidden tiers) for forward-compat pass-through.
+  // By design, both donation modes ship the full tier set (including disabled/hidden tiers) — the backend discards tiers when mode is 'open'.
   public getValue(): Pick<UpdateInitiativeInput, 'donationMode' | 'sponsorshipTiers'> {
     const value = this.form.getRawValue();
     return {

--- a/apps/lfx-one/src/server/types/crowdfunding.types.ts
+++ b/apps/lfx-one/src/server/types/crowdfunding.types.ts
@@ -55,7 +55,7 @@ export interface BackendInitiative {
     total_disbursed_cents: number;
     available_cents: number;
   };
-  sponsorship_tiers?: BackendSponsorshipTierInput[];
+  sponsorship_tiers?: BackendSponsorshipTier[];
   donation_mode?: string;
 }
 
@@ -154,7 +154,15 @@ export interface BackendBeneficiaryInput {
   email?: string;
 }
 
-/** Not yet processed upstream — sent as-is for forward compatibility. */
+/** Sponsorship tier as returned by the upstream crowdfunding service (GET). */
+export interface BackendSponsorshipTier {
+  name: string;
+  enabled: boolean;
+  minimum?: number;
+  benefits: string[];
+}
+
+/** Sponsorship tier as sent to the upstream crowdfunding service (PATCH) — same fields, aliased key. */
 export interface BackendSponsorshipTierInput {
   name: string;
   enabled: boolean;

--- a/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
+++ b/apps/lfx-one/src/server/utils/crowdfunding-mapper.ts
@@ -29,7 +29,7 @@ import {
   BackendGoal,
   BackendInitiative,
   BackendSponsor,
-  BackendSponsorshipTierInput,
+  BackendSponsorshipTier,
   BackendSubscription,
   BackendTransaction,
   PaymentMethodWire,
@@ -43,9 +43,9 @@ function toValidDonationMode(value: unknown): SponsorshipDonationMode | undefine
   return SPONSORSHIP_DONATION_MODES.includes(value as SponsorshipDonationMode) ? (value as SponsorshipDonationMode) : undefined;
 }
 
-function mapSponsorshipTier(t: BackendSponsorshipTierInput): SponsorshipTier | undefined {
+function mapSponsorshipTier(t: BackendSponsorshipTier): SponsorshipTier | undefined {
   if (!SPONSORSHIP_TIER_NAMES.includes(t.name as SponsorshipTier['name'])) return undefined;
-  return { name: t.name as SponsorshipTier['name'], enabled: t.enabled, goalCents: t.goal_amount_cents, benefits: t.benefits };
+  return { name: t.name as SponsorshipTier['name'], enabled: t.enabled, goalCents: t.minimum, benefits: t.benefits };
 }
 
 function toValidFundType(value: unknown): FundType {

--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -115,10 +115,11 @@ export const CROWDFUNDING_INITIATIVE_STATUSES = ['submitted', 'pending', 'publis
 export const SPONSORSHIP_TIER_NAMES = ['platinum', 'gold', 'silver', 'bronze'] as const;
 
 // Runtime-checkable tuple of every valid donation mode — used for server-side input validation.
-export const SPONSORSHIP_DONATION_MODES = ['tier', 'open'] as const;
+// Matches the upstream crowdfunding service's donation_mode enum ('tiers', not 'tier').
+export const SPONSORSHIP_DONATION_MODES = ['tiers', 'open'] as const;
 
 export const SPONSORSHIP_DONATION_MODE_OPTIONS: { label: string; value: SponsorshipDonationMode }[] = [
-  { label: 'Sponsorship Tiers', value: 'tier' },
+  { label: 'Sponsorship Tiers', value: 'tiers' },
   { label: 'Open Donation', value: 'open' },
 ];
 

--- a/packages/shared/src/interfaces/crowdfunding.interface.ts
+++ b/packages/shared/src/interfaces/crowdfunding.interface.ts
@@ -305,7 +305,7 @@ export interface UpdateBeneficiaryInput {
 
 export type SponsorshipTierName = (typeof SPONSORSHIP_TIER_NAMES)[number];
 
-/** A configurable sponsorship level a project can offer sponsors. Not yet processed upstream — sent as-is for forward compatibility. */
+/** A configurable sponsorship level a project can offer sponsors. */
 export interface SponsorshipTier {
   name: SponsorshipTierName;
   enabled: boolean;


### PR DESCRIPTION
## Summary
- Aligns the sponsorship-tiers settings tab (built in #1058) with the now-deployed backend from linuxfoundation/lfx-crowdfunding#213
- Fixes `donation_mode` enum mismatch (`'tier'` → `'tiers'`) that would have failed upstream validation on save
- Splits the sponsorship tier wire type into read (`minimum`) and write (`goal_amount_cents`) shapes — the previous single type silently dropped the saved goal on every read
- Fixes the settings tab so loaded tier data (goal, benefits, enabled state) renders immediately instead of requiring a manual checkbox toggle to refresh

## Notes
- Depends on linuxfoundation/lfx-crowdfunding#213 being deployed (confirmed live)