### PR TITLE
fix(newsletters): handle async send and stop duplicate-send retries

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -152,7 +152,9 @@ export class NewsletterManageComponent {
   public readonly subjectFilled = computed(() => (this.subjectValue() ?? '').trim().length > 0);
   public readonly bodyFilled = computed(() => stripHtml(this.bodyValue() ?? '').length > 0);
   public readonly audienceFilled = computed(() => (this.committeeUidsValue() ?? []).length > 0);
-  public readonly canSend = computed(() => this.audienceFilled() && this.subjectFilled() && this.bodyFilled() && this.hasContext() && !this.submitting());
+  public readonly canSend = computed(
+    () => this.audienceFilled() && this.subjectFilled() && this.bodyFilled() && this.hasContext() && !this.submitting() && !this.resolvingSend()
+  );
   public readonly canSendTest = computed(
     () => this.subjectFilled() && this.bodyFilled() && this.hasContext() && this.edEmail().length > 0 && !this.testSending()
   );

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -383,28 +383,84 @@ export class NewsletterManageComponent {
         finalize(() => this.submitting.set(false))
       )
       .subscribe({
-        next: (result: NewsletterSendResult) => {
-          if (result.failed > 0) {
+        next: (result: NewsletterSendResult) => this.handleSendResponse(result),
+        error: (err: HttpErrorResponse) => this.handleSendError(err, id),
+      });
+  }
+
+  /**
+   * The upstream send is asynchronous: acceptance returns the newsletter in
+   * status='sending' (fan-out completes in a background job), while
+   * status='sent' means it settled synchronously (zero-recipient edge case, or
+   * a pre-async upstream deployment). Both land on the Sent tab — there is
+   * deliberately no in-app progress indicator.
+   */
+  private handleSendResponse(result: NewsletterSendResult): void {
+    if (result.newsletter.status === 'sending') {
+      const total = result.total_recipients;
+      this.messageService.add({
+        severity: 'info',
+        summary: 'Sending newsletter',
+        detail: `Your newsletter is being sent to ${total} ${total === 1 ? 'recipient' : 'recipients'}.`,
+      });
+      this.goToList('sent');
+      return;
+    }
+    if (result.failed > 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sent with errors',
+        detail: `Delivered ${result.sent} of ${result.total_recipients}. ${result.failed} failed.`,
+        life: 8000,
+      });
+    } else {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Newsletter sent',
+        detail: `Delivered to ${result.sent} ${result.sent === 1 ? 'recipient' : 'recipients'}.`,
+      });
+    }
+    this.goToList('sent');
+  }
+
+  /**
+   * A send error is ambiguous: a timeout or 5xx may have raced a send the
+   * upstream actually accepted (or even completed), and a 409 means one is
+   * definitely in flight. Refetch the newsletter and branch on its real status
+   * instead of unconditionally re-arming Send — the previous handler did the
+   * latter, inviting the duplicate delivery in LFXV2-2604.
+   */
+  private handleSendError(err: HttpErrorResponse, id: string): void {
+    this.newsletterService
+      .getNewsletter(this.projectUid(), id)
+      .pipe(take(1))
+      .subscribe({
+        next: (newsletter) => {
+          if (newsletter.status === 'sent' || newsletter.status === 'sending') {
             this.messageService.add({
-              severity: 'warn',
-              summary: 'Sent with errors',
-              detail: `Delivered ${result.sent} of ${result.total_recipients}. ${result.failed} failed.`,
-              life: 8000,
+              severity: 'info',
+              summary: newsletter.status === 'sent' ? 'Newsletter sent' : 'Sending newsletter',
+              detail: newsletter.status === 'sent' ? 'Your newsletter was sent.' : 'Your newsletter is being sent.',
             });
-          } else {
-            this.messageService.add({
-              severity: 'success',
-              summary: 'Newsletter sent',
-              detail: `Delivered to ${result.sent} ${result.sent === 1 ? 'recipient' : 'recipients'}.`,
-            });
+            this.goToList('sent');
+            return;
           }
-          this.goToList('sent');
-        },
-        error: (err: HttpErrorResponse) => {
+          // Genuinely still a draft — the send did not go through. Refresh the
+          // version (the failed attempt or an earlier save may have bumped it)
+          // so the next attempt doesn't fail on a stale If-Match.
+          this.version.set(newsletter.version);
           this.messageService.add({
             severity: 'error',
             summary: 'Send failed',
             detail: err?.error?.message || err?.message || 'Could not send newsletter. Please try again.',
+          });
+        },
+        error: () => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Send failed',
+            detail: 'Could not confirm the send status. Check the Sent tab before trying again.',
+            life: 8000,
           });
         },
       });
@@ -560,7 +616,13 @@ export class NewsletterManageComponent {
     combineLatest([this.form.valueChanges, toObservable(this.edEmail)])
       .pipe(
         debounceTime(1000),
-        filter(([, email]) => this.hasContext() && this.hasAnythingToSave() && email.length > 0),
+        // Never autosave while a send is in flight: the PUT would bump the
+        // newsletter's version mid-send and race the upstream status
+        // transition (the direct cause of the LFXV2-2604 duplicate-send
+        // incident). The upstream also rejects edits while status='sending',
+        // but suppressing the write here avoids surfacing that 409 as a
+        // spurious save-error toast.
+        filter(([, email]) => !this.submitting() && this.hasContext() && this.hasAnythingToSave() && email.length > 0),
         filter(() => !this.snapshotMatchesLastSaved()),
         takeUntilDestroyed(this.destroyRef)
       )

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -95,6 +95,10 @@ export class NewsletterManageComponent {
   public readonly isEditMode = computed(() => this.newsletterId() !== null);
   public readonly draftLoading = signal<boolean>(false);
   public readonly submitting = signal<boolean>(false);
+  // True while a failed send's status refetch is in flight — keeps autosave
+  // suppressed across the gap between finalize() resetting `submitting` and
+  // handleSendError resolving the newsletter's real status.
+  private readonly resolvingSend = signal<boolean>(false);
   public readonly testSending = signal<boolean>(false);
   public readonly savedAt = signal<Date | null>(null);
   public readonly savingDraft = signal<boolean>(false);
@@ -431,9 +435,14 @@ export class NewsletterManageComponent {
    * latter, inviting the duplicate delivery in LFXV2-2604.
    */
   private handleSendError(err: HttpErrorResponse, id: string): void {
+    this.resolvingSend.set(true);
     this.newsletterService
       .getNewsletter(this.projectUid(), id)
-      .pipe(take(1))
+      .pipe(
+        take(1),
+        finalize(() => this.resolvingSend.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe({
         next: (newsletter) => {
           if (newsletter.status === 'sent' || newsletter.status === 'sending') {
@@ -622,7 +631,7 @@ export class NewsletterManageComponent {
         // incident). The upstream also rejects edits while status='sending',
         // but suppressing the write here avoids surfacing that 409 as a
         // spurious save-error toast.
-        filter(([, email]) => !this.submitting() && this.hasContext() && this.hasAnythingToSave() && email.length > 0),
+        filter(([, email]) => !this.submitting() && !this.resolvingSend() && this.hasContext() && this.hasAnythingToSave() && email.length > 0),
         filter(() => !this.snapshotMatchesLastSaved()),
         takeUntilDestroyed(this.destroyRef)
       )

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -114,8 +114,8 @@ export class NewsletterController {
       const statusParam = req.query['status'] ? String(req.query['status']) : undefined;
       const pageToken = req.query['page_token'] ? String(req.query['page_token']) : undefined;
 
-      if (statusParam && statusParam !== 'draft' && statusParam !== 'sent') {
-        throw ServiceValidationError.forField('status', "status must be 'draft' or 'sent'", {
+      if (statusParam && statusParam !== 'draft' && statusParam !== 'sending' && statusParam !== 'sent') {
+        throw ServiceValidationError.forField('status', "status must be 'draft', 'sending', or 'sent'", {
           operation: 'newsletter_list',
           service: 'newsletter_controller',
           path: req.path,

--- a/apps/lfx-one/src/server/services/api-client.service.ts
+++ b/apps/lfx-one/src/server/services/api-client.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ApiClientConfig, ApiResponse } from '@lfx-one/shared/interfaces';
+import { ApiClientConfig, ApiRequestOptions, ApiResponse } from '@lfx-one/shared/interfaces';
 
 import { MicroserviceError } from '../errors';
 import { getHttpErrorCode } from '../helpers/http-status.helper';
@@ -23,15 +23,16 @@ export class ApiClientService {
     bearerToken?: string,
     query?: Record<string, any>,
     data?: any,
-    customHeaders?: Record<string, string>
+    customHeaders?: Record<string, string>,
+    options?: ApiRequestOptions
   ): Promise<ApiResponse<T>> {
     const fullUrl = this.getFullUrl(url, query);
 
     if (['GET', 'DELETE'].includes(type)) {
-      return this.makeRequest<T>(type, fullUrl, bearerToken, undefined, customHeaders);
+      return this.makeRequest<T>(type, fullUrl, bearerToken, undefined, customHeaders, options);
     }
 
-    return this.makeRequest<T>(type, fullUrl, bearerToken, data, customHeaders);
+    return this.makeRequest<T>(type, fullUrl, bearerToken, data, customHeaders, options);
   }
 
   /**
@@ -177,7 +178,14 @@ export class ApiClientService {
     return response;
   }
 
-  private async makeRequest<T>(method: string, url: string, bearerToken?: string, data?: any, customHeaders?: Record<string, string>): Promise<ApiResponse<T>> {
+  private async makeRequest<T>(
+    method: string,
+    url: string,
+    bearerToken?: string,
+    data?: any,
+    customHeaders?: Record<string, string>,
+    options?: ApiRequestOptions
+  ): Promise<ApiResponse<T>> {
     // Check if data is FormData (from form-data package for Node.js)
     const isFormData = data && typeof data === 'object' && typeof data.append === 'function' && typeof data.getHeaders === 'function';
 
@@ -203,10 +211,11 @@ export class ApiClientService {
       Object.assign(headers, customHeaders);
     }
 
+    const timeoutMs = options?.timeoutMs ?? this.config.timeout;
     const requestInit: RequestInit = {
       method,
       headers,
-      signal: AbortSignal.timeout(this.config.timeout),
+      signal: AbortSignal.timeout(timeoutMs),
     };
 
     if (data && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
@@ -238,10 +247,14 @@ export class ApiClientService {
       }
     }
 
-    return this.executeRequest<T>(url, requestInit);
+    return this.executeRequest<T>(url, requestInit, { binary: false, timeoutMs });
   }
 
-  private async executeRequest<T>(url: string, requestInit: RequestInit, options: { binary: boolean } = { binary: false }): Promise<ApiResponse<T>> {
+  private async executeRequest<T>(
+    url: string,
+    requestInit: RequestInit,
+    options: { binary: boolean; timeoutMs?: number } = { binary: false }
+  ): Promise<ApiResponse<T>> {
     try {
       const response = await fetch(url, requestInit);
 
@@ -290,7 +303,7 @@ export class ApiClientService {
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.name === 'AbortError') {
-          throw new MicroserviceError(`Request timeout after ${this.config.timeout}ms`, 408, 'TIMEOUT', {
+          throw new MicroserviceError(`Request timeout after ${options.timeoutMs ?? this.config.timeout}ms`, 408, 'TIMEOUT', {
             operation: options.binary ? 'api_client_binary_timeout' : 'api_client_timeout',
             service: 'api_client_service',
             path: url,

--- a/apps/lfx-one/src/server/services/microservice-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/microservice-proxy.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DEFAULT_QUERY_PARAMS } from '@lfx-one/shared/constants';
-import { ApiResponse, MicroserviceUrls } from '@lfx-one/shared/interfaces';
+import { ApiRequestOptions, ApiResponse, MicroserviceUrls } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
@@ -18,7 +18,8 @@ export class MicroserviceProxyService {
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET',
     query?: Record<string, any>,
     data?: any,
-    customHeaders?: Record<string, string>
+    customHeaders?: Record<string, string>,
+    options?: ApiRequestOptions
   ): Promise<T> {
     const operation = `${method.toLowerCase()}_${path.replace(/\//g, '_')}`;
 
@@ -31,7 +32,7 @@ export class MicroserviceProxyService {
       // This ensures that default params cannot be overridden by the caller
       const mergedQuery = { ...query, ...DEFAULT_QUERY_PARAMS };
 
-      const response = await this.apiClient.request<T>(method, endpoint, token, mergedQuery, data, customHeaders);
+      const response = await this.apiClient.request<T>(method, endpoint, token, mergedQuery, data, customHeaders, options);
       return response.data;
     } catch (error: any) {
       // Transform HTTP errors from API client into MicroserviceError

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NEWSLETTER_SEND_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import {
   CreateNewsletterRequest,
   Newsletter,
@@ -80,11 +81,14 @@ export class NewsletterServiceClient {
   }
 
   /**
-   * Send a previously-saved newsletter draft. The Go service mints group_id,
-   * resolves recipients, fans out to email-service, and persists the status
-   * transition. The sender's display name is resolved server-side from the
+   * Send a previously-saved newsletter draft. The Go service transitions the
+   * draft to status='sending' (202) and completes the per-recipient fan-out in
+   * a detached background job — callers branch on `newsletter.status` in the
+   * response body. The sender's display name is resolved server-side from the
    * signed JWT principal via the auth-service NATS lookup — Express forwards
-   * only the bearer token and the If-Match version.
+   * only the bearer token and the If-Match version. The extended per-request
+   * timeout covers pre-async upstream deployments whose synchronous fan-out
+   * can exceed the client's 30s default (LFXV2-2604).
    */
   public async sendNewsletter(req: Request, projectUid: string, newsletterUid: string, ifMatchVersion: number): Promise<NewsletterSendResult> {
     return this.microserviceProxy.proxyRequest<NewsletterSendResult>(
@@ -94,7 +98,8 @@ export class NewsletterServiceClient {
       'POST',
       undefined,
       {},
-      { 'If-Match': `"${ifMatchVersion}"` }
+      { 'If-Match': `"${ifMatchVersion}"` },
+      { timeoutMs: NEWSLETTER_SEND_TIMEOUT_MS }
     );
   }
 

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -25,3 +25,11 @@ export const NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH = 20_000;
 // caps bodyHtml at 100k chars, so we still have room before the schema
 // pushes back).
 export const NEWSLETTER_AI_MAX_TOKENS = 12_000;
+
+// Per-request timeout for the send endpoint, overriding the API client's 30s
+// default. The new upstream accepts sends in well under a second (202 +
+// background fan-out), but while a pre-async newsletter-service is deployed
+// the synchronous fan-out for large audiences can run several minutes — the
+// AAIF incident (LFXV2-2604) measured 37-41s for ~500 recipients, past the
+// 30s abort, so the UI reported failure for sends that actually delivered.
+export const NEWSLETTER_SEND_TIMEOUT_MS = 120_000;

--- a/packages/shared/src/interfaces/api.interface.ts
+++ b/packages/shared/src/interfaces/api.interface.ts
@@ -19,7 +19,7 @@ export interface ApiClientConfig {
  * @description Overrides applied to a single upstream request
  */
 export interface ApiRequestOptions {
-  /** Per-request timeout in milliseconds; falls back to the client's configured default (30s) */
+  /** Per-request timeout in milliseconds; falls back to the client's configured default (`ApiClientConfig.timeout`, default 30s) */
   timeoutMs?: number;
 }
 

--- a/packages/shared/src/interfaces/api.interface.ts
+++ b/packages/shared/src/interfaces/api.interface.ts
@@ -15,6 +15,15 @@ export interface ApiClientConfig {
 }
 
 /**
+ * Per-request options for the server-side API client
+ * @description Overrides applied to a single upstream request
+ */
+export interface ApiRequestOptions {
+  /** Per-request timeout in milliseconds; falls back to the client's configured default (30s) */
+  timeoutMs?: number;
+}
+
+/**
  * Standardized API response wrapper
  * @description Generic response structure for all API endpoints
  */

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -3,7 +3,16 @@
 
 export type NewsletterStatusTabId = 'draft' | 'sent';
 
-export type NewsletterStatus = 'draft' | 'sent';
+/**
+ * Newsletter lifecycle states.
+ *
+ * `sending` is the transient state between the newsletter-service accepting a
+ * send (202) and the background fan-out settling — to `sent` on completion, or
+ * back to `draft` when zero recipients could be delivered to. The upstream
+ * `status=sent` list filter also matches `sending` rows, so in-flight sends
+ * appear on the Sent tab.
+ */
+export type NewsletterStatus = 'draft' | 'sending' | 'sent';
 
 /**
  * Top-level view shown by the newsletter manage screen.
@@ -47,6 +56,14 @@ export interface NewsletterSendFailure {
   error: string;
 }
 
+/**
+ * Response of POST …/newsletters/{uid}/send.
+ *
+ * The upstream send is asynchronous: acceptance returns the newsletter in
+ * `status='sending'` with `sent=0`, and the fan-out completes in a detached
+ * background job. Branch on `newsletter.status` — `'sent'` means the send
+ * settled synchronously (zero-recipient edge case, or a pre-async upstream).
+ */
 export interface NewsletterSendResult {
   newsletter: Newsletter;
   group_id: string;


### PR DESCRIPTION
## Problem — LFXV2-2604

The AAIF ED newsletter send (500+ recipients) took 37–41s upstream against this BFF's hard 30s `AbortSignal.timeout`, so the UI reported failure for sends that actually delivered, left the Send button armed, and a retry re-delivered to the full list. An autosave landing mid-send also bumped the newsletter version and stranded the first (delivered) send in `draft`. Full incident analysis and Datadog evidence in [LFXV2-2604](https://linuxfoundation.atlassian.net/browse/LFXV2-2604).

## Changes

- **BFF:** `ApiClientService`/`MicroserviceProxyService` accept an optional per-request `timeoutMs` (`ApiRequestOptions`); the newsletter send call uses `NEWSLETTER_SEND_TIMEOUT_MS` (120s) so a pre-async upstream's synchronous fan-out can't be aborted mid-send. Timeout errors now report the effective value.
- **Shared types:** `NewsletterStatus` gains `'sending'` (the async upstream accepts sends with 202 + `status='sending'`); list-filter validation accepts it.
- **Frontend (`newsletter-manage`):**
  - autosave is suppressed while a send is in flight and while a failed send's status refetch is resolving (`resolvingSend`) — the version-bump race that stranded send #1;
  - `runSend` branches on `newsletter.status` in the response body (backward compatible with the old synchronous `'sent'` upstream) and always lands on the Sent tab;
  - on any send error the component **refetches the newsletter first** and only re-arms Send when the record is genuinely still a draft (with a refreshed version); `canSend` is disarmed throughout.

## Deliberate UX trade-off (product decision)

There is **no in-app progress indicator** for in-flight sends: no "Sending" tag, no polling, no live status transition. A `sending` newsletter appears on the Sent tab rendered like a sent one with a `—` date until it settles (the async window is typically minutes at most; row click opens analytics, which degrades gracefully upstream). Flagged by review; intentionally kept per the requested UX.

## Protected files

`apps/lfx-one/src/server/services/microservice-proxy.service.ts` — adds only the optional trailing `options` parameter threaded to the API client (default behavior unchanged for all existing callers). Requesting code-owner review for this touch.

## External references / deploy ordering

- Upstream root fix: linuxfoundation/lfx-v2-newsletter-service#32 — **deploy the Go service first**. New UI + old service is safe (body carries `status='sent'` → existing synchronous branch); old UI + new service is safe (2xx, shape-compatible body, server-side duplicate guard active).

## Testing

`yarn check-types`, `yarn lint`, `yarn build` green; license/format hooks pass. Manual flow verified against both response shapes. No existing Playwright specs assert the send toast, so none required updates.

JIRA: [LFXV2-2604](https://linuxfoundation.atlassian.net/browse/LFXV2-2604)

[LFXV2-2604]: https://linuxfoundation.atlassian.net/browse/LFXV2-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2604]: https://linuxfoundation.atlassian.net/browse/LFXV2-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes newsletter send/delivery UX and optimistic-concurrency behavior on a user-facing path; mistakes could still allow duplicate sends or block legitimate retries, though the refetch-on-error pattern reduces that risk.
> 
> **Overview**
> Addresses **LFXV2-2604** duplicate delivery and false send failures when large sends outlast the BFF’s 30s upstream timeout or autosave races the send.
> 
> **BFF:** Adds optional per-request `timeoutMs` (`ApiRequestOptions`) through `ApiClientService` and `MicroserviceProxyService`; newsletter **send** uses **120s** (`NEWSLETTER_SEND_TIMEOUT_MS`). List API validation accepts **`sending`** as a status filter. Shared types document async send (`NewsletterStatus` includes `'sending'`).
> 
> **`newsletter-manage`:** Successful sends branch on **`newsletter.status`** (`sending` vs settled `sent`) and navigate to the Sent tab. On send errors, the UI **refetches the draft** and only re-enables Send when status is still **`draft`** (refreshes version for the next `If-Match`). **`canSend`** and **autosave** stay off during send and during post-error status resolution (`resolvingSend`), avoiding mid-send version bumps that previously stranded sends and invited retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f27fd3bae84ed42a93eda33c6957297318bc57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->