### PR TITLE
fix(crowdfunding): render unset tier minimum as blank

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-sponsorship-tiers-tab/settings-sponsorship-tiers-tab.component.ts
@@ -56,10 +56,7 @@ export class SettingsSponsorshipTiersTabComponent {
           const saved = init.sponsorshipTiers?.find((t) => t.name === defaultTier.name);
           tiersArray
             .at(i)
-            .patchValue(
-              { enabled: saved?.enabled ?? defaultTier.enabled, goal: saved?.goalCents != null ? saved.goalCents / 100 : null },
-              { emitEvent: false }
-            );
+            .patchValue({ enabled: saved?.enabled ?? defaultTier.enabled, goal: saved?.goalCents ? saved.goalCents / 100 : null }, { emitEvent: false });
 
           const benefits = tiersArray.at(i).get('benefits') as FormArray<FormControl<string>>;
           benefits.clear({ emitEvent: false });


### PR DESCRIPTION
## Summary

- A sponsorship tier with no configured minimum arrives from the upstream crowdfunding service as `minimum: 0` (the Go field has no `omitempty`), which `mapSponsorshipTier` passed through as `goalCents: 0`
- The settings tab loaded that with a `!= null` check, so an unset tier rendered a literal `0` in the goal input instead of blank
- Changed the load-side check to treat `0` as unset (`saved?.goalCents ? ... : null`), so an unset tier now renders blank; `getValue()` already omits `goalCents` when the field is empty, so the PATCH round-trip stays clean

## Notes

- Deliberate trade-off: this also means a tier explicitly saved with a `0` minimum will render blank on reload, since the wire format can't distinguish "unset" from "$0" (upstream sends `0` for both). A `$0` sponsorship minimum isn't a meaningful distinct value in this feature, so collapsing it to blank was chosen over preserving the literal `0`.
- Scope is limited to this one settings input — public/display surfaces (`initiative-card`, `initiative-finance-summary`) read a separate `fundingStatus.goalsTotalCents` field and are unaffected