### PR TITLE
fix(meetings): keep created orgs selectable in guest search

### DIFF
--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -113,6 +113,14 @@ export class OrganizationSearchComponent {
   public onOrganizationSelected(event: AutoCompleteSelectEvent): void {
     const selectedOrganization = event.value as OrganizationSuggestion;
 
+    // Remember the pick so it stays selectable for the rest of the session,
+    // even for flows that store the org as free text (no CDP resolve).
+    this.organizationService.registerSessionOrg({
+      name: selectedOrganization.name,
+      domain: selectedOrganization.domain,
+      logo: selectedOrganization.logo,
+    });
+
     // Update form controls if they are specified
     const parentForm = this.form();
     const nameControlName = this.nameControl();
@@ -159,11 +167,16 @@ export class OrganizationSearchComponent {
     this.clearResolveState();
 
     const nameControlName = this.nameControl();
+    const typedName = (this.organizationForm.get('organizationSearch')?.value || this.searchTerm())?.trim();
 
     if (nameControlName && this.form().get(nameControlName)) {
-      this.form()
-        .get(nameControlName)
-        ?.setValue(this.organizationForm.get('organizationSearch')?.value || this.searchTerm());
+      this.form().get(nameControlName)?.setValue(typedName);
+    }
+
+    // Remember the just-created org (free text, no domain) so re-opening the
+    // field on the next guest surfaces it instead of forcing re-creation.
+    if (typedName) {
+      this.organizationService.registerSessionOrg({ name: typedName, domain: '' });
     }
 
     // Clear search field when switching to manual

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -217,6 +217,10 @@ export class OrganizationSearchComponent {
       return of(null);
     }
 
+    // Remember the final entry (the manual name may have been edited after switchToManualMode())
+    // so it stays selectable for the rest of the session. No-ops when the name is blank.
+    this.organizationService.registerSessionOrg({ name: (name || '').trim(), domain: (domain || '').trim() });
+
     this.resolvingOrg.set(true);
 
     return this.organizationService.resolveOrganization(name || '', domain || '').pipe(

--- a/apps/lfx-one/src/app/shared/services/organization.service.ts
+++ b/apps/lfx-one/src/app/shared/services/organization.service.ts
@@ -4,6 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { CdpOrganization, OrganizationSuggestion, OrganizationSuggestionsResponse } from '@lfx-one/shared';
+import { matchesOrgQuery, mergeOrgSuggestions, normalizeOrgKey } from '@lfx-one/shared/utils';
 import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -12,6 +13,16 @@ import { catchError, map, Observable, of } from 'rxjs';
 export class OrganizationService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = '/api/organizations';
+
+  /**
+   * Organizations the user has created or selected during this browser session.
+   * The upstream typeahead is served from a third-party company database that
+   * never contains user-invented orgs, so without this a freshly created org
+   * (e.g. an inline "create" in the meetings guest flow) would vanish from
+   * search and force re-creation for every subsequent guest. Root-provided, so
+   * the list persists across every modal and form for the whole session.
+   */
+  private readonly sessionOrgs: OrganizationSuggestion[] = [];
 
   /**
    * Search for organizations by name
@@ -23,17 +34,40 @@ export class OrganizationService {
       return of([]);
     }
 
+    const trimmed = searchTerm.trim();
+    const localMatches = this.sessionOrgs.filter((org) => matchesOrgQuery(org, trimmed));
+
     return this.http
       .get<OrganizationSuggestionsResponse>(`${this.baseUrl}/search`, {
-        params: { query: searchTerm.trim() },
+        params: { query: trimmed },
       })
       .pipe(
-        map((response) => response.suggestions || []),
+        map((response) => mergeOrgSuggestions(localMatches, response.suggestions || [])),
+        // Even if the upstream call fails, surface the session's remembered orgs
+        // so a just-created org stays selectable.
         catchError((error) => {
           console.error('Error searching organizations:', error);
-          return of([]);
+          return of(localMatches);
         })
       );
+  }
+
+  /**
+   * Remember an organization the user created or selected so it stays selectable
+   * for the rest of the session. Deduped by domain (or name, for free-text orgs)
+   * and kept most-recent-first. No-op for blank names.
+   */
+  public registerSessionOrg(org: OrganizationSuggestion): void {
+    if (!org.name?.trim()) {
+      return;
+    }
+
+    const key = normalizeOrgKey(org);
+    const existingIndex = this.sessionOrgs.findIndex((existing) => normalizeOrgKey(existing) === key);
+    if (existingIndex !== -1) {
+      this.sessionOrgs.splice(existingIndex, 1);
+    }
+    this.sessionOrgs.unshift(org);
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/organization.service.ts
+++ b/apps/lfx-one/src/app/shared/services/organization.service.ts
@@ -47,10 +47,11 @@ export class OrganizationService {
       .pipe(
         map((response) => mergeOrgSuggestions(localMatches, response.suggestions || [])),
         // Even if the upstream call fails, surface the session's remembered orgs
-        // so a just-created org stays selectable.
+        // so a just-created org stays selectable. Run them through the same merge
+        // so the collapse/dedupe applies on the error path too.
         catchError((error) => {
           console.error('Error searching organizations:', error);
-          return of(localMatches);
+          return of(mergeOrgSuggestions(localMatches, []));
         })
       );
   }

--- a/apps/lfx-one/src/app/shared/services/organization.service.ts
+++ b/apps/lfx-one/src/app/shared/services/organization.service.ts
@@ -24,6 +24,9 @@ export class OrganizationService {
    */
   private readonly sessionOrgs: OrganizationSuggestion[] = [];
 
+  /** Cap the session list so a long editing session can't grow it without bound. Most-recent-first, so older entries drop off. */
+  private readonly maxSessionOrgs = 25;
+
   /**
    * Search for organizations by name
    * @param searchTerm - The search term to look for
@@ -68,6 +71,9 @@ export class OrganizationService {
       this.sessionOrgs.splice(existingIndex, 1);
     }
     this.sessionOrgs.unshift(org);
+    if (this.sessionOrgs.length > this.maxSessionOrgs) {
+      this.sessionOrgs.length = this.maxSessionOrgs;
+    }
   }
 
   /**

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -33,6 +33,7 @@ export * from './project-counts.utils';
 export * from './identity.utils';
 export * from './enrollment.utils';
 export * from './org-selector.utils';
+export * from './org.utils';
 export * from './search.utils';
 export * from './email.utils';
 export * from './invitation.utils';

--- a/packages/shared/src/utils/org.utils.spec.ts
+++ b/packages/shared/src/utils/org.utils.spec.ts
@@ -1,0 +1,84 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { OrganizationSuggestion } from '../interfaces';
+import { matchesOrgQuery, mergeOrgSuggestions, normalizeOrgKey } from './org.utils';
+
+/** Builds an OrganizationSuggestion fixture, defaulting fields so tests set only what they assert on. */
+function org(partial: Partial<OrganizationSuggestion>): OrganizationSuggestion {
+  return {
+    name: 'Acme',
+    domain: '',
+    ...partial,
+  };
+}
+
+describe('normalizeOrgKey', () => {
+  it('keys by domain when present, ignoring case, scheme, www, and trailing slash', () => {
+    expect(normalizeOrgKey(org({ name: 'Example', domain: 'https://WWW.Example.com/' }))).toBe('domain:example.com');
+    expect(normalizeOrgKey(org({ name: 'Different Name', domain: 'example.com' }))).toBe('domain:example.com');
+  });
+
+  it('falls back to the normalized name when there is no domain', () => {
+    expect(normalizeOrgKey(org({ name: '  VelocityEngine ', domain: '' }))).toBe('name:velocityengine');
+  });
+
+  it('never collides a name key with a domain key', () => {
+    expect(normalizeOrgKey(org({ name: 'example.com', domain: '' }))).not.toBe(normalizeOrgKey(org({ name: 'x', domain: 'example.com' })));
+  });
+});
+
+describe('matchesOrgQuery', () => {
+  it('matches by case-insensitive name substring', () => {
+    expect(matchesOrgQuery(org({ name: 'VelocityEngine' }), 'velo')).toBe(true);
+    expect(matchesOrgQuery(org({ name: 'VelocityEngine' }), 'ENGINE')).toBe(true);
+  });
+
+  it('does not match on an empty or whitespace query', () => {
+    expect(matchesOrgQuery(org({ name: 'VelocityEngine' }), '')).toBe(false);
+    expect(matchesOrgQuery(org({ name: 'VelocityEngine' }), '   ')).toBe(false);
+  });
+
+  it('does not match unrelated names', () => {
+    expect(matchesOrgQuery(org({ name: 'Acme' }), 'velo')).toBe(false);
+  });
+});
+
+describe('mergeOrgSuggestions', () => {
+  it('returns local entries ahead of remote entries', () => {
+    const local = [org({ name: 'VelocityEngine' })];
+    const remote = [org({ name: 'Acme', domain: 'acme.com' })];
+    expect(mergeOrgSuggestions(local, remote).map((o) => o.name)).toEqual(['VelocityEngine', 'Acme']);
+  });
+
+  it('drops a remote entry that duplicates a local one by domain, keeping the local casing and logo', () => {
+    const local = [org({ name: 'Example Inc', domain: 'example.com', logo: 'https://logo/local.png' })];
+    const remote = [org({ name: 'example', domain: 'https://www.example.com', logo: 'https://logo/remote.png' })];
+    const merged = mergeOrgSuggestions(local, remote);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual(local[0]);
+  });
+
+  it('dedupes by name when neither entry has a domain', () => {
+    const local = [org({ name: 'VelocityEngine' })];
+    const remote = [org({ name: 'velocityengine' })];
+    expect(mergeOrgSuggestions(local, remote)).toHaveLength(1);
+  });
+
+  it('passes remote through when local is empty', () => {
+    const remote = [org({ name: 'Acme', domain: 'acme.com' }), org({ name: 'Beta', domain: 'beta.com' })];
+    expect(mergeOrgSuggestions([], remote)).toEqual(remote);
+  });
+
+  it('returns local when remote is empty', () => {
+    const local = [org({ name: 'VelocityEngine' })];
+    expect(mergeOrgSuggestions(local, [])).toEqual(local);
+  });
+
+  it('dedupes within the local list itself', () => {
+    const local = [org({ name: 'VelocityEngine' }), org({ name: 'velocityengine' })];
+    expect(mergeOrgSuggestions(local, [])).toHaveLength(1);
+  });
+});

--- a/packages/shared/src/utils/org.utils.spec.ts
+++ b/packages/shared/src/utils/org.utils.spec.ts
@@ -28,6 +28,16 @@ describe('normalizeOrgKey', () => {
   it('never collides a name key with a domain key', () => {
     expect(normalizeOrgKey(org({ name: 'example.com', domain: '' }))).not.toBe(normalizeOrgKey(org({ name: 'x', domain: 'example.com' })));
   });
+
+  it('keys a scheme-less host with a path the same as the bare host', () => {
+    expect(normalizeOrgKey(org({ name: 'x', domain: 'example.com/path' }))).toBe(normalizeOrgKey(org({ name: 'y', domain: 'example.com' })));
+  });
+
+  it('returns a deterministic key without throwing on an unparseable scheme value', () => {
+    const key = normalizeOrgKey(org({ name: 'x', domain: 'https://[' }));
+    expect(typeof key).toBe('string');
+    expect(normalizeOrgKey(org({ name: 'x', domain: 'https://[' }))).toBe(key);
+  });
 });
 
 describe('matchesOrgQuery', () => {
@@ -75,6 +85,15 @@ describe('mergeOrgSuggestions', () => {
   it('returns local when remote is empty', () => {
     const local = [org({ name: 'VelocityEngine' })];
     expect(mergeOrgSuggestions(local, [])).toEqual(local);
+  });
+
+  it('collapses a domainless session org into the canonical domained one with the same name', () => {
+    const local = [org({ name: 'Google', domain: '' })];
+    const remote = [org({ name: 'google', domain: 'google.com', logo: 'https://logo/google.png' })];
+    const merged = mergeOrgSuggestions(local, remote);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].domain).toBe('google.com');
+    expect(merged[0].logo).toBe('https://logo/google.png');
   });
 
   it('dedupes within the local list itself', () => {

--- a/packages/shared/src/utils/org.utils.ts
+++ b/packages/shared/src/utils/org.utils.ts
@@ -20,10 +20,18 @@ function normalize(value: string | null | undefined): string {
 export function normalizeOrgKey(org: Pick<OrganizationSuggestion, 'name' | 'domain'>): string {
   const domain = normalize(org.domain);
   if (domain) {
-    const host = domain.includes('://') ? safeHost(domain) : domain;
-    // Strip a leading www. and anything from the first slash so a bare host,
-    // a host with a trailing slash, and a host with a path all key the same.
-    return `domain:${host.replace(/^www\./, '').replace(/\/.*$/, '')}`;
+    let host = domain.includes('://') ? safeHost(domain) : domain;
+    // Strip a leading www. and anything from the first slash so a bare host, a host with a
+    // trailing slash, and a host with a path all key the same. Plain string ops (not regex)
+    // to avoid a polynomial-backtracking pattern on slash-heavy input.
+    if (host.startsWith('www.')) {
+      host = host.slice(4);
+    }
+    const slashIndex = host.indexOf('/');
+    if (slashIndex !== -1) {
+      host = host.slice(0, slashIndex);
+    }
+    return `domain:${host}`;
   }
   return `name:${normalize(org.name)}`;
 }

--- a/packages/shared/src/utils/org.utils.ts
+++ b/packages/shared/src/utils/org.utils.ts
@@ -21,7 +21,9 @@ export function normalizeOrgKey(org: Pick<OrganizationSuggestion, 'name' | 'doma
   const domain = normalize(org.domain);
   if (domain) {
     const host = domain.includes('://') ? safeHost(domain) : domain;
-    return `domain:${host.replace(/^www\./, '').replace(/\/+$/, '')}`;
+    // Strip a leading www. and anything from the first slash so a bare host,
+    // a host with a trailing slash, and a host with a path all key the same.
+    return `domain:${host.replace(/^www\./, '').replace(/\/.*$/, '')}`;
   }
   return `name:${normalize(org.name)}`;
 }
@@ -49,12 +51,27 @@ export function matchesOrgQuery(org: Pick<OrganizationSuggestion, 'name'>, query
  * would otherwise vanish from search. Merging the session's remembered orgs in
  * front of the upstream results keeps them one click away. Local entries win on
  * a key collision so the user's chosen name casing and logo are preserved.
+ *
+ * A free-text session org (no domain, e.g. "Google" typed inline) and the
+ * canonical upstream org for the same name (domain + logo) key differently and
+ * would otherwise both show, with the poorer free-text row on top. When a
+ * domained entry exists for a name, the domainless one is dropped in favor of
+ * the richer record.
  */
 export function mergeOrgSuggestions(local: OrganizationSuggestion[], remote: OrganizationSuggestion[]): OrganizationSuggestion[] {
+  const combined = [...local, ...remote];
+
+  // Names that appear anywhere with a real domain: a canonical record exists,
+  // so a domainless (free-text) entry for the same name is redundant.
+  const domainedNames = new Set(combined.filter((org) => normalize(org.domain)).map((org) => normalize(org.name)));
+
   const seen = new Set<string>();
   const merged: OrganizationSuggestion[] = [];
 
-  for (const org of [...local, ...remote]) {
+  for (const org of combined) {
+    if (!normalize(org.domain) && domainedNames.has(normalize(org.name))) {
+      continue;
+    }
     const key = normalizeOrgKey(org);
     if (seen.has(key)) {
       continue;

--- a/packages/shared/src/utils/org.utils.ts
+++ b/packages/shared/src/utils/org.utils.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { OrganizationSuggestion } from '../interfaces';
+
+/** Null-safe normalization for case-insensitive comparison: coalesces nullish to '', trims, lowercases. */
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+/**
+ * Stable dedupe key for an organization suggestion.
+ *
+ * Domain is the stronger identity signal, so it wins when present: full URLs
+ * (e.g. "https://Example.com/") collapse to their bare host ("example.com").
+ * Falls back to the normalized name for free-text orgs that have no domain
+ * (the meetings guest flow creates these). Keys are prefixed so a name that
+ * happens to equal a bare domain can never collide with a real domain key.
+ */
+export function normalizeOrgKey(org: Pick<OrganizationSuggestion, 'name' | 'domain'>): string {
+  const domain = normalize(org.domain);
+  if (domain) {
+    const host = domain.includes('://') ? safeHost(domain) : domain;
+    return `domain:${host.replace(/^www\./, '').replace(/\/+$/, '')}`;
+  }
+  return `name:${normalize(org.name)}`;
+}
+
+/**
+ * True when an organization matches a typeahead query by name (case-insensitive
+ * substring). Used to filter session-remembered orgs down to the current query
+ * before merging them into upstream suggestions. An empty query matches nothing
+ * so a blank field never floods the list with every remembered org.
+ */
+export function matchesOrgQuery(org: Pick<OrganizationSuggestion, 'name'>, query: string): boolean {
+  const q = normalize(query);
+  if (!q) {
+    return false;
+  }
+  return normalize(org.name).includes(q);
+}
+
+/**
+ * Merge locally-remembered organization suggestions with upstream (Clearbit)
+ * results, local-first and deduped by {@link normalizeOrgKey}.
+ *
+ * The upstream org typeahead is served live from a third-party company database
+ * that never contains user-invented orgs, so an org a user just created inline
+ * would otherwise vanish from search. Merging the session's remembered orgs in
+ * front of the upstream results keeps them one click away. Local entries win on
+ * a key collision so the user's chosen name casing and logo are preserved.
+ */
+export function mergeOrgSuggestions(local: OrganizationSuggestion[], remote: OrganizationSuggestion[]): OrganizationSuggestion[] {
+  const seen = new Set<string>();
+  const merged: OrganizationSuggestion[] = [];
+
+  for (const org of [...local, ...remote]) {
+    const key = normalizeOrgKey(org);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(org);
+  }
+
+  return merged;
+}
+
+/** Extracts the host from a URL, returning the raw value unchanged if it is not parseable. */
+function safeHost(value: string): string {
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
## What

External meeting guests were forcing users to re-create the same organization for every guest: an org created inline (e.g. "VelocityEngine" via **I want to create 'X'**) never came back in subsequent org searches.

## Root cause (not what the ticket assumed)

- `/api/organizations/search` proxies **live to Clearbit's third-party company autocomplete** (`lfx-v2-query-service` → `autocomplete.clearbit.com`), not a CDP-backed index. **There is no index lag** — a user-invented org is simply never in Clearbit and never will be.
- The **meetings guest org field is free text by design** (`registrant-form` + `public-registration-modal` use `resolveToCdpName=false`, no domain, no resolve-on-save). `org_name` is forwarded verbatim to ITX; the registrant payload has **no org-id field**, so nothing is ever written to CDP.

So the ticket's proposed "merge CDP into search" wouldn't surface these orgs (they aren't in CDP, and CDP has no name-search anyway). The right, low-risk lever is a **session-scoped** cache.

## Fix

- Root-provided `OrganizationService` remembers every org the user **selects or creates inline** and merges session matches into upstream suggestions (deduped, local-first). They stay one click away for the rest of the session, across every form/modal.
- Merge/dedupe is a pure util in `packages/shared/src/utils/org.utils.ts` — the only layer with a working unit runner (Vitest); `apps/lfx-one` has none.
- Dedupe keys by domain (host-normalized) or name; a free-text org collapses into the canonical domained one for the same name so no duplicate rows; session list capped at 25 (MRU); the upstream-error path dedupes identically.

## Scope / trade-offs (session-scoped mitigation; durable fix is upstream)

- **Session-scoped only.** Remembered orgs live in memory and clear on reload — the durable fix (persisting guest orgs to a searchable store / an org index that includes them) is upstream.
- **Accepted:** if a user free-text-creates a name that later collides with a *different* real Clearbit company of the same name, the domainless row collapses into the canonical one. Rare; the canonical record is the richer one.
- **Not addressed here:** the separate "one guest wouldn't save at all" report. In the meetings flow nothing awaits org resolution and `org_name` has no validators, so the proposed resolve-guard is inapplicable — it's an upstream ITX rejection (likely duplicate-registrant). Left as needs-live-repro per maintainer decision.

## Tests

`packages/shared` Vitest: 180 passing incl. new `org.utils` coverage (domain/name dedupe, local-first, collapse, scheme-less/path/unparseable keys, empty passthrough). Lint + SSR build green.

## Note

Branch/ticket: this is **LFXV2-2605** (meetings/org search). The worktree was initially on a mis-named `feat/LFXV2-2606-wizard-bulk-invite` branch; work was rebased onto a correctly-named branch off `main` (the stray 2606 wizard commit was excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
