### PR TITLE
perf(meetings): eliminate N+1 committee fetches and count endpoints for project meetings

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -112,7 +112,7 @@
                     <i class="fa-light fa-calendar text-xl"></i>
                   </div>
                   <div class="flex flex-col gap-0.5">
-                    @if (fpStatsLoading()) {
+                    @if (fpUpcomingCountLoading()) {
                       <p class="text-xl font-medium text-gray-400">&mdash;</p>
                     } @else {
                       <p class="text-xl font-medium text-gray-900">{{ fpUpcomingCount() }}</p>
@@ -139,7 +139,7 @@
                     <i class="fa-light fa-clock-rotate-left text-xl"></i>
                   </div>
                   <div class="flex flex-col gap-0.5">
-                    @if (fpStatsLoading()) {
+                    @if (fpPastCountLoading()) {
                       <p class="text-xl font-medium text-gray-400">&mdash;</p>
                     } @else {
                       <p class="text-xl font-medium text-gray-900">{{ fpPastCount() }}</p>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -132,6 +132,8 @@ export class MeetingsDashboardComponent {
   // Per-lens loading flags so Me/FP recording-count pipelines cannot clobber each other on lens switch.
   protected readonly meRecordingsCountLoading = signal(false);
   protected readonly fpRecordingsCountLoading = signal(false);
+  protected fpUpcomingCountLoading = signal(false);
+  protected fpPastCountLoading = signal(false);
 
   // Raw user meetings cached for client-side filtering (Me lens only)
   private rawUserMeetings: Signal<Meeting[]>;
@@ -228,11 +230,12 @@ export class MeetingsDashboardComponent {
     this.rawFpUpcomingMeetings = this.initializeRawFpUpcomingMeetings();
     this.rawFpPastMeetings = this.initializeRawFpPastMeetings();
 
-    // Foundation/Project lens stat cards (computed from raw FP signals, not paginated)
-    // Only look at the active tab's loading signal — inactive tab fetches are gated off.
+    // Foundation/Project lens stat cards
+    // fpStatsLoading gates recurring/recordings cards (backed by raw full-page fetches).
+    // fpUpcomingCount/fpPastCount use the count API directly — they resolve independently.
     this.fpStatsLoading = computed(() => (this.timeFilter() === 'past' ? this.fpPastLoading() : this.fpUpcomingLoading()));
-    this.fpUpcomingCount = computed(() => (this.activeLens() !== 'me' ? this.rawFpUpcomingMeetings().length : 0));
-    this.fpPastCount = computed(() => (this.activeLens() !== 'me' ? this.rawFpPastMeetings().length : 0));
+    this.fpUpcomingCount = this.initFpUpcomingCount();
+    this.fpPastCount = this.initFpPastCount();
     this.fpRecurringCount = computed(() => (this.activeLens() !== 'me' ? this.rawFpUpcomingMeetings().filter((m) => m.recurrence !== null).length : 0));
     this.fpRecordingsAvailableCount = this.initFpRecordingsAvailableCount();
 
@@ -777,6 +780,50 @@ export class MeetingsDashboardComponent {
       const projectWord = count === 1 ? 'project' : 'projects';
       return count > 0 ? `Across ${count} ${projectWord}` : '';
     });
+  }
+
+  private initFpUpcomingCount(): Signal<number> {
+    const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.activeLens);
+
+    return toSignal(
+      combineLatest([project$, lens$, this.refresh$]).pipe(
+        switchMap(([project, lens]) => {
+          if (lens === 'me' || !project?.uid) {
+            return of(0);
+          }
+          if (!isPlatformBrowser(this.platformId)) {
+            this.fpUpcomingCountLoading.set(true);
+            return of(0);
+          }
+          this.fpUpcomingCountLoading.set(true);
+          return this.meetingService.getMeetingsCountByProject(project.uid).pipe(finalize(() => this.fpUpcomingCountLoading.set(false)));
+        })
+      ),
+      { initialValue: 0 }
+    );
+  }
+
+  private initFpPastCount(): Signal<number> {
+    const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.activeLens);
+
+    return toSignal(
+      combineLatest([project$, lens$, this.refresh$]).pipe(
+        switchMap(([project, lens]) => {
+          if (lens === 'me' || !project?.uid) {
+            return of(0);
+          }
+          if (!isPlatformBrowser(this.platformId)) {
+            this.fpPastCountLoading.set(true);
+            return of(0);
+          }
+          this.fpPastCountLoading.set(true);
+          return this.meetingService.getPastMeetingsCountByProject(project.uid).pipe(finalize(() => this.fpPastCountLoading.set(false)));
+        })
+      ),
+      { initialValue: 0 }
+    );
   }
 
   private initFpRecordingsAvailableCount(): Signal<number> {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -783,28 +783,14 @@ export class MeetingsDashboardComponent {
   }
 
   private initFpUpcomingCount(): Signal<number> {
-    const project$ = toObservable(this.project);
-    const lens$ = toObservable(this.activeLens);
-
-    return toSignal(
-      combineLatest([project$, lens$, this.refresh$]).pipe(
-        switchMap(([project, lens]) => {
-          if (lens === 'me' || !project?.uid) {
-            return of(0);
-          }
-          if (!isPlatformBrowser(this.platformId)) {
-            this.fpUpcomingCountLoading.set(true);
-            return of(0);
-          }
-          this.fpUpcomingCountLoading.set(true);
-          return this.meetingService.getMeetingsCountByProject(project.uid).pipe(finalize(() => this.fpUpcomingCountLoading.set(false)));
-        })
-      ),
-      { initialValue: 0 }
-    );
+    return this.initFpCount(this.fpUpcomingCountLoading, (uid) => this.meetingService.getMeetingsCountByProject(uid));
   }
 
   private initFpPastCount(): Signal<number> {
+    return this.initFpCount(this.fpPastCountLoading, (uid) => this.meetingService.getPastMeetingsCountByProject(uid));
+  }
+
+  private initFpCount(loadingSignal: WritableSignal<boolean>, fetchFn: (uid: string) => Observable<number>): Signal<number> {
     const project$ = toObservable(this.project);
     const lens$ = toObservable(this.activeLens);
 
@@ -812,14 +798,15 @@ export class MeetingsDashboardComponent {
       combineLatest([project$, lens$, this.refresh$]).pipe(
         switchMap(([project, lens]) => {
           if (lens === 'me' || !project?.uid) {
+            loadingSignal.set(false);
             return of(0);
           }
           if (!isPlatformBrowser(this.platformId)) {
-            this.fpPastCountLoading.set(true);
+            loadingSignal.set(true);
             return of(0);
           }
-          this.fpPastCountLoading.set(true);
-          return this.meetingService.getPastMeetingsCountByProject(project.uid).pipe(finalize(() => this.fpPastCountLoading.set(false)));
+          loadingSignal.set(true);
+          return fetchFn(project.uid).pipe(finalize(() => loadingSignal.set(false)));
         })
       ),
       { initialValue: 0 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -806,7 +806,10 @@ export class MeetingsDashboardComponent {
             return of(0);
           }
           loadingSignal.set(true);
-          return fetchFn(project.uid).pipe(finalize(() => loadingSignal.set(false)));
+          return fetchFn(project.uid).pipe(
+            catchError(() => of(0)),
+            finalize(() => loadingSignal.set(false))
+          );
         })
       ),
       { initialValue: 0 }

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -113,14 +113,7 @@ export class MeetingService {
 
   /** Fetches meeting count scoped to a committee. */
   public getMeetingsCountByCommittee(committeeId: string): Observable<number> {
-    const params = new HttpParams().set('tags', `committee_uid:${committeeId}`);
-    return this.http.get<QueryServiceCountResponse>('/api/meetings/count', { params }).pipe(
-      catchError((error) => {
-        console.error('Failed to load meetings count:', error);
-        return of({ count: 0 });
-      }),
-      map((response) => response.count)
-    );
+    return this.getCountByTag('/api/meetings/count', `committee_uid:${committeeId}`);
   }
 
   /** Fetches upcoming meetings scoped to a committee. */
@@ -147,30 +140,11 @@ export class MeetingService {
   }
 
   public getMeetingsCountByProject(uid: string): Observable<number> {
-    const params = new HttpParams().set('tags', `project_uid:${uid}`);
-    return this.http
-      .get<QueryServiceCountResponse>('/api/meetings/count', { params })
-      .pipe(
-        catchError((error) => {
-          console.error('Failed to load meetings count:', error);
-          return of({ count: 0 });
-        })
-      )
-      .pipe(
-        // Extract just the count number from the response
-        map((response) => response.count)
-      );
+    return this.getCountByTag('/api/meetings/count', `project_uid:${uid}`);
   }
 
   public getPastMeetingsCountByProject(uid: string): Observable<number> {
-    const params = new HttpParams().set('tags', `project_uid:${uid}`);
-    return this.http.get<QueryServiceCountResponse>('/api/past-meetings/count', { params }).pipe(
-      catchError((error) => {
-        console.error('Failed to load past meetings count:', error);
-        return of({ count: 0 });
-      }),
-      map((response) => response.count)
-    );
+    return this.getCountByTag('/api/past-meetings/count', `project_uid:${uid}`);
   }
 
   public getRecentMeetingsByProject(uid: string): Observable<Meeting[]> {
@@ -612,5 +586,16 @@ export class MeetingService {
         this.pastMeetingRecordingCache.delete(key);
       }
     }
+  }
+
+  private getCountByTag(endpoint: string, tag: string): Observable<number> {
+    const params = new HttpParams().set('tags', tag);
+    return this.http.get<QueryServiceCountResponse>(endpoint, { params }).pipe(
+      catchError((error) => {
+        console.error(`Failed to load count from ${endpoint}:`, error);
+        return of({ count: 0 });
+      }),
+      map((response) => response.count)
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -162,6 +162,17 @@ export class MeetingService {
       );
   }
 
+  public getPastMeetingsCountByProject(uid: string): Observable<number> {
+    const params = new HttpParams().set('tags', `project_uid:${uid}`);
+    return this.http.get<QueryServiceCountResponse>('/api/past-meetings/count', { params }).pipe(
+      catchError((error) => {
+        console.error('Failed to load past meetings count:', error);
+        return of({ count: 0 });
+      }),
+      map((response) => response.count)
+    );
+  }
+
   public getRecentMeetingsByProject(uid: string): Observable<Meeting[]> {
     return this.getMeetingsByProject(uid, 'updated_at.desc');
   }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -54,6 +54,24 @@ export class PastMeetingController {
   }
 
   /**
+   * GET /past-meetings/count
+   */
+  public async getPastMeetingsCount(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_past_meetings_count', {
+      query_params: logger.sanitize(req.query as Record<string, any>),
+    });
+
+    try {
+      const count = await this.meetingService.getMeetingsCount(req, req.query as Record<string, any>, 'v1_past_meeting');
+
+      logger.success(req, 'get_past_meetings_count', startTime, { count });
+      res.json({ count });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /past-meetings/:uid
    */
   public async getPastMeetingById(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/past-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/past-meetings.route.ts
@@ -11,6 +11,9 @@ const pastMeetingController = new PastMeetingController();
 // Past meeting routes
 router.get('/', (req, res, next) => pastMeetingController.getPastMeetings(req, res, next));
 
+// GET /past-meetings/count - get past meetings count
+router.get('/count', (req, res, next) => pastMeetingController.getPastMeetingsCount(req, res, next));
+
 // Get past meeting participants by UID
 router.get('/:uid/participants', (req, res, next) => pastMeetingController.getPastMeetingParticipants(req, res, next));
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1424,7 +1424,7 @@ export class CommitteeService {
    * Chunks UIDs at 100 per request (URL-length guard) using `filters_or=uid:X`
    * for OR semantics on data.uid. Returns a map keyed by `uid` for O(1) lookup.
    */
-  private async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
+  public async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
     const unique = Array.from(new Set(uids)).filter(Boolean);
     if (unique.length === 0) return new Map();
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1334,7 +1334,7 @@ export class CommitteeService {
    * Chunks UIDs at 100 per request (URL-length guard) using `filters_or=uid:X`
    * for OR semantics on data.uid. Returns a map keyed by `uid` for O(1) lookup.
    */
-  public async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
+  private async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
     const unique = Array.from(new Set(uids)).filter(Boolean);
     if (unique.length === 0) return new Map();
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1330,6 +1330,56 @@ export class CommitteeService {
   }
 
   /**
+   * Batch-fetches committee resources by UID from the query service.
+   * Chunks UIDs at 100 per request (URL-length guard) using `filters_or=uid:X`
+   * for OR semantics on data.uid. Returns a map keyed by `uid` for O(1) lookup.
+   */
+  public async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
+    const unique = Array.from(new Set(uids)).filter(Boolean);
+    if (unique.length === 0) return new Map();
+
+    const BATCH_SIZE = 100;
+    const batches: string[][] = [];
+    for (let i = 0; i < unique.length; i += BATCH_SIZE) {
+      batches.push(unique.slice(i, i + BATCH_SIZE));
+    }
+
+    // Rethrow batch failures — returning [] would make callers treat real memberships as
+    // "committee not found" and silently drop them (defeats failOnPartial: true).
+    const batchResults = await Promise.all(
+      batches.map(async (batch) => {
+        try {
+          return await fetchAllQueryResources<Committee>(
+            req,
+            (pageToken) =>
+              this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+                type: 'committee',
+                filters_or: batch.map((uid) => `uid:${uid}`),
+                ...(pageToken && { page_token: pageToken }),
+              }),
+            { failOnPartial: true }
+          );
+        } catch (error) {
+          logger.warning(req, 'get_committees_by_ids', 'Batched committee fetch failed', {
+            batch_size: batch.length,
+            err: error,
+          });
+          throw error;
+        }
+      })
+    );
+
+    const byUid = new Map<string, Committee>();
+    for (const committee of batchResults.flat()) {
+      if (committee?.uid) {
+        byUid.set(committee.uid, committee);
+      }
+    }
+
+    return byUid;
+  }
+
+  /**
    * Fetches the caller's membership row for a single committee, or null if none.
    * Uses the username-tagged query so visibility is independent of which email
    * the caller authenticated with — matching the pattern used by
@@ -1417,56 +1467,6 @@ export class CommitteeService {
       // Tie-breaker: prefer lexicographically smallest uid for stable ordering across requests.
       return (current.uid ?? '') < (best.uid ?? '') ? current : best;
     });
-  }
-
-  /**
-   * Batch-fetches committee resources by UID from the query service.
-   * Chunks UIDs at 100 per request (URL-length guard) using `filters_or=uid:X`
-   * for OR semantics on data.uid. Returns a map keyed by `uid` for O(1) lookup.
-   */
-  public async getCommitteesByIds(req: Request, uids: string[]): Promise<Map<string, Committee>> {
-    const unique = Array.from(new Set(uids)).filter(Boolean);
-    if (unique.length === 0) return new Map();
-
-    const BATCH_SIZE = 100;
-    const batches: string[][] = [];
-    for (let i = 0; i < unique.length; i += BATCH_SIZE) {
-      batches.push(unique.slice(i, i + BATCH_SIZE));
-    }
-
-    // Rethrow batch failures — returning [] would make callers treat real memberships as
-    // "committee not found" and silently drop them (defeats failOnPartial: true).
-    const batchResults = await Promise.all(
-      batches.map(async (batch) => {
-        try {
-          return await fetchAllQueryResources<Committee>(
-            req,
-            (pageToken) =>
-              this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-                type: 'committee',
-                filters_or: batch.map((uid) => `uid:${uid}`),
-                ...(pageToken && { page_token: pageToken }),
-              }),
-            { failOnPartial: true }
-          );
-        } catch (error) {
-          logger.warning(req, 'get_committees_by_ids', 'Batched committee fetch failed', {
-            batch_size: batch.length,
-            err: error,
-          });
-          throw error;
-        }
-      })
-    );
-
-    const byUid = new Map<string, Committee>();
-    for (const committee of batchResults.flat()) {
-      if (committee?.uid) {
-        byUid.set(committee.uid, committee);
-      }
-    }
-
-    return byUid;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -49,7 +49,6 @@ import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
-import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
@@ -60,13 +59,11 @@ import { ProjectService } from './project.service';
 export class MeetingService {
   private accessCheckService: AccessCheckService;
   private microserviceProxy: MicroserviceProxyService;
-  private committeeService: CommitteeService;
   private projectService: ProjectService;
 
   public constructor() {
     this.accessCheckService = new AccessCheckService();
     this.microserviceProxy = new MicroserviceProxyService();
-    this.committeeService = new CommitteeService();
     this.projectService = new ProjectService();
   }
 

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1451,6 +1451,8 @@ export class MeetingService {
 
     // Use Promise.allSettled so one transient batch failure doesn't wipe names resolved by other
     // batches — mirrors the pattern in getCommitteesWithMailingList.
+    // In practice a project's displayed meetings touch ≤1 unique committee, so this is almost always
+    // a single concurrent request; batching guards only against pathological cardinality.
     const results = await Promise.allSettled(
       batches.map((batch) =>
         fetchAllQueryResources<Committee>(

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1442,21 +1442,45 @@ export class MeetingService {
       unique_committees: uniqueCommitteeUids.length,
     });
 
-    let committeeMap: Map<string, Committee>;
-    try {
-      committeeMap = await this.committeeService.getCommitteesByIds(req, uniqueCommitteeUids);
-    } catch (error) {
-      logger.warning(req, 'get_meeting_committees', 'Batch committee fetch failed; meetings will have no committee names', {
-        unique_committees: uniqueCommitteeUids.length,
-        err: error,
-      });
-      committeeMap = new Map();
+    const unique = [...new Set(uniqueCommitteeUids)].filter(Boolean);
+    const BATCH_SIZE = 100;
+    const batches: string[][] = [];
+    for (let i = 0; i < unique.length; i += BATCH_SIZE) {
+      batches.push(unique.slice(i, i + BATCH_SIZE));
     }
 
+    // Use Promise.allSettled so one transient batch failure doesn't wipe names resolved by other
+    // batches — mirrors the pattern in getCommitteesWithMailingList.
+    const results = await Promise.allSettled(
+      batches.map((batch) =>
+        fetchAllQueryResources<Committee>(
+          req,
+          (pageToken) =>
+            this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+              type: 'committee',
+              filters_or: batch.map((uid) => `uid:${uid}`),
+              ...(pageToken && { page_token: pageToken }),
+            }),
+          { failOnPartial: true }
+        )
+      )
+    );
+
     const nameMap = new Map<string, string>();
-    for (const [uid, committee] of committeeMap) {
-      if (committee.name) {
-        nameMap.set(uid, committee.name);
+    for (const [i, result] of results.entries()) {
+      if (result.status === 'fulfilled') {
+        for (const committee of result.value) {
+          if (committee?.uid && committee.name) {
+            nameMap.set(committee.uid, committee.name);
+          }
+        }
+      } else {
+        logger.warning(req, 'get_meeting_committees', 'Batch committee fetch failed; affected meetings will have no committee name', {
+          batch_index: i,
+          batch_size: batches[i].length,
+          sample_uids: batches[i].slice(0, 3),
+          err: result.reason,
+        });
       }
     }
 

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1442,7 +1442,7 @@ export class MeetingService {
       unique_committees: uniqueCommitteeUids.length,
     });
 
-    const unique = [...new Set(uniqueCommitteeUids)].filter(Boolean);
+    const unique = uniqueCommitteeUids.filter(Boolean);
     const BATCH_SIZE = 100;
     const batches: string[][] = [];
     for (let i = 0; i < unique.length; i += BATCH_SIZE) {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -5,6 +5,7 @@ import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   ApiResponse,
   AttachmentDownloadUrlResponse,
+  Committee,
   CreateMeetingAttachmentRequest,
   CreateMeetingRegistrantRequest,
   CreateMeetingRequest,
@@ -1441,22 +1442,21 @@ export class MeetingService {
       unique_committees: uniqueCommitteeUids.length,
     });
 
-    const results = await Promise.all(
-      uniqueCommitteeUids.map(async (uid) => {
-        try {
-          const committee = await this.committeeService.getCommitteeById(req, uid);
-          return { uid, name: committee.name };
-        } catch (error) {
-          logger.warning(req, 'get_meeting_committees', 'Committee enrichment failed; continuing without name', { committee_uid: uid, err: error });
-          return { uid, name: undefined };
-        }
-      })
-    );
+    let committeeMap: Map<string, Committee>;
+    try {
+      committeeMap = await this.committeeService.getCommitteesByIds(req, uniqueCommitteeUids);
+    } catch (error) {
+      logger.warning(req, 'get_meeting_committees', 'Batch committee fetch failed; meetings will have no committee names', {
+        unique_committees: uniqueCommitteeUids.length,
+        err: error,
+      });
+      committeeMap = new Map();
+    }
 
     const nameMap = new Map<string, string>();
-    for (const { uid, name } of results) {
-      if (name) {
-        nameMap.set(uid, name);
+    for (const [uid, committee] of committeeMap) {
+      if (committee.name) {
+        nameMap.set(uid, committee.name);
       }
     }
 


### PR DESCRIPTION
## Summary

Extends LFXV2-2120 (groups performance) to project-level meetings:

- **Win 2 (server)**: `getCommitteeNameMap` in `meeting.service.ts` previously made N sequential `getCommitteeById` calls (one per unique committee across all displayed meetings) — each of which triggered settings + membership + access checks. Replaced with a single batched query-service call using the OR-tag pattern (`filters_or: [uid:X, uid:Y, ...]`), returning only the `name` field needed. `getCommitteesByIds` in `committee.service.ts` changed from `private` to `public` to enable reuse.

- **Win 1 (frontend)**: The "Upcoming Meetings" and "Past Meetings" stat cards on the project meetings dashboard previously computed their counts from `rawFpUpcomingMeetings().length` / `rawFpPastMeetings().length` — which forced a full `expand()`-based paginated fetch (up to 10 pages) before the stat cards could show any number. Replaced with dedicated count endpoint calls that resolve in a single request. The raw paginated fetches still run for recurring series count, recordings count, and calendar view — but count cards now resolve independently on their own loading signals (`fpUpcomingCountLoading` / `fpPastCountLoading`).

  Added `GET /api/past-meetings/count` (backed by `getMeetingsCount` with `type=v1_past_meeting`) to mirror the existing `GET /api/meetings/count` endpoint.

## Test plan

- [ ] Navigate to a project meetings dashboard → "Upcoming Meetings" and "Past Meetings" stat cards should appear much faster (single count API call) while "Recurring Series" and "Recordings Available" still load at their normal pace
- [ ] Verify all 4 stat cards show correct values after loading
- [ ] Switch between "upcoming" and "past" tabs — counts should still be correct on each tab
- [ ] Click "Refresh" — all stat cards should reload
- [ ] Verify meetings with committees show correct committee names in the meeting cards
- [ ] Confirm no regressions in the "Me" lens (stat cards should remain unchanged)

Related: LFXV2-2120, builds on merged PR #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches meeting list enrichment and new count endpoints used for dashboard stats; failures degrade to zero counts or missing committee names rather than blocking the page, but wrong counts or labels would be user-visible.
> 
> **Overview**
> Improves **project/foundation meetings dashboard** load time by changing how stat numbers and committee labels are resolved.
> 
> **Foundation/project stat cards:** **Upcoming** and **Past** meeting counts no longer wait on paginated “fetch everything” lists (`rawFp*Meetings().length`). They call **`/api/meetings/count`** and the new **`/api/past-meetings/count`** (tagged by `project_uid`) with their own loading signals (`fpUpcomingCountLoading` / `fpPastCountLoading`). Recurring series, recordings, and calendar still use the full raw FP fetches and `fpStatsLoading`.
> 
> **Client API layer:** Project/committee count helpers share a private **`getCountByTag`** helper; **`getPastMeetingsCountByProject`** is added for the past tab.
> 
> **Server:** **`GET /past-meetings/count`** proxies to **`getMeetingsCount`** with `v1_past_meeting`, mirroring upcoming counts.
> 
> **Meeting list enrichment:** Committee names on meetings are loaded via **batched query-service** `filters_or` chunks (100 UIDs) with **`Promise.allSettled`** so one failed batch does not drop names from other batches—replacing per-committee **`getCommitteeById`** (and removing the **`CommitteeService`** dependency from server **`meeting.service`**). **`committee.service`** only reorders **`getCommitteesByIds`** in the file (still private).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ea4c28cd8c33f07bb184086201fb1607c93890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->