### PR TITLE
fix(committees): use b2b SFID instead of CDP org id

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/components/work-experience-form-dialog/work-experience-form-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/work-experience-form-dialog/work-experience-form-dialog.component.ts
@@ -77,7 +77,7 @@ export class WorkExperienceFormDialogComponent {
   }
 
   public onOrganizationResolved(result: OrganizationResolveResult): void {
-    this.form.patchValue({ organizationId: result.id });
+    this.form.patchValue({ organizationId: result.id ?? '' });
   }
 
   public onSubmit(): void {

--- a/apps/lfx-one/src/app/shared/services/organization.service.ts
+++ b/apps/lfx-one/src/app/shared/services/organization.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { CdpOrganization, OrganizationSuggestion, OrganizationSuggestionsResponse } from '@lfx-one/shared';
+import { OrganizationResolveResponse, OrganizationSuggestion, OrganizationSuggestionsResponse } from '@lfx-one/shared';
 import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -42,8 +42,8 @@ export class OrganizationService {
    * @param domain - Organization domain
    * @returns Observable of the resolved CDP organization
    */
-  public resolveOrganization(name: string, domain: string, logo?: string): Observable<CdpOrganization> {
+  public resolveOrganization(name: string, domain: string, logo?: string): Observable<OrganizationResolveResponse> {
     // Drop empty-string logos — they're not meaningful URLs
-    return this.http.post<CdpOrganization>(`${this.baseUrl}/resolve`, { name, domain, ...(logo ? { logo } : {}) });
+    return this.http.post<OrganizationResolveResponse>(`${this.baseUrl}/resolve`, { name, domain, ...(logo ? { logo } : {}) });
   }
 }

--- a/apps/lfx-one/src/server/controllers/organization.controller.ts
+++ b/apps/lfx-one/src/server/controllers/organization.controller.ts
@@ -102,12 +102,16 @@ export class OrganizationController {
 
       const org = await this.cdpService.resolveOrganization(req, name, domain || '', logo);
 
+      // Look up the b2b Salesforce SFID by domain so committee-service payloads carry a valid
+      // v1 organization ID. Failures are soft — null falls back to name+website-only resolution.
+      const b2bSfid = await this.organizationService.resolveB2bSfidByDomain(req, domain || '');
+
       logger.success(req, 'resolve_organization', startTime, {
-        organization_id: org.id,
+        has_b2b_sfid: Boolean(b2bSfid),
         organization_name: org.name,
       });
 
-      res.json(org);
+      res.json({ id: b2bSfid, name: org.name, logo: org.logo });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/organization.controller.ts
+++ b/apps/lfx-one/src/server/controllers/organization.controller.ts
@@ -100,20 +100,15 @@ export class OrganizationController {
         return;
       }
 
-      // CDP resolve and b2b SFID lookup are independent — run in parallel to halve latency.
-      // resolveB2bSfidByDomain swallows its own failures to null, so a SFID lookup error
-      // does not reject the Promise.all or affect the CDP result.
-      const [org, b2bSfid] = await Promise.all([
-        this.cdpService.resolveOrganization(req, name, domain || '', logo),
-        this.organizationService.resolveB2bSfidByDomain(req, domain || ''),
-      ]);
+      const org = await this.cdpService.resolveOrganization(req, name, domain || '', logo);
 
       logger.success(req, 'resolve_organization', startTime, {
-        has_b2b_sfid: Boolean(b2bSfid),
         organization_name: org.name,
       });
 
-      res.json({ id: b2bSfid, name: org.name, logo: org.logo });
+      // id is always null here — b2b SFID resolution requires committee-service
+      // to call member-service directly (b2b_org is not publicly queryable via query-service).
+      res.json({ id: null, name: org.name, logo: org.logo });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/organization.controller.ts
+++ b/apps/lfx-one/src/server/controllers/organization.controller.ts
@@ -106,9 +106,10 @@ export class OrganizationController {
         organization_name: org.name,
       });
 
-      // id is always null here — b2b SFID resolution requires committee-service
-      // to call member-service directly (b2b_org is not publicly queryable via query-service).
-      res.json({ id: null, name: org.name, logo: org.logo });
+      // Return the raw CDP org ID so work-experience consumers can store it.
+      // Committee-service consumers must NOT forward this as organization.id —
+      // buildCommitteeOrganizationPayload strips it to null at the payload layer.
+      res.json({ id: org.id, name: org.name, logo: org.logo });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/organization.controller.ts
+++ b/apps/lfx-one/src/server/controllers/organization.controller.ts
@@ -100,11 +100,13 @@ export class OrganizationController {
         return;
       }
 
-      const org = await this.cdpService.resolveOrganization(req, name, domain || '', logo);
-
-      // Look up the b2b Salesforce SFID by domain so committee-service payloads carry a valid
-      // v1 organization ID. Failures are soft — null falls back to name+website-only resolution.
-      const b2bSfid = await this.organizationService.resolveB2bSfidByDomain(req, domain || '');
+      // CDP resolve and b2b SFID lookup are independent — run in parallel to halve latency.
+      // resolveB2bSfidByDomain swallows its own failures to null, so a SFID lookup error
+      // does not reject the Promise.all or affect the CDP result.
+      const [org, b2bSfid] = await Promise.all([
+        this.cdpService.resolveOrganization(req, name, domain || '', logo),
+        this.organizationService.resolveB2bSfidByDomain(req, domain || ''),
+      ]);
 
       logger.success(req, 'resolve_organization', startTime, {
         has_b2b_sfid: Boolean(b2bSfid),

--- a/apps/lfx-one/src/server/services/organization.service.ts
+++ b/apps/lfx-one/src/server/services/organization.service.ts
@@ -106,7 +106,15 @@ export class OrganizationService {
    * All failures are caught and return null — callers fall back to name+website-only payloads.
    */
   public async resolveB2bSfidByDomain(req: Request, domain: string): Promise<string | null> {
-    const normalizedDomain = domain.includes('://') ? new URL(domain).hostname : domain;
+    let normalizedDomain = domain;
+    if (domain.includes('://')) {
+      try {
+        normalizedDomain = new URL(domain).hostname;
+      } catch {
+        logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Skipping b2b SFID lookup for malformed URL', { domain });
+        return null;
+      }
+    }
 
     // Only query when the domain is a syntactically valid hostname (no colons or other characters
     // that would corrupt the filters_all field:value grammar).

--- a/apps/lfx-one/src/server/services/organization.service.ts
+++ b/apps/lfx-one/src/server/services/organization.service.ts
@@ -37,8 +37,10 @@ import {
   OrganizationEventAttendanceMonthlyRow,
   OrganizationMaintainersMonthlyRow,
   OrganizationMaintainersResponse,
+  B2bOrgIndexedDoc,
   OrganizationSuggestion,
   OrganizationSuggestionsResponse,
+  QueryServiceResponse,
   TrainingEnrollmentDailyRow,
   TrainingEnrollmentsResponse,
 } from '@lfx-one/shared';
@@ -96,6 +98,65 @@ export class OrganizationService {
     const response = await this.microserviceProxy.proxyRequest<OrganizationSuggestionsResponse>(req, 'LFX_V2_SERVICE', '/query/orgs/suggest', 'GET', params);
 
     return response.suggestions || [];
+  }
+
+  /**
+   * Try to resolve the b2b Salesforce Account SFID for an organization by its primary domain.
+   * Returns the SFID (b2b_org uid) when the org is found in the member-service index, null otherwise.
+   * All failures are caught and return null — callers fall back to name+website-only payloads.
+   */
+  public async resolveB2bSfidByDomain(req: Request, domain: string): Promise<string | null> {
+    const normalizedDomain = domain.includes('://') ? new URL(domain).hostname : domain;
+
+    // Only query when the domain is a syntactically valid hostname (no colons or other characters
+    // that would corrupt the filters_all field:value grammar).
+    if (!normalizedDomain || normalizedDomain.length > 253 || !/^[a-zA-Z0-9][a-zA-Z0-9-_.]*\.[a-zA-Z]{2,}$/.test(normalizedDomain)) {
+      logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Skipping b2b SFID lookup for invalid domain', { domain });
+      return null;
+    }
+
+    try {
+      const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<B2bOrgIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'b2b_org',
+        filters_all: `primary_domain:${normalizedDomain}`,
+        per_page: 2,
+      });
+
+      const resources = response.resources ?? [];
+      if (resources.length === 0) {
+        logger.debug(req, 'resolve_b2b_sfid_by_domain', 'No b2b_org found for domain', { domain: normalizedDomain });
+        return null;
+      }
+
+      if (resources.length > 1) {
+        logger.warning(req, 'resolve_b2b_sfid_by_domain', 'Multiple b2b_orgs found for domain; using first', {
+          domain: normalizedDomain,
+          count: resources.length,
+        });
+      }
+
+      // resource.id is in the format "b2b_org:<sfid>"; strip the type prefix.
+      const resourceId = resources[0].id;
+      const colonIndex = resourceId.indexOf(':');
+      const sfid = colonIndex >= 0 ? resourceId.slice(colonIndex + 1) : resourceId;
+
+      if (!sfid) {
+        logger.warning(req, 'resolve_b2b_sfid_by_domain', 'b2b_org found but could not extract SFID', {
+          domain: normalizedDomain,
+          resource_id: resourceId,
+        });
+        return null;
+      }
+
+      logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Resolved b2b SFID for domain', { domain: normalizedDomain, sfid });
+      return sfid;
+    } catch (error) {
+      logger.warning(req, 'resolve_b2b_sfid_by_domain', 'b2b SFID lookup failed; returning null', {
+        domain: normalizedDomain,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return null;
+    }
   }
 
   /**

--- a/apps/lfx-one/src/server/services/organization.service.ts
+++ b/apps/lfx-one/src/server/services/organization.service.ts
@@ -37,10 +37,8 @@ import {
   OrganizationEventAttendanceMonthlyRow,
   OrganizationMaintainersMonthlyRow,
   OrganizationMaintainersResponse,
-  B2bOrgIndexedDoc,
   OrganizationSuggestion,
   OrganizationSuggestionsResponse,
-  QueryServiceResponse,
   TrainingEnrollmentDailyRow,
   TrainingEnrollmentsResponse,
 } from '@lfx-one/shared';
@@ -98,73 +96,6 @@ export class OrganizationService {
     const response = await this.microserviceProxy.proxyRequest<OrganizationSuggestionsResponse>(req, 'LFX_V2_SERVICE', '/query/orgs/suggest', 'GET', params);
 
     return response.suggestions || [];
-  }
-
-  /**
-   * Try to resolve the b2b Salesforce Account SFID for an organization by its primary domain.
-   * Returns the SFID (b2b_org uid) when the org is found in the member-service index, null otherwise.
-   * All failures are caught and return null — callers fall back to name+website-only payloads.
-   */
-  public async resolveB2bSfidByDomain(req: Request, domain: string): Promise<string | null> {
-    let normalizedDomain = domain;
-    if (domain.includes('://')) {
-      try {
-        normalizedDomain = new URL(domain).hostname;
-      } catch {
-        logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Skipping b2b SFID lookup for malformed URL', { domain });
-        return null;
-      }
-    }
-
-    // Only query when the domain is a syntactically valid hostname (no colons or other characters
-    // that would corrupt the filters_all field:value grammar).
-    if (!normalizedDomain || normalizedDomain.length > 253 || !/^[a-zA-Z0-9][a-zA-Z0-9-_.]*\.[a-zA-Z]{2,}$/.test(normalizedDomain)) {
-      logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Skipping b2b SFID lookup for invalid domain', { domain });
-      return null;
-    }
-
-    try {
-      const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<B2bOrgIndexedDoc>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'b2b_org',
-        filters_all: `primary_domain:${normalizedDomain}`,
-        per_page: 2,
-      });
-
-      const resources = response.resources ?? [];
-      if (resources.length === 0) {
-        logger.debug(req, 'resolve_b2b_sfid_by_domain', 'No b2b_org found for domain', { domain: normalizedDomain });
-        return null;
-      }
-
-      if (resources.length > 1) {
-        logger.warning(req, 'resolve_b2b_sfid_by_domain', 'Multiple b2b_orgs found for domain; using first', {
-          domain: normalizedDomain,
-          count: resources.length,
-        });
-      }
-
-      // resource.id is in the format "b2b_org:<sfid>"; strip the type prefix.
-      const resourceId = resources[0].id;
-      const colonIndex = resourceId.indexOf(':');
-      const sfid = colonIndex >= 0 ? resourceId.slice(colonIndex + 1) : resourceId;
-
-      if (!sfid) {
-        logger.warning(req, 'resolve_b2b_sfid_by_domain', 'b2b_org found but could not extract SFID', {
-          domain: normalizedDomain,
-          resource_id: resourceId,
-        });
-        return null;
-      }
-
-      logger.debug(req, 'resolve_b2b_sfid_by_domain', 'Resolved b2b SFID for domain', { domain: normalizedDomain, sfid });
-      return sfid;
-    } catch (error) {
-      logger.warning(req, 'resolve_b2b_sfid_by_domain', 'b2b SFID lookup failed; returning null', {
-        domain: normalizedDomain,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      return null;
-    }
   }
 
   /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -46,7 +46,7 @@ export interface BehavioralClassDisplayConfig {
  * Mirrors the committee-service organization object: `id`, `name`, and `website`.
  */
 export interface CommitteeOrganizationReference {
-  /** CDP organization ID */
+  /** b2b Salesforce Account SFID (18-char); null/omit when the org has no LF member account */
   id?: string | null;
   /** Organization display name */
   name?: string | null;

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -113,7 +113,7 @@ export interface CreateCommitteeMemberRequest {
   country?: string | null;
   /** Member's organization information */
   organization?: {
-    /** CDP organization ID */
+    /** b2b Salesforce Account SFID (18-char); null/omit when the org has no LF member account */
     id?: string | null;
     /** Organization name */
     name?: string | null;

--- a/packages/shared/src/interfaces/organization.interface.ts
+++ b/packages/shared/src/interfaces/organization.interface.ts
@@ -28,8 +28,12 @@ export interface OrganizationSuggestionsResponse {
  * @description Returned when finding or creating an organization via CDP API
  */
 export interface CdpOrganization {
-  /** CDP organization ID */
-  id: string;
+  /**
+   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
+   * Never a CDP org ID — the resolve endpoint now returns the b2b SFID so committee-service
+   * can forward it to v1-sync-helper without triggering "some organization IDs do not exist".
+   */
+  id: string | null;
   /** Organization display name */
   name: string;
   /** Organization logo URL */
@@ -41,8 +45,12 @@ export interface CdpOrganization {
  * @description Contains the resolved organization details and whether the display name changed
  */
 export interface OrganizationResolveResult {
-  /** CDP organization ID */
-  id: string;
+  /**
+   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
+   * Never a CDP org ID — callers that use this as organization.id in committee-service payloads
+   * must treat null as "omit id" so v1-sync-helper falls back to resolveV1OrgID(name, website).
+   */
+  id: string | null;
   /** CDP display name (may differ from what the user searched) */
   name: string;
   /** Organization logo URL */

--- a/packages/shared/src/interfaces/organization.interface.ts
+++ b/packages/shared/src/interfaces/organization.interface.ts
@@ -38,14 +38,11 @@ export interface CdpOrganization {
 
 /**
  * Response from the BFF POST /api/organizations/resolve endpoint
- * @description Distinct from CdpOrganization — the BFF replaces the CDP org ID with the b2b SFID
- * before returning to the client, so the id field has different semantics.
  */
 export interface OrganizationResolveResponse {
   /**
-   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
-   * Callers that store this as organization.id in committee-service payloads must treat null
-   * as "omit id" so v1-sync-helper falls back to resolveV1OrgID(name, website).
+   * Raw CDP org ID. Work-experience consumers may store this; committee-service
+   * consumers must NOT forward it — buildCommitteeOrganizationPayload strips it to null.
    */
   id: string | null;
   /** Organization display name (may differ from what the user searched) */
@@ -60,8 +57,8 @@ export interface OrganizationResolveResponse {
  */
 export interface OrganizationResolveResult {
   /**
-   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
-   * Sourced from OrganizationResolveResponse.id — treat null as "omit id" in committee-service payloads.
+   * Raw CDP org ID (sourced from OrganizationResolveResponse.id). Do not forward to
+   * committee-service — buildCommitteeOrganizationPayload strips it to null.
    */
   id: string | null;
   /** CDP display name (may differ from what the user searched) */

--- a/packages/shared/src/interfaces/organization.interface.ts
+++ b/packages/shared/src/interfaces/organization.interface.ts
@@ -25,15 +25,11 @@ export interface OrganizationSuggestionsResponse {
 
 /**
  * Organization record from the CDP (Community Data Platform)
- * @description Returned when finding or creating an organization via CDP API
+ * @description Raw shape returned by the CDP API when finding or creating an organization
  */
 export interface CdpOrganization {
-  /**
-   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
-   * Never a CDP org ID — the resolve endpoint now returns the b2b SFID so committee-service
-   * can forward it to v1-sync-helper without triggering "some organization IDs do not exist".
-   */
-  id: string | null;
+  /** CDP internal organization ID (not a Salesforce SFID — never forward to v1 Project Service) */
+  id: string;
   /** Organization display name */
   name: string;
   /** Organization logo URL */
@@ -41,14 +37,31 @@ export interface CdpOrganization {
 }
 
 /**
+ * Response from the BFF POST /api/organizations/resolve endpoint
+ * @description Distinct from CdpOrganization — the BFF replaces the CDP org ID with the b2b SFID
+ * before returning to the client, so the id field has different semantics.
+ */
+export interface OrganizationResolveResponse {
+  /**
+   * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
+   * Callers that store this as organization.id in committee-service payloads must treat null
+   * as "omit id" so v1-sync-helper falls back to resolveV1OrgID(name, website).
+   */
+  id: string | null;
+  /** Organization display name (may differ from what the user searched) */
+  name: string;
+  /** Organization logo URL */
+  logo: string;
+}
+
+/**
  * Result of resolving an organization through CDP
- * @description Contains the resolved organization details and whether the display name changed
+ * @description Enriched form of OrganizationResolveResponse with name-change metadata
  */
 export interface OrganizationResolveResult {
   /**
    * b2b Salesforce Account SFID (18-char), or null when no LF member account was found.
-   * Never a CDP org ID — callers that use this as organization.id in committee-service payloads
-   * must treat null as "omit id" so v1-sync-helper falls back to resolveV1OrgID(name, website).
+   * Sourced from OrganizationResolveResponse.id — treat null as "omit id" in committee-service payloads.
    */
   id: string | null;
   /** CDP display name (may differ from what the user searched) */

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -160,7 +160,7 @@ describe('invitationRequiresOrganization', () => {
 });
 
 describe('buildCommitteeOrganizationPayload', () => {
-  it('maps form values to the committee-service organization shape', () => {
+  it('maps form values to the committee-service organization shape (id always null)', () => {
     expect(
       buildCommitteeOrganizationPayload({
         organization: 'Acme Corp',
@@ -168,7 +168,7 @@ describe('buildCommitteeOrganizationPayload', () => {
         organization_id: 'org-1',
       })
     ).toEqual({
-      id: 'org-1',
+      id: null,
       name: 'Acme Corp',
       website: 'https://acme.example',
     });
@@ -192,7 +192,7 @@ describe('buildCommitteeOrganizationPayload', () => {
         organization_id: '  org-1  ',
       })
     ).toEqual({
-      id: 'org-1',
+      id: null,
       name: 'Acme Corp',
       website: 'https://acme.example',
     });

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -67,16 +67,17 @@ export function invitationRequiresOrganization(flags: {
 
 /**
  * Maps organization form controls to the committee-service organization payload.
+ * id is always null — organization_id holds the CDP UUID which committee-service
+ * must never receive (v1-sync-helper rejects non-SFID IDs).
  */
 export function buildCommitteeOrganizationPayload(
   formValue: Pick<CommitteeOrganizationFormValue, 'organization' | 'organization_url' | 'organization_id'>
 ): CommitteeOrganizationReference | null {
   const name = formValue.organization?.trim() || null;
   const website = formValue.organization_url?.trim() || null;
-  const id = formValue.organization_id?.trim() || null;
 
-  if (name || website || id) {
-    return { id, name, website };
+  if (name || website) {
+    return { id: null, name, website };
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- Stop forwarding CDP org UUIDs to committee-service — they are not Salesforce SFIDs and cause v1-sync-helper failures (\`"some organization IDs do not exist"\`)
- The BFF \`POST /api/organizations/resolve\` returns the raw CDP org ID in \`id\` (needed by work-experience consumers) and \`name\`/\`logo\` from CDP
- \`buildCommitteeOrganizationPayload\` (shared util used by all three committee member consumers) now always emits \`id: null\`, so CDP UUIDs never reach committee-service
- b2b SFID resolution is deferred to committee-service, which will call member-service directly once domain lookup is added (DR-002)

## Changes

- **\`packages/shared/src/utils/invitation.utils.ts\`**: \`buildCommitteeOrganizationPayload\` strips \`organization_id\` to null — applies to member-form, add-member-dialog, and accept-invite-organization-dialog
- **\`apps/lfx-one/src/server/controllers/organization.controller.ts\`**: Returns \`{ id: org.id, name, logo }\` — raw CDP id for work-experience; committee consumers go through the utility above
- **\`packages/shared/src/interfaces/organization.interface.ts\`**: \`CdpOrganization.id\` comment clarifies it is the CDP UUID; \`OrganizationResolveResponse\`/\`OrganizationResolveResult\` updated to reflect actual semantics

## Staging verification

- Create/update a committee member whose organization resolves to a CDP UUID — confirm the member record stores no org ID (null), no \`"some organization IDs do not exist"\` error from v1-sync-helper
- Add/edit work experience — confirm the organization ID is stored correctly and the save succeeds

## Tests

- \`invitation.utils.spec.ts\`: updated 2 assertions to expect \`id: null\` from \`buildCommitteeOrganizationPayload\`; all 45 tests pass
- \`yarn check-types\` ✅

## Ticket

[LFXV2-2647](https://linuxfoundation.atlassian.net/browse/LFXV2-2647)

[LFXV2-2647]: https://linuxfoundation.atlassian.net/browse/LFXV2-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches committee member/invite organization payloads and BFF resolve contract; wrong ID semantics could break sync or work-experience saves, but the change is narrowly scoped with tests and explicit stripping at the payload layer.
> 
> **Overview**
> **Stops CDP organization UUIDs from being sent to committee-service** as `organization.id`, which was breaking v1 sync (`"some organization IDs do not exist"`) because those IDs are not Salesforce SFIDs.
> 
> `buildCommitteeOrganizationPayload` now always sets **`id: null`** and only forwards trimmed **name** and **website**; `organization_id` from forms is ignored for upstream payloads (member form, add-member, accept-invite). Shared types document that committee `organization.id` is an **18-char b2b SFID**, while CDP resolve ids stay on **`OrganizationResolveResponse`** / **`OrganizationResolveResult`** for profile work experience.
> 
> The BFF **`POST /api/organizations/resolve`** still returns `{ id, name, logo }` with the raw CDP id; work experience patching uses **`result.id ?? ''`**. Client **`resolveOrganization`** is typed to **`OrganizationResolveResponse`**. Unit tests for the payload builder expect **`id: null`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ceb11d9a65390d2e1bfbb2087ccdb35ce48dbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->