### PR TITLE
feat(committees): import meeting registrants into add-member flow

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -43,7 +43,7 @@
           data-testid="add-member-import"></lfx-button>
       </div>
       @if (importSummary()) {
-        <p class="text-xs text-emerald-600" data-testid="add-member-import-summary">{{ importSummary() }}</p>
+        <p class="text-xs text-emerald-600" role="status" aria-live="polite" data-testid="add-member-import-summary">{{ importSummary() }}</p>
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -14,6 +14,40 @@
     </p>
   }
 
+  <!-- ── Import from a meeting (optional) ─────────────────────────────────────── -->
+  @if (meetingOptions().length > 0) {
+    <div class="flex flex-col gap-2" data-testid="add-member-import-section">
+      <label class="block text-sm font-medium text-gray-700">Import from a meeting <span class="text-gray-400 font-normal">(optional)</span></label>
+      <p class="text-xs text-gray-500">Pull a meeting's registrants into the list below. Their emails flow through the same review before anyone is invited.</p>
+      <div class="flex items-end gap-2">
+        <lfx-select
+          class="flex-1"
+          [form]="importForm"
+          control="meeting"
+          [options]="meetingOptions()"
+          [filter]="true"
+          placeholder="Select a meeting…"
+          size="small"
+          [showClear]="true"
+          styleClass="w-full"
+          appendTo="body"
+          data-testid="add-member-meeting-select"></lfx-select>
+        <lfx-button
+          label="Import"
+          icon="fa-light fa-user-plus"
+          [loading]="importing()"
+          [disabled]="!importForm.get('meeting')!.value || importing()"
+          (onClick)="onImportFromMeeting()"
+          size="small"
+          type="button"
+          data-testid="add-member-import"></lfx-button>
+      </div>
+      @if (importSummary()) {
+        <p class="text-xs text-emerald-600" data-testid="add-member-import-summary">{{ importSummary() }}</p>
+      }
+    </div>
+  }
+
   <!-- ── Find existing people (typeahead autofill, optional) ──────────────────── -->
   <div class="flex flex-col gap-2">
     <label class="block text-sm font-medium text-gray-700">Find existing people <span class="text-gray-400 font-normal">(optional)</span></label>

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -14,8 +14,8 @@
     </p>
   }
 
-  <!-- ── Import from a meeting (optional; invite mode only — direct-add is out of scope, LFXV2-2227) ── -->
-  @if (!isDirectAdd() && meetingOptions().length > 0) {
+  <!-- ── Import from a meeting (optional) ─────────────────────────────────────── -->
+  @if (meetingOptions().length > 0) {
     <div class="flex flex-col gap-2" data-testid="add-member-import-section">
       <label class="block text-sm font-medium text-gray-700">Import from a meeting <span class="text-gray-400 font-normal">(optional)</span></label>
       <p class="text-xs text-gray-500">Pull a meeting's registrants into the list below. Their emails flow through the same review before anyone is invited.</p>

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -14,8 +14,8 @@
     </p>
   }
 
-  <!-- ── Import from a meeting (optional) ─────────────────────────────────────── -->
-  @if (meetingOptions().length > 0) {
+  <!-- ── Import from a meeting (optional; invite mode only — direct-add is out of scope, LFXV2-2227) ── -->
+  @if (!isDirectAdd() && meetingOptions().length > 0) {
     <div class="flex flex-col gap-2" data-testid="add-member-import-section">
       <label class="block text-sm font-medium text-gray-700">Import from a meeting <span class="text-gray-400 font-normal">(optional)</span></label>
       <p class="text-xs text-gray-500">Pull a meeting's registrants into the list below. Their emails flow through the same review before anyone is invited.</p>

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -36,7 +36,7 @@
           label="Import"
           icon="fa-light fa-user-plus"
           [loading]="importing()"
-          [disabled]="!importForm.get('meeting')!.value || importing()"
+          [disabled]="!importForm.value.meeting || importing()"
           (onClick)="onImportFromMeeting()"
           size="small"
           type="button"

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.html
@@ -36,7 +36,7 @@
           label="Import"
           icon="fa-light fa-user-plus"
           [loading]="importing()"
-          [disabled]="!importForm.value.meeting || importing()"
+          [disabled]="!selectedMeetingId() || importing()"
           (onClick)="onImportFromMeeting()"
           size="small"
           type="button"

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -299,6 +299,7 @@ export class AddMemberDialogComponent {
         next: (registrants) => this.applyImportedRegistrants(meetingId, registrants),
         error: () => {
           this.importing.set(false);
+          this.importSummary.set(null);
           this.messageService.add({
             severity: 'warn',
             summary: 'Import Failed',
@@ -679,7 +680,7 @@ export class AddMemberDialogComponent {
       this.meetingService.getMeetingsByProject(projectUid).pipe(
         map((meetings) =>
           [...meetings]
-            .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime())
+            .sort((a, b) => this.meetingStartMs(b.start_time) - this.meetingStartMs(a.start_time))
             .map((meeting) => ({ value: meeting.id, label: this.buildMeetingLabel(meeting.title, meeting.start_time), title: meeting.title }))
         ),
         catchError(() => of([] as MeetingSelectOption[])),
@@ -687,6 +688,15 @@ export class AddMemberDialogComponent {
       ),
       { initialValue: [] as MeetingSelectOption[] }
     );
+  }
+
+  /** Epoch ms for a meeting start, or 0 when missing/unparseable so the sort stays stable. */
+  private meetingStartMs(startTime: string | null | undefined): number {
+    if (!startTime) {
+      return 0;
+    }
+    const ms = new Date(startTime).getTime();
+    return Number.isNaN(ms) ? 0 : ms;
   }
 
   /** "<title> — <Mon D, YYYY>", or just the title when start_time is missing/unparseable. */

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -26,6 +26,8 @@ import {
   CreateCommitteeMemberRequest,
   DecoratedCommitteeSearchResult,
   EmailListParseResult,
+  MeetingRegistrant,
+  MeetingSelectOption,
   OrganizationResolveResult,
   UserSearchResult,
 } from '@lfx-one/shared/interfaces';
@@ -33,6 +35,7 @@ import {
   buildCommitteeOrganizationPayload,
   committeeOrganizationFormComplete,
   committeeRequiresOrganization,
+  extractRegistrantEmails,
   hasLfAccount,
   normalizeToUrl,
   parseEmailList,
@@ -41,6 +44,7 @@ import {
 import { UserAvatarColorPipe } from '@pipes/user-avatar-color.pipe';
 import { UserInitialsPipe } from '@pipes/user-initials.pipe';
 import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
 import { SearchService } from '@services/search.service';
 import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
@@ -85,6 +89,7 @@ interface DirectAddResult {
 })
 export class AddMemberDialogComponent {
   private readonly committeeService = inject(CommitteeService);
+  private readonly meetingService = inject(MeetingService);
   private readonly searchService = inject(SearchService);
   private readonly messageService = inject(MessageService);
   private readonly dialogRef = inject(DynamicDialogRef);
@@ -134,9 +139,14 @@ export class AddMemberDialogComponent {
     send_notification: new FormControl<boolean>(false, { nonNullable: true }),
   });
   public readonly searchForm = new FormGroup({ query: new FormControl('') });
+  /** Picker for "import registrants from a meeting" (LFXV2-2607). */
+  public readonly importForm = new FormGroup({ meeting: new FormControl<string | null>(null) });
 
   public submitting = signal(false);
   public searchLoading = signal(false);
+  public importing = signal(false);
+  /** Human-readable outcome of the last import, shown under the picker. */
+  public importSummary = signal<string | null>(null);
   private readonly orgSubmitAttempted = signal(false);
 
   private readonly rawEmails = toSignal(this.form.get('emails')!.valueChanges.pipe(startWith(this.form.get('emails')!.value)), { initialValue: '' });
@@ -196,6 +206,8 @@ export class AddMemberDialogComponent {
     { initialValue: '' }
   );
   public searchResults: Signal<DecoratedCommitteeSearchResult[]> = this.initSearchResults();
+  /** Meetings in the committee's project, for the import picker. Empty when none / no project. */
+  public readonly meetingOptions: Signal<MeetingSelectOption[]> = this.initMeetingOptions();
 
   public readonly roleOptions = MEMBER_ROLES;
 
@@ -265,6 +277,36 @@ export class AddMemberDialogComponent {
     // feedback. Guard that late close instead of re-disabling Cancel (see onSubmit's comment).
     this.cancelled = true;
     this.dialogRef.close(false);
+  }
+
+  /**
+   * Pull the selected meeting's registrant emails into the email list (LFXV2-2607).
+   * The BFF returns the full roster in one call (it auto-pages), so the imported
+   * emails just flow through the existing parse/dedupe/preview and invite fan-out —
+   * no invite logic is duplicated here.
+   */
+  public onImportFromMeeting(): void {
+    const meetingId = this.importForm.get('meeting')!.value;
+    if (!meetingId || this.importing()) {
+      return;
+    }
+
+    this.importing.set(true);
+    this.meetingService
+      .getMeetingRegistrants(meetingId, false)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (registrants) => this.applyImportedRegistrants(meetingId, registrants),
+        error: () => {
+          this.importing.set(false);
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Import Failed',
+            detail: 'Could not load registrants for that meeting. Please try again.',
+            life: 5000,
+          });
+        },
+      });
   }
 
   public onSubmit(): void {
@@ -591,6 +633,72 @@ export class AddMemberDialogComponent {
       organization_id: null,
       organization_url: normalizedUrl,
     });
+  }
+
+  /**
+   * Append imported emails not already listed to the emails textarea and report the outcome.
+   * Filters against `parsed().valid` (already lowercased) so re-imports don't re-add rows and
+   * the summary's "already listed" count is accurate.
+   */
+  private applyImportedRegistrants(meetingId: string, registrants: MeetingRegistrant[]): void {
+    const { emails, skippedNoEmail } = extractRegistrantEmails(registrants);
+    const meetingTitle = this.meetingOptions().find((option) => option.value === meetingId)?.title ?? 'the meeting';
+
+    const alreadyListed = new Set(this.parsed().valid);
+    const toAppend = emails.filter((email) => !alreadyListed.has(email.toLowerCase()));
+    if (toAppend.length > 0) {
+      const current = this.form.get('emails')!.value.trim();
+      const appended = toAppend.join('\n');
+      this.form.get('emails')!.setValue(current ? `${current}\n${appended}` : appended);
+    }
+
+    this.importSummary.set(this.buildImportSummary(meetingTitle, toAppend.length, emails.length - toAppend.length, skippedNoEmail));
+    this.importForm.get('meeting')!.setValue(null);
+    this.importing.set(false);
+  }
+
+  /** Compose the import result line: how many were added, already listed, and skipped for no email. */
+  private buildImportSummary(meetingTitle: string, added: number, alreadyListed: number, skippedNoEmail: number): string {
+    const parts: string[] = [added === 1 ? `Added 1 address from "${meetingTitle}"` : `Added ${added} addresses from "${meetingTitle}"`];
+    if (alreadyListed > 0) {
+      parts.push(`${alreadyListed} already listed`);
+    }
+    if (skippedNoEmail > 0) {
+      parts.push(skippedNoEmail === 1 ? '1 registrant had no email and was skipped' : `${skippedNoEmail} registrants had no email and were skipped`);
+    }
+    return `${parts.join(' — ')}.`;
+  }
+
+  private initMeetingOptions(): Signal<MeetingSelectOption[]> {
+    const projectUid = this.committee?.project_uid;
+    if (!projectUid) {
+      return signal<MeetingSelectOption[]>([]);
+    }
+
+    return toSignal(
+      this.meetingService.getMeetingsByProject(projectUid).pipe(
+        map((meetings) =>
+          [...meetings]
+            .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime())
+            .map((meeting) => ({ value: meeting.id, label: this.buildMeetingLabel(meeting.title, meeting.start_time), title: meeting.title }))
+        ),
+        catchError(() => of([] as MeetingSelectOption[])),
+        take(1)
+      ),
+      { initialValue: [] as MeetingSelectOption[] }
+    );
+  }
+
+  /** "<title> — <Mon D, YYYY>", or just the title when start_time is missing/unparseable. */
+  private buildMeetingLabel(title: string, startTime: string | null | undefined): string {
+    if (!startTime) {
+      return title;
+    }
+    const date = new Date(startTime);
+    if (Number.isNaN(date.getTime())) {
+      return title;
+    }
+    return `${title} — ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
   }
 
   private initSearchResults(): Signal<DecoratedCommitteeSearchResult[]> {

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -33,9 +33,11 @@ import {
 } from '@lfx-one/shared/interfaces';
 import {
   buildCommitteeOrganizationPayload,
+  buildImportSummary,
   committeeOrganizationFormComplete,
   committeeRequiresOrganization,
   extractRegistrantEmails,
+  filterUnlistedEmails,
   hasLfAccount,
   normalizeToUrl,
   parseEmailList,
@@ -309,7 +311,7 @@ export class AddMemberDialogComponent {
 
     this.importing.set(true);
     this.meetingService
-      .getMeetingRegistrants(meetingId, false, undefined, true)
+      .getMeetingRegistrants(meetingId, false, undefined, true, this.committee?.uid)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (registrants) => this.applyImportedRegistrants(meetingId, registrants),
@@ -661,29 +663,16 @@ export class AddMemberDialogComponent {
     const { emails, skippedNoEmail } = extractRegistrantEmails(registrants);
     const meetingTitle = this.meetingOptions().find((option) => option.value === meetingId)?.title ?? 'the meeting';
 
-    const alreadyListed = new Set(this.parsed().valid);
-    const toAppend = emails.filter((email) => !alreadyListed.has(email.toLowerCase()));
+    const toAppend = filterUnlistedEmails(emails, this.parsed().valid);
     if (toAppend.length > 0) {
       const current = this.form.get('emails')!.value.trim();
       const appended = toAppend.join('\n');
       this.form.get('emails')!.setValue(current ? `${current}\n${appended}` : appended);
     }
 
-    this.importSummary.set(this.buildImportSummary(meetingTitle, toAppend.length, emails.length - toAppend.length, skippedNoEmail));
+    this.importSummary.set(buildImportSummary(meetingTitle, toAppend.length, emails.length - toAppend.length, skippedNoEmail));
     this.importForm.get('meeting')!.setValue(null);
     this.importing.set(false);
-  }
-
-  /** Compose the import result line: how many were added, already listed, and skipped for no email. */
-  private buildImportSummary(meetingTitle: string, added: number, alreadyListed: number, skippedNoEmail: number): string {
-    const parts: string[] = [added === 1 ? `Added 1 address from "${meetingTitle}"` : `Added ${added} addresses from "${meetingTitle}"`];
-    if (alreadyListed > 0) {
-      parts.push(`${alreadyListed} already listed`);
-    }
-    if (skippedNoEmail > 0) {
-      parts.push(skippedNoEmail === 1 ? '1 registrant had no email and was skipped' : `${skippedNoEmail} registrants had no email and were skipped`);
-    }
-    return `${parts.join(' — ')}.`;
   }
 
   private initMeetingOptions(): Signal<MeetingSelectOption[]> {

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -50,7 +50,23 @@ import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, debounceTime, distinctUntilChanged, from, map, mergeMap, Observable, of, startWith, switchMap, take, tap, toArray } from 'rxjs';
+import {
+  catchError,
+  debounceTime,
+  distinctUntilChanged,
+  EMPTY,
+  expand,
+  from,
+  map,
+  mergeMap,
+  Observable,
+  of,
+  startWith,
+  switchMap,
+  take,
+  tap,
+  toArray,
+} from 'rxjs';
 
 interface DirectAddResult {
   email: string;
@@ -676,15 +692,20 @@ export class AddMemberDialogComponent {
       return signal<MeetingSelectOption[]>([]);
     }
 
+    const fetchPage = (pageToken?: string) => this.meetingService.getMeetingsByProjectPaginated(projectUid, undefined, pageToken);
+
     return toSignal(
-      this.meetingService.getMeetingsByProject(projectUid).pipe(
-        map((meetings) =>
-          [...meetings]
+      fetchPage().pipe(
+        expand((response) => (response.page_token ? fetchPage(response.page_token) : EMPTY)),
+        take(10),
+        toArray(),
+        map((responses) =>
+          responses
+            .flatMap((response) => response.data)
             .sort((a, b) => this.meetingStartMs(b.start_time) - this.meetingStartMs(a.start_time))
             .map((meeting) => ({ value: meeting.id, label: this.buildMeetingLabel(meeting.title, meeting.start_time), title: meeting.title }))
         ),
-        catchError(() => of([] as MeetingSelectOption[])),
-        take(1)
+        catchError(() => of([] as MeetingSelectOption[]))
       ),
       { initialValue: [] as MeetingSelectOption[] }
     );

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -688,7 +688,7 @@ export class AddMemberDialogComponent {
 
   private initMeetingOptions(): Signal<MeetingSelectOption[]> {
     const projectUid = this.committee?.project_uid;
-    if (!projectUid || this.isDirectAdd()) {
+    if (!projectUid) {
       return signal<MeetingSelectOption[]>([]);
     }
 

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -168,6 +168,11 @@ export class AddMemberDialogComponent {
   private readonly orgSubmitAttempted = signal(false);
 
   private readonly rawEmails = toSignal(this.form.get('emails')!.valueChanges.pipe(startWith(this.form.get('emails')!.value)), { initialValue: '' });
+  /** Bridges the meeting picker's plain FormControl value into a signal so the Import button's
+   * `[disabled]` binding reliably re-evaluates under zoneless change detection. */
+  public readonly selectedMeetingId = toSignal(this.importForm.get('meeting')!.valueChanges.pipe(startWith(this.importForm.get('meeting')!.value)), {
+    initialValue: null as string | null,
+  });
   private readonly orgFormValues = this.initOrgFormValues();
   private readonly orgUrlStatus = toSignal(this.form.get('organization_url')!.statusChanges.pipe(startWith(this.form.get('organization_url')!.status)), {
     initialValue: this.form.get('organization_url')!.status,

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -315,13 +315,13 @@ export class AddMemberDialogComponent {
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (registrants) => this.applyImportedRegistrants(meetingId, registrants),
-        error: () => {
+        error: (error: unknown) => {
           this.importing.set(false);
           this.importSummary.set(null);
           this.messageService.add({
             severity: 'warn',
             summary: 'Import Failed',
-            detail: 'Could not load registrants for that meeting. Please try again.',
+            detail: extractErrorMessage(error, 'Could not load registrants for that meeting. Please try again.'),
             life: 5000,
           });
         },

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -195,9 +195,13 @@ export class AddMemberDialogComponent {
   });
   /** Org-required direct-add uses one shared organization field — bulk add would mis-assign employers. */
   public readonly directAddRequiresSingleEmail = computed(() => this.organizationRequiredForDirectAdd() && this.categorized().toInvite.length > 1);
+  /** Blocks submit while an import is in flight — otherwise submitting closes the dialog,
+   * destroying the import's subscription and silently dropping the selected meeting's
+   * registrants before they're appended to the textarea. */
   public readonly canSubmit = computed(
     () =>
       !this.submitting() &&
+      !this.importing() &&
       this.categorized().toInvite.length > 0 &&
       !this.directAddRequiresSingleEmail() &&
       !(this.showOrganizationField() && this.orgInvalid())
@@ -337,7 +341,8 @@ export class AddMemberDialogComponent {
     const committeeId = this.committee?.uid;
     const emails = this.categorized().toInvite;
     // Immediate mode POSTs to a committee, so it needs one; collect mode only stages payloads.
-    if ((!this.collectOnly && !committeeId) || emails.length === 0) {
+    // Also refuses while an import is in flight — see canSubmit.
+    if ((!this.collectOnly && !committeeId) || emails.length === 0 || this.importing()) {
       return;
     }
 

--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -309,7 +309,7 @@ export class AddMemberDialogComponent {
 
     this.importing.set(true);
     this.meetingService
-      .getMeetingRegistrants(meetingId, false)
+      .getMeetingRegistrants(meetingId, false, undefined, true)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (registrants) => this.applyImportedRegistrants(meetingId, registrants),
@@ -688,7 +688,7 @@ export class AddMemberDialogComponent {
 
   private initMeetingOptions(): Signal<MeetingSelectOption[]> {
     const projectUid = this.committee?.project_uid;
-    if (!projectUid) {
+    if (!projectUid || this.isDirectAdd()) {
       return signal<MeetingSelectOption[]>([]);
     }
 
@@ -697,7 +697,6 @@ export class AddMemberDialogComponent {
     return toSignal(
       fetchPage().pipe(
         expand((response) => (response.page_token ? fetchPage(response.page_token) : EMPTY)),
-        take(10),
         toArray(),
         map((responses) =>
           responses

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -389,10 +389,23 @@ export class MeetingService {
     );
   }
 
-  public getMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Observable<MeetingRegistrant[]> {
+  /**
+   * @param failOnPartial - If true, the request fails instead of returning a truncated roster
+   *   when a later page fails server-side. Callers that rely on the complete list for
+   *   correctness (e.g. importing every registrant) should set this.
+   */
+  public getMeetingRegistrants(
+    meetingUid: string,
+    includeRsvp: boolean = false,
+    occurrenceId?: string,
+    failOnPartial: boolean = false
+  ): Observable<MeetingRegistrant[]> {
     let params = new HttpParams().set('include_rsvp', includeRsvp.toString());
     if (occurrenceId) {
       params = params.set('occurrence_id', occurrenceId);
+    }
+    if (failOnPartial) {
+      params = params.set('fail_on_partial', 'true');
     }
     return this.http.get<MeetingRegistrant[]>(`/api/meetings/${meetingUid}/registrants`, { params });
   }

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -393,12 +393,16 @@ export class MeetingService {
    * @param failOnPartial - If true, the request fails instead of returning a truncated roster
    *   when a later page fails server-side. Callers that rely on the complete list for
    *   correctness (e.g. importing every registrant) should set this.
+   * @param committeeUid - Required whenever `failOnPartial` is true. The server verifies the
+   *   caller has writer access on this committee and that it belongs to the same project as the
+   *   meeting before returning a complete roster — see meeting.controller.ts.
    */
   public getMeetingRegistrants(
     meetingUid: string,
     includeRsvp: boolean = false,
     occurrenceId?: string,
-    failOnPartial: boolean = false
+    failOnPartial: boolean = false,
+    committeeUid?: string
   ): Observable<MeetingRegistrant[]> {
     let params = new HttpParams().set('include_rsvp', includeRsvp.toString());
     if (occurrenceId) {
@@ -406,6 +410,9 @@ export class MeetingService {
     }
     if (failOnPartial) {
       params = params.set('fail_on_partial', 'true');
+    }
+    if (committeeUid) {
+      params = params.set('committee_uid', committeeUid);
     }
     return this.http.get<MeetingRegistrant[]>(`/api/meetings/${meetingUid}/registrants`, { params });
   }

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -394,8 +394,9 @@ export class MeetingService {
    *   when a later page fails server-side. Callers that rely on the complete list for
    *   correctness (e.g. importing every registrant) should set this.
    * @param committeeUid - Required whenever `failOnPartial` is true. The server verifies the
-   *   caller has writer access on this committee and that it belongs to the same project as the
-   *   meeting before returning a complete roster — see meeting.controller.ts.
+   *   committee belongs to the same project as the meeting, and that the caller either has writer
+   *   access on the committee or is a member of it when the committee is invite_only (mirroring
+   *   canSendMemberInvites() client-side) — see meeting.controller.ts.
    */
   public getMeetingRegistrants(
     meetingUid: string,

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,10 +5,14 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { isTransientHttpError, retryTransientHttpError } from './http-error.utils';
+import { extractErrorMessage, isTransientHttpError, retryTransientHttpError } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
+}
+
+function httpErrorWithBody(status: number, error: unknown): HttpErrorResponse {
+  return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing', error });
 }
 
 describe('isTransientHttpError', () => {
@@ -82,5 +86,50 @@ describe('retryTransientHttpError', () => {
     const boom = new Error('boom');
 
     await expect(firstValueFrom(throwError(() => boom).pipe(retryTransientHttpError(2)))).rejects.toBe(boom);
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('prefers the field-level detail in a ServiceValidationError body over the generic top-level message', () => {
+    // Mirrors ServiceValidationError.forField's response shape: a generic top-level `error`
+    // wrapper plus the actionable detail buried in `errors[0].message`.
+    const error = httpErrorWithBody(400, {
+      error: 'Validation failed for registrants',
+      code: 'VALIDATION_ERROR',
+      errors: [{ field: 'registrants', message: 'This meeting has 62 registrants — imports are limited to 50 per meeting.', code: 'FIELD_VALIDATION_ERROR' }],
+    });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('This meeting has 62 registrants — imports are limited to 50 per meeting.');
+  });
+
+  it('falls back to the top-level message when errors is absent', () => {
+    const error = httpErrorWithBody(404, { message: 'Meeting not found' });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Meeting not found');
+  });
+
+  it('falls back to the top-level error when message is absent', () => {
+    const error = httpErrorWithBody(403, { error: 'Not authorized' });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Not authorized');
+  });
+
+  it('falls back to the synthesized HttpErrorResponse message when the body has no usable message', () => {
+    // HttpErrorResponse always synthesizes a `.message` ("Http failure response for ..."), so an
+    // empty/unusable body never reaches the caller-provided fallback string for a real HTTP error.
+    const error = httpErrorWithBody(500, {});
+
+    expect(extractErrorMessage(error, 'fallback')).toContain('Http failure response');
+  });
+
+  it('returns a plain string body directly', () => {
+    const error = httpErrorWithBody(500, 'upstream down');
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('upstream down');
+  });
+
+  it('handles a plain Error and an unknown value', () => {
+    expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+    expect(extractErrorMessage('not an error', 'fallback')).toBe('fallback');
   });
 });

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -122,6 +122,20 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage(error, 'fallback')).toContain('Http failure response');
   });
 
+  it('does not throw when errors is present but not an array — falls back to the top-level message', () => {
+    // body.error is unknown runtime data; a non-ServiceValidationError upstream could shape
+    // `errors` as anything (e.g. a string), not just the expected array of field errors.
+    const error = httpErrorWithBody(400, { message: 'Bad request', errors: 'validation failed' });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Bad request');
+  });
+
+  it('tolerates malformed entries inside a well-formed errors array', () => {
+    const error = httpErrorWithBody(400, { error: 'Validation failed', errors: [null, { field: 'x' }, { message: 'The real detail' }] });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('The real detail');
+  });
+
   it('returns a plain string body directly', () => {
     const error = httpErrorWithBody(500, 'upstream down');
 

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -43,7 +43,11 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
       // ServiceValidationError's `errors[].message` (server) carries the specific, actionable
       // detail for the failing field — the top-level message/error is often a generic
       // "Validation failed for <field>" wrapper, so prefer the field-level detail when present.
-      const fieldDetail = body.errors?.find((e): e is { message: string } => typeof e.message === 'string' && e.message.trim().length > 0);
+      // `body` is unknown runtime data cast through a type assertion, not a runtime guarantee —
+      // `errors` could be any shape (e.g. a string), so Array.isArray guards before searching it.
+      const fieldDetail = Array.isArray(body.errors)
+        ? body.errors.find((e): e is { message: string } => !!e && typeof e.message === 'string' && e.message.trim().length > 0)
+        : undefined;
       if (fieldDetail) return fieldDetail.message;
       const candidate = [body.message, body.error].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
       if (candidate) return candidate;

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -37,9 +37,14 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  */
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpErrorResponse) {
-    const body = error.error as { message?: string; error?: string } | string | null;
+    const body = error.error as { message?: string; error?: string; errors?: { message?: string }[] } | string | null;
     if (typeof body === 'string' && body.trim().length > 0) return body;
     if (body && typeof body === 'object') {
+      // ServiceValidationError's `errors[].message` (server) carries the specific, actionable
+      // detail for the failing field — the top-level message/error is often a generic
+      // "Validation failed for <field>" wrapper, so prefer the field-level detail when present.
+      const fieldDetail = body.errors?.find((e): e is { message: string } => typeof e.message === 'string' && e.message.trim().length > 0);
+      if (fieldDetail) return fieldDetail.message;
       const candidate = [body.message, body.error].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
       if (candidate) return candidate;
     }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -98,7 +98,7 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
 
     expect(committeeSvc.getCommitteeById).not.toHaveBeenCalled();
     expect(accessCheckSvc.checkSingleAccess).not.toHaveBeenCalled();
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false);
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false, undefined);
     expect(res.json).toHaveBeenCalledWith([]);
     expect(next).not.toHaveBeenCalled();
   });
@@ -126,8 +126,8 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
     expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
   });
 
-  it('passes through for a non-writer on an invite_only committee — mirrors canSendMemberInvites()', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only' });
+  it('passes through for a non-writer *member* on an invite_only committee — mirrors canSendMemberInvites()', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only', my_role: 'Member' });
     meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
     accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
@@ -136,8 +136,22 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
 
+    expect(committeeSvc.getCommitteeById).toHaveBeenCalledWith(expect.anything(), COMMITTEE_UID, { includeMembership: true });
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-writer, non-member on an invite_only committee — join_mode alone does not prove membership', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
   });
 
   it('rejects when the committee and meeting belong to different projects', async () => {
@@ -164,12 +178,12 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
 
     expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(expect.anything(), { resource: 'committee', id: COMMITTEE_UID, access: 'writer' });
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true);
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true, 50);
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('rejects an authorized import once the roster exceeds the size cap', async () => {
+  it('rejects an authorized import once the roster exceeds the size cap, bounding the fetch itself', async () => {
     committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
     meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
     accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
@@ -179,7 +193,12 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
 
+    // maxResults (6th arg) is threaded through so the fetch itself stops early on a large roster,
+    // not just the count check after a full fetch completes.
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true, 50);
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+    const thrownError = next.mock.calls[0][0];
+    expect(thrownError.validationErrors[0].message).toBe('This meeting has more than 50 registrants — imports are limited to 50 per meeting.');
     expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -7,16 +7,10 @@ const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc, committeeSvc, accessCheckSvc } = vi.hoisted(() => ({
+const { meetingSvc } = vi.hoisted(() => ({
   meetingSvc: {
     getMeetingRegistrants: vi.fn(),
-    getMeetingById: vi.fn(),
-  },
-  committeeSvc: {
-    getCommitteeById: vi.fn(),
-  },
-  accessCheckSvc: {
-    checkSingleAccess: vi.fn(),
+    getAuthorizedRegistrantsForImport: vi.fn(),
   },
 }));
 
@@ -44,12 +38,12 @@ vi.mock('../services/meeting.service', () => ({
 }));
 vi.mock('../services/committee.service', () => ({
   CommitteeService: vi.fn(function () {
-    return committeeSvc;
+    return {};
   }),
 }));
 vi.mock('../services/access-check.service', () => ({
   AccessCheckService: vi.fn(function () {
-    return accessCheckSvc;
+    return {};
   }),
 }));
 vi.mock('../services/ai.service', () => ({
@@ -81,7 +75,11 @@ function buildRes(): any {
   return { json: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn() };
 }
 
-describe('MeetingController.getMeetingRegistrants — completeness authorization gate', () => {
+// Authorization, membership, project-match, and size-cap rules are business logic tested at
+// their source — MeetingService.getAuthorizedRegistrantsForImport (meeting.service.spec.ts) —
+// per the three-file pattern (docs/reviews/backend-checklist.md). This spec covers only the
+// controller's HTTP-layer responsibility: parsing params and delegating to the right service call.
+describe('MeetingController.getMeetingRegistrants — delegation', () => {
   let controller: MeetingController;
 
   beforeEach(() => {
@@ -90,115 +88,51 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
   });
 
-  it('skips the gate for the 3 pre-existing partial-tolerant callers (no fail_on_partial)', async () => {
+  it('calls the partial-tolerant getMeetingRegistrants for the 3 pre-existing callers (no fail_on_partial)', async () => {
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({}), res, next);
 
-    expect(committeeSvc.getCommitteeById).not.toHaveBeenCalled();
-    expect(accessCheckSvc.checkSingleAccess).not.toHaveBeenCalled();
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false, undefined);
+    expect(meetingSvc.getAuthorizedRegistrantsForImport).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false);
     expect(res.json).toHaveBeenCalledWith([]);
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('rejects a complete-roster request with no committee_uid', async () => {
+  it('rejects a complete-roster request with no committee_uid, without calling either service method', async () => {
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true' }), res, next);
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getAuthorizedRegistrantsForImport).not.toHaveBeenCalled();
     expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
   });
 
-  it('rejects when the caller lacks writer access and the committee is not invite_only', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'open' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+  it('delegates a complete-roster request to getAuthorizedRegistrantsForImport with the parsed uid and committee_uid', async () => {
+    meetingSvc.getAuthorizedRegistrantsForImport.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getAuthorizedRegistrantsForImport).toHaveBeenCalledWith(expect.anything(), MEETING_UID, COMMITTEE_UID);
     expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
-  });
-
-  it('passes through for a non-writer *member* on an invite_only committee — mirrors canSendMemberInvites()', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only', my_role: 'Member' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
-    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
-    const res = buildRes();
-    const next = vi.fn();
-
-    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
-
-    expect(committeeSvc.getCommitteeById).toHaveBeenCalledWith(expect.anything(), COMMITTEE_UID, { includeMembership: true });
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('rejects a non-writer, non-member on an invite_only committee — join_mode alone does not prove membership', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+  it('propagates a rejection from getAuthorizedRegistrantsForImport via next, without responding', async () => {
+    const authError = Object.assign(new Error('Not authorized'), { statusCode: 403 });
+    meetingSvc.getAuthorizedRegistrantsForImport.mockRejectedValue(authError);
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
-    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
-  });
-
-  it('rejects when the committee and meeting belong to different projects', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-2' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
-    const res = buildRes();
-    const next = vi.fn();
-
-    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
-    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
-  });
-
-  it('passes through when the caller is a writer on a same-project committee', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
-    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
-    const res = buildRes();
-    const next = vi.fn();
-
-    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
-
-    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(expect.anything(), { resource: 'committee', id: COMMITTEE_UID, access: 'writer' });
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true, 50);
-    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('rejects an authorized import once the roster exceeds the size cap, bounding the fetch itself', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
-    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
-    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
-    meetingSvc.getMeetingRegistrants.mockResolvedValue(Array.from({ length: 51 }, (_, i) => ({ uid: `r${i}`, email: `r${i}@example.com` })));
-    const res = buildRes();
-    const next = vi.fn();
-
-    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
-
-    // maxResults (6th arg) is threaded through so the fetch itself stops early on a large roster,
-    // not just the count check after a full fetch completes.
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true, 50);
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
-    const thrownError = next.mock.calls[0][0];
-    expect(thrownError.validationErrors[0].message).toBe('This meeting has more than 50 registrants — imports are limited to 50 per meeting.');
+    expect(next).toHaveBeenCalledWith(authError);
     expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -1,0 +1,157 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
+const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { meetingSvc, committeeSvc, accessCheckSvc } = vi.hoisted(() => ({
+  meetingSvc: {
+    getMeetingRegistrants: vi.fn(),
+    getMeetingById: vi.fn(),
+  },
+  committeeSvc: {
+    getCommitteeById: vi.fn(),
+  },
+  accessCheckSvc: {
+    checkSingleAccess: vi.fn(),
+  },
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
+vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
+// The real module transitively needs @angular/compiler outside an Angular bootstrap (see
+// meeting.utils.spec.ts); validation.helper only needs resolvePeriodRange from it, so stub that.
+vi.mock('@lfx-one/shared/utils', () => ({ resolvePeriodRange: vi.fn() }));
+
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+vi.mock('../helpers/committee-v1-mapping.helper', () => ({ resolveCommitteeV2UidsToV1Ids: vi.fn() }));
+vi.mock('../helpers/meeting.helper', () => ({
+  addInvitedStatusToMeeting: vi.fn(),
+  applyHostKeyVisibility: vi.fn(),
+  enrichMeetingsWithCreatedBy: vi.fn(),
+  stripHostKey: vi.fn(),
+}));
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return meetingSvc;
+  }),
+}));
+vi.mock('../services/committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return committeeSvc;
+  }),
+}));
+vi.mock('../services/access-check.service', () => ({
+  AccessCheckService: vi.fn(function () {
+    return accessCheckSvc;
+  }),
+}));
+vi.mock('../services/ai.service', () => ({
+  AiService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/nats.service', () => ({
+  NatsService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/user.service', () => ({
+  UserService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { MeetingController } from './meeting.controller';
+
+function buildReq(query: Record<string, string> = {}): any {
+  return { params: { uid: MEETING_UID }, query, path: '/test', log: {} };
+}
+
+function buildRes(): any {
+  return { json: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn() };
+}
+
+describe('MeetingController.getMeetingRegistrants — completeness authorization gate', () => {
+  let controller: MeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new MeetingController();
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+  });
+
+  it('skips the gate for the 3 pre-existing partial-tolerant callers (no fail_on_partial)', async () => {
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({}), res, next);
+
+    expect(committeeSvc.getCommitteeById).not.toHaveBeenCalled();
+    expect(accessCheckSvc.checkSingleAccess).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false);
+    expect(res.json).toHaveBeenCalledWith([]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a complete-roster request with no committee_uid', async () => {
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true' }), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the caller lacks committee writer access', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the committee and meeting belong to different projects', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-2' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+  });
+
+  it('passes through when the caller is a writer on a same-project committee', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(expect.anything(), { resource: 'committee', id: COMMITTEE_UID, access: 'writer' });
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true);
+    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -113,8 +113,8 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
     expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
   });
 
-  it('rejects when the caller lacks committee writer access', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+  it('rejects when the caller lacks writer access and the committee is not invite_only', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'open' });
     meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
     accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
     const res = buildRes();
@@ -124,6 +124,20 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
     expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+  });
+
+  it('passes through for a non-writer on an invite_only committee — mirrors canSendMemberInvites()', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('rejects when the committee and meeting belong to different projects', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -168,4 +168,18 @@ describe('MeetingController.getMeetingRegistrants — completeness authorization
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
     expect(next).not.toHaveBeenCalled();
   });
+
+  it('rejects an authorized import once the roster exceeds the size cap', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    meetingSvc.getMeetingById.mockResolvedValue({ id: MEETING_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue(Array.from({ length: 51 }, (_, i) => ({ uid: `r${i}`, email: `r${i}@example.com` })));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', committee_uid: COMMITTEE_UID }), res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -409,7 +409,10 @@ export class MeetingController {
       // also allowed on invite_only committees — mirroring canSendMemberInvites() client-side — since
       // they're already independently authorized to send invites for that committee (upstream, via
       // their own bearer token, same as createCommitteeInvite always has been), so letting them
-      // populate the invite textarea via import grants no new privilege.
+      // populate the invite textarea via import grants no new privilege. join_mode alone doesn't
+      // prove the caller belongs to the committee, so membership is loaded and checked explicitly —
+      // canSendMemberInvites() requires !isVisitor() (myRole() !== null) client-side; my_role is the
+      // server-side equivalent.
       if (failOnPartial) {
         if (!committeeUid) {
           throw new AuthorizationError('committee_uid is required when requesting a complete registrant roster', {
@@ -419,12 +422,13 @@ export class MeetingController {
         }
 
         const [committee, meeting, isCommitteeWriter] = await Promise.all([
-          this.committeeService.getCommitteeById(req, committeeUid),
+          this.committeeService.getCommitteeById(req, committeeUid, { includeMembership: true }),
           this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: false }),
           this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
         ]);
 
-        const canImport = isCommitteeWriter || committee.join_mode === 'invite_only';
+        const isCommitteeMember = !!committee.my_role;
+        const canImport = isCommitteeWriter || (committee.join_mode === 'invite_only' && isCommitteeMember);
         if (!canImport || committee.project_uid !== meeting.project_uid) {
           throw new AuthorizationError('Not authorized to import registrants for this meeting', {
             operation: 'get_meeting_registrants',
@@ -433,17 +437,25 @@ export class MeetingController {
         }
       }
 
-      // Get the meeting registrants
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);
-
       // A sync fetch-then-invite-fan-out for a large roster risks timeouts and confusing
       // partial-failure states — refuse rather than hand the caller a roster it can't safely act
       // on. Only applies to the import flow (failOnPartial); the 3 partial-tolerant callers render
-      // whatever loaded and are unaffected.
+      // whatever loaded and are unaffected. Bounding the fetch itself (not just the count check
+      // after it) via maxResults keeps a 500-registrant meeting from paging to completion before
+      // being refused — the exact scenario that broke in PCC.
+      const registrants = await this.meetingService.getMeetingRegistrants(
+        req,
+        uid,
+        includeRsvp,
+        occurrenceId,
+        failOnPartial,
+        failOnPartial ? IMPORT_REGISTRANTS_MAX : undefined
+      );
+
       if (failOnPartial && registrants.length > IMPORT_REGISTRANTS_MAX) {
         throw ServiceValidationError.forField(
           'registrants',
-          `This meeting has ${registrants.length} registrants — imports are limited to ${IMPORT_REGISTRANTS_MAX} per meeting.`,
+          `This meeting has more than ${IMPORT_REGISTRANTS_MAX} registrants — imports are limited to ${IMPORT_REGISTRANTS_MAX} per meeting.`,
           { operation: 'get_meeting_registrants', service: 'meeting_controller' }
         );
       }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -21,7 +21,7 @@ import {
 import { NextFunction, Request, Response } from 'express';
 
 import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
-import { ServiceValidationError } from '../errors';
+import { AuthorizationError, ServiceValidationError } from '../errors';
 import { addInvitedStatusToMeeting, applyHostKeyVisibility, enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
@@ -372,16 +372,18 @@ export class MeetingController {
    */
   public async getMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const { include_rsvp, occurrence_id, fail_on_partial } = req.query;
+    const { include_rsvp, occurrence_id, fail_on_partial, committee_uid } = req.query;
     const includeRsvp = include_rsvp === 'true';
     const occurrenceId = typeof occurrence_id === 'string' && occurrence_id.length > 0 ? occurrence_id : undefined;
     const failOnPartial = fail_on_partial === 'true';
+    const committeeUid = typeof committee_uid === 'string' && committee_uid.length > 0 ? committee_uid : undefined;
 
     const startTime = logger.startOperation(req, 'get_meeting_registrants', {
       meeting_id: uid,
       include_rsvp: includeRsvp,
       occurrence_id: occurrenceId,
       fail_on_partial: failOnPartial,
+      committee_id: committeeUid,
     });
 
     try {
@@ -393,6 +395,36 @@ export class MeetingController {
         })
       ) {
         return;
+      }
+
+      // The upstream query-service has no default per-user grant filtering on
+      // v1_meeting_registrant (no filter_grants param is set here), so this endpoint returns any
+      // meeting's full registrant PII to any authenticated caller who supplies its uid — there's
+      // no organizer/registrant relationship required, unlike the sibling getMyMeetingRegistrants.
+      // failOnPartial is only ever set by the committee "import registrants" flow, whose caller has
+      // no such relationship to the target meeting either. Require and verify committee write
+      // access whenever completeness is requested, so that flow can't be used to bulk-harvest
+      // registrant PII from meetings the caller doesn't manage.
+      if (failOnPartial) {
+        if (!committeeUid) {
+          throw new AuthorizationError('committee_uid is required when requesting a complete registrant roster', {
+            operation: 'get_meeting_registrants',
+            service: 'meeting_controller',
+          });
+        }
+
+        const [committee, meeting, isCommitteeWriter] = await Promise.all([
+          this.committeeService.getCommitteeById(req, committeeUid),
+          this.meetingService.getMeetingById(req, uid, 'v1_meeting', false),
+          this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
+        ]);
+
+        if (!isCommitteeWriter || committee.project_uid !== meeting.project_uid) {
+          throw new AuthorizationError('Not authorized to import registrants for this meeting', {
+            operation: 'get_meeting_registrants',
+            service: 'meeting_controller',
+          });
+        }
       }
 
       // Get the meeting registrants

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -402,9 +402,13 @@ export class MeetingController {
       // meeting's full registrant PII to any authenticated caller who supplies its uid — there's
       // no organizer/registrant relationship required, unlike the sibling getMyMeetingRegistrants.
       // failOnPartial is only ever set by the committee "import registrants" flow, whose caller has
-      // no such relationship to the target meeting either. Require and verify committee write
-      // access whenever completeness is requested, so that flow can't be used to bulk-harvest
-      // registrant PII from meetings the caller doesn't manage.
+      // no such relationship to the target meeting either. Require and verify committee access
+      // whenever completeness is requested, so that flow can't be used to bulk-harvest registrant
+      // PII from meetings the caller doesn't manage. Writers always qualify; non-writer members are
+      // also allowed on invite_only committees — mirroring canSendMemberInvites() client-side — since
+      // they're already independently authorized to send invites for that committee (upstream, via
+      // their own bearer token, same as createCommitteeInvite always has been), so letting them
+      // populate the invite textarea via import grants no new privilege.
       if (failOnPartial) {
         if (!committeeUid) {
           throw new AuthorizationError('committee_uid is required when requesting a complete registrant roster', {
@@ -419,7 +423,8 @@ export class MeetingController {
           this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
         ]);
 
-        if (!isCommitteeWriter || committee.project_uid !== meeting.project_uid) {
+        const canImport = isCommitteeWriter || committee.join_mode === 'invite_only';
+        if (!canImport || committee.project_uid !== meeting.project_uid) {
           throw new AuthorizationError('Not authorized to import registrants for this meeting', {
             operation: 'get_meeting_registrants',
             service: 'meeting_controller',

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -420,7 +420,7 @@ export class MeetingController {
 
         const [committee, meeting, isCommitteeWriter] = await Promise.all([
           this.committeeService.getCommitteeById(req, committeeUid),
-          this.meetingService.getMeetingById(req, uid, 'v1_meeting', false),
+          this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: false }),
           this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
         ]);
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { IMPORT_REGISTRANTS_MAX } from '@lfx-one/shared/constants';
 import {
   AttachmentCategory,
   BatchRegistrantOperationResponse,
@@ -398,21 +397,11 @@ export class MeetingController {
         return;
       }
 
-      // The upstream query-service has no default per-user grant filtering on
-      // v1_meeting_registrant (no filter_grants param is set here), so this endpoint returns any
-      // meeting's full registrant PII to any authenticated caller who supplies its uid — there's
-      // no organizer/registrant relationship required, unlike the sibling getMyMeetingRegistrants.
-      // failOnPartial is only ever set by the committee "import registrants" flow, whose caller has
-      // no such relationship to the target meeting either. Require and verify committee access
-      // whenever completeness is requested, so that flow can't be used to bulk-harvest registrant
-      // PII from meetings the caller doesn't manage. Writers always qualify; non-writer members are
-      // also allowed on invite_only committees — mirroring canSendMemberInvites() client-side — since
-      // they're already independently authorized to send invites for that committee (upstream, via
-      // their own bearer token, same as createCommitteeInvite always has been), so letting them
-      // populate the invite textarea via import grants no new privilege. join_mode alone doesn't
-      // prove the caller belongs to the committee, so membership is loaded and checked explicitly —
-      // canSendMemberInvites() requires !isVisitor() (myRole() !== null) client-side; my_role is the
-      // server-side equivalent.
+      // Completeness (failOnPartial) is only ever requested by the committee "import registrants"
+      // flow — that's a privileged, business-logic-heavy path (authorization, size cap), so it's
+      // delegated to MeetingService.getAuthorizedRegistrantsForImport per the three-file pattern
+      // (docs/reviews/backend-checklist.md). The 3 partial-tolerant callers are unaffected.
+      let registrants: MeetingRegistrant[];
       if (failOnPartial) {
         if (!committeeUid) {
           throw new AuthorizationError('committee_uid is required when requesting a complete registrant roster', {
@@ -420,44 +409,9 @@ export class MeetingController {
             service: 'meeting_controller',
           });
         }
-
-        const [committee, meeting, isCommitteeWriter] = await Promise.all([
-          this.committeeService.getCommitteeById(req, committeeUid, { includeMembership: true }),
-          this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: false }),
-          this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
-        ]);
-
-        const isCommitteeMember = !!committee.my_role;
-        const canImport = isCommitteeWriter || (committee.join_mode === 'invite_only' && isCommitteeMember);
-        if (!canImport || committee.project_uid !== meeting.project_uid) {
-          throw new AuthorizationError('Not authorized to import registrants for this meeting', {
-            operation: 'get_meeting_registrants',
-            service: 'meeting_controller',
-          });
-        }
-      }
-
-      // A sync fetch-then-invite-fan-out for a large roster risks timeouts and confusing
-      // partial-failure states — refuse rather than hand the caller a roster it can't safely act
-      // on. Only applies to the import flow (failOnPartial); the 3 partial-tolerant callers render
-      // whatever loaded and are unaffected. Bounding the fetch itself (not just the count check
-      // after it) via maxResults keeps a 500-registrant meeting from paging to completion before
-      // being refused — the exact scenario that broke in PCC.
-      const registrants = await this.meetingService.getMeetingRegistrants(
-        req,
-        uid,
-        includeRsvp,
-        occurrenceId,
-        failOnPartial,
-        failOnPartial ? IMPORT_REGISTRANTS_MAX : undefined
-      );
-
-      if (failOnPartial && registrants.length > IMPORT_REGISTRANTS_MAX) {
-        throw ServiceValidationError.forField(
-          'registrants',
-          `This meeting has more than ${IMPORT_REGISTRANTS_MAX} registrants — imports are limited to ${IMPORT_REGISTRANTS_MAX} per meeting.`,
-          { operation: 'get_meeting_registrants', service: 'meeting_controller' }
-        );
+        registrants = await this.meetingService.getAuthorizedRegistrantsForImport(req, uid, committeeUid);
+      } else {
+        registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);
       }
 
       logger.success(req, 'get_meeting_registrants', startTime, {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { IMPORT_REGISTRANTS_MAX } from '@lfx-one/shared/constants';
 import {
   AttachmentCategory,
   BatchRegistrantOperationResponse,
@@ -434,6 +435,18 @@ export class MeetingController {
 
       // Get the meeting registrants
       const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);
+
+      // A sync fetch-then-invite-fan-out for a large roster risks timeouts and confusing
+      // partial-failure states — refuse rather than hand the caller a roster it can't safely act
+      // on. Only applies to the import flow (failOnPartial); the 3 partial-tolerant callers render
+      // whatever loaded and are unaffected.
+      if (failOnPartial && registrants.length > IMPORT_REGISTRANTS_MAX) {
+        throw ServiceValidationError.forField(
+          'registrants',
+          `This meeting has ${registrants.length} registrants — imports are limited to ${IMPORT_REGISTRANTS_MAX} per meeting.`,
+          { operation: 'get_meeting_registrants', service: 'meeting_controller' }
+        );
+      }
 
       logger.success(req, 'get_meeting_registrants', startTime, {
         meeting_id: uid,

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -372,14 +372,16 @@ export class MeetingController {
    */
   public async getMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const { include_rsvp, occurrence_id } = req.query;
+    const { include_rsvp, occurrence_id, fail_on_partial } = req.query;
     const includeRsvp = include_rsvp === 'true';
     const occurrenceId = typeof occurrence_id === 'string' && occurrence_id.length > 0 ? occurrence_id : undefined;
+    const failOnPartial = fail_on_partial === 'true';
 
     const startTime = logger.startOperation(req, 'get_meeting_registrants', {
       meeting_id: uid,
       include_rsvp: includeRsvp,
       occurrence_id: occurrenceId,
+      fail_on_partial: failOnPartial,
     });
 
     try {
@@ -394,7 +396,7 @@ export class MeetingController {
       }
 
       // Get the meeting registrants
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
+      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);
 
       logger.success(req, 'get_meeting_registrants', startTime, {
         meeting_id: uid,

--- a/apps/lfx-one/src/server/helpers/query-service.helper.ts
+++ b/apps/lfx-one/src/server/helpers/query-service.helper.ts
@@ -54,6 +54,13 @@ export interface FetchAllQueryResourcesOptions {
    * Defaults to false — partial results are returned on later-page failures.
    */
   failOnPartial?: boolean;
+  /**
+   * Stop paging as soon as the accumulated count exceeds this many results, without fetching
+   * further pages. For callers that only need to know "is this over N" (e.g. enforcing a size
+   * cap before an expensive downstream operation) rather than the true total — the returned
+   * array's length is then a lower bound, not the exact count, once it exceeds `maxResults`.
+   */
+  maxResults?: number;
 }
 
 /**
@@ -64,7 +71,9 @@ export interface FetchAllQueryResourcesOptions {
  *
  * By default, returns whatever pages were successfully fetched when a later page
  * fails (partial results). Pass `failOnPartial: true` when completeness is
- * required for correctness.
+ * required for correctness. Pass `maxResults` to stop early once a threshold is
+ * exceeded, bounding the number of upstream calls for callers that only need to
+ * know "is this over N", not the true total.
  *
  * @param req - Express request object for log correlation
  * @param fetchPage - Callback that fetches a single page given an optional page_token
@@ -84,14 +93,14 @@ export async function fetchAllQueryResources<T>(
   fetchPage: (pageToken?: string) => Promise<QueryServiceResponse<T>>,
   options: FetchAllQueryResourcesOptions = {}
 ): Promise<T[]> {
-  const { failOnPartial = false } = options;
+  const { failOnPartial = false, maxResults } = options;
   const results: T[] = [];
 
   let response = await fetchWithRetry(req, () => fetchPage(), { page: 1 });
   results.push(...response.resources.map((resource) => resource.data));
 
   let page = 1;
-  while (response.page_token) {
+  while (response.page_token && !(maxResults !== undefined && results.length > maxResults)) {
     page++;
     logger.debug(req, 'fetch_all_query_resources', 'Fetching next page', {
       page,
@@ -118,7 +127,13 @@ export async function fetchAllQueryResources<T>(
     }
   }
 
-  if (page > 1) {
+  if (maxResults !== undefined && results.length > maxResults) {
+    logger.debug(req, 'fetch_all_query_resources', 'Stopped early — accumulated count exceeded maxResults', {
+      page,
+      accumulated_count: results.length,
+      max_results: maxResults,
+    });
+  } else if (page > 1) {
     logger.debug(req, 'fetch_all_query_resources', 'Pagination complete', {
       total_pages: page,
       total_results: results.length,

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -8,9 +8,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // path alias isn't wired here, so runtime shared subpaths and the constructed collaborators must be
 // mocked (mirrors session-store.service.spec.ts / meeting.helper.spec.ts). Only the
 // microservice-proxy call path is exercised; the query-service pagination helper runs for real.
-const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
+const { proxyRequest, committeeSvc, accessCheckSvc } = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  committeeSvc: { getCommitteeById: vi.fn() },
+  accessCheckSvc: { checkSingleAccess: vi.fn() },
+}));
 
-vi.mock('@lfx-one/shared/enums', () => ({}));
+vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
 vi.mock('@lfx-one/shared/utils', () => ({
   buildRecurrenceNeverEndDate: vi.fn(),
   getPastMeetingTranscriptUrl: vi.fn(),
@@ -23,7 +27,16 @@ vi.mock('./microservice-proxy.service', () => ({
     public proxyRequest = proxyRequest;
   },
 }));
-vi.mock('./access-check.service', () => ({ AccessCheckService: class {} }));
+vi.mock('./access-check.service', () => ({
+  AccessCheckService: vi.fn(function () {
+    return accessCheckSvc;
+  }),
+}));
+vi.mock('./committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return committeeSvc;
+  }),
+}));
 vi.mock('./project.service', () => ({ ProjectService: class {} }));
 vi.mock('../utils/auth-helper', () => ({
   getEffectiveEmail: vi.fn(),
@@ -390,5 +403,85 @@ describe('MeetingService.getMeetingRegistrants', () => {
 
     expect(result).toHaveLength(1);
     expect(proxyRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MeetingService.getAuthorizedRegistrantsForImport', () => {
+  let service: MeetingService;
+
+  const COMMITTEE_UID = 'committee-1';
+  const MEETING_UID = 'meeting-1';
+
+  const registrantRecord = (id: string) => ({ id: `v1_meeting_registrant:${id}`, data: { uid: id, email: `${id}@example.com` } as MeetingRegistrant });
+  // getMeetingById issues exactly one proxyRequest call (no committees on the fixture, so the
+  // committee-name-map enrichment path is skipped).
+  const meetingResponse = (projectUid: string) => ({ id: MEETING_UID, project_uid: projectUid });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    committeeSvc.getCommitteeById.mockReset();
+    accessCheckSvc.checkSingleAccess.mockReset();
+    service = new MeetingService();
+  });
+
+  it('rejects when the caller lacks writer access and the committee is not invite_only', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'open' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1'));
+
+    await expect(service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('passes through for a non-writer *member* on an invite_only committee — mirrors canSendMemberInvites()', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only', my_role: 'Member' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1')).mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    const result = await service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID);
+
+    expect(committeeSvc.getCommitteeById).toHaveBeenCalledWith(req, COMMITTEE_UID, { includeMembership: true });
+    expect(result).toHaveLength(1);
+  });
+
+  it('rejects a non-writer, non-member on an invite_only committee — join_mode alone does not prove membership', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1', join_mode: 'invite_only' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1'));
+
+    await expect(service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('rejects when the committee and meeting belong to different projects', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-2'));
+
+    await expect(service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('passes through when the caller is a writer on a same-project committee', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1')).mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    const result = await service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID);
+
+    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'committee', id: COMMITTEE_UID, access: 'writer' });
+    expect(result).toEqual([{ uid: 'a', email: 'a@example.com' }]);
+  });
+
+  it('rejects an authorized import once the roster exceeds the size cap, bounding the fetch itself', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    const bigPage = { resources: Array.from({ length: 51 }, (_, i) => registrantRecord(`r${i}`)) };
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1')).mockResolvedValueOnce(bigPage);
+
+    await expect(service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID)).rejects.toMatchObject({
+      statusCode: 400,
+      validationErrors: [expect.objectContaining({ message: 'This meeting has more than 50 registrants — imports are limited to 50 per meeting.' })],
+    });
+    // maxResults bounds the fetch itself: one page already exceeds the cap, so pagination never
+    // continues even though the fixture's single page doesn't set page_token either way.
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -369,4 +369,26 @@ describe('MeetingService.getMeetingRegistrants', () => {
 
     await expect(service.getMeetingRegistrants(req, 'meeting-1', false, undefined, true)).rejects.toThrow('query service down');
   });
+
+  it('stops paging once the roster exceeds maxResults, without fetching remaining pages', async () => {
+    proxyRequest
+      .mockResolvedValueOnce({ resources: [registrantRecord('a'), registrantRecord('b')], page_token: 'next' })
+      .mockResolvedValueOnce({ resources: [registrantRecord('c')], page_token: 'next-2' });
+
+    const result = await service.getMeetingRegistrants(req, 'meeting-1', false, undefined, true, 2);
+
+    // Exceeded maxResults (2) after page 2 (3 accumulated) — page 3 is never requested even
+    // though page_token: 'next-2' would otherwise continue pagination.
+    expect(result).toHaveLength(3);
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('pages to completion when the roster stays within maxResults', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    const result = await service.getMeetingRegistrants(req, 'meeting-1', false, undefined, true, 50);
+
+    expect(result).toHaveLength(1);
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { Meeting, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type { Meeting, MeetingRegistrant, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
@@ -342,5 +342,31 @@ describe('MeetingService.addMeetingRegistrantSelf', () => {
     expect(body).toMatchObject({ org: 'Linux Foundation', job_title: 'Engineer', occurrence: 'occ-42' });
     expect(body).not.toHaveProperty('org_name');
     expect(body).not.toHaveProperty('occurrence_id');
+  });
+});
+
+describe('MeetingService.getMeetingRegistrants', () => {
+  let service: MeetingService;
+
+  const registrantRecord = (id: string) => ({ id: `v1_meeting_registrant:${id}`, data: { uid: id, email: `${id}@example.com` } as MeetingRegistrant });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('returns the partial roster by default when a later page fails', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')], page_token: 'next' }).mockRejectedValueOnce(new Error('query service down'));
+
+    const result = await service.getMeetingRegistrants(req, 'meeting-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe('a');
+  });
+
+  it('rejects instead of returning a truncated roster when failOnPartial is true', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')], page_token: 'next' }).mockRejectedValueOnce(new Error('query service down'));
+
+    await expect(service.getMeetingRegistrants(req, 'meeting-1', false, undefined, true)).rejects.toThrow('query service down');
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -599,8 +599,18 @@ export class MeetingService {
    *   caller is rendering; when omitted, each registrant's most recent RSVP is
    *   returned regardless of scope — correct only for non-recurring meetings or
    *   aggregate views. See LFXV2-2864 for the seconds↔ms unit mismatch.
+   * @param failOnPartial - If true, throw instead of returning a truncated roster when a
+   *   later page fails. Callers that rely on the complete list for correctness (e.g.
+   *   importing every registrant) should set this; default preserves the existing
+   *   partial-tolerant behavior for callers that just render whatever loaded.
    */
-  public async getMeetingRegistrants(req: Request, meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Promise<MeetingRegistrant[]> {
+  public async getMeetingRegistrants(
+    req: Request,
+    meetingUid: string,
+    includeRsvp: boolean = false,
+    occurrenceId?: string,
+    failOnPartial: boolean = false
+  ): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
     const params: Record<string, any> = {
@@ -610,11 +620,14 @@ export class MeetingService {
 
     logger.debug(req, 'get_meeting_registrants', 'Fetching meeting registrants', { meeting_id: meetingUid, params });
 
-    let registrants = await fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    let registrants = await fetchAllQueryResources<MeetingRegistrant>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          ...params,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial }
     );
 
     // If include_rsvp is true, fetch RSVP data and attach to registrants.

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { IMPORT_REGISTRANTS_MAX } from '@lfx-one/shared/constants';
 import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   ApiResponse,
@@ -49,11 +50,12 @@ import {
 } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { ResourceNotFoundError } from '../errors';
+import { AuthorizationError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
+import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
@@ -63,11 +65,13 @@ import { ProjectService } from './project.service';
  */
 export class MeetingService {
   private accessCheckService: AccessCheckService;
+  private committeeService: CommitteeService;
   private microserviceProxy: MicroserviceProxyService;
   private projectService: ProjectService;
 
   public constructor() {
     this.accessCheckService = new AccessCheckService();
+    this.committeeService = new CommitteeService();
     this.microserviceProxy = new MicroserviceProxyService();
     this.projectService = new ProjectService();
   }
@@ -668,6 +672,56 @@ export class MeetingService {
           err: error,
         });
       }
+    }
+
+    return registrants;
+  }
+
+  /**
+   * Fetches a meeting's complete registrant roster for the committee "import registrants" flow
+   * (LFXV2-2607), enforcing the authorization and size-cap rules that gate it. Business logic
+   * lives here rather than in the controller per the three-file pattern
+   * (docs/reviews/backend-checklist.md) — this orchestrates two domain resources plus an access
+   * check and a security-critical decision, not just HTTP request/response handling.
+   *
+   * The upstream query-service has no default per-user grant filtering on v1_meeting_registrant,
+   * so `getMeetingRegistrants` with `failOnPartial: true` would otherwise return any meeting's
+   * full registrant PII to any authenticated caller who supplies its uid. Requires the caller to
+   * either have writer access on `committeeUid`, or be a member of it when it's invite_only
+   * (mirroring `canSendMemberInvites()` client-side — those callers are already independently
+   * authorized to send invites for that committee upstream, via their own bearer token, so
+   * letting them populate the invite textarea via import grants no new privilege). Also requires
+   * the committee and meeting to share a project, and refuses rosters over `IMPORT_REGISTRANTS_MAX`
+   * — a sync fetch-then-invite-fan-out for a large roster risks timeouts and confusing
+   * partial-failure states (this exact failure mode broke in PCC).
+   *
+   * @throws AuthorizationError if the caller isn't authorized, per the rules above.
+   * @throws ServiceValidationError if the roster exceeds IMPORT_REGISTRANTS_MAX.
+   */
+  public async getAuthorizedRegistrantsForImport(req: Request, meetingUid: string, committeeUid: string): Promise<MeetingRegistrant[]> {
+    const [committee, meeting, isCommitteeWriter] = await Promise.all([
+      this.committeeService.getCommitteeById(req, committeeUid, { includeMembership: true }),
+      this.getMeetingById(req, meetingUid, 'v1_meeting', { access: false }),
+      this.accessCheckService.checkSingleAccess(req, { resource: 'committee', id: committeeUid, access: 'writer' }),
+    ]);
+
+    const isCommitteeMember = !!committee.my_role;
+    const canImport = isCommitteeWriter || (committee.join_mode === 'invite_only' && isCommitteeMember);
+    if (!canImport || committee.project_uid !== meeting.project_uid) {
+      throw new AuthorizationError('Not authorized to import registrants for this meeting', {
+        operation: 'get_authorized_registrants_for_import',
+        service: 'meeting_service',
+      });
+    }
+
+    const registrants = await this.getMeetingRegistrants(req, meetingUid, false, undefined, true, IMPORT_REGISTRANTS_MAX);
+
+    if (registrants.length > IMPORT_REGISTRANTS_MAX) {
+      throw ServiceValidationError.forField(
+        'registrants',
+        `This meeting has more than ${IMPORT_REGISTRANTS_MAX} registrants — imports are limited to ${IMPORT_REGISTRANTS_MAX} per meeting.`,
+        { operation: 'get_authorized_registrants_for_import', service: 'meeting_service' }
+      );
     }
 
     return registrants;

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -603,13 +603,18 @@ export class MeetingService {
    *   later page fails. Callers that rely on the complete list for correctness (e.g.
    *   importing every registrant) should set this; default preserves the existing
    *   partial-tolerant behavior for callers that just render whatever loaded.
+   * @param maxResults - If set, stop paging once the accumulated count exceeds this many
+   *   registrants — bounds upstream calls for callers that only need to know "is this over N"
+   *   (e.g. enforcing a size cap) rather than the true total. The returned array's length is a
+   *   lower bound, not an exact count, once it exceeds `maxResults`.
    */
   public async getMeetingRegistrants(
     req: Request,
     meetingUid: string,
     includeRsvp: boolean = false,
     occurrenceId?: string,
-    failOnPartial: boolean = false
+    failOnPartial: boolean = false,
+    maxResults?: number
   ): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
@@ -627,7 +632,7 @@ export class MeetingService {
           ...params,
           ...(pageToken && { page_token: pageToken }),
         }),
-      { failOnPartial }
+      { failOnPartial, maxResults }
     );
 
     // If include_rsvp is true, fetch RSVP data and attach to registrants.

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -13,6 +13,14 @@ import { lfxColors } from './colors.constants';
 export const MEETING_ORGANIZER_SKIP_IDENTIFIERS = ['zoom.webhooks', 'zoom.events'];
 
 /**
+ * Upper bound on registrants a single "import from a meeting" (LFXV2-2607) can pull in. A sync
+ * BFF fetch-then-invite-fan-out for a large roster (100s-1000s of registrants) risks timeouts and
+ * confusing partial-failure states — the same failure mode that broke this feature in PCC. Above
+ * this, the import is refused rather than attempted; see meeting.controller.ts:getMeetingRegistrants.
+ */
+export const IMPORT_REGISTRANTS_MAX = 50;
+
+/**
  * Host-key visibility window — minutes before meeting start when the key becomes visible.
  * Mirrors PCC's showHostKey() logic. The Zoom host key is account-level and can change
  * leading up to a meeting, so exposing it too early risks showing a stale value.

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -482,10 +482,6 @@ export interface MeetingTemplateGroup {
 }
 
 /**
- * Meeting registrant information from microproxy service
- * @description Individual registrant/guest for a meeting
- */
-/**
  * Dropdown option for the "import registrants from a meeting" picker (LFXV2-2607).
  * `label` is the display string (title + date); `title` is kept separately so
  * import summaries can name the meeting cleanly.
@@ -511,6 +507,10 @@ export interface RegistrantEmailExtraction {
   skippedNoEmail: number;
 }
 
+/**
+ * Meeting registrant information from microproxy service
+ * @description Individual registrant/guest for a meeting
+ */
 export interface MeetingRegistrant {
   /** Unique identifier for the registrant (auto-generated) */
   uid: string;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -485,6 +485,32 @@ export interface MeetingTemplateGroup {
  * Meeting registrant information from microproxy service
  * @description Individual registrant/guest for a meeting
  */
+/**
+ * Dropdown option for the "import registrants from a meeting" picker (LFXV2-2607).
+ * `label` is the display string (title + date); `title` is kept separately so
+ * import summaries can name the meeting cleanly.
+ */
+export interface MeetingSelectOption {
+  /** Meeting id passed to the registrants fetch */
+  value: string;
+  /** Display label, e.g. "Q3 Roadmap — Jul 3, 2026" */
+  label: string;
+  /** Bare meeting title, for summary copy */
+  title: string;
+}
+
+/**
+ * Result of pulling invite-ready emails off a meeting's registrant list.
+ * `emails` is de-duplicated (case-insensitive, first-seen casing preserved);
+ * `skippedNoEmail` counts registrants that carried no usable email.
+ */
+export interface RegistrantEmailExtraction {
+  /** Unique, trimmed registrant emails ready to feed the invite flow */
+  emails: string[];
+  /** Count of registrants skipped because they had no email */
+  skippedNoEmail: number;
+}
+
 export interface MeetingRegistrant {
   /** Unique identifier for the registrant (auto-generated) */
   uid: string;

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -25,6 +25,7 @@ import type {
   MeetingCommittee,
   MeetingOccurrence,
   MeetingRecurrence,
+  MeetingRegistrant,
   PastMeeting,
   PastMeetingSummary,
   PastOccurrenceSummary,
@@ -43,6 +44,7 @@ import {
   collectMeetingOrganizers,
   compareMeetingPeopleByHostThenName,
   convertRecurrenceToPattern,
+  extractRegistrantEmails,
   getMeetingEditCommands,
   getMeetingOrganizerDisplayName,
   isCalendarDeadlinePast,
@@ -1139,5 +1141,39 @@ describe('sanitizeMeetingCommitteeUids', () => {
 
   it('drops null, undefined, and blank uids', () => {
     expect(sanitizeMeetingCommitteeUids([null, undefined, '', '   ', 'group-1', 'group-2'])).toEqual(['group-1', 'group-2']);
+  });
+});
+
+/** Builds a minimal MeetingRegistrant fixture; extractRegistrantEmails only reads `email`. */
+function registrant(email: string): MeetingRegistrant {
+  return { email } as MeetingRegistrant;
+}
+
+describe('extractRegistrantEmails', () => {
+  it('returns trimmed emails and counts registrants with no email', () => {
+    const result = extractRegistrantEmails([registrant('a@example.com'), registrant('  b@example.com  '), registrant(''), registrant('   ')]);
+
+    expect(result.emails).toEqual(['a@example.com', 'b@example.com']);
+    expect(result.skippedNoEmail).toBe(2);
+  });
+
+  it('de-duplicates case-insensitively, preserving first-seen casing', () => {
+    const result = extractRegistrantEmails([registrant('Person@Example.com'), registrant('person@example.com'), registrant('PERSON@EXAMPLE.COM')]);
+
+    expect(result.emails).toEqual(['Person@Example.com']);
+    expect(result.skippedNoEmail).toBe(0);
+  });
+
+  it('handles an all-blank roster', () => {
+    const result = extractRegistrantEmails([registrant(''), registrant('  '), registrant(undefined as unknown as string)]);
+
+    expect(result.emails).toEqual([]);
+    expect(result.skippedNoEmail).toBe(3);
+  });
+
+  it('returns an empty result for empty or nullish input', () => {
+    expect(extractRegistrantEmails([])).toEqual({ emails: [], skippedNoEmail: 0 });
+    expect(extractRegistrantEmails(null)).toEqual({ emails: [], skippedNoEmail: 0 });
+    expect(extractRegistrantEmails(undefined)).toEqual({ emails: [], skippedNoEmail: 0 });
   });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -39,12 +39,14 @@ import {
   getMeetingSeriesUid,
   buildMeetingOrganizerChip,
   buildMeetingOrganizerMailto,
+  buildImportSummary,
   buildRecurrenceNeverEndDate,
   buildRecurrenceSummary,
   collectMeetingOrganizers,
   compareMeetingPeopleByHostThenName,
   convertRecurrenceToPattern,
   extractRegistrantEmails,
+  filterUnlistedEmails,
   getMeetingEditCommands,
   getMeetingOrganizerDisplayName,
   isCalendarDeadlinePast,
@@ -1175,5 +1177,51 @@ describe('extractRegistrantEmails', () => {
     expect(extractRegistrantEmails([])).toEqual({ emails: [], skippedNoEmail: 0 });
     expect(extractRegistrantEmails(null)).toEqual({ emails: [], skippedNoEmail: 0 });
     expect(extractRegistrantEmails(undefined)).toEqual({ emails: [], skippedNoEmail: 0 });
+  });
+});
+
+describe('filterUnlistedEmails', () => {
+  it('drops emails already present in alreadyListed, case-insensitively', () => {
+    const result = filterUnlistedEmails(['a@example.com', 'B@Example.com', 'c@example.com'], ['a@example.com', 'b@example.com']);
+
+    expect(result).toEqual(['c@example.com']);
+  });
+
+  it('returns all emails unchanged when alreadyListed is empty', () => {
+    expect(filterUnlistedEmails(['a@example.com'], [])).toEqual(['a@example.com']);
+  });
+
+  it('returns an empty array when emails is empty', () => {
+    expect(filterUnlistedEmails([], ['a@example.com'])).toEqual([]);
+  });
+});
+
+describe('buildImportSummary', () => {
+  it('reports a single added address in singular form', () => {
+    expect(buildImportSummary('Q3 Roadmap', 1, 0, 0)).toBe('Added 1 address from "Q3 Roadmap".');
+  });
+
+  it('reports multiple added addresses in plural form', () => {
+    expect(buildImportSummary('Q3 Roadmap', 3, 0, 0)).toBe('Added 3 addresses from "Q3 Roadmap".');
+  });
+
+  it('appends an already-listed count when present', () => {
+    expect(buildImportSummary('Q3 Roadmap', 2, 1, 0)).toBe('Added 2 addresses from "Q3 Roadmap" — 1 already listed.');
+  });
+
+  it('appends a singular skipped-no-email note', () => {
+    expect(buildImportSummary('Q3 Roadmap', 2, 0, 1)).toBe('Added 2 addresses from "Q3 Roadmap" — 1 registrant had no email and was skipped.');
+  });
+
+  it('appends a plural skipped-no-email note', () => {
+    expect(buildImportSummary('Q3 Roadmap', 2, 0, 3)).toBe('Added 2 addresses from "Q3 Roadmap" — 3 registrants had no email and were skipped.');
+  });
+
+  it('combines already-listed and skipped-no-email notes', () => {
+    expect(buildImportSummary('Q3 Roadmap', 1, 2, 1)).toBe('Added 1 address from "Q3 Roadmap" — 2 already listed — 1 registrant had no email and was skipped.');
+  });
+
+  it('reports zero added addresses in plural form', () => {
+    expect(buildImportSummary('Q3 Roadmap', 0, 4, 0)).toBe('Added 0 addresses from "Q3 Roadmap" — 4 already listed.');
   });
 });

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -30,6 +30,7 @@ import type {
   MeetingOrganizerChipModel,
   MeetingOrganizerLink,
   MeetingRecurrence,
+  MeetingRegistrant,
   MeetingUserInfo,
   OccurrenceNavItem,
   PastMeeting,
@@ -38,6 +39,7 @@ import type {
   PublicMeetingOccurrencesResponse,
   QueryServiceItem,
   RecurrenceSummary,
+  RegistrantEmailExtraction,
   SummaryData,
   TranscriptCue,
   User,
@@ -74,6 +76,35 @@ export function isRecurrenceNeverEndSentinel(endDateTime: string | null | undefi
   const end = new Date(endDateTime).getTime();
   if (!Number.isFinite(end)) return false;
   return end - Date.now() >= FIFTY_YEARS_MS;
+}
+
+/**
+ * Pulls invite-ready emails off a meeting's registrant list (LFXV2-2607).
+ * Trims each email, drops blanks (counting them as skipped so the UI can report
+ * "N registrants had no email"), and de-duplicates case-insensitively while
+ * preserving the first-seen casing. The caller feeds `emails` into the existing
+ * invite dedupe/fan-out, so this deliberately does no member/invite matching.
+ */
+export function extractRegistrantEmails(registrants: MeetingRegistrant[] | null | undefined): RegistrantEmailExtraction {
+  const emails: string[] = [];
+  const seen = new Set<string>();
+  let skippedNoEmail = 0;
+
+  for (const registrant of registrants ?? []) {
+    const email = (registrant?.email ?? '').trim();
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    const key = email.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    emails.push(email);
+  }
+
+  return { emails, skippedNoEmail };
 }
 
 /**

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -107,6 +107,24 @@ export function extractRegistrantEmails(registrants: MeetingRegistrant[] | null 
   return { emails, skippedNoEmail };
 }
 
+/** Filters `emails` down to those not already present (case-insensitively) in `alreadyListed`. */
+export function filterUnlistedEmails(emails: string[], alreadyListed: string[]): string[] {
+  const listed = new Set(alreadyListed.map((email) => email.toLowerCase()));
+  return emails.filter((email) => !listed.has(email.toLowerCase()));
+}
+
+/** Compose the import result line: how many were added, already listed, and skipped for no email. */
+export function buildImportSummary(meetingTitle: string, added: number, alreadyListed: number, skippedNoEmail: number): string {
+  const parts: string[] = [added === 1 ? `Added 1 address from "${meetingTitle}"` : `Added ${added} addresses from "${meetingTitle}"`];
+  if (alreadyListed > 0) {
+    parts.push(`${alreadyListed} already listed`);
+  }
+  if (skippedNoEmail > 0) {
+    parts.push(skippedNoEmail === 1 ? '1 registrant had no email and was skipped' : `${skippedNoEmail} registrants had no email and were skipped`);
+  }
+  return `${parts.join(' — ')}.`;
+}
+
 /**
  * Build a human-readable recurrence summary from custom recurrence pattern
  * @param pattern The custom recurrence pattern


### PR DESCRIPTION
## LFXV2-2607 — Import meeting registrants into a group

Lets a group manager pull a meeting's registrants into the group instead of re-typing them. Today linking is one-way only (committee → meeting via `MeetingCommitteeManagerComponent`); there was no registrants → group path. A real manager (Connie, Velocity Engine) built the meeting roster first and faced full manual re-entry into the group.

## What changed
Adds an optional **"Import from a meeting"** picker to the committee `AddMemberDialogComponent`:
- Lists meetings in the committee's project via the existing `MeetingService.getMeetingsByProject` endpoint.
- On **Import**, `getMeetingRegistrants` returns the full roster (the BFF auto-pages internally), and a new shared util `extractRegistrantEmails` trims, de-dupes case-insensitively, and counts registrants with no email.
- The resulting emails are appended to the dialog's existing `emails` textarea, so they flow through the **existing** parse → dedupe (already-member / already-invited / invalid) → preview → bounded-concurrency invite fan-out unchanged. No invite logic is duplicated.

## Decisions (per ticket)
- **No new BFF routes** — reuses `getMeetingsByProject` and `getMeetingRegistrants`.
- **Invite-based only** — direct add is out of scope (LFXV2-2227).
- **No role/org prefill** from the registrant record in v1 — import contributes emails only.
- **Registrants without an email are skipped** and surfaced in the import summary line.
- **Large rosters — capped at 50** (updated after review) — a sync fetch-then-invite-fan-out for meetings with 100s-1000s of registrants risks timeouts and confusing partial-failure states (this exact failure mode broke in PCC per @jordane). The server now refuses the import above `IMPORT_REGISTRANTS_MAX` (50) registrants rather than attempting it.

## No 2606 / commit 9d497dc dependency
The ticket noted `existingInvites` might depend on a pending `getCommitteeInvites()` from PR #1078 (feat/LFXV2-2606-wizard-bulk-invite). That does not apply to this surface: `getCommitteeInvites()` is already on `main` and this dialog's member+invite dedupe was already wired. Commit `9d497dc` is a separate dedupe fix in `committee-members-manager.component.ts`, unrelated here. No rebase or cherry-pick.

## Tests
- New Vitest cases for `extractRegistrantEmails` (mixed valid/blank, case-insensitive dedupe, all-blank, empty/nullish).
- `yarn check-types`, `yarn lint`, `yarn build` (SSR bundle) all pass.

Draft: pending integration validation before marking ready for review.
