### PR TITLE
fix(committees): sort past meetings by most-recent-first

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -107,8 +107,10 @@ export class CommitteeMeetingsComponent {
       filter(({ time, uid }) => time === 'past' && !!uid),
       distinctUntilChanged((a, b) => a.uid === b.uid),
       tap(() => this.pastMeetingsLoading.set(true)),
-      // Sort client-side: the query-service can't sort past meetings by start_time (only name/updated),
-      // so the descending date order must be applied here to render most-recent-first. (LFXV2-2053)
+      // NAME_DESC sorts by sort_name, which the meeting-service indexer populates with each
+      // occurrence's series-template start_time — not its actual scheduled_start_time. For a
+      // recurring committee's past occurrences those can diverge, so re-sort client-side by
+      // scheduled_start_time to guarantee true most-recent-first order. (LFXV2-2053)
       switchMap(({ uid }) =>
         this.meetingService.getPastMeetingsByCommittee(uid!, PAST_MEETING_SORT.NAME_DESC).pipe(
           map((meetings) => sortPastMeetingsDescending(meetings)),

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -13,7 +13,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
+import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
 import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
 import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
@@ -110,7 +110,7 @@ export class CommitteeMeetingsComponent {
       // Sort client-side: the query-service can't sort past meetings by start_time (only name/updated),
       // so the descending date order must be applied here to render most-recent-first. (LFXV2-2053)
       switchMap(({ uid }) =>
-        this.meetingService.getPastMeetingsByCommittee(uid!, 'name_desc').pipe(
+        this.meetingService.getPastMeetingsByCommittee(uid!, PAST_MEETING_SORT.NAME_DESC).pipe(
           map((meetings) => sortPastMeetingsDescending(meetings)),
           finalize(() => this.pastMeetingsLoading.set(false))
         )
@@ -287,7 +287,9 @@ export class CommitteeMeetingsComponent {
           forkJoin({
             votes: this.voteService.getVotesByCommittee(committeeUid!).pipe(catchError(() => of([] as Vote[]))),
             surveys: this.surveyService.getSurveysByCommittee(committeeUid!).pipe(catchError(() => of([] as Survey[]))),
-            pastMeetings: this.meetingService.getPastMeetingsByCommittee(committeeUid!, 'name_desc').pipe(catchError(() => of([] as PastMeeting[]))),
+            pastMeetings: this.meetingService
+              .getPastMeetingsByCommittee(committeeUid!, PAST_MEETING_SORT.NAME_DESC)
+              .pipe(catchError(() => of([] as PastMeeting[]))),
           }).pipe(finalize(() => this.calendarLoading.set(false)))
         ),
         tap(() => this.calendarLoading.set(false))

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -110,7 +110,7 @@ export class CommitteeMeetingsComponent {
       // Sort client-side: the query-service can't sort past meetings by start_time (only name/updated),
       // so the descending date order must be applied here to render most-recent-first. (LFXV2-2053)
       switchMap(({ uid }) =>
-        this.meetingService.getPastMeetingsByCommittee(uid!).pipe(
+        this.meetingService.getPastMeetingsByCommittee(uid!, 'name_desc').pipe(
           map((meetings) => sortPastMeetingsDescending(meetings)),
           finalize(() => this.pastMeetingsLoading.set(false))
         )
@@ -287,7 +287,7 @@ export class CommitteeMeetingsComponent {
           forkJoin({
             votes: this.voteService.getVotesByCommittee(committeeUid!).pipe(catchError(() => of([] as Vote[]))),
             surveys: this.surveyService.getSurveysByCommittee(committeeUid!).pipe(catchError(() => of([] as Survey[]))),
-            pastMeetings: this.meetingService.getPastMeetingsByCommittee(committeeUid!).pipe(catchError(() => of([] as PastMeeting[]))),
+            pastMeetings: this.meetingService.getPastMeetingsByCommittee(committeeUid!, 'name_desc').pipe(catchError(() => of([] as PastMeeting[]))),
           }).pipe(finalize(() => this.calendarLoading.set(false)))
         ),
         tap(() => this.calendarLoading.set(false))

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -7,7 +7,13 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PENDING_ACTION_EMPTY_GRACE_MS, PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL, PENDING_ACTION_SEVERITY } from '@lfx-one/shared/constants';
+import {
+  PAST_MEETING_SORT,
+  PENDING_ACTION_EMPTY_GRACE_MS,
+  PENDING_ACTION_FADE_OUT_MS,
+  PENDING_ACTION_LABEL,
+  PENDING_ACTION_SEVERITY,
+} from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import { Committee, CommitteeMember, CommitteePendingActionRow, Meeting, PastMeeting, PendingActionItem, Survey, Vote } from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
@@ -398,7 +404,7 @@ export class CommitteeOverviewComponent {
         filter((c) => !!c?.uid),
         switchMap((c) => {
           this.pastMeetingsLoading.set(true);
-          return this.meetingService.getPastMeetingsByCommittee(c.uid, 'name_desc').pipe(
+          return this.meetingService.getPastMeetingsByCommittee(c.uid, PAST_MEETING_SORT.NAME_DESC).pipe(
             catchError(() => of([])),
             finalize(() => this.pastMeetingsLoading.set(false))
           );

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -398,7 +398,7 @@ export class CommitteeOverviewComponent {
         filter((c) => !!c?.uid),
         switchMap((c) => {
           this.pastMeetingsLoading.set(true);
-          return this.meetingService.getPastMeetingsByCommittee(c.uid, 'updated_desc').pipe(
+          return this.meetingService.getPastMeetingsByCommittee(c.uid, 'name_desc').pipe(
             catchError(() => of([])),
             finalize(() => this.pastMeetingsLoading.set(false))
           );

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { LINKEDIN_PROFILE_PATTERN } from '@lfx-one/shared/constants';
+import { LINKEDIN_PROFILE_PATTERN, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import {
   AttachmentDownloadUrlResponse,
   BatchRegistrantOperationResponse,
@@ -29,6 +29,7 @@ import {
   PastMeetingAttachment,
   PastMeetingParticipant,
   PastMeetingRecording,
+  PastMeetingSort,
   PastMeetingTranscript,
   PastMeetingTranscriptContent,
   PastMeetingSummary,
@@ -134,7 +135,7 @@ export class MeetingService {
    * (e.g. `updated_desc`). The `order` param with dot-notation is only for `/api/meetings`
    * which proxies to the meeting service.
    */
-  public getPastMeetingsByCommittee(committeeId: string, sort?: string): Observable<PastMeeting[]> {
+  public getPastMeetingsByCommittee(committeeId: string, sort?: PastMeetingSort): Observable<PastMeeting[]> {
     let params = new HttpParams().set('tags', `committee_uid:${committeeId}`);
 
     if (sort) {
@@ -173,7 +174,7 @@ export class MeetingService {
   }
 
   public getPastMeetingsByProject(uid: string): Observable<PastMeeting[]> {
-    const params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', 'name_desc');
+    const params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', PAST_MEETING_SORT.NAME_DESC);
 
     return this.getPastMeetings(params).pipe(map((response) => response.data));
   }
@@ -209,7 +210,7 @@ export class MeetingService {
     searchName?: string,
     filters?: string[]
   ): Observable<PaginatedResponse<PastMeeting>> {
-    let params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', 'name_desc');
+    let params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', PAST_MEETING_SORT.NAME_DESC);
     if (pageToken) {
       params = params.set('page_token', pageToken);
     }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -520,3 +520,19 @@ export const LATEST_PAST_MEETINGS_FETCH_SIZE = 10;
  * filter. Five is the row count surfaced by the dashboard Last Meeting / past-meetings card.
  */
 export const LATEST_PAST_MEETINGS_RETURN_LIMIT = 5;
+
+// ============================================================================
+// Past Meeting Sort Values
+// ============================================================================
+
+/**
+ * Query-service `sort` values for the `v1_past_meeting` resource type.
+ * @description The meeting-service indexer populates `sort_name` with the meeting's RFC3339 UTC
+ * `start_time` (not the literal meeting title), so `NAME_DESC` sorts most-recent-first.
+ */
+export const PAST_MEETING_SORT = {
+  NAME_DESC: 'name_desc',
+  NAME_ASC: 'name_asc',
+  UPDATED_DESC: 'updated_desc',
+  UPDATED_ASC: 'updated_asc',
+} as const;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { PAST_MEETING_SORT } from '../constants/meeting.constants';
 import { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
 import { TagSeverity } from './components.interface';
 
@@ -1193,3 +1194,9 @@ export interface MeetingTypeBadge {
   styleClass?: string;
   icon?: string;
 }
+
+/**
+ * Query-service `sort` value for the `v1_past_meeting` resource type.
+ * Derived from the {@link PAST_MEETING_SORT} constant so the union stays in sync with it.
+ */
+export type PastMeetingSort = (typeof PAST_MEETING_SORT)[keyof typeof PAST_MEETING_SORT];

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PAST_MEETING_SORT } from '../constants/meeting.constants';
+import type { PAST_MEETING_SORT } from '../constants/meeting.constants';
 import { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
 import { TagSeverity } from './components.interface';
 


### PR DESCRIPTION
## Summary
- Committee past-meeting queries were requesting no sort (list/calendar views) or `sort=updated_desc` (overview last-meeting card), so the query-service returned past meetings in the wrong order — or truncated the page before the true most-recent meeting.
- Changed all three `getPastMeetingsByCommittee()` call sites to pass `sort=name_desc`, matching the existing convention already used for project-scoped past meetings (`getPastMeetingsByProject`, `getPastMeetingsByProjectPaginated`), where the query-service's `sort_name` field is derived from `start_time`.

## Ticket
[LFXV2-2053](https://linuxfoundation.atlassian.net/browse/LFXV2-2053)

## Test plan
- [x] `yarn check-types`
- [x] `yarn lint`
- [x] `yarn build`
- [ ] Manually verify committee past-meetings list, calendar view, and overview "last meeting" card render most-recent-first

[LFXV2-2053]: https://linuxfoundation.atlassian.net/browse/LFXV2-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order and query-parameter changes only; no auth or data writes. Residual risk is wrong “last meeting” or list order if manual QA misses recurring edge cases.
> 
> **Overview**
> Fixes **committee past-meeting ordering** (LFXV2-2053) by standardizing query-service sort and tightening types.
> 
> **Committee UI** now passes `PAST_MEETING_SORT.NAME_DESC` (`name_desc`) on every `getPastMeetingsByCommittee` call—past list, calendar lazy-load, and overview (replacing missing sort or `updated_desc`). That aligns with project-scoped past meetings, where `sort_name` is indexed from meeting `start_time` for most-recent-first pages.
> 
> **Shared layer** adds `PAST_MEETING_SORT` and a `PastMeetingSort` type; `MeetingService.getPastMeetingsByCommittee` and project past-meeting helpers use the constant instead of raw strings.
> 
> The **past-meetings list** still runs `sortPastMeetingsDescending` after fetch because `name_desc` can follow series-template `start_time` rather than each occurrence’s `scheduled_start_time` for recurring committees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01422293dadaab6e14013ab831436cb1ef2c8a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->