### PR TITLE
fix(meetings): stop UTC flash on join page date/time badge (LFXV2-2540)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -157,11 +157,15 @@
                   <!-- Date/Time Badge -->
                   @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
                     <div class="flex items-center gap-3">
-                      <lfx-tag
-                        [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact'"
-                        severity="secondary"
-                        icon="fa-light fa-calendar-days"
-                        [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                      @if (userTimezone(); as tz) {
+                        <lfx-tag
+                          [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact' : tz"
+                          severity="secondary"
+                          icon="fa-light fa-calendar-days"
+                          [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                      } @else {
+                        <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
+                      }
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, isPlatformBrowser, isPlatformServer, NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
+import { DatePipe, isPlatformServer, NgClass } from '@angular/common';
+import { afterNextRender, Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -324,12 +324,16 @@ export class MeetingJoinComponent implements OnInit {
     this.parentProject = this.initializeParentProject();
     this.initializeAutoJoin();
     this.initializePublicMeetingPageviewTracking();
+
+    // Runs only in the browser after the first render, so the SSR skeleton
+    // hydrates first and only then swaps to the timezone-formatted tag —
+    // avoids a hydration DOM mismatch (LFXV2-2540).
+    afterNextRender(() => {
+      this.userTimezone.set(getUserTimezone());
+    });
   }
 
   public ngOnInit(): void {
-    if (isPlatformBrowser(this.platformId)) {
-      this.userTimezone.set(getUserTimezone());
-    }
     if (typeof window !== 'undefined') {
       const mql = window.matchMedia('(max-width: 639px)'); // Matches Tailwind sm: breakpoint (640px)
       this.isMobileViewport.set(mql.matches);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, isPlatformServer, NgClass } from '@angular/common';
+import { DatePipe, isPlatformBrowser, isPlatformServer, NgClass } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -47,6 +47,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
+import { getUserTimezone } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -59,6 +60,7 @@ import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import {
   BehaviorSubject,
@@ -102,6 +104,7 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     GuestFormComponent,
     TooltipModule,
     DrawerModule,
+    SkeletonModule,
     MeetingTimePipe,
     RecurrenceSummaryPipe,
     LinkifyPipe,
@@ -214,6 +217,9 @@ export class MeetingJoinComponent implements OnInit {
     return name.substring(0, 2).toUpperCase();
   });
   protected isMobileViewport = signal(false);
+  // Null on the server and until hydration resolves the browser timezone — the date/time
+  // badge shows a skeleton while null so SSR never emits a UTC time (LFXV2-2540).
+  protected userTimezone = signal<string | null>(null);
   protected drawerPosition = computed(() => (this.isMobileViewport() ? 'bottom' : 'right') as 'bottom' | 'right');
   // Parent project (foundation) for context display
   protected parentProject: Signal<Project | null>;
@@ -321,6 +327,9 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   public ngOnInit(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      this.userTimezone.set(getUserTimezone());
+    }
     if (typeof window !== 'undefined') {
       const mql = window.matchMedia('(max-width: 639px)'); // Matches Tailwind sm: breakpoint (640px)
       this.isMobileViewport.set(mql.matches);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -217,8 +217,7 @@ export class MeetingJoinComponent implements OnInit {
     return name.substring(0, 2).toUpperCase();
   });
   protected isMobileViewport = signal(false);
-  // Null on the server and until hydration resolves the browser timezone — the date/time
-  // badge shows a skeleton while null so SSR never emits a UTC time (LFXV2-2540).
+  // Null on the server and until hydration resolves the browser timezone — the badge shows a skeleton while null.
   protected userTimezone = signal<string | null>(null);
   protected drawerPosition = computed(() => (this.isMobileViewport() ? 'bottom' : 'right') as 'bottom' | 'right');
   // Parent project (foundation) for context display
@@ -325,9 +324,7 @@ export class MeetingJoinComponent implements OnInit {
     this.initializeAutoJoin();
     this.initializePublicMeetingPageviewTracking();
 
-    // Runs only in the browser after the first render, so the SSR skeleton
-    // hydrates first and only then swaps to the timezone-formatted tag —
-    // avoids a hydration DOM mismatch (LFXV2-2540).
+    // Runs after first render so the SSR skeleton hydrates before swapping to the timezone tag.
     afterNextRender(() => {
       this.userTimezone.set(getUserTimezone());
     });

--- a/apps/lfx-one/src/app/shared/pipes/meeting-time.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/meeting-time.pipe.ts
@@ -7,7 +7,12 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'meetingTime',
 })
 export class MeetingTimePipe implements PipeTransform {
-  public transform(startTime: string | null, duration: number | null, format: 'full' | 'full-start' | 'date' | 'time' | 'compact' = 'full'): string {
+  public transform(
+    startTime: string | null,
+    duration: number | null,
+    format: 'full' | 'full-start' | 'date' | 'time' | 'compact' = 'full',
+    timeZone?: string
+  ): string {
     if (!startTime) {
       return 'Time not set';
     }
@@ -30,6 +35,7 @@ export class MeetingTimePipe implements PipeTransform {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        ...(timeZone ? { timeZone } : {}),
       };
 
       // Format time: 3:00 PM
@@ -37,6 +43,7 @@ export class MeetingTimePipe implements PipeTransform {
         hour: 'numeric',
         minute: '2-digit',
         hour12: true,
+        ...(timeZone ? { timeZone } : {}),
       };
 
       const dateStr = startDate.toLocaleDateString('en-US', dateOptions);
@@ -49,6 +56,7 @@ export class MeetingTimePipe implements PipeTransform {
             weekday: 'short',
             month: 'short',
             day: 'numeric',
+            ...(timeZone ? { timeZone } : {}),
           };
           const compactDateStr = startDate.toLocaleDateString('en-US', compactDateOptions);
           if (endDate) {


### PR DESCRIPTION
# Summary

The meeting join page previously rendered its date/time badge from the raw start time during SSR, which briefly showed a UTC time before hydration resolved the viewer's timezone. The join page now waits for the browser timezone before formatting the badge, showing a skeleton placeholder in the meantime so a UTC value never flashes. The `MeetingTimePipe` accepts an optional `timeZone` argument that it forwards to the locale formatting calls, and `MeetingJoinComponent` resolves that timezone via `getUserTimezone` on the browser only (gated with `isPlatformBrowser`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized join-page display and an optional pipe parameter; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes a brief **UTC time flash** on the meeting join page during SSR/hydration by not rendering the date/time badge until the viewer’s timezone is known.
> 
> The join template shows a **PrimeNG skeleton** while `userTimezone` is null (server and first client paint), then renders the compact datetime tag after `afterNextRender` sets the zone via `getUserTimezone()`. **`MeetingTimePipe`** gains an optional fourth `timeZone` argument passed through to `Intl` date/time formatting; existing call sites stay unchanged when it is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649aec5a1ed94db13794bafdb39ca452ea0eb56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->