### PR TITLE
feat(meetings): split meeting privacy into visibility and join restriction (LFXV2-2658)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -62,12 +62,12 @@
       <!-- Visibility dot badge -->
       <div
         class="absolute -top-2 left-[47px] w-5 h-5 rounded-full flex items-center justify-center"
-        [style.background-color]="dateBadgeDotInfo().bgColor"
-        [pTooltip]="isPrivate() ? 'Private meeting' : 'Public meeting'"
-        [attr.aria-label]="isPrivate() ? 'Private meeting' : 'Public meeting'"
+        [style.background-color]="privacyDotInfo().bgColor"
+        [pTooltip]="privacyDotInfo().label"
+        [attr.aria-label]="privacyDotInfo().label"
         tooltipPosition="top"
         data-testid="dashboard-meeting-card-type-dot">
-        <i [class]="'text-white text-[10px] leading-none block ' + dateBadgeDotInfo().icon" aria-hidden="true"></i>
+        <i [class]="'text-white text-[10px] leading-none block ' + privacyDotInfo().icon" aria-hidden="true"></i>
       </div>
     </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -61,9 +61,10 @@
       </div>
       <!-- Privacy dot badges (hidden for public + unrestricted) -->
       @if (showPrivateDot() || showRestrictedDot()) {
-        <div class="absolute -top-2 left-[47px] flex gap-0.5">
+        <div class="absolute -top-2 right-0 flex flex-row-reverse gap-0.5">
           @if (showPrivateDot()) {
             <div
+              role="img"
               class="w-5 h-5 rounded-full flex items-center justify-center"
               [style.background-color]="privateDotStyle.bgColor"
               [pTooltip]="privateDotStyle.label"
@@ -75,6 +76,7 @@
           }
           @if (showRestrictedDot()) {
             <div
+              role="img"
               class="w-5 h-5 rounded-full flex items-center justify-center"
               [style.background-color]="restrictedDotStyle.bgColor"
               [pTooltip]="restrictedDotStyle.label"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -59,16 +59,33 @@
           </span>
         </div>
       </div>
-      <!-- Visibility dot badge -->
-      <div
-        class="absolute -top-2 left-[47px] w-5 h-5 rounded-full flex items-center justify-center"
-        [style.background-color]="privacyDotInfo().bgColor"
-        [pTooltip]="privacyDotInfo().label"
-        [attr.aria-label]="privacyDotInfo().label"
-        tooltipPosition="top"
-        data-testid="dashboard-meeting-card-type-dot">
-        <i [class]="'text-white text-[10px] leading-none block ' + privacyDotInfo().icon" aria-hidden="true"></i>
-      </div>
+      <!-- Privacy dot badges (hidden for public + unrestricted) -->
+      @if (showPrivateDot() || showRestrictedDot()) {
+        <div class="absolute -top-2 left-[47px] flex gap-0.5">
+          @if (showPrivateDot()) {
+            <div
+              class="w-5 h-5 rounded-full flex items-center justify-center"
+              [style.background-color]="privateDotStyle.bgColor"
+              [pTooltip]="privateDotStyle.label"
+              [attr.aria-label]="privateDotStyle.label"
+              tooltipPosition="top"
+              data-testid="dashboard-meeting-card-private-dot">
+              <i [class]="'text-white text-[10px] leading-none block ' + privateDotStyle.icon" aria-hidden="true"></i>
+            </div>
+          }
+          @if (showRestrictedDot()) {
+            <div
+              class="w-5 h-5 rounded-full flex items-center justify-center"
+              [style.background-color]="restrictedDotStyle.bgColor"
+              [pTooltip]="restrictedDotStyle.label"
+              [attr.aria-label]="restrictedDotStyle.label"
+              tooltipPosition="top"
+              data-testid="dashboard-meeting-card-restricted-dot">
+              <i [class]="'text-white text-[10px] leading-none block ' + restrictedDotStyle.icon" aria-hidden="true"></i>
+            </div>
+          }
+        </div>
+      }
     </div>
 
     <!-- Meeting details -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -65,7 +65,7 @@ export class DashboardMeetingCardComponent {
   public readonly meetingTypeInfo: Signal<MeetingTypeBadge> = this.initMeetingTypeInfo();
   public readonly meetingStartTime: Signal<string> = this.initMeetingStartTime();
   public readonly formattedTimeWithDuration: Signal<string> = this.initFormattedTimeWithDuration();
-  public readonly isPrivate: Signal<boolean> = this.initIsPrivate();
+  public readonly privacyDotInfo: Signal<{ label: string; bgColor: string; icon: string }> = this.initPrivacyDotInfo();
   public readonly hasRecording: Signal<boolean> = this.initHasRecording();
   public readonly hasTranscripts: Signal<boolean> = this.initHasTranscripts();
   public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
@@ -87,7 +87,6 @@ export class DashboardMeetingCardComponent {
   public readonly meetingDuration: Signal<number> = this.initMeetingDuration();
   public readonly meetingDescription: Signal<string> = this.initMeetingDescription();
   public readonly projectChipLabel: Signal<string | null> = this.initProjectChipLabel();
-  public readonly dateBadgeDotInfo: Signal<{ bgColor: string; icon: string }> = this.initDateBadgeDotInfo();
 
   public constructor() {
     const meeting$ = toObservable(this.meeting);
@@ -152,9 +151,28 @@ export class DashboardMeetingCardComponent {
     });
   }
 
-  private initIsPrivate(): Signal<boolean> {
+  private initPrivacyDotInfo(): Signal<{ label: string; bgColor: string; icon: string }> {
     return computed(() => {
-      return this.meeting().visibility === 'private';
+      const meeting = this.meeting();
+      if (meeting.restricted) {
+        return {
+          label: 'Restricted meeting',
+          bgColor: '#d97706',
+          icon: 'fa-solid fa-lock',
+        };
+      }
+      if (meeting.visibility === 'private') {
+        return {
+          label: 'Private meeting',
+          bgColor: '#d4183d',
+          icon: 'fa-solid fa-shield-halved',
+        };
+      }
+      return {
+        label: 'Public meeting',
+        bgColor: '#00bc7d',
+        icon: 'fa-solid fa-globe',
+      };
     });
   }
 
@@ -304,10 +322,4 @@ export class DashboardMeetingCardComponent {
     });
   }
 
-  private initDateBadgeDotInfo(): Signal<{ bgColor: string; icon: string }> {
-    return computed(() => ({
-      bgColor: this.isPrivate() ? '#d4183d' : '#00bc7d',
-      icon: this.isPrivate() ? 'fa-solid fa-shield-halved' : 'fa-solid fa-globe',
-    }));
-  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -11,12 +11,10 @@ import {
   buildJoinUrlWithParams,
   canJoinMeeting,
   DEFAULT_MEETING_TYPE_CONFIG,
-  fieldsToPrivacyType,
   lfxColors,
   Meeting,
   MEETING_TYPE_CONFIGS,
   MeetingOccurrence,
-  MeetingPrivacyType,
   MeetingRecurrence,
   MeetingTypeBadge,
   PastMeetingRecording,
@@ -68,7 +66,10 @@ export class DashboardMeetingCardComponent {
   public readonly meetingTypeInfo: Signal<MeetingTypeBadge> = this.initMeetingTypeInfo();
   public readonly meetingStartTime: Signal<string> = this.initMeetingStartTime();
   public readonly formattedTimeWithDuration: Signal<string> = this.initFormattedTimeWithDuration();
-  public readonly privacyDotInfo: Signal<{ label: string; bgColor: string; icon: string }> = this.initPrivacyDotInfo();
+  public readonly showPrivateDot: Signal<boolean> = computed(() => this.meeting().visibility === 'private');
+  public readonly showRestrictedDot: Signal<boolean> = computed(() => !!this.meeting().restricted);
+  public readonly privateDotStyle = { bgColor: lfxColors.red[600], icon: 'fa-solid fa-shield-halved', label: 'Private meeting' };
+  public readonly restrictedDotStyle = { bgColor: lfxColors.amber[700], icon: 'fa-solid fa-lock', label: 'Restricted meeting' };
   public readonly hasRecording: Signal<boolean> = this.initHasRecording();
   public readonly hasTranscripts: Signal<boolean> = this.initHasTranscripts();
   public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
@@ -150,35 +151,6 @@ export class DashboardMeetingCardComponent {
         return duration > 0 ? `${weekday}, ${time} · ${duration}m` : `${weekday}, ${time}`;
       } catch {
         return startTime;
-      }
-    });
-  }
-
-  private initPrivacyDotInfo(): Signal<{ label: string; bgColor: string; icon: string }> {
-    return computed(() => {
-      const meeting = this.meeting();
-      const privacyType = fieldsToPrivacyType(meeting.visibility, meeting.restricted);
-
-      switch (privacyType) {
-        case MeetingPrivacyType.RESTRICTED:
-          return {
-            label: 'Restricted meeting',
-            bgColor: lfxColors.amber[700],
-            icon: 'fa-solid fa-lock',
-          };
-        case MeetingPrivacyType.PUBLIC:
-          return {
-            label: 'Public meeting',
-            bgColor: lfxColors.emerald[700],
-            icon: 'fa-solid fa-globe',
-          };
-        case MeetingPrivacyType.PRIVATE:
-        default:
-          return {
-            label: 'Private meeting',
-            bgColor: lfxColors.red[600],
-            icon: 'fa-solid fa-shield-halved',
-          };
       }
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -11,9 +11,12 @@ import {
   buildJoinUrlWithParams,
   canJoinMeeting,
   DEFAULT_MEETING_TYPE_CONFIG,
+  fieldsToPrivacyType,
+  lfxColors,
   Meeting,
   MEETING_TYPE_CONFIGS,
   MeetingOccurrence,
+  MeetingPrivacyType,
   MeetingRecurrence,
   MeetingTypeBadge,
   PastMeetingRecording,
@@ -154,25 +157,29 @@ export class DashboardMeetingCardComponent {
   private initPrivacyDotInfo(): Signal<{ label: string; bgColor: string; icon: string }> {
     return computed(() => {
       const meeting = this.meeting();
-      if (meeting.restricted) {
-        return {
-          label: 'Restricted meeting',
-          bgColor: '#d97706',
-          icon: 'fa-solid fa-lock',
-        };
+      const privacyType = fieldsToPrivacyType(meeting.visibility, meeting.restricted);
+
+      switch (privacyType) {
+        case MeetingPrivacyType.RESTRICTED:
+          return {
+            label: 'Restricted meeting',
+            bgColor: lfxColors.amber[700],
+            icon: 'fa-solid fa-lock',
+          };
+        case MeetingPrivacyType.PUBLIC:
+          return {
+            label: 'Public meeting',
+            bgColor: lfxColors.emerald[700],
+            icon: 'fa-solid fa-globe',
+          };
+        case MeetingPrivacyType.PRIVATE:
+        default:
+          return {
+            label: 'Private meeting',
+            bgColor: lfxColors.red[600],
+            icon: 'fa-solid fa-shield-halved',
+          };
       }
-      if (meeting.visibility === 'private') {
-        return {
-          label: 'Private meeting',
-          bgColor: '#d4183d',
-          icon: 'fa-solid fa-shield-halved',
-        };
-      }
-      return {
-        label: 'Public meeting',
-        bgColor: '#00bc7d',
-        icon: 'fa-solid fa-globe',
-      };
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -13,12 +13,15 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   lfxColors,
   Meeting,
+  MeetingPrivacyDotStyle,
   MEETING_TYPE_CONFIGS,
   MeetingOccurrence,
   MeetingRecurrence,
   MeetingTypeBadge,
   PastMeetingRecording,
   resolveOccurrenceRecurrence,
+  shouldShowPrivateMeetingLabel,
+  shouldShowRestrictedMeetingLabel,
   TagSeverity,
 } from '@lfx-one/shared';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
@@ -66,10 +69,10 @@ export class DashboardMeetingCardComponent {
   public readonly meetingTypeInfo: Signal<MeetingTypeBadge> = this.initMeetingTypeInfo();
   public readonly meetingStartTime: Signal<string> = this.initMeetingStartTime();
   public readonly formattedTimeWithDuration: Signal<string> = this.initFormattedTimeWithDuration();
-  public readonly showPrivateDot: Signal<boolean> = computed(() => this.meeting().visibility === 'private');
-  public readonly showRestrictedDot: Signal<boolean> = computed(() => !!this.meeting().restricted);
-  public readonly privateDotStyle = { bgColor: lfxColors.red[600], icon: 'fa-solid fa-shield-halved', label: 'Private meeting' };
-  public readonly restrictedDotStyle = { bgColor: lfxColors.amber[700], icon: 'fa-solid fa-lock', label: 'Restricted meeting' };
+  public readonly showPrivateDot: Signal<boolean> = computed(() => shouldShowPrivateMeetingLabel(this.meeting().visibility));
+  public readonly showRestrictedDot: Signal<boolean> = computed(() => shouldShowRestrictedMeetingLabel(this.meeting().restricted));
+  public readonly privateDotStyle: MeetingPrivacyDotStyle = { bgColor: lfxColors.red[600], icon: 'fa-solid fa-shield-halved', label: 'Private meeting' };
+  public readonly restrictedDotStyle: MeetingPrivacyDotStyle = { bgColor: lfxColors.amber[700], icon: 'fa-solid fa-lock', label: 'Restricted meeting' };
   public readonly hasRecording: Signal<boolean> = this.initHasRecording();
   public readonly hasTranscripts: Signal<boolean> = this.initHasTranscripts();
   public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -321,5 +321,4 @@ export class DashboardMeetingCardComponent {
       return meeting.project_name || meeting.committees?.[0]?.name || null;
     });
   }
-
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -6,11 +6,12 @@
     <!-- Header with badges and action menu -->
     <div class="flex items-start justify-between mb-4" data-testid="meeting-details-header">
       <div class="flex items-center gap-2 flex-wrap">
-        <!-- Privacy Badge -->
+        <!-- Privacy Badges -->
+        @if (meeting().visibility === 'private') {
+          <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private"></lfx-tag>
+        }
         @if (meeting().restricted) {
           <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted"></lfx-tag>
-        } @else if (meeting().visibility === 'private') {
-          <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private"></lfx-tag>
         }
 
         <!-- Meeting Type Badge -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -7,10 +7,10 @@
     <div class="flex items-start justify-between mb-4" data-testid="meeting-details-header">
       <div class="flex items-center gap-2 flex-wrap">
         <!-- Privacy Badges -->
-        @if (meeting().visibility === 'private') {
+        @if (showPrivateMeetingLabel(meeting().visibility)) {
           <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private"></lfx-tag>
         }
-        @if (meeting().restricted) {
+        @if (showRestrictedMeetingLabel(meeting().restricted)) {
           <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted"></lfx-tag>
         }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -7,7 +7,9 @@
     <div class="flex items-start justify-between mb-4" data-testid="meeting-details-header">
       <div class="flex items-center gap-2 flex-wrap">
         <!-- Privacy Badge -->
-        @if (meeting().visibility === 'private') {
+        @if (meeting().restricted) {
+          <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted"></lfx-tag>
+        } @else if (meeting().visibility === 'private') {
           <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private"></lfx-tag>
         }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -59,6 +59,8 @@ import {
   PastMeetingSummary,
   PastMeetingTranscript,
   resolveOccurrenceRecurrence,
+  shouldShowPrivateMeetingLabel,
+  shouldShowRestrictedMeetingLabel,
   TagSeverity,
 } from '@lfx-one/shared';
 import { RecordingModalComponent } from '@components/recording-modal/recording-modal.component';
@@ -122,6 +124,9 @@ export class MeetingCardComponent implements OnInit {
   public readonly pastMeeting = input<boolean>(false);
   public readonly loading = input<boolean>(false);
   public readonly showBorder = input<boolean>(false);
+
+  public readonly showPrivateMeetingLabel = shouldShowPrivateMeetingLabel;
+  public readonly showRestrictedMeetingLabel = shouldShowRestrictedMeetingLabel;
 
   public showRegistrants: WritableSignal<boolean> = signal(false);
   public showMyRsvp: WritableSignal<boolean> = signal(false);

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -128,9 +128,6 @@
           </div>
         </div>
       }
-
-      <!-- Show in Public Calendar -->
-      <lfx-feature-toggle [feature]="calendarFeature" [form]="form()"></lfx-feature-toggle>
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
@@ -51,7 +51,6 @@ export class MeetingPlatformFeaturesComponent implements OnInit {
   public readonly transcriptFeature = MEETING_FEATURES.find((f) => f.key === 'transcript_enabled')!;
   public readonly youtubeFeature = MEETING_FEATURES.find((f) => f.key === 'youtube_upload_enabled')!;
   public readonly aiSummaryFeature = MEETING_FEATURES.find((f) => f.key === 'zoom_ai_enabled')!;
-  public readonly calendarFeature = MEETING_FEATURES.find((f) => f.key === 'visibility')!;
 
   // Transform platforms into dropdown options (only available platforms)
   public readonly platformDropdownOptions = MEETING_PLATFORMS.map((platform) => ({

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
@@ -24,7 +24,7 @@
 
     <!-- Right Column - Privacy Settings -->
     <div class="flex flex-col gap-3">
-      <lfx-card-selector [options]="privacyOptions" [form]="form()" control="restricted" label="Select Privacy Setting" testIdPrefix="meeting-privacy" />
+      <lfx-card-selector [options]="privacyOptions" [form]="form()" control="privacy_type" label="Select Privacy Setting" testIdPrefix="meeting-privacy" />
 
       <!-- Info box -->
       <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
@@ -32,9 +32,10 @@
           <i class="fa-light fa-info-circle text-blue-500 flex-shrink-0 mt-0.5"></i>
           <div>
             <p class="text-sm text-blue-500">
-              <span class="font-semibold">Transparency is key</span>
+              <span class="font-semibold">Choose the right access level</span>
               <br />
-              Public meetings help build trust and encourage community participation. Consider making meetings public unless they involve confidential matters.
+              Public meetings build community trust. Private meetings stay off the public calendar but still allow guest join. Restricted meetings are
+              invite-only.
             </p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
@@ -5,7 +5,7 @@
   <!-- Step Title -->
   <div class="mb-6">
     <h2 class="font-normal">Meeting Type & Privacy</h2>
-    <p class="text-sm text-gray-500 mt-1">Choose the meeting category and visibility to ensure the right people have access</p>
+    <p class="text-sm text-gray-500 mt-1">Choose the meeting category and access settings to ensure the right people can find and join</p>
   </div>
 
   <!-- Two Column Layout -->
@@ -22,9 +22,27 @@
         testIdPrefix="meeting-type" />
     </div>
 
-    <!-- Right Column - Privacy Settings -->
-    <div class="flex flex-col gap-3">
-      <lfx-card-selector [options]="privacyOptions" [form]="form()" control="privacy_type" label="Select Privacy Setting" testIdPrefix="meeting-privacy" />
+    <!-- Right Column - Visibility & Join Restriction -->
+    <div class="flex flex-col gap-6">
+      <lfx-card-selector
+        [options]="visibilityOptions"
+        [form]="form()"
+        control="visibility"
+        label="Who can find this meeting?"
+        [required]="true"
+        [gridColumns]="2"
+        errorMessage="Visibility is required"
+        testIdPrefix="meeting-visibility" />
+
+      <lfx-card-selector
+        [options]="joinRestrictionOptions"
+        [form]="form()"
+        control="restricted"
+        label="Who can join this meeting?"
+        [required]="true"
+        [gridColumns]="2"
+        errorMessage="Join restriction is required"
+        testIdPrefix="meeting-join-restriction" />
 
       <!-- Info box -->
       <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
@@ -32,10 +50,10 @@
           <i class="fa-light fa-info-circle text-blue-500 flex-shrink-0 mt-0.5"></i>
           <div>
             <p class="text-sm text-blue-500">
-              <span class="font-semibold">Choose the right access level</span>
+              <span class="font-semibold">Visibility</span> controls discoverability — public meetings appear on the project calendar and in the app; private
+              meetings are only found by guests with the link.
               <br />
-              Public meetings build community trust. Private meetings stay off the public calendar but still allow guest join. Restricted meetings are
-              invite-only.
+              <span class="font-semibold">Join restriction</span> controls access — anyone with the link can join unless you restrict to invited guests only.
             </p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
@@ -4,8 +4,8 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardSelectorComponent } from '@components/card-selector/card-selector.component';
-import { MEETING_PRIVACY_OPTIONS, lfxColors } from '@lfx-one/shared/constants';
-import { MeetingPrivacyType, MeetingType } from '@lfx-one/shared/enums';
+import { MEETING_JOIN_RESTRICTION_OPTIONS, MEETING_VISIBILITY_OPTIONS, lfxColors } from '@lfx-one/shared/constants';
+import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import { CardSelectorOption, CardSelectorOptionInfo } from '@lfx-one/shared/interfaces';
 import { PersonaService } from '@services/persona.service';
 
@@ -20,8 +20,13 @@ export class MeetingTypeSelectionComponent {
   // Form group input from parent
   public readonly form = input.required<FormGroup>();
 
-  // Privacy options for Public / Private / Restricted selection (PCC parity)
-  public readonly privacyOptions: CardSelectorOption<MeetingPrivacyType>[] = MEETING_PRIVACY_OPTIONS.map((option) => ({
+  public readonly visibilityOptions: CardSelectorOption<MeetingVisibility>[] = MEETING_VISIBILITY_OPTIONS.map((option) => ({
+    label: option.label,
+    value: option.value,
+    info: option.info,
+  }));
+
+  public readonly joinRestrictionOptions: CardSelectorOption<boolean>[] = MEETING_JOIN_RESTRICTION_OPTIONS.map((option) => ({
     label: option.label,
     value: option.value,
     info: option.info,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
@@ -4,8 +4,8 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardSelectorComponent } from '@components/card-selector/card-selector.component';
-import { lfxColors } from '@lfx-one/shared/constants';
-import { MeetingType } from '@lfx-one/shared/enums';
+import { MEETING_PRIVACY_OPTIONS, lfxColors } from '@lfx-one/shared/constants';
+import { MeetingPrivacyType, MeetingType } from '@lfx-one/shared/enums';
 import { CardSelectorOption, CardSelectorOptionInfo } from '@lfx-one/shared/interfaces';
 import { PersonaService } from '@services/persona.service';
 
@@ -20,27 +20,12 @@ export class MeetingTypeSelectionComponent {
   // Form group input from parent
   public readonly form = input.required<FormGroup>();
 
-  // Privacy options for Public/Restricted selection
-  public readonly privacyOptions: CardSelectorOption<boolean>[] = [
-    {
-      label: 'Public',
-      value: false,
-      info: {
-        icon: 'fa-light fa-globe',
-        description: 'Anyone can join this meeting. Best for community meetings and open discussions.',
-        color: lfxColors.emerald[500],
-      },
-    },
-    {
-      label: 'Restricted',
-      value: true,
-      info: {
-        icon: 'fa-light fa-lock',
-        description: 'Only invited guests can join. Best for board meetings and confidential discussions.',
-        color: lfxColors.amber[500],
-      },
-    },
-  ];
+  // Privacy options for Public / Private / Restricted selection (PCC parity)
+  public readonly privacyOptions: CardSelectorOption<MeetingPrivacyType>[] = MEETING_PRIVACY_OPTIONS.map((option) => ({
+    label: option.label,
+    value: option.value,
+    info: option.info,
+  }));
 
   // Meeting type options with their info - computed for template efficiency
   // Filtered based on user role (maintainers only see a subset of meeting types)

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -32,8 +32,15 @@
                   <lfx-tag value="Ended" severity="warn" icon="fa-light fa-check" styleClass="tag-ended" [attr.data-testid]="'meeting-badge-ended'"></lfx-tag>
                 }
 
-                <!-- Private Badge -->
-                @if (meeting().visibility === 'private') {
+                <!-- Privacy Badge -->
+                @if (meeting().restricted) {
+                  <lfx-tag
+                    value="Restricted"
+                    severity="warn"
+                    icon="fa-light fa-lock"
+                    styleClass="tag-restricted"
+                    [attr.data-testid]="'meeting-badge-restricted'"></lfx-tag>
+                } @else if (meeting().visibility === 'private') {
                   <lfx-tag
                     value="Private"
                     severity="danger"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -32,7 +32,15 @@
                   <lfx-tag value="Ended" severity="warn" icon="fa-light fa-check" styleClass="tag-ended" [attr.data-testid]="'meeting-badge-ended'"></lfx-tag>
                 }
 
-                <!-- Privacy Badge -->
+                <!-- Privacy Badges -->
+                @if (meeting().visibility === 'private') {
+                  <lfx-tag
+                    value="Private"
+                    severity="danger"
+                    icon="fa-light fa-shield"
+                    styleClass="tag-private"
+                    [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
+                }
                 @if (meeting().restricted) {
                   <lfx-tag
                     value="Restricted"
@@ -40,13 +48,6 @@
                     icon="fa-light fa-lock"
                     styleClass="tag-restricted"
                     [attr.data-testid]="'meeting-badge-restricted'"></lfx-tag>
-                } @else if (meeting().visibility === 'private') {
-                  <lfx-tag
-                    value="Private"
-                    severity="danger"
-                    icon="fa-light fa-shield"
-                    styleClass="tag-private"
-                    [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
                 }
 
                 <!-- Meeting Type Badge -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -33,7 +33,7 @@
                 }
 
                 <!-- Privacy Badges -->
-                @if (meeting().visibility === 'private') {
+                @if (showPrivateMeetingLabel(meeting().visibility)) {
                   <lfx-tag
                     value="Private"
                     severity="danger"
@@ -41,7 +41,7 @@
                     styleClass="tag-private"
                     [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
                 }
-                @if (meeting().restricted) {
+                @if (showRestrictedMeetingLabel(meeting().restricted)) {
                   <lfx-tag
                     value="Restricted"
                     severity="warn"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -339,8 +339,10 @@ export class MeetingJoinComponent implements OnInit {
     const meeting = this.meeting();
     const meetingUrl: URL = new URL(environment.urls.home + '/meetings/' + meeting.id);
 
-    if (meeting.password) {
-      meetingUrl.searchParams.set('password', meeting.password);
+    const accessPassword = this.password() ?? meeting.password;
+
+    if (accessPassword) {
+      meetingUrl.searchParams.set('password', accessPassword);
     }
     this.clipboard.copy(meetingUrl.toString());
     this.messageService.add({
@@ -763,9 +765,10 @@ export class MeetingJoinComponent implements OnInit {
     return computed(() => {
       const meeting = this.meeting();
       const params = new URLSearchParams();
+      const accessPassword = this.password() ?? meeting.password;
 
-      if (meeting.password) {
-        params.set('password', meeting.password);
+      if (accessPassword) {
+        params.set('password', accessPassword);
       }
       const queryString = params.toString();
       return queryString ? `${environment.urls.home}/meetings/${meeting.id}?${queryString}` : `${environment.urls.home}/meetings/${meeting.id}`;
@@ -860,7 +863,9 @@ export class MeetingJoinComponent implements OnInit {
   private fetchJoinUrl(meeting: Meeting, email: string): Observable<string | undefined> {
     this.isLoadingJoinUrl.set(true);
 
-    return this.meetingService.getPublicMeetingJoinUrl(meeting.id, meeting.password, { email }).pipe(
+    const accessPassword = this.password() ?? meeting.password;
+
+    return this.meetingService.getPublicMeetingJoinUrl(meeting.id, accessPassword, { email }).pipe(
       map((res) => {
         this.isLoadingJoinUrl.set(false);
         if (res.link) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -44,6 +44,8 @@ import {
   Project,
   PublicPastMeetingResponse,
   ROOT_PROJECT_SLUG,
+  shouldShowPrivateMeetingLabel,
+  shouldShowRestrictedMeetingLabel,
   TagSeverity,
   User,
 } from '@lfx-one/shared';
@@ -129,6 +131,9 @@ export class MeetingJoinComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
+
+  public readonly showPrivateMeetingLabel = shouldShowPrivateMeetingLabel;
+  public readonly showRestrictedMeetingLabel = shouldShowRestrictedMeetingLabel;
 
   // Class variables with types
   public authenticated: WritableSignal<boolean>;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -20,7 +20,7 @@ import {
   TOTAL_STEPS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
 } from '@lfx-one/shared/constants';
-import { MeetingVisibility, MeetingPrivacyType } from '@lfx-one/shared/enums';
+import { MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   CreateMeetingRequest,
@@ -43,8 +43,6 @@ import {
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
-  fieldsToPrivacyType,
-  privacyTypeToFields,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
 import { MeetingService } from '@services/meeting.service';
@@ -203,15 +201,6 @@ export class MeetingManageComponent {
         }
         titleControl.updateValueAndValidity();
         this.updateCanProceed();
-      });
-
-    // Keep legacy visibility/restricted form fields in sync with the unified privacy selector.
-    this.form()
-      .get('privacy_type')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((privacyType: MeetingPrivacyType) => {
-        const fields = privacyTypeToFields(privacyType);
-        this.form().patchValue({ visibility: fields.visibility, restricted: fields.restricted }, { emitEvent: false });
       });
 
     // Separate subscription for meeting data changes - populates form only once
@@ -511,8 +500,6 @@ export class MeetingManageComponent {
       }
     }
 
-    const privacyFields = privacyTypeToFields(formValue.privacy_type ?? MeetingPrivacyType.PRIVATE);
-
     return {
       project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid(),
       title: formValue.title,
@@ -525,8 +512,8 @@ export class MeetingManageComponent {
         const parsed = parseInt(formValue.early_join_time_minutes, 10);
         return isNaN(parsed) ? DEFAULT_EARLY_JOIN_TIME : parsed;
       })(),
-      visibility: privacyFields.visibility,
-      restricted: privacyFields.restricted,
+      visibility: formValue.visibility ?? MeetingVisibility.PRIVATE,
+      restricted: formValue.restricted ?? false,
       recording_enabled: formValue.recording_enabled || false,
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,
       youtube_upload_enabled: formValue.recording_enabled ? formValue.youtube_upload_enabled || false : false,
@@ -777,9 +764,6 @@ export class MeetingManageComponent {
       this.form().get('youtube_upload_enabled')?.enable();
     }
 
-    const privacyType = fieldsToPrivacyType(meeting.visibility, meeting.restricted);
-    const privacyFields = privacyTypeToFields(privacyType);
-
     this.form().patchValue({
       title: meeting.title,
       description: meeting.description,
@@ -790,9 +774,8 @@ export class MeetingManageComponent {
       timezone: meeting.timezone || getUserTimezone(),
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
-      privacy_type: privacyType,
-      visibility: privacyFields.visibility,
-      restricted: privacyFields.restricted,
+      visibility: meeting.visibility ?? MeetingVisibility.PRIVATE,
+      restricted: meeting.restricted ?? false,
       recording_enabled: meeting.recording_enabled || false,
       transcript_enabled: meeting.transcript_enabled || false,
       youtube_upload_enabled: meeting.youtube_upload_enabled || false,
@@ -905,7 +888,7 @@ export class MeetingManageComponent {
 
     switch (step) {
       case 1: // Meeting Type
-        return !!form.get('meeting_type')?.value && form.get('meeting_type')?.value !== '' && !!form.get('privacy_type')?.value;
+        return !!form.get('meeting_type')?.value && form.get('meeting_type')?.value !== '' && !!form.get('visibility')?.value;
 
       case 2: // Meeting Details
         return !!(
@@ -938,9 +921,8 @@ export class MeetingManageComponent {
       {
         // Step 1: Meeting Type
         meeting_type: new FormControl('', [Validators.required]),
-        privacy_type: new FormControl(MeetingPrivacyType.PRIVATE, [Validators.required]),
-        visibility: new FormControl(MeetingVisibility.PRIVATE),
-        restricted: new FormControl(false),
+        visibility: new FormControl(MeetingVisibility.PRIVATE, [Validators.required]),
+        restricted: new FormControl(false, [Validators.required]),
 
         // Step 2: Meeting Details
         title: new FormControl('', [Validators.required]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -888,7 +888,7 @@ export class MeetingManageComponent {
 
     switch (step) {
       case 1: // Meeting Type
-        return form.get('meeting_type')?.valid === true && form.get('visibility')?.valid === true && form.get('restricted')?.valid === true;
+        return form.get('meeting_type')?.valid === true && form.get('visibility')?.valid === true && typeof form.get('restricted')?.value === 'boolean';
 
       case 2: // Meeting Details
         return !!(
@@ -922,7 +922,7 @@ export class MeetingManageComponent {
         // Step 1: Meeting Type
         meeting_type: new FormControl('', [Validators.required]),
         visibility: new FormControl(MeetingVisibility.PRIVATE, [Validators.required]),
-        restricted: new FormControl(false, [Validators.required]),
+        restricted: new FormControl(false),
 
         // Step 2: Meeting Details
         title: new FormControl('', [Validators.required]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -512,7 +512,7 @@ export class MeetingManageComponent {
         const parsed = parseInt(formValue.early_join_time_minutes, 10);
         return isNaN(parsed) ? DEFAULT_EARLY_JOIN_TIME : parsed;
       })(),
-      visibility: formValue.visibility ?? MeetingVisibility.PRIVATE,
+      visibility: formValue.visibility || MeetingVisibility.PRIVATE,
       restricted: formValue.restricted ?? false,
       recording_enabled: formValue.recording_enabled || false,
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,
@@ -774,7 +774,7 @@ export class MeetingManageComponent {
       timezone: meeting.timezone || getUserTimezone(),
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
-      visibility: meeting.visibility ?? MeetingVisibility.PRIVATE,
+      visibility: meeting.visibility || MeetingVisibility.PRIVATE,
       restricted: meeting.restricted ?? false,
       recording_enabled: meeting.recording_enabled || false,
       transcript_enabled: meeting.transcript_enabled || false,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -20,7 +20,7 @@ import {
   TOTAL_STEPS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
 } from '@lfx-one/shared/constants';
-import { MeetingVisibility } from '@lfx-one/shared/enums';
+import { MeetingVisibility, MeetingPrivacyType } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   CreateMeetingRequest,
@@ -43,6 +43,8 @@ import {
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
+  fieldsToPrivacyType,
+  privacyTypeToFields,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
 import { MeetingService } from '@services/meeting.service';
@@ -201,6 +203,15 @@ export class MeetingManageComponent {
         }
         titleControl.updateValueAndValidity();
         this.updateCanProceed();
+      });
+
+    // Keep legacy visibility/restricted form fields in sync with the unified privacy selector.
+    this.form()
+      .get('privacy_type')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((privacyType: MeetingPrivacyType) => {
+        const fields = privacyTypeToFields(privacyType);
+        this.form().patchValue({ visibility: fields.visibility, restricted: fields.restricted }, { emitEvent: false });
       });
 
     // Separate subscription for meeting data changes - populates form only once
@@ -500,6 +511,8 @@ export class MeetingManageComponent {
       }
     }
 
+    const privacyFields = privacyTypeToFields(formValue.privacy_type ?? MeetingPrivacyType.PRIVATE);
+
     return {
       project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid(),
       title: formValue.title,
@@ -512,8 +525,8 @@ export class MeetingManageComponent {
         const parsed = parseInt(formValue.early_join_time_minutes, 10);
         return isNaN(parsed) ? DEFAULT_EARLY_JOIN_TIME : parsed;
       })(),
-      visibility: formValue.visibility || MeetingVisibility.PRIVATE,
-      restricted: formValue.restricted || false,
+      visibility: privacyFields.visibility,
+      restricted: privacyFields.restricted,
       recording_enabled: formValue.recording_enabled || false,
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,
       youtube_upload_enabled: formValue.recording_enabled ? formValue.youtube_upload_enabled || false : false,
@@ -764,6 +777,9 @@ export class MeetingManageComponent {
       this.form().get('youtube_upload_enabled')?.enable();
     }
 
+    const privacyType = fieldsToPrivacyType(meeting.visibility, meeting.restricted);
+    const privacyFields = privacyTypeToFields(privacyType);
+
     this.form().patchValue({
       title: meeting.title,
       description: meeting.description,
@@ -774,8 +790,9 @@ export class MeetingManageComponent {
       timezone: meeting.timezone || getUserTimezone(),
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
-      visibility: meeting.visibility || MeetingVisibility.PRIVATE,
-      restricted: meeting.restricted ?? false,
+      privacy_type: privacyType,
+      visibility: privacyFields.visibility,
+      restricted: privacyFields.restricted,
       recording_enabled: meeting.recording_enabled || false,
       transcript_enabled: meeting.transcript_enabled || false,
       youtube_upload_enabled: meeting.youtube_upload_enabled || false,
@@ -888,7 +905,7 @@ export class MeetingManageComponent {
 
     switch (step) {
       case 1: // Meeting Type
-        return !!form.get('meeting_type')?.value && form.get('meeting_type')?.value !== '';
+        return !!form.get('meeting_type')?.value && form.get('meeting_type')?.value !== '' && !!form.get('privacy_type')?.value;
 
       case 2: // Meeting Details
         return !!(
@@ -921,6 +938,7 @@ export class MeetingManageComponent {
       {
         // Step 1: Meeting Type
         meeting_type: new FormControl('', [Validators.required]),
+        privacy_type: new FormControl(MeetingPrivacyType.PRIVATE, [Validators.required]),
         visibility: new FormControl(MeetingVisibility.PRIVATE),
         restricted: new FormControl(false),
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -888,7 +888,7 @@ export class MeetingManageComponent {
 
     switch (step) {
       case 1: // Meeting Type
-        return !!form.get('meeting_type')?.value && form.get('meeting_type')?.value !== '' && !!form.get('visibility')?.value;
+        return form.get('meeting_type')?.valid === true && form.get('visibility')?.valid === true && form.get('restricted')?.valid === true;
 
       case 2: // Meeting Details
         return !!(

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -72,10 +72,11 @@
       <div class="flex flex-col gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <lfx-tag value="Ended" severity="warn" icon="fa-light fa-circle-check" data-testid="meeting-ended-badge"></lfx-tag>
+          @if (meeting.visibility === 'private') {
+            <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
+          }
           @if (meeting.restricted) {
             <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted" data-testid="badge-restricted"></lfx-tag>
-          } @else if (meeting.visibility === 'private') {
-            <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
           }
           @if (meetingTypeBadge(); as badge) {
             <lfx-tag [value]="badge.text" [severity]="badge.severity" [icon]="badge.icon" [styleClass]="badge.styleClass" data-testid="badge-type"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -72,7 +72,9 @@
       <div class="flex flex-col gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <lfx-tag value="Ended" severity="warn" icon="fa-light fa-circle-check" data-testid="meeting-ended-badge"></lfx-tag>
-          @if (meeting.visibility === 'private') {
+          @if (meeting.restricted) {
+            <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted" data-testid="badge-restricted"></lfx-tag>
+          } @else if (meeting.visibility === 'private') {
             <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
           }
           @if (meetingTypeBadge(); as badge) {

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -72,10 +72,10 @@
       <div class="flex flex-col gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <lfx-tag value="Ended" severity="warn" icon="fa-light fa-circle-check" data-testid="meeting-ended-badge"></lfx-tag>
-          @if (meeting.visibility === 'private') {
+          @if (meeting && showPrivateMeetingLabel(meeting.visibility)) {
             <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
           }
-          @if (meeting.restricted) {
+          @if (meeting && showRestrictedMeetingLabel(meeting.restricted)) {
             <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted" data-testid="badge-restricted"></lfx-tag>
           }
           @if (meetingTypeBadge(); as badge) {

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -24,6 +24,8 @@ import {
   PastMeetingRecording,
   PastMeetingSummary,
   PastMeetingTranscript,
+  shouldShowPrivateMeetingLabel,
+  shouldShowRestrictedMeetingLabel,
   TagSeverity,
 } from '@lfx-one/shared';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
@@ -65,6 +67,9 @@ export class PastMeetingDetailsComponent {
   private readonly messageService = inject(MessageService);
   private readonly committeeService = inject(CommitteeService);
   private readonly dialogService = inject(DialogService);
+
+  public readonly showPrivateMeetingLabel = shouldShowPrivateMeetingLabel;
+  public readonly showRestrictedMeetingLabel = shouldShowRestrictedMeetingLabel;
 
   // Simple writable signals
   public loading = signal(true);

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
@@ -20,12 +20,12 @@
       'grid-cols-1 md:grid-cols-2': gridColumns() === 2,
       'grid-cols-1': gridColumns() === 1,
     }">
-    @for (option of options(); track option.value) {
+    @for (option of options(); track option.value; let i = $index) {
       <div
         #radioOption
         role="radio"
         [attr.aria-checked]="isSelected(option.value)"
-        [attr.tabindex]="isSelected(option.value) ? 0 : -1"
+        [attr.tabindex]="getTabIndex(i, option.value)"
         class="p-4 border-2 rounded-lg cursor-pointer transition-all text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         [ngClass]="{
           'border-gray-200 bg-white hover:border-gray-300': !isSelected(option.value),

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
@@ -3,7 +3,7 @@
 
 <div>
   @if (label()) {
-    <h3 class="mb-4">
+    <h3 class="mb-4" [id]="labelId()">
       {{ label() }}
       @if (required()) {
         <span class="text-red-500">*</span>
@@ -11,6 +11,9 @@
     </h3>
   }
   <div
+    role="radiogroup"
+    [attr.aria-labelledby]="label() ? labelId() : null"
+    [attr.aria-required]="required() || null"
     class="grid gap-3"
     [ngClass]="{
       'grid-cols-1 md:grid-cols-3': gridColumns() === 3,
@@ -19,20 +22,24 @@
     }">
     @for (option of options(); track option.value) {
       <div
-        class="p-4 border-2 rounded-lg cursor-pointer transition-all text-left"
+        role="radio"
+        [attr.aria-checked]="isSelected(option.value)"
+        [attr.tabindex]="isSelected(option.value) ? 0 : -1"
+        class="p-4 border-2 rounded-lg cursor-pointer transition-all text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         [ngClass]="{
-          'border-gray-200 bg-white hover:border-gray-300': form().get(control())?.value !== option.value,
+          'border-gray-200 bg-white hover:border-gray-300': !isSelected(option.value),
         }"
-        [style.border-color]="form().get(control())?.value === option.value ? option.info.color : null"
-        [style.background-color]="form().get(control())?.value === option.value ? option.info.color + '15' : null"
+        [style.border-color]="isSelected(option.value) ? option.info.color : null"
+        [style.background-color]="isSelected(option.value) ? option.info.color + '15' : null"
         (click)="onSelect(option.value)"
+        (keydown)="onKeydown($event, option.value)"
         [attr.data-testid]="testIdPrefix() + '-option-' + option.value">
         <div class="flex items-start gap-3">
           <div
             class="w-10 h-10 rounded-lg flex-shrink-0 flex items-center justify-center"
-            [style.background-color]="form().get(control())?.value === option.value ? option.info.color : option.info.color + '1A'"
-            [style.color]="form().get(control())?.value === option.value ? 'white' : option.info.color">
-            <i [class]="option.info.icon + ' text-xl'"></i>
+            [style.background-color]="isSelected(option.value) ? option.info.color : option.info.color + '1A'"
+            [style.color]="isSelected(option.value) ? 'white' : option.info.color">
+            <i [class]="option.info.icon + ' text-xl'" aria-hidden="true"></i>
           </div>
           <div class="flex-1">
             <h4 class="text-neutral-950 mb-1">{{ option.label }}</h4>

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
@@ -13,6 +13,8 @@
   <div
     role="radiogroup"
     [attr.aria-labelledby]="label() ? labelId() : null"
+    [attr.aria-describedby]="hasError() ? errorId() : null"
+    [attr.aria-invalid]="hasError() || null"
     [attr.aria-required]="required() || null"
     class="grid gap-3"
     [ngClass]="{
@@ -50,7 +52,7 @@
       </div>
     }
   </div>
-  @if (form().get(control())?.errors?.['required'] && form().get(control())?.touched) {
-    <p class="text-sm text-red-600 mt-2">{{ errorMessage() }}</p>
+  @if (hasError()) {
+    <p class="text-sm text-red-600 mt-2" [id]="errorId()">{{ errorMessage() }}</p>
   }
 </div>

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.html
@@ -22,6 +22,7 @@
     }">
     @for (option of options(); track option.value) {
       <div
+        #radioOption
         role="radio"
         [attr.aria-checked]="isSelected(option.value)"
         [attr.tabindex]="isSelected(option.value) ? 0 : -1"

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardSelectorOption } from '@lfx-one/shared/interfaces';
 
@@ -25,10 +25,40 @@ export class CardSelectorComponent<T = string> {
   // Output
   public readonly selectionChange = output<T>();
 
+  public readonly labelId = computed(() => `${this.testIdPrefix()}-label`);
+
+  public isSelected(value: T): boolean {
+    return this.form().get(this.control())?.value === value;
+  }
+
   // Handle selection
   public onSelect(value: T): void {
     this.form().get(this.control())?.setValue(value);
     this.form().get(this.control())?.markAsTouched();
     this.selectionChange.emit(value);
+  }
+
+  public onKeydown(event: KeyboardEvent, value: T): void {
+    const options = this.options();
+    const currentIndex = options.findIndex((option) => option.value === this.form().get(this.control())?.value);
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onSelect(value);
+      return;
+    }
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length;
+      this.onSelect(options[nextIndex].value);
+      return;
+    }
+
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const nextIndex = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length;
+      this.onSelect(options[nextIndex].value);
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -29,6 +29,7 @@ export class CardSelectorComponent<T = string> {
   public readonly selectionChange = output<T>();
 
   public readonly labelId = computed(() => `${this.testIdPrefix()}-label`);
+  public readonly errorId = computed(() => `${this.testIdPrefix()}-error`);
 
   public isSelected(value: T): boolean {
     return this.form().get(this.control())?.value === value;
@@ -45,6 +46,11 @@ export class CardSelectorComponent<T = string> {
     }
 
     return !this.hasSelection() && index === 0 ? 0 : -1;
+  }
+
+  public hasError(): boolean {
+    const control = this.form().get(this.control());
+    return !!(control?.errors?.['required'] && control?.touched);
   }
 
   // Handle selection

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -56,6 +56,10 @@ export class CardSelectorComponent<T = string> {
 
   public onKeydown(event: KeyboardEvent, value: T): void {
     const options = this.options();
+    if (options.length === 0) {
+      return;
+    }
+
     const currentIndex = options.findIndex((option) => option.value === this.form().get(this.control())?.value);
 
     if (event.key === 'Enter' || event.key === ' ') {

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -12,6 +12,9 @@ import { CardSelectorOption } from '@lfx-one/shared/interfaces';
   templateUrl: './card-selector.component.html',
 })
 export class CardSelectorComponent<T = string> {
+  @ViewChildren('radioOption')
+  private readonly radioOptions!: QueryList<ElementRef<HTMLElement>>;
+
   // Inputs
   public readonly options = input.required<CardSelectorOption<T>[]>();
   public readonly form = input.required<FormGroup>();
@@ -24,9 +27,6 @@ export class CardSelectorComponent<T = string> {
 
   // Output
   public readonly selectionChange = output<T>();
-
-  @ViewChildren('radioOption')
-  private readonly radioOptions!: QueryList<ElementRef<HTMLElement>>;
 
   public readonly labelId = computed(() => `${this.testIdPrefix()}-label`);
 

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, input, output } from '@angular/core';
+import { Component, computed, ElementRef, input, output, QueryList, ViewChildren } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardSelectorOption } from '@lfx-one/shared/interfaces';
 
@@ -24,6 +24,9 @@ export class CardSelectorComponent<T = string> {
 
   // Output
   public readonly selectionChange = output<T>();
+
+  @ViewChildren('radioOption')
+  private readonly radioOptions!: QueryList<ElementRef<HTMLElement>>;
 
   public readonly labelId = computed(() => `${this.testIdPrefix()}-label`);
 
@@ -52,6 +55,7 @@ export class CardSelectorComponent<T = string> {
       event.preventDefault();
       const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length;
       this.onSelect(options[nextIndex].value);
+      this.focusOptionAt(nextIndex);
       return;
     }
 
@@ -59,6 +63,11 @@ export class CardSelectorComponent<T = string> {
       event.preventDefault();
       const nextIndex = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length;
       this.onSelect(options[nextIndex].value);
+      this.focusOptionAt(nextIndex);
     }
+  }
+
+  private focusOptionAt(index: number): void {
+    this.radioOptions.get(index)?.nativeElement.focus();
   }
 }

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -60,7 +60,10 @@ export class CardSelectorComponent<T = string> {
       return;
     }
 
-    const currentIndex = options.findIndex((option) => option.value === this.form().get(this.control())?.value);
+    const currentIndex = options.findIndex((option) => option.value === value);
+    if (currentIndex < 0) {
+      return;
+    }
 
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
@@ -70,7 +73,7 @@ export class CardSelectorComponent<T = string> {
 
     if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
       event.preventDefault();
-      const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length;
+      const nextIndex = (currentIndex + 1) % options.length;
       this.onSelect(options[nextIndex].value);
       this.focusOptionAt(nextIndex);
       return;
@@ -78,7 +81,7 @@ export class CardSelectorComponent<T = string> {
 
     if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
       event.preventDefault();
-      const nextIndex = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length;
+      const nextIndex = (currentIndex - 1 + options.length) % options.length;
       this.onSelect(options[nextIndex].value);
       this.focusOptionAt(nextIndex);
     }

--- a/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-selector/card-selector.component.ts
@@ -34,6 +34,19 @@ export class CardSelectorComponent<T = string> {
     return this.form().get(this.control())?.value === value;
   }
 
+  public hasSelection(): boolean {
+    const value = this.form().get(this.control())?.value;
+    return this.options().some((option) => option.value === value);
+  }
+
+  public getTabIndex(index: number, value: T): number {
+    if (this.isSelected(value)) {
+      return 0;
+    }
+
+    return !this.hasSelection() && index === 0 ? 0 : -1;
+  }
+
   // Handle selection
   public onSelect(value: T): void {
     this.form().get(this.control())?.setValue(value);
@@ -68,6 +81,8 @@ export class CardSelectorComponent<T = string> {
   }
 
   private focusOptionAt(index: number): void {
-    this.radioOptions.get(index)?.nativeElement.focus();
+    queueMicrotask(() => {
+      this.radioOptions.get(index)?.nativeElement.focus();
+    });
   }
 }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -1374,8 +1374,8 @@ export class CommitteeController {
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
       ]);
 
-      // Filter PRIVATE/restricted meetings from the public feed (mirrors PublicMeetingController visibility guard).
-      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC && !m.restricted);
+      // Public calendar lists all public-visibility meetings; join access remains gated by `restricted`.
+      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
       const ics = buildVCalendar(events, '-//LFX//Committee Calendar//EN');
 

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -887,7 +887,7 @@ export class ProjectController {
     }
   }
 
-  /** GET /public/api/projects/:id/calendar.ics — PUBLIC non-restricted meetings; serves both foundation and project lenses. */
+  /** GET /public/api/projects/:id/calendar.ics — public-visibility meetings; join access remains gated by `restricted`. */
   public async getProjectCalendar(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
     const startTime = logger.startOperation(req, 'get_project_calendar', { project_id: id });

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -912,8 +912,8 @@ export class ProjectController {
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
       ]);
 
-      // Filter PRIVATE/restricted meetings from the public feed (mirrors PublicMeetingController visibility guard).
-      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC && !m.restricted);
+      // Public calendar lists all public-visibility meetings; join access remains gated by `restricted`.
+      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
       const ics = buildVCalendar(events, '-//LFX//Project Calendar//EN');
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -331,9 +331,9 @@ export class PublicMeetingController {
         });
       }
 
-      // Public unrestricted meetings are open to anyone with the link; other meetings keep the password gate.
-      const isPublicUnrestricted = meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted;
-      if (!isPublicUnrestricted && !this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)) {
+      // Public meetings skip the access-password gate on join-url; restricted meetings use
+      // registrant check below and private meetings keep the password gate.
+      if (meeting.visibility !== MeetingVisibility.PUBLIC && !this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)) {
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -333,7 +333,10 @@ export class PublicMeetingController {
 
       // Public meetings skip the access-password gate on join-url; restricted meetings use
       // registrant check below and private meetings keep the password gate.
-      if (meeting.visibility !== MeetingVisibility.PUBLIC && !this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)) {
+      if (
+        meeting.visibility !== MeetingVisibility.PUBLIC &&
+        !this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)
+      ) {
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { AuthorizationError } from '../errors/authentication.error';
-import { addInvitedStatusToMeeting, checkPastMeetingAccess } from '../helpers/meeting.helper';
+import { addInvitedStatusToMeeting, checkPastMeetingAccess, stripMeetingJoinCredentials } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
@@ -135,8 +135,10 @@ export class PublicMeetingController {
         if (!meeting.organizer) {
           delete (meeting as Partial<Meeting>).host_key;
         }
+
+        const meetingResponse = meeting.organizer || meeting.invited ? meeting : stripMeetingJoinCredentials(meeting);
         res.json({
-          meeting,
+          meeting: meetingResponse,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
         });
         return;

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -132,11 +132,7 @@ export class PublicMeetingController {
       logger.success(req, 'get_public_meeting_by_id', startTime, { meeting_id: id, project_uid: meeting.project_uid, title: meeting.title });
 
       if (meeting.visibility === MeetingVisibility.PUBLIC) {
-        if (!meeting.organizer) {
-          delete (meeting as Partial<Meeting>).host_key;
-        }
-
-        const meetingResponse = meeting.organizer || meeting.invited ? meeting : stripMeetingJoinCredentials(meeting);
+        const meetingResponse = meeting.organizer ? meeting : stripMeetingJoinCredentials(meeting);
         res.json({
           meeting: meetingResponse,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -131,7 +131,10 @@ export class PublicMeetingController {
       // Log the success
       logger.success(req, 'get_public_meeting_by_id', startTime, { meeting_id: id, project_uid: meeting.project_uid, title: meeting.title });
 
-      if (meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted) {
+      if (meeting.visibility === MeetingVisibility.PUBLIC) {
+        if (!meeting.organizer) {
+          delete (meeting as Partial<Meeting>).host_key;
+        }
         res.json({
           meeting,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -331,8 +331,9 @@ export class PublicMeetingController {
         });
       }
 
-      // Check if the user has passed in a password, if so, check if it's correct
-      if (!this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)) {
+      // Public unrestricted meetings are open to anyone with the link; other meetings keep the password gate.
+      const isPublicUnrestricted = meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted;
+      if (!isPublicUnrestricted && !this.validateMeetingPassword(password as string, meeting.password as string, 'post_meeting_link', req, next)) {
         return;
       }
 

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -147,3 +147,20 @@ export async function checkPastMeetingAccess(req: Request, meeting: PastMeeting,
 
   return hasAccess;
 }
+
+/** Removes join credentials from a meeting payload for public discoverability responses. */
+export function stripMeetingJoinCredentials(meeting: Meeting): Meeting {
+  const sanitized = { ...meeting };
+  delete sanitized.host_key;
+  delete sanitized.password;
+  delete sanitized.passcode;
+
+  if (sanitized.zoom_config) {
+    sanitized.zoom_config = {
+      ai_companion_enabled: sanitized.zoom_config.ai_companion_enabled,
+      ai_summary_require_approval: sanitized.zoom_config.ai_summary_require_approval,
+    };
+  }
+
+  return sanitized;
+}

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -83,7 +83,9 @@ export async function addInvitedStatusToMeetings(req: Request, meetings: Meeting
  * organizer, or committee member).
  */
 export async function checkPastMeetingAccess(req: Request, meeting: PastMeeting, m2mToken: string, isOrganizer: boolean): Promise<boolean> {
-  // Public, non-restricted meetings are accessible to everyone
+  // Public, non-restricted meetings grant full past-meeting access to everyone.
+  // Public+restricted and private meetings still return basic discoverability from the controller;
+  // full access requires membership checks below.
   if (meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted) {
     return true;
   }

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -152,7 +152,7 @@ export async function checkPastMeetingAccess(req: Request, meeting: PastMeeting,
 export function stripMeetingJoinCredentials(meeting: Meeting): Meeting {
   const sanitized = { ...meeting };
   delete sanitized.host_key;
-  delete sanitized.password;
+  sanitized.password = null;
   delete sanitized.passcode;
 
   if (sanitized.zoom_config) {

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -263,6 +263,12 @@
     color: #fff;
   }
 
+  /* Restricted badge — solid fill */
+  &.tag-restricted {
+    background: #d97706;
+    color: #fff;
+  }
+
   /* Meeting type badges */
   &.tag-meeting-board {
     background: var(--meeting-board-bg);

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -263,9 +263,9 @@
     color: #fff;
   }
 
-  /* Restricted badge — solid fill */
+  /* Restricted badge — lfxColors.amber[700] for WCAG contrast with white text */
   &.tag-restricted {
-    background: #d97706;
+    background: #bb4d00;
     color: #fff;
   }
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ArtifactVisibility } from '../enums';
+import { ArtifactVisibility, MeetingPrivacyType } from '../enums';
 import type { MeetingTypeConfig } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 
@@ -35,6 +35,40 @@ export const MEETING_PLATFORMS = [
     color: lfxColors.gray[500],
   },
 ];
+
+/**
+ * Meeting privacy options for the create/edit wizard (PCC parity).
+ * @description Each option maps to an ITX `visibility` + `restricted` pair via meeting-privacy utils.
+ */
+export const MEETING_PRIVACY_OPTIONS = [
+  {
+    label: 'Public',
+    value: MeetingPrivacyType.PUBLIC,
+    info: {
+      icon: 'fa-light fa-globe',
+      description: 'Listed on the public project calendar. Anyone can join — best for community meetings and open discussions.',
+      color: lfxColors.emerald[500],
+    },
+  },
+  {
+    label: 'Private',
+    value: MeetingPrivacyType.PRIVATE,
+    info: {
+      icon: 'fa-light fa-eye-slash',
+      description: 'Hidden from the public calendar. Guests can still join with a name only — SSO required to see it in your dashboard.',
+      color: lfxColors.blue[500],
+    },
+  },
+  {
+    label: 'Restricted',
+    value: MeetingPrivacyType.RESTRICTED,
+    info: {
+      icon: 'fa-light fa-lock',
+      description: 'Hidden from the public calendar. Only invited guests can join — best for board meetings and confidential discussions.',
+      color: lfxColors.amber[500],
+    },
+  },
+] as const;
 
 /**
  * Available meeting features that can be enabled/disabled
@@ -72,16 +106,6 @@ export const MEETING_FEATURES = [
     description: "Automatically publish recordings to your project's YouTube channel",
     recommended: false,
     color: lfxColors.red[500],
-  },
-  {
-    key: 'visibility',
-    icon: 'fa-light fa-calendar-check',
-    title: 'Show in Public Calendar',
-    description: 'Make this meeting visible in the public project calendar',
-    recommended: true,
-    color: lfxColors.amber[500],
-    trueValue: 'public',
-    falseValue: 'private',
   },
 ];
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ArtifactVisibility, MeetingPrivacyType } from '../enums';
+import { ArtifactVisibility, MeetingVisibility } from '../enums';
 import type { MeetingTypeConfig } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 
@@ -37,35 +37,50 @@ export const MEETING_PLATFORMS = [
 ];
 
 /**
- * Meeting privacy options for the create/edit wizard (PCC parity).
- * @description Each option maps to an ITX `visibility` + `restricted` pair via meeting-privacy utils.
+ * Meeting visibility options for the create/edit wizard (PCC parity).
+ * @description Controls who can discover the meeting — public calendar vs link-only.
  */
-export const MEETING_PRIVACY_OPTIONS = [
+export const MEETING_VISIBILITY_OPTIONS = [
   {
     label: 'Public',
-    value: MeetingPrivacyType.PUBLIC,
+    value: MeetingVisibility.PUBLIC,
     info: {
       icon: 'fa-light fa-globe',
-      description: 'Listed on the public project calendar. Anyone can join — best for community meetings and open discussions.',
+      description: 'Listed on the public project calendar and discoverable in the app.',
       color: lfxColors.emerald[500],
     },
   },
   {
     label: 'Private',
-    value: MeetingPrivacyType.PRIVATE,
+    value: MeetingVisibility.PRIVATE,
     info: {
       icon: 'fa-light fa-eye-slash',
-      description:
-        'Hidden from the public calendar. Guests can join without signing in (name and email required). SSO is required to see it in your dashboard.',
+      description: 'Hidden from the public calendar. Only guests with the meeting link can find this meeting.',
       color: lfxColors.blue[500],
     },
   },
+] as const;
+
+/**
+ * Meeting join-restriction options for the create/edit wizard (PCC parity).
+ * @description Controls who can join once they have the meeting link.
+ */
+export const MEETING_JOIN_RESTRICTION_OPTIONS = [
   {
-    label: 'Restricted',
-    value: MeetingPrivacyType.RESTRICTED,
+    label: 'Anyone with the link',
+    value: false,
+    info: {
+      icon: 'fa-light fa-link',
+      description: 'Anyone who has the meeting link can join.',
+      color: lfxColors.emerald[500],
+    },
+  },
+  {
+    label: 'Invited guests only',
+    value: true,
     info: {
       icon: 'fa-light fa-lock',
-      description: 'Hidden from the public calendar. Only invited guests can join — best for board meetings and confidential discussions.',
+      description: 'Only guests you invite can join this meeting.',
       color: lfxColors.amber[500],
     },
   },

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -55,7 +55,8 @@ export const MEETING_PRIVACY_OPTIONS = [
     value: MeetingPrivacyType.PRIVATE,
     info: {
       icon: 'fa-light fa-eye-slash',
-      description: 'Hidden from the public calendar. Guests can still join with a name only — SSO required to see it in your dashboard.',
+      description:
+        'Hidden from the public calendar. Guests can join without signing in (name and email required). SSO is required to see it in your dashboard.',
       color: lfxColors.blue[500],
     },
   },

--- a/packages/shared/src/enums/meeting.enum.ts
+++ b/packages/shared/src/enums/meeting.enum.ts
@@ -19,7 +19,7 @@ export enum MeetingVisibility {
 export enum MeetingPrivacyType {
   /** Public calendar listing; anyone can join */
   PUBLIC = 'public_unrestricted',
-  /** Hidden from public calendar; guest join allowed with name only */
+  /** Hidden from public calendar; guest join without SSO (name and email required) */
   PRIVATE = 'private_unrestricted',
   /** Hidden from public calendar; invite-only join */
   RESTRICTED = 'private_restricted',

--- a/packages/shared/src/enums/meeting.enum.ts
+++ b/packages/shared/src/enums/meeting.enum.ts
@@ -13,8 +13,8 @@ export enum MeetingVisibility {
 }
 
 /**
- * Unified meeting privacy selector values (PCC parity).
- * @description Maps to the ITX pair of `visibility` + `restricted` via meeting-privacy utils.
+ * Derived meeting privacy labels for display (badges, tooltips).
+ * @description Computed from the independent `visibility` + `restricted` fields via meeting-privacy utils.
  */
 export enum MeetingPrivacyType {
   /** Public calendar listing; anyone can join */

--- a/packages/shared/src/enums/meeting.enum.ts
+++ b/packages/shared/src/enums/meeting.enum.ts
@@ -13,19 +13,6 @@ export enum MeetingVisibility {
 }
 
 /**
- * Derived meeting privacy labels for display (badges, tooltips).
- * @description Computed from the independent `visibility` + `restricted` fields via meeting-privacy utils.
- */
-export enum MeetingPrivacyType {
-  /** Public calendar listing; anyone can join */
-  PUBLIC = 'public_unrestricted',
-  /** Hidden from public calendar; guest join without SSO (name and email required) */
-  PRIVATE = 'private_unrestricted',
-  /** Hidden from public calendar; invite-only join */
-  RESTRICTED = 'private_restricted',
-}
-
-/**
  * Meeting type categories
  * @description Categorizes meetings by their purpose and governance structure
  */

--- a/packages/shared/src/enums/meeting.enum.ts
+++ b/packages/shared/src/enums/meeting.enum.ts
@@ -13,6 +13,19 @@ export enum MeetingVisibility {
 }
 
 /**
+ * Unified meeting privacy selector values (PCC parity).
+ * @description Maps to the ITX pair of `visibility` + `restricted` via meeting-privacy utils.
+ */
+export enum MeetingPrivacyType {
+  /** Public calendar listing; anyone can join */
+  PUBLIC = 'public_unrestricted',
+  /** Hidden from public calendar; guest join allowed with name only */
+  PRIVATE = 'private_unrestricted',
+  /** Hidden from public calendar; invite-only join */
+  RESTRICTED = 'private_restricted',
+}
+
+/**
  * Meeting type categories
  * @description Categorizes meetings by their purpose and governance structure
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1184,11 +1184,20 @@ export interface MeetingTypeConfig {
 }
 
 /**
- * ITX visibility + restricted pair derived from the unified privacy selector.
+ * ITX visibility + restricted pair for meeting create/update payloads.
  */
 export interface MeetingPrivacyFields {
   visibility: MeetingVisibility;
   restricted: boolean;
+}
+
+/**
+ * Style metadata for compact meeting privacy indicator dots.
+ */
+export interface MeetingPrivacyDotStyle {
+  label: string;
+  bgColor: string;
+  icon: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1184,6 +1184,14 @@ export interface MeetingTypeConfig {
 }
 
 /**
+ * ITX visibility + restricted pair derived from the unified privacy selector.
+ */
+export interface MeetingPrivacyFields {
+  visibility: MeetingVisibility;
+  restricted: boolean;
+}
+
+/**
  * Meeting type badge interface
  * @description Structure for meeting type badge display
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1184,14 +1184,6 @@ export interface MeetingTypeConfig {
 }
 
 /**
- * ITX visibility + restricted pair for meeting create/update payloads.
- */
-export interface MeetingPrivacyFields {
-  visibility: MeetingVisibility;
-  restricted: boolean;
-}
-
-/**
  * Style metadata for compact meeting privacy indicator dots.
  */
 export interface MeetingPrivacyDotStyle {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
 export * from './meeting.utils';
+export * from './meeting-privacy.utils';
 export * from './past-meeting-summary.utils';
 export * from './past-meeting.utils';
 export * from './rsvp-calculator.util';

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -3,60 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { MeetingPrivacyType, MeetingVisibility } from '../enums';
-import { fieldsToPrivacyType, privacyTypeToFields, shouldShowPrivateMeetingLabel, shouldShowRestrictedMeetingLabel } from './meeting-privacy.utils';
-
-describe('privacyTypeToFields', () => {
-  it('maps Public to public visibility with unrestricted join', () => {
-    expect(privacyTypeToFields(MeetingPrivacyType.PUBLIC)).toEqual({
-      visibility: MeetingVisibility.PUBLIC,
-      restricted: false,
-    });
-  });
-
-  it('maps Private to private visibility with unrestricted join', () => {
-    expect(privacyTypeToFields(MeetingPrivacyType.PRIVATE)).toEqual({
-      visibility: MeetingVisibility.PRIVATE,
-      restricted: false,
-    });
-  });
-
-  it('maps Restricted to private visibility with invite-only join', () => {
-    expect(privacyTypeToFields(MeetingPrivacyType.RESTRICTED)).toEqual({
-      visibility: MeetingVisibility.PRIVATE,
-      restricted: true,
-    });
-  });
-
-  it('falls back to Private when privacy type is missing or unknown', () => {
-    expect(privacyTypeToFields(null)).toEqual({
-      visibility: MeetingVisibility.PRIVATE,
-      restricted: false,
-    });
-    expect(privacyTypeToFields(undefined)).toEqual({
-      visibility: MeetingVisibility.PRIVATE,
-      restricted: false,
-    });
-  });
-});
-
-describe('fieldsToPrivacyType', () => {
-  it('derives Public from public + unrestricted', () => {
-    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, false)).toBe(MeetingPrivacyType.PUBLIC);
-  });
-
-  it('derives Private from private + unrestricted', () => {
-    expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, false)).toBe(MeetingPrivacyType.PRIVATE);
-  });
-
-  it('derives Restricted from private + invite-only', () => {
-    expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, true)).toBe(MeetingPrivacyType.RESTRICTED);
-  });
-
-  it('derives Public from public + invite-only (legacy enum cannot encode join restriction)', () => {
-    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, true)).toBe(MeetingPrivacyType.PUBLIC);
-  });
-});
+import { MeetingVisibility } from '../enums';
+import { shouldShowPrivateMeetingLabel, shouldShowRestrictedMeetingLabel } from './meeting-privacy.utils';
 
 describe('shouldShowPrivateMeetingLabel', () => {
   it('shows Private for private visibility and null/unknown legacy values', () => {

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { MeetingPrivacyType, MeetingVisibility } from '../enums';
+import { fieldsToPrivacyType, privacyTypeToFields } from './meeting-privacy.utils';
+
+describe('privacyTypeToFields', () => {
+  it('maps Public to public visibility with unrestricted join', () => {
+    expect(privacyTypeToFields(MeetingPrivacyType.PUBLIC)).toEqual({
+      visibility: MeetingVisibility.PUBLIC,
+      restricted: false,
+    });
+  });
+
+  it('maps Private to private visibility with unrestricted join', () => {
+    expect(privacyTypeToFields(MeetingPrivacyType.PRIVATE)).toEqual({
+      visibility: MeetingVisibility.PRIVATE,
+      restricted: false,
+    });
+  });
+
+  it('maps Restricted to private visibility with invite-only join', () => {
+    expect(privacyTypeToFields(MeetingPrivacyType.RESTRICTED)).toEqual({
+      visibility: MeetingVisibility.PRIVATE,
+      restricted: true,
+    });
+  });
+});
+
+describe('fieldsToPrivacyType', () => {
+  it('derives Public from public + unrestricted', () => {
+    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, false)).toBe(MeetingPrivacyType.PUBLIC);
+  });
+
+  it('derives Private from private + unrestricted', () => {
+    expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, false)).toBe(MeetingPrivacyType.PRIVATE);
+  });
+
+  it('derives Restricted when restricted is true regardless of visibility', () => {
+    expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, true)).toBe(MeetingPrivacyType.RESTRICTED);
+    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, true)).toBe(MeetingPrivacyType.RESTRICTED);
+  });
+});

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -49,9 +49,12 @@ describe('fieldsToPrivacyType', () => {
     expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, false)).toBe(MeetingPrivacyType.PRIVATE);
   });
 
-  it('derives Restricted when restricted is true regardless of visibility', () => {
+  it('derives Restricted from private + invite-only', () => {
     expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, true)).toBe(MeetingPrivacyType.RESTRICTED);
-    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, true)).toBe(MeetingPrivacyType.RESTRICTED);
+  });
+
+  it('derives Public from public + invite-only (legacy enum cannot encode join restriction)', () => {
+    expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, true)).toBe(MeetingPrivacyType.PUBLIC);
   });
 });
 

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { MeetingPrivacyType, MeetingVisibility } from '../enums';
-import { fieldsToPrivacyType, privacyTypeToFields } from './meeting-privacy.utils';
+import { fieldsToPrivacyType, privacyTypeToFields, shouldShowPrivateMeetingLabel, shouldShowRestrictedMeetingLabel } from './meeting-privacy.utils';
 
 describe('privacyTypeToFields', () => {
   it('maps Public to public visibility with unrestricted join', () => {
@@ -52,5 +52,26 @@ describe('fieldsToPrivacyType', () => {
   it('derives Restricted when restricted is true regardless of visibility', () => {
     expect(fieldsToPrivacyType(MeetingVisibility.PRIVATE, true)).toBe(MeetingPrivacyType.RESTRICTED);
     expect(fieldsToPrivacyType(MeetingVisibility.PUBLIC, true)).toBe(MeetingPrivacyType.RESTRICTED);
+  });
+});
+
+describe('shouldShowPrivateMeetingLabel', () => {
+  it('shows Private for private visibility and null/unknown legacy values', () => {
+    expect(shouldShowPrivateMeetingLabel(MeetingVisibility.PRIVATE)).toBe(true);
+    expect(shouldShowPrivateMeetingLabel(null)).toBe(true);
+    expect(shouldShowPrivateMeetingLabel(undefined)).toBe(true);
+  });
+
+  it('hides Private for explicit public visibility', () => {
+    expect(shouldShowPrivateMeetingLabel(MeetingVisibility.PUBLIC)).toBe(false);
+    expect(shouldShowPrivateMeetingLabel('public')).toBe(false);
+  });
+});
+
+describe('shouldShowRestrictedMeetingLabel', () => {
+  it('shows Restricted only when restricted is true', () => {
+    expect(shouldShowRestrictedMeetingLabel(true)).toBe(true);
+    expect(shouldShowRestrictedMeetingLabel(false)).toBe(false);
+    expect(shouldShowRestrictedMeetingLabel(null)).toBe(false);
   });
 });

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -27,6 +27,17 @@ describe('privacyTypeToFields', () => {
       restricted: true,
     });
   });
+
+  it('falls back to Private when privacy type is missing or unknown', () => {
+    expect(privacyTypeToFields(null)).toEqual({
+      visibility: MeetingVisibility.PRIVATE,
+      restricted: false,
+    });
+    expect(privacyTypeToFields(undefined)).toEqual({
+      visibility: MeetingVisibility.PRIVATE,
+      restricted: false,
+    });
+  });
 });
 
 describe('fieldsToPrivacyType', () => {

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -28,3 +28,13 @@ export function fieldsToPrivacyType(visibility: MeetingVisibility | string | nul
   }
   return MeetingPrivacyType.PRIVATE;
 }
+
+/** True when a Private visibility label/badge should be shown (includes null/unknown legacy data). */
+export function shouldShowPrivateMeetingLabel(visibility: MeetingVisibility | string | null | undefined): boolean {
+  return visibility !== MeetingVisibility.PUBLIC && visibility !== 'public';
+}
+
+/** True when a Restricted join label/badge should be shown. */
+export function shouldShowRestrictedMeetingLabel(restricted: boolean | null | undefined): boolean {
+  return restricted === true;
+}

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -1,36 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MeetingPrivacyType, MeetingVisibility } from '../enums';
-import { MeetingPrivacyFields } from '../interfaces/meeting.interface';
-
-/** Maps the unified privacy selector to the ITX `visibility` + `restricted` pair. */
-export function privacyTypeToFields(privacyType: MeetingPrivacyType | null | undefined): MeetingPrivacyFields {
-  switch (privacyType) {
-    case MeetingPrivacyType.PUBLIC:
-      return { visibility: MeetingVisibility.PUBLIC, restricted: false };
-    case MeetingPrivacyType.PRIVATE:
-      return { visibility: MeetingVisibility.PRIVATE, restricted: false };
-    case MeetingPrivacyType.RESTRICTED:
-      return { visibility: MeetingVisibility.PRIVATE, restricted: true };
-    default:
-      return { visibility: MeetingVisibility.PRIVATE, restricted: false };
-  }
-}
-
-/** Derives the legacy privacy selector value from stored meeting fields.
- *  Note: `MeetingPrivacyType` cannot losslessly represent public+restricted; that combo maps to PUBLIC. */
-export function fieldsToPrivacyType(visibility: MeetingVisibility | string | null | undefined, restricted: boolean | null | undefined): MeetingPrivacyType {
-  const isPublic = visibility === MeetingVisibility.PUBLIC || visibility === 'public';
-
-  if (isPublic) {
-    return MeetingPrivacyType.PUBLIC;
-  }
-  if (restricted) {
-    return MeetingPrivacyType.RESTRICTED;
-  }
-  return MeetingPrivacyType.PRIVATE;
-}
+import { MeetingVisibility } from '../enums';
 
 /** True when a Private visibility label/badge should be shown (includes null/unknown legacy data). */
 export function shouldShowPrivateMeetingLabel(visibility: MeetingVisibility | string | null | undefined): boolean {

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -18,13 +18,16 @@ export function privacyTypeToFields(privacyType: MeetingPrivacyType | null | und
   }
 }
 
-/** Derives the privacy selector value from stored meeting fields (PCC parity). */
+/** Derives the legacy privacy selector value from stored meeting fields.
+ *  Note: `MeetingPrivacyType` cannot losslessly represent public+restricted; that combo maps to PUBLIC. */
 export function fieldsToPrivacyType(visibility: MeetingVisibility | string | null | undefined, restricted: boolean | null | undefined): MeetingPrivacyType {
+  const isPublic = visibility === MeetingVisibility.PUBLIC || visibility === 'public';
+
+  if (isPublic) {
+    return MeetingPrivacyType.PUBLIC;
+  }
   if (restricted) {
     return MeetingPrivacyType.RESTRICTED;
-  }
-  if (visibility === MeetingVisibility.PUBLIC || visibility === 'public') {
-    return MeetingPrivacyType.PUBLIC;
   }
   return MeetingPrivacyType.PRIVATE;
 }

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingPrivacyType, MeetingVisibility } from '../enums';
-
-export interface MeetingPrivacyFields {
-  visibility: MeetingVisibility;
-  restricted: boolean;
-}
+import { MeetingPrivacyFields } from '../interfaces/meeting.interface';
 
 /** Maps the unified privacy selector to the ITX `visibility` + `restricted` pair. */
-export function privacyTypeToFields(privacyType: MeetingPrivacyType): MeetingPrivacyFields {
+export function privacyTypeToFields(privacyType: MeetingPrivacyType | null | undefined): MeetingPrivacyFields {
   switch (privacyType) {
     case MeetingPrivacyType.PUBLIC:
       return { visibility: MeetingVisibility.PUBLIC, restricted: false };
@@ -17,6 +13,8 @@ export function privacyTypeToFields(privacyType: MeetingPrivacyType): MeetingPri
       return { visibility: MeetingVisibility.PRIVATE, restricted: false };
     case MeetingPrivacyType.RESTRICTED:
       return { visibility: MeetingVisibility.PRIVATE, restricted: true };
+    default:
+      return { visibility: MeetingVisibility.PRIVATE, restricted: false };
   }
 }
 

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MeetingPrivacyType, MeetingVisibility } from '../enums';
+
+export interface MeetingPrivacyFields {
+  visibility: MeetingVisibility;
+  restricted: boolean;
+}
+
+/** Maps the unified privacy selector to the ITX `visibility` + `restricted` pair. */
+export function privacyTypeToFields(privacyType: MeetingPrivacyType): MeetingPrivacyFields {
+  switch (privacyType) {
+    case MeetingPrivacyType.PUBLIC:
+      return { visibility: MeetingVisibility.PUBLIC, restricted: false };
+    case MeetingPrivacyType.PRIVATE:
+      return { visibility: MeetingVisibility.PRIVATE, restricted: false };
+    case MeetingPrivacyType.RESTRICTED:
+      return { visibility: MeetingVisibility.PRIVATE, restricted: true };
+  }
+}
+
+/** Derives the privacy selector value from stored meeting fields (PCC parity). */
+export function fieldsToPrivacyType(visibility: MeetingVisibility | string | null | undefined, restricted: boolean | null | undefined): MeetingPrivacyType {
+  if (restricted) {
+    return MeetingPrivacyType.RESTRICTED;
+  }
+  if (visibility === MeetingVisibility.PUBLIC || visibility === 'public') {
+    return MeetingPrivacyType.PUBLIC;
+  }
+  return MeetingPrivacyType.PRIVATE;
+}


### PR DESCRIPTION
## Summary
- Replace the single Public/Restricted privacy control with two PCC-aligned card selectors in the create/edit wizard: **Visibility** (who can find the meeting) and **Join restriction** (who can join).
- Form binds directly to ITX `visibility` and `restricted` fields, supporting all four combinations (including public + invited-only).
- Add shared display helpers and independent Private/Restricted badges across meeting cards, join page, and dashboard.
- Public calendar feeds now list all public-visibility meetings regardless of join restriction; join access remains gated by `restricted`.
- Improve `lfx-card-selector` keyboard accessibility (roving tabindex, arrow-key focus).

## Test plan
- [x] `yarn format && yarn lint && yarn build`
- [x] `yarn workspace @lfx-one/shared test meeting-privacy`
- [ ] Create meetings for each visibility/restriction combo and verify persisted `visibility` + `restricted`
- [ ] Edit existing meetings; confirm both selectors pre-populate correctly
- [ ] Verify join page behavior for public, private, and restricted combinations
- [ ] Confirm public-visibility meetings appear on project/committee calendars; private do not
- [ ] Manual keyboard navigation through meeting-type and privacy card selectors

Closes LFXV2-2658

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes public meeting discovery, calendar feeds, credential stripping, and join-url password gating—security-sensitive access paths that need regression across all visibility/restriction combos.
> 
> **Overview**
> Replaces the single **Public/Restricted** privacy control with two wizard steps: **visibility** (`public` vs `private`) and **join restriction** (`restricted`), wired directly to ITX fields so all four combinations are supported.
> 
> **UI** uses shared `shouldShowPrivateMeetingLabel` / `shouldShowRestrictedMeetingLabel` for separate **Private** and **Restricted** badges on meeting cards, join, past details, and dashboard date-badge dots (no indicator for public + unrestricted). The platform-features **Show in Public Calendar** toggle is removed; visibility is set only in step 1. `lfx-card-selector` gains radiogroup semantics, roving tabindex, and arrow-key navigation.
> 
> **Backend/API**: project and committee `.ics` feeds include every **public-visibility** meeting (restricted ones still listed; join remains gated). Public meeting detail responses for non-organizers strip join credentials via `stripMeetingJoinCredentials`. **Public** meetings skip the access-password check when fetching join URLs; private meetings still require it. Join page copy-link and return URLs prefer the query `password` when present.
> 
> Form save uses `restricted ?? false`; step 1 validation requires `visibility` and a boolean `restricted`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdeb680f5dd4744a62aef8127da49229eed77566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->