### PR TITLE
feat: record HTTP client errors on OTel spans

### DIFF
--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -149,6 +149,16 @@ if (!otlpEndpoint) {
           requestHeaders: ['content-type'],
           responseHeaders: ['content-type'],
         },
+        responseHook: (span, { request, response }) => {
+          if (response.statusCode >= 500) {
+            const path = request.path.split('?')[0];
+            const err = new Error(
+              `HTTP ${response.statusCode} ${request.method} ${request.origin}${path}`
+            );
+            err.name = 'HttpClientError';
+            span.recordException(err);
+          }
+        },
       }),
     ],
   });


### PR DESCRIPTION
## What

Adds a `responseHook` to the `UndiciInstrumentation` configuration in `otel.mjs` so that outbound HTTP spans for 5xx responses include `error.message`, `error.type`, and `error.stack` in Datadog APM. Query parameters are stripped from the path before recording to avoid exposing tokens or PII in telemetry.

4xx responses (401, 403, 404) are intentionally excluded — they represent expected application behaviour, not errors.

## Why

Investigation of Datadog APM showed ~2,400 error spans per day from `lfx-self-serve` with empty error details. The OTel undici instrumentation sets `otel.status_code: Error` on spans based on HTTP status codes but does not call `span.recordException()`, which is what Datadog uses to populate `error.message`, `error.type`, and `error.stack`.

Issue: LFXV2-2660

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change in `otel.mjs`; no application request handling or auth logic is modified.
> 
> **Overview**
> Outbound HTTP traces from **Undici** now call `span.recordException()` when the response status is **5xx**, so Datadog APM can show `error.message`, `error.type`, and `error.stack` instead of empty error spans.
> 
> The hook builds a synthetic `HttpClientError` with method, origin, and a **query-stripped** path. **4xx** responses are left unchanged so expected client/auth/not-found outcomes are not treated as exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a75f76a4e7cdf5a1b81bd1ad927eee9e6aefdcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->