### PR TITLE
fix(mailing-lists): align delivery_mode enum values with Groups.io API contract

### DIFF
--- a/packages/shared/src/enums/mailing-list.enum.ts
+++ b/packages/shared/src/enums/mailing-list.enum.ts
@@ -51,12 +51,15 @@ export enum MailingListMemberType {
 
 /**
  * Mailing list member delivery mode
- * @description How emails are delivered to this member
+ * @description How emails are delivered to this member (Groups.io API values)
  */
 export enum MailingListMemberDeliveryMode {
-  NORMAL = 'normal',
-  DIGEST = 'digest',
-  NONE = 'none',
+  NORMAL = 'email_delivery_single',
+  DIGEST = 'email_delivery_digest',
+  NONE = 'email_delivery_none',
+  SPECIAL = 'email_delivery_special',
+  HTML_DIGEST = 'email_delivery_html_digest',
+  SUMMARY = 'email_delivery_summary',
 }
 
 /**

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -243,7 +243,7 @@ export interface MailingListMember {
   job_title?: string;
   /** How member was added (committee or direct) */
   member_type: MailingListMemberType;
-  /** Email delivery mode (normal, digest, none) */
+  /** Email delivery mode (Groups.io API values, e.g. email_delivery_single, email_delivery_digest, email_delivery_none) */
   delivery_mode: MailingListMemberDeliveryMode;
   /** Moderation status (none, moderator, owner) */
   mod_status: MailingListMemberModStatus;


### PR DESCRIPTION
## Summary

- `MailingListMemberDeliveryMode` enum values were `'normal'`/`'digest'`/`'none'` but the upstream Groups.io API requires `'email_delivery_single'`/`'email_delivery_digest'`/`'email_delivery_none'`, causing a `BAD_REQUEST` on every mailing list member creation and update
- Corrected all three values to match the API contract
- Added the three remaining API-defined values (`SPECIAL`, `HTML_DIGEST`, `SUMMARY`) for completeness

## Ticket

No JIRA ticket tracked yet — please create one if needed.

## Test plan

- [x] Add a mailing list member with default delivery mode (Individual) — should succeed without `BAD_REQUEST`
- [x] Add a member with Digest delivery mode — should succeed
- [x] Add a member with None delivery mode — should succeed
- [x] Update an existing member's delivery mode — should succeed
- [x] Delivery mode filter on the members list still works correctly
- [x] Dashboard digest-count stat reflects the correct count

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the serialized values for delivery_mode on all member API calls; callers that still compare or send the old strings would break, though the app appears to use the enum constants.
> 
> **Overview**
> **`MailingListMemberDeliveryMode`** string values are updated from shorthand (`normal`, `digest`, `none`) to the Groups.io API literals (`email_delivery_single`, `email_delivery_digest`, `email_delivery_none`), which should stop **`BAD_REQUEST`** responses on member create/update when `delivery_mode` is sent upstream.
> 
> Three additional API modes are added on the enum (**`SPECIAL`**, **`HTML_DIGEST`**, **`SUMMARY`**). Docs on **`MailingListMember.delivery_mode`** in the shared interface are updated to describe the new wire values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e74d76c907be3443ef82fb13147006e1942089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->