### PR TITLE
feat(meetings): render join-page meeting time in local timezone with SSR-safe skeleton (LFXV2-2540)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -157,11 +157,15 @@
                   <!-- Date/Time Badge -->
                   @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
                     <div class="flex items-center gap-3">
-                      <lfx-tag
-                        [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact'"
-                        severity="secondary"
-                        icon="fa-light fa-calendar-days"
-                        [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                      @if (userTimezone(); as tz) {
+                        <lfx-tag
+                          [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact' : tz"
+                          severity="secondary"
+                          icon="fa-light fa-calendar-days"
+                          [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                      } @else {
+                        <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
+                      }
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, isPlatformBrowser, isPlatformServer, NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
+import { DatePipe, isPlatformServer, NgClass } from '@angular/common';
+import { afterNextRender, Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -324,12 +324,16 @@ export class MeetingJoinComponent implements OnInit {
     this.parentProject = this.initializeParentProject();
     this.initializeAutoJoin();
     this.initializePublicMeetingPageviewTracking();
+
+    // Runs only in the browser after the first render, so the SSR skeleton
+    // hydrates first and only then swaps to the timezone-formatted tag —
+    // avoids a hydration DOM mismatch (LFXV2-2540).
+    afterNextRender(() => {
+      this.userTimezone.set(getUserTimezone());
+    });
   }
 
   public ngOnInit(): void {
-    if (isPlatformBrowser(this.platformId)) {
-      this.userTimezone.set(getUserTimezone());
-    }
     if (typeof window !== 'undefined') {
       const mql = window.matchMedia('(max-width: 639px)'); // Matches Tailwind sm: breakpoint (640px)
       this.isMobileViewport.set(mql.matches);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, isPlatformServer, NgClass } from '@angular/common';
+import { DatePipe, isPlatformBrowser, isPlatformServer, NgClass } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -47,6 +47,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
+import { getUserTimezone } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -59,6 +60,7 @@ import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import {
   BehaviorSubject,
@@ -102,6 +104,7 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     GuestFormComponent,
     TooltipModule,
     DrawerModule,
+    SkeletonModule,
     MeetingTimePipe,
     RecurrenceSummaryPipe,
     LinkifyPipe,
@@ -214,6 +217,9 @@ export class MeetingJoinComponent implements OnInit {
     return name.substring(0, 2).toUpperCase();
   });
   protected isMobileViewport = signal(false);
+  // Null on the server and until hydration resolves the browser timezone — the date/time
+  // badge shows a skeleton while null so SSR never emits a UTC time (LFXV2-2540).
+  protected userTimezone = signal<string | null>(null);
   protected drawerPosition = computed(() => (this.isMobileViewport() ? 'bottom' : 'right') as 'bottom' | 'right');
   // Parent project (foundation) for context display
   protected parentProject: Signal<Project | null>;
@@ -321,6 +327,9 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   public ngOnInit(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      this.userTimezone.set(getUserTimezone());
+    }
     if (typeof window !== 'undefined') {
       const mql = window.matchMedia('(max-width: 639px)'); // Matches Tailwind sm: breakpoint (640px)
       this.isMobileViewport.set(mql.matches);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -217,8 +217,7 @@ export class MeetingJoinComponent implements OnInit {
     return name.substring(0, 2).toUpperCase();
   });
   protected isMobileViewport = signal(false);
-  // Null on the server and until hydration resolves the browser timezone — the date/time
-  // badge shows a skeleton while null so SSR never emits a UTC time (LFXV2-2540).
+  // Null on the server and until hydration resolves the browser timezone — the badge shows a skeleton while null.
   protected userTimezone = signal<string | null>(null);
   protected drawerPosition = computed(() => (this.isMobileViewport() ? 'bottom' : 'right') as 'bottom' | 'right');
   // Parent project (foundation) for context display
@@ -325,9 +324,7 @@ export class MeetingJoinComponent implements OnInit {
     this.initializeAutoJoin();
     this.initializePublicMeetingPageviewTracking();
 
-    // Runs only in the browser after the first render, so the SSR skeleton
-    // hydrates first and only then swaps to the timezone-formatted tag —
-    // avoids a hydration DOM mismatch (LFXV2-2540).
+    // Runs after first render so the SSR skeleton hydrates before swapping to the timezone tag.
     afterNextRender(() => {
       this.userTimezone.set(getUserTimezone());
     });

--- a/apps/lfx-one/src/app/shared/pipes/meeting-time.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/meeting-time.pipe.ts
@@ -7,7 +7,12 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'meetingTime',
 })
 export class MeetingTimePipe implements PipeTransform {
-  public transform(startTime: string | null, duration: number | null, format: 'full' | 'full-start' | 'date' | 'time' | 'compact' = 'full'): string {
+  public transform(
+    startTime: string | null,
+    duration: number | null,
+    format: 'full' | 'full-start' | 'date' | 'time' | 'compact' = 'full',
+    timeZone?: string
+  ): string {
     if (!startTime) {
       return 'Time not set';
     }
@@ -30,6 +35,7 @@ export class MeetingTimePipe implements PipeTransform {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        ...(timeZone ? { timeZone } : {}),
       };
 
       // Format time: 3:00 PM
@@ -37,6 +43,7 @@ export class MeetingTimePipe implements PipeTransform {
         hour: 'numeric',
         minute: '2-digit',
         hour12: true,
+        ...(timeZone ? { timeZone } : {}),
       };
 
       const dateStr = startDate.toLocaleDateString('en-US', dateOptions);
@@ -49,6 +56,7 @@ export class MeetingTimePipe implements PipeTransform {
             weekday: 'short',
             month: 'short',
             day: 'numeric',
+            ...(timeZone ? { timeZone } : {}),
           };
           const compactDateStr = startDate.toLocaleDateString('en-US', compactDateOptions);
           if (endDate) {


### PR DESCRIPTION
# Summary

Renders the meeting date/time badge on the public meeting join page in the visitor's local timezone instead of the server's default timezone. The browser timezone is read after hydration via `afterNextRender`, with a PrimeNG skeleton placeholder shown until the value resolves so the SSR-rendered markup hydrates cleanly.

# Before / After

**Before:** The join page date/time badge was formatted with `MeetingTimePipe` using the runtime's default timezone. Because the page is SSR-rendered, the server (UTC) timezone was baked into the rendered string, and there was no placeholder state while the browser value was unavailable.

**After:** The badge formats the start time in the user's detected browser timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone` via `getUserTimezone`). `MeetingTimePipe` accepts an optional `timeZone` argument applied to its date/time `toLocale*` options. The component exposes a `userTimezone` signal that stays `null` on the server and until the first post-hydration render; the template renders a `p-skeleton` while it is `null` and swaps to the `lfx-tag` once the timezone is set.

# Changes

## `MeetingTimePipe`
- Added an optional `timeZone` parameter to `transform()` (last argument, after `format`).
- When `timeZone` is provided, spreads `{ timeZone }` into the `full`/`compact` date and time `toLocale*` option objects; omitted entirely when absent so existing callers see no behavior change.

## `MeetingJoinComponent` (template)
- Wrapped the date/time `lfx-tag` in an `@if (userTimezone(); as tz)` block that passes `tz` as the new `timeZone` pipe argument.
- Added a `@else` branch rendering a `p-skeleton` (width `14rem`, height `1.5rem`, rounded pill, `wave` animation, `data-testid="meeting-badge-datetime-skeleton"`) so the badge area is non-empty during SSR/hydration instead of flashing.

## `MeetingJoinComponent` (component)
- Added `userTimezone = signal<string | null>(null)` — `null` on the server and until the post-hydration callback resolves it.
- Registered `afterNextRender(() => this.userTimezone.set(getUserTimezone()))` in the constructor so the SSR skeleton hydrates first, then the timezone is read on the client only.
- Imported `afterNextRender`, `getUserTimezone` from `@lfx-one/shared/utils`, and `SkeletonModule` from `primeng/skeleton`; registered `SkeletonModule` in the component imports.

## Tests
- No test changes in this PR; the join page is covered by existing E2E. The skeleton state and post-hydration swap are guardable via the existing `meeting-badge-datetime` / new `meeting-badge-datetime-skeleton` test IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display and hydration UX on the public join page only; pipe change is backward compatible and does not touch auth or APIs.
> 
> **Overview**
> The public meeting **join page** date/time badge now formats in the **visitor's browser timezone** instead of the SSR server's default (often UTC).
> 
> **`MeetingTimePipe`** gains an optional fourth `timeZone` argument; when set, it is applied to all `Intl` date/time formatting paths. Call sites that omit it behave as before.
> 
> **`MeetingJoinComponent`** keeps `userTimezone` as `null` during SSR and until **`afterNextRender`**, then sets it from **`getUserTimezone()`**. The template shows a **PrimeNG skeleton** while `userTimezone` is null and passes the resolved zone into the pipe for the compact datetime tag, avoiding a wrong-time flash and hydration mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c7190537397c1b6ed8542922763023e08c2c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->