### PR TITLE
fix(mailing-lists): skip indexing poll on member update

### DIFF
--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -560,13 +560,7 @@ export class MailingListService {
       member_uid: memberId,
     });
 
-    // Poll the query service until the updated member is indexed
-    const indexed = await this.pollUntilResourceIndexed<MailingListMember>(req, 'update_mailing_list_member', 'groupsio_member', 'member_uid', memberId, {
-      mailing_list_uid: mailingListId,
-      member_uid: memberId,
-    });
-
-    return indexed ?? updatedMember;
+    return updatedMember;
   }
 
   /**


### PR DESCRIPTION
## Summary

After updating a mailing list member, the BFF was polling the query service for up to 10s (5 retries × 2s) waiting for the member to appear in the index. The async DynamoDB CDC pipeline consistently takes longer than that window, so every update exhausted all retries with no benefit — pure overhead added to every response.

This PR removes the poll from `updateMember`, returning the `updatedMember` response directly. This matches the pattern already shipped for `createMember` (and other create paths) in #1148.

**What's covered here:**
- `updateMember` — poll removed, returns PUT response directly

**Not in scope:**
- `createMember` — already handled by #1148
- `deleteMember` — `pollUntilResourceRemoved` is intentional (confirms removal before responding)

## Ticket

[LFXV2-2664 — investigate slow create/update member operations in mailing lists](https://linuxfoundation.atlassian.net/browse/LFXV2-2664)