### PR TITLE
refactor(dashboards): standardize drawer info tooltips via pTooltip (LFXV2-2669)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -55,6 +55,7 @@
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             pTooltip="Monthly average unique contributors across the foundation over the last 12 months"
             tooltipPosition="top"
+            tooltipEvent="both"
             aria-label="Monthly average unique contributors across the foundation over the last 12 months">
             <i class="fa-light fa-circle-info"></i>
           </button>
@@ -92,6 +93,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Share of total contributions made by each percentile group of contributors over the last 12 months"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Share of total contributions made by each percentile group of contributors over the last 12 months">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -50,17 +50,14 @@
         <!-- Title + Tooltip -->
         <div class="flex items-center gap-2">
           <h3 class="text-sm font-medium text-gray-900">Active Contributors</h3>
-          <div class="group relative">
-            <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke-width="2" />
-              <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-            </svg>
-            <div
-              class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-              role="tooltip">
-              Monthly average unique contributors across the foundation over the last 12 months
-            </div>
-          </div>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Monthly average unique contributors across the foundation over the last 12 months"
+            tooltipPosition="top"
+            aria-label="Monthly average unique contributors across the foundation over the last 12 months">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         </div>
 
         <!-- Metric Value -->
@@ -90,17 +87,14 @@
     <div class="flex flex-col gap-3" data-testid="active-contributors-drawer-distribution-section">
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Contribution Distribution by Percentile Band</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Share of total contributions made by each percentile group of contributors over the last 12 months
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Share of total contributions made by each percentile group of contributors over the last 12 months"
+          tooltipPosition="top"
+          aria-label="Share of total contributions made by each percentile group of contributors over the last 12 months">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       @if (drawerLoading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -12,6 +12,7 @@ import { buildLensAwareInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -23,7 +24,7 @@ import type {
 
 @Component({
   selector: 'lfx-active-contributors-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent, TooltipModule],
   templateUrl: './active-contributors-drawer.component.html',
 })
 export class ActiveContributorsDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -50,17 +50,14 @@
         <!-- Title + Tooltip -->
         <div class="flex items-center gap-2">
           <h3 class="text-sm font-medium text-gray-900">Foundation Events</h3>
-          <div class="group relative">
-            <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke-width="2" />
-              <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-            </svg>
-            <div
-              class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-              role="tooltip">
-              Total events across all foundation projects per quarter over the last 8 quarters
-            </div>
-          </div>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Total events across all foundation projects per quarter over the last 8 quarters"
+            tooltipPosition="top"
+            aria-label="Total events across all foundation projects per quarter over the last 8 quarters">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         </div>
 
         <!-- Metric Value -->
@@ -91,17 +88,14 @@
       <div class="flex flex-col gap-1">
         <div class="flex items-center gap-2">
           <h3 class="text-sm font-medium text-gray-900">Event Distribution by Attendance Size</h3>
-          <div class="group relative">
-            <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke-width="2" />
-              <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-            </svg>
-            <div
-              class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-              role="tooltip">
-              Number of events in each attendance size category over the last 12 months
-            </div>
-          </div>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Number of events in each attendance size category over the last 12 months"
+            tooltipPosition="top"
+            aria-label="Number of events in each attendance size category over the last 12 months">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         </div>
         <p class="text-sm text-gray-500">Foundation events segmented by attendance</p>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -55,6 +55,7 @@
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             pTooltip="Total events across all foundation projects per quarter over the last 8 quarters"
             tooltipPosition="top"
+            tooltipEvent="both"
             aria-label="Total events across all foundation projects per quarter over the last 8 quarters">
             <i class="fa-light fa-circle-info"></i>
           </button>
@@ -93,6 +94,7 @@
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             pTooltip="Number of events in each attendance size category over the last 12 months"
             tooltipPosition="top"
+            tooltipEvent="both"
             aria-label="Number of events in each attendance size category over the last 12 months">
             <i class="fa-light fa-circle-info"></i>
           </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
@@ -10,6 +10,7 @@ import { DEFAULT_FOUNDATION_EVENTS_ATTENDANCE_DISTRIBUTION, DEFAULT_FOUNDATION_E
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -21,7 +22,7 @@ import type {
 
 @Component({
   selector: 'lfx-events-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule],
   templateUrl: './events-drawer.component.html',
 })
 export class EventsDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -55,6 +55,7 @@
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             pTooltip="Number of active maintainers across all foundation repositories per month"
             tooltipPosition="top"
+            tooltipEvent="both"
             aria-label="Number of active maintainers across all foundation repositories per month">
             <i class="fa-light fa-circle-info"></i>
           </button>
@@ -92,6 +93,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Share of total contributions made by each percentile group of maintainers over the last 12 months"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Share of total contributions made by each percentile group of maintainers over the last 12 months">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -50,17 +50,14 @@
         <!-- Title + Tooltip -->
         <div class="flex items-center gap-2">
           <h3 class="text-sm font-medium text-gray-900">Maintainer Count</h3>
-          <div class="group relative">
-            <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke-width="2" />
-              <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-            </svg>
-            <div
-              class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-              role="tooltip">
-              Number of active maintainers across all foundation repositories per month
-            </div>
-          </div>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Number of active maintainers across all foundation repositories per month"
+            tooltipPosition="top"
+            aria-label="Number of active maintainers across all foundation repositories per month">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         </div>
 
         <!-- Metric Value -->
@@ -90,17 +87,14 @@
     <div class="flex flex-col gap-3" data-testid="maintainers-drawer-distribution-section">
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Maintainer Contribution Distribution by Percentile Band</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Share of total contributions made by each percentile group of maintainers over the last 12 months
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Share of total contributions made by each percentile group of maintainers over the last 12 months"
+          tooltipPosition="top"
+          aria-label="Share of total contributions made by each percentile group of maintainers over the last 12 months">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       @if (drawerLoading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -12,6 +12,7 @@ import { buildLensAwareInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -23,7 +24,7 @@ import type {
 
 @Component({
   selector: 'lfx-maintainers-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent, TooltipModule],
   templateUrl: './maintainers-drawer.component.html',
 })
 export class MaintainersDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
@@ -36,17 +36,14 @@
       <!-- Section Header -->
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Active Contributors</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Monthly unique contributors from your organization across the foundation over the last 12 months
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Monthly unique contributors from your organization across the foundation over the last 12 months"
+          tooltipPosition="top"
+          aria-label="Monthly unique contributors from your organization across the foundation over the last 12 months">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       <!-- Chart -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
@@ -41,6 +41,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Monthly unique contributors from your organization across the foundation over the last 12 months"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Monthly unique contributors from your organization across the foundation over the last 12 months">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.ts
@@ -10,6 +10,7 @@ import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -20,7 +21,7 @@ const DEFAULT_DISTRIBUTION: OrgContributorsProjectDistributionResponse = { proje
 
 @Component({
   selector: 'lfx-org-active-contributors-drawer',
-  imports: [DrawerModule, ChartComponent],
+  imports: [DrawerModule, ChartComponent, TooltipModule],
   templateUrl: './org-active-contributors-drawer.component.html',
 })
 export class OrgActiveContributorsDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
@@ -41,6 +41,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Monthly active maintainers from your organization across the foundation"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Monthly active maintainers from your organization across the foundation">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
@@ -36,17 +36,14 @@
       <!-- Section Header -->
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Active Maintainers</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Monthly active maintainers from your organization across the foundation
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Monthly active maintainers from your organization across the foundation"
+          tooltipPosition="top"
+          aria-label="Monthly active maintainers from your organization across the foundation">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       <!-- Chart -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.ts
@@ -10,6 +10,7 @@ import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -21,7 +22,7 @@ const DEFAULT_KEY_MEMBERS: OrgMaintainersKeyMembersResponse = { members: [] };
 
 @Component({
   selector: 'lfx-org-maintainers-drawer',
-  imports: [DrawerModule, ChartComponent],
+  imports: [DrawerModule, ChartComponent, TooltipModule],
   templateUrl: './org-maintainers-drawer.component.html',
 })
 export class OrgMaintainersDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -43,17 +43,14 @@
       <!-- Section Header -->
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Projects by Health Status</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Number of foundation projects in each health score category
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Number of foundation projects in each health score category"
+          tooltipPosition="top"
+          aria-label="Number of foundation projects in each health score category">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       <!-- Legend -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -48,6 +48,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Number of foundation projects in each health score category"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Number of foundation projects in each health score category">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -8,13 +8,14 @@ import { lfxColors } from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl } from '@lfx-one/shared/utils';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 
 import type { ChartData, ChartOptions } from 'chart.js';
 import type { FoundationHealthScoreDistributionResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-project-health-scores-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent, TooltipModule],
   templateUrl: './project-health-scores-drawer.component.html',
 })
 export class ProjectHealthScoresDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -53,6 +53,7 @@
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
           pTooltip="Total # of member organizations across the foundation per month"
           tooltipPosition="top"
+          tooltipEvent="both"
           aria-label="Total # of member organizations across the foundation per month">
           <i class="fa-light fa-circle-info"></i>
         </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -48,17 +48,14 @@
       <!-- Section Header -->
       <div class="flex items-center gap-2">
         <h3 class="text-sm font-medium text-gray-900">Member Organizations</h3>
-        <div class="group relative">
-          <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
-          <div
-            class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-            role="tooltip">
-            Total # of member organizations across the foundation per month
-          </div>
-        </div>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Total # of member organizations across the foundation per month"
+          tooltipPosition="top"
+          aria-label="Total # of member organizations across the foundation per month">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
       <!-- Chart -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -7,13 +7,14 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_TOTAL_MEMBERS, lfxColors } from '@lfx-one/shared/constants';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 
 import type { ChartData, ChartOptions } from 'chart.js';
 import type { FoundationTotalMembersResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-total-members-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule],
   templateUrl: './total-members-drawer.component.html',
 })
 export class TotalMembersDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -55,6 +55,7 @@
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
             pTooltip="Total # of active projects across the foundation"
             tooltipPosition="top"
+            tooltipEvent="both"
             aria-label="Total # of active projects across the foundation">
             <i class="fa-light fa-circle-info"></i>
           </button>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -50,17 +50,14 @@
         <!-- Title + Tooltip -->
         <div class="flex items-center gap-2">
           <h3 class="text-sm font-medium text-gray-900">Total Projects</h3>
-          <div class="group relative">
-            <svg class="w-3.5 h-3.5 text-gray-400 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke-width="2" />
-              <path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01" />
-            </svg>
-            <div
-              class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-64 p-2 bg-slate-900 text-white text-xs rounded shadow-lg z-10"
-              role="tooltip">
-              Total # of active projects across the foundation
-            </div>
-          </div>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Total # of active projects across the foundation"
+            tooltipPosition="top"
+            aria-label="Total # of active projects across the foundation">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
         </div>
 
         <!-- Chart / Table Toggle -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -22,6 +22,7 @@ import { buildLensAwareInsightsUrl, buildVisiblePages, hexToRgba } from '@lfx-on
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
@@ -46,6 +47,7 @@ import type {
     DecimalPipe,
     NgClass,
     InsightsHandoffSectionComponent,
+    TooltipModule,
   ],
   templateUrl: './total-projects-drawer.component.html',
 })


### PR DESCRIPTION
# Summary

Standardizes the info tooltips across all dashboard drawer components by replacing the bespoke CSS-only hover tooltips with PrimeNG's `pTooltip` directive. The previous implementation relied on a `group relative` wrapper, an inline SVG info icon, and an absolutely-positioned tooltip `<div>` toggled via `group-hover` — which only worked on pointer devices and produced inconsistent positioning/contrasts. This PR swaps that pattern for a single `<button>` with the FontAwesome `fa-circle-info` icon and a PrimeNG `pTooltip`, giving every drawer a consistent, accessible, and SSR-safe tooltip behavior.

# Before / After

**Before:** Each drawer title rendered a custom info icon as an inline SVG wrapped in a `div.group.relative`, with a sibling absolutely-positioned tooltip `<div>` shown via `hidden group-hover:block`. The tooltip was hover-only (no keyboard/focus access), was not announced by screen readers, and each drawer duplicated the same ~12 lines of markup. None of the drawer components imported `TooltipModule`.

**After:** Each drawer title now renders a single `<button type="button">` decorated with `pTooltip`, `tooltipPosition="top"`, and a matching `aria-label`, containing an `<i class="fa-light fa-circle-info">` icon. PrimeNG owns positioning, show/hide, and focus handling. Every affected drawer component now imports `TooltipModule` from `primeng/tooltip`.

# Changes

## Dashboard drawers (8 components)
- `active-contributors-drawer` — replaced both info tooltips (Active Contributors + Contribution Distribution by Percentile Band) with `pTooltip` buttons; added `TooltipModule` import.
- `events-drawer` — replaced both info tooltips; added `TooltipModule` import.
- `maintainers-drawer` — replaced both info tooltips; added `TooltipModule` import.
- `org-active-contributors-drawer` — replaced info tooltip; added `TooltipModule` import.
- `org-maintainers-drawer` — replaced info tooltip; added `TooltipModule` import.
- `project-health-scores-drawer` — replaced info tooltip; added `TooltipModule` import.
- `total-members-drawer` — replaced info tooltip; added `TooltipModule` import.
- `total-projects-drawer` — replaced info tooltip; added `TooltipModule` import.

## Accessibility
- Tooltip trigger is now a real `<button>` element, making it focusable and operable via keyboard, with `aria-label` mirroring the tooltip text for screen-reader announcement.
- Removed the previous `role="tooltip"` div that was not associated with any trigger element.

## Tests
- No test changes — drawers are covered by existing dashboard drawer specs; the tooltip swap is a presentation-only change with no behavioral surface change to assert beyond the existing render checks.

Made with [Cursor](https://cursor.com)