### PR TITLE
feat(meetings): add separate visibility and join restriction controls

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -74,6 +74,7 @@
       @if (isRestricted()) {
         <div
           class="absolute -top-2 left-[26px] w-5 h-5 rounded-full flex items-center justify-center bg-amber-500"
+          role="img"
           pTooltip="Restricted — invited guests only"
           aria-label="Restricted — invited guests only"
           tooltipPosition="top"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -69,6 +69,18 @@
         data-testid="dashboard-meeting-card-type-dot">
         <i [class]="'text-white text-[10px] leading-none block ' + dateBadgeDotInfo().icon" aria-hidden="true"></i>
       </div>
+
+      <!-- Restricted dot badge (shown independently when join is restricted) -->
+      @if (isRestricted()) {
+        <div
+          class="absolute -top-2 left-[26px] w-5 h-5 rounded-full flex items-center justify-center bg-amber-500"
+          pTooltip="Restricted — invited guests only"
+          aria-label="Restricted — invited guests only"
+          tooltipPosition="top"
+          data-testid="dashboard-meeting-card-restricted-dot">
+          <i class="text-white text-[10px] leading-none block fa-solid fa-lock" aria-hidden="true"></i>
+        </div>
+      }
     </div>
 
     <!-- Meeting details -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -66,6 +66,7 @@ export class DashboardMeetingCardComponent {
   public readonly meetingStartTime: Signal<string> = this.initMeetingStartTime();
   public readonly formattedTimeWithDuration: Signal<string> = this.initFormattedTimeWithDuration();
   public readonly isPrivate: Signal<boolean> = this.initIsPrivate();
+  public readonly isRestricted: Signal<boolean> = this.initIsRestricted();
   public readonly hasRecording: Signal<boolean> = this.initHasRecording();
   public readonly hasTranscripts: Signal<boolean> = this.initHasTranscripts();
   public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
@@ -156,6 +157,10 @@ export class DashboardMeetingCardComponent {
     return computed(() => {
       return this.meeting().visibility === 'private';
     });
+  }
+
+  private initIsRestricted(): Signal<boolean> {
+    return computed(() => !!this.meeting().restricted);
   }
 
   private initHasRecording(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -11,6 +11,11 @@
           <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private"></lfx-tag>
         }
 
+        <!-- Restricted Badge -->
+        @if (meeting().restricted) {
+          <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted"></lfx-tag>
+        }
+
         <!-- Meeting Type Badge -->
         @if (meetingTypeBadge(); as badge) {
           @if (badge.text !== 'None') {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -13,7 +13,7 @@
 
         <!-- Restricted Badge -->
         @if (meeting().restricted) {
-          <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted"></lfx-tag>
+          <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock"></lfx-tag>
         }
 
         <!-- Meeting Type Badge -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -5,7 +5,7 @@
   <!-- Step Title -->
   <div class="mb-6">
     <h2 class="font-normal">Meeting Platform & Features</h2>
-    <p class="text-sm text-gray-500 mt-1">Select your video platform and enable transparency features like recording and public calendars</p>
+    <p class="text-sm text-gray-500 mt-1">Select your video platform and enable transparency features like recording and transcripts</p>
   </div>
 
   <!-- Two Column Layout -->
@@ -128,9 +128,6 @@
           </div>
         </div>
       }
-
-      <!-- Show in Public Calendar -->
-      <lfx-feature-toggle [feature]="calendarFeature" [form]="form()"></lfx-feature-toggle>
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
@@ -51,7 +51,6 @@ export class MeetingPlatformFeaturesComponent implements OnInit {
   public readonly transcriptFeature = MEETING_FEATURES.find((f) => f.key === 'transcript_enabled')!;
   public readonly youtubeFeature = MEETING_FEATURES.find((f) => f.key === 'youtube_upload_enabled')!;
   public readonly aiSummaryFeature = MEETING_FEATURES.find((f) => f.key === 'zoom_ai_enabled')!;
-  public readonly calendarFeature = MEETING_FEATURES.find((f) => f.key === 'visibility')!;
 
   // Transform platforms into dropdown options (only available platforms)
   public readonly platformDropdownOptions = MEETING_PLATFORMS.map((platform) => ({

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.html
@@ -5,7 +5,7 @@
   <!-- Step Title -->
   <div class="mb-6">
     <h2 class="font-normal">Meeting Type & Privacy</h2>
-    <p class="text-sm text-gray-500 mt-1">Choose the meeting category and visibility to ensure the right people have access</p>
+    <p class="text-sm text-gray-500 mt-1">Choose the meeting category and configure who can find and join this meeting</p>
   </div>
 
   <!-- Two Column Layout -->
@@ -23,18 +23,34 @@
     </div>
 
     <!-- Right Column - Privacy Settings -->
-    <div class="flex flex-col gap-3">
-      <lfx-card-selector [options]="privacyOptions" [form]="form()" control="restricted" label="Select Privacy Setting" testIdPrefix="meeting-privacy" />
+    <div class="flex flex-col gap-6">
+      <!-- Visibility: who can find the meeting -->
+      <lfx-card-selector
+        [options]="visibilityOptions"
+        [form]="form()"
+        control="visibility"
+        label="Visibility"
+        [gridColumns]="2"
+        testIdPrefix="meeting-visibility" />
+
+      <!-- Join restriction: who can join the meeting -->
+      <lfx-card-selector
+        [options]="joinRestrictionOptions"
+        [form]="form()"
+        control="restricted"
+        label="Join Restriction"
+        [gridColumns]="2"
+        testIdPrefix="meeting-join-restriction" />
 
       <!-- Info box -->
       <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
         <div class="flex gap-3">
           <i class="fa-light fa-info-circle text-blue-500 flex-shrink-0 mt-0.5"></i>
-          <div>
+          <div class="flex flex-col gap-1">
+            <p class="text-sm font-semibold text-blue-500">Two independent privacy controls</p>
             <p class="text-sm text-blue-500">
-              <span class="font-semibold">Transparency is key</span>
-              <br />
-              Public meetings help build trust and encourage community participation. Consider making meetings public unless they involve confidential matters.
+              <span class="font-medium">Visibility</span> controls discoverability — whether the meeting appears in the public project calendar.
+              <span class="font-medium">Join Restriction</span> controls access — who is allowed to join once they have the meeting link.
             </p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-type-selection/meeting-type-selection.component.ts
@@ -4,7 +4,7 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardSelectorComponent } from '@components/card-selector/card-selector.component';
-import { lfxColors } from '@lfx-one/shared/constants';
+import { lfxColors, MEETING_JOIN_RESTRICTION_OPTIONS, MEETING_VISIBILITY_OPTIONS } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import { CardSelectorOption, CardSelectorOptionInfo } from '@lfx-one/shared/interfaces';
 import { PersonaService } from '@services/persona.service';
@@ -20,27 +20,11 @@ export class MeetingTypeSelectionComponent {
   // Form group input from parent
   public readonly form = input.required<FormGroup>();
 
-  // Privacy options for Public/Restricted selection
-  public readonly privacyOptions: CardSelectorOption<boolean>[] = [
-    {
-      label: 'Public',
-      value: false,
-      info: {
-        icon: 'fa-light fa-globe',
-        description: 'Anyone can join this meeting. Best for community meetings and open discussions.',
-        color: lfxColors.emerald[500],
-      },
-    },
-    {
-      label: 'Restricted',
-      value: true,
-      info: {
-        icon: 'fa-light fa-lock',
-        description: 'Only invited guests can join. Best for board meetings and confidential discussions.',
-        color: lfxColors.amber[500],
-      },
-    },
-  ];
+  // Visibility options (Public / Private) — bound to `visibility` form control
+  public readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
+
+  // Join restriction options (Anyone / Invited only) — bound to `restricted` form control
+  public readonly joinRestrictionOptions = MEETING_JOIN_RESTRICTION_OPTIONS;
 
   // Meeting type options with their info - computed for template efficiency
   // Filtered based on user role (maintainers only see a subset of meeting types)

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -44,12 +44,7 @@
 
                 <!-- Restricted Badge -->
                 @if (meeting().restricted) {
-                  <lfx-tag
-                    value="Restricted"
-                    severity="warn"
-                    icon="fa-light fa-lock"
-                    styleClass="tag-restricted"
-                    [attr.data-testid]="'meeting-badge-restricted'"></lfx-tag>
+                  <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" [attr.data-testid]="'meeting-badge-restricted'"></lfx-tag>
                 }
 
                 <!-- Meeting Type Badge -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -42,6 +42,16 @@
                     [attr.data-testid]="'meeting-badge-private'"></lfx-tag>
                 }
 
+                <!-- Restricted Badge -->
+                @if (meeting().restricted) {
+                  <lfx-tag
+                    value="Restricted"
+                    severity="warn"
+                    icon="fa-light fa-lock"
+                    styleClass="tag-restricted"
+                    [attr.data-testid]="'meeting-badge-restricted'"></lfx-tag>
+                }
+
                 <!-- Meeting Type Badge -->
                 @if (meetingTypeBadge(); as badge) {
                   <lfx-tag

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -543,7 +543,7 @@ export class MeetingManageComponent {
         const parsed = parseInt(formValue.early_join_time_minutes, 10);
         return isNaN(parsed) ? DEFAULT_EARLY_JOIN_TIME : parsed;
       })(),
-      visibility: formValue.visibility || MeetingVisibility.PUBLIC,
+      visibility: formValue.visibility || MeetingVisibility.PRIVATE,
       restricted: formValue.restricted || false,
       recording_enabled: formValue.recording_enabled || false,
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -222,27 +222,6 @@ export class MeetingManageComponent {
         }
       });
 
-    // PCC matrix constraint: PUBLIC+restricted is not a valid state.
-    // Sync the two controls so they stay consistent: restricted→true forces PRIVATE visibility;
-    // visibility→PUBLIC forces restricted=false.
-    this.form()
-      .get('restricted')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((restricted: boolean) => {
-        if (restricted && this.form().get('visibility')?.value === MeetingVisibility.PUBLIC) {
-          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE }, { emitEvent: false });
-        }
-      });
-
-    this.form()
-      .get('visibility')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((visibility: string) => {
-        if (visibility === MeetingVisibility.PUBLIC && this.form().get('restricted')?.value === true) {
-          this.form().patchValue({ restricted: false }, { emitEvent: false });
-        }
-      });
-
     // Separate subscription for meeting data changes - populates form only once
     toObservable(this.meeting)
       .pipe(

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -216,10 +216,15 @@ export class MeetingManageComponent {
     // PCC matrix constraint: PUBLIC+restricted is not a valid state.
     // Sync the two controls so they stay consistent: restricted→true forces PRIVATE visibility;
     // visibility→PUBLIC forces restricted=false.
+    // Board meetings always lock back to PRIVATE+restricted regardless of which control changed.
     this.form()
       .get('restricted')
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((restricted: boolean) => {
+        if (this.form().get('meeting_type')?.value === MeetingType.BOARD) {
+          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true }, { emitEvent: false });
+          return;
+        }
         if (restricted && this.form().get('visibility')?.value === MeetingVisibility.PUBLIC) {
           this.form().patchValue({ visibility: MeetingVisibility.PRIVATE }, { emitEvent: false });
         }
@@ -229,6 +234,10 @@ export class MeetingManageComponent {
       .get('visibility')
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((visibility: string) => {
+        if (this.form().get('meeting_type')?.value === MeetingType.BOARD) {
+          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true }, { emitEvent: false });
+          return;
+        }
         if (visibility === MeetingVisibility.PUBLIC && this.form().get('restricted')?.value === true) {
           this.form().patchValue({ restricted: false }, { emitEvent: false });
         }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -20,7 +20,7 @@ import {
   TOTAL_STEPS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
 } from '@lfx-one/shared/constants';
-import { MeetingVisibility } from '@lfx-one/shared/enums';
+import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   CreateMeetingRequest,
@@ -201,6 +201,16 @@ export class MeetingManageComponent {
         }
         titleControl.updateValueAndValidity();
         this.updateCanProceed();
+      });
+
+    // When Board meeting type is selected, enforce private + restricted-only access
+    this.form()
+      .get('meeting_type')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((meetingType: string) => {
+        if (meetingType === MeetingType.BOARD) {
+          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true });
+        }
       });
 
     // Separate subscription for meeting data changes - populates form only once
@@ -512,7 +522,7 @@ export class MeetingManageComponent {
         const parsed = parseInt(formValue.early_join_time_minutes, 10);
         return isNaN(parsed) ? DEFAULT_EARLY_JOIN_TIME : parsed;
       })(),
-      visibility: formValue.visibility || MeetingVisibility.PRIVATE,
+      visibility: formValue.visibility || MeetingVisibility.PUBLIC,
       restricted: formValue.restricted || false,
       recording_enabled: formValue.recording_enabled || false,
       transcript_enabled: formValue.recording_enabled ? formValue.transcript_enabled || false : false,
@@ -921,7 +931,7 @@ export class MeetingManageComponent {
       {
         // Step 1: Meeting Type
         meeting_type: new FormControl('', [Validators.required]),
-        visibility: new FormControl(MeetingVisibility.PRIVATE),
+        visibility: new FormControl(MeetingVisibility.PUBLIC),
         restricted: new FormControl(false),
 
         // Step 2: Meeting Details

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -52,7 +52,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, pairwise, startWith, switchMap, take, toArray } from 'rxjs';
 
 import { MeetingDetailsComponent } from '../components/meeting-details/meeting-details.component';
 import { MeetingPlatformFeaturesComponent } from '../components/meeting-platform-features/meeting-platform-features.component';
@@ -203,13 +203,21 @@ export class MeetingManageComponent {
         this.updateCanProceed();
       });
 
-    // When Board meeting type is selected, enforce private + restricted-only access
+    // When Board meeting type is selected, enforce private + restricted-only access.
+    // When switching away from Board, reset privacy to defaults so the user isn't
+    // left with Board-level restrictions silently applied to a non-Board meeting.
     this.form()
       .get('meeting_type')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((meetingType: string) => {
-        if (meetingType === MeetingType.BOARD) {
+      ?.valueChanges.pipe(
+        startWith(this.form().get('meeting_type')?.value as string),
+        pairwise(),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(([previousType, currentType]: [string, string]) => {
+        if (currentType === MeetingType.BOARD) {
           this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true });
+        } else if (previousType === MeetingType.BOARD) {
+          this.form().patchValue({ visibility: MeetingVisibility.PUBLIC, restricted: false });
         }
       });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -213,6 +213,27 @@ export class MeetingManageComponent {
         }
       });
 
+    // PCC matrix constraint: PUBLIC+restricted is not a valid state.
+    // Sync the two controls so they stay consistent: restricted→true forces PRIVATE visibility;
+    // visibility→PUBLIC forces restricted=false.
+    this.form()
+      .get('restricted')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((restricted: boolean) => {
+        if (restricted && this.form().get('visibility')?.value === MeetingVisibility.PUBLIC) {
+          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE }, { emitEvent: false });
+        }
+      });
+
+    this.form()
+      .get('visibility')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((visibility: string) => {
+        if (visibility === MeetingVisibility.PUBLIC && this.form().get('restricted')?.value === true) {
+          this.form().patchValue({ restricted: false }, { emitEvent: false });
+        }
+      });
+
     // Separate subscription for meeting data changes - populates form only once
     toObservable(this.meeting)
       .pipe(
@@ -785,7 +806,7 @@ export class MeetingManageComponent {
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
       visibility: meeting.visibility || MeetingVisibility.PRIVATE,
-      restricted: meeting.restricted ?? false,
+      restricted: meeting.meeting_type === MeetingType.BOARD ? true : (meeting.restricted ?? false),
       recording_enabled: meeting.recording_enabled || false,
       transcript_enabled: meeting.transcript_enabled || false,
       youtube_upload_enabled: meeting.youtube_upload_enabled || false,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -203,9 +203,10 @@ export class MeetingManageComponent {
         this.updateCanProceed();
       });
 
-    // When Board meeting type is selected, enforce private + restricted-only access.
-    // When switching away from Board, reset privacy to defaults so the user isn't
-    // left with Board-level restrictions silently applied to a non-Board meeting.
+    // When Board meeting type is selected, default to private + restricted access.
+    // When switching away from Board, reset to public + unrestricted defaults so the
+    // user isn't left with Board-level settings silently applied to a non-Board meeting.
+    // The user can freely override visibility and restriction after the default is applied.
     this.form()
       .get('meeting_type')
       ?.valueChanges.pipe(
@@ -224,15 +225,10 @@ export class MeetingManageComponent {
     // PCC matrix constraint: PUBLIC+restricted is not a valid state.
     // Sync the two controls so they stay consistent: restricted→true forces PRIVATE visibility;
     // visibility→PUBLIC forces restricted=false.
-    // Board meetings always lock back to PRIVATE+restricted regardless of which control changed.
     this.form()
       .get('restricted')
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((restricted: boolean) => {
-        if (this.form().get('meeting_type')?.value === MeetingType.BOARD) {
-          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true }, { emitEvent: false });
-          return;
-        }
         if (restricted && this.form().get('visibility')?.value === MeetingVisibility.PUBLIC) {
           this.form().patchValue({ visibility: MeetingVisibility.PRIVATE }, { emitEvent: false });
         }
@@ -242,10 +238,6 @@ export class MeetingManageComponent {
       .get('visibility')
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((visibility: string) => {
-        if (this.form().get('meeting_type')?.value === MeetingType.BOARD) {
-          this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true }, { emitEvent: false });
-          return;
-        }
         if (visibility === MeetingVisibility.PUBLIC && this.form().get('restricted')?.value === true) {
           this.form().patchValue({ restricted: false }, { emitEvent: false });
         }
@@ -823,7 +815,7 @@ export class MeetingManageComponent {
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
       visibility: meeting.visibility || MeetingVisibility.PRIVATE,
-      restricted: meeting.meeting_type === MeetingType.BOARD ? true : (meeting.restricted ?? false),
+      restricted: meeting.restricted ?? false,
       recording_enabled: meeting.recording_enabled || false,
       transcript_enabled: meeting.transcript_enabled || false,
       youtube_upload_enabled: meeting.youtube_upload_enabled || false,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -52,7 +52,23 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, pairwise, startWith, switchMap, take, toArray } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  concat,
+  filter,
+  finalize,
+  forkJoin,
+  from,
+  mergeMap,
+  Observable,
+  of,
+  pairwise,
+  startWith,
+  switchMap,
+  take,
+  toArray,
+} from 'rxjs';
 
 import { MeetingDetailsComponent } from '../components/meeting-details/meeting-details.component';
 import { MeetingPlatformFeaturesComponent } from '../components/meeting-platform-features/meeting-platform-features.component';
@@ -209,11 +225,7 @@ export class MeetingManageComponent {
     // The user can freely override visibility and restriction after the default is applied.
     this.form()
       .get('meeting_type')
-      ?.valueChanges.pipe(
-        startWith(this.form().get('meeting_type')?.value as string),
-        pairwise(),
-        takeUntilDestroyed(this.destroyRef)
-      )
+      ?.valueChanges.pipe(startWith(this.form().get('meeting_type')?.value as string), pairwise(), takeUntilDestroyed(this.destroyRef))
       .subscribe(([previousType, currentType]: [string, string]) => {
         if (currentType === MeetingType.BOARD) {
           this.form().patchValue({ visibility: MeetingVisibility.PRIVATE, restricted: true });

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -76,7 +76,7 @@
             <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
           }
           @if (meeting.restricted) {
-            <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted" data-testid="badge-restricted"></lfx-tag>
+            <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" data-testid="badge-restricted"></lfx-tag>
           }
           @if (meetingTypeBadge(); as badge) {
             <lfx-tag [value]="badge.text" [severity]="badge.severity" [icon]="badge.icon" [styleClass]="badge.styleClass" data-testid="badge-type"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -75,6 +75,9 @@
           @if (meeting.visibility === 'private') {
             <lfx-tag value="Private" severity="danger" icon="fa-light fa-shield" styleClass="tag-private" data-testid="badge-private"></lfx-tag>
           }
+          @if (meeting.restricted) {
+            <lfx-tag value="Restricted" severity="warn" icon="fa-light fa-lock" styleClass="tag-restricted" data-testid="badge-restricted"></lfx-tag>
+          }
           @if (meetingTypeBadge(); as badge) {
             <lfx-tag [value]="badge.text" [severity]="badge.severity" [icon]="badge.icon" [styleClass]="badge.styleClass" data-testid="badge-type"></lfx-tag>
           }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -1374,8 +1374,9 @@ export class CommitteeController {
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
       ]);
 
-      // Filter PRIVATE/restricted meetings from the public feed (mirrors PublicMeetingController visibility guard).
-      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC && !m.restricted);
+      // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
+      // still listed so their existence is discoverable; join authorization is enforced separately at join time.
+      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
       const ics = buildVCalendar(events, '-//LFX//Committee Calendar//EN');
 

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -887,7 +887,7 @@ export class ProjectController {
     }
   }
 
-  /** GET /public/api/projects/:id/calendar.ics — PUBLIC non-restricted meetings; serves both foundation and project lenses. */
+  /** GET /public/api/projects/:id/calendar.ics — PUBLIC meetings (any join restriction); serves both foundation and project lenses. */
   public async getProjectCalendar(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
     const startTime = logger.startOperation(req, 'get_project_calendar', { project_id: id });
@@ -912,8 +912,9 @@ export class ProjectController {
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
       ]);
 
-      // Filter PRIVATE/restricted meetings from the public feed (mirrors PublicMeetingController visibility guard).
-      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC && !m.restricted);
+      // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
+      // still listed so their existence is discoverable; join authorization is enforced separately at join time.
+      const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
       const ics = buildVCalendar(events, '-//LFX//Project Calendar//EN');
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ArtifactVisibility, MeetingVisibility } from '../enums';
-import type { CardSelectorOption } from '../interfaces/components.interface';
-import type { MeetingTypeConfig } from '../interfaces/meeting.interface';
+import type { CardSelectorOption, MeetingTypeConfig } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
 /**

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ArtifactVisibility } from '../enums';
+import { ArtifactVisibility, MeetingVisibility } from '../enums';
+import type { CardSelectorOption } from '../interfaces/components.interface';
 import type { MeetingTypeConfig } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 
@@ -73,16 +74,6 @@ export const MEETING_FEATURES = [
     recommended: false,
     color: lfxColors.red[500],
   },
-  {
-    key: 'visibility',
-    icon: 'fa-light fa-calendar-check',
-    title: 'Show in Public Calendar',
-    description: 'Make this meeting visible in the public project calendar',
-    recommended: true,
-    color: lfxColors.amber[500],
-    trueValue: 'public',
-    falseValue: 'private',
-  },
 ];
 
 /**
@@ -93,6 +84,56 @@ export const ARTIFACT_VISIBILITY_OPTIONS = [
   { label: 'Meeting Hosts Only', value: ArtifactVisibility.MEETING_HOSTS },
   { label: 'Meeting Guests', value: ArtifactVisibility.MEETING_PARTICIPANTS },
   { label: 'Public', value: ArtifactVisibility.PUBLIC },
+];
+
+/**
+ * Meeting visibility card-selector options
+ * @description Controls who can find the meeting in calendars and listings (maps to the `visibility` API field)
+ */
+export const MEETING_VISIBILITY_OPTIONS: CardSelectorOption<MeetingVisibility>[] = [
+  {
+    label: 'Public',
+    value: MeetingVisibility.PUBLIC,
+    info: {
+      icon: 'fa-light fa-globe',
+      description: 'Listed on the public project calendar and discoverable in the app',
+      color: lfxColors.emerald[500],
+    },
+  },
+  {
+    label: 'Private',
+    value: MeetingVisibility.PRIVATE,
+    info: {
+      icon: 'fa-light fa-eye-slash',
+      description: 'Hidden from the public calendar; only guests with the meeting link can find it',
+      color: lfxColors.gray[500],
+    },
+  },
+];
+
+/**
+ * Meeting join restriction card-selector options
+ * @description Controls who can join the meeting (maps to the `restricted` API field)
+ */
+export const MEETING_JOIN_RESTRICTION_OPTIONS: CardSelectorOption<boolean>[] = [
+  {
+    label: 'Anyone with the link',
+    value: false,
+    info: {
+      icon: 'fa-light fa-link',
+      description: 'Anyone who has the meeting link can join',
+      color: lfxColors.blue[500],
+    },
+  },
+  {
+    label: 'Invited guests only',
+    value: true,
+    info: {
+      icon: 'fa-light fa-lock',
+      description: 'Only invited guests can join',
+      color: lfxColors.amber[500],
+    },
+  },
 ];
 
 /**

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
 export * from './meeting.utils';
+export * from './meeting-privacy.utils';
 export * from './past-meeting-summary.utils';
 export * from './past-meeting.utils';
 export * from './rsvp-calculator.util';

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -35,8 +35,8 @@ describe('getMeetingPrivacyIcon', () => {
     expect(getMeetingPrivacyIcon(MeetingVisibility.PUBLIC, false)).toBe('fa-light fa-globe');
   });
 
-  it('returns eye-slash icon for private + unrestricted', () => {
-    expect(getMeetingPrivacyIcon(MeetingVisibility.PRIVATE, false)).toBe('fa-light fa-eye-slash');
+  it('returns shield icon for private + unrestricted', () => {
+    expect(getMeetingPrivacyIcon(MeetingVisibility.PRIVATE, false)).toBe('fa-light fa-shield');
   });
 
   it('returns lock icon when restricted is true', () => {

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -24,6 +24,10 @@ describe('getMeetingPrivacyLabel', () => {
   it('returns "Public" when both fields are null', () => {
     expect(getMeetingPrivacyLabel(null, null)).toBe('Public');
   });
+
+  it('returns "Public (Restricted)" for public + restricted (edge case)', () => {
+    expect(getMeetingPrivacyLabel(MeetingVisibility.PUBLIC, true)).toBe('Public (Restricted)');
+  });
 });
 
 describe('getMeetingPrivacyIcon', () => {

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MeetingVisibility } from '../enums';
+import { getMeetingPrivacyIcon, getMeetingPrivacyLabel } from './meeting-privacy.utils';
+
+describe('getMeetingPrivacyLabel', () => {
+  it('returns "Public" for public + unrestricted', () => {
+    expect(getMeetingPrivacyLabel(MeetingVisibility.PUBLIC, false)).toBe('Public');
+  });
+
+  it('returns "Private" for private + unrestricted', () => {
+    expect(getMeetingPrivacyLabel(MeetingVisibility.PRIVATE, false)).toBe('Private');
+  });
+
+  it('returns "Private (Restricted)" for private + restricted', () => {
+    expect(getMeetingPrivacyLabel(MeetingVisibility.PRIVATE, true)).toBe('Private (Restricted)');
+  });
+
+  it('returns "Public" when visibility is null', () => {
+    expect(getMeetingPrivacyLabel(null, false)).toBe('Public');
+  });
+
+  it('returns "Public" when both fields are null', () => {
+    expect(getMeetingPrivacyLabel(null, null)).toBe('Public');
+  });
+});
+
+describe('getMeetingPrivacyIcon', () => {
+  it('returns globe icon for public + unrestricted', () => {
+    expect(getMeetingPrivacyIcon(MeetingVisibility.PUBLIC, false)).toBe('fa-light fa-globe');
+  });
+
+  it('returns eye-slash icon for private + unrestricted', () => {
+    expect(getMeetingPrivacyIcon(MeetingVisibility.PRIVATE, false)).toBe('fa-light fa-eye-slash');
+  });
+
+  it('returns lock icon when restricted is true', () => {
+    expect(getMeetingPrivacyIcon(MeetingVisibility.PRIVATE, true)).toBe('fa-light fa-lock');
+  });
+
+  it('returns lock icon when public + restricted (edge case)', () => {
+    expect(getMeetingPrivacyIcon(MeetingVisibility.PUBLIC, true)).toBe('fa-light fa-lock');
+  });
+});

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MeetingVisibility } from '../enums';
+
+/**
+ * Returns a human-readable label for the combined meeting privacy state.
+ * @description Maps the two independent privacy fields (`visibility` + `restricted`)
+ * to a single display string matching the PCC privacy matrix:
+ * - Public + unrestricted → "Public"
+ * - Private + unrestricted → "Private"
+ * - Private + restricted  → "Private (Restricted)"
+ */
+export function getMeetingPrivacyLabel(visibility: MeetingVisibility | null, restricted: boolean | null): string {
+  if (visibility === MeetingVisibility.PRIVATE && restricted) {
+    return 'Private (Restricted)';
+  }
+  if (visibility === MeetingVisibility.PRIVATE) {
+    return 'Private';
+  }
+  return 'Public';
+}
+
+/**
+ * Returns the Font Awesome icon class for the combined meeting privacy state.
+ */
+export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, restricted: boolean | null): string {
+  if (restricted) {
+    return 'fa-light fa-lock';
+  }
+  if (visibility === MeetingVisibility.PRIVATE) {
+    return 'fa-light fa-eye-slash';
+  }
+  return 'fa-light fa-globe';
+}

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -10,7 +10,7 @@ import { MeetingVisibility } from '../enums';
  * - Public + unrestricted → "Public"
  * - Private + unrestricted → "Private"
  * - Private + restricted  → "Private (Restricted)"
- * - Public + restricted   → "Public (Restricted)" (edge case; PCC matrix enforces PRIVATE+restricted)
+ * - Public + restricted   → "Public (Restricted)"
  */
 export function getMeetingPrivacyLabel(visibility: MeetingVisibility | null, restricted: boolean | null): string {
   if (visibility === MeetingVisibility.PRIVATE && restricted) {

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -10,10 +10,14 @@ import { MeetingVisibility } from '../enums';
  * - Public + unrestricted → "Public"
  * - Private + unrestricted → "Private"
  * - Private + restricted  → "Private (Restricted)"
+ * - Public + restricted   → "Public (Restricted)" (edge case; PCC matrix enforces PRIVATE+restricted)
  */
 export function getMeetingPrivacyLabel(visibility: MeetingVisibility | null, restricted: boolean | null): string {
   if (visibility === MeetingVisibility.PRIVATE && restricted) {
     return 'Private (Restricted)';
+  }
+  if (restricted) {
+    return 'Public (Restricted)';
   }
   if (visibility === MeetingVisibility.PRIVATE) {
     return 'Private';
@@ -23,6 +27,9 @@ export function getMeetingPrivacyLabel(visibility: MeetingVisibility | null, res
 
 /**
  * Returns the Font Awesome icon class for the combined meeting privacy state.
+ * @description Icon prioritizes restriction state over visibility: `restricted=true` always
+ * shows a lock regardless of visibility, matching the PCC join-access model. This differs
+ * from `getMeetingPrivacyLabel`, which prioritizes visibility in its primary branches.
  */
 export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, restricted: boolean | null): string {
   if (restricted) {

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -36,7 +36,7 @@ export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, rest
     return 'fa-light fa-lock';
   }
   if (visibility === MeetingVisibility.PRIVATE) {
-    return 'fa-light fa-eye-slash';
+    return 'fa-light fa-shield';
   }
   return 'fa-light fa-globe';
 }


### PR DESCRIPTION
## Summary

- Replaces the single Public/Restricted card-selector in wizard step 1 with **two independent card-selectors** matching PCC's two-setting privacy model
- **Visibility** (Public / Private) — controls discoverability; bound directly to the existing `visibility` form control
- **Join Restriction** (Anyone with the link / Invited guests only) — controls who can join; bound directly to the existing `restricted` form control
- Removes the redundant "Show in Public Calendar" toggle from step 3 (Platform & Features) since visibility is now set in step 1

## Ticket

[LFXV2-2658](https://linuxfoundation.atlassian.net/browse/LFXV2-2658) — Align meeting privacy settings with PCC (visibility + join restriction) in LFX Self-Service

## Screenshots

Creating/updating meeting options before and after these updates.

Before:
<img width="1718" height="1037" alt="Screenshot 2026-07-13 at 12 06 22 PM" src="https://github.com/user-attachments/assets/c6ffb5bc-ec3d-43ef-905e-512165c36eee" />

After:
<img width="1718" height="1037" alt="Screenshot 2026-07-13 at 12 06 02 PM" src="https://github.com/user-attachments/assets/41217068-a55e-4974-9716-88774cecbdea" />

Meeting join page when you are not invited to a restricted meeting:
<img width="1718" height="1037" alt="Screenshot 2026-07-13 at 2 38 20 PM" src="https://github.com/user-attachments/assets/358571d8-7fdb-46f-94be-db2f1e25b973" />

## Files changed

**Shared package:**
- `packages/shared/src/constants/meeting.constants.ts` — Added `MEETING_VISIBILITY_OPTIONS` and `MEETING_JOIN_RESTRICTION_OPTIONS` card-selector option arrays; removed `visibility` from `MEETING_FEATURES` (moved to step 1)
- `packages/shared/src/utils/meeting-privacy.utils.ts` — New utility: `getMeetingPrivacyLabel()` and `getMeetingPrivacyIcon()` for derived privacy display
- `packages/shared/src/utils/meeting-privacy.utils.spec.ts` — Unit tests covering all PCC matrix combinations
- `packages/shared/src/utils/index.ts` — Barrel export for the new utility

**Frontend:**
- `meeting-type-selection.component.ts/.html` — Two card-selectors (visibility + restricted) replace the old single selector
- `meeting-platform-features.component.ts/.html` — Removed `calendarFeature` and its toggle (now handled in step 1)

**Backend:**
- `project.controller.ts` / `committee.controller.ts` — Calendar `.ics` feeds now include all public meetings regardless of join restriction; previously `restricted=true` meetings were filtered out even when public

## PCC privacy matrix supported

All four combinations are independently reachable via the wizard:

| State | `visibility` | `restricted` | Public calendar | Join |
|---|---|---|---|---|
| Public Unrestricted | `public` | `false` | ✅ listed | Anyone with the link |
| Public Restricted | `public` | `true` | ✅ listed | Invited guests only |
| Private Unrestricted | `private` | `false` | ❌ hidden | Anyone with the link |
| Private Restricted | `private` | `true` | ❌ hidden | Invited guests only |

> Visibility controls calendar discoverability. Join restriction (`restricted`) controls who can actually join. These are fully independent.

## Notes

- Branch name uses a descriptive suffix (`-meeting-privacy-settings`) beyond the ticket number for clarity — no functional impact
- No backend microservice changes required; both fields (`visibility` + `restricted`) are already supported end-to-end by the meeting service
- `yarn format`, `yarn lint`, `yarn build`, and `./check-headers.sh` all pass clean

## Test plan

1. Create meetings for each of the four combinations and verify API payload
2. Edit each combination; confirm form pre-population and update round-trip
3. Verify visibility controls calendar listing (public → appears in `.ics`, private → excluded)
4. Verify restricted controls join access (restricted → invited guests only, unrestricted → anyone with link)
5. Confirm Public + Restricted meeting appears in calendar feed but blocks uninvited users at join time
6. Regression: committee-linked meetings, recurring meetings

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2658]: https://linuxfoundation.atlassian.net/browse/LFXV2-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ