### PR TITLE
refactor(shared): create lfx-confirm-dialog wrapper and migrate 25 call sites

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.html
@@ -159,4 +159,4 @@
   </div>
 </div>
 
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -12,7 +12,7 @@ import { Committee, MemberPendingChanges } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { StepperModule } from 'primeng/stepper';
 import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, Observable, of, switchMap, take, toArray } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
@@ -26,10 +26,10 @@ import { CommitteeSettingsComponent } from '../components/committee-settings/com
 @Component({
   selector: 'lfx-committee-manage',
   imports: [
+    ConfirmDialogComponent,
     RouterLink,
     ReactiveFormsModule,
     StepperModule,
-    ConfirmDialogModule,
     ButtonComponent,
     CommitteeCategorySelectionComponent,
     CommitteeBasicInfoComponent,

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
@@ -3,7 +3,7 @@
 
 <div class="committee-members-manager-container max-w-4xl mx-auto" data-testid="committee-members-manager-container">
   <!-- Confirm Dialog for member deletion -->
-  <p-confirmDialog></p-confirmDialog>
+  <lfx-confirm-dialog />
 
   <!-- Header -->
   <div class="text-center mb-8">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
@@ -24,7 +24,7 @@ import {
 import { generateTempId } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { BehaviorSubject, catchError, finalize, of, take, tap } from 'rxjs';
@@ -34,6 +34,7 @@ import { MemberFormComponent } from '../member-form/member-form.component';
 @Component({
   selector: 'lfx-committee-members-manager',
   imports: [
+    ConfirmDialogComponent,
     NgClass,
     ReactiveFormsModule,
     AvatarComponent,
@@ -42,7 +43,6 @@ import { MemberFormComponent } from '../member-form/member-form.component';
     FullNamePipe,
     InputTextComponent,
     SelectComponent,
-    ConfirmDialogModule,
     DynamicDialogModule,
     TooltipModule,
   ],

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -3,7 +3,7 @@
 
 <div class="flex flex-col gap-4 pt-2">
   <!-- Confirm dialog host for revoke-invite and remove-member actions -->
-  <p-confirmDialog></p-confirmDialog>
+  <lfx-confirm-dialog />
 
   <!-- Committee Members Section -->
   <lfx-card>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -30,7 +30,7 @@ import {
 import { canManageCommitteeMembers, resolveCommitteeMemberPermission } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { Skeleton } from 'primeng/skeleton';
 import { catchError, debounceTime, distinctUntilChanged, of, startWith, take } from 'rxjs';
@@ -42,6 +42,7 @@ import { MemberFormComponent } from '../member-form/member-form.component';
 @Component({
   selector: 'lfx-committee-members',
   imports: [
+    ConfirmDialogComponent,
     TitleCasePipe,
     ReactiveFormsModule,
     CardComponent,
@@ -52,7 +53,6 @@ import { MemberFormComponent } from '../member-form/member-form.component';
     SelectComponent,
     TableComponent,
     TagComponent,
-    ConfirmDialogModule,
     DynamicDialogModule,
     Skeleton,
   ],

--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.html
@@ -119,4 +119,4 @@
   }
 </div>
 
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
@@ -13,7 +13,7 @@ import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { catchError, filter, finalize, forkJoin, map, merge, Observable, of, Subject, switchMap, take } from 'rxjs';
 
@@ -24,7 +24,7 @@ import { MailingListTypePipe } from './pipes/mailing-list-type.pipe';
 
 @Component({
   selector: 'lfx-committee-settings-tab',
-  imports: [CommitteeSettingsComponent, ButtonComponent, TagComponent, ConfirmDialogModule, MailingListEmailPipe, MailingListTypePipe],
+  imports: [ConfirmDialogComponent, CommitteeSettingsComponent, ButtonComponent, TagComponent, MailingListEmailPipe, MailingListTypePipe],
   providers: [DialogService],
   templateUrl: './committee-settings-tab.component.html',
   styleUrl: './committee-settings-tab.component.scss',

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.html
@@ -106,4 +106,4 @@
   </div>
 </lfx-card>
 
-<p-confirmDialog key="initiative-status" />
+<lfx-confirm-dialog key="initiative-status" />

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-detail-header/initiative-detail-header.component.ts
@@ -17,11 +17,11 @@ import {
 import { CrowdfundingInitiativeStatus, InitiativeDetail, InitiativeMenuItem, TabOption } from '@lfx-one/shared/interfaces';
 import { environment } from '@environments/environment';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'lfx-initiative-detail-header',
-  imports: [AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent, MarkdownRendererComponent, ConfirmDialogModule],
+  imports: [ConfirmDialogComponent, AvatarComponent, CardComponent, TagComponent, ButtonComponent, MenuComponent, MarkdownRendererComponent],
   templateUrl: './initiative-detail-header.component.html',
   styleUrl: './initiative-detail-header.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-announcements-tab/settings-announcements-tab.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-announcements-tab/settings-announcements-tab.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<p-confirmDialog key="settings-announcements"></p-confirmDialog>
+<lfx-confirm-dialog key="settings-announcements" />
 <div class="flex flex-col gap-5" data-testid="settings-announcements-tab">
   <div class="flex items-center justify-between">
     <h3 class="text-xs font-bold text-gray-500 uppercase tracking-wide">Announcements</h3>

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-announcements-tab/settings-announcements-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/components/settings-announcements-tab/settings-announcements-tab.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { filter, firstValueFrom, map } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { RichEditorComponent } from '@components/rich-editor/rich-editor.component';
@@ -17,7 +17,7 @@ import { CrowdfundingService } from '@services/crowdfunding.service';
 
 @Component({
   selector: 'lfx-settings-announcements-tab',
-  imports: [DatePipe, ReactiveFormsModule, ConfirmDialogModule, ButtonComponent, InputTextComponent, RichEditorComponent],
+  imports: [ConfirmDialogComponent, DatePipe, ReactiveFormsModule, ButtonComponent, InputTextComponent, RichEditorComponent],
   providers: [ConfirmationService],
   templateUrl: './settings-announcements-tab.component.html',
 })

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.html
@@ -55,4 +55,4 @@
   </div>
 }
 
-<p-confirmDialog />
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/my-donations/my-donations.component.ts
@@ -16,20 +16,20 @@ import { DonationHistoryTableComponent } from './components/donation-history-tab
 import { PaymentMethodsComponent } from './components/payment-methods/payment-methods.component';
 import { RecurringDonationsListComponent } from './components/recurring-donations-list/recurring-donations-list.component';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { BehaviorSubject } from 'rxjs';
 import { finalize, map, scan, switchMap, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'lfx-my-donations',
   imports: [
+    ConfirmDialogComponent,
     ButtonComponent,
     StatCardGridComponent,
     RouteLoadingComponent,
     RecurringDonationsListComponent,
     DonationHistoryTableComponent,
     PaymentMethodsComponent,
-    ConfirmDialogModule,
   ],
   providers: [ConfirmationService],
   templateUrl: './my-donations.component.html',

--- a/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.html
@@ -27,4 +27,4 @@
   }
 </div>
 
-<p-confirmDialog />
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
@@ -7,7 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { concatMap, filter, map, scan, startWith, switchMap, tap } from 'rxjs/operators';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 
 import { CrowdfundingTransaction, RecurringDonation } from '@lfx-one/shared/interfaces';
 import { DEFAULT_CROWDFUNDING_PAGE_SIZE } from '@lfx-one/shared/constants';
@@ -20,8 +20,8 @@ import { RecurringDonationChargeHistoryComponent } from './components/recurring-
 @Component({
   selector: 'lfx-recurring-donation-detail',
   imports: [
+    ConfirmDialogComponent,
     RouterLink,
-    ConfirmDialogModule,
     ButtonComponent,
     RecurringDonationInitiativeHeaderComponent,
     RecurringDonationSubscriptionSummaryComponent,

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-members/mailing-list-members.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-members/mailing-list-members.component.html
@@ -159,4 +159,4 @@
   }
 </lfx-card>
 
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-members/mailing-list-members.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-members/mailing-list-members.component.ts
@@ -17,7 +17,7 @@ import { MailingListMemberDeliveryMode, MailingListMemberModStatus } from '@lfx-
 import { GroupsIOMailingList, MailingListMember, UpdateMailingListMemberRequest } from '@lfx-one/shared/interfaces';
 import { MailingListService } from '@services/mailing-list.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, take } from 'rxjs';
 
@@ -26,13 +26,13 @@ import { ManageMemberModalComponent } from '../manage-member-modal/manage-member
 @Component({
   selector: 'lfx-mailing-list-members',
   imports: [
+    ConfirmDialogComponent,
     CardComponent,
     ButtonComponent,
     TableComponent,
     LowerCasePipe,
     FullNamePipe,
     SelectChipComponent,
-    ConfirmDialogModule,
     ReactiveFormsModule,
     InputTextComponent,
     SelectComponent,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -464,6 +464,6 @@
     }
 
     <!-- Confirmation Dialog -->
-    <p-confirmDialog></p-confirmDialog>
+    <lfx-confirm-dialog />
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -71,7 +71,7 @@ import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { AnimateOnScrollModule } from 'primeng/animateonscroll';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
@@ -85,6 +85,7 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
 @Component({
   selector: 'lfx-meeting-card',
   imports: [
+    ConfirmDialogComponent,
     NgClass,
     ButtonComponent,
     TagComponent,
@@ -92,7 +93,6 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
     RecurrenceSummaryPipe,
     TooltipModule,
     AnimateOnScrollModule,
-    ConfirmDialogModule,
     DrawerModule,
     ExpandableTextComponent,
     LinkifyPipe,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-manager/meeting-registrants-manager.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-manager/meeting-registrants-manager.component.html
@@ -3,7 +3,7 @@
 
 <div class="pb-4" data-testid="meeting-registrants-container">
   <!-- Confirm Dialog for registrant deletion -->
-  <p-confirmDialog></p-confirmDialog>
+  <lfx-confirm-dialog />
 
   <!-- Step Title -->
   <div class="mb-6">

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-manager/meeting-registrants-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-manager/meeting-registrants-manager.component.ts
@@ -20,7 +20,7 @@ import {
 import { generateTempId } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { BehaviorSubject, catchError, finalize, of, take, tap } from 'rxjs';
 
 import { MeetingCommitteeManagerComponent } from '../meeting-committee-manager/meeting-committee-manager.component';
@@ -30,13 +30,13 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 @Component({
   selector: 'lfx-meeting-registrants-manager',
   imports: [
+    ConfirmDialogComponent,
     ReactiveFormsModule,
     ButtonComponent,
     FeatureToggleComponent,
     InputTextComponent,
     MeetingCommitteeManagerComponent,
     SelectComponent,
-    ConfirmDialogModule,
     RegistrantCardComponent,
     RegistrantFormComponent,
   ],

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
@@ -229,4 +229,4 @@
 </div>
 
 <!-- Confirmation Dialog -->
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -49,7 +49,7 @@ import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { toZonedTime } from 'date-fns-tz';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
 import { BehaviorSubject, catchError, concat, filter, finalize, forkJoin, from, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
@@ -64,11 +64,11 @@ import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss
 @Component({
   selector: 'lfx-meeting-manage',
   imports: [
+    ConfirmDialogComponent,
     StepperModule,
     ButtonComponent,
     MessageComponent,
     ReactiveFormsModule,
-    ConfirmDialogModule,
     MeetingTypeSelectionComponent,
     MeetingDetailsComponent,
     MeetingPlatformFeaturesComponent,

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.html
@@ -62,4 +62,4 @@
   (generated)="onGenerated($event)">
 </lfx-newsletter-generate-drawer>
 
-<p-confirmDialog key="newsletter-content-step" data-testid="newsletter-content-confirm-dialog"></p-confirmDialog>
+<lfx-confirm-dialog key="newsletter-content-step" data-testid="newsletter-content-confirm-dialog" />

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-content-step/newsletter-content-step.component.ts
@@ -9,14 +9,14 @@ import { RichEditorComponent } from '@components/rich-editor/rich-editor.compone
 import { GenerateNewsletterResponse } from '@lfx-one/shared/interfaces';
 import { stripHtml } from '@lfx-one/shared/utils';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { EMPTY, startWith, switchMap } from 'rxjs';
 
 import { NewsletterGenerateDrawerComponent } from '../newsletter-generate-drawer/newsletter-generate-drawer.component';
 
 @Component({
   selector: 'lfx-newsletter-content-step',
-  imports: [ReactiveFormsModule, RichEditorComponent, InputTextComponent, NewsletterGenerateDrawerComponent, ConfirmDialogModule],
+  imports: [ConfirmDialogComponent, ReactiveFormsModule, RichEditorComponent, InputTextComponent, NewsletterGenerateDrawerComponent],
   templateUrl: './newsletter-content-step.component.html',
 })
 export class NewsletterContentStepComponent {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -148,7 +148,7 @@
   </div>
 </div>
 
-<p-confirmDialog key="newsletter-list"></p-confirmDialog>
+<lfx-confirm-dialog key="newsletter-list" />
 
 @if (selectedNewsletter(); as n) {
   <!--

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -16,7 +16,7 @@ import { FilterPillOption, NewsletterListItem, NewsletterRow, NewsletterStatus, 
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { TooltipModule } from 'primeng/tooltip';
 import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
 
@@ -25,6 +25,7 @@ import { NewsletterPreviewDrawerComponent } from '../components/newsletter-previ
 @Component({
   selector: 'lfx-newsletter-list',
   imports: [
+    ConfirmDialogComponent,
     DatePipe,
     ButtonComponent,
     CardComponent,
@@ -32,7 +33,6 @@ import { NewsletterPreviewDrawerComponent } from '../components/newsletter-previ
     EmptyStateComponent,
     TableComponent,
     TagComponent,
-    ConfirmDialogModule,
     TooltipModule,
     NewsletterPreviewDrawerComponent,
   ],

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -217,4 +217,4 @@
   [displayName]="displayName()">
 </lfx-newsletter-preview-drawer>
 
-<p-confirmDialog key="newsletter-manage"></p-confirmDialog>
+<lfx-confirm-dialog key="newsletter-manage" />

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -23,7 +23,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { SkeletonModule } from 'primeng/skeleton';
 import { StepperModule } from 'primeng/stepper';
 import {
@@ -52,11 +52,11 @@ import { NewsletterSendStepComponent } from '../components/newsletter-send-step/
 @Component({
   selector: 'lfx-newsletter-manage',
   imports: [
+    ConfirmDialogComponent,
     ReactiveFormsModule,
     RouterLink,
     StepperModule,
     SkeletonModule,
-    ConfirmDialogModule,
     ButtonComponent,
     NewsletterAudienceStepComponent,
     NewsletterContentStepComponent,

--- a/apps/lfx-one/src/app/modules/profile/email/profile-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/email/profile-email.component.html
@@ -193,4 +193,4 @@
 <p-toast position="top-right" />
 
 <!-- Confirmation dialog -->
-<p-confirmDialog />
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/profile/email/profile-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/email/profile-email.component.ts
@@ -13,7 +13,7 @@ import { MessageComponent } from '@components/message/message.component';
 import { EmailManagementData, UserEmail } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -22,6 +22,7 @@ import { BehaviorSubject, catchError, finalize, of, switchMap, take } from 'rxjs
 @Component({
   selector: 'lfx-profile-email',
   imports: [
+    ConfirmDialogComponent,
     NgClass,
     ReactiveFormsModule,
     CardComponent,
@@ -29,7 +30,6 @@ import { BehaviorSubject, catchError, finalize, of, switchMap, take } from 'rxjs
     MessageComponent,
     ButtonComponent,
     BadgeComponent,
-    ConfirmDialogModule,
     ToastModule,
     TooltipModule,
   ],

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -186,4 +186,4 @@
 </div>
 
 <p-toast position="top-right" />
-<p-confirmDialog data-testid="individual-enrollment-confirm-dialog" />
+<lfx-confirm-dialog data-testid="individual-enrollment-confirm-dialog" />

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -9,7 +9,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DisplayEnrollment, EnrollmentsState } from '@lfx-one/shared/interfaces';
 import { deriveEnrollmentStatus, enrollmentStatusSeverity } from '@lfx-one/shared/utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { ToastModule } from 'primeng/toast';
 import { finalize, take } from 'rxjs';
 
@@ -23,7 +23,7 @@ import { UserService } from '@services/user.service';
 
 @Component({
   selector: 'lfx-profile-individual-enrollment',
-  imports: [ButtonComponent, CardComponent, ConfirmDialogModule, DatePipe, EmptyStateComponent, TagComponent, ToastModule],
+  imports: [ConfirmDialogComponent, ButtonComponent, CardComponent, DatePipe, EmptyStateComponent, TagComponent, ToastModule],
   templateUrl: './profile-individual-enrollment.component.html',
   styleUrl: './profile-individual-enrollment.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -600,4 +600,4 @@
 <p-toast position="top-right" />
 
 <!-- Confirmation dialog -->
-<p-confirmDialog />
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -14,7 +14,7 @@ import { useResendCooldown } from '@shared/utils/resend-cooldown';
 import { ChangePasswordRequest, EmailManagementData, PasswordStrength, UserEmail } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
@@ -25,12 +25,12 @@ import { BehaviorSubject, catchError, finalize, of, switchMap, take } from 'rxjs
   selector: 'lfx-account-settings',
   host: { class: 'block' },
   imports: [
+    ConfirmDialogComponent,
     NgClass,
     ReactiveFormsModule,
     BadgeComponent,
     ButtonComponent,
     InputTextComponent,
-    ConfirmDialogModule,
     ToastModule,
     TooltipModule,
     DynamicDialogModule,

--- a/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.html
+++ b/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.html
@@ -124,4 +124,4 @@
 </ng-template>
 
 <!-- Confirmation Dialog -->
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/components/user-form/user-form.component.ts
@@ -11,14 +11,14 @@ import { AddUserToProjectRequest, ProjectPermissionUser, UpdateUserRoleRequest }
 import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { take } from 'rxjs';
 
 @Component({
   selector: 'lfx-user-form',
-  imports: [ReactiveFormsModule, InputTextComponent, ButtonComponent, RadioButtonComponent, TooltipModule, ConfirmDialogModule],
+  imports: [ConfirmDialogComponent, ReactiveFormsModule, InputTextComponent, ButtonComponent, RadioButtonComponent, TooltipModule],
   templateUrl: './user-form.component.html',
 })
 export class UserFormComponent {

--- a/apps/lfx-one/src/app/modules/settings/components/user-permissions-table/user-permissions-table.component.html
+++ b/apps/lfx-one/src/app/modules/settings/components/user-permissions-table/user-permissions-table.component.html
@@ -119,4 +119,4 @@
 }
 
 <!-- Confirmation Dialog -->
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/settings/components/user-permissions-table/user-permissions-table.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/components/user-permissions-table/user-permissions-table.component.ts
@@ -10,7 +10,7 @@ import { ProjectPermissionUser } from '@lfx-one/shared/interfaces';
 import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { take } from 'rxjs';
@@ -19,7 +19,7 @@ import { UserFormComponent } from '../user-form/user-form.component';
 
 @Component({
   selector: 'lfx-user-permissions-table',
-  imports: [TableComponent, TooltipModule, CardComponent, ConfirmDialogModule, ButtonComponent, MenuComponent],
+  imports: [ConfirmDialogComponent, TableComponent, TooltipModule, CardComponent, ButtonComponent, MenuComponent],
   templateUrl: './user-permissions-table.component.html',
 })
 export class UserPermissionsTableComponent {

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -261,4 +261,4 @@
   }
 </lfx-card>
 
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -22,13 +22,14 @@ import { ScheduledSendAriaLabelPipe, ScheduledSendTooltipPipe } from '@pipes/sch
 import { SurveyStatusLabelPipe } from '@pipes/survey-status-label.pipe';
 import { SurveyStatusSeverityPipe } from '@pipes/survey-status-severity.pipe';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { TooltipModule } from 'primeng/tooltip';
 import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
 
 @Component({
   selector: 'lfx-surveys-table',
   imports: [
+    ConfirmDialogComponent,
     CardComponent,
     CardTabsBarComponent,
     TableComponent,
@@ -45,7 +46,6 @@ import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
     ScheduledSendTooltipPipe,
     ScheduledSendAriaLabelPipe,
     TooltipModule,
-    ConfirmDialogModule,
     EmptyStateComponent,
   ],
   providers: [ConfirmationService],

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- Confirmation Dialog -->
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />
 
 <div class="container px-8" data-testid="survey-manage">
   <!-- Back Navigation -->

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -22,7 +22,7 @@ import { MessageComponent } from '@components/message/message.component';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { StepperModule } from 'primeng/stepper';
 import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
 
@@ -34,11 +34,11 @@ import { SurveyTimingRemindersComponent } from '../components/survey-timing-remi
 @Component({
   selector: 'lfx-survey-manage',
   imports: [
+    ConfirmDialogComponent,
     ReactiveFormsModule,
     RouterLink,
     ButtonComponent,
     MessageComponent,
-    ConfirmDialogModule,
     StepperModule,
     SurveyAudienceTypeComponent,
     SurveyTimingRemindersComponent,

--- a/apps/lfx-one/src/app/modules/trainings/components/rewards/rewards.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/rewards/rewards.component.html
@@ -171,4 +171,4 @@
   </div>
 }
 
-<p-confirmDialog data-testid="rewards-confirm-dialog" />
+<lfx-confirm-dialog data-testid="rewards-confirm-dialog" />

--- a/apps/lfx-one/src/app/modules/trainings/components/rewards/rewards.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/rewards/rewards.component.ts
@@ -9,7 +9,7 @@ import { REWARD_STEP_SIZE } from '@lfx-one/shared/constants';
 import { RewardPromotion, RewardsState, RewardsSummaryResponse } from '@lfx-one/shared/interfaces';
 import { EMPTY_REWARD_PROMOTIONS } from '@lfx-one/shared/utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, firstValueFrom, map, Observable, of, startWith, Subject, switchMap, tap } from 'rxjs';
 
@@ -24,7 +24,7 @@ const SUMMARY_LOAD_FALLBACK = 'Rewards are temporarily unavailable. Please try a
 
 @Component({
   selector: 'lfx-rewards',
-  imports: [AvailableIncentivesComponent, ButtonComponent, ConfirmDialogModule, DatePipe, MyCouponsComponent, SkeletonModule],
+  imports: [ConfirmDialogComponent, AvailableIncentivesComponent, ButtonComponent, DatePipe, MyCouponsComponent, SkeletonModule],
   templateUrl: './rewards.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -256,4 +256,4 @@
   }
 </lfx-card>
 
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -22,13 +22,14 @@ import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { VoteService } from '@services/vote.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { TooltipModule } from 'primeng/tooltip';
 import { combineLatest, debounceTime, distinctUntilChanged, map, startWith, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-votes-table',
   imports: [
+    ConfirmDialogComponent,
     CardComponent,
     CardTabsBarComponent,
     TableComponent,
@@ -43,7 +44,6 @@ import { combineLatest, debounceTime, distinctUntilChanged, map, startWith, take
     DueDateLabelPipe,
     DueDateLabelColorPipe,
     TooltipModule,
-    ConfirmDialogModule,
     EmptyStateComponent,
   ],
   providers: [ConfirmationService],

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.html
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- Confirmation Dialog -->
-<p-confirmDialog></p-confirmDialog>
+<lfx-confirm-dialog />
 
 <div class="container px-8" data-testid="vote-manage">
   <!-- Back Navigation -->

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -22,7 +22,7 @@ import { trimmedMinLength, trimmedRequired, validCommitteeReference } from '@lfx
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogComponent } from '@components/confirm-dialog/confirm-dialog.component';
 import { StepperModule } from 'primeng/stepper';
 import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take, tap } from 'rxjs';
 
@@ -34,11 +34,11 @@ import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss
 @Component({
   selector: 'lfx-vote-manage',
   imports: [
+    ConfirmDialogComponent,
     ReactiveFormsModule,
     RouterLink,
     ButtonComponent,
     MessageComponent,
-    ConfirmDialogModule,
     StepperModule,
     VoteBasicsComponent,
     VoteQuestionComponent,

--- a/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,4 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-confirmDialog [key]="key()" />

--- a/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
+++ b/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import { ConfirmDialogProps } from '@lfx-one/shared/interfaces';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+
+@Component({
+  selector: 'lfx-confirm-dialog',
+  imports: [ConfirmDialogModule],
+  templateUrl: './confirm-dialog.component.html',
+})
+export class ConfirmDialogComponent {
+  public readonly key = input<ConfirmDialogProps['key']>();
+}

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -693,3 +693,12 @@ export interface TabOption<T = string> {
   /** Tab manages its own per-item save flow, so shared save/cancel footer should stay hidden */
   savesInline?: boolean;
 }
+
+/**
+ * Confirm dialog component properties
+ * @description Configuration for LFX confirm dialog wrapper component (wraps PrimeNG ConfirmDialog)
+ */
+export interface ConfirmDialogProps {
+  /** Scoping key — when set, only ConfirmationService.confirm({ key }) calls with the same key trigger this dialog instance. Use when a template contains multiple confirm dialogs. */
+  key?: string;
+}


### PR DESCRIPTION
## Summary

- Add `lfx-confirm-dialog` wrapper component (`shared/components/confirm-dialog/`) that wraps PrimeNG's `<p-confirmDialog>` for UI-library independence
- Add `ConfirmDialogProps` interface to `@lfx-one/shared/interfaces/components.interface.ts` with optional `key` field for scoped multi-dialog templates
- Migrate all 25 feature templates from raw `<p-confirmDialog>` to `<lfx-confirm-dialog />`, swapping `ConfirmDialogModule` for `ConfirmDialogComponent` in each TS file

## Motivation

Per `.claude/rules/styling.md`, feature templates must not use raw `<p-*>` components when an `lfx-` wrapper exists. No wrapper existed for `ConfirmDialog` — this PR creates it and eliminates all 25 bypass violations in one pass.

## Modules affected

committees (×4), crowdfunding (×4), mailing-lists (×1), meetings (×3), newsletters (×3), profile (×2), settings (×3), surveys (×2), trainings (×1), votes (×2)

## Test plan

- [ ] `yarn lint` — passes (1 pre-existing unrelated warning)
- [ ] Confirm dialogs render and trigger correctly in: meetings, surveys, votes, committees, newsletters (key-scoped), crowdfunding
- [ ] Verify key-scoped dialogs (`key="newsletter-content-step"`, `key="newsletter-manage"`, `key="newsletter-list"`, `key="initiative-status"`, `key="settings-announcements"`) still scope correctly

LFXV2-2671

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical template/import swap with PrimeNG still backing the wrapper; behavior depends on unchanged ConfirmationService usage. Broad touch surface warrants spot-checking keyed dialogs in QA.
> 
> **Overview**
> Introduces **`lfx-confirm-dialog`**, a shared wrapper around PrimeNG’s confirm dialog, and **`ConfirmDialogProps`** (optional `key` for scoped dialogs). Feature templates no longer use raw **`p-confirmDialog`** / **`ConfirmDialogModule`** directly.
> 
> **25 components** across committees, crowdfunding, mailing lists, meetings, newsletters, profile, settings, surveys, trainings, and votes now host **`<lfx-confirm-dialog />`** (or the same with `key`, `data-testid`, etc.). Existing **`ConfirmationService.confirm()`** calls are unchanged; keyed flows (e.g. newsletter manage/list/content, initiative status, settings announcements) still pass matching `key` values.
> 
> This is a UI-library boundary change for styling rules, not a new confirmation API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b557cc6c419e3338e9f39475c5181943102c7810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->