### PR TITLE
fix(dashboards): correct campaign performance drawer metric labels

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -159,7 +159,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-attribution-table">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Revenue by Channel</h3>
-              <p class="text-sm text-gray-600">Multi-touch attribution across marketing channels for the last completed month</p>
+              <p class="text-sm text-gray-600">Multi-touch attribution across marketing channels over the last 6 months</p>
             </div>
 
             <!-- Table Header -->
@@ -271,7 +271,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-paid-projects-section">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Performance by Project</h3>
-              <p class="text-sm text-gray-600">Paid campaign performance grouped by project for the last completed month</p>
+              <p class="text-sm text-gray-600">Paid campaign performance grouped by project over the last 6 months</p>
             </div>
 
             <!-- Table Header -->
@@ -397,7 +397,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Campaign Performance by Type</h3>
-              <p class="text-sm text-gray-600">Email performance grouped by campaign type for the last completed month</p>
+              <p class="text-sm text-gray-600">Email performance grouped by campaign type over the last 6 months</p>
             </div>
 
             <!-- Table Header -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -159,7 +159,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-attribution-table">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Revenue by Channel</h3>
-              <p class="text-sm text-gray-600">Multi-touch attribution across marketing channels over the last 6 months</p>
+              <p class="text-sm text-gray-600">Multi-touch attribution across marketing channels for the last completed month</p>
             </div>
 
             <!-- Table Header -->
@@ -242,7 +242,7 @@
           </lfx-card>
           <lfx-card styleClass="flex-1 min-w-[100px]">
             <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Revenue (first-touch)</span>
+              <span class="text-sm text-gray-500">Revenue (last-touch)</span>
               <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalRevenue() }}</span>
             </div>
           </lfx-card>
@@ -271,7 +271,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-paid-projects-section">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Performance by Project</h3>
-              <p class="text-sm text-gray-600">Paid campaign performance grouped by project over the last 6 months</p>
+              <p class="text-sm text-gray-600">Paid campaign performance grouped by project for the last completed month</p>
             </div>
 
             <!-- Table Header -->
@@ -279,7 +279,7 @@
               <span class="flex-[2] min-w-[120px]">Project / Campaign</span>
               <span class="w-16 text-center">Funnel</span>
               <span class="flex-1 text-right">Spend</span>
-              <span class="flex-1 text-right">Rev (linear)</span>
+              <span class="flex-1 text-right">Rev (last-touch)</span>
               <span class="w-14 text-right">ROAS</span>
               <span class="flex-1 text-right">Conv.</span>
               <span class="w-14 text-right">Conv %</span>
@@ -397,7 +397,7 @@
           <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
             <div class="flex flex-col gap-1">
               <h3 class="text-sm font-semibold text-gray-900">Campaign Performance by Type</h3>
-              <p class="text-sm text-gray-600">Email performance grouped by campaign type over the last 6 months</p>
+              <p class="text-sm text-gray-600">Email performance grouped by campaign type for the last completed month</p>
             </div>
 
             <!-- Table Header -->


### PR DESCRIPTION
## Summary

The Campaign Performance drawer (ED dashboard, `email-ctr-drawer` component) labeled revenue figures with attribution models that don't match the data:

1. **"Revenue (first-touch)"** KPI — bound to `paidData().totalRevenue`, which is `SUM(LAST_TOUCH_REVENUE)` from `PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH`.
2. **"Rev (linear)"** table column — also last-touch revenue.

## Changes

Label-only change in `email-ctr-drawer.component.html`:

- "Revenue (first-touch)" → "Revenue (last-touch)"
- "Rev (linear)" → "Rev (last-touch)"

These are correct regardless of any reporting-window decisions.

## Scope note

An earlier revision of this PR also relabeled three section subtitles from "over the last 6 months" to "for the last completed month" (the queries currently default to the previous completed month because no period is passed). That change was **backed out**: the 6-month wording is the intended design across all ED drawers, and a follow-up PR wires the `last-6` period preset through these endpoints so the original subtitles become true — rather than codifying the accidental 1-month window here.

JIRA: [LFXV2-2680](https://linuxfoundation.atlassian.net/browse/LFXV2-2680)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2680]: https://linuxfoundation.atlassian.net/browse/LFXV2-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ