### PR TITLE
fix(meetings): pass meeting password through calendar view navigation

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -259,10 +259,10 @@ export class MeetingsDashboardComponent {
 
   /** FullCalendar event click → navigate to the meeting detail. Cancelled occurrences are inert. */
   public onCalendarEventClick(arg: EventClickArg): void {
-    const props = arg.event.extendedProps as { type: string; meetingId?: string; cancelled?: boolean };
+    const props = arg.event.extendedProps as { type: string; meetingId?: string; cancelled?: boolean; password?: string };
     if (props.cancelled) return;
     if (props.type === 'meeting' && props.meetingId) {
-      void this.router.navigate(['/meetings', props.meetingId]);
+      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : {});
     }
   }
 
@@ -956,7 +956,7 @@ export class MeetingsDashboardComponent {
           display: 'block',
           // meeting-event scopes the shared dimming/future-event styles; cursor-default disables the click affordance on cancelled occurrences.
           classNames: isCancelled ? ['meeting-event', 'cursor-default'] : ['meeting-event'],
-          extendedProps: { type: 'meeting', meetingId: meeting.id, cancelled: isCancelled },
+          extendedProps: { type: 'meeting', meetingId: meeting.id, cancelled: isCancelled, password: meeting.password },
         };
       });
     }
@@ -972,7 +972,7 @@ export class MeetingsDashboardComponent {
         textColor: '#ffffff',
         display: 'block',
         classNames: ['meeting-event'],
-        extendedProps: { type: 'meeting', meetingId: meeting.id },
+        extendedProps: { type: 'meeting', meetingId: meeting.id, password: meeting.password },
       },
     ];
   }


### PR DESCRIPTION
## Summary
- Calendar view event clicks navigated to `/meetings/:id` without forwarding the meeting's `password`, so password-protected meetings surfaced as "meeting not found" on the join page.
- `meetingToEvents()` now includes `password` in `extendedProps` for both the occurrence and single-event branches; `onCalendarEventClick()` forwards it as a `password` query param when present.

Fixes [LFXV2-2362](https://linuxfoundation.atlassian.net/browse/LFXV2-2362)

## Test plan
- [ ] Click a password-protected meeting on the calendar view (Project/Foundation lens) and confirm it navigates to the join page with `?password=...` and loads correctly instead of "meeting not found"
- [ ] Click a non-password meeting and confirm no `password` query param is added and it still navigates correctly
- [ ] Click a cancelled recurring occurrence and confirm it remains inert (no navigation)

[LFXV2-2362]: https://linuxfoundation.atlassian.net/browse/LFXV2-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized navigation fix that mirrors existing list-view password handling; no auth or API changes.
> 
> **Overview**
> Calendar clicks on password-protected meetings went to `/meetings/:id` **without** the `password` query param, so the join page could not load the meeting (same pattern list links already use via `meeting-card`).
> 
> **`meetingToEvents()`** now puts `meeting.password` on FullCalendar **`extendedProps`** for single events and recurring occurrences. **`onCalendarEventClick()`** reads that value and navigates with `{ queryParams: { password } }` when it is set; meetings without a password keep the previous bare navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb20ae2100a233a5514522ef21097ba465a325a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->