### PR TITLE
refactor(crowdfunding): remove shipped feature flags

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.html
@@ -28,7 +28,7 @@
   <div class="flex flex-col gap-6 pb-2 overflow-x-hidden" data-testid="initiative-settings-drawer-content">
     <!-- Tab bar -->
     <div role="tablist" class="flex items-center border-b border-gray-200 -mx-6 px-6 -mt-2" data-testid="initiative-settings-tabs">
-      @for (tab of settingsTabs(); track tab.value) {
+      @for (tab of settingsTabs; track tab.value) {
         <button
           type="button"
           class="relative px-4 py-2.5 text-sm font-medium transition-colors whitespace-nowrap"
@@ -76,24 +76,20 @@
       [class.hidden]="activeSettingsTab() !== 'funding'"
       [visible]="visible()"
       [initiative]="initiative()" />
-    @if (sponsorshipTiersEnabled()) {
-      <lfx-settings-sponsorship-tiers-tab
-        id="settings-panel-sponsorship-tiers"
-        role="tabpanel"
-        aria-labelledby="settings-tab-sponsorship-tiers"
-        [class.hidden]="activeSettingsTab() !== 'sponsorship-tiers'"
-        [visible]="visible()"
-        [initiative]="initiative()" />
-    }
-    @if (announcementsEnabled()) {
-      <lfx-settings-announcements-tab
-        id="settings-panel-announcements"
-        role="tabpanel"
-        aria-labelledby="settings-tab-announcements"
-        [class.hidden]="activeSettingsTab() !== 'announcements'"
-        [visible]="visible()"
-        [initiative]="initiative()" />
-    }
+    <lfx-settings-sponsorship-tiers-tab
+      id="settings-panel-sponsorship-tiers"
+      role="tabpanel"
+      aria-labelledby="settings-tab-sponsorship-tiers"
+      [class.hidden]="activeSettingsTab() !== 'sponsorship-tiers'"
+      [visible]="visible()"
+      [initiative]="initiative()" />
+    <lfx-settings-announcements-tab
+      id="settings-panel-announcements"
+      role="tabpanel"
+      aria-labelledby="settings-tab-announcements"
+      [class.hidden]="activeSettingsTab() !== 'announcements'"
+      [visible]="visible()"
+      [initiative]="initiative()" />
 
     <!-- Footer actions — hidden on tabs that manage their own inline save flow -->
     @if (!activeTab()?.savesInline) {

--- a/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/initiative-detail/components/initiative-settings-drawer/initiative-settings-drawer.component.ts
@@ -7,10 +7,8 @@ import { filter, firstValueFrom } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { ButtonComponent } from '@components/button/button.component';
-import { ANNOUNCEMENT_ENABLED_FLAG, CROWDFUNDING_SPONSOR_TIERS_FLAG } from '@lfx-one/shared/constants';
 import { InitiativeDetail, TabOption, UpdateInitiativeInput } from '@lfx-one/shared/interfaces';
 import { CrowdfundingService } from '@services/crowdfunding.service';
-import { FeatureFlagService } from '@services/feature-flag.service';
 import { SettingsAnnouncementsTabComponent } from './components/settings-announcements-tab/settings-announcements-tab.component';
 import { SettingsBeneficiariesTabComponent } from './components/settings-beneficiaries-tab/settings-beneficiaries-tab.component';
 import { SettingsBrandingTabComponent } from './components/settings-branding-tab/settings-branding-tab.component';
@@ -36,7 +34,6 @@ import { SettingsSponsorshipTiersTabComponent } from './components/settings-spon
 export class InitiativeSettingsDrawerComponent {
   private readonly crowdfundingService = inject(CrowdfundingService);
   private readonly messageService = inject(MessageService);
-  private readonly featureFlagService = inject(FeatureFlagService);
 
   public readonly initiative = input.required<InitiativeDetail>();
   public readonly visible = model(false);
@@ -45,27 +42,22 @@ export class InitiativeSettingsDrawerComponent {
   protected readonly activeSettingsTab = signal<string>('details');
   protected readonly saving = signal(false);
 
-  protected readonly announcementsEnabled = this.featureFlagService.getBooleanFlag(ANNOUNCEMENT_ENABLED_FLAG, false);
-  protected readonly sponsorshipTiersEnabled = this.featureFlagService.getBooleanFlag(CROWDFUNDING_SPONSOR_TIERS_FLAG, false);
-
-  protected readonly settingsTabs: Signal<TabOption<string>[]> = computed(() => [
+  protected readonly settingsTabs: TabOption<string>[] = [
     { value: 'details', label: 'Initiative details' },
     { value: 'branding', label: 'Branding' },
     { value: 'beneficiaries', label: 'Beneficiaries' },
     { value: 'funding', label: 'Funding' },
-    ...(this.sponsorshipTiersEnabled() ? [{ value: 'sponsorship-tiers', label: 'Sponsorship Tiers' }] : []),
-    ...(this.announcementsEnabled() ? [{ value: 'announcements', label: 'Announcements', savesInline: true }] : []),
-  ]);
+    { value: 'sponsorship-tiers', label: 'Sponsorship Tiers' },
+    { value: 'announcements', label: 'Announcements', savesInline: true },
+  ];
 
-  protected readonly activeTab: Signal<TabOption<string> | undefined> = computed(() =>
-    this.settingsTabs().find((tab) => tab.value === this.activeSettingsTab())
-  );
+  protected readonly activeTab: Signal<TabOption<string> | undefined> = computed(() => this.settingsTabs.find((tab) => tab.value === this.activeSettingsTab()));
 
   private readonly detailsTab = viewChild.required(SettingsDetailsTabComponent);
   private readonly brandingTab = viewChild.required(SettingsBrandingTabComponent);
   private readonly beneficiariesTab = viewChild.required(SettingsBeneficiariesTabComponent);
   private readonly fundingTab = viewChild.required(SettingsFundingTabComponent);
-  private readonly sponsorshipTiersTab = viewChild(SettingsSponsorshipTiersTabComponent);
+  private readonly sponsorshipTiersTab = viewChild.required(SettingsSponsorshipTiersTabComponent);
 
   public constructor() {
     toObservable(this.visible)
@@ -85,10 +77,10 @@ export class InitiativeSettingsDrawerComponent {
     const sponsorshipTiersTab = this.sponsorshipTiersTab();
 
     const invalidBeneficiary = beneficiaries.beneficiaryGroups().some((g) => g.invalid);
-    if (details.form.invalid || funding.form.invalid || sponsorshipTiersTab?.form.invalid || invalidBeneficiary) {
+    if (details.form.invalid || funding.form.invalid || sponsorshipTiersTab.form.invalid || invalidBeneficiary) {
       details.form.markAllAsTouched();
       funding.form.markAllAsTouched();
-      sponsorshipTiersTab?.form.markAllAsTouched();
+      sponsorshipTiersTab.form.markAllAsTouched();
       beneficiaries.beneficiaryGroups().forEach((g) => g.markAllAsTouched());
       return;
     }
@@ -150,7 +142,7 @@ export class InitiativeSettingsDrawerComponent {
         }))
         .filter((b) => b.name || b.email);
 
-      const sponsorshipTiers = sponsorshipTiersTab?.getValue();
+      const sponsorshipTiers = sponsorshipTiersTab.getValue();
       if (sponsorshipTiers) {
         input.donationMode = sponsorshipTiers.donationMode;
         input.sponsorshipTiers = sponsorshipTiers.sponsorshipTiers;

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -7,7 +7,6 @@ import { environment } from '@environments/environment';
 import {
   AKRITES_ENABLED_FLAG,
   COMMITTEE_LABEL,
-  CROWDFUNDING_ENABLED_FLAG,
   DOCUMENT_LABEL,
   MAILING_LIST_LABEL,
   MKTG_OS_AGENTS_ENABLED_FLAG,
@@ -43,8 +42,6 @@ export class SidebarNavService {
 
   /** Dark-launch gate; falls back to Me Lens nav when off. */
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
-  /** Dark-launch gate; the Crowdfunding section is shown only when on (no Crowdfunding nav entry when off). */
-  private readonly isCrowdfundingEnabled = this.featureFlagService.getBooleanFlag(CROWDFUNDING_ENABLED_FLAG, false);
   /** Dark-launch gate for the Akrites admin dashboard; hides the Security nav section when off. */
   private readonly isAkritesEnabled = this.featureFlagService.getBooleanFlag(AKRITES_ENABLED_FLAG, false);
   /** Dark-launch gate for the Marketing OS agents marketplace; hides the project-lens nav entry when off. */
@@ -82,17 +79,95 @@ export class SidebarNavService {
 
   // Me Lens nav with feature-flagged sections stripped (Security/Akrites is dark-launched).
   private readonly visibleMeLensItems = computed((): SidebarMenuItem[] =>
-    this.isAkritesEnabled() ? this.meLensItems() : this.meLensItems().filter((item) => item.label !== 'Security')
+    this.isAkritesEnabled() ? this.meLensItems : this.meLensItems.filter((item) => item.label !== 'Security')
   );
 
   // --- Me Lens Items ---
-  // Computed so both Crowdfunding and Security/Akrites nav entries react to their feature flags in real time.
-  private readonly meLensItems = computed((): SidebarMenuItem[] => {
-    const crowdfundingEnabled = this.isCrowdfundingEnabled();
-
-    // Flag ON: Crowdfunding is promoted to its own top-level section (peer of
-    // My Engagement / My Growth), with its sub-pages as section children.
-    const crowdfundingSection: SidebarMenuItem = {
+  // Crowdfunding is a top-level section (peer of My Engagement / My Growth), with its
+  // sub-pages as section children. Security/Akrites is filtered out reactively in visibleMeLensItems.
+  private readonly meLensItems: SidebarMenuItem[] = [
+    {
+      label: 'My Dashboard',
+      icon: 'fa-light fa-grid-2',
+      routerLink: '/',
+    },
+    {
+      label: 'My Engagement',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'My Meetings',
+          icon: 'fa-light fa-calendar',
+          routerLink: '/meetings',
+        },
+        {
+          label: 'My Events',
+          icon: 'fa-light fa-ticket',
+          routerLink: '/events',
+        },
+        {
+          label: 'My Meetups',
+          icon: 'fa-light fa-handshake',
+          routerLink: '/meetups',
+        },
+        {
+          label: 'My ' + COMMITTEE_LABEL.plural,
+          icon: 'fa-light fa-users-rectangle',
+          routerLink: '/groups',
+        },
+        {
+          label: 'My ' + MAILING_LIST_LABEL.plural,
+          icon: 'fa-light fa-envelope',
+          routerLink: '/mailing-lists',
+        },
+        {
+          label: 'My ' + VOTE_LABEL.plural,
+          icon: 'fa-light fa-check-to-slot',
+          routerLink: '/votes',
+        },
+        {
+          label: 'My ' + SURVEY_LABEL.plural,
+          icon: 'fa-light fa-clipboard-list',
+          routerLink: '/surveys',
+        },
+        {
+          label: 'My ' + DOCUMENT_LABEL.plural,
+          icon: 'fa-light fa-folder-open',
+          routerLink: '/documents',
+        },
+      ],
+    },
+    {
+      label: 'Security',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'Akrites Program',
+          icon: 'fa-light fa-shield-halved',
+          routerLink: '/akrites',
+        },
+      ],
+    },
+    {
+      label: 'My Growth',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'Training & Certifications',
+          icon: 'fa-light fa-graduation-cap',
+          routerLink: '/me/training',
+        },
+        {
+          label: 'Badges',
+          icon: 'fa-light fa-award',
+          routerLink: '/badges',
+        },
+      ],
+    },
+    {
       label: 'Crowdfunding',
       isSection: true,
       expanded: true,
@@ -108,115 +183,30 @@ export class SidebarNavService {
           routerLink: '/crowdfunding/donations',
         },
       ],
-    };
-
-    return [
-      {
-        label: 'My Dashboard',
-        icon: 'fa-light fa-grid-2',
-        routerLink: '/',
-      },
-      {
-        label: 'My Engagement',
-        isSection: true,
-        expanded: true,
-        items: [
-          {
-            label: 'My Meetings',
-            icon: 'fa-light fa-calendar',
-            routerLink: '/meetings',
-          },
-          {
-            label: 'My Events',
-            icon: 'fa-light fa-ticket',
-            routerLink: '/events',
-          },
-          {
-            label: 'My Meetups',
-            icon: 'fa-light fa-handshake',
-            routerLink: '/meetups',
-          },
-          {
-            label: 'My ' + COMMITTEE_LABEL.plural,
-            icon: 'fa-light fa-users-rectangle',
-            routerLink: '/groups',
-          },
-          {
-            label: 'My ' + MAILING_LIST_LABEL.plural,
-            icon: 'fa-light fa-envelope',
-            routerLink: '/mailing-lists',
-          },
-          {
-            label: 'My ' + VOTE_LABEL.plural,
-            icon: 'fa-light fa-check-to-slot',
-            routerLink: '/votes',
-          },
-          {
-            label: 'My ' + SURVEY_LABEL.plural,
-            icon: 'fa-light fa-clipboard-list',
-            routerLink: '/surveys',
-          },
-          {
-            label: 'My ' + DOCUMENT_LABEL.plural,
-            icon: 'fa-light fa-folder-open',
-            routerLink: '/documents',
-          },
-        ],
-      },
-      {
-        label: 'Security',
-        isSection: true,
-        expanded: true,
-        items: [
-          {
-            label: 'Akrites Program',
-            icon: 'fa-light fa-shield-halved',
-            routerLink: '/akrites',
-          },
-        ],
-      },
-      {
-        label: 'My Growth',
-        isSection: true,
-        expanded: true,
-        items: [
-          {
-            label: 'Training & Certifications',
-            icon: 'fa-light fa-graduation-cap',
-            routerLink: '/me/training',
-          },
-          {
-            label: 'Badges',
-            icon: 'fa-light fa-award',
-            routerLink: '/badges',
-          },
-        ],
-      },
-      ...(crowdfundingEnabled ? [crowdfundingSection] : []),
-      {
-        label: 'My Account',
-        isSection: true,
-        expanded: true,
-        items: [
-          {
-            label: 'Profile',
-            icon: 'fa-light fa-user',
-            routerLink: '/profile',
-          },
-          {
-            label: 'Settings',
-            icon: 'fa-light fa-gear',
-            routerLink: '/settings',
-          },
-          {
-            label: 'Transactions',
-            icon: 'fa-light fa-receipt',
-            routerLink: '/me/transactions',
-          },
-        ],
-      },
-    ];
-  });
+    },
+    {
+      label: 'My Account',
+      isSection: true,
+      expanded: true,
+      items: [
+        {
+          label: 'Profile',
+          icon: 'fa-light fa-user',
+          routerLink: '/profile',
+        },
+        {
+          label: 'Settings',
+          icon: 'fa-light fa-gear',
+          routerLink: '/settings',
+        },
+        {
+          label: 'Transactions',
+          icon: 'fa-light fa-receipt',
+          routerLink: '/me/transactions',
+        },
+      ],
+    },
+  ];
 
   // Whether the currently selected foundation has project-level data in Snowflake.
   // Drives the conditional "Projects" sidebar entry — hidden when the foundation has no rows.

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -3,7 +3,4 @@
 
 export const ORG_LENS_ENABLED_FLAG = 'org-lens-enabled';
 export const AKRITES_ENABLED_FLAG = 'akrites-enabled';
-export const CROWDFUNDING_ENABLED_FLAG = 'crowdfunding-enabled';
 export const MKTG_OS_AGENTS_ENABLED_FLAG = 'mktg-os-agents-enabled';
-export const ANNOUNCEMENT_ENABLED_FLAG = 'announcement-enabled';
-export const CROWDFUNDING_SPONSOR_TIERS_FLAG = 'crowdfunding-sponsor-tiers';


### PR DESCRIPTION
## Summary

- Removes three LaunchDarkly dark-launch flags whose features have fully shipped: `crowdfunding-sponsor-tiers` (Sponsorship Tiers tab), `announcement-enabled` (Announcements tab), and `crowdfunding-enabled` (Crowdfunding nav section).
- Sponsorship Tiers and Announcements now always render in the initiative settings drawer; the Crowdfunding section is now always shown in the Me lens sidebar.
- Converts `settingsTabs` and `meLensItems` from `computed()` signals to static arrays now that they no longer depend on flag state.

## Notes

- No JIRA ticket for this branch — small, self-contained flag-removal cleanup with no user-facing ambiguity to track.
- LaunchDarkly flag archival in the dashboard is a manual follow-up outside this PR's scope.