### PR TITLE
feat(dashboards): surface per-project health scores with scored/total count (LFXV2-2670)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -231,7 +231,8 @@
 <lfx-project-health-scores-drawer
   [visible]="activeDrawer() === DashboardDrawerType.ProjectHealthScores"
   (visibleChange)="handleDrawerClose()"
-  [data]="healthScoresData()"></lfx-project-health-scores-drawer>
+  [data]="healthScoresData()"
+  [total]="totalProjectsData().totalProjects"></lfx-project-health-scores-drawer>
 
 <lfx-org-dependency-drawer
   [visible]="activeDrawer() === DashboardDrawerType.OrganizationDependency"

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -232,7 +232,7 @@
   [visible]="activeDrawer() === DashboardDrawerType.ProjectHealthScores"
   (visibleChange)="handleDrawerClose()"
   [data]="healthScoresData()"
-  [total]="totalProjectsData().totalProjects"></lfx-project-health-scores-drawer>
+  [total]="reconciledTotalProjects()"></lfx-project-health-scores-drawer>
 
 <lfx-org-dependency-drawer
   [visible]="activeDrawer() === DashboardDrawerType.OrganizationDependency"

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -86,6 +86,13 @@ export class FoundationHealthComponent {
   protected readonly activeContributorsData = this.initializeActiveContributorsData();
   protected readonly eventsData = this.initializeEventsData();
 
+  // totalProjectsData retains the prior foundation's total until the next request
+  // resolves; surface 0 while loading so the card and drawer never reconcile a
+  // new scored count against a stale total.
+  protected readonly reconciledTotalProjects = computed(() =>
+    this.totalProjectsLoading() ? 0 : this.totalProjectsData().totalProjects
+  );
+
   public readonly selectedFilter = signal<string>('all');
 
   public readonly filterOptions: FilterPillOption[] = [
@@ -518,7 +525,7 @@ export class FoundationHealthComponent {
   private transformProjectHealthScores(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.healthScoresData();
     const scored = data.excellent + data.healthy + data.stable + data.unsteady + data.critical;
-    const total = this.totalProjectsData().totalProjects;
+    const total = this.reconciledTotalProjects();
 
     let subtitle = '';
     if (scored > 0 || total > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -89,9 +89,7 @@ export class FoundationHealthComponent {
   // totalProjectsData retains the prior foundation's total until the next request
   // resolves; surface 0 while loading so the card and drawer never reconcile a
   // new scored count against a stale total.
-  protected readonly reconciledTotalProjects = computed(() =>
-    this.totalProjectsLoading() ? 0 : this.totalProjectsData().totalProjects
-  );
+  protected readonly reconciledTotalProjects = computed(() => (this.totalProjectsLoading() ? 0 : this.totalProjectsData().totalProjects));
 
   public readonly selectedFilter = signal<string>('all');
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -521,7 +521,7 @@ export class FoundationHealthComponent {
     const total = this.totalProjectsData().totalProjects;
 
     let subtitle = '';
-    if (scored > 0) {
+    if (scored > 0 || total > 0) {
       // The two counts come from independent Snowflake tables; only reconcile
       // against the total when it is loaded and not smaller than the scored count.
       subtitle = total > scored ? `${scored} of ${total} projects scored` : `${scored} projects scored`;

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -190,7 +190,7 @@ export class FoundationHealthComponent {
       const data = [
         { category: 'Critical', count: distribution.critical, color: lfxColors.red[500] },
         { category: 'Unsteady', count: distribution.unsteady, color: lfxColors.amber[400] },
-        { category: 'Stable', count: distribution.stable, color: lfxColors.amber[500] },
+        { category: 'Stable', count: distribution.stable, color: lfxColors.violet[500] },
         { category: 'Healthy', count: distribution.healthy, color: lfxColors.blue[500] },
         { category: 'Excellent', count: distribution.excellent, color: lfxColors.emerald[500] },
       ];
@@ -518,12 +518,20 @@ export class FoundationHealthComponent {
   private transformProjectHealthScores(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.healthScoresData();
     const scored = data.excellent + data.healthy + data.stable + data.unsteady + data.critical;
+    const total = this.totalProjectsData().totalProjects;
+
+    let subtitle = '';
+    if (scored > 0) {
+      // The two counts come from independent Snowflake tables; only reconcile
+      // against the total when it is loaded and not smaller than the scored count.
+      subtitle = total > scored ? `${scored} of ${total} projects scored` : `${scored} projects scored`;
+    }
 
     return {
       ...metric,
       loading: this.healthScoresLoading(),
       value: '',
-      subtitle: scored > 0 ? `${scored} projects scored` : '',
+      subtitle,
       healthScores: data,
     };
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -91,6 +91,131 @@
       }
     </div>
 
+    <!-- Projects Table -->
+    @if (hasData()) {
+      <div class="flex flex-col gap-3" data-testid="project-health-scores-drawer-table-section">
+        <h3 class="text-sm font-medium text-gray-900">Projects by health status</h3>
+
+        <!-- Search -->
+        <lfx-input-text
+          [form]="searchForm"
+          control="query"
+          type="text"
+          size="small"
+          icon="fa-light fa-magnifying-glass"
+          placeholder="Search projects by name..."
+          data-testid="project-health-scores-drawer-search"></lfx-input-text>
+
+        <!-- Status Filter -->
+        <div class="flex flex-wrap gap-2" data-testid="project-health-scores-drawer-status-filter">
+          @for (option of statusFilterOptions; track option.value) {
+            <button
+              type="button"
+              (click)="toggleStatus(option.value)"
+              [style.backgroundColor]="selectedStatuses().has(option.value) ? option.bg : null"
+              [style.color]="selectedStatuses().has(option.value) ? option.text : null"
+              [ngClass]="
+                selectedStatuses().has(option.value) ? 'border-transparent' : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
+              "
+              class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors"
+              [attr.aria-pressed]="selectedStatuses().has(option.value)"
+              [attr.data-testid]="'project-health-scores-drawer-status-filter-' + option.value">
+              {{ option.label }}
+            </button>
+          }
+        </div>
+
+        @if (tableLoading()) {
+          <div class="flex items-center justify-center py-12" data-testid="project-health-scores-drawer-table-loading">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          </div>
+        } @else {
+          <div class="overflow-auto border border-slate-200 rounded-lg">
+            <table class="w-full text-sm" data-testid="project-health-scores-drawer-table">
+              <thead class="bg-slate-50 border-b border-slate-200">
+                <tr>
+                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Health status</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (project of paginatedProjects(); track project.id) {
+                  <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'project-health-scores-drawer-table-row-' + project.id">
+                    <td class="py-3 px-4">
+                      <div class="flex items-center gap-2.5">
+                        <span
+                          class="flex-shrink-0 w-7 h-7 rounded-md bg-slate-100 text-slate-500 text-xs font-semibold flex items-center justify-center uppercase">
+                          {{ project.projectName.charAt(0) || '·' }}
+                        </span>
+                        <span class="font-medium text-slate-900">{{ project.projectName }}</span>
+                      </div>
+                    </td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers | number }}</td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
+                    <td class="text-right py-3 px-4">
+                      @if (project.healthScoreCategory; as category) {
+                        <span
+                          class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
+                          [style.backgroundColor]="categoryBadge[category].bg"
+                          [style.color]="categoryBadge[category].text">
+                          {{ categoryLabel[category] }}
+                        </span>
+                      } @else {
+                        <span class="text-sm text-gray-400">&mdash;</span>
+                      }
+                    </td>
+                  </tr>
+                } @empty {
+                  <tr>
+                    <td colspan="5" class="py-8 text-center text-slate-500">
+                      @if (hasActiveFilters()) {
+                        No projects match the current filters.
+                      } @else {
+                        No project data available for this foundation.
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          @if (totalPages() > 1) {
+            <div class="flex items-center justify-between" data-testid="project-health-scores-drawer-pagination">
+              <span class="text-sm text-slate-600">{{ pageInfo() }}</span>
+
+              <div class="flex items-center gap-1">
+                <lfx-button
+                  icon="fa-light fa-chevron-left"
+                  [outlined]="true"
+                  size="small"
+                  [disabled]="page() === 1"
+                  (onClick)="goToPage(page() - 1)"
+                  ariaLabel="Previous page"></lfx-button>
+
+                @for (p of visiblePages(); track p) {
+                  <lfx-button [label]="p.toString()" [outlined]="page() !== p" size="small" (onClick)="goToPage(p)" [ariaLabel]="'Page ' + p"></lfx-button>
+                }
+
+                <lfx-button
+                  icon="fa-light fa-chevron-right"
+                  [outlined]="true"
+                  size="small"
+                  [disabled]="page() === totalPages()"
+                  (onClick)="goToPage(page() + 1)"
+                  ariaLabel="Next page"></lfx-button>
+              </div>
+            </div>
+          }
+        }
+      </div>
+    }
+
     <!-- Insights Handoff -->
     <lfx-insights-handoff-section
       title="Looking for detailed project health metrics?"

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -114,9 +114,7 @@
               (click)="toggleStatus(option.value)"
               [style.backgroundColor]="selectedStatuses().has(option.value) ? option.bg : null"
               [style.color]="selectedStatuses().has(option.value) ? option.text : null"
-              [ngClass]="
-                selectedStatuses().has(option.value) ? 'border-transparent' : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
-              "
+              [ngClass]="selectedStatuses().has(option.value) ? 'border-transparent' : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'"
               class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors"
               [attr.aria-pressed]="selectedStatuses().has(option.value)"
               [attr.data-testid]="'project-health-scores-drawer-status-filter-' + option.value">

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -20,7 +20,7 @@
       <!-- Projects Scored Badge -->
       @if (hasData()) {
         <div class="flex items-center gap-1.5 px-3 py-1 bg-gray-100 rounded-full" data-testid="project-health-scores-drawer-total">
-          <span class="text-sm font-medium text-gray-700">{{ totalProjects().toLocaleString() }} projects scored</span>
+          <span class="text-sm font-medium text-gray-700">{{ scoredLabel() }}</span>
         </div>
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -18,7 +18,7 @@
       </div>
 
       <!-- Projects Scored Badge -->
-      @if (hasData()) {
+      @if (hasData() || total() > 0) {
         <div class="flex items-center gap-1.5 px-3 py-1 bg-gray-100 rounded-full" data-testid="project-health-scores-drawer-total">
           <span class="text-sm font-medium text-gray-700">{{ scoredLabel() }}</span>
         </div>
@@ -92,127 +92,125 @@
     </div>
 
     <!-- Projects Table -->
-    @if (hasData()) {
-      <div class="flex flex-col gap-3" data-testid="project-health-scores-drawer-table-section">
-        <h3 class="text-sm font-medium text-gray-900">Projects by health status</h3>
+    <div class="flex flex-col gap-3" data-testid="project-health-scores-drawer-table-section">
+      <h3 class="text-sm font-medium text-gray-900">Projects by health status</h3>
 
-        <!-- Search -->
-        <lfx-input-text
-          [form]="searchForm"
-          control="query"
-          type="text"
-          size="small"
-          icon="fa-light fa-magnifying-glass"
-          placeholder="Search projects by name..."
-          data-testid="project-health-scores-drawer-search"></lfx-input-text>
+      <!-- Search -->
+      <lfx-input-text
+        [form]="searchForm"
+        control="query"
+        type="text"
+        size="small"
+        icon="fa-light fa-magnifying-glass"
+        placeholder="Search projects by name..."
+        data-testid="project-health-scores-drawer-search"></lfx-input-text>
 
-        <!-- Status Filter -->
-        <div class="flex flex-wrap gap-2" data-testid="project-health-scores-drawer-status-filter">
-          @for (option of statusFilterOptions; track option.value) {
-            <button
-              type="button"
-              (click)="toggleStatus(option.value)"
-              [style.backgroundColor]="selectedStatuses().has(option.value) ? option.bg : null"
-              [style.color]="selectedStatuses().has(option.value) ? option.text : null"
-              [ngClass]="selectedStatuses().has(option.value) ? 'border-transparent' : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'"
-              class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors"
-              [attr.aria-pressed]="selectedStatuses().has(option.value)"
-              [attr.data-testid]="'project-health-scores-drawer-status-filter-' + option.value">
-              {{ option.label }}
-            </button>
-          }
-        </div>
-
-        @if (tableLoading()) {
-          <div class="flex items-center justify-center py-12" data-testid="project-health-scores-drawer-table-loading">
-            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
-          </div>
-        } @else {
-          <div class="overflow-auto border border-slate-200 rounded-lg">
-            <table class="w-full text-sm" data-testid="project-health-scores-drawer-table">
-              <thead class="bg-slate-50 border-b border-slate-200">
-                <tr>
-                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Health status</th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (project of paginatedProjects(); track project.id) {
-                  <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'project-health-scores-drawer-table-row-' + project.id">
-                    <td class="py-3 px-4">
-                      <div class="flex items-center gap-2.5">
-                        <span
-                          class="flex-shrink-0 w-7 h-7 rounded-md bg-slate-100 text-slate-500 text-xs font-semibold flex items-center justify-center uppercase">
-                          {{ project.projectName.charAt(0) || '·' }}
-                        </span>
-                        <span class="font-medium text-slate-900">{{ project.projectName }}</span>
-                      </div>
-                    </td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers | number }}</td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
-                    <td class="text-right py-3 px-4">
-                      @if (project.healthScoreCategory; as category) {
-                        <span
-                          class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
-                          [style.backgroundColor]="categoryBadge[category].bg"
-                          [style.color]="categoryBadge[category].text">
-                          {{ categoryLabel[category] }}
-                        </span>
-                      } @else {
-                        <span class="text-sm text-gray-400">&mdash;</span>
-                      }
-                    </td>
-                  </tr>
-                } @empty {
-                  <tr>
-                    <td colspan="5" class="py-8 text-center text-slate-500">
-                      @if (hasActiveFilters()) {
-                        No projects match the current filters.
-                      } @else {
-                        No project data available for this foundation.
-                      }
-                    </td>
-                  </tr>
-                }
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Pagination -->
-          @if (totalPages() > 1) {
-            <div class="flex items-center justify-between" data-testid="project-health-scores-drawer-pagination">
-              <span class="text-sm text-slate-600">{{ pageInfo() }}</span>
-
-              <div class="flex items-center gap-1">
-                <lfx-button
-                  icon="fa-light fa-chevron-left"
-                  [outlined]="true"
-                  size="small"
-                  [disabled]="page() === 1"
-                  (onClick)="goToPage(page() - 1)"
-                  ariaLabel="Previous page"></lfx-button>
-
-                @for (p of visiblePages(); track p) {
-                  <lfx-button [label]="p.toString()" [outlined]="page() !== p" size="small" (onClick)="goToPage(p)" [ariaLabel]="'Page ' + p"></lfx-button>
-                }
-
-                <lfx-button
-                  icon="fa-light fa-chevron-right"
-                  [outlined]="true"
-                  size="small"
-                  [disabled]="page() === totalPages()"
-                  (onClick)="goToPage(page() + 1)"
-                  ariaLabel="Next page"></lfx-button>
-              </div>
-            </div>
-          }
+      <!-- Status Filter -->
+      <div class="flex flex-wrap gap-2" data-testid="project-health-scores-drawer-status-filter">
+        @for (option of statusFilterOptions; track option.value) {
+          <button
+            type="button"
+            (click)="toggleStatus(option.value)"
+            [style.backgroundColor]="selectedStatuses().has(option.value) ? option.bg : null"
+            [style.color]="selectedStatuses().has(option.value) ? option.text : null"
+            [ngClass]="selectedStatuses().has(option.value) ? 'border-transparent' : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'"
+            class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors"
+            [attr.aria-pressed]="selectedStatuses().has(option.value)"
+            [attr.data-testid]="'project-health-scores-drawer-status-filter-' + option.value">
+            {{ option.label }}
+          </button>
         }
       </div>
-    }
+
+      @if (tableLoading()) {
+        <div class="flex items-center justify-center py-12" data-testid="project-health-scores-drawer-table-loading">
+          <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+        </div>
+      } @else {
+        <div class="overflow-auto border border-slate-200 rounded-lg">
+          <table class="w-full text-sm" data-testid="project-health-scores-drawer-table">
+            <thead class="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project</th>
+                <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
+                <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
+                <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
+                <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Health status</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (project of paginatedProjects(); track project.id) {
+                <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'project-health-scores-drawer-table-row-' + project.id">
+                  <td class="py-3 px-4">
+                    <div class="flex items-center gap-2.5">
+                      <span
+                        class="flex-shrink-0 w-7 h-7 rounded-md bg-slate-100 text-slate-500 text-xs font-semibold flex items-center justify-center uppercase">
+                        {{ project.projectName.charAt(0) || '·' }}
+                      </span>
+                      <span class="font-medium text-slate-900">{{ project.projectName }}</span>
+                    </div>
+                  </td>
+                  <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers | number }}</td>
+                  <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
+                  <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
+                  <td class="text-right py-3 px-4">
+                    @if (project.healthScoreCategory; as category) {
+                      <span
+                        class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
+                        [style.backgroundColor]="categoryBadge[category].bg"
+                        [style.color]="categoryBadge[category].text">
+                        {{ categoryLabel[category] }}
+                      </span>
+                    } @else {
+                      <span class="text-sm text-gray-400">&mdash;</span>
+                    }
+                  </td>
+                </tr>
+              } @empty {
+                <tr>
+                  <td colspan="5" class="py-8 text-center text-slate-500">
+                    @if (hasActiveFilters()) {
+                      No projects match the current filters.
+                    } @else {
+                      No project data available for this foundation.
+                    }
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        @if (totalPages() > 1) {
+          <div class="flex items-center justify-between" data-testid="project-health-scores-drawer-pagination">
+            <span class="text-sm text-slate-600">{{ pageInfo() }}</span>
+
+            <div class="flex items-center gap-1">
+              <lfx-button
+                icon="fa-light fa-chevron-left"
+                [outlined]="true"
+                size="small"
+                [disabled]="page() === 1"
+                (onClick)="goToPage(page() - 1)"
+                ariaLabel="Previous page"></lfx-button>
+
+              @for (p of visiblePages(); track p) {
+                <lfx-button [label]="p.toString()" [outlined]="page() !== p" size="small" (onClick)="goToPage(p)" [ariaLabel]="'Page ' + p"></lfx-button>
+              }
+
+              <lfx-button
+                icon="fa-light fa-chevron-right"
+                [outlined]="true"
+                size="small"
+                [disabled]="page() === totalPages()"
+                (onClick)="goToPage(page() + 1)"
+                ariaLabel="Next page"></lfx-button>
+            </div>
+          </div>
+        }
+      }
+    </div>
 
     <!-- Insights Handoff -->
     <lfx-insights-handoff-section

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -96,9 +96,11 @@
       <h3 class="text-sm font-medium text-gray-900">Projects by health status</h3>
 
       <!-- Search -->
+      <label for="project-health-scores-search" class="sr-only">Search projects by name</label>
       <lfx-input-text
         [form]="searchForm"
         control="query"
+        id="project-health-scores-search"
         type="text"
         size="small"
         icon="fa-light fa-magnifying-glass"

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -17,7 +17,6 @@ import {
   PROJECT_HEALTH_SCORE_CATEGORIES,
   PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE,
   PROJECT_HEALTH_STATUS_FILTER_OPTIONS,
-  TOOLTIP_MAX_PROJECT_NAMES,
 } from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl, buildVisiblePages } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
@@ -72,22 +71,13 @@ export class ProjectHealthScoresDrawerComponent {
         borderWidth: 1,
         padding: 10,
         cornerRadius: 6,
-        displayColors: false,
+        displayColors: true,
         callbacks: {
-          // Title reads "Healthy · 2"; body lists the project names in that bucket.
           title: (items) => {
             const category = PROJECT_HEALTH_SCORE_CATEGORIES[items[0]?.dataIndex ?? 0];
-            return `${PROJECT_HEALTH_CATEGORY_LABEL[category]} · ${(items[0]?.parsed.y as number)?.toLocaleString() ?? 0}`;
+            return PROJECT_HEALTH_CATEGORY_LABEL[category];
           },
-          label: (ctx) => {
-            const category = PROJECT_HEALTH_SCORE_CATEGORIES[ctx.dataIndex];
-            const names = this.projectsByCategory()[category];
-            if (!names.length) return ` ${(ctx.parsed.y as number).toLocaleString()} projects`;
-            // Cap the list so a large bucket doesn't produce an oversized tooltip.
-            return names.length > TOOLTIP_MAX_PROJECT_NAMES
-              ? [...names.slice(0, TOOLTIP_MAX_PROJECT_NAMES), `+${names.length - TOOLTIP_MAX_PROJECT_NAMES} more`]
-              : names;
-          },
+          label: (ctx) => ` ${(ctx.parsed.y as number).toLocaleString()} projects`,
         },
       },
     },
@@ -159,7 +149,6 @@ export class ProjectHealthScoresDrawerComponent {
 
   protected readonly search: Signal<string> = this.initSearch();
   protected readonly projectsData: Signal<FoundationProjectsDetailResponse> = this.initProjectsData();
-  protected readonly projectsByCategory: Signal<Record<FoundationHealthScore, string[]>> = this.initProjectsByCategory();
   protected readonly filteredProjects: Signal<ProjectTableRow[]> = this.initFilteredProjects();
   protected readonly totalPages: Signal<number> = computed(() => Math.ceil(this.filteredProjects().length / PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE));
   protected readonly paginatedProjects: Signal<ProjectTableRow[]> = this.initPaginatedProjects();
@@ -247,18 +236,6 @@ export class ProjectHealthScoresDrawerComponent {
       ),
       { initialValue: DEFAULT_FOUNDATION_PROJECTS_DETAIL }
     );
-  }
-
-  private initProjectsByCategory(): Signal<Record<FoundationHealthScore, string[]>> {
-    return computed(() => {
-      const groups: Record<FoundationHealthScore, string[]> = { critical: [], unsteady: [], stable: [], healthy: [], excellent: [] };
-      for (const project of this.projectsData().projects) {
-        if (project.healthScoreCategory) {
-          groups[project.healthScoreCategory].push(project.projectName);
-        }
-      }
-      return groups;
-    });
   }
 
   private initFilteredProjects(): Signal<ProjectTableRow[]> {

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -36,7 +36,17 @@ import type {
 
 @Component({
   selector: 'lfx-project-health-scores-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent, TooltipModule, InputTextComponent, ButtonComponent, ReactiveFormsModule, DecimalPipe, NgClass],
+  imports: [
+    DrawerModule,
+    ChartComponent,
+    InsightsHandoffSectionComponent,
+    TooltipModule,
+    InputTextComponent,
+    ButtonComponent,
+    ReactiveFormsModule,
+    DecimalPipe,
+    NgClass,
+  ],
   templateUrl: './project-health-scores-drawer.component.html',
 })
 export class ProjectHealthScoresDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -77,6 +77,10 @@ export class ProjectHealthScoresDrawerComponent {
     critical: 0,
   });
 
+  // Total foundation projects (from FOUNDATION_TOTAL_PROJECTS_MONTHLY) — may exceed
+  // the number of scored projects because the two counts come from separate tables.
+  public readonly total = input<number>(0);
+
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);
 
@@ -85,12 +89,18 @@ export class ProjectHealthScoresDrawerComponent {
     buildLensAwareInsightsUrl(this.projectContextService.activeContext()?.slug, this.projectContextService.isFoundationContext())
   );
 
-  protected readonly totalProjects: Signal<number> = computed(() => {
+  protected readonly scoredProjects: Signal<number> = computed(() => {
     const d = this.data();
     return d.excellent + d.healthy + d.stable + d.unsteady + d.critical;
   });
 
-  protected readonly hasData: Signal<boolean> = computed(() => this.totalProjects() > 0);
+  protected readonly scoredLabel: Signal<string> = computed(() => {
+    const scored = this.scoredProjects();
+    const total = this.total();
+    return total > scored ? `${scored.toLocaleString()} of ${total.toLocaleString()} projects scored` : `${scored.toLocaleString()} projects scored`;
+  });
+
+  protected readonly hasData: Signal<boolean> = computed(() => this.scoredProjects() > 0);
 
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -1,26 +1,50 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, model, Signal } from '@angular/core';
+import { DecimalPipe, NgClass } from '@angular/common';
+import { Component, computed, inject, input, model, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
-import { lfxColors } from '@lfx-one/shared/constants';
-import { buildLensAwareInsightsUrl } from '@lfx-one/shared/utils';
+import {
+  DEFAULT_FOUNDATION_PROJECTS_DETAIL,
+  lfxColors,
+  PROJECT_HEALTH_CATEGORY_BADGE,
+  PROJECT_HEALTH_CATEGORY_LABEL,
+  PROJECT_HEALTH_SCORE_CATEGORIES,
+  PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE,
+  PROJECT_HEALTH_STATUS_FILTER_OPTIONS,
+  TOOLTIP_MAX_PROJECT_NAMES,
+} from '@lfx-one/shared/constants';
+import { buildLensAwareInsightsUrl, buildVisiblePages } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
 import { TooltipModule } from 'primeng/tooltip';
+import { catchError, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { FoundationHealthScoreDistributionResponse } from '@lfx-one/shared/interfaces';
+import type {
+  FoundationHealthScore,
+  FoundationHealthScoreDistributionResponse,
+  FoundationProjectsDetailResponse,
+  HealthStatusFilterValue,
+  ProjectTableRow,
+} from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-project-health-scores-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent, TooltipModule],
+  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent, TooltipModule, InputTextComponent, ButtonComponent, ReactiveFormsModule, DecimalPipe, NgClass],
   templateUrl: './project-health-scores-drawer.component.html',
 })
 export class ProjectHealthScoresDrawerComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
   protected readonly legendColors = {
@@ -30,6 +54,10 @@ export class ProjectHealthScoresDrawerComponent {
     healthy: lfxColors.blue[500],
     excellent: lfxColors.emerald[500],
   };
+
+  protected readonly categoryBadge = PROJECT_HEALTH_CATEGORY_BADGE;
+  protected readonly categoryLabel = PROJECT_HEALTH_CATEGORY_LABEL;
+  protected readonly statusFilterOptions = PROJECT_HEALTH_STATUS_FILTER_OPTIONS;
 
   protected readonly chartOptions: ChartOptions<'bar'> = {
     responsive: true,
@@ -44,8 +72,22 @@ export class ProjectHealthScoresDrawerComponent {
         borderWidth: 1,
         padding: 10,
         cornerRadius: 6,
+        displayColors: false,
         callbacks: {
-          label: (ctx) => ` ${(ctx.parsed.y as number).toLocaleString()} projects`,
+          // Title reads "Healthy · 2"; body lists the project names in that bucket.
+          title: (items) => {
+            const category = PROJECT_HEALTH_SCORE_CATEGORIES[items[0]?.dataIndex ?? 0];
+            return `${PROJECT_HEALTH_CATEGORY_LABEL[category]} · ${(items[0]?.parsed.y as number)?.toLocaleString() ?? 0}`;
+          },
+          label: (ctx) => {
+            const category = PROJECT_HEALTH_SCORE_CATEGORIES[ctx.dataIndex];
+            const names = this.projectsByCategory()[category];
+            if (!names.length) return ` ${(ctx.parsed.y as number).toLocaleString()} projects`;
+            // Cap the list so a large bucket doesn't produce an oversized tooltip.
+            return names.length > TOOLTIP_MAX_PROJECT_NAMES
+              ? [...names.slice(0, TOOLTIP_MAX_PROJECT_NAMES), `+${names.length - TOOLTIP_MAX_PROJECT_NAMES} more`]
+              : names;
+          },
         },
       },
     },
@@ -68,6 +110,14 @@ export class ProjectHealthScoresDrawerComponent {
     datasets: { bar: { barPercentage: 0.55, categoryPercentage: 0.7, borderRadius: 4 } },
   };
 
+  // === Forms ===
+  protected readonly searchForm: FormGroup = this.fb.group({
+    query: [''],
+  });
+
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
   // === Inputs ===
   public readonly data = input<FoundationHealthScoreDistributionResponse>({
     excellent: 0,
@@ -81,8 +131,11 @@ export class ProjectHealthScoresDrawerComponent {
   // the number of scored projects because the two counts come from separate tables.
   public readonly total = input<number>(0);
 
-  // === Model Signals (two-way binding) ===
-  public readonly visible = model<boolean>(false);
+  // === WritableSignals ===
+  protected readonly page = signal(1);
+  protected readonly tableLoading = signal(false);
+  // Empty set = no filter (show all); otherwise only rows whose status is selected.
+  protected readonly selectedStatuses = signal<Set<HealthStatusFilterValue>>(new Set());
 
   // === Computed Signals ===
   protected readonly insightsUrl: Signal<string> = computed(() =>
@@ -101,12 +154,40 @@ export class ProjectHealthScoresDrawerComponent {
   });
 
   protected readonly hasData: Signal<boolean> = computed(() => this.scoredProjects() > 0);
-
+  protected readonly hasActiveFilters: Signal<boolean> = computed(() => !!this.search().trim() || this.selectedStatuses().size > 0);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
+
+  protected readonly search: Signal<string> = this.initSearch();
+  protected readonly projectsData: Signal<FoundationProjectsDetailResponse> = this.initProjectsData();
+  protected readonly projectsByCategory: Signal<Record<FoundationHealthScore, string[]>> = this.initProjectsByCategory();
+  protected readonly filteredProjects: Signal<ProjectTableRow[]> = this.initFilteredProjects();
+  protected readonly totalPages: Signal<number> = computed(() => Math.ceil(this.filteredProjects().length / PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE));
+  protected readonly paginatedProjects: Signal<ProjectTableRow[]> = this.initPaginatedProjects();
+  protected readonly pageInfo: Signal<string> = this.initPageInfo();
+  protected readonly visiblePages: Signal<number[]> = computed(() => buildVisiblePages(this.page(), this.totalPages()));
 
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
+  }
+
+  protected goToPage(page: number): void {
+    const total = this.totalPages();
+    const clamped = Math.min(Math.max(page, 1), total > 0 ? total : 1);
+    this.page.set(clamped);
+  }
+
+  protected toggleStatus(value: HealthStatusFilterValue): void {
+    this.selectedStatuses.update((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+    this.page.set(1);
   }
 
   // === Private Initializers ===
@@ -131,5 +212,90 @@ export class ProjectHealthScoresDrawerComponent {
         ],
       };
     });
+  }
+
+  private initSearch(): Signal<string> {
+    return toSignal(this.searchForm.get('query')!.valueChanges.pipe(tap(() => this.page.set(1))), { initialValue: '' });
+  }
+
+  private initProjectsData(): Signal<FoundationProjectsDetailResponse> {
+    return toSignal(
+      toObservable(this.visible).pipe(
+        skip(1),
+        switchMap((isVisible) => {
+          if (!isVisible) {
+            this.tableLoading.set(false);
+            return of(DEFAULT_FOUNDATION_PROJECTS_DETAIL);
+          }
+          const slug = this.projectContextService.selectedFoundation()?.slug ?? '';
+          if (!slug) {
+            this.tableLoading.set(false);
+            return of(DEFAULT_FOUNDATION_PROJECTS_DETAIL);
+          }
+          this.tableLoading.set(true);
+          // Reset to first page on each reopen so a stale page index can't
+          // point past the fresh list and trigger a false "no data" empty state.
+          this.page.set(1);
+          return this.analyticsService.getFoundationProjectsDetail(slug).pipe(
+            tap(() => this.tableLoading.set(false)),
+            catchError(() => {
+              this.tableLoading.set(false);
+              return of(DEFAULT_FOUNDATION_PROJECTS_DETAIL);
+            })
+          );
+        })
+      ),
+      { initialValue: DEFAULT_FOUNDATION_PROJECTS_DETAIL }
+    );
+  }
+
+  private initProjectsByCategory(): Signal<Record<FoundationHealthScore, string[]>> {
+    return computed(() => {
+      const groups: Record<FoundationHealthScore, string[]> = { critical: [], unsteady: [], stable: [], healthy: [], excellent: [] };
+      for (const project of this.projectsData().projects) {
+        if (project.healthScoreCategory) {
+          groups[project.healthScoreCategory].push(project.projectName);
+        }
+      }
+      return groups;
+    });
+  }
+
+  private initFilteredProjects(): Signal<ProjectTableRow[]> {
+    return computed(() => {
+      const query = this.search().toLowerCase().trim();
+      const statuses = this.selectedStatuses();
+      const filtered = this.projectsData().projects.filter((p) => {
+        const matchesQuery = !query || p.projectName.toLowerCase().includes(query);
+        const matchesStatus = statuses.size === 0 || statuses.has(p.healthScoreCategory ?? 'unscored');
+        return matchesQuery && matchesStatus;
+      });
+      // Sort by health (Excellent → unscored), then most active by 90d commits, to match the design.
+      return [...filtered].sort(
+        (a, b) => this.healthRank(b.healthScoreCategory) - this.healthRank(a.healthScoreCategory) || b.commitsLast90Days - a.commitsLast90Days
+      );
+    });
+  }
+
+  private initPaginatedProjects(): Signal<ProjectTableRow[]> {
+    return computed(() => {
+      const start = (this.page() - 1) * PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE;
+      return this.filteredProjects().slice(start, start + PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE);
+    });
+  }
+
+  private initPageInfo(): Signal<string> {
+    return computed(() => {
+      const filtered = this.filteredProjects();
+      const page = this.page();
+      const start = (page - 1) * PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE + 1;
+      const end = Math.min(page * PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE, filtered.length);
+      return `Showing ${start}–${end} of ${filtered.length} projects`;
+    });
+  }
+
+  // Ordinal rank for sorting; unscored (null) sorts last.
+  private healthRank(category: FoundationHealthScore | null): number {
+    return category ? PROJECT_HEALTH_SCORE_CATEGORIES.indexOf(category) : -1;
   }
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -38,6 +38,7 @@ import {
   FoundationContributorsMentoredRow,
   FoundationEventsAttendanceDistributionResponse,
   FoundationEventsAttendanceDistributionRow,
+  FoundationHealthScore,
   FoundationEventsQuarterlyResponse,
   FoundationEventsQuarterlyRow,
   FoundationHealthEventsMonthlyRow,
@@ -136,6 +137,15 @@ import { SnowflakeService } from './snowflake.service';
 
 /** Valid LifecycleStage values used to guard the Snowflake LIFECYCLE_STAGE string. Hoisted to module scope so the Set isn't re-created on every row mapping. */
 const VALID_LIFECYCLE_STAGES: ReadonlySet<LifecycleStage> = new Set(Object.values(LifecycleStage));
+
+/** Valid (lowercased) health-score categories used to guard the Snowflake HEALTH_SCORE_CATEGORY string. */
+const VALID_HEALTH_SCORE_CATEGORIES: ReadonlySet<FoundationHealthScore> = new Set(['excellent', 'healthy', 'stable', 'unsteady', 'critical']);
+
+/** Lowercase + validate the upstream HEALTH_SCORE_CATEGORY; null when absent or unrecognized. */
+function normalizeHealthScoreCategory(raw: string | null): FoundationHealthScore | null {
+  const category = raw?.toLowerCase() as FoundationHealthScore | undefined;
+  return category && VALID_HEALTH_SCORE_CATEGORIES.has(category) ? category : null;
+}
 
 /** Upstream response shape for project folders (POST response) */
 interface ProjectFolder {
@@ -1676,24 +1686,35 @@ export class ProjectService {
   public async getFoundationProjectsDetail(foundationSlug: string): Promise<FoundationProjectsDetailResponse> {
     logger.debug(undefined, 'get_foundation_projects_detail', 'Fetching project detail rows', { foundationSlug });
 
+    // LEFT JOIN latest per-project health category (separate daily table) for the badge;
+    // keyed on PROJECT_SLUG since the two tables use different PROJECT_ID systems.
     const query = `
       SELECT
-        PROJECT_ID,
-        PROJECT_NAME,
-        PROJECT_SLUG,
-        LIFECYCLE_STAGE,
-        CONTRIBUTORS_90D_COUNT,
-        COMMITS_90D_COUNT,
-        MAINTAINERS_CURRENT_COUNT,
-        STARS_YTD_COUNT,
-        LAST_UPDATED_TS
-      FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_TOTAL_PROJECTS_DETAIL
-      WHERE FOUNDATION_SLUG = ?
-      ORDER BY PROJECT_NAME ASC
+        d.PROJECT_ID,
+        d.PROJECT_NAME,
+        d.PROJECT_SLUG,
+        d.LIFECYCLE_STAGE,
+        d.CONTRIBUTORS_90D_COUNT,
+        d.COMMITS_90D_COUNT,
+        d.MAINTAINERS_CURRENT_COUNT,
+        d.STARS_YTD_COUNT,
+        d.LAST_UPDATED_TS,
+        h.HEALTH_SCORE_CATEGORY
+      FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_TOTAL_PROJECTS_DETAIL d
+      LEFT JOIN (
+        SELECT PROJECT_SLUG, HEALTH_SCORE_CATEGORY
+        FROM ANALYTICS.PLATINUM_LFX_ONE.PROJECT_HEALTH_METRICS_DAILY
+        WHERE FOUNDATION_SLUG = ?
+          AND HEALTH_SCORE IS NOT NULL
+          AND HEALTH_SCORE_CATEGORY IS NOT NULL
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY PROJECT_SLUG ORDER BY METRIC_DATE DESC) = 1
+      ) h ON d.PROJECT_SLUG = h.PROJECT_SLUG
+      WHERE d.FOUNDATION_SLUG = ?
+      ORDER BY d.PROJECT_NAME ASC
     `;
 
     try {
-      const result = await this.snowflakeService.execute<FoundationProjectsDetailRow>(query, [foundationSlug]);
+      const result = await this.snowflakeService.execute<FoundationProjectsDetailRow>(query, [foundationSlug, foundationSlug]);
 
       const projects = result.rows.map((row) => ({
         id: row.PROJECT_SLUG,
@@ -1714,6 +1735,9 @@ export class ProjectService {
         maintainers: row.MAINTAINERS_CURRENT_COUNT ?? 0,
         stars: row.STARS_YTD_COUNT ?? 0,
         lastUpdated: row.LAST_UPDATED_TS ? new Date(row.LAST_UPDATED_TS).toISOString().split('T')[0] : null,
+        // Normalize the upstream capitalized category to our lowercase union; guard
+        // against unexpected strings so the interface's promise (FoundationHealthScore | null) holds.
+        healthScoreCategory: normalizeHealthScoreCategory(row.HEALTH_SCORE_CATEGORY),
       }));
 
       logger.debug(undefined, 'get_foundation_projects_detail', 'Fetched project detail rows', { count: projects.length });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1688,6 +1688,8 @@ export class ProjectService {
 
     // LEFT JOIN latest per-project health category (separate daily table) for the badge;
     // keyed on PROJECT_SLUG since the two tables use different PROJECT_ID systems.
+    // Rank all daily rows first, then take the newest, so a project whose latest row
+    // is unscored surfaces a null category (Unscored) instead of a stale prior score.
     const query = `
       SELECT
         d.PROJECT_ID,
@@ -1705,8 +1707,6 @@ export class ProjectService {
         SELECT PROJECT_SLUG, HEALTH_SCORE_CATEGORY
         FROM ANALYTICS.PLATINUM_LFX_ONE.PROJECT_HEALTH_METRICS_DAILY
         WHERE FOUNDATION_SLUG = ?
-          AND HEALTH_SCORE IS NOT NULL
-          AND HEALTH_SCORE_CATEGORY IS NOT NULL
         QUALIFY ROW_NUMBER() OVER (PARTITION BY PROJECT_SLUG ORDER BY METRIC_DATE DESC) = 1
       ) h ON d.PROJECT_SLUG = h.PROJECT_SLUG
       WHERE d.FOUNDATION_SLUG = ?

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -37,6 +37,7 @@ export * from './profile.constants';
 export * from './pending-action.constants';
 export * from './survey.constants';
 export * from './total-projects-drawer.constants';
+export * from './project-health-scores-drawer.constants';
 export * from './total-members-drawer.constants';
 export * from './active-contributors-drawer.constants';
 export * from './maintainers-drawer.constants';

--- a/packages/shared/src/constants/project-health-scores-drawer.constants.ts
+++ b/packages/shared/src/constants/project-health-scores-drawer.constants.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { lfxColors } from './colors.constants';
+import type { FoundationHealthScore, HealthStatusFilterOption } from '../interfaces';
+
+export const PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE = 10;
+
+// Max project names listed in a chart-bar tooltip before collapsing to "+N more".
+export const TOOLTIP_MAX_PROJECT_NAMES = 10;
+
+// Ordered health buckets (low → high), matching the distribution chart's bar order.
+export const PROJECT_HEALTH_SCORE_CATEGORIES: readonly FoundationHealthScore[] = ['critical', 'unsteady', 'stable', 'healthy', 'excellent'];
+
+// Display label per health category (table badge + chart axis / tooltip title).
+export const PROJECT_HEALTH_CATEGORY_LABEL: Record<FoundationHealthScore, string> = {
+  critical: 'Critical',
+  unsteady: 'Unsteady',
+  stable: 'Stable',
+  healthy: 'Healthy',
+  excellent: 'Excellent',
+};
+
+// Badge bg/text per health category, sourced from the same lfxColors scales the
+// chart legend uses (100/700 for a lighter pill) — single source of truth for
+// category color across bars and badges.
+export const PROJECT_HEALTH_CATEGORY_BADGE: Record<FoundationHealthScore, { bg: string; text: string }> = {
+  critical: { bg: lfxColors.red[100], text: lfxColors.red[700] },
+  unsteady: { bg: lfxColors.amber[100], text: lfxColors.amber[700] },
+  stable: { bg: lfxColors.violet[100], text: lfxColors.violet[700] },
+  healthy: { bg: lfxColors.blue[100], text: lfxColors.blue[700] },
+  excellent: { bg: lfxColors.emerald[100], text: lfxColors.emerald[700] },
+};
+
+// Drawer table status-filter pills: the 5 scored categories plus an "Unscored" bucket
+// for projects whose per-project health score hasn't been emitted yet (null category).
+export const PROJECT_HEALTH_STATUS_FILTER_OPTIONS: readonly HealthStatusFilterOption[] = [
+  ...PROJECT_HEALTH_SCORE_CATEGORIES.map((value) => ({
+    value,
+    label: PROJECT_HEALTH_CATEGORY_LABEL[value],
+    ...PROJECT_HEALTH_CATEGORY_BADGE[value],
+  })),
+  { value: 'unscored', label: 'Unscored', bg: lfxColors.gray[100], text: lfxColors.gray[600] },
+];

--- a/packages/shared/src/constants/project-health-scores-drawer.constants.ts
+++ b/packages/shared/src/constants/project-health-scores-drawer.constants.ts
@@ -6,9 +6,6 @@ import type { FoundationHealthScore, HealthStatusFilterOption } from '../interfa
 
 export const PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE = 10;
 
-// Max project names listed in a chart-bar tooltip before collapsing to "+N more".
-export const TOOLTIP_MAX_PROJECT_NAMES = 10;
-
 // Ordered health buckets (low → high), matching the distribution chart's bar order.
 export const PROJECT_HEALTH_SCORE_CATEGORIES: readonly FoundationHealthScore[] = ['critical', 'unsteady', 'stable', 'healthy', 'excellent'];
 

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2224,6 +2224,8 @@ export interface FoundationProjectsDetailRow {
   STARS_YTD_COUNT: number;
   STARS_12M_COUNT: number;
   LAST_UPDATED_TS: Date | string | null;
+  // Joined from PROJECT_HEALTH_METRICS_DAILY (latest row per project); null when unscored.
+  HEALTH_SCORE_CATEGORY: string | null;
 }
 
 /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -275,6 +275,20 @@ export interface ProjectTableRow {
   maintainers: number;
   stars: number;
   lastUpdated: string | null;
+  // Latest health-score category from PROJECT_HEALTH_METRICS_DAILY; null when the
+  // project has no computed score yet (it comes from a separate Snowflake table).
+  healthScoreCategory: FoundationHealthScore | null;
+}
+
+// Health-status filter value for the drawer table; 'unscored' covers null-category rows.
+export type HealthStatusFilterValue = FoundationHealthScore | 'unscored';
+
+export interface HealthStatusFilterOption {
+  value: HealthStatusFilterValue;
+  label: string;
+  // lfxColors-derived hex pair so filter pills share the badge color source of truth.
+  bg: string;
+  text: string;
 }
 
 /**


### PR DESCRIPTION
# Summary

Reworks the project health scores drawer on the Foundation dashboard so users can drill into *which* projects fall into each health bucket, not just the aggregate distribution. Adds a searchable, paginated projects table with per-project health badges and status-filter pills, reconciles the "projects scored" count against the foundation's total project count, and centralizes the health category colors/labels in `@lfx-one/shared` as the single source of truth shared with the distribution chart.

# Before / After

**Before:** The drawer showed only the distribution chart and a single "X projects scored" badge with no way to see individual projects or their health status. The scored count was taken in isolation, with no reference to how many total projects the foundation has. The Stable chart segment reused the amber scale, making it hard to distinguish from the adjacent Unsteady segment. Category colors and labels were duplicated between the chart and any consuming component.

**After:** The drawer exposes a "Projects by health status" table — searchable by name, filterable by status pill (including an Unscored bucket), paginated 10 per page — where each row carries a colored health badge sourced from the latest per-project health category. The badge/subtitle now reads "X of Y projects scored" when the total exceeds the scored count (falling back to "X projects scored"). The Stable segment uses the violet scale to visually separate it from Unsteady amber.

# Changes

## Drawer component (`project-health-scores-drawer`)
- Added "Projects by health status" table section: name (with avatar initial), maintainers, contributors, commits (90d), and a colored health-status badge per row.
- Added name search input and status-filter pills (5 scored categories + Unscored), with empty-state messaging that distinguishes "no matches" from "no data".
- Added client-side pagination (10 per page) with page-info label and prev/next + numbered controls.
- Added filtering/sorting computed signals: text query, selected status set, unscored-last sort by health rank, then 90-day commits (most active first).
- Replaced the static "X projects scored" badge label with a `scoredLabel()` signal that reconciles scored vs. total.
- Accepts a new `total` input from the parent for the scored/total reconciliation.

## Foundation health component (`foundation-health`)
- Passes `totalProjectsData().totalProjects` into the drawer.
- `transformProjectHealthScores` now renders "X of Y projects scored" when total > scored, else "X projects scored".
- Switched the Stable distribution bar from `amber[500]` to `violet[500]` to distinguish it from the Unsteady `amber[400]` segment.
- Simplified the chart tooltip to a count-only format.

## Server / data layer (`project.service.ts`)
- `getFoundationProjectsDetail` now LEFT JOINs the latest per-project `HEALTH_SCORE_CATEGORY` from `PROJECT_HEALTH_METRICS_DAILY` onto `FOUNDATION_TOTAL_PROJECTS_DETAIL`, keyed on `PROJECT_SLUG` (the two tables use different PROJECT_ID systems). Uses `QUALIFY ROW_NUMBER() OVER (...) = 1` to pick the latest daily row per project.
- Added `normalizeHealthScoreCategory` (lowercase + validate against a fixed set) so the mapped `healthScoreCategory` always satisfies the `FoundationHealthScore | null` contract regardless of upstream capitalization or unexpected strings.

## Shared package (`@lfx-one/shared`)
- New `project-health-scores-drawer.constants.ts`: `PROJECT_HEALTH_SCORE_CATEGORIES` (ordered buckets), `PROJECT_HEALTH_CATEGORY_LABEL`, `PROJECT_HEALTH_CATEGORY_BADGE` (lfxColors 100/700 pairs), `PROJECT_HEALTH_STATUS_FILTER_OPTIONS`, and the page-size constant. Exported from the constants barrel.
- `FoundationProjectsDetailRow` gains `HEALTH_SCORE_CATEGORY: string | null`.
- `ProjectTableRow` gains `healthScoreCategory: FoundationHealthScore | null`.
- New `HealthStatusFilterValue` and `HealthStatusFilterOption` types in `dashboard-metric.interface.ts`.

## Tests
- No automated test changes in this PR; the new table/filter/pagination is client-side computed state over existing Snowflake-backed rows. Manual verification against the dev environment is the intended coverage for the drawer UX.

# Sort order

Within each health bucket, projects are ordered by 90-day commit count descending (most active first), after the primary health-rank sort (Excellent → unscored). This surfaces the most active projects at the top of each bucket and matches the design intent. The row order within a bucket therefore reflects recent activity and may change as activity changes.

# Breaking changes

None. The drawer receives a new optional `total` input and the Snowflake row gains a nullable joined column; both are additive and the existing drawer/chart behavior degrades gracefully when totals or categories are absent.

Made with [Cursor](https://cursor.com)
