### PR TITLE
fix(invite): delay committee invite auto-accept to allow FGA propagation

### DIFF
--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -182,13 +182,13 @@ export class InviteController {
       return null;
     }
 
-    // A non-empty resource_uid means this LFID invite is tied to a specific committee invite
-    // resource. The NATS publish above triggers HandleInviteAccepted in the committee service,
-    // which writes the FGA invitee tuple that grants query-service read access to the pending
-    // invite. Because that handler runs asynchronously, the first attempt may find no invites
-    // yet — retry up to FGA_PROPAGATION_MAX_RETRIES times with a delay between each so the
-    // tuple has time to propagate. Non-committee LFID invites skip the retry entirely.
-    const isCommitteeInvite = !!payload.resource_uid?.trim();
+    // When resource_type is present: 'group' means committee invite (retry while FGA propagates),
+    // any other value means not a committee invite (skip retry).
+    // When resource_type is absent we can't rule out a committee invite, so still attempt
+    // auto-accept rather than silently skip it.
+    const isCommitteeInvite = payload.resource_type
+      ? payload.resource_type === 'group'
+      : !!payload.resource_uid?.trim();
 
     for (let attempt = 0; attempt <= FGA_PROPAGATION_MAX_RETRIES; attempt++) {
       if (attempt > 0) {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -186,9 +186,7 @@ export class InviteController {
     // any other value means not a committee invite (skip retry).
     // When resource_type is absent we can't rule out a committee invite, so still attempt
     // auto-accept rather than silently skip it.
-    const isCommitteeInvite = payload.resource_type
-      ? payload.resource_type === 'group'
-      : !!payload.resource_uid?.trim();
+    const isCommitteeInvite = payload.resource_type ? payload.resource_type === 'group' : !!payload.resource_uid?.trim();
 
     for (let attempt = 0; attempt <= FGA_PROPAGATION_MAX_RETRIES; attempt++) {
       if (attempt > 0) {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -13,6 +13,11 @@ import { CommitteeService } from '../services/committee.service';
 import { NatsService } from '../services/nats.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 
+/** Delay between auto-accept retries while waiting for FGA invitee tuple propagation. */
+const FGA_PROPAGATION_DELAY_MS = 3_000;
+/** Maximum number of retries after the initial attempt (total wait: up to 9 s). */
+const FGA_PROPAGATION_MAX_RETRIES = 3;
+
 /** Controller for non-LF user invite acceptance via signed JWT. */
 export class InviteController {
   private readonly natsService = new NatsService();
@@ -177,9 +182,31 @@ export class InviteController {
       return null;
     }
 
-    return this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
-      invitedEmail,
-      resourceUid: payload.resource_uid,
-    });
+    // A non-empty resource_uid means this LFID invite is tied to a specific committee invite
+    // resource. The NATS publish above triggers HandleInviteAccepted in the committee service,
+    // which writes the FGA invitee tuple that grants query-service read access to the pending
+    // invite. Because that handler runs asynchronously, the first attempt may find no invites
+    // yet — retry up to FGA_PROPAGATION_MAX_RETRIES times with a delay between each so the
+    // tuple has time to propagate. Non-committee LFID invites skip the retry entirely.
+    const isCommitteeInvite = !!payload.resource_uid?.trim();
+
+    for (let attempt = 0; attempt <= FGA_PROPAGATION_MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));
+      }
+
+      const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
+        invitedEmail,
+        resourceUid: payload.resource_uid,
+      });
+
+      // undefined = no pending invites found yet; the FGA tuple may still be in-flight — retry.
+      // null or PendingCommitteeInviteForOrg = invite was found and processed; return immediately.
+      if (result !== undefined || !isCommitteeInvite) {
+        return result ?? null;
+      }
+    }
+
+    return null;
   }
 }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -717,11 +717,12 @@ export class CommitteeService {
   public async acceptPendingCommitteeInvitesAfterLfidAccept(
     req: Request,
     params: { invitedEmail: string; resourceUid?: string }
-  ): Promise<PendingCommitteeInviteForOrg | null> {
+  ): Promise<PendingCommitteeInviteForOrg | null | undefined> {
     const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
     if (pendingInvites.length === 0) {
       logger.debug(req, 'accept_invite', 'No pending committee invitations to auto-accept after LFID invite');
-      return null;
+      // undefined signals "not found" to the caller so it can retry while FGA propagates.
+      return undefined;
     }
 
     const toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
@@ -730,7 +731,7 @@ export class CommitteeService {
         pending_count: pendingInvites.length,
         resource_uid: params.resourceUid,
       });
-      return null;
+      return undefined;
     }
 
     logger.info(req, 'accept_invite', 'Auto-accepting committee invitations after LFID invite', {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -741,6 +741,7 @@ export class CommitteeService {
     });
 
     let pendingForOrg: PendingCommitteeInviteForOrg | null = null;
+    let anyAccepted = false;
 
     for (const invite of toAccept) {
       try {
@@ -780,6 +781,7 @@ export class CommitteeService {
         } else {
           await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
         }
+        anyAccepted = true;
       } catch (error) {
         logger.warning(req, 'accept_invite', 'Failed to auto-accept committee invitation after LFID invite', {
           committee_uid: invite.committee_uid,
@@ -789,7 +791,15 @@ export class CommitteeService {
       }
     }
 
-    return pendingForOrg;
+    // Return the org-required signal whenever it is set — the org-required case is surfaced to
+    // the user regardless of whether other invites succeeded or failed.
+    if (pendingForOrg) {
+      return pendingForOrg;
+    }
+    // If every acceptCommitteeInvite call threw, return undefined so the controller retries —
+    // the acceptance failure may be transient, and the committee-service accept endpoint is
+    // idempotent so retrying is safe.
+    return anyAccepted ? null : undefined;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -706,7 +706,8 @@ export class CommitteeService {
    * {@link invitedEmail}. Callers must verify the session email matches the invite token
    * email before invoking. {@link resourceUid} (from the LFID invite JWT) disambiguates
    * when multiple pending invites exist — matched against committee_invite UID first, then
-   * committee UID; if no match and exactly one pending invite remains, that one is accepted.
+   * committee UID; if neither matches, returns undefined so the caller can retry while the
+   * target invite's FGA invitee tuple propagates.
    *
    * Returns the first invite that requires an organization but had none pre-filled — the
    * caller must surface this to the user to collect their organization and complete acceptance.
@@ -1731,6 +1732,9 @@ export class CommitteeService {
       return byCommitteeUid;
     }
 
-    return pending.length === 1 ? pending : [];
+    // When resource_uid is specified, require a positive match — the single-invite fallback
+    // could accept an unrelated invite while the target's FGA invitee tuple is still
+    // propagating, which would stop the retry loop before the correct invite is processed.
+    return [];
   }
 }

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -10,6 +10,7 @@ export interface InviteTokenPayload {
   jti: string;
   invite_uid: string;
   resource_uid: string;
+  resource_type?: string;
   return_url: string;
   role: string;
 }


### PR DESCRIPTION
## Summary

- Replace the single fixed delay in `InviteController.autoAcceptPendingCommitteeInvites` with a retry loop (up to 3 retries, 3 s apart) that exits as soon as the committee invite is found and processed
- Non-committee LFID invites (no `resource_uid` in the token) skip the retry loop entirely
- `CommitteeService.acceptPendingCommitteeInvitesAfterLfidAccept` now returns `undefined` when no pending invites are found, allowing the controller to distinguish "not found yet — retry" from "found and processed — done"

## Root Cause

The NATS `invite.accepted` publish is fire-and-forget. The committee service's `HandleInviteAccepted` handler writes the FGA `invitee` tuple asynchronously — this tuple is what grants the new user read access to their own pending committee invite in the query service. The auto-accept query was running immediately after the publish, before the tuple existed, so `fetchPendingCommitteeInvitesByEmail` returned empty and auto-accept was silently skipped. In the same browser session the invite list was cached as empty, so the user saw no pending invites until a hard refresh in a new browser window.

## Retry logic

- Initial attempt runs immediately (no delay)
- If no pending invites are found, waits 3 s and retries — up to 3 retries
- Total wait: **at most 9 s**; exits early as soon as the invite is found and processed
- The user is on a processing screen during LFID invite acceptance so the latency is not visible
- Non-committee LFID invites (empty `resource_uid`) skip the retry loop with no added latency

## Test plan

- [ ] Accept a new LFID committee invite and confirm the committee invite is auto-accepted immediately after redirect (no manual acceptance required)
- [ ] Confirm the invite is visible and accepted without a hard refresh
- [ ] Confirm the processing screen during LFID acceptance completes within ~9 s in the worst case
- [ ] Confirm non-committee LFID invites are unaffected (no added latency)

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

## Related PRs

- Committee service fix (merged): linuxfoundation/lfx-v2-committee-service#150

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ