### PR TITLE
fix(newsletters): lazy-load open rates on sent newsletter list

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -82,7 +82,7 @@
                   <td class="text-right">
                     <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
                   </td>
-                  <td class="text-right">
+                  <td class="text-right" aria-live="polite">
                     @if (newsletter.openRatePending) {
                       <span aria-hidden="true" class="inline-block" [attr.data-testid]="'newsletter-open-rate-loading-' + newsletter.id">
                         <p-skeleton width="2rem" height="0.75rem"></p-skeleton>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -85,13 +85,16 @@
                   <td class="text-right">
                     @if (newsletter.openRatePending) {
                       <span
+                        aria-hidden="true"
                         class="inline-block h-3 w-8 rounded bg-gray-200 animate-pulse"
                         [attr.data-testid]="'newsletter-open-rate-loading-' + newsletter.id"></span>
                     } @else {
                       <span
                         class="text-sm text-gray-700"
+                        tabindex="0"
                         [pTooltip]="newsletter.openRateTooltip"
                         tooltipPosition="top"
+                        [attr.aria-label]="newsletter.openRateAria"
                         [attr.data-testid]="'newsletter-open-rate-' + newsletter.id">
                         {{ newsletter.openRateLabel }}
                       </span>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -91,9 +91,11 @@
                     } @else {
                       <span
                         class="text-sm text-gray-700"
+                        role="note"
                         tabindex="0"
                         [pTooltip]="newsletter.openRateTooltip"
                         tooltipPosition="top"
+                        tooltipEvent="both"
                         [attr.aria-label]="newsletter.openRateAria"
                         [attr.data-testid]="'newsletter-open-rate-' + newsletter.id">
                         {{ newsletter.openRateLabel }}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -84,10 +84,10 @@
                   </td>
                   <td class="text-right">
                     @if (newsletter.openRatePending) {
-                      <span
-                        aria-hidden="true"
-                        class="inline-block h-3 w-8 rounded bg-gray-200 animate-pulse"
-                        [attr.data-testid]="'newsletter-open-rate-loading-' + newsletter.id"></span>
+                      <span aria-hidden="true" class="inline-block" [attr.data-testid]="'newsletter-open-rate-loading-' + newsletter.id">
+                        <p-skeleton width="2rem" height="0.75rem"></p-skeleton>
+                      </span>
+                      <span class="sr-only">Loading open rate</span>
                     } @else {
                       <span
                         class="text-sm text-gray-700"

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -83,9 +83,19 @@
                     <span class="text-sm text-gray-700">{{ newsletter.recipientsLabel }}</span>
                   </td>
                   <td class="text-right">
-                    <span class="text-sm text-gray-700" [pTooltip]="newsletter.openRateTooltip" tooltipPosition="top">
-                      {{ newsletter.openRateLabel }}
-                    </span>
+                    @if (newsletter.openRatePending) {
+                      <span
+                        class="inline-block h-3 w-8 rounded bg-gray-200 animate-pulse"
+                        [attr.data-testid]="'newsletter-open-rate-loading-' + newsletter.id"></span>
+                    } @else {
+                      <span
+                        class="text-sm text-gray-700"
+                        [pTooltip]="newsletter.openRateTooltip"
+                        tooltipPosition="top"
+                        [attr.data-testid]="'newsletter-open-rate-' + newsletter.id">
+                        {{ newsletter.openRateLabel }}
+                      </span>
+                    }
                   </td>
                   <td class="text-right">
                     <div class="flex items-center justify-end gap-2">

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -13,7 +13,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY } from '@lfx-one/shared/constants';
-import { FilterPillOption, NewsletterAnalytics, NewsletterListItem, NewsletterRow, NewsletterStatus, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
+import { FilterPillOption, NewsletterAnalytics, NewsletterListItem, NewsletterRow, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -116,19 +116,23 @@ export class NewsletterListComponent {
 
   protected loadMore(): void {
     const token = this.nextPageToken();
-    if (!token || this.loadingMore() || !this.projectUid()) return;
+    const uid = this.projectUid();
+    const status = this.statusTab();
+    if (!token || this.loadingMore() || !uid) return;
     this.loadingMore.set(true);
     this.newsletterService
-      .listNewsletters(this.projectUid(), {
-        status: this.statusTab() as NewsletterStatus,
-        page_token: token,
-      })
+      .listNewsletters(uid, { status, page_token: token })
       .pipe(
         take(1),
         finalize(() => this.loadingMore.set(false))
       )
       .subscribe({
         next: (response) => {
+          // Discard the page if the tab or project changed while it was in flight —
+          // appending it would clobber the newer context's rows and page token.
+          if (this.projectUid() !== uid || this.statusTab() !== status) {
+            return;
+          }
           this.newsletters.update((current) => [...current, ...response.newsletters]);
           this.nextPageToken.set(response.next_page_token);
           this.loadOpenRates(response.newsletters);
@@ -150,30 +154,6 @@ export class NewsletterListComponent {
       rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
       accept: () => this.runDelete(item.id),
     });
-  }
-
-  private runDelete(id: string): void {
-    if (!this.projectUid()) return;
-    this.deletingId.set(id);
-    this.newsletterService
-      .deleteNewsletter(this.projectUid(), id)
-      .pipe(
-        take(1),
-        finalize(() => this.deletingId.set(null))
-      )
-      .subscribe({
-        next: () => {
-          this.newsletters.update((current) => current.filter((n) => n.id !== id));
-          this.messageService.add({ severity: 'success', summary: 'Draft deleted', detail: 'The draft has been removed.' });
-        },
-        error: (err: HttpErrorResponse) => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Delete failed',
-            detail: err?.error?.message || err?.message || 'Could not delete the draft. Please try again.',
-          });
-        },
-      });
   }
 
   private initRows(): Signal<NewsletterRow[]> {
@@ -203,11 +183,13 @@ export class NewsletterListComponent {
     });
   }
 
-  // switchMap cancels the in-flight list request when the tab or project changes,
-  // so a slow response can never clobber the newer tab's rows or fan out analytics
-  // for rows that are no longer displayed. Loading is cleared in next/catchError
-  // rather than finalize: a cancelled request's teardown runs after the newer
-  // request sets loading, and must not wipe it.
+  // switchMap cancels the in-flight initial list request when the tab or project
+  // changes, so a slow response can never clobber the newer tab's rows or fan out
+  // analytics for rows that are no longer displayed. (loadMore requests are not
+  // cancelled — loadMore guards its own response against context changes instead.)
+  // Loading is cleared explicitly on every outcome path (empty uid, error, next)
+  // rather than via finalize, so cancellation can never produce a loading write
+  // regardless of operator teardown ordering.
   private initLoadOnContextOrTab(): void {
     combineLatest([toObservable(this.projectUid), toObservable(this.statusTab)])
       .pipe(
@@ -222,7 +204,7 @@ export class NewsletterListComponent {
             return EMPTY;
           }
           this.loading.set(true);
-          return this.newsletterService.listNewsletters(uid, { status: status as NewsletterStatus }).pipe(
+          return this.newsletterService.listNewsletters(uid, { status }).pipe(
             catchError((err: HttpErrorResponse) => {
               this.loading.set(false);
               this.showLoadError(err);
@@ -240,13 +222,37 @@ export class NewsletterListComponent {
       });
   }
 
+  private runDelete(id: string): void {
+    if (!this.projectUid()) return;
+    this.deletingId.set(id);
+    this.newsletterService
+      .deleteNewsletter(this.projectUid(), id)
+      .pipe(
+        take(1),
+        finalize(() => this.deletingId.set(null))
+      )
+      .subscribe({
+        next: () => {
+          this.newsletters.update((current) => current.filter((n) => n.id !== id));
+          this.messageService.add({ severity: 'success', summary: 'Draft deleted', detail: 'The draft has been removed.' });
+        },
+        error: (err: HttpErrorResponse) => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Delete failed',
+            detail: err?.error?.message || err?.message || 'Could not delete the draft. Please try again.',
+          });
+        },
+      });
+  }
+
   // Fan out one analytics call per newly loaded sent row to fill the Open Rate
   // column. Browser-only: SSR skips the fan-out and the client replay of the
   // list load (via the transfer cache) triggers it. Rows whose analytics are
   // already loaded or in flight are skipped, so tab toggles and load-more never
   // duplicate requests. `sending` rows are excluded rather than negatively
-  // cached — their analytics don't exist yet, and the next list refresh retries
-  // them once they settle to `sent`.
+  // cached — their analytics don't exist yet, and the next list load (tab or
+  // project change) retries them once they settle to `sent`.
   private loadOpenRates(items: NewsletterListItem[]): void {
     if (!isPlatformBrowser(this.platformId)) {
       return;

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
+import { DatePipe, isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -12,13 +12,14 @@ import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { FilterPillOption, NewsletterListItem, NewsletterRow, NewsletterStatus, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
+import { NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY } from '@lfx-one/shared/constants';
+import { FilterPillOption, NewsletterAnalytics, NewsletterListItem, NewsletterRow, NewsletterStatus, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { combineLatest, distinctUntilChanged, finalize, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, finalize, from, map, mergeMap, of, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -49,6 +50,7 @@ export class NewsletterListComponent {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
 
   // === Tab options ===
   protected readonly statusTabOptions: FilterPillOption[] = [
@@ -65,6 +67,12 @@ export class NewsletterListComponent {
   protected readonly deletingId = signal<string | null>(null);
   protected readonly previewVisible = signal<boolean>(false);
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
+  // Analytics fetched lazily per sent row (the list endpoint intentionally omits
+  // open_rate/unique_opens). Kept in a side map keyed by newsletter id — never
+  // written back into `newsletters` — so row identity stays stable and results
+  // are cached across draft/sent tab toggles. `null` marks a failed fetch.
+  private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
+  private readonly openRatePendingIds = signal<Set<string>>(new Set());
 
   // === Reactive context ===
   public readonly projectUid: Signal<string> = this.projectContextService.activeContextUid;
@@ -72,21 +80,26 @@ export class NewsletterListComponent {
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
 
   // Pre-compute per-row labels so the template doesn't call functions-with-args.
-  protected readonly rows: Signal<NewsletterRow[]> = computed(() =>
-    this.newsletters().map((n) => {
+  protected readonly rows: Signal<NewsletterRow[]> = computed(() => {
+    const analyticsMap = this.openRateAnalytics();
+    const pendingIds = this.openRatePendingIds();
+    return this.newsletters().map((n) => {
+      const analytics = analyticsMap.get(n.id);
       const total = n.total_recipients ?? 0;
-      const opens = n.unique_opens ?? 0;
+      const opens = n.unique_opens ?? analytics?.unique_opens ?? 0;
+      const openRate = n.open_rate ?? analytics?.open_rate;
       const groupCount = n.committee_uids?.length ?? 0;
-      const openRateLabel = n.open_rate === undefined || n.open_rate === null ? '—' : `${Math.round(n.open_rate * 100)}%`;
+      const openRateLabel = openRate === undefined || openRate === null ? '—' : `${Math.round(openRate * 100)}%`;
       return {
         ...n,
         openRateLabel,
+        openRatePending: pendingIds.has(n.id),
         openRateTooltip: `${opens} of ${total} recipients opened`,
         recipientsLabel: n.total_recipients !== undefined && n.total_recipients !== null ? String(n.total_recipients) : '—',
         groupsLabel: `${groupCount} ${groupCount === 1 ? 'group' : 'groups'}`,
       };
-    })
-  );
+    });
+  });
 
   public constructor() {
     const tabFromQuery = this.route.snapshot.queryParamMap.get('tab');
@@ -136,6 +149,7 @@ export class NewsletterListComponent {
         next: (response) => {
           this.newsletters.update((current) => [...current, ...response.newsletters]);
           this.nextPageToken.set(response.next_page_token);
+          this.loadOpenRates(response.newsletters);
         },
         error: (err: HttpErrorResponse) => this.showLoadError(err),
       });
@@ -212,8 +226,49 @@ export class NewsletterListComponent {
         next: (response) => {
           this.newsletters.set(response.newsletters);
           this.nextPageToken.set(response.next_page_token);
+          this.loadOpenRates(response.newsletters);
         },
         error: (err: HttpErrorResponse) => this.showLoadError(err),
+      });
+  }
+
+  // Fan out one analytics call per newly loaded sent row to fill the Open Rate
+  // column. Browser-only: SSR skips the fan-out and the client re-run of
+  // loadInitial (via the transfer-cache replay) triggers it. Rows whose
+  // analytics are already loaded or in flight are skipped, so tab toggles and
+  // load-more never duplicate requests.
+  private loadOpenRates(items: NewsletterListItem[]): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    const targets = items.filter(
+      (n) => n.status !== 'draft' && n.open_rate === undefined && !this.openRateAnalytics().has(n.id) && !this.openRatePendingIds().has(n.id)
+    );
+    if (targets.length === 0) {
+      return;
+    }
+    this.openRatePendingIds.update((ids) => new Set([...ids, ...targets.map((n) => n.id)]));
+    from(targets)
+      .pipe(
+        mergeMap(
+          // Use the item's own project_uid rather than ambient context — see goToRow.
+          (n) =>
+            this.newsletterService.getAnalytics(n.project_uid, n.id).pipe(
+              map((analytics) => ({ id: n.id, analytics: analytics as NewsletterAnalytics | null })),
+              // A single failed row (e.g. still `sending`) keeps its "—" without breaking the rest.
+              catchError(() => of({ id: n.id, analytics: null }))
+            ),
+          NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ id, analytics }) => {
+        this.openRateAnalytics.update((current) => new Map(current).set(id, analytics));
+        this.openRatePendingIds.update((ids) => {
+          const next = new Set(ids);
+          next.delete(id);
+          return next;
+        });
       });
   }
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -18,6 +18,7 @@ import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, distinctUntilChanged, EMPTY, finalize, from, map, mergeMap, of, switchMap, take } from 'rxjs';
 
@@ -34,6 +35,7 @@ import { NewsletterPreviewDrawerComponent } from '../components/newsletter-previ
     TableComponent,
     TagComponent,
     ConfirmDialogModule,
+    SkeletonModule,
     TooltipModule,
     NewsletterPreviewDrawerComponent,
   ],
@@ -72,8 +74,10 @@ export class NewsletterListComponent {
   // written back into `newsletters` — so row identity stays stable and results
   // are cached across draft/sent tab toggles. `null` marks a failed fetch for a
   // settled (`sent`) row; those are not retried for the component's lifetime.
+  // The cache is cleared on project change to keep it bounded.
   private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
   private readonly openRatePendingIds = signal<Set<string>>(new Set());
+  private lastLoadedUid: string | null = null;
   // Incremented on every context-driven list reload. loadMore captures it at
   // request time and discards responses from an older generation — covering
   // change-and-revert (A→B→A) sequences a value comparison would miss. Not a
@@ -212,6 +216,11 @@ export class NewsletterListComponent {
           this.selectedNewsletter.set(null);
           this.nextPageToken.set(undefined);
           this.newsletters.set([]);
+          if (uid !== this.lastLoadedUid) {
+            this.lastLoadedUid = uid;
+            this.openRateAnalytics.set(new Map());
+            this.openRatePendingIds.set(new Set());
+          }
           if (!uid) {
             this.loading.set(false);
             return EMPTY;
@@ -289,7 +298,10 @@ export class NewsletterListComponent {
             this.newsletterService.getAnalytics(n.project_uid, n.id).pipe(
               map((analytics): { id: string; analytics: NewsletterAnalytics | null } => ({ id: n.id, analytics })),
               // A single failed row keeps its "—" without breaking the rest.
-              catchError(() => of({ id: n.id, analytics: null }))
+              catchError((err: HttpErrorResponse) => {
+                console.error(`Failed to load analytics for newsletter ${n.id}:`, err);
+                return of({ id: n.id, analytics: null });
+              })
             ),
           NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY
         ),

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -73,8 +73,8 @@ export class NewsletterListComponent {
   // open_rate/unique_opens). Kept in a side map keyed by newsletter id — never
   // written back into `newsletters` — so row identity stays stable and results
   // are cached across draft/sent tab toggles. `null` marks a failed fetch for a
-  // settled (`sent`) row; those are not retried for the component's lifetime.
-  // The cache is cleared on project change to keep it bounded.
+  // settled (`sent`) row; those are not retried while the project context is
+  // unchanged. The cache is cleared on project change to keep it bounded.
   private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
   private readonly openRatePendingIds = signal<Set<string>>(new Set());
   private lastLoadedUid: string | null = null;
@@ -308,7 +308,15 @@ export class NewsletterListComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(({ id, analytics }) => {
-        this.openRateAnalytics.update((current) => new Map(current).set(id, analytics));
+        // A late failure must not clobber a value a competing fetch already loaded
+        // (possible on rapid project change-and-revert, where the cache prune drops
+        // the pending-set dedupe for in-flight ids).
+        this.openRateAnalytics.update((current) => {
+          if (analytics === null && current.get(id)) {
+            return current;
+          }
+          return new Map(current).set(id, analytics);
+        });
         this.openRatePendingIds.update((ids) => {
           const next = new Set(ids);
           next.delete(id);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -19,7 +19,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, distinctUntilChanged, finalize, from, map, mergeMap, of, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, EMPTY, finalize, from, map, mergeMap, of, switchMap, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -70,7 +70,8 @@ export class NewsletterListComponent {
   // Analytics fetched lazily per sent row (the list endpoint intentionally omits
   // open_rate/unique_opens). Kept in a side map keyed by newsletter id — never
   // written back into `newsletters` — so row identity stays stable and results
-  // are cached across draft/sent tab toggles. `null` marks a failed fetch.
+  // are cached across draft/sent tab toggles. `null` marks a failed fetch for a
+  // settled (`sent`) row; those are not retried for the component's lifetime.
   private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
   private readonly openRatePendingIds = signal<Set<string>>(new Set());
 
@@ -80,26 +81,7 @@ export class NewsletterListComponent {
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
 
   // Pre-compute per-row labels so the template doesn't call functions-with-args.
-  protected readonly rows: Signal<NewsletterRow[]> = computed(() => {
-    const analyticsMap = this.openRateAnalytics();
-    const pendingIds = this.openRatePendingIds();
-    return this.newsletters().map((n) => {
-      const analytics = analyticsMap.get(n.id);
-      const total = n.total_recipients ?? 0;
-      const opens = n.unique_opens ?? analytics?.unique_opens ?? 0;
-      const openRate = n.open_rate ?? analytics?.open_rate;
-      const groupCount = n.committee_uids?.length ?? 0;
-      const openRateLabel = openRate === undefined || openRate === null ? '—' : `${Math.round(openRate * 100)}%`;
-      return {
-        ...n,
-        openRateLabel,
-        openRatePending: pendingIds.has(n.id),
-        openRateTooltip: `${opens} of ${total} recipients opened`,
-        recipientsLabel: n.total_recipients !== undefined && n.total_recipients !== null ? String(n.total_recipients) : '—',
-        groupsLabel: `${groupCount} ${groupCount === 1 ? 'group' : 'groups'}`,
-      };
-    });
-  });
+  protected readonly rows: Signal<NewsletterRow[]> = this.initRows();
 
   public constructor() {
     const tabFromQuery = this.route.snapshot.queryParamMap.get('tab');
@@ -194,55 +176,87 @@ export class NewsletterListComponent {
       });
   }
 
+  private initRows(): Signal<NewsletterRow[]> {
+    return computed(() => {
+      const analyticsMap = this.openRateAnalytics();
+      const pendingIds = this.openRatePendingIds();
+      return this.newsletters().map((n) => {
+        const analytics = analyticsMap.get(n.id);
+        const total = n.total_recipients ?? 0;
+        const opens = n.unique_opens ?? analytics?.unique_opens ?? 0;
+        const openRate = n.open_rate ?? analytics?.open_rate;
+        const groupCount = n.committee_uids?.length ?? 0;
+        const hasOpenRate = openRate !== undefined && openRate !== null;
+        const openRateLabel = hasOpenRate ? `${Math.round(openRate * 100)}%` : '—';
+        // Don't fabricate "0 of N opened" when analytics are missing or failed.
+        const openRateTooltip = hasOpenRate ? `${opens} of ${total} recipients opened` : 'Analytics not available';
+        return {
+          ...n,
+          openRateLabel,
+          openRatePending: pendingIds.has(n.id),
+          openRateTooltip,
+          openRateAria: hasOpenRate ? `Open rate ${openRateLabel}, ${openRateTooltip}` : 'Open rate not available',
+          recipientsLabel: n.total_recipients !== undefined && n.total_recipients !== null ? String(n.total_recipients) : '—',
+          groupsLabel: `${groupCount} ${groupCount === 1 ? 'group' : 'groups'}`,
+        };
+      });
+    });
+  }
+
+  // switchMap cancels the in-flight list request when the tab or project changes,
+  // so a slow response can never clobber the newer tab's rows or fan out analytics
+  // for rows that are no longer displayed. Loading is cleared in next/catchError
+  // rather than finalize: a cancelled request's teardown runs after the newer
+  // request sets loading, and must not wipe it.
   private initLoadOnContextOrTab(): void {
     combineLatest([toObservable(this.projectUid), toObservable(this.statusTab)])
       .pipe(
         distinctUntilChanged(([prevUid, prevTab], [uid, tab]) => prevUid === uid && prevTab === tab),
+        switchMap(([uid, status]) => {
+          this.previewVisible.set(false);
+          this.selectedNewsletter.set(null);
+          this.nextPageToken.set(undefined);
+          this.newsletters.set([]);
+          if (!uid) {
+            this.loading.set(false);
+            return EMPTY;
+          }
+          this.loading.set(true);
+          return this.newsletterService.listNewsletters(uid, { status: status as NewsletterStatus }).pipe(
+            catchError((err: HttpErrorResponse) => {
+              this.loading.set(false);
+              this.showLoadError(err);
+              return EMPTY;
+            })
+          );
+        }),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe(([uid, status]) => {
-        this.previewVisible.set(false);
-        this.selectedNewsletter.set(null);
-        if (uid) {
-          this.loadInitial(status as NewsletterStatus);
-        } else {
-          this.newsletters.set([]);
-          this.nextPageToken.set(undefined);
-        }
-      });
-  }
-
-  private loadInitial(status: NewsletterStatus): void {
-    this.loading.set(true);
-    this.nextPageToken.set(undefined);
-    this.newsletters.set([]);
-    this.newsletterService
-      .listNewsletters(this.projectUid(), { status })
-      .pipe(
-        take(1),
-        finalize(() => this.loading.set(false))
-      )
-      .subscribe({
-        next: (response) => {
-          this.newsletters.set(response.newsletters);
-          this.nextPageToken.set(response.next_page_token);
-          this.loadOpenRates(response.newsletters);
-        },
-        error: (err: HttpErrorResponse) => this.showLoadError(err),
+      .subscribe((response) => {
+        this.loading.set(false);
+        this.newsletters.set(response.newsletters);
+        this.nextPageToken.set(response.next_page_token);
+        this.loadOpenRates(response.newsletters);
       });
   }
 
   // Fan out one analytics call per newly loaded sent row to fill the Open Rate
-  // column. Browser-only: SSR skips the fan-out and the client re-run of
-  // loadInitial (via the transfer-cache replay) triggers it. Rows whose
-  // analytics are already loaded or in flight are skipped, so tab toggles and
-  // load-more never duplicate requests.
+  // column. Browser-only: SSR skips the fan-out and the client replay of the
+  // list load (via the transfer cache) triggers it. Rows whose analytics are
+  // already loaded or in flight are skipped, so tab toggles and load-more never
+  // duplicate requests. `sending` rows are excluded rather than negatively
+  // cached — their analytics don't exist yet, and the next list refresh retries
+  // them once they settle to `sent`.
   private loadOpenRates(items: NewsletterListItem[]): void {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
     const targets = items.filter(
-      (n) => n.status !== 'draft' && n.open_rate === undefined && !this.openRateAnalytics().has(n.id) && !this.openRatePendingIds().has(n.id)
+      (n) =>
+        n.status === 'sent' &&
+        (n.open_rate === undefined || n.open_rate === null) &&
+        !this.openRateAnalytics().has(n.id) &&
+        !this.openRatePendingIds().has(n.id)
     );
     if (targets.length === 0) {
       return;
@@ -254,8 +268,8 @@ export class NewsletterListComponent {
           // Use the item's own project_uid rather than ambient context — see goToRow.
           (n) =>
             this.newsletterService.getAnalytics(n.project_uid, n.id).pipe(
-              map((analytics) => ({ id: n.id, analytics: analytics as NewsletterAnalytics | null })),
-              // A single failed row (e.g. still `sending`) keeps its "—" without breaking the rest.
+              map((analytics): { id: string; analytics: NewsletterAnalytics | null } => ({ id: n.id, analytics })),
+              // A single failed row keeps its "—" without breaking the rest.
               catchError(() => of({ id: n.id, analytics: null }))
             ),
           NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -78,6 +78,11 @@ export class NewsletterListComponent {
   private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
   private readonly openRatePendingIds = signal<Set<string>>(new Set());
   private lastLoadedUid: string | null = null;
+  // Incremented whenever the analytics cache is cleared (project change). Each
+  // fan-out batch captures it at start; results from an older generation are
+  // discarded so a stale batch can't repopulate the pruned cache or race a
+  // newer batch's entries and pending markers (A→B→A project toggles).
+  private analyticsCacheGeneration = 0;
   // Incremented on every context-driven list reload. loadMore captures it at
   // request time and discards responses from an older generation — covering
   // change-and-revert (A→B→A) sequences a value comparison would miss. Not a
@@ -218,6 +223,7 @@ export class NewsletterListComponent {
           this.newsletters.set([]);
           if (uid !== this.lastLoadedUid) {
             this.lastLoadedUid = uid;
+            this.analyticsCacheGeneration++;
             this.openRateAnalytics.set(new Map());
             this.openRatePendingIds.set(new Set());
           }
@@ -289,6 +295,7 @@ export class NewsletterListComponent {
     if (targets.length === 0) {
       return;
     }
+    const cacheGeneration = this.analyticsCacheGeneration;
     this.openRatePendingIds.update((ids) => new Set([...ids, ...targets.map((n) => n.id)]));
     from(targets)
       .pipe(
@@ -308,15 +315,13 @@ export class NewsletterListComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(({ id, analytics }) => {
-        // A late failure must not clobber a value a competing fetch already loaded
-        // (possible on rapid project change-and-revert, where the cache prune drops
-        // the pending-set dedupe for in-flight ids).
-        this.openRateAnalytics.update((current) => {
-          if (analytics === null && current.get(id)) {
-            return current;
-          }
-          return new Map(current).set(id, analytics);
-        });
+        // A result from before the last cache clear is stale — writing it would
+        // repopulate the pruned cache and race the newer batch for the same ids.
+        // Within a generation the pending-set dedupe guarantees one fetch per id.
+        if (cacheGeneration !== this.analyticsCacheGeneration) {
+          return;
+        }
+        this.openRateAnalytics.update((current) => new Map(current).set(id, analytics));
         this.openRatePendingIds.update((ids) => {
           const next = new Set(ids);
           next.delete(id);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -74,6 +74,11 @@ export class NewsletterListComponent {
   // settled (`sent`) row; those are not retried for the component's lifetime.
   private readonly openRateAnalytics = signal<Map<string, NewsletterAnalytics | null>>(new Map());
   private readonly openRatePendingIds = signal<Set<string>>(new Set());
+  // Incremented on every context-driven list reload. loadMore captures it at
+  // request time and discards responses from an older generation — covering
+  // change-and-revert (A→B→A) sequences a value comparison would miss. Not a
+  // signal: nothing renders from it.
+  private loadGeneration = 0;
 
   // === Reactive context ===
   public readonly projectUid: Signal<string> = this.projectContextService.activeContextUid;
@@ -118,6 +123,7 @@ export class NewsletterListComponent {
     const token = this.nextPageToken();
     const uid = this.projectUid();
     const status = this.statusTab();
+    const generation = this.loadGeneration;
     if (!token || this.loadingMore() || !uid) return;
     this.loadingMore.set(true);
     this.newsletterService
@@ -128,16 +134,22 @@ export class NewsletterListComponent {
       )
       .subscribe({
         next: (response) => {
-          // Discard the page if the tab or project changed while it was in flight —
-          // appending it would clobber the newer context's rows and page token.
-          if (this.projectUid() !== uid || this.statusTab() !== status) {
+          // Discard the page if the list was reloaded while it was in flight —
+          // appending it would clobber the newer load's rows and page token.
+          if (generation !== this.loadGeneration) {
             return;
           }
           this.newsletters.update((current) => [...current, ...response.newsletters]);
           this.nextPageToken.set(response.next_page_token);
           this.loadOpenRates(response.newsletters);
         },
-        error: (err: HttpErrorResponse) => this.showLoadError(err),
+        error: (err: HttpErrorResponse) => {
+          // A stale request's failure is irrelevant to the context now on screen.
+          if (generation !== this.loadGeneration) {
+            return;
+          }
+          this.showLoadError(err);
+        },
       });
   }
 
@@ -195,6 +207,7 @@ export class NewsletterListComponent {
       .pipe(
         distinctUntilChanged(([prevUid, prevTab], [uid, tab]) => prevUid === uid && prevTab === tab),
         switchMap(([uid, status]) => {
+          this.loadGeneration++;
           this.previewVisible.set(false);
           this.selectedNewsletter.set(null);
           this.nextPageToken.set(undefined);

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -28,8 +28,9 @@ export const NEWSLETTER_AI_MAX_TOKENS = 12_000;
 
 // The list endpoint intentionally omits open_rate/unique_opens (per-newsletter
 // analytics need a separate /analytics call upstream), so the list page fans
-// out one analytics request per sent row. Cap the concurrency so a full page
-// doesn't stampede the BFF/email-service.
+// out one analytics request per sent row. Caps each fan-out batch (initial page
+// or load-more) — batches are user-paced, so this is a per-batch ceiling, not a
+// global one.
 export const NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY = 5;
 
 // Per-request timeout for the send endpoint, overriding the API client's 30s

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -26,6 +26,12 @@ export const NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH = 20_000;
 // pushes back).
 export const NEWSLETTER_AI_MAX_TOKENS = 12_000;
 
+// The list endpoint intentionally omits open_rate/unique_opens (per-newsletter
+// analytics need a separate /analytics call upstream), so the list page fans
+// out one analytics request per sent row. Cap the concurrency so a full page
+// doesn't stampede the BFF/email-service.
+export const NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY = 5;
+
 // Per-request timeout for the send endpoint, overriding the API client's 30s
 // default. The new upstream accepts sends in well under a second (202 +
 // background fan-out), but while a pre-async newsletter-service is deployed

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -106,8 +106,9 @@ export interface UpdateNewsletterRequest {
 
 export interface NewsletterListItem extends Newsletter {
   // The upstream list DTO currently omits both fields (per-newsletter analytics
-  // require a separate /analytics call); the list page fills them client-side.
-  // Kept optional for forward-compat should upstream ever inline them.
+  // require a separate /analytics call); the list page derives the displayed
+  // values client-side. Kept optional for forward-compat should upstream ever
+  // inline them.
   unique_opens?: number;
   open_rate?: number;
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -105,6 +105,9 @@ export interface UpdateNewsletterRequest {
 }
 
 export interface NewsletterListItem extends Newsletter {
+  // The upstream list DTO currently omits both fields (per-newsletter analytics
+  // require a separate /analytics call); the list page fills them client-side.
+  // Kept optional for forward-compat should upstream ever inline them.
   unique_opens?: number;
   open_rate?: number;
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -146,6 +146,7 @@ export interface NewsletterAnalytics {
 
 export interface NewsletterRow extends NewsletterListItem {
   openRateLabel: string;
+  openRatePending: boolean;
   openRateTooltip: string;
   recipientsLabel: string;
   groupsLabel: string;

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -146,8 +146,11 @@ export interface NewsletterAnalytics {
 
 export interface NewsletterRow extends NewsletterListItem {
   openRateLabel: string;
+  /** UI-populated: true while the row's analytics fetch is in flight. */
   openRatePending: boolean;
   openRateTooltip: string;
+  /** UI-populated: screen-reader label combining the open-rate value and its tooltip context. */
+  openRateAria: string;
   recipientsLabel: string;
   groupsLabel: string;
 }


### PR DESCRIPTION
## Summary

The Newsletters list (Sent tab) showed an empty Open Rate ("—") for every sent newsletter, while the per-newsletter analytics page showed the rate correctly.

**Root cause:** the `lfx-v2-newsletter-service` list endpoint intentionally never populates `open_rate`/`unique_opens` — per-newsletter analytics require a separate `/analytics` call so the list query stays a single DB round-trip (see `internal/handler/list.go` in that repo, deliberate as of its May 29 refactor). The BFF is a pure passthrough, so the UI's optional `NewsletterListItem.open_rate` was never populated and every row fell back to "—".

**Fix (UI-only):** after the Sent list loads, the list component lazily fans out one `getAnalytics` call per sent row on the current page and fills cells in as results arrive:

- Concurrency capped at 5 per batch (`NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY`); per-row `catchError` with `console.error` so one failure never breaks the list
- Results cached in an id-keyed side map (kept across draft/sent tab toggles, pruned on project change); `sending` rows excluded so they retry once settled
- `p-skeleton` while pending; same endpoint as the analytics page so numbers match exactly
- SSR-safe: fan-out is browser-only; the transfer-cache replay of the list load triggers it client-side

**Hardening found during review:** the list-load pipeline now uses `switchMap` and a load-generation counter, closing a pre-existing race where a slow list or load-more response could clobber a newer tab/project's rows and page token (including change-and-revert sequences). The Open Rate cell is now keyboard- and screen-reader-accessible (`tabindex`, `aria-label`, `tooltipEvent="both"`, sr-only loading text).

## Trade-offs

- Failed analytics fetches for settled rows are negatively cached until the project context changes (documented in code); a late failure never overwrites an already-loaded value
- The concurrency cap is per-batch (initial page / load-more), not global — batches are user-paced
- One tab stop per sent row for tooltip keyboard access
- No E2E spec for the new column states yet; `data-testid` hooks (`newsletter-open-rate-{id}`, `newsletter-open-rate-loading-{id}`) are in place to make one cheap
- N+1 fan-out is the only available path — upstream has no batch analytics endpoint

## External references

- Upstream design decision this works around: `linuxfoundation/lfx-v2-newsletter-service` `internal/handler/list.go` — list DTO intentionally omits engagement fields; no upstream change required or made

## Ticket

[LFXV2-2693](https://linuxfoundation.atlassian.net/browse/LFXV2-2693)

[LFXV2-2693]: https://linuxfoundation.atlassian.net/browse/LFXV2-2693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ