### PR TITLE
fix(dashboards): deliver the 6-month window the drawer labels promise

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -29,7 +29,7 @@ export class BrandHealthDrawerComponent {
     totalMentions: 0,
     sentiment: { positive: 0, neutral: 0, negative: 0 },
     sentimentMomChangePp: 0,
-    mentionMomChangePct: 0,
+    mentionMomChangePct: null,
     trend: 'up',
     monthlyMentions: [],
     topProjects: [],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -42,7 +42,7 @@
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Monthly Sessions</span>
+          <span class="text-sm text-gray-500">Sessions (last 30 days)</span>
           @if (data().totalMonthlySessions > 0) {
             <span class="text-2xl font-semibold text-gray-900">{{ data().totalMonthlySessions | number }}</span>
           } @else {
@@ -152,7 +152,7 @@
     <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-website-sessions">
       <div class="flex flex-col gap-1">
         <h3 class="text-sm font-semibold text-gray-900">Website Sessions by Domain</h3>
-        <p class="text-sm text-gray-600">Monthly sessions across foundation web properties</p>
+        <p class="text-sm text-gray-600">Sessions across foundation web properties over the last 30 days</p>
       </div>
       @if (data().websiteDomains.length > 0) {
         <div class="flex flex-col gap-0">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -161,7 +161,7 @@ export class BrandReachDrawerComponent {
       if (totalMonthlySessions > 0 && websiteDomains.length > 0) {
         const topDomain = [...websiteDomains].sort((a, b) => b.sessions - a.sessions)[0];
         insights.push({
-          text: `${topDomain.domain} drives ${formatNumber(topDomain.sessions)} monthly sessions`,
+          text: `${topDomain.domain} drives ${formatNumber(topDomain.sessions)} sessions in the last 30 days`,
           type: 'info',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -257,7 +257,7 @@ export class EmailCtrDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getEmailCtr(foundationSlug).pipe(
+          this.analyticsService.getEmailCtr(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);
@@ -578,7 +578,7 @@ export class EmailCtrDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.paidDataResolved.set(false)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getSocialReach(foundationSlug).pipe(
+          this.analyticsService.getSocialReach(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.paidDataResolved.set(true)),
             catchError(() => {
               this.paidDataResolved.set(true);
@@ -603,7 +603,7 @@ export class EmailCtrDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.attributionDataResolved.set(false)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getMarketingAttribution(foundationSlug).pipe(
+          this.analyticsService.getMarketingAttribution(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.attributionDataResolved.set(true)),
             catchError(() => {
               this.attributionDataResolved.set(true);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -350,8 +350,11 @@ export class EmailCtrDrawerComponent {
       }
 
       if (paidActions.length === 0 && paid.monthlyData.length >= 3) {
+        // The series is calendar zero-filled — all three months must have
+        // actual impressions, or a trailing no-campaign month fabricates a
+        // "3 consecutive months" decline (spend gap, not a trend).
         const recent3 = paid.monthlyData.slice(-3);
-        if (recent3[0] > recent3[1] && recent3[1] > recent3[2]) {
+        if (recent3.every((v) => v > 0) && recent3[0] > recent3[1] && recent3[1] > recent3[2]) {
           paidActions.push({
             title: 'Investigate declining paid impressions',
             description: 'Impressions dropped for 3 consecutive months — review budget pacing and bid strategy',
@@ -384,7 +387,16 @@ export class EmailCtrDrawerComponent {
         });
       }
 
-      if (emailActions.length === 0 && email.monthlySends.length >= 2 && email.monthlyOpens.length >= 2) {
+      // Open-rate comparison requires sends in BOTH months: the series is
+      // calendar zero-filled, and a no-send month has no open rate — treating
+      // it as 0% fabricates an "Open rate declined" action.
+      if (
+        emailActions.length === 0 &&
+        email.monthlySends.length >= 2 &&
+        email.monthlyOpens.length >= 2 &&
+        email.monthlySends[email.monthlySends.length - 1] > 0 &&
+        email.monthlySends[email.monthlySends.length - 2] > 0
+      ) {
         const latestOpenRate =
           email.monthlySends[email.monthlySends.length - 1] > 0
             ? (email.monthlyOpens[email.monthlyOpens.length - 1] / email.monthlySends[email.monthlySends.length - 1]) * 100
@@ -515,7 +527,9 @@ export class EmailCtrDrawerComponent {
       if (paidInsights.length === 0 && paid.totalReach > 0 && paid.monthlyData.length >= 2) {
         const prev = paid.monthlyData[paid.monthlyData.length - 2];
         const curr = paid.monthlyData[paid.monthlyData.length - 1];
-        if (prev > 0) {
+        // Both months must be active: a zero-filled trailing no-campaign
+        // month reads as ~-100% MoM — a spend gap, not an impressions drop.
+        if (prev > 0 && curr > 0) {
           const paidMom = ((curr - prev) / prev) * 100;
           if (paidMom > 20) {
             paidInsights.push({ text: `Paid impressions surged ${paidMom.toFixed(0)}% MoM — ${formatNumber(curr)} last month`, type: 'driver' });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -371,11 +371,15 @@ export class EmailCtrDrawerComponent {
       }
 
       // --- Email — pick highest-priority ---
-      if (email.changePercentage < 0) {
+      // Use the true MoM figure: with a trailing (last-6) period, changePercentage
+      // compares the window's blended CTR against its own monthly average and sits
+      // near zero by construction.
+      const emailCtrMom = email.momChangePercentage;
+      if (emailCtrMom !== null && emailCtrMom < 0) {
         emailActions.push({
           title: 'Test new call-to-action formats',
-          description: `Email CTR dropped ${Math.abs(email.changePercentage).toFixed(1)}% — experiment with button placement and copy`,
-          priority: email.changePercentage < -10 ? 'high' : 'medium',
+          description: `Email CTR dropped ${Math.abs(emailCtrMom).toFixed(1)}% MoM — experiment with button placement and copy`,
+          priority: emailCtrMom < -10 ? 'high' : 'medium',
           actionType: 'optimize',
         });
       }
@@ -522,15 +526,19 @@ export class EmailCtrDrawerComponent {
       }
 
       // --- Email — pick 1 best ---
-      if (email.currentCtr > 0 || email.monthlyData.length > 0) {
-        if (email.changePercentage > 10) {
-          emailInsights.push({ text: `Email CTR grew ${email.changePercentage.toFixed(1)}% vs 6-month avg — strong improvement`, type: 'driver' });
-        } else if (email.changePercentage < -10) {
-          emailInsights.push({ text: `Email CTR dropped ${Math.abs(email.changePercentage).toFixed(1)}% vs 6-month avg`, type: 'warning' });
-        } else if (email.changePercentage !== 0) {
+      // momChangePercentage is the true MoM (unaffected by the trailing window);
+      // changePercentage under last-6 is the blended-vs-average figure and is
+      // structurally near zero.
+      const emailCtrMomInsight = email.momChangePercentage;
+      if ((email.currentCtr > 0 || email.monthlyData.length > 0) && emailCtrMomInsight !== null) {
+        if (emailCtrMomInsight > 10) {
+          emailInsights.push({ text: `Email CTR grew ${emailCtrMomInsight.toFixed(1)}% MoM — strong improvement`, type: 'driver' });
+        } else if (emailCtrMomInsight < -10) {
+          emailInsights.push({ text: `Email CTR dropped ${Math.abs(emailCtrMomInsight).toFixed(1)}% MoM`, type: 'warning' });
+        } else if (emailCtrMomInsight !== 0) {
           emailInsights.push({
-            text: `Email CTR ${email.changePercentage > 0 ? 'up' : 'down'} ${Math.abs(email.changePercentage).toFixed(1)}% vs 6-month avg`,
-            type: email.changePercentage > 0 ? 'info' : 'warning',
+            text: `Email CTR ${emailCtrMomInsight > 0 ? 'up' : 'down'} ${Math.abs(emailCtrMomInsight).toFixed(1)}% MoM`,
+            type: emailCtrMomInsight > 0 ? 'info' : 'warning',
           });
         }
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -350,11 +350,13 @@ export class EmailCtrDrawerComponent {
       }
 
       if (paidActions.length === 0 && paid.monthlyData.length >= 3) {
-        // The series is calendar zero-filled — all three months must have
-        // actual impressions, or a trailing no-campaign month fabricates a
-        // "3 consecutive months" decline (spend gap, not a trend).
+        // The series is calendar zero-filled — all three months must be
+        // ACTIVE (spend or impressions), or a trailing no-campaign month
+        // fabricates a "3 consecutive months" decline (spend gap, not a
+        // trend). An active month with zero impressions is a real data point.
         const recent3 = paid.monthlyData.slice(-3);
-        if (recent3.every((v) => v > 0) && recent3[0] > recent3[1] && recent3[1] > recent3[2]) {
+        const active3 = recent3.map((v, i) => v > 0 || (paid.monthlySpend?.[paid.monthlyData.length - 3 + i] ?? 0) > 0);
+        if (active3.every(Boolean) && recent3[0] > recent3[1] && recent3[1] > recent3[2]) {
           paidActions.push({
             title: 'Investigate declining paid impressions',
             description: 'Impressions dropped for 3 consecutive months — review budget pacing and bid strategy',
@@ -527,9 +529,11 @@ export class EmailCtrDrawerComponent {
       if (paidInsights.length === 0 && paid.totalReach > 0 && paid.monthlyData.length >= 2) {
         const prev = paid.monthlyData[paid.monthlyData.length - 2];
         const curr = paid.monthlyData[paid.monthlyData.length - 1];
-        // Both months must be active: a zero-filled trailing no-campaign
-        // month reads as ~-100% MoM — a spend gap, not an impressions drop.
-        if (prev > 0 && curr > 0) {
+        // Both months must be ACTIVE (spend or impressions): a zero-filled
+        // no-campaign month reads as ~-100% MoM — a spend gap, not a drop —
+        // while an active month with zero impressions is a real data point.
+        const currActive = curr > 0 || (paid.monthlySpend?.[paid.monthlyData.length - 1] ?? 0) > 0;
+        if (prev > 0 && currActive) {
           const paidMom = ((curr - prev) / prev) * 100;
           if (paidMom > 20) {
             paidInsights.push({ text: `Paid impressions surged ${paidMom.toFixed(0)}% MoM — ${formatNumber(curr)} last month`, type: 'driver' });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -47,15 +47,16 @@
           <span class="text-sm text-gray-500">Growth</span>
           @if (reengagement().reengagementMomChange !== 0) {
             <div class="flex items-center gap-2">
+              <!-- reengagementMomChange is a percentage-POINT delta between two monthly rates, not a percent change -->
               <span class="text-2xl font-semibold" [class]="reengagement().reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
-                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange | number: '1.1-1' }}%
+                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange | number: '1.1-1' }}pp
               </span>
               <i
                 class="text-sm"
                 [class]="reengagement().reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>
           } @else {
-            <span class="text-2xl font-semibold text-gray-500">0%</span>
+            <span class="text-2xl font-semibold text-gray-500">0pp</span>
           }
         </div>
       </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -296,7 +296,7 @@ export class MarketingOverviewComponent {
       this.mentionsTrigger$.pipe(
         switchMap((slug) => {
           if (!slug) return of(null);
-          return this.analyticsService.getBrandHealth(slug, true).pipe(
+          return this.analyticsService.getBrandHealth(slug, true, 'last-6').pipe(
             map((res) => ({ topPositiveMentions: res.topPositiveMentions, topNegativeMentions: res.topNegativeMentions })),
             catchError(() => of(null))
           );
@@ -326,10 +326,14 @@ export class MarketingOverviewComponent {
             engagedCommunity: safe('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),
             eventGrowth: safe('eventGrowth', this.analyticsService.getEventGrowth(slug)),
             brandReach: safe('brandReach', this.analyticsService.getBrandReach(slug)),
-            brandHealth: safe('brandHealth', this.analyticsService.getBrandHealth(slug)),
-            revenueImpact: safe('revenueImpact', this.analyticsService.getRevenueImpact(slug)),
-            emailCtr: safe('emailCtr', this.analyticsService.getEmailCtr(slug)),
-            paidCampaign: safe('paidCampaign', this.analyticsService.getSocialReach(slug)),
+            // Period-aware endpoints get the last-6 preset explicitly: their trend
+            // sections are designed (and labeled) as 6-month windows, and omitting
+            // the period silently falls back to the previous completed month. MoM
+            // KPIs are unaffected — both windows share the same period END.
+            brandHealth: safe('brandHealth', this.analyticsService.getBrandHealth(slug, false, 'last-6')),
+            revenueImpact: safe('revenueImpact', this.analyticsService.getRevenueImpact(slug, undefined, 'last-6')),
+            emailCtr: safe('emailCtr', this.analyticsService.getEmailCtr(slug, undefined, 'last-6')),
+            paidCampaign: safe('paidCampaign', this.analyticsService.getSocialReach(slug, undefined, 'last-6')),
           })
         )
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -130,7 +130,7 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     totalMentions: 0,
     sentiment: { positive: 0, neutral: 0, negative: 0 },
     sentimentMomChangePp: 0,
-    mentionMomChangePct: 0,
+    mentionMomChangePct: null,
     trend: 'up',
     monthlyMentions: [],
     topProjects: [],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -232,7 +232,7 @@
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-total-members-section">
         <div class="flex flex-col gap-1">
           <h3 class="text-sm font-semibold text-gray-900">Total Members Over Time</h3>
-          <p class="text-sm text-gray-600">Cumulative membership growth over the last 6 months</p>
+          <p class="text-sm text-gray-600">Cumulative membership growth over the last 12 months</p>
         </div>
         <div class="h-[200px]" data-testid="member-acquisition-drawer-total-members-chart">
           <lfx-chart type="line" [data]="totalMembersChartData()" [options]="totalMembersChartOptions" height="100%"></lfx-chart>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -153,7 +153,7 @@
           <h3 class="text-sm font-semibold text-gray-900">Monthly Paid Impressions</h3>
           <p class="text-sm text-gray-600">Paid ad impressions across all channels over the last 6 months</p>
         </div>
-        @if (drawerData().monthlyData.length > 0) {
+        @if (hasImpressionData()) {
           <div class="h-[240px]" data-testid="paid-social-reach-drawer-chart">
             <lfx-chart type="bar" [data]="chartData()" [options]="chartOptions" height="100%"></lfx-chart>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -215,10 +215,14 @@ export class PaidSocialReachDrawerComponent {
         });
       }
 
-      // ROAS trending down — separate from absolute level
+      // ROAS trending down — separate from absolute level. All three months
+      // must have actual ROAS (> 0): the series is calendar zero-filled, so a
+      // month with no campaigns carries 0 — that's a spend gap, not a
+      // performance trend, and must not fabricate a "3 months straight" streak.
       if (monthlyRoas && monthlyRoas.length >= 3) {
         const recent3 = monthlyRoas.slice(-3);
-        const falling = recent3[0] > recent3[1] && recent3[1] > recent3[2];
+        const allActive = recent3.every((v) => v > 0);
+        const falling = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const drop = recent3[0] - recent3[2];
         if (falling && drop >= 0.5) {
           actions.push({
@@ -280,11 +284,13 @@ export class PaidSocialReachDrawerComponent {
         insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
       }
 
-      // ROAS trend
+      // ROAS trend — streak claims require all three months to have actual
+      // ROAS (> 0); zero-filled no-campaign months are spend gaps, not trend.
       if (monthlyRoas && monthlyRoas.length >= 3) {
         const recent3 = monthlyRoas.slice(-3);
-        const isDecreasing = recent3[0] > recent3[1] && recent3[1] > recent3[2];
-        const isIncreasing = recent3[0] < recent3[1] && recent3[1] < recent3[2];
+        const allActive = recent3.every((v) => v > 0);
+        const isDecreasing = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
+        const isIncreasing = allActive && recent3[0] < recent3[1] && recent3[1] < recent3[2];
         if (isIncreasing) {
           insights.push({ text: `ROAS improving 3 months straight — now at ${recent3[2].toFixed(2)}x`, type: 'driver' });
         } else if (isDecreasing) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -192,7 +192,10 @@ export class PaidSocialReachDrawerComponent {
       const { roas, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
       // changePercentage from the API is ROAS MoM — impressions MoM must come
       // from the impressions series itself, or reach texts report the wrong metric.
-      const impressionsMomPct = computeMomPct(monthlyData);
+      // The series is calendar zero-filled: a latest month with no campaigns
+      // reads as ~-100% MoM — that's a spend gap, not a reach decline, so MoM
+      // claims require the latest month to have actual impressions.
+      const impressionsMomPct = (monthlyData.at(-1) ?? 0) > 0 ? computeMomPct(monthlyData) : null;
       const actions: MarketingRecommendedAction[] = [];
 
       // Losing money — the most urgent signal (includes 0.00x — spend with no attributed revenue)
@@ -254,8 +257,10 @@ export class PaidSocialReachDrawerComponent {
     return computed(() => {
       const { roas, totalReach, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
       // changePercentage from the API is ROAS MoM — impressions texts must use
-      // the impressions series' own MoM.
-      const impressionsMomPct = computeMomPct(monthlyData);
+      // the impressions series' own MoM. A zero-filled trailing no-campaign
+      // month would read as ~-100% MoM — a spend gap, not a reach decline —
+      // so MoM claims require the latest month to have actual impressions.
+      const impressionsMomPct = (monthlyData.at(-1) ?? 0) > 0 ? computeMomPct(monthlyData) : null;
       const insights: MarketingKeyInsight[] = [];
 
       if (totalReach === 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -219,12 +219,13 @@ export class PaidSocialReachDrawerComponent {
       }
 
       // ROAS trending down — separate from absolute level. All three months
-      // must have actual ROAS (> 0): the series is calendar zero-filled, so a
-      // month with no campaigns carries 0 — that's a spend gap, not a
-      // performance trend, and must not fabricate a "3 months straight" streak.
-      if (monthlyRoas && monthlyRoas.length >= 3) {
+      // must be ACTIVE, judged by the aligned zero-filled impressions series:
+      // a month with no impressions is a spend gap (must not fabricate a
+      // "3 months straight" streak), while a measured 0x ROAS in an active
+      // month (spend, no attributed revenue) is a legitimate trend point.
+      if (monthlyRoas && monthlyRoas.length >= 3 && monthlyData.length === monthlyRoas.length) {
         const recent3 = monthlyRoas.slice(-3);
-        const allActive = recent3.every((v) => v > 0);
+        const allActive = monthlyData.slice(-3).every((v) => v > 0);
         const falling = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const drop = recent3[0] - recent3[2];
         if (falling && drop >= 0.5) {
@@ -289,11 +290,12 @@ export class PaidSocialReachDrawerComponent {
         insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
       }
 
-      // ROAS trend — streak claims require all three months to have actual
-      // ROAS (> 0); zero-filled no-campaign months are spend gaps, not trend.
-      if (monthlyRoas && monthlyRoas.length >= 3) {
+      // ROAS trend — streak claims require all three months to be ACTIVE per
+      // the aligned impressions series: no-impression months are spend gaps,
+      // while a measured 0x ROAS in an active month is a real trend point.
+      if (monthlyRoas && monthlyRoas.length >= 3 && monthlyData.length === monthlyRoas.length) {
         const recent3 = monthlyRoas.slice(-3);
-        const allActive = recent3.every((v) => v > 0);
+        const allActive = monthlyData.slice(-3).every((v) => v > 0);
         const isDecreasing = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const isIncreasing = allActive && recent3[0] < recent3[1] && recent3[1] < recent3[2];
         if (isIncreasing) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -55,6 +55,9 @@ export class PaidSocialReachDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
+  // The server zero-fills monthlyData for calendar alignment, so array length
+  // no longer signals "no data" — presence of any actual impressions does.
+  protected readonly hasImpressionData: Signal<boolean> = computed(() => this.drawerData().monthlyData.some((v) => v > 0));
   protected readonly roasChartData: Signal<ChartData<'bar'>> = this.initRoasChartData();
   protected readonly hasRoasData: Signal<boolean> = computed(() => {
     const roas = this.drawerData().monthlyRoas;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -293,11 +293,17 @@ export class PaidSocialReachDrawerComponent {
       // Impressions trend
       // "grew to" must quote the latest MONTH's impressions — totalReach is the
       // whole window's cumulative figure, a different window than the MoM claim.
+      // A prior ACTIVE month with zero impressions is a real baseline, but a
+      // percentage from zero is undefined — report the rebound in absolute
+      // terms instead of dropping the insight.
       const latestMonthImpressions = monthlyData.at(-1) ?? 0;
+      const reboundFromActiveZero = (monthActive.at(-2) ?? false) && (monthlyData.at(-2) ?? 0) === 0 && latestMonthImpressions > 0;
       if (impressionsMomPct !== null && impressionsMomPct >= 10) {
         insights.push({ text: `Impressions grew ${impressionsMomPct.toFixed(1)}% MoM to ${formatNumber(latestMonthImpressions)}`, type: 'driver' });
       } else if (impressionsMomPct !== null && impressionsMomPct <= -5) {
         insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
+      } else if (reboundFromActiveZero) {
+        insights.push({ text: `Impressions rebounded from zero to ${formatNumber(latestMonthImpressions)} last month`, type: 'driver' });
       }
 
       // ROAS trend — streak claims require all three months to be ACTIVE

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -9,7 +9,7 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { createBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
-import { formatCurrency, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { computeMomPct, formatCurrency, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -169,7 +169,7 @@ export class PaidSocialReachDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getSocialReach(foundationSlug).pipe(
+          this.analyticsService.getSocialReach(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);
@@ -189,7 +189,10 @@ export class PaidSocialReachDrawerComponent {
 
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { roas, changePercentage, totalSpend, totalRevenue, monthlyRoas } = this.drawerData();
+      const { roas, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
+      // changePercentage from the API is ROAS MoM — impressions MoM must come
+      // from the impressions series itself, or reach texts report the wrong metric.
+      const impressionsMomPct = computeMomPct(monthlyData);
       const actions: MarketingRecommendedAction[] = [];
 
       // Losing money — the most urgent signal (includes 0.00x — spend with no attributed revenue)
@@ -229,10 +232,10 @@ export class PaidSocialReachDrawerComponent {
       }
 
       // Reach drop — separate from ROAS
-      if (changePercentage <= -10) {
+      if (impressionsMomPct !== null && impressionsMomPct <= -10) {
         actions.push({
           title: 'Investigate reach decline',
-          description: `Impressions dropped ${Math.abs(changePercentage).toFixed(1)}% MoM — review targeting, bid strategy, and platform algorithm changes`,
+          description: `Impressions dropped ${Math.abs(impressionsMomPct).toFixed(1)}% MoM — review targeting, bid strategy, and platform algorithm changes`,
           priority: 'high',
 
           actionType: 'investigate',
@@ -245,7 +248,10 @@ export class PaidSocialReachDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { roas, totalReach, totalSpend, totalRevenue, changePercentage, monthlyRoas } = this.drawerData();
+      const { roas, totalReach, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
+      // changePercentage from the API is ROAS MoM — impressions texts must use
+      // the impressions series' own MoM.
+      const impressionsMomPct = computeMomPct(monthlyData);
       const insights: MarketingKeyInsight[] = [];
 
       if (totalReach === 0) {
@@ -265,10 +271,10 @@ export class PaidSocialReachDrawerComponent {
       }
 
       // Impressions trend
-      if (changePercentage >= 10) {
-        insights.push({ text: `Impressions grew ${changePercentage.toFixed(1)}% MoM to ${formatNumber(totalReach)}`, type: 'driver' });
-      } else if (changePercentage <= -5) {
-        insights.push({ text: `Impressions declined ${Math.abs(changePercentage).toFixed(1)}% MoM`, type: 'warning' });
+      if (impressionsMomPct !== null && impressionsMomPct >= 10) {
+        insights.push({ text: `Impressions grew ${impressionsMomPct.toFixed(1)}% MoM to ${formatNumber(totalReach)}`, type: 'driver' });
+      } else if (impressionsMomPct !== null && impressionsMomPct <= -5) {
+        insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
       }
 
       // ROAS trend

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -56,8 +56,13 @@ export class PaidSocialReachDrawerComponent {
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
   // The server zero-fills monthlyData for calendar alignment, so array length
-  // no longer signals "no data" — presence of any actual impressions does.
-  protected readonly hasImpressionData: Signal<boolean> = computed(() => this.drawerData().monthlyData.some((v) => v > 0));
+  // no longer signals "no data" — presence of any campaign activity (spend or
+  // impressions) does; an active window that delivered zero impressions still
+  // warrants the chart rather than a "no data" state.
+  protected readonly hasImpressionData: Signal<boolean> = computed(() => {
+    const { monthlyData, monthlySpend } = this.drawerData();
+    return monthlyData.some((v, i) => v > 0 || (monthlySpend?.[i] ?? 0) > 0);
+  });
   protected readonly roasChartData: Signal<ChartData<'bar'>> = this.initRoasChartData();
   protected readonly hasRoasData: Signal<boolean> = computed(() => {
     const roas = this.drawerData().monthlyRoas;
@@ -192,13 +197,15 @@ export class PaidSocialReachDrawerComponent {
 
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { roas, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
+      const { roas, totalSpend, totalRevenue, monthlyRoas, monthlyData, monthlySpend } = this.drawerData();
       // changePercentage from the API is ROAS MoM — impressions MoM must come
       // from the impressions series itself, or reach texts report the wrong metric.
-      // The series is calendar zero-filled: a latest month with no campaigns
-      // reads as ~-100% MoM — that's a spend gap, not a reach decline, so MoM
-      // claims require the latest month to have actual impressions.
-      const impressionsMomPct = (monthlyData.at(-1) ?? 0) > 0 ? computeMomPct(monthlyData) : null;
+      // The series is calendar zero-filled: a month is ACTIVE when it had spend
+      // OR impressions — an active month that delivered zero impressions is a
+      // real observation (its ~-100% MoM is a genuine alert), while a month
+      // with neither is a spend gap that must not read as a reach decline.
+      const monthActive = monthlyData.map((v, i) => v > 0 || (monthlySpend?.[i] ?? 0) > 0);
+      const impressionsMomPct = (monthActive.at(-1) ?? false) ? computeMomPct(monthlyData) : null;
       const actions: MarketingRecommendedAction[] = [];
 
       // Losing money — the most urgent signal (includes 0.00x — spend with no attributed revenue)
@@ -222,13 +229,12 @@ export class PaidSocialReachDrawerComponent {
       }
 
       // ROAS trending down — separate from absolute level. All three months
-      // must be ACTIVE, judged by the aligned zero-filled impressions series:
-      // a month with no impressions is a spend gap (must not fabricate a
-      // "3 months straight" streak), while a measured 0x ROAS in an active
-      // month (spend, no attributed revenue) is a legitimate trend point.
-      if (monthlyRoas && monthlyRoas.length >= 3 && monthlyData.length === monthlyRoas.length) {
+      // must be ACTIVE (spend or impressions): inactive months are spend gaps
+      // that must not fabricate a "3 months straight" streak, while a measured
+      // 0x ROAS in an active month is a legitimate trend point.
+      if (monthlyRoas && monthlyRoas.length >= 3 && monthActive.length === monthlyRoas.length) {
         const recent3 = monthlyRoas.slice(-3);
-        const allActive = monthlyData.slice(-3).every((v) => v > 0);
+        const allActive = monthActive.slice(-3).every(Boolean);
         const falling = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const drop = recent3[0] - recent3[2];
         if (falling && drop >= 0.5) {
@@ -259,12 +265,13 @@ export class PaidSocialReachDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { roas, totalReach, totalSpend, totalRevenue, monthlyRoas, monthlyData } = this.drawerData();
+      const { roas, totalReach, totalSpend, totalRevenue, monthlyRoas, monthlyData, monthlySpend } = this.drawerData();
       // changePercentage from the API is ROAS MoM — impressions texts must use
-      // the impressions series' own MoM. A zero-filled trailing no-campaign
-      // month would read as ~-100% MoM — a spend gap, not a reach decline —
-      // so MoM claims require the latest month to have actual impressions.
-      const impressionsMomPct = (monthlyData.at(-1) ?? 0) > 0 ? computeMomPct(monthlyData) : null;
+      // the impressions series' own MoM. A month is ACTIVE when it had spend
+      // OR impressions; only an inactive trailing month (a spend gap) blocks
+      // the MoM claim — active-but-zero-impression months are real data.
+      const monthActive = monthlyData.map((v, i) => v > 0 || (monthlySpend?.[i] ?? 0) > 0);
+      const impressionsMomPct = (monthActive.at(-1) ?? false) ? computeMomPct(monthlyData) : null;
       const insights: MarketingKeyInsight[] = [];
 
       if (totalReach === 0) {
@@ -293,12 +300,12 @@ export class PaidSocialReachDrawerComponent {
         insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
       }
 
-      // ROAS trend — streak claims require all three months to be ACTIVE per
-      // the aligned impressions series: no-impression months are spend gaps,
-      // while a measured 0x ROAS in an active month is a real trend point.
-      if (monthlyRoas && monthlyRoas.length >= 3 && monthlyData.length === monthlyRoas.length) {
+      // ROAS trend — streak claims require all three months to be ACTIVE
+      // (spend or impressions): inactive months are spend gaps, while a
+      // measured 0x ROAS in an active month is a real trend point.
+      if (monthlyRoas && monthlyRoas.length >= 3 && monthActive.length === monthlyRoas.length) {
         const recent3 = monthlyRoas.slice(-3);
-        const allActive = monthlyData.slice(-3).every((v) => v > 0);
+        const allActive = monthActive.slice(-3).every(Boolean);
         const isDecreasing = allActive && recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const isIncreasing = allActive && recent3[0] < recent3[1] && recent3[1] < recent3[2];
         if (isIncreasing) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -271,8 +271,11 @@ export class PaidSocialReachDrawerComponent {
       }
 
       // Impressions trend
+      // "grew to" must quote the latest MONTH's impressions — totalReach is the
+      // whole window's cumulative figure, a different window than the MoM claim.
+      const latestMonthImpressions = monthlyData.at(-1) ?? 0;
       if (impressionsMomPct !== null && impressionsMomPct >= 10) {
-        insights.push({ text: `Impressions grew ${impressionsMomPct.toFixed(1)}% MoM to ${formatNumber(totalReach)}`, type: 'driver' });
+        insights.push({ text: `Impressions grew ${impressionsMomPct.toFixed(1)}% MoM to ${formatNumber(latestMonthImpressions)}`, type: 'driver' });
       } else if (impressionsMomPct !== null && impressionsMomPct <= -5) {
         insights.push({ text: `Impressions declined ${Math.abs(impressionsMomPct).toFixed(1)}% MoM`, type: 'warning' });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
-import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { monthLabelOrdinal, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -345,10 +345,9 @@ export class RevenueImpactDrawerComponent {
         // The backend series has no rows for months without campaigns, so the
         // last three entries can span gaps — "3 consecutive months" is only
         // claimable when the entries are truly adjacent calendar months.
-        const ordinals = recent3.map((entry) => {
-          const date = new Date(entry.month);
-          return date.getUTCFullYear() * 12 + date.getUTCMonth();
-        });
+        // entry.month is the raw CAMPAIGN_MONTH date serialization; parse it
+        // explicitly rather than via implementation-defined new Date(string).
+        const ordinals = recent3.map((entry) => monthLabelOrdinal(entry.month));
         const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
         const isRisingRev = consecutive && recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
         const isFallingRev = consecutive && recent3[0].revenue > recent3[1].revenue && recent3[1].revenue > recent3[2].revenue && recent3[0].revenue > 0;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -348,7 +348,16 @@ export class RevenueImpactDrawerComponent {
         // entry.month is the raw CAMPAIGN_MONTH date serialization; parse it
         // explicitly rather than via implementation-defined new Date(string).
         const ordinals = recent3.map((entry) => monthLabelOrdinal(entry.month));
-        const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
+        // Freshness: the newest entry must be the latest completed month —
+        // this drawer's data always covers a last-6 window anchored at now,
+        // and a stale streak must not read as a present-tense claim.
+        const now = new Date();
+        const latestCompletedOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth() - 1;
+        const consecutive =
+          ordinals.every((ord) => Number.isFinite(ord)) &&
+          ordinals[1] === ordinals[0] + 1 &&
+          ordinals[2] === ordinals[1] + 1 &&
+          ordinals[2] >= latestCompletedOrdinal;
         const isRisingRev = consecutive && recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
         const isFallingRev = consecutive && recent3[0].revenue > recent3[1].revenue && recent3[1].revenue > recent3[2].revenue && recent3[0].revenue > 0;
         if (isRisingRev) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -342,8 +342,16 @@ export class RevenueImpactDrawerComponent {
 
       if (paidMedia.monthlyTrend.length >= 3) {
         const recent3 = paidMedia.monthlyTrend.slice(-3);
-        const isRisingRev = recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
-        const isFallingRev = recent3[0].revenue > recent3[1].revenue && recent3[1].revenue > recent3[2].revenue && recent3[0].revenue > 0;
+        // The backend series has no rows for months without campaigns, so the
+        // last three entries can span gaps — "3 consecutive months" is only
+        // claimable when the entries are truly adjacent calendar months.
+        const ordinals = recent3.map((entry) => {
+          const date = new Date(entry.month);
+          return date.getUTCFullYear() * 12 + date.getUTCMonth();
+        });
+        const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
+        const isRisingRev = consecutive && recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
+        const isFallingRev = consecutive && recent3[0].revenue > recent3[1].revenue && recent3[1].revenue > recent3[2].revenue && recent3[0].revenue > 0;
         if (isRisingRev) {
           insights.push({ text: 'Paid-attributed revenue rising for 3 consecutive months', type: 'driver' });
         } else if (isFallingRev) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -187,7 +187,7 @@ export class SocialMediaDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getSocialMedia(foundationSlug).pipe(
+          this.analyticsService.getSocialMedia(foundationSlug, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -308,11 +308,19 @@ export class SocialMediaDrawerComponent {
         }
       }
 
-      // Monthly trend
+      // Monthly trend. The series only contains months with snapshots, so the
+      // last three points can span gaps — "3 consecutive months" is only
+      // claimable when they are truly adjacent calendar months. (Follower
+      // counts are snapshots, so zero-filling gaps would be wrong here.)
       if (monthlyData.length >= 3) {
         const recent3 = monthlyData.slice(-3);
-        const isGrowing = recent3[0].totalFollowers < recent3[1].totalFollowers && recent3[1].totalFollowers < recent3[2].totalFollowers;
-        const isShrinking = recent3[0].totalFollowers > recent3[1].totalFollowers && recent3[1].totalFollowers > recent3[2].totalFollowers;
+        const ordinals = recent3.map((point) => {
+          const date = new Date(point.month);
+          return date.getUTCFullYear() * 12 + date.getUTCMonth();
+        });
+        const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
+        const isGrowing = consecutive && recent3[0].totalFollowers < recent3[1].totalFollowers && recent3[1].totalFollowers < recent3[2].totalFollowers;
+        const isShrinking = consecutive && recent3[0].totalFollowers > recent3[1].totalFollowers && recent3[1].totalFollowers > recent3[2].totalFollowers;
         if (isGrowing) {
           insights.push({ text: 'Follower count growing for 3 consecutive months', type: 'driver' });
         } else if (isShrinking) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -10,7 +10,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { formatNumber, hexToRgba, monthLabelOrdinal, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -312,12 +312,11 @@ export class SocialMediaDrawerComponent {
       // last three points can span gaps — "3 consecutive months" is only
       // claimable when they are truly adjacent calendar months. (Follower
       // counts are snapshots, so zero-filling gaps would be wrong here.)
+      // point.month is the server's en-US "MMM YYYY" label; parse it
+      // explicitly rather than via implementation-defined new Date(string).
       if (monthlyData.length >= 3) {
         const recent3 = monthlyData.slice(-3);
-        const ordinals = recent3.map((point) => {
-          const date = new Date(point.month);
-          return date.getUTCFullYear() * 12 + date.getUTCMonth();
-        });
+        const ordinals = recent3.map((point) => monthLabelOrdinal(point.month));
         const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
         const isGrowing = consecutive && recent3[0].totalFollowers < recent3[1].totalFollowers && recent3[1].totalFollowers < recent3[2].totalFollowers;
         const isShrinking = consecutive && recent3[0].totalFollowers > recent3[1].totalFollowers && recent3[1].totalFollowers > recent3[2].totalFollowers;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -317,7 +317,16 @@ export class SocialMediaDrawerComponent {
       if (monthlyData.length >= 3) {
         const recent3 = monthlyData.slice(-3);
         const ordinals = recent3.map((point) => monthLabelOrdinal(point.month));
-        const consecutive = ordinals.every((ord) => Number.isFinite(ord)) && ordinals[1] === ordinals[0] + 1 && ordinals[2] === ordinals[1] + 1;
+        // Freshness: the newest point must be the latest completed month —
+        // this drawer always requests a last-6 window anchored at now, and a
+        // stale Jan–Mar streak must not read as a present-tense claim in July.
+        const now = new Date();
+        const latestCompletedOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth() - 1;
+        const consecutive =
+          ordinals.every((ord) => Number.isFinite(ord)) &&
+          ordinals[1] === ordinals[0] + 1 &&
+          ordinals[2] === ordinals[1] + 1 &&
+          ordinals[2] >= latestCompletedOrdinal;
         const isGrowing = consecutive && recent3[0].totalFollowers < recent3[1].totalFollowers && recent3[1].totalFollowers < recent3[2].totalFollowers;
         const isShrinking = consecutive && recent3[0].totalFollowers > recent3[1].totalFollowers && recent3[1].totalFollowers > recent3[2].totalFollowers;
         if (isGrowing) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -49,7 +49,7 @@
         </lfx-card>
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Page Views</span>
+            <span class="text-sm text-gray-500">Page Views (last 30 days)</span>
             <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalPageViews() }}</span>
           </div>
         </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -43,7 +43,7 @@
       <div class="flex gap-4" data-testid="website-visits-drawer-stats">
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Total Sessions</span>
+            <span class="text-sm text-gray-500">Total Sessions (last 30 days)</span>
             <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalSessions() }}</span>
           </div>
         </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -162,7 +162,7 @@ export class WebsiteVisitsDrawerComponent {
         map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
         switchMap((foundationSlug) =>
-          this.analyticsService.getWebActivitiesSummary(foundationSlug).pipe(
+          this.analyticsService.getWebActivitiesSummary(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -84,9 +84,12 @@ export class EmailTabComponent {
       const lastOpens = minLen > 0 ? (opens[minLen - 1] ?? 0) : 0;
       const prevOpens = minLen > 1 ? (opens[minLen - 2] ?? 0) : 0;
 
-      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : 0;
-      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : 0;
-      const openRateMom = prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
+      // Open rate is undefined without sends — the series is calendar
+      // zero-filled, so a no-send month must suppress the value and the MoM
+      // delta rather than read as a measured 0% (a false -100% decline).
+      const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : null;
+      const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : null;
+      const openRateMom = currentOpenRate !== null && prevOpenRate !== null && prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
         {
@@ -122,7 +125,7 @@ export class EmailTabComponent {
           label: 'Open Rate',
           icon: 'fa-light fa-chart-simple',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${currentOpenRate.toFixed(1)}%`,
+          value: currentOpenRate !== null ? `${currentOpenRate.toFixed(1)}%` : '—',
           momChange: formatChangePct(openRateMom, 'MoM'),
           momTrend: trendDirection(openRateMom),
           momTrendClass: trendColorClass(openRateMom),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -89,7 +89,8 @@ export class EmailTabComponent {
       // delta rather than read as a measured 0% (a false -100% decline).
       const currentOpenRate = lastSends !== undefined && lastSends > 0 ? (lastOpens / lastSends) * 100 : null;
       const prevOpenRate = prevSends !== undefined && prevSends > 0 ? (prevOpens / prevSends) * 100 : null;
-      const openRateMom = currentOpenRate !== null && prevOpenRate !== null && prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
+      const openRateMom =
+        currentOpenRate !== null && prevOpenRate !== null && prevOpenRate > 0 ? ((currentOpenRate - prevOpenRate) / prevOpenRate) * 100 : null;
 
       return [
         {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -73,9 +73,6 @@ export class EmailTabComponent {
       const totalOpens = data.monthlyOpens?.reduce((s, v) => s + v, 0) ?? 0;
       const changePct = data.momChangePercentage;
 
-      const sendsMom = computeMomPct(data.monthlySends);
-      const opensMom = computeMomPct(data.monthlyOpens);
-
       const sends = data.monthlySends ?? [];
       const opens = data.monthlyOpens ?? [];
       const minLen = Math.min(sends.length, opens.length);
@@ -83,6 +80,13 @@ export class EmailTabComponent {
       const prevSends = minLen > 1 ? sends[minLen - 2] : undefined;
       const lastOpens = minLen > 0 ? (opens[minLen - 1] ?? 0) : 0;
       const prevOpens = minLen > 1 ? (opens[minLen - 2] ?? 0) : 0;
+
+      // The series are calendar zero-filled, so a trailing no-send month
+      // would read as a -100% MoM on sends/opens — a send gap, not a decline.
+      // MoM claims require the latest month to have actual sends.
+      const lastMonthActive = lastSends !== undefined && lastSends > 0;
+      const sendsMom = lastMonthActive ? computeMomPct(data.monthlySends) : null;
+      const opensMom = lastMonthActive ? computeMomPct(data.monthlyOpens) : null;
 
       // Open rate is undefined without sends — the series is calendar
       // zero-filled, so a no-send month must suppress the value and the MoM

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1257,7 +1257,7 @@ export class AnalyticsService {
           totalMentions: 0,
           sentiment: { positive: 0, neutral: 0, negative: 0 },
           sentimentMomChangePp: 0,
-          mentionMomChangePct: 0,
+          mentionMomChangePct: null,
           trend: 'up' as const,
           monthlyMentions: [],
           topProjects: [],

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2339,9 +2339,13 @@ export class ProjectService {
         const lastOrd = monthOrdinal(ProjectService.toIsoDate(monthlyRows[monthlyRows.length - 1].PUBLISHED_MONTH_DATE));
         const priorOrd = monthOrdinal(ProjectService.toIsoDate(monthlyRows[monthlyRows.length - 2].PUBLISHED_MONTH_DATE));
         const adjacent = lastOrd !== null && priorOrd !== null && lastOrd - priorOrd === 1;
+        // Both months must have SENDS: with zero-filled rows, a trailing
+        // no-send month has CTR 0 by construction — CTR is undefined without
+        // sends, and reporting it as a "-100% MoM" drop would be noise.
+        const lastHasSends = (monthlyRows[monthlyRows.length - 1].TOTAL_SENDS ?? 0) > 0;
         const current = rawMonthlyCtrs[rawMonthlyCtrs.length - 1];
         const prior = rawMonthlyCtrs[rawMonthlyCtrs.length - 2];
-        if (adjacent && prior > 0) {
+        if (adjacent && lastHasSends && prior > 0) {
           momChangePercentage = ((current - prior) / prior) * 100;
         }
       }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2562,7 +2562,7 @@ export class ProjectService {
 
       // Block 4: Monthly impressions (bar chart, period range)
       const monthlyImpressionsQuery = `
-      SELECT CAMPAIGN_MONTH, SUM(IMPRESSIONS) AS IMPRESSIONS
+      SELECT CAMPAIGN_MONTH, SUM(IMPRESSIONS) AS IMPRESSIONS, SUM(SPEND) AS SPEND
       FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
       WHERE CAMPAIGN_MONTH >= TO_DATE(?)
         AND CAMPAIGN_MONTH < TO_DATE(?)
@@ -2636,7 +2636,7 @@ export class ProjectService {
           ...foundationParams,
           ...classificationParams,
         ]),
-        this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [
+        this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number; SPEND: number }>(monthlyImpressionsQuery, [
           this.trendStartDate(resolved),
           resolved.endDate,
           ...foundationParams,
@@ -2746,9 +2746,11 @@ export class ProjectService {
         return match ? match[1] : monthKey(new Date(value));
       };
       const impressionsByMonth = new Map(monthlyImpressionsResult.rows.map((row) => [rowMonthKey(row.CAMPAIGN_MONTH), row.IMPRESSIONS ?? 0]));
+      const spendByMonth = new Map(monthlyImpressionsResult.rows.map((row) => [rowMonthKey(row.CAMPAIGN_MONTH), row.SPEND ?? 0]));
       const roasByMonth = new Map(monthlyRoasResult.rows.map((row) => [rowMonthKey(row.CAMPAIGN_MONTH), Math.round((row.ROAS ?? 0) * 100) / 100]));
       const monthlyData: number[] = [];
       const monthlyRoas: number[] = [];
+      const monthlySpend: number[] = [];
       const monthlyLabels: string[] = [];
       // Walk from trendStartDate, not resolved.startDate — the monthly queries
       // bind trendStartDate (one month earlier for single-month periods, to give
@@ -2760,6 +2762,7 @@ export class ProjectService {
         const key = monthKey(monthCursor);
         monthlyData.push(impressionsByMonth.get(key) ?? 0);
         monthlyRoas.push(roasByMonth.get(key) ?? 0);
+        monthlySpend.push(spendByMonth.get(key) ?? 0);
         monthlyLabels.push(monthCursor.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }));
         monthCursor.setUTCMonth(monthCursor.getUTCMonth() + 1);
       }
@@ -2944,6 +2947,7 @@ export class ProjectService {
         monthlyData,
         monthlyLabels,
         monthlyRoas,
+        monthlySpend,
         channelGroups,
         projectBreakdown,
         platformBreakdown,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2312,9 +2312,20 @@ export class ProjectService {
 
       let momChangePercentage: number | null = null;
       if (rawMonthlyCtrs.length >= 2) {
+        // Only claim MoM when the last two rows are ADJACENT calendar months —
+        // the series has no rows for months without sends, so the tail can
+        // otherwise span a gap and compare non-consecutive months.
+        const monthOrdinal = (iso: string | null): number | null => {
+          if (!iso) return null;
+          const [year, month] = iso.split('-').map(Number);
+          return year * 12 + month;
+        };
+        const lastOrd = monthOrdinal(ProjectService.toIsoDate(monthlyResult.rows[monthlyResult.rows.length - 1].PUBLISHED_MONTH_DATE));
+        const priorOrd = monthOrdinal(ProjectService.toIsoDate(monthlyResult.rows[monthlyResult.rows.length - 2].PUBLISHED_MONTH_DATE));
+        const adjacent = lastOrd !== null && priorOrd !== null && lastOrd - priorOrd === 1;
         const current = rawMonthlyCtrs[rawMonthlyCtrs.length - 1];
         const prior = rawMonthlyCtrs[rawMonthlyCtrs.length - 2];
-        if (prior > 0) {
+        if (adjacent && prior > 0) {
           momChangePercentage = ((current - prior) / prior) * 100;
         }
       }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5375,7 +5375,7 @@ export class ProjectService {
       totalMentions: 0,
       sentiment: { positive: 0, neutral: 0, negative: 0 },
       sentimentMomChangePp: 0,
-      mentionMomChangePct: 0,
+      mentionMomChangePct: null,
       trend: 'up',
       monthlyMentions: [],
       topProjects: [],
@@ -5535,7 +5535,7 @@ export class ProjectService {
       // older pair). resolved.endDate is the exclusive first-of-next-month
       // boundary, so the expected newest month is one ordinal below it —
       // wall-clock "now" would permanently zero MoM for historical periods.
-      let mentionMomChangePct = 0;
+      let mentionMomChangePct: number | null = null;
       if (trendResult.rows.length >= 2) {
         const rowOrdinal = (value: string | Date): number => {
           const date = new Date(value);
@@ -5583,7 +5583,7 @@ export class ProjectService {
         sentiment: { positive: positivePct, neutral: neutralPct, negative: negativePct },
         sentimentMomChangePp,
         mentionMomChangePct,
-        trend: mentionMomChangePct >= 0 ? 'up' : 'down',
+        trend: (mentionMomChangePct ?? 0) >= 0 ? 'up' : 'down',
         monthlyMentions,
         topProjects,
         topPositiveMentions: positiveMentionsResult.rows.map(mapMention),

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2287,8 +2287,24 @@ export class ProjectService {
       // Note: Snowflake values are already percentages (e.g., 2.32 = 2.32%), no conversion needed
       const summaryRow = summaryResult.rows[0];
 
+      // Zero-fill the monthly rows across the query window (trendStartDate →
+      // endDate): EMAIL_CTR_BY_MONTH emits only months that had sends, so gaps
+      // would let every downstream series (CTR, sends, opens) and any MoM
+      // comparison span non-consecutive months. A month with no sends genuinely
+      // had 0 sends and 0 opens.
+      const emailMonthKey = (d: Date): string => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+      const emailRowsByMonth = new Map(monthlyResult.rows.map((row) => [(ProjectService.toIsoDate(row.PUBLISHED_MONTH_DATE) ?? '').slice(0, 7), row]));
+      const monthlyRows: typeof monthlyResult.rows = [];
+      const emailCursor = new Date(`${this.trendStartDate(resolved)}T00:00:00Z`);
+      const emailFillEnd = new Date(`${resolved.endDate}T00:00:00Z`);
+      while (emailCursor < emailFillEnd) {
+        const key = emailMonthKey(emailCursor);
+        monthlyRows.push(emailRowsByMonth.get(key) ?? { PUBLISHED_MONTH: key, PUBLISHED_MONTH_DATE: `${key}-01`, TOTAL_SENDS: 0, TOTAL_OPENS: 0 });
+        emailCursor.setUTCMonth(emailCursor.getUTCMonth() + 1);
+      }
+
       // Compute unrounded CTR from raw sends/opens for MoM precision
-      const rawMonthlyCtrs = monthlyResult.rows.map((row) => {
+      const rawMonthlyCtrs = monthlyRows.map((row) => {
         const sends = row.TOTAL_SENDS ?? 0;
         const opens = row.TOTAL_OPENS ?? 0;
         return sends > 0 ? (opens * 100) / sends : 0;
@@ -2296,7 +2312,7 @@ export class ProjectService {
       const monthlyData = rawMonthlyCtrs.map((v) => Math.round(v * 10) / 10);
 
       const summaryCtr = summaryRow ? Math.round((summaryRow.CTR_LAST_COMPLETED_MONTH ?? 0) * 10) / 10 : 0;
-      const periodRows = monthlyResult.rows.filter((row) => (ProjectService.toIsoDate(row.PUBLISHED_MONTH_DATE) ?? '') >= resolved.startDate);
+      const periodRows = monthlyRows.filter((row) => (ProjectService.toIsoDate(row.PUBLISHED_MONTH_DATE) ?? '') >= resolved.startDate);
       const periodSends = periodRows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
       const periodOpens = periodRows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
       const periodCtr = periodSends > 0 ? Math.round(((periodOpens * 100) / periodSends) * 10) / 10 : 0;
@@ -2320,8 +2336,8 @@ export class ProjectService {
           const [year, month] = iso.split('-').map(Number);
           return year * 12 + month;
         };
-        const lastOrd = monthOrdinal(ProjectService.toIsoDate(monthlyResult.rows[monthlyResult.rows.length - 1].PUBLISHED_MONTH_DATE));
-        const priorOrd = monthOrdinal(ProjectService.toIsoDate(monthlyResult.rows[monthlyResult.rows.length - 2].PUBLISHED_MONTH_DATE));
+        const lastOrd = monthOrdinal(ProjectService.toIsoDate(monthlyRows[monthlyRows.length - 1].PUBLISHED_MONTH_DATE));
+        const priorOrd = monthOrdinal(ProjectService.toIsoDate(monthlyRows[monthlyRows.length - 2].PUBLISHED_MONTH_DATE));
         const adjacent = lastOrd !== null && priorOrd !== null && lastOrd - priorOrd === 1;
         const current = rawMonthlyCtrs[rawMonthlyCtrs.length - 1];
         const prior = rawMonthlyCtrs[rawMonthlyCtrs.length - 2];
@@ -2330,11 +2346,11 @@ export class ProjectService {
         }
       }
 
-      const monthlySends = monthlyResult.rows.map((row) => row.TOTAL_SENDS ?? 0);
-      const monthlyOpens = monthlyResult.rows.map((row) => row.TOTAL_OPENS ?? 0);
-      const monthlyLabels = monthlyResult.rows.map((row) => {
+      const monthlySends = monthlyRows.map((row) => row.TOTAL_SENDS ?? 0);
+      const monthlyOpens = monthlyRows.map((row) => row.TOTAL_OPENS ?? 0);
+      const monthlyLabels = monthlyRows.map((row) => {
         const date = new Date(row.PUBLISHED_MONTH_DATE);
-        return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
       });
 
       const campaignGroups = campaignResult.rows.map((row) => ({

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2689,12 +2689,28 @@ export class ProjectService {
         };
       }
 
-      const monthlyData = monthlyImpressionsResult.rows.map((row) => row.IMPRESSIONS ?? 0);
-      const monthlyRoas = monthlyRoasResult.rows.map((row) => Math.round((row.ROAS ?? 0) * 100) / 100);
-      const monthlyLabels = monthlyImpressionsResult.rows.map((row) => {
-        const date = new Date(row.CAMPAIGN_MONTH);
-        return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-      });
+      // Zero-fill the monthly series across the whole requested period: the
+      // queries emit only months that have campaign rows, so gaps would leave
+      // the series with non-consecutive months — chart bars would sit side by
+      // side across a hole, and client-side MoM (computeMomPct on monthlyData)
+      // would compare two non-adjacent months as if consecutive. A month with
+      // no campaigns genuinely had 0 impressions; ROAS fills as 0 for series
+      // alignment (labels are shared across both series).
+      const monthKey = (d: Date): string => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+      const impressionsByMonth = new Map(monthlyImpressionsResult.rows.map((row) => [monthKey(new Date(row.CAMPAIGN_MONTH)), row.IMPRESSIONS ?? 0]));
+      const roasByMonth = new Map(monthlyRoasResult.rows.map((row) => [monthKey(new Date(row.CAMPAIGN_MONTH)), Math.round((row.ROAS ?? 0) * 100) / 100]));
+      const monthlyData: number[] = [];
+      const monthlyRoas: number[] = [];
+      const monthlyLabels: string[] = [];
+      const monthCursor = new Date(`${resolved.startDate}T00:00:00Z`);
+      const periodEnd = new Date(`${resolved.endDate}T00:00:00Z`);
+      while (monthCursor < periodEnd) {
+        const key = monthKey(monthCursor);
+        monthlyData.push(impressionsByMonth.get(key) ?? 0);
+        monthlyRoas.push(roasByMonth.get(key) ?? 0);
+        monthlyLabels.push(monthCursor.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }));
+        monthCursor.setUTCMonth(monthCursor.getUTCMonth() + 1);
+      }
 
       // Aggregate platform rows by CHANNEL for channelGroups and platformBreakdown
       const platformMap = new Map<

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5494,12 +5494,24 @@ export class ProjectService {
       const sentimentMomChangePp = 0;
 
       // Mention volume MoM: compute from the two most recent months in trendResult.
-      // trendResult is ordered DESC, so [0] = latest, [1] = previous.
+      // trendResult is ordered DESC, so [0] = latest, [1] = previous. The series
+      // only contains months with mention rows, so a genuine MoM additionally
+      // requires: (a) the two rows are ADJACENT calendar months, and (b) the
+      // newest row is the latest completed month (not a stale older pair).
       let mentionMomChangePct = 0;
       if (trendResult.rows.length >= 2) {
+        const rowOrdinal = (value: string | Date): number => {
+          const date = new Date(value);
+          return date.getUTCFullYear() * 12 + date.getUTCMonth();
+        };
+        const now = new Date();
+        const latestCompletedOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth() - 1;
+        const newestOrdinal = rowOrdinal(trendResult.rows[0].MONTH_START_DATE);
+        const priorOrdinal = rowOrdinal(trendResult.rows[1].MONTH_START_DATE);
+        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= latestCompletedOrdinal;
         const current = trendResult.rows[0].MENTION_COUNT ?? 0;
         const previous = trendResult.rows[1].MENTION_COUNT ?? 0;
-        if (previous > 0) {
+        if (validPair && previous > 0) {
           mentionMomChangePct = Number((((current - previous) / previous) * 100).toFixed(2));
         }
       }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2715,8 +2715,16 @@ export class ProjectService {
       // no campaigns genuinely had 0 impressions; ROAS fills as 0 for series
       // alignment (labels are shared across both series).
       const monthKey = (d: Date): string => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
-      const impressionsByMonth = new Map(monthlyImpressionsResult.rows.map((row) => [monthKey(new Date(row.CAMPAIGN_MONTH)), row.IMPRESSIONS ?? 0]));
-      const roasByMonth = new Map(monthlyRoasResult.rows.map((row) => [monthKey(new Date(row.CAMPAIGN_MONTH)), Math.round((row.ROAS ?? 0) * 100) / 100]));
+      // Row keys come from the CAMPAIGN_MONTH string prefix, not a Date
+      // round-trip — new Date() on a driver-provided value could carry a
+      // timezone shift and land the row one month off the fill loop's
+      // explicit-UTC keys.
+      const rowMonthKey = (value: string): string => {
+        const match = /^(\d{4}-\d{2})/.exec(String(value));
+        return match ? match[1] : monthKey(new Date(value));
+      };
+      const impressionsByMonth = new Map(monthlyImpressionsResult.rows.map((row) => [rowMonthKey(row.CAMPAIGN_MONTH), row.IMPRESSIONS ?? 0]));
+      const roasByMonth = new Map(monthlyRoasResult.rows.map((row) => [rowMonthKey(row.CAMPAIGN_MONTH), Math.round((row.ROAS ?? 0) * 100) / 100]));
       const monthlyData: number[] = [];
       const monthlyRoas: number[] = [];
       const monthlyLabels: string[] = [];

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2316,7 +2316,10 @@ export class ProjectService {
       const periodSends = periodRows.reduce((sum, row) => sum + (row.TOTAL_SENDS ?? 0), 0);
       const periodOpens = periodRows.reduce((sum, row) => sum + (row.TOTAL_OPENS ?? 0), 0);
       const periodCtr = periodSends > 0 ? Math.round(((periodOpens * 100) / periodSends) * 10) / 10 : 0;
-      const currentCtr = periodRows.length > 0 ? periodCtr : summaryCtr;
+      // Fall back to summaryCtr when the period had no sends — zero-filling
+      // makes periodRows always non-empty, so row count no longer signals
+      // whether the monthly view actually had data.
+      const currentCtr = periodSends > 0 ? periodCtr : summaryCtr;
 
       let changePercentage = 0;
       if (monthlyData.length >= 2 && currentCtr > 0) {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2137,11 +2137,12 @@ export class ProjectService {
       // to preserve the no-data signal.
       const dailyData: number[] = [];
       const dailyLabels: string[] = [];
-      if (dailyResult.rows.length > 0) {
+      const firstBucketIso = dailyResult.rows.length > 0 ? ProjectService.toIsoDate(dailyResult.rows[0].ACTIVITY_DATE) : null;
+      if (firstBucketIso) {
         const weekRowsByStart = new Map(
           dailyResult.rows.map((row) => [(ProjectService.toIsoDate(row.ACTIVITY_DATE) ?? '').slice(0, 10), row.DAILY_SESSIONS ?? 0])
         );
-        const firstBucket = new Date(`${(ProjectService.toIsoDate(dailyResult.rows[0].ACTIVITY_DATE) ?? '').slice(0, 10)}T00:00:00Z`);
+        const firstBucket = new Date(`${firstBucketIso.slice(0, 10)}T00:00:00Z`);
         const weekCursor = new Date(`${resolved.startDate}T00:00:00Z`);
         weekCursor.setUTCDate(weekCursor.getUTCDate() - ((weekCursor.getUTCDay() - firstBucket.getUTCDay() + 7) % 7));
         const weekFillEnd = new Date(`${resolved.endDate}T00:00:00Z`);
@@ -2150,6 +2151,13 @@ export class ProjectService {
           dailyData.push(weekRowsByStart.get(key) ?? 0);
           dailyLabels.push(weekCursor.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }));
           weekCursor.setUTCDate(weekCursor.getUTCDate() + 7);
+        }
+      } else if (dailyResult.rows.length > 0) {
+        // Unparseable bucket dates — fall back to direct row mapping rather
+        // than walking NaN-anchored week cursors and breaking the response.
+        for (const row of dailyResult.rows) {
+          dailyData.push(row.DAILY_SESSIONS ?? 0);
+          dailyLabels.push(new Date(row.ACTIVITY_DATE).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }));
         }
       }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2128,11 +2128,30 @@ export class ProjectService {
       const totalSessions = domainGroups.reduce((sum, g) => sum + g.totalSessions, 0);
       const totalPageViews = domainGroups.reduce((sum, g) => sum + g.totalPageViews, 0);
 
-      const dailyData = dailyResult.rows.map((row) => row.DAILY_SESSIONS ?? 0);
-      const dailyLabels = dailyResult.rows.map((row) => {
-        const date = new Date(row.ACTIVITY_DATE);
-        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-      });
+      // Zero-fill weekly buckets across the requested range: the query only
+      // groups weeks that HAVE rows, so a silent week would otherwise vanish
+      // and downstream trend math (e.g. the drawer's midpoint split) would
+      // compare observed weeks instead of the window's calendar halves. The
+      // walk is anchored to the first returned bucket's weekday so keys match
+      // Snowflake's DATE_TRUNC('WEEK') alignment; an empty result stays empty
+      // to preserve the no-data signal.
+      const dailyData: number[] = [];
+      const dailyLabels: string[] = [];
+      if (dailyResult.rows.length > 0) {
+        const weekRowsByStart = new Map(
+          dailyResult.rows.map((row) => [(ProjectService.toIsoDate(row.ACTIVITY_DATE) ?? '').slice(0, 10), row.DAILY_SESSIONS ?? 0])
+        );
+        const firstBucket = new Date(`${(ProjectService.toIsoDate(dailyResult.rows[0].ACTIVITY_DATE) ?? '').slice(0, 10)}T00:00:00Z`);
+        const weekCursor = new Date(`${resolved.startDate}T00:00:00Z`);
+        weekCursor.setUTCDate(weekCursor.getUTCDate() - ((weekCursor.getUTCDay() - firstBucket.getUTCDay() + 7) % 7));
+        const weekFillEnd = new Date(`${resolved.endDate}T00:00:00Z`);
+        while (weekCursor < weekFillEnd) {
+          const key = weekCursor.toISOString().slice(0, 10);
+          dailyData.push(weekRowsByStart.get(key) ?? 0);
+          dailyLabels.push(weekCursor.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }));
+          weekCursor.setUTCDate(weekCursor.getUTCDate() + 7);
+        }
+      }
 
       return { totalSessions, totalPageViews, domainGroups, dailyData, dailyLabels };
     } catch (error) {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3420,7 +3420,11 @@ export class ProjectService {
       const monthlyData = trendResult.rows.map((row) => {
         const date = new Date(row.SNAPSHOT_MONTH);
         return {
-          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+          // timeZone: 'UTC' is load-bearing: the drawer parses this label back
+          // into a calendar ordinal for its streak-freshness check, and a
+          // non-UTC server would shift UTC-midnight month starts into the
+          // prior month's label.
+          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }),
           totalFollowers: row.TOTAL_FOLLOWERS ?? 0,
         };
       });
@@ -5564,7 +5568,9 @@ export class ProjectService {
       const monthlyMentions: NorthStarMonthlyDataPoint[] = [...trendResult.rows].reverse().map((row) => {
         const date = new Date(row.MONTH_START_DATE);
         return {
-          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+          // Display-only today, but pinned to UTC to match the convention for
+          // month labels elsewhere (a non-UTC server would shift the label).
+          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }),
           value: row.MENTION_COUNT ?? 0,
         };
       });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5497,18 +5497,21 @@ export class ProjectService {
       // trendResult is ordered DESC, so [0] = latest, [1] = previous. The series
       // only contains months with mention rows, so a genuine MoM additionally
       // requires: (a) the two rows are ADJACENT calendar months, and (b) the
-      // newest row is the latest completed month (not a stale older pair).
+      // newest row is the final month of the REQUESTED period (not a stale
+      // older pair). resolved.endDate is the exclusive first-of-next-month
+      // boundary, so the expected newest month is one ordinal below it —
+      // wall-clock "now" would permanently zero MoM for historical periods.
       let mentionMomChangePct = 0;
       if (trendResult.rows.length >= 2) {
         const rowOrdinal = (value: string | Date): number => {
           const date = new Date(value);
           return date.getUTCFullYear() * 12 + date.getUTCMonth();
         };
-        const now = new Date();
-        const latestCompletedOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth() - 1;
+        const periodEnd = new Date(resolved.endDate);
+        const expectedNewestOrdinal = periodEnd.getUTCFullYear() * 12 + periodEnd.getUTCMonth() - 1;
         const newestOrdinal = rowOrdinal(trendResult.rows[0].MONTH_START_DATE);
         const priorOrdinal = rowOrdinal(trendResult.rows[1].MONTH_START_DATE);
-        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= latestCompletedOrdinal;
+        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= expectedNewestOrdinal;
         const current = trendResult.rows[0].MENTION_COUNT ?? 0;
         const previous = trendResult.rows[1].MENTION_COUNT ?? 0;
         if (validPair && previous > 0) {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2672,22 +2672,9 @@ export class ProjectService {
       const roas = periodRoas;
       const roasMomPct = previousRoas > 0 ? ((currentRoas - previousRoas) / previousRoas) * 100 : 0;
 
-      if (monthlyImpressionsResult.rows.length === 0) {
-        return {
-          totalReach,
-          roas: Math.round(roas * 100) / 100,
-          totalSpend,
-          totalRevenue,
-          changePercentage: Math.round(roasMomPct * 10) / 10,
-          trend: roasMomPct >= 0 ? 'up' : 'down',
-          monthlyData: [],
-          monthlyLabels: [],
-          monthlyRoas: [],
-          channelGroups: [],
-          projectBreakdown: [],
-          platformBreakdown: [],
-        };
-      }
+      // NOTE: no early return on an empty month set — a valid period with zero
+      // paid rows still gets a zero-filled series below, so consumers always
+      // receive calendar-complete arrays for the requested window.
 
       // Zero-fill the monthly series across the whole requested period: the
       // queries emit only months that have campaign rows, so gaps would leave
@@ -2702,7 +2689,11 @@ export class ProjectService {
       const monthlyData: number[] = [];
       const monthlyRoas: number[] = [];
       const monthlyLabels: string[] = [];
-      const monthCursor = new Date(`${resolved.startDate}T00:00:00Z`);
+      // Walk from trendStartDate, not resolved.startDate — the monthly queries
+      // bind trendStartDate (one month earlier for single-month periods, to give
+      // the trend charts an MoM reference point), so the fill window must match
+      // the query window or that extra month's data would be silently dropped.
+      const monthCursor = new Date(`${this.trendStartDate(resolved)}T00:00:00Z`);
       const periodEnd = new Date(`${resolved.endDate}T00:00:00Z`);
       while (monthCursor < periodEnd) {
         const key = monthKey(monthCursor);

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -758,9 +758,10 @@ function flatSparklineData(value: number): number[] {
   return [Math.max(value - nudge, 0), value, value, value, value, value + nudge];
 }
 
-/** Build a time-window label from the number of data points available.
- *  Reports the ACTUAL count — capping at 6 mislabeled the 12-month member
- *  growth series as "Last 6 months". */
+/** Build a "Last N months" label from a caller-supplied month count. Formats
+ *  exactly the number it is given (no cap — capping at 6 mislabeled the
+ *  12-month member growth series); callers estimating the count from other
+ *  granularities (e.g. weeks) own the accuracy of the estimate. */
 function trendWindow(monthCount: number): string {
   if (monthCount <= 0) return '';
   return `Last ${monthCount} month${monthCount === 1 ? '' : 's'}`;

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -990,7 +990,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       trend: trendFromChange(eventGrowth.registrantYoyChange),
       subtitle:
         eventGrowth.monthlyData.length > 0
-          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: ${trendWindow(eventGrowth.monthlyData.length)}`
+          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: last ${eventGrowth.monthlyData.length} quarter${eventGrowth.monthlyData.length === 1 ? '' : 's'}`
           : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -843,22 +843,25 @@ function monthlyValues(data: { month: string; value: number }[]): number[] {
   return data.map((d) => d.value);
 }
 
-/** Compute MoM change display from a monthly numeric series (last vs second-to-last). */
+/** Compute MoM change display from a monthly numeric series (last vs second-to-last).
+ *  Both months must be non-zero: the feeding series are calendar zero-filled,
+ *  so a trailing no-activity month would otherwise display as a steep -100%. */
 function seriesMomChange(series: number[]): string | undefined {
   if (series.length < 2) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
-  if (prev === 0) return undefined;
+  if (prev === 0 || curr === 0) return undefined;
   return formatMomChange(((curr - prev) / prev) * 100);
 }
 
 /** Compute trend direction from a monthly numeric series.
- *  Uses the same MoM % formula as seriesMomChange so the color matches the displayed text. */
+ *  Uses the same MoM % formula and zero guards as seriesMomChange so the
+ *  color never diverges from the displayed text. */
 function seriesTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
   if (series.length < 2) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
-  if (prev === 0) return undefined;
+  if (prev === 0 || curr === 0) return undefined;
   return trendFromChange(((curr - prev) / prev) * 100);
 }
 
@@ -1057,9 +1060,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         ),
         protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
       ],
+      // monthlyMentions only holds months WITH rows, so its length is not the
+      // reporting window — the ED caller always requests last-6, so the trend
+      // window is labeled directly rather than derived from row count.
       caption:
         brandHealth.monthlyMentions.length > 0
-          ? `${formatNumber(brandHealth.totalMentions)} mentions (30d) · trend ${trendWindow(brandHealth.monthlyMentions.length).toLowerCase()}`
+          ? `${formatNumber(brandHealth.totalMentions)} mentions (30d) · trend last 6 months`
           : `${formatNumber(brandHealth.totalMentions)} mentions (30d)`,
       tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -886,6 +886,9 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   const emailTotalOpens = emailCtr.monthlyOpens.reduce((sum, v) => sum + v, 0);
   const emailOpenRate = emailTotalSends > 0 ? (emailTotalOpens / emailTotalSends) * 100 : 0;
 
+  // Paid month activity: spend OR impressions (a spend-only month is active).
+  const paidActivity = paidCampaign.monthlyData.map((v, i) => v + (paidCampaign.monthlySpend?.[i] ?? 0));
+
   return [
     // === Campaign Performance (dual-signal: Email Opens + Paid Impressions) ===
     // Categorised as 'memberships' (North Star) intentionally — campaigns directly
@@ -913,8 +916,11 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           formatNumber(paidCampaign.totalReach) + ' impressions',
           paidCampaign.monthlyData,
           lfxColors.violet[500],
-          seriesMomChange(paidCampaign.monthlyData),
-          seriesTrendDirection(paidCampaign.monthlyData)
+          // Activity = spend OR impressions per month: an active month that
+          // delivered zero impressions keeps its real MoM, while zero-filled
+          // no-campaign months stay suppressed.
+          seriesMomChange(paidCampaign.monthlyData, paidActivity),
+          seriesTrendDirection(paidCampaign.monthlyData, paidActivity)
         ),
       ],
       caption: trendWindow(Math.max(emailCtr.monthlyOpens.length, paidCampaign.monthlyData.length)),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -759,10 +759,10 @@ function flatSparklineData(value: number): number[] {
 }
 
 /** Build a time-window label from the number of data points available.
- *  Returns "Last N months" for any count, capped at 6. */
+ *  Reports the ACTUAL count — capping at 6 mislabeled the 12-month member
+ *  growth series as "Last 6 months". */
 function trendWindow(monthCount: number): string {
   if (monthCount <= 0) return '';
-  if (monthCount >= 6) return 'Last 6 months';
   return `Last ${monthCount} month${monthCount === 1 ? '' : 's'}`;
 }
 
@@ -955,7 +955,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         lfxColors.blue[500]
       ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Total paying corporate members with monthly net new over the last 6 months.',
+      tooltipText: 'Total paying corporate members with monthly net new over the last 12 months.',
       drawerType: DashboardDrawerType.NorthStarMemberAcquisition,
     } as DashboardMetricCard,
     {
@@ -1022,7 +1022,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           normalizeTrend(brandReach.changePercentage, brandReach.trend)
         ),
         protoDualSignal(
-          'Monthly Sessions',
+          'Sessions (30d)',
           formatNumber(brandReach.totalMonthlySessions),
           brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : [],
           lfxColors.violet[500],
@@ -1058,8 +1058,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       ],
       caption:
         brandHealth.monthlyMentions.length > 0
-          ? `${formatNumber(brandHealth.totalMentions)} mentions · ${trendWindow(brandHealth.monthlyMentions.length)}`
-          : `${formatNumber(brandHealth.totalMentions)} mentions`,
+          ? `${formatNumber(brandHealth.totalMentions)} mentions (30d) · trend ${trendWindow(brandHealth.monthlyMentions.length).toLowerCase()}`
+          : `${formatNumber(brandHealth.totalMentions)} mentions (30d)`,
       tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,
     } as DashboardMetricCard,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1064,8 +1064,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           formatNumber(brandHealth.totalMentions),
           brandHealth.monthlyMentions.length > 0 ? monthlyValues(brandHealth.monthlyMentions) : [],
           lfxColors.blue[500],
-          formatMomChange(brandHealth.mentionMomChangePct),
-          normalizeTrend(brandHealth.mentionMomChangePct, brandHealth.trend)
+          // null (no genuine MoM available) renders the same as a flat month:
+          // hidden delta, neutral trend.
+          formatMomChange(brandHealth.mentionMomChangePct ?? 0),
+          normalizeTrend(brandHealth.mentionMomChangePct ?? 0, brandHealth.trend)
         ),
         protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
       ],

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1021,7 +1021,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-reach',
-      description: 'Social followers across all platforms and monthly website sessions.',
+      description: 'Social followers across all platforms and rolling 30-day website sessions.',
       customContentType: 'dual-signal',
       dualSignals: [
         protoDualSignal(
@@ -1047,7 +1047,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       // reporting window — the endpoint covers a fixed six-month range, so
       // the window is labeled directly rather than estimated from row count.
       caption: brandReach.weeklyTrend.length > 0 ? `${brandReach.activePlatforms} platforms · Last 6 months` : `${brandReach.activePlatforms} platforms`,
-      tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
+      tooltipText: 'Social followers across all platforms (stock) and rolling 30-day website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,
     } as DashboardMetricCard,
     {

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -844,24 +844,27 @@ function monthlyValues(data: { month: string; value: number }[]): number[] {
 }
 
 /** Compute MoM change display from a monthly numeric series (last vs second-to-last).
- *  Both months must be non-zero: the feeding series are calendar zero-filled,
- *  so a trailing no-activity month would otherwise display as a steep -100%. */
-function seriesMomChange(series: number[]): string | undefined {
-  if (series.length < 2) return undefined;
+ *  The feeding series are calendar zero-filled, so months with no underlying
+ *  activity must not read as measured zeros. By default the series is its own
+ *  activity signal; callers whose series can carry a legitimate zero in an
+ *  active month (e.g. opens in a month that HAD sends) pass the aligned
+ *  activity series separately so real -100% observations still display. */
+function seriesMomChange(series: number[], activity: number[] = series): string | undefined {
+  if (series.length < 2 || activity.length !== series.length) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
-  if (prev === 0 || curr === 0) return undefined;
+  if (prev === 0 || activity[activity.length - 1] === 0 || activity[activity.length - 2] === 0) return undefined;
   return formatMomChange(((curr - prev) / prev) * 100);
 }
 
 /** Compute trend direction from a monthly numeric series.
- *  Uses the same MoM % formula and zero guards as seriesMomChange so the
+ *  Uses the same MoM % formula and activity guards as seriesMomChange so the
  *  color never diverges from the displayed text. */
-function seriesTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
-  if (series.length < 2) return undefined;
+function seriesTrendDirection(series: number[], activity: number[] = series): 'up' | 'down' | 'neutral' | undefined {
+  if (series.length < 2 || activity.length !== series.length) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
-  if (prev === 0 || curr === 0) return undefined;
+  if (prev === 0 || activity[activity.length - 1] === 0 || activity[activity.length - 2] === 0) return undefined;
   return trendFromChange(((curr - prev) / prev) * 100);
 }
 
@@ -902,8 +905,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           formatNumber(emailTotalOpens) + ' opens',
           emailCtr.monthlyOpens,
           lfxColors.blue[500],
-          seriesMomChange(emailCtr.monthlyOpens),
-          seriesTrendDirection(emailCtr.monthlyOpens)
+          seriesMomChange(emailCtr.monthlyOpens, emailCtr.monthlySends),
+          seriesTrendDirection(emailCtr.monthlyOpens, emailCtr.monthlySends)
         ),
         protoDualSignal(
           `Paid · ${formatCurrency(paidCampaign.totalSpend)} spend`,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1037,10 +1037,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down')
         ),
       ],
-      caption:
-        brandReach.weeklyTrend.length > 0
-          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.max(1, Math.round(brandReach.weeklyTrend.length / 4.345)))}`
-          : `${brandReach.activePlatforms} platforms`,
+      // weeklyTrend only holds weeks WITH rows, so its length is not the
+      // reporting window — the endpoint covers a fixed six-month range, so
+      // the window is labeled directly rather than estimated from row count.
+      caption: brandReach.weeklyTrend.length > 0 ? `${brandReach.activePlatforms} platforms · Last 6 months` : `${brandReach.activePlatforms} platforms`,
       tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,
     } as DashboardMetricCard,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1047,7 +1047,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       // reporting window — the endpoint covers a fixed six-month range, so
       // the window is labeled directly rather than estimated from row count.
       caption: brandReach.weeklyTrend.length > 0 ? `${brandReach.activePlatforms} platforms · Last 6 months` : `${brandReach.activePlatforms} platforms`,
-      tooltipText: 'Social followers across all platforms (stock) and rolling 30-day website sessions (flow). Shown separately — these are different metric types.',
+      tooltipText:
+        'Social followers across all platforms (stock) and rolling 30-day website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,
     } as DashboardMetricCard,
     {

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -949,7 +949,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
       subtitle:
         memberAcquisition.totalMembersMonthlyData.length > 0
-          ? `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · ${trendWindow(memberAcquisition.totalMembersMonthlyData.length)}`
+          ? `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 12 months`
           : `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}%`,
       chartData: protoSparkline(
         memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : flatSparklineData(memberAcquisition.totalMembers),
@@ -991,7 +991,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       trend: trendFromChange(eventGrowth.registrantYoyChange),
       subtitle:
         eventGrowth.monthlyData.length > 0
-          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: last ${eventGrowth.monthlyData.length} quarter${eventGrowth.monthlyData.length === 1 ? '' : 's'}`
+          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: quarterly, 3 yrs + upcoming`
           : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1032,7 +1032,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       ],
       caption:
         brandReach.weeklyTrend.length > 0
-          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.ceil(brandReach.weeklyTrend.length / 4))}`
+          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.round(brandReach.weeklyTrend.length / 4.345))}`
           : `${brandReach.activePlatforms} platforms`,
       tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1032,7 +1032,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       ],
       caption:
         brandReach.weeklyTrend.length > 0
-          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.round(brandReach.weeklyTrend.length / 4.345))}`
+          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.max(1, Math.round(brandReach.weeklyTrend.length / 4.345)))}`
           : `${brandReach.activePlatforms} platforms`,
       tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2707,6 +2707,13 @@ export interface SocialReachResponse {
   monthlyData: number[];
   monthlyLabels: string[];
   monthlyRoas: number[];
+  /**
+   * Zero-filled monthly ad spend aligned with monthlyData/monthlyRoas.
+   * Distinguishes a truly inactive month (no spend, no impressions) from an
+   * active campaign month that delivered zero impressions — consumers should
+   * treat a month as active when spend OR impressions are non-zero.
+   */
+  monthlySpend?: number[];
   channelGroups: SocialReachChannelGroup[];
   projectBreakdown?: PaidProjectBreakdown[];
   platformBreakdown?: PaidPlatformBreakdown[];

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3144,7 +3144,8 @@ export interface BrandHealthResponse {
   sentiment: BrandHealthSentimentBreakdown;
   sentimentMomChangePp: number;
   /** Mention volume MoM change (%), computed from monthly trend data. */
-  mentionMomChangePct: number;
+  /** MoM change in mention volume; null when the trend rows cannot support a genuine MoM (gap or stale pair) — 0 is a measured flat month. */
+  mentionMomChangePct: number | null;
   trend: 'up' | 'down';
   monthlyMentions: NorthStarMonthlyDataPoint[];
   topProjects: BrandHealthTopProject[];

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -129,7 +129,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
   if (reengagement.reengagementMomChange < -5) {
     actions.push({
       title: 'Address re-engagement rate decline',
-      description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
+      description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}pp MoM — review post-event follow-up effectiveness`,
       priority: 'high',
 
       actionType: 'decline',
@@ -147,7 +147,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
   }
 
   if (actions.length === 0) {
-    const growthSuffix = reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}%` : '';
+    const growthSuffix = reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}pp MoM` : '';
     actions.push({
       title: 'Continue flywheel optimization',
       description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${growthSuffix} across ${formatNumber(attendees)} attendees`,
@@ -199,10 +199,10 @@ export function buildFlywheelKeyInsights(data: FlywheelConversionResponse | null
   }
 
   if (reengagement.reengagementMomChange > 3) {
-    insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}% — flywheel is accelerating`, type: 'driver' });
+    insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}pp MoM — flywheel is accelerating`, type: 'driver' });
   } else if (reengagement.reengagementMomChange < -3) {
     insights.push({
-      text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% — flywheel is slowing`,
+      text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}pp MoM — flywheel is slowing`,
       type: 'warning',
     });
   }

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -41,6 +41,22 @@ export function formatChangePct(pct: number | null | undefined, suffix: string):
   return `${sign}${pct.toFixed(1)}% ${suffix}`;
 }
 
+const MONTH_LABEL_REGEX = /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4})$/;
+const SHORT_MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Calendar month ordinal (year * 12 + monthIndex) parsed from an en-US
+ * "MMM YYYY" label (e.g. "Jan 2026"), as emitted by
+ * toLocaleDateString('en-US', { month: 'short', year: 'numeric' }).
+ * Returns NaN for any other format so adjacency checks fail closed
+ * instead of relying on implementation-defined Date string parsing.
+ */
+export function monthLabelOrdinal(label: string): number {
+  const match = MONTH_LABEL_REGEX.exec(label);
+  if (!match) return Number.NaN;
+  return Number(match[2]) * 12 + SHORT_MONTH_NAMES.indexOf(match[1]);
+}
+
 /** Returns MoM percent change from the last two values of a monthly series. */
 export function computeMomPct(arr: number[] | undefined): number | null {
   if (!arr || arr.length < 2) return null;

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -42,19 +42,28 @@ export function formatChangePct(pct: number | null | undefined, suffix: string):
 }
 
 const MONTH_LABEL_REGEX = /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4})$/;
+const ISO_YEAR_MONTH_REGEX = /^(\d{4})-(0[1-9]|1[0-2])(?:$|-)/;
 const SHORT_MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 /**
- * Calendar month ordinal (year * 12 + monthIndex) parsed from an en-US
- * "MMM YYYY" label (e.g. "Jan 2026"), as emitted by
- * toLocaleDateString('en-US', { month: 'short', year: 'numeric' }).
- * Returns NaN for any other format so adjacency checks fail closed
- * instead of relying on implementation-defined Date string parsing.
+ * Calendar month ordinal (year * 12 + monthIndex) parsed deterministically
+ * from a month string: either an en-US "MMM YYYY" label (e.g. "Jan 2026",
+ * as emitted by toLocaleDateString('en-US', { month: 'short', year:
+ * 'numeric' })) or an ISO "YYYY-MM"-prefixed string ("2026-01",
+ * "2026-01-01", "2026-01-01T00:00:00.000Z"). Returns NaN for any other
+ * format so adjacency checks fail closed instead of relying on
+ * implementation-defined Date string parsing.
  */
 export function monthLabelOrdinal(label: string): number {
-  const match = MONTH_LABEL_REGEX.exec(label);
-  if (!match) return Number.NaN;
-  return Number(match[2]) * 12 + SHORT_MONTH_NAMES.indexOf(match[1]);
+  const labelMatch = MONTH_LABEL_REGEX.exec(label);
+  if (labelMatch) {
+    return Number(labelMatch[2]) * 12 + SHORT_MONTH_NAMES.indexOf(labelMatch[1]);
+  }
+  const isoMatch = ISO_YEAR_MONTH_REGEX.exec(label);
+  if (isoMatch) {
+    return Number(isoMatch[1]) * 12 + (Number(isoMatch[2]) - 1);
+  }
+  return Number.NaN;
 }
 
 /** Returns MoM percent change from the last two values of a monthly series. */


### PR DESCRIPTION
## Summary

An audit of every ED drawer's time-window claims against its backing Snowflake queries found that the **"over the last 6 months" labels (11 places across 6 drawers) sat over 1–2 months of data**: no caller ever passed a `period`, so every analytics endpoint silently fell back to `defaultPeriodRange()` = previous completed calendar month. The 6-month wording was clearly the design intent everywhere — so this PR fixes the *data* to match the labels, rather than relabeling the accident (the approach chosen in #1096's scope-narrowing).

## Changes

**Period wiring (11 call sites):** the marketing-overview `forkJoin` and the self-loading drawers (Campaign Performance, Paid Social, Social Media, Website Visits) now pass the existing `last-6` preset. Every "last 6 months" trend chart genuinely covers 6 months; the Social Media follower chart now renders at all (it used to hide itself with 1 data point); Revenue Impact's "3 consecutive months" insights can now mathematically fire. **MoM KPIs are unchanged** — both windows share the same period end.

**Three mislabeled metrics fixed:**
- Paid Social insights labeled **ROAS MoM as impressions MoM** — impressions texts now compute MoM from the impressions series (`computeMomPct`), and "grew to N" quotes the latest month rather than the window cumulative
- Member Acquisition's growth chart pulls **12 months but said 6** — label now says 12 (incl. the card's `trendWindow` cap removal)
- Flywheel "Growth" KPI is a **percentage-point delta rendered with a % suffix** — now renders `pp`

**Window-label truth on cards and 30-day metrics:** email drawer CTR texts use the true MoM (the old field flatlines by construction under a trailing window); Brand Reach "Monthly Sessions" → "Sessions (30d)"; Website Visits "Total Sessions (last 30 days)"; Brand Health caption separates its 30-day mentions total from the 6-month trend.

## Conscious trade-offs (reviewers, please confirm)

1. **Top Positive/Negative Mentions** now rank by relevance across 6 months instead of ~2 — an older but highly relevant mention can outrank a fresh one. Labels are window-agnostic, so not incorrect; flag if a shorter mentions window is preferred.
2. **Drawer ROAS-style KPI cards** show window-blended values with an MoM badge beside them — same presentation Marketing Impact uses with its period presets.

## Verification

Types, lint, prettier, and full production build pass. The `trailing` period path is already exercised in production by the Marketing Impact page presets — this PR extends the same mechanism to the ED drawers.

Related: #1096 (restored these subtitles pending this PR), #1105 (same label-truth arc for Event Growth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)