### PR TITLE
fix(profile): recover linux alias claim UI after partial forward failure

### DIFF
--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -1,0 +1,109 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Linux.com email tab — partial-claim-failure recovery.
+ *
+ * Covers the fix for the non-atomic claim flow: `add_alias` (auth-service) succeeds
+ * but `set_target` (forwards-service) fails, so the server returns
+ * `502 FORWARD_SET_FAILED`. The alias is immutable once claimed, so the component
+ * must recover into the claimed/edit view (where the user can set forwarding)
+ * instead of leaving them stuck on the claim form, where a retry would fail with
+ * `already_claimed`.
+ */
+
+import type { EmailManagementData, LinuxAliasData } from '@lfx-one/shared/interfaces';
+import { expect, Page, test } from '@playwright/test';
+
+const DOMAIN = 'example.org';
+const ALIAS = 'jane-doe';
+const PRIMARY_EMAIL = 'jane.doe@example.com';
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test run and surface a useful failure.
+  }
+}
+
+/** Stub the sibling fetches the tab needs to render deterministically. */
+async function stubProfileContext(page: Page): Promise<void> {
+  await page.route('**/api/profile/emails', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    const body: EmailManagementData = { primary_email: PRIMARY_EMAIL, alternate_emails: [] };
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  await page.route('**/api/profile/identities', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+}
+
+/**
+ * Stub the alias GET/POST pair so the claim endpoint fails on the forward step
+ * while the alias itself is left claimed upstream (mirrors the real add_alias-then-
+ * set_target semantics: the first call succeeds and is immutable, the second fails).
+ */
+async function stubPartialClaimFailure(page: Page): Promise<void> {
+  let claimed = false;
+
+  await page.route('**/api/profile/linux-email', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    const body: LinuxAliasData = claimed
+      ? { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: `${ALIAS}@${DOMAIN}`, forwardTo: null }
+      : { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null };
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  await page.route('**/api/profile/linux-email/claim', (route) => {
+    if (route.request().method() !== 'POST') return route.fallback();
+    // The alias claim (add_alias) succeeded and is immutable — only the forward
+    // (set_target) step failed. The next GET must reflect the claimed state.
+    claimed = true;
+    return route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'Alias claimed, but forwarding could not be set. Please set your forwarding address again.',
+        code: 'FORWARD_SET_FAILED',
+        service: 'profile_controller',
+        path: '/api/profile/linux-email/claim',
+      }),
+    });
+  });
+}
+
+test.describe('Linux.com email — partial claim failure recovery', () => {
+  test('recovers into the claimed/edit view after a FORWARD_SET_FAILED response', async ({ page }) => {
+    await stubProfileContext(page);
+    await stubPartialClaimFailure(page);
+
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // Starting state: purchased but unclaimed — the claim form is shown.
+    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
+
+    await page.getByTestId('linux-email-alias-input').locator('input').fill(ALIAS);
+    await page.getByTestId('linux-email-claim-forward-select').click();
+    await page.getByRole('option', { name: `${PRIMARY_EMAIL} (Primary)`, exact: true }).click();
+    await page.getByTestId('linux-email-claim-button').locator('button').click();
+
+    // Recovery: even though the claim request failed, the tab transitions to the
+    // claimed/edit view (not left stuck on the claim form) and surfaces a guiding toast.
+    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claimed-address')).toContainText(`${ALIAS}@${DOMAIN}`);
+    await expect(page.getByTestId('linux-email-forward-form')).toBeVisible();
+    await expect(page.getByText(/set your forwarding address below/i)).toBeVisible();
+
+    // The claim form is gone — retrying the old form is no longer possible (and would
+    // have failed with already_claimed since the alias is immutable upstream).
+    await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
+  });
+});

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -97,10 +97,12 @@ test.describe('Linux.com email — partial claim failure recovery', () => {
 
     // Recovery: even though the claim request failed, the tab transitions to the
     // claimed/edit view (not left stuck on the claim form) and surfaces a guiding toast.
+    // The toast assertion runs first — PrimeNG toasts have a short default lifetime, so
+    // checking it after the other awaits below risks it disappearing before we see it.
+    await expect(page.getByText(/set your forwarding address below/i)).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-claimed-address')).toContainText(`${ALIAS}@${DOMAIN}`);
     await expect(page.getByTestId('linux-email-forward-form')).toBeVisible();
-    await expect(page.getByText(/set your forwarding address below/i)).toBeVisible();
 
     // The claim form is gone — retrying the old form is no longer possible (and would
     // have failed with already_claimed since the alias is immutable upstream).

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -39,6 +39,10 @@ export class ProfileLinuxEmailComponent {
   // One-shot guard (sessionStorage key) so a tokenless re-auth round-trip can't loop.
   private readonly reauthFlagKey = 'linux-email:forward-reauth-attempted';
 
+  // Set on FORWARD_SET_FAILED so the recovery toast can be shown once the refreshed
+  // alias state is known, instead of assuming the refetch lands on 'claimed'.
+  private pendingForwardRecoveryToast = false;
+
   // Refresh mechanism
   private refresh = new BehaviorSubject<void>(undefined);
 
@@ -141,15 +145,12 @@ export class ProfileLinuxEmailComponent {
           // Partial failure: the alias was claimed but forwarding could not be set. The
           // alias is immutable upstream, so a retry here would just fail with
           // already_claimed — recover into the claimed/edit state instead of stranding
-          // the user on the claim form.
+          // the user on the claim form. The recovery toast is deferred until the refetch
+          // resolves — see maybeShowForwardRecoveryToast.
           if (err.error?.code === 'FORWARD_SET_FAILED') {
             this.claimForm.reset();
+            this.pendingForwardRecoveryToast = true;
             this.refresh.next();
-            this.messageService.add({
-              severity: 'warn',
-              summary: 'Alias claimed',
-              detail: 'Your alias is active, but we couldn’t set forwarding. Please set your forwarding address below.',
-            });
             return;
           }
           this.handleError(err, 'Failed to claim your alias. Please try again.');
@@ -224,6 +225,7 @@ export class ProfileLinuxEmailComponent {
             tap(({ alias, emails }) => {
               this.applyFormDefaults(alias, emails);
               this.maybeReauthForForward(alias);
+              this.maybeShowForwardRecoveryToast(alias);
             }),
             finalize(() => this.loading.set(false))
           );
@@ -253,6 +255,27 @@ export class ProfileLinuxEmailComponent {
     if (!alias.authorizeUrl || sessionStorage.getItem(this.reauthFlagKey)) return;
     sessionStorage.setItem(this.reauthFlagKey, '1');
     window.location.href = alias.authorizeUrl;
+  }
+
+  /**
+   * Shows the FORWARD_SET_FAILED recovery toast once the refreshed alias state is known,
+   * so the message matches what actually renders. If the forwards-service is still down
+   * (the same outage that likely caused the original failure), the refetch degrades to
+   * 'service_unavailable' and the retry panel renders instead of the claimed/edit form —
+   * in that case the toast must not tell the user to look for a form "below".
+   */
+  private maybeShowForwardRecoveryToast(alias: LinuxAliasData | null): void {
+    if (!this.pendingForwardRecoveryToast) return;
+    this.pendingForwardRecoveryToast = false;
+
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Alias claimed',
+      detail:
+        alias?.state === 'claimed'
+          ? 'Your alias is active, but we couldn’t set forwarding. Please set your forwarding address below.'
+          : 'Your alias is active, but we couldn’t set forwarding. Please try again once the service is available.',
+    });
   }
 
   /** Default the forward selection to the current target (if any) or the primary email. */

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -137,7 +137,23 @@ export class ProfileLinuxEmailComponent {
           this.refresh.next();
           this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Your Linux.com alias is active.' });
         },
-        error: (err: HttpErrorResponse) => this.handleError(err, 'Failed to claim your alias. Please try again.'),
+        error: (err: HttpErrorResponse) => {
+          // Partial failure: the alias was claimed but forwarding could not be set. The
+          // alias is immutable upstream, so a retry here would just fail with
+          // already_claimed — recover into the claimed/edit state instead of stranding
+          // the user on the claim form.
+          if (err.error?.code === 'FORWARD_SET_FAILED') {
+            this.claimForm.reset();
+            this.refresh.next();
+            this.messageService.add({
+              severity: 'warn',
+              summary: 'Alias claimed',
+              detail: 'Your alias is active, but we couldn’t set forwarding. Please set your forwarding address below.',
+            });
+            return;
+          }
+          this.handleError(err, 'Failed to claim your alias. Please try again.');
+        },
       });
   }
 


### PR DESCRIPTION
## Summary
- Recover into the claimed/edit view when the Linux.com alias claim partially fails (`502 FORWARD_SET_FAILED` — alias claimed but forwarding target set failed), instead of stranding the user on the claim form where a retry would hit `409 already_claimed`
- Add an E2E spec covering the partial-failure recovery path

Fixes #LFXV2-2703