### PR TITLE
feat(invite): use committee_invite_uid for unambiguous committee invite acceptance

### DIFF
--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
+import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 import { errors as JoseErrors, JWK, JWT } from 'jose';
 
@@ -12,11 +12,6 @@ import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
 import { NatsService } from '../services/nats.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
-
-/** Delay between auto-accept retries while waiting for FGA invitee tuple propagation. */
-const FGA_PROPAGATION_DELAY_MS = 3_000;
-/** Maximum number of retries after the initial attempt (total wait: up to 9 s). */
-const FGA_PROPAGATION_MAX_RETRIES = 3;
 
 /** Controller for non-LF user invite acceptance via signed JWT. */
 export class InviteController {
@@ -103,7 +98,7 @@ export class InviteController {
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
-      const pendingCommitteeInvite = (await this.autoAcceptPendingCommitteeInvites(req, payload)) ?? undefined;
+      await this.autoAcceptCommitteeInvite(req, payload);
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,
@@ -111,7 +106,7 @@ export class InviteController {
         resource_uid: payload.resource_uid,
       });
 
-      res.json({ return_url: safeReturnUrl, ...(pendingCommitteeInvite && { pending_committee_invite: pendingCommitteeInvite }) });
+      res.json({ return_url: safeReturnUrl });
     } catch (error) {
       next(error);
     }
@@ -141,24 +136,19 @@ export class InviteController {
 
   /**
    * When the LFID invite JWT carries a {@link InviteTokenPayload.committee_invite_uid} claim,
-   * accepts that specific committee_invite so a committee_member is created with the session
-   * username. No-ops if the claim is absent — the LFID invite may be unrelated to any committee.
+   * accepts that specific committee_invite directly via the committee API. No-ops when the claim
+   * is absent — the LFID invite is unrelated to any committee.
    *
-   * Returns a {@link PendingCommitteeInviteForOrg} when the invite requires an organization
-   * that was not pre-filled — the caller should surface this to the client for manual org
-   * collection. Returns null when the invite was accepted or the flow was skipped.
-   *
-   * Throws when the invite cannot be found or accepted after all FGA-propagation retries so
-   * the caller can surface the failure rather than silently redirecting to a stale committee page.
+   * Requires the authenticated session email to match the email embedded in the JWT.
+   * Throws on acceptance failure so the caller can surface it rather than silently redirecting.
    */
-  private async autoAcceptPendingCommitteeInvites(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
-    // JWT.verify only validates the signature — committee_invite_uid can be null, a non-string,
-    // or whitespace if the token was crafted with malformed custom claims. Normalize to a trimmed
-    // string and treat only a non-empty result as an actionable claim.
+  private async autoAcceptCommitteeInvite(req: Request, payload: InviteTokenPayload): Promise<void> {
+    // JWT.verify only validates the signature — claims can be null, non-strings, or whitespace.
     const committeeInviteUid = typeof payload.committee_invite_uid === 'string' ? payload.committee_invite_uid.trim() : '';
+    const committeeUid = typeof payload.resource_uid === 'string' ? payload.resource_uid.trim() : '';
+
     if (!committeeInviteUid) {
-      // No committee_invite_uid means the LFID invite is unrelated to any committee.
-      return null;
+      return; // LFID invite is unrelated to any committee — nothing to accept
     }
 
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
@@ -168,54 +158,32 @@ export class InviteController {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — LFID invite token has no email claim', {
         invite_uid: payload.invite_uid,
       });
-      return null;
+      return;
     }
 
     if (!sessionEmail) {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — session email unavailable', {
         invite_uid: payload.invite_uid,
       });
-      return null;
+      return;
     }
 
     if (invitedEmail !== sessionEmail) {
       logger.info(req, 'accept_invite', 'Skipping committee invite auto-accept — session email does not match LFID invite token email', {
         invite_uid: payload.invite_uid,
       });
-      return null;
+      return;
     }
 
-    for (let attempt = 0; attempt <= FGA_PROPAGATION_MAX_RETRIES; attempt++) {
-      if (attempt > 0) {
-        await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));
-      }
-
-      const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
-        invitedEmail,
-        committeeInviteUid,
-      });
-
-      // null or PendingCommitteeInviteForOrg = invite was found and processed; return immediately.
-      // undefined = invite not visible yet in the email index — FGA invitee tuple may still be
-      // propagating; retry.
-      if (result !== undefined) {
-        return result ?? null;
-      }
+    if (!committeeUid) {
+      throw new Error(`Cannot accept committee invite ${committeeInviteUid}: resource_uid (committee UID) is absent from the JWT`);
     }
 
-    // All retries returned undefined — the invite was never found in the pending email index.
-    // This can happen when the invite was already accepted (response lost, page refreshed) and
-    // is no longer pending, OR when FGA propagation has not completed. Call accept directly:
-    // the committee-service AcceptInvite endpoint is idempotent (already-accepted → success),
-    // so this covers both cases. resource_uid carries the committee UID for committee LFID invites.
-    const committeeUid = typeof payload.resource_uid === 'string' ? payload.resource_uid.trim() : '';
-    if (committeeUid) {
-      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
-      return null;
-    }
+    await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
 
-    throw new Error(
-      `Committee invite ${committeeInviteUid} could not be accepted: not found after ${FGA_PROPAGATION_MAX_RETRIES} retries and resource_uid (committee UID) is absent from the JWT`
-    );
+    logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
+      committee_uid: committeeUid,
+      committee_invite_uid: committeeInviteUid,
+    });
   }
 }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { InviteTokenPayload } from '@lfx-one/shared/interfaces';
+import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 import { errors as JoseErrors, JWK, JWT } from 'jose';
 
@@ -12,6 +12,11 @@ import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
 import { NatsService } from '../services/nats.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
+
+/** Delay before each legacy email-search attempt while waiting for FGA tuple propagation. */
+const FGA_PROPAGATION_DELAY_MS = 3_000;
+/** Total number of legacy email-search attempts (each preceded by FGA_PROPAGATION_DELAY_MS). */
+const FGA_LEGACY_MAX_ATTEMPTS = 3;
 
 /** Controller for non-LF user invite acceptance via signed JWT. */
 export class InviteController {
@@ -98,7 +103,7 @@ export class InviteController {
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
-      await this.autoAcceptCommitteeInvite(req, payload);
+      const pendingCommitteeInvite = await this.autoAcceptCommitteeInvite(req, payload);
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,
@@ -106,7 +111,7 @@ export class InviteController {
         resource_uid: payload.resource_uid,
       });
 
-      res.json({ return_url: safeReturnUrl });
+      res.json({ return_url: safeReturnUrl, ...(pendingCommitteeInvite && { pending_committee_invite: pendingCommitteeInvite }) });
     } catch (error) {
       next(error);
     }
@@ -135,22 +140,22 @@ export class InviteController {
   }
 
   /**
-   * When the LFID invite JWT carries a {@link InviteTokenPayload.committee_invite_uid} claim,
-   * accepts that specific committee_invite directly via the committee API. No-ops when the claim
-   * is absent — the LFID invite is unrelated to any committee.
+   * Accepts the committee invite associated with the LFID invite JWT.
    *
-   * Requires the authenticated session email to match the email embedded in the JWT.
-   * Throws on acceptance failure so the caller can surface it rather than silently redirecting.
+   * **New path** (JWT carries `committee_invite_uid`): calls the committee accept endpoint
+   * directly — no email search needed since both the committee UID (`resource_uid`) and the
+   * invite UID (`committee_invite_uid`) are embedded in the JWT.
+   *
+   * **Legacy path** (JWT pre-dates `committee_invite_uid`): falls back to searching pending
+   * invites by email. Waits {@link FGA_PROPAGATION_DELAY_MS} before each attempt so that the
+   * FGA invitee tuple has time to propagate; retries up to {@link FGA_LEGACY_MAX_ATTEMPTS}
+   * times total. Returns a {@link PendingCommitteeInviteForOrg} when an invite requires an
+   * organization that was not pre-filled — the client must collect the org and re-submit.
+   *
+   * Requires the session email to match the email claim in the JWT. Throws on unrecoverable
+   * failures so the caller can surface the error rather than silently redirecting.
    */
-  private async autoAcceptCommitteeInvite(req: Request, payload: InviteTokenPayload): Promise<void> {
-    // JWT.verify only validates the signature — claims can be null, non-strings, or whitespace.
-    const committeeInviteUid = typeof payload.committee_invite_uid === 'string' ? payload.committee_invite_uid.trim() : '';
-    const committeeUid = typeof payload.resource_uid === 'string' ? payload.resource_uid.trim() : '';
-
-    if (!committeeInviteUid) {
-      return; // LFID invite is unrelated to any committee — nothing to accept
-    }
-
+  private async autoAcceptCommitteeInvite(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
     const sessionEmail = getEffectiveEmail(req)?.trim() ?? null;
 
@@ -158,32 +163,61 @@ export class InviteController {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — LFID invite token has no email claim', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
     if (!sessionEmail) {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — session email unavailable', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
     if (invitedEmail !== sessionEmail) {
       logger.info(req, 'accept_invite', 'Skipping committee invite auto-accept — session email does not match LFID invite token email', {
         invite_uid: payload.invite_uid,
       });
-      return;
+      return null;
     }
 
-    if (!committeeUid) {
-      throw new Error(`Cannot accept committee invite ${committeeInviteUid}: resource_uid (committee UID) is absent from the JWT`);
+    // JWT.verify only validates the signature — claims can be null, non-strings, or whitespace.
+    const committeeInviteUid = typeof payload.committee_invite_uid === 'string' ? payload.committee_invite_uid.trim() : '';
+    const committeeUid = typeof payload.resource_uid === 'string' ? payload.resource_uid.trim() : '';
+
+    if (committeeInviteUid) {
+      // Both UIDs are known — call accept directly without searching.
+      if (!committeeUid) {
+        throw new Error(`Cannot accept committee invite ${committeeInviteUid}: resource_uid (committee UID) is absent from the JWT`);
+      }
+      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+      logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
+        committee_uid: committeeUid,
+        committee_invite_uid: committeeInviteUid,
+      });
+      return null;
     }
 
-    await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+    // Legacy path: JWT pre-dates committee_invite_uid — search pending invites by email.
+    // Wait before every attempt (including the first) so the FGA invitee tuple can propagate.
+    for (let attempt = 0; attempt < FGA_LEGACY_MAX_ATTEMPTS; attempt++) {
+      await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));
 
-    logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
-      committee_uid: committeeUid,
-      committee_invite_uid: committeeInviteUid,
+      const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
+        invitedEmail,
+        resourceUid: committeeUid,
+      });
+
+      // undefined = invite not visible yet — FGA still propagating; retry.
+      // null | PendingCommitteeInviteForOrg = processed; return immediately.
+      if (result !== undefined) {
+        return result ?? null;
+      }
+    }
+
+    logger.warning(req, 'accept_invite', 'Legacy committee invite auto-accept exhausted retries without finding a matching invite', {
+      invite_uid: payload.invite_uid,
+      resource_uid: committeeUid,
     });
+    return null;
   }
 }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -100,10 +100,13 @@ export class InviteController {
         );
       }
 
+      // Accept committee invite before publishing INVITE_ACCEPTED — if committee accept
+      // throws, NATS must not have fired yet so downstream services aren't left with a
+      // partially-processed state.
+      const pendingCommitteeInvite = await this.autoAcceptCommitteeInvite(req, payload);
+
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
-
-      const pendingCommitteeInvite = await this.autoAcceptCommitteeInvite(req, payload);
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,
@@ -157,7 +160,7 @@ export class InviteController {
    */
   private async autoAcceptCommitteeInvite(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
-    const sessionEmail = getEffectiveEmail(req)?.trim() ?? null;
+    const sessionEmail = getEffectiveEmail(req)?.trim().toLowerCase() ?? null;
 
     if (!invitedEmail) {
       logger.warning(req, 'accept_invite', 'Skipping committee invite auto-accept — LFID invite token has no email claim', {
@@ -187,7 +190,11 @@ export class InviteController {
     if (committeeInviteUid) {
       // Both UIDs are known — call accept directly without searching.
       if (!committeeUid) {
-        throw new Error(`Cannot accept committee invite ${committeeInviteUid}: resource_uid (committee UID) is absent from the JWT`);
+        throw ServiceValidationError.forField('resource_uid', 'Invite token is missing the committee UID required to accept this invite', {
+          operation: 'accept_invite',
+          service: 'invite_controller',
+          path: req.path,
+        });
       }
       await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
       logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
@@ -198,6 +205,15 @@ export class InviteController {
     }
 
     // Legacy path: JWT pre-dates committee_invite_uid — search pending invites by email.
+    // Require committeeUid so the search is scoped to the specific committee; without it we
+    // cannot safely identify which pending invite to accept and must skip.
+    if (!committeeUid) {
+      logger.warning(req, 'accept_invite', 'Skipping legacy committee invite auto-accept — resource_uid (committee UID) is absent from the JWT', {
+        invite_uid: payload.invite_uid,
+      });
+      return null;
+    }
+
     // Wait before every attempt (including the first) so the FGA invitee tuple can propagate.
     for (let attempt = 0; attempt < FGA_LEGACY_MAX_ATTEMPTS; attempt++) {
       await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -103,16 +103,7 @@ export class InviteController {
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
-      let pendingCommitteeInvite: PendingCommitteeInviteForOrg | undefined;
-      try {
-        pendingCommitteeInvite = (await this.autoAcceptPendingCommitteeInvites(req, payload)) ?? undefined;
-      } catch (error) {
-        // Best-effort — committee auto-accept failures must not block LFID invite acceptance.
-        logger.warning(req, 'accept_invite', 'Committee invite auto-accept failed; LFID accept continues', {
-          invite_uid: payload.invite_uid,
-          err: error,
-        });
-      }
+      const pendingCommitteeInvite = (await this.autoAcceptPendingCommitteeInvites(req, payload)) ?? undefined;
 
       logger.success(req, 'accept_invite', startTime, {
         invite_uid: payload.invite_uid,
@@ -149,15 +140,24 @@ export class InviteController {
   }
 
   /**
-   * When an LFID invite is accepted for a committee invitee, accept any matching pending
-   * committee_invite so a committee_member is created with the session username. Requires
-   * the authenticated user's email to match the email embedded in the LFID invite JWT.
+   * When the LFID invite JWT carries a {@link InviteTokenPayload.committee_invite_uid} claim,
+   * accepts that specific committee_invite so a committee_member is created with the session
+   * username. No-ops if the claim is absent — the LFID invite may be unrelated to any committee.
    *
-   * Returns a {@link PendingCommitteeInviteForOrg} when an invite requires an organization
+   * Returns a {@link PendingCommitteeInviteForOrg} when the invite requires an organization
    * that was not pre-filled — the caller should surface this to the client for manual org
-   * collection. Returns null when all invites were handled or the flow was skipped.
+   * collection. Returns null when the invite was accepted or the flow was skipped.
+   *
+   * Throws when the invite cannot be found or accepted after all FGA-propagation retries so
+   * the caller can surface the failure rather than silently redirecting to a stale committee page.
    */
   private async autoAcceptPendingCommitteeInvites(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
+    // committee_invite_uid is the source of truth. Without it we cannot know which committee
+    // invite to accept — the LFID invite may be unrelated to any committee, so we skip.
+    if (!payload.committee_invite_uid) {
+      return null;
+    }
+
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
     const sessionEmail = getEffectiveEmail(req)?.trim() ?? null;
 
@@ -182,12 +182,6 @@ export class InviteController {
       return null;
     }
 
-    // When resource_type is present: 'group' means committee invite (retry while FGA propagates),
-    // any other value means not a committee invite (skip retry).
-    // When resource_type is absent we can't rule out a committee invite, so still attempt
-    // auto-accept rather than silently skip it.
-    const isCommitteeInvite = payload.resource_type ? payload.resource_type === 'group' : !!payload.resource_uid?.trim();
-
     for (let attempt = 0; attempt <= FGA_PROPAGATION_MAX_RETRIES; attempt++) {
       if (attempt > 0) {
         await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));
@@ -195,17 +189,18 @@ export class InviteController {
 
       const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
         invitedEmail,
-        resourceUid: payload.resource_uid,
         committeeInviteUid: payload.committee_invite_uid,
       });
 
-      // undefined = no pending invites found yet; the FGA tuple may still be in-flight — retry.
       // null or PendingCommitteeInviteForOrg = invite was found and processed; return immediately.
-      if (result !== undefined || !isCommitteeInvite) {
+      // undefined = invite not visible yet — FGA invitee tuple may still be propagating; retry.
+      if (result !== undefined) {
         return result ?? null;
       }
     }
 
-    return null;
+    throw new Error(
+      `Committee invite ${payload.committee_invite_uid} could not be accepted: not found after ${FGA_PROPAGATION_MAX_RETRIES} retries — FGA propagation may have stalled`
+    );
   }
 }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -99,11 +99,6 @@ export class InviteController {
         );
       }
 
-      // Accept committee invite before publishing INVITE_ACCEPTED — if committee accept
-      // throws, NATS must not have fired yet so downstream services aren't left with a
-      // partially-processed state.
-      const pendingCommitteeInvite = await this.autoAcceptCommitteeInvite(req, payload);
-
       const codec = this.natsService.getCodec();
       await this.natsService.publish(NatsSubjects.INVITE_ACCEPTED, codec.encode(JSON.stringify({ invite_uid: payload.invite_uid, username })));
 
@@ -112,6 +107,20 @@ export class InviteController {
         username,
         resource_uid: payload.resource_uid,
       });
+
+      // Best-effort — committee auto-accept failures must not block LFID invite acceptance.
+      // The LFID invite is already accepted at this point (user has registered/logged in);
+      // INVITE_ACCEPTED has been published above. Committee auto-accept is a separate side
+      // effect that runs after.
+      let pendingCommitteeInvite: PendingCommitteeInviteForOrg | undefined;
+      try {
+        pendingCommitteeInvite = (await this.autoAcceptCommitteeInvite(req, payload)) ?? undefined;
+      } catch (error) {
+        logger.warning(req, 'accept_invite', 'Committee invite auto-accept failed — LFID invite already accepted', {
+          invite_uid: payload.invite_uid,
+          err: error,
+        });
+      }
 
       res.json({ return_url: safeReturnUrl, ...(pendingCommitteeInvite && { pending_committee_invite: pendingCommitteeInvite }) });
     } catch (error) {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -152,9 +152,12 @@ export class InviteController {
    * the caller can surface the failure rather than silently redirecting to a stale committee page.
    */
   private async autoAcceptPendingCommitteeInvites(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
-    // committee_invite_uid is the source of truth. Without it we cannot know which committee
-    // invite to accept — the LFID invite may be unrelated to any committee, so we skip.
-    if (!payload.committee_invite_uid) {
+    // JWT.verify only validates the signature — committee_invite_uid can be null, a non-string,
+    // or whitespace if the token was crafted with malformed custom claims. Normalize to a trimmed
+    // string and treat only a non-empty result as an actionable claim.
+    const committeeInviteUid = typeof payload.committee_invite_uid === 'string' ? payload.committee_invite_uid.trim() : '';
+    if (!committeeInviteUid) {
+      // No committee_invite_uid means the LFID invite is unrelated to any committee.
       return null;
     }
 
@@ -189,18 +192,30 @@ export class InviteController {
 
       const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
         invitedEmail,
-        committeeInviteUid: payload.committee_invite_uid,
+        committeeInviteUid,
       });
 
       // null or PendingCommitteeInviteForOrg = invite was found and processed; return immediately.
-      // undefined = invite not visible yet — FGA invitee tuple may still be propagating; retry.
+      // undefined = invite not visible yet in the email index — FGA invitee tuple may still be
+      // propagating; retry.
       if (result !== undefined) {
         return result ?? null;
       }
     }
 
+    // All retries returned undefined — the invite was never found in the pending email index.
+    // This can happen when the invite was already accepted (response lost, page refreshed) and
+    // is no longer pending, OR when FGA propagation has not completed. Call accept directly:
+    // the committee-service AcceptInvite endpoint is idempotent (already-accepted → success),
+    // so this covers both cases. resource_uid carries the committee UID for committee LFID invites.
+    const committeeUid = typeof payload.resource_uid === 'string' ? payload.resource_uid.trim() : '';
+    if (committeeUid) {
+      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+      return null;
+    }
+
     throw new Error(
-      `Committee invite ${payload.committee_invite_uid} could not be accepted: not found after ${FGA_PROPAGATION_MAX_RETRIES} retries — FGA propagation may have stalled`
+      `Committee invite ${committeeInviteUid} could not be accepted: not found after ${FGA_PROPAGATION_MAX_RETRIES} retries and resource_uid (committee UID) is absent from the JWT`
     );
   }
 }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -196,6 +196,7 @@ export class InviteController {
       const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
         invitedEmail,
         resourceUid: payload.resource_uid,
+        committeeInviteUid: payload.committee_invite_uid,
       });
 
       // undefined = no pending invites found yet; the FGA tuple may still be in-flight — retry.

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -214,6 +214,8 @@ export class InviteController {
       const committeeName = typeof payload.committee_name === 'string' ? payload.committee_name.trim() || committeeUid : committeeUid;
 
       if (organizationRequired) {
+        // If no org name was pre-filled on the invite, we can't auto-accept — return to
+        // the client so the user can supply one via the org-collection dialog.
         const orgName = typeof payload.organization_name === 'string' ? payload.organization_name.trim() || null : null;
         if (!orgName) {
           logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
@@ -231,16 +233,13 @@ export class InviteController {
             },
           };
         }
-        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, {
-          organization: {
-            name: orgName,
-            id: typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null,
-            website: typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null,
-          },
-        });
-      } else {
-        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
       }
+
+      // Do not relay JWT org claims back to the committee service. The JWT claims are an
+      // immutable snapshot and can be stale (e.g. invite revoked and reinstated with a
+      // different org). The committee service's acceptInvite falls back to its stored invite
+      // organization when no body org is supplied, ensuring the live value is always used.
+      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
 
       logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
         committee_uid: committeeUid,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -164,8 +164,8 @@ export class InviteController {
    * {@link PendingCommitteeInviteForOrg} when an invite requires an
    * organization that was not pre-filled — the client must collect the org and re-submit.
    *
-   * Requires the session email to match the email claim in the JWT. Throws on unrecoverable
-   * failures so the caller can surface the error rather than silently redirecting.
+   * Requires the session email to match the email claim in the JWT. Committee auto-accept is
+   * best-effort — failures are caught by the caller, logged, and do not block the redirect.
    */
   private async autoAcceptCommitteeInvite(req: Request, payload: InviteTokenPayload): Promise<PendingCommitteeInviteForOrg | null> {
     const invitedEmail = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
@@ -220,15 +220,16 @@ export class InviteController {
             committee_uid: committeeUid,
             committee_invite_uid: committeeInviteUid,
           });
+          const orgId = typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null;
+          const orgWebsite = typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null;
           return {
             committee_uid: committeeUid,
             invite_uid: committeeInviteUid,
             committee_name: committeeName,
-            organization: {
-              id: typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null,
-              name: null,
-              website: typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null,
-            },
+            // Only pass an organization object when there is at least one field to pre-fill.
+            // An all-null object is truthy and would suppress the current-employer fallback
+            // in InvitationAcceptFlowService.
+            organization: orgId || orgWebsite ? { id: orgId, name: null, website: orgWebsite } : null,
           };
         }
         await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, {

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -149,9 +149,10 @@ export class InviteController {
    * invite UID (`committee_invite_uid`) are embedded in the JWT.
    *
    * **Legacy path** (JWT pre-dates `committee_invite_uid`): falls back to searching pending
-   * invites by email. Waits {@link FGA_PROPAGATION_DELAY_MS} before each attempt so that the
-   * FGA invitee tuple has time to propagate; retries up to {@link FGA_LEGACY_MAX_ATTEMPTS}
-   * times total. Returns a {@link PendingCommitteeInviteForOrg} when an invite requires an
+   * invites by email. Waits {@link InviteController.fgaPropagationDelayMs} before each attempt
+   * so that the FGA invitee tuple has time to propagate; retries up to
+   * {@link InviteController.fgaLegacyMaxAttempts} times total. Returns a
+   * {@link PendingCommitteeInviteForOrg} when an invite requires an
    * organization that was not pre-filled — the client must collect the org and re-submit.
    *
    * Requires the session email to match the email claim in the JWT. Throws on unrecoverable
@@ -245,6 +246,17 @@ export class InviteController {
     if (!committeeUid) {
       logger.warning(req, 'accept_invite', 'Skipping legacy committee invite auto-accept — resource_uid (committee UID) is absent from the JWT', {
         invite_uid: payload.invite_uid,
+      });
+      return null;
+    }
+
+    // Skip the committee path entirely for explicitly non-committee resource types. Omitting
+    // resource_type (very old JWTs) still enters this path for backward compatibility.
+    const resourceType = typeof payload.resource_type === 'string' ? payload.resource_type.trim() : '';
+    if (resourceType && resourceType !== 'group') {
+      logger.info(req, 'accept_invite', 'Skipping legacy committee invite auto-accept — resource is not a committee', {
+        invite_uid: payload.invite_uid,
+        resource_type: resourceType,
       });
       return null;
     }

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -3,7 +3,6 @@
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
-import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { errors as JoseErrors, JWK, JWT } from 'jose';
 
@@ -14,13 +13,12 @@ import { CommitteeService } from '../services/committee.service';
 import { NatsService } from '../services/nats.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 
-/** Delay before each legacy email-search attempt while waiting for FGA tuple propagation. */
-const FGA_PROPAGATION_DELAY_MS = 3_000;
-/** Total number of legacy email-search attempts (each preceded by FGA_PROPAGATION_DELAY_MS). */
-const FGA_LEGACY_MAX_ATTEMPTS = 3;
-
 /** Controller for non-LF user invite acceptance via signed JWT. */
 export class InviteController {
+  /** Delay before each legacy email-search attempt while waiting for FGA tuple propagation. */
+  private static readonly fgaPropagationDelayMs = 3_000;
+  /** Total number of legacy email-search attempts (each preceded by fgaPropagationDelayMs). */
+  private static readonly fgaLegacyMaxAttempts = 3;
   private readonly natsService = new NatsService();
   private readonly committeeService = new CommitteeService();
 
@@ -198,39 +196,39 @@ export class InviteController {
         });
       }
 
-      // Fetch the specific pending invite to check whether an organization is required.
-      // getPendingInviteForUser returns null when the invite is not yet visible in the email
-      // index (FGA propagation delay) or when it has already been accepted (idempotent retry).
-      // In both cases we attempt accept directly and let the upstream enforce org requirements.
-      const pendingInvite = await this.committeeService.getPendingInviteForUser(req, invitedEmail, committeeUid, committeeInviteUid);
+      // Read org context directly from JWT claims — no email fetch needed. Claims are
+      // map[string]string in Go so organization_required is the string "true" or "false".
+      // Claims are absent on JWTs issued before the committee service v0.4.17 deploy;
+      // in that transitional window we accept directly without org check.
+      const organizationRequired = payload.organization_required === 'true';
+      const committeeName = typeof payload.committee_name === 'string' ? payload.committee_name.trim() || committeeUid : committeeUid;
 
-      if (pendingInvite) {
-        const requiresOrganization = invitationRequiresOrganization({ organization_required: pendingInvite.organization_required });
-        if (requiresOrganization) {
-          const orgName = pendingInvite.organization?.name?.trim() || null;
-          if (!orgName) {
-            logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
-              committee_uid: committeeUid,
-              committee_invite_uid: committeeInviteUid,
-            });
-            return {
-              committee_uid: committeeUid,
-              invite_uid: committeeInviteUid,
-              committee_name: pendingInvite.committee_name?.trim() || committeeUid,
-              organization: pendingInvite.organization ?? null,
-            };
-          }
-          const orgPayload = {
-            name: orgName,
-            id: pendingInvite.organization?.id?.trim() || null,
-            website: pendingInvite.organization?.website?.trim() || null,
+      if (organizationRequired) {
+        const orgName = typeof payload.organization_name === 'string' ? payload.organization_name.trim() || null : null;
+        if (!orgName) {
+          logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
+            committee_uid: committeeUid,
+            committee_invite_uid: committeeInviteUid,
+          });
+          return {
+            committee_uid: committeeUid,
+            invite_uid: committeeInviteUid,
+            committee_name: committeeName,
+            organization: {
+              id: typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null,
+              name: null,
+              website: typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null,
+            },
           };
-          await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, { organization: orgPayload });
-        } else {
-          await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
         }
+        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, {
+          organization: {
+            name: orgName,
+            id: typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null,
+            website: typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null,
+          },
+        });
       } else {
-        // Invite not in pending index — accept directly (idempotent if already accepted).
         await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
       }
 
@@ -252,8 +250,8 @@ export class InviteController {
     }
 
     // Wait before every attempt (including the first) so the FGA invitee tuple can propagate.
-    for (let attempt = 0; attempt < FGA_LEGACY_MAX_ATTEMPTS; attempt++) {
-      await new Promise<void>((resolve) => setTimeout(resolve, FGA_PROPAGATION_DELAY_MS));
+    for (let attempt = 0; attempt < InviteController.fgaLegacyMaxAttempts; attempt++) {
+      await new Promise<void>((resolve) => setTimeout(resolve, InviteController.fgaPropagationDelayMs));
 
       const result = await this.committeeService.acceptPendingCommitteeInvitesAfterLfidAccept(req, {
         invitedEmail,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -214,8 +214,6 @@ export class InviteController {
       const committeeName = typeof payload.committee_name === 'string' ? payload.committee_name.trim() || committeeUid : committeeUid;
 
       if (organizationRequired) {
-        // If no org name was pre-filled on the invite, we can't auto-accept — return to
-        // the client so the user can supply one via the org-collection dialog.
         const orgName = typeof payload.organization_name === 'string' ? payload.organization_name.trim() || null : null;
         if (!orgName) {
           logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
@@ -233,13 +231,16 @@ export class InviteController {
             },
           };
         }
+        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, {
+          organization: {
+            name: orgName,
+            id: typeof payload.organization_id === 'string' ? payload.organization_id.trim() || null : null,
+            website: typeof payload.organization_website === 'string' ? payload.organization_website.trim() || null : null,
+          },
+        });
+      } else {
+        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
       }
-
-      // Do not relay JWT org claims back to the committee service. The JWT claims are an
-      // immutable snapshot and can be stale (e.g. invite revoked and reinstated with a
-      // different org). The committee service's acceptInvite falls back to its stored invite
-      // organization when no body org is supplied, ensuring the live value is always used.
-      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
 
       logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
         committee_uid: committeeUid,

--- a/apps/lfx-one/src/server/controllers/invite.controller.ts
+++ b/apps/lfx-one/src/server/controllers/invite.controller.ts
@@ -3,6 +3,7 @@
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { InviteTokenPayload, PendingCommitteeInviteForOrg } from '@lfx-one/shared/interfaces';
+import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { errors as JoseErrors, JWK, JWT } from 'jose';
 
@@ -196,7 +197,43 @@ export class InviteController {
           path: req.path,
         });
       }
-      await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+
+      // Fetch the specific pending invite to check whether an organization is required.
+      // getPendingInviteForUser returns null when the invite is not yet visible in the email
+      // index (FGA propagation delay) or when it has already been accepted (idempotent retry).
+      // In both cases we attempt accept directly and let the upstream enforce org requirements.
+      const pendingInvite = await this.committeeService.getPendingInviteForUser(req, invitedEmail, committeeUid, committeeInviteUid);
+
+      if (pendingInvite) {
+        const requiresOrganization = invitationRequiresOrganization({ organization_required: pendingInvite.organization_required });
+        if (requiresOrganization) {
+          const orgName = pendingInvite.organization?.name?.trim() || null;
+          if (!orgName) {
+            logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
+              committee_uid: committeeUid,
+              committee_invite_uid: committeeInviteUid,
+            });
+            return {
+              committee_uid: committeeUid,
+              invite_uid: committeeInviteUid,
+              committee_name: pendingInvite.committee_name?.trim() || committeeUid,
+              organization: pendingInvite.organization ?? null,
+            };
+          }
+          const orgPayload = {
+            name: orgName,
+            id: pendingInvite.organization?.id?.trim() || null,
+            website: pendingInvite.organization?.website?.trim() || null,
+          };
+          await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid, { organization: orgPayload });
+        } else {
+          await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+        }
+      } else {
+        // Invite not in pending index — accept directly (idempotent if already accepted).
+        await this.committeeService.acceptCommitteeInvite(req, committeeUid, committeeInviteUid);
+      }
+
       logger.info(req, 'accept_invite', 'Committee invite accepted directly after LFID invite', {
         committee_uid: committeeUid,
         committee_invite_uid: committeeInviteUid,

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1693,5 +1693,4 @@ export class CommitteeService {
 
     return invites.filter((invite) => invite.status === 'pending');
   }
-
 }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -717,7 +717,7 @@ export class CommitteeService {
    */
   public async acceptPendingCommitteeInvitesAfterLfidAccept(
     req: Request,
-    params: { invitedEmail: string; resourceUid?: string }
+    params: { invitedEmail: string; resourceUid?: string; committeeInviteUid?: string }
   ): Promise<PendingCommitteeInviteForOrg | null | undefined> {
     const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
     if (pendingInvites.length === 0) {
@@ -726,17 +726,34 @@ export class CommitteeService {
       return undefined;
     }
 
-    const toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
-    if (toAccept.length === 0) {
-      logger.warning(req, 'accept_invite', 'Pending committee invitations found but none selected for auto-accept', {
-        pending_count: pendingInvites.length,
-        resource_uid: params.resourceUid,
-      });
-      return undefined;
+    let toAccept: CommitteeInvite[];
+    const trimmedCommitteeInviteUid = params.committeeInviteUid?.trim();
+
+    if (trimmedCommitteeInviteUid) {
+      // JWT carries the exact committee invite UID — accept only that invite; no fuzzy matching needed.
+      const target = pendingInvites.find((invite) => invite.uid === trimmedCommitteeInviteUid);
+      if (!target) {
+        // The invite isn't visible yet — FGA invitee tuple may still be propagating; retry.
+        logger.debug(req, 'accept_invite', 'Target committee invite not yet visible — will retry', {
+          committee_invite_uid: trimmedCommitteeInviteUid,
+        });
+        return undefined;
+      }
+      toAccept = [target];
+    } else {
+      toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
+      if (toAccept.length === 0) {
+        logger.warning(req, 'accept_invite', 'Pending committee invitations found but none selected for auto-accept', {
+          pending_count: pendingInvites.length,
+          resource_uid: params.resourceUid,
+        });
+        return undefined;
+      }
     }
 
     logger.info(req, 'accept_invite', 'Auto-accepting committee invitations after LFID invite', {
       accept_count: toAccept.length,
+      committee_invite_uid: trimmedCommitteeInviteUid,
       resource_uid: params.resourceUid,
     });
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -779,6 +779,7 @@ export class CommitteeService {
           invite_uid: invite.uid,
           err: error,
         });
+        throw error;
       }
     }
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1721,7 +1721,7 @@ export class CommitteeService {
   private selectCommitteeInvitesForLfidAccept(pending: CommitteeInvite[], resourceUid: string): CommitteeInvite[] {
     const trimmedResourceUid = resourceUid.trim();
     if (!trimmedResourceUid) {
-      return pending;
+      return [];
     }
     return pending.filter((invite) => invite.committee_uid === trimmedResourceUid);
   }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -736,7 +736,6 @@ export class CommitteeService {
     });
 
     let pendingForOrg: PendingCommitteeInviteForOrg | null = null;
-    let anyAccepted = false;
 
     for (const invite of toAccept) {
       try {
@@ -772,7 +771,6 @@ export class CommitteeService {
         } else {
           await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
         }
-        anyAccepted = true;
       } catch (error) {
         logger.warning(req, 'accept_invite', 'Failed to auto-accept committee invitation after LFID invite', {
           committee_uid: invite.committee_uid,
@@ -786,8 +784,7 @@ export class CommitteeService {
     if (pendingForOrg) {
       return pendingForOrg;
     }
-    // If every accept threw, return undefined so the controller can retry — accept is idempotent.
-    return anyAccepted ? null : undefined;
+    return null;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -19,7 +19,6 @@ import {
   CreateCommitteeMemberRequest,
   GroupsIOMailingList,
   MyCommittee,
-  PendingCommitteeInviteForOrg,
   PendingInvitation,
   Project,
   ProjectSettings,
@@ -27,7 +26,6 @@ import {
   QueryServiceResponse,
   UploadCommitteeDocumentRequest,
 } from '@lfx-one/shared/interfaces';
-import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -699,78 +697,6 @@ export class CommitteeService {
         // sending an explicit null that consumers would have to disambiguate from "set".
       } satisfies PendingInvitation;
     });
-  }
-
-  /**
-   * After LFID invite acceptance, accepts the specific pending committee_invite identified by
-   * {@link params.committeeInviteUid}. Callers must verify the session email matches the invite
-   * token email before invoking.
-   *
-   * Returns {@link PendingCommitteeInviteForOrg} when the invite requires an organization that
-   * was not pre-filled — the caller must surface this to the user to collect the org and complete
-   * acceptance manually. Returns null when the invite was accepted successfully. Returns undefined
-   * when the invite is not yet visible in the email index (FGA invitee tuple still propagating),
-   * signalling the caller to retry.
-   *
-   * Accept failures propagate as thrown errors so the caller can surface them to the client.
-   */
-  public async acceptPendingCommitteeInvitesAfterLfidAccept(
-    req: Request,
-    params: { invitedEmail: string; committeeInviteUid: string }
-  ): Promise<PendingCommitteeInviteForOrg | null | undefined> {
-    const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
-    if (pendingInvites.length === 0) {
-      logger.debug(req, 'accept_invite', 'No pending committee invitations to auto-accept after LFID invite');
-      return undefined;
-    }
-
-    const invite = pendingInvites.find((i) => i.uid === params.committeeInviteUid);
-    if (!invite) {
-      // The invite isn't visible yet — FGA invitee tuple may still be propagating; retry.
-      logger.debug(req, 'accept_invite', 'Target committee invite not yet visible — will retry', {
-        committee_invite_uid: params.committeeInviteUid,
-      });
-      return undefined;
-    }
-
-    logger.info(req, 'accept_invite', 'Auto-accepting committee invitation after LFID invite', {
-      committee_uid: invite.committee_uid,
-      committee_invite_uid: params.committeeInviteUid,
-    });
-
-    // organization_required is carried on the invite itself (committee-service ≥ v1.1) so no
-    // committee/settings fetch is needed — those fail the access check for non-viewer invitees.
-    // Fail-closed when the field is absent: treat as org-required so we skip rather than
-    // auto-accept without the required organization.
-    const requiresOrganization = invitationRequiresOrganization({ organization_required: invite.organization_required });
-
-    if (requiresOrganization) {
-      const orgName = invite.organization?.name?.trim() || null;
-      if (!orgName) {
-        logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
-          committee_uid: invite.committee_uid,
-          invite_uid: invite.uid,
-        });
-        return {
-          committee_uid: invite.committee_uid,
-          invite_uid: invite.uid,
-          committee_name: invite.committee_name?.trim() || invite.committee_uid,
-          organization: invite.organization ?? null,
-        };
-      }
-      // Build an explicit allowlist payload — trim fields and coerce empty strings to null
-      // rather than forwarding the raw query-service organization reference upstream.
-      const orgPayload = {
-        name: orgName,
-        id: invite.organization?.id?.trim() || null,
-        website: invite.organization?.website?.trim() || null,
-      };
-      await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid, { organization: orgPayload });
-    } else {
-      await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
-    }
-
-    return null;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -702,121 +702,75 @@ export class CommitteeService {
   }
 
   /**
-   * After LFID invite acceptance, auto-accept pending committee invitations addressed to
-   * {@link invitedEmail}. Callers must verify the session email matches the invite token
-   * email before invoking. {@link resourceUid} (from the LFID invite JWT) disambiguates
-   * when multiple pending invites exist — matched against committee_invite UID first, then
-   * committee UID; if neither matches, returns undefined so the caller can retry while the
-   * target invite's FGA invitee tuple propagates.
+   * After LFID invite acceptance, accepts the specific pending committee_invite identified by
+   * {@link params.committeeInviteUid}. Callers must verify the session email matches the invite
+   * token email before invoking.
    *
-   * Returns the first invite that requires an organization but had none pre-filled — the
-   * caller must surface this to the user to collect their organization and complete acceptance.
-   * Other invites (those that can be auto-accepted) are still processed before returning.
+   * Returns {@link PendingCommitteeInviteForOrg} when the invite requires an organization that
+   * was not pre-filled — the caller must surface this to the user to collect the org and complete
+   * acceptance manually. Returns null when the invite was accepted successfully. Returns undefined
+   * when the invite is not yet visible in the email index (FGA invitee tuple still propagating),
+   * signalling the caller to retry.
    *
-   * Other failures are logged and swallowed so LFID acceptance still succeeds.
+   * Accept failures propagate as thrown errors so the caller can surface them to the client.
    */
   public async acceptPendingCommitteeInvitesAfterLfidAccept(
     req: Request,
-    params: { invitedEmail: string; resourceUid?: string; committeeInviteUid?: string }
+    params: { invitedEmail: string; committeeInviteUid: string }
   ): Promise<PendingCommitteeInviteForOrg | null | undefined> {
     const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
     if (pendingInvites.length === 0) {
       logger.debug(req, 'accept_invite', 'No pending committee invitations to auto-accept after LFID invite');
-      // undefined signals "not found" to the caller so it can retry while FGA propagates.
       return undefined;
     }
 
-    let toAccept: CommitteeInvite[];
-    const trimmedCommitteeInviteUid = params.committeeInviteUid?.trim();
-
-    if (trimmedCommitteeInviteUid) {
-      // JWT carries the exact committee invite UID — accept only that invite; no fuzzy matching needed.
-      const target = pendingInvites.find((invite) => invite.uid === trimmedCommitteeInviteUid);
-      if (!target) {
-        // The invite isn't visible yet — FGA invitee tuple may still be propagating; retry.
-        logger.debug(req, 'accept_invite', 'Target committee invite not yet visible — will retry', {
-          committee_invite_uid: trimmedCommitteeInviteUid,
-        });
-        return undefined;
-      }
-      toAccept = [target];
-    } else {
-      toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
-      if (toAccept.length === 0) {
-        logger.warning(req, 'accept_invite', 'Pending committee invitations found but none selected for auto-accept', {
-          pending_count: pendingInvites.length,
-          resource_uid: params.resourceUid,
-        });
-        return undefined;
-      }
+    const invite = pendingInvites.find((i) => i.uid === params.committeeInviteUid);
+    if (!invite) {
+      // The invite isn't visible yet — FGA invitee tuple may still be propagating; retry.
+      logger.debug(req, 'accept_invite', 'Target committee invite not yet visible — will retry', {
+        committee_invite_uid: params.committeeInviteUid,
+      });
+      return undefined;
     }
 
-    logger.info(req, 'accept_invite', 'Auto-accepting committee invitations after LFID invite', {
-      accept_count: toAccept.length,
-      committee_invite_uid: trimmedCommitteeInviteUid,
-      resource_uid: params.resourceUid,
+    logger.info(req, 'accept_invite', 'Auto-accepting committee invitation after LFID invite', {
+      committee_uid: invite.committee_uid,
+      committee_invite_uid: params.committeeInviteUid,
     });
 
-    let pendingForOrg: PendingCommitteeInviteForOrg | null = null;
-    let anyAccepted = false;
+    // organization_required is carried on the invite itself (committee-service ≥ v1.1) so no
+    // committee/settings fetch is needed — those fail the access check for non-viewer invitees.
+    // Fail-closed when the field is absent: treat as org-required so we skip rather than
+    // auto-accept without the required organization.
+    const requiresOrganization = invitationRequiresOrganization({ organization_required: invite.organization_required });
 
-    for (const invite of toAccept) {
-      try {
-        // organization_required is carried on the invite itself (committee-service ≥ v1.1) so no
-        // committee/settings fetch is needed — those fail the access check for non-viewer invitees.
-        // Fail-closed when the field is absent: treat as org-required so we skip rather than
-        // auto-accept without the required organization.
-        const requiresOrganization = invitationRequiresOrganization({ organization_required: invite.organization_required });
-
-        if (requiresOrganization) {
-          const orgName = invite.organization?.name?.trim() || null;
-          if (!orgName) {
-            // Return the first such invite so the client can collect the org and complete acceptance.
-            // Keep processing other invites — those that don't need org can still be auto-accepted.
-            if (!pendingForOrg) {
-              logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
-                committee_uid: invite.committee_uid,
-                invite_uid: invite.uid,
-              });
-              pendingForOrg = {
-                committee_uid: invite.committee_uid,
-                invite_uid: invite.uid,
-                committee_name: invite.committee_name?.trim() || invite.committee_uid,
-                organization: invite.organization ?? null,
-              };
-            }
-            continue;
-          }
-          // Build an explicit allowlist payload — trim fields and coerce empty strings to null
-          // rather than forwarding the raw query-service organization reference upstream.
-          const orgPayload = {
-            name: orgName,
-            id: invite.organization?.id?.trim() || null,
-            website: invite.organization?.website?.trim() || null,
-          };
-          await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid, { organization: orgPayload });
-        } else {
-          await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
-        }
-        anyAccepted = true;
-      } catch (error) {
-        logger.warning(req, 'accept_invite', 'Failed to auto-accept committee invitation after LFID invite', {
+    if (requiresOrganization) {
+      const orgName = invite.organization?.name?.trim() || null;
+      if (!orgName) {
+        logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
           committee_uid: invite.committee_uid,
           invite_uid: invite.uid,
-          err: error,
         });
+        return {
+          committee_uid: invite.committee_uid,
+          invite_uid: invite.uid,
+          committee_name: invite.committee_name?.trim() || invite.committee_uid,
+          organization: invite.organization ?? null,
+        };
       }
+      // Build an explicit allowlist payload — trim fields and coerce empty strings to null
+      // rather than forwarding the raw query-service organization reference upstream.
+      const orgPayload = {
+        name: orgName,
+        id: invite.organization?.id?.trim() || null,
+        website: invite.organization?.website?.trim() || null,
+      };
+      await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid, { organization: orgPayload });
+    } else {
+      await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
     }
 
-    // Return the org-required signal whenever it is set — the org-required case is surfaced to
-    // the user regardless of whether other invites succeeded or failed.
-    if (pendingForOrg) {
-      return pendingForOrg;
-    }
-    // If every acceptCommitteeInvite call threw, return undefined so the controller retries —
-    // the acceptance failure may be transient, and the committee-service accept endpoint is
-    // idempotent so retrying is safe.
-    return anyAccepted ? null : undefined;
+    return null;
   }
 
   /**
@@ -1740,28 +1694,4 @@ export class CommitteeService {
     return invites.filter((invite) => invite.status === 'pending');
   }
 
-  /**
-   * Narrows pending committee invites using the LFID invite JWT {@link resourceUid} when present.
-   */
-  private selectCommitteeInvitesForLfidAccept(pending: CommitteeInvite[], resourceUid?: string): CommitteeInvite[] {
-    const trimmedResourceUid = resourceUid?.trim();
-    if (!trimmedResourceUid) {
-      return pending;
-    }
-
-    const byInviteUid = pending.filter((invite) => invite.uid === trimmedResourceUid);
-    if (byInviteUid.length > 0) {
-      return byInviteUid;
-    }
-
-    const byCommitteeUid = pending.filter((invite) => invite.committee_uid === trimmedResourceUid);
-    if (byCommitteeUid.length > 0) {
-      return byCommitteeUid;
-    }
-
-    // When resource_uid is specified, require a positive match — the single-invite fallback
-    // could accept an unrelated invite while the target's FGA invitee tuple is still
-    // propagating, which would stop the retry loop before the correct invite is processed.
-    return [];
-  }
 }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -19,6 +19,7 @@ import {
   CreateCommitteeMemberRequest,
   GroupsIOMailingList,
   MyCommittee,
+  PendingCommitteeInviteForOrg,
   PendingInvitation,
   Project,
   ProjectSettings,
@@ -26,6 +27,7 @@ import {
   QueryServiceResponse,
   UploadCommitteeDocumentRequest,
 } from '@lfx-one/shared/interfaces';
+import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -697,6 +699,94 @@ export class CommitteeService {
         // sending an explicit null that consumers would have to disambiguate from "set".
       } satisfies PendingInvitation;
     });
+  }
+
+  /**
+   * Legacy path for LFID invite JWTs that pre-date the {@link committee_invite_uid} claim.
+   * Searches pending committee_invites by email, selects the one(s) matching
+   * {@link params.resourceUid} (the committee UID from the JWT), and auto-accepts them.
+   *
+   * Returns `undefined` when no matching invite is visible yet — the FGA invitee tuple may
+   * still be propagating; the caller should wait and retry. Returns `null` when acceptance
+   * completed successfully. Returns {@link PendingCommitteeInviteForOrg} when the invite
+   * requires an organization that was not pre-filled — the client must collect it.
+   */
+  public async acceptPendingCommitteeInvitesAfterLfidAccept(
+    req: Request,
+    params: { invitedEmail: string; resourceUid: string }
+  ): Promise<PendingCommitteeInviteForOrg | null | undefined> {
+    const pendingInvites = await this.fetchPendingCommitteeInvitesByEmail(req, params.invitedEmail);
+    if (pendingInvites.length === 0) {
+      logger.debug(req, 'accept_invite', 'No pending committee invitations to auto-accept after LFID invite');
+      return undefined;
+    }
+
+    const toAccept = this.selectCommitteeInvitesForLfidAccept(pendingInvites, params.resourceUid);
+    if (toAccept.length === 0) {
+      logger.warning(req, 'accept_invite', 'Pending committee invitations found but none matched the committee UID — will retry', {
+        pending_count: pendingInvites.length,
+        resource_uid: params.resourceUid,
+      });
+      return undefined;
+    }
+
+    logger.info(req, 'accept_invite', 'Auto-accepting committee invitations after LFID invite (legacy path)', {
+      accept_count: toAccept.length,
+      resource_uid: params.resourceUid,
+    });
+
+    let pendingForOrg: PendingCommitteeInviteForOrg | null = null;
+    let anyAccepted = false;
+
+    for (const invite of toAccept) {
+      try {
+        // organization_required is carried on the invite itself (committee-service ≥ v1.1) so no
+        // committee/settings fetch is needed — those fail the access check for non-viewer invitees.
+        // Fail-closed when the field is absent: treat as org-required so we skip rather than
+        // auto-accept without the required organization.
+        const requiresOrganization = invitationRequiresOrganization({ organization_required: invite.organization_required });
+
+        if (requiresOrganization) {
+          const orgName = invite.organization?.name?.trim() || null;
+          if (!orgName) {
+            if (!pendingForOrg) {
+              logger.info(req, 'accept_invite', 'Committee invite requires organization — returning to client for manual org collection', {
+                committee_uid: invite.committee_uid,
+                invite_uid: invite.uid,
+              });
+              pendingForOrg = {
+                committee_uid: invite.committee_uid,
+                invite_uid: invite.uid,
+                committee_name: invite.committee_name?.trim() || invite.committee_uid,
+                organization: invite.organization ?? null,
+              };
+            }
+            continue;
+          }
+          const orgPayload = {
+            name: orgName,
+            id: invite.organization?.id?.trim() || null,
+            website: invite.organization?.website?.trim() || null,
+          };
+          await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid, { organization: orgPayload });
+        } else {
+          await this.acceptCommitteeInvite(req, invite.committee_uid, invite.uid);
+        }
+        anyAccepted = true;
+      } catch (error) {
+        logger.warning(req, 'accept_invite', 'Failed to auto-accept committee invitation after LFID invite', {
+          committee_uid: invite.committee_uid,
+          invite_uid: invite.uid,
+          err: error,
+        });
+      }
+    }
+
+    if (pendingForOrg) {
+      return pendingForOrg;
+    }
+    // If every accept threw, return undefined so the controller can retry — accept is idempotent.
+    return anyAccepted ? null : undefined;
   }
 
   /**
@@ -1618,5 +1708,21 @@ export class CommitteeService {
     );
 
     return invites.filter((invite) => invite.status === 'pending');
+  }
+
+  /**
+   * Filters {@link pending} invites to those whose committee UID matches {@link resourceUid}.
+   * Used by the legacy LFID invite flow where the JWT carries the committee UID (resource_uid)
+   * but not the exact invite UID.
+   *
+   * Returns an empty array when no match is found — the caller should treat this as
+   * "not yet visible" and retry (FGA invitee tuple may still be propagating).
+   */
+  private selectCommitteeInvitesForLfidAccept(pending: CommitteeInvite[], resourceUid: string): CommitteeInvite[] {
+    const trimmedResourceUid = resourceUid.trim();
+    if (!trimmedResourceUid) {
+      return pending;
+    }
+    return pending.filter((invite) => invite.committee_uid === trimmedResourceUid);
   }
 }

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -15,8 +15,9 @@ export interface InviteTokenPayload {
   role: string;
   /**
    * UID of the specific committee_invite record to accept, embedded by the committee service
-   * as a custom JWT claim. When present, the BFF accepts this exact invite directly instead of
-   * fetching all pending invites by email and fuzzy-selecting by resource_uid.
+   * as a custom JWT claim. When present, the BFF resolves the exact pending invite by both
+   * `committee_invite_uid` and `resource_uid` (committee UID) and accepts it directly, rather
+   * than searching all pending invites by email and matching by committee UID.
    */
   committee_invite_uid?: string;
 }

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -13,6 +13,12 @@ export interface InviteTokenPayload {
   resource_type?: string;
   return_url: string;
   role: string;
+  /**
+   * UID of the specific committee_invite record to accept, embedded by the committee service
+   * as a custom JWT claim. When present, the BFF accepts this exact invite directly instead of
+   * fetching all pending invites by email and fuzzy-selecting by resource_uid.
+   */
+  committee_invite_uid?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/invite.interface.ts
+++ b/packages/shared/src/interfaces/invite.interface.ts
@@ -15,11 +15,24 @@ export interface InviteTokenPayload {
   role: string;
   /**
    * UID of the specific committee_invite record to accept, embedded by the committee service
-   * as a custom JWT claim. When present, the BFF resolves the exact pending invite by both
-   * `committee_invite_uid` and `resource_uid` (committee UID) and accepts it directly, rather
-   * than searching all pending invites by email and matching by committee UID.
+   * as a custom JWT claim. When present, the BFF accepts the invite directly using both UIDs
+   * from the token, rather than searching pending invites by email.
+   *
+   * The five claims below are embedded alongside `committee_invite_uid` by the committee
+   * service. JWT custom claims are `map[string]string` in Go, so `organization_required` is
+   * the string `"true"` or `"false"` — not a boolean.
    */
   committee_invite_uid?: string;
+  /** `"true"` when the committee requires the member to supply an organization on acceptance. */
+  organization_required?: string;
+  /** Committee display name; used as the org-collection dialog header on the client. */
+  committee_name?: string;
+  /** Pre-filled organization name if the invite already carries a suggested organization. */
+  organization_name?: string;
+  /** Pre-filled Salesforce account SFID (18-char) for the suggested organization, if any. */
+  organization_id?: string;
+  /** Pre-filled organization website URL for the suggested organization, if any. */
+  organization_website?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds five new fields to \`InviteTokenPayload\` for custom JWT claims embedded by the committee service: \`organization_required\`, \`committee_name\`, \`organization_name\`, \`organization_id\`, \`organization_website\`
- **New path** (JWT carries \`committee_invite_uid\`): reads org context directly from JWT claims — no secondary email fetch. Handles \`organization_required\` (returns \`PendingCommitteeInviteForOrg\` if org is needed but not pre-filled), then calls accept directly
- **Legacy path** (JWT pre-dates \`committee_invite_uid\`): falls back to searching pending invites by email scoped to the committee UID from \`resource_uid\`, with a 3s delay before each of 3 attempts so the FGA invitee tuple can propagate. Includes full org-required handling
- Removes the fuzzy \`selectCommitteeInvitesForLfidAccept\` logic (root cause of invites never auto-accepting) and the module-scope constants (now private static class fields on \`InviteController\`)

## LFID invite acceptance flow

When `POST /api/invite/accept` is called with a signed JWT, the server processes the LFID invite and then attempts committee auto-accept as a separate best-effort step.

**1. LFID invite acceptance**
The JWT is verified (HS256), required claims are validated, and `INVITE_ACCEPTED` is published to NATS. This marks the LFID invite as accepted — the user has already registered or logged in at this point, and this event is unconditional.

**2. Email match check**
Before attempting committee auto-accept, the JWT's `email` claim is compared against the authenticated session email. If either is missing, or if they don't match, committee auto-accept is skipped entirely and the user is redirected. This is the primary guard ensuring a user can only accept their own committee invites.

**3. New path — `committee_invite_uid` present in JWT**
The committee service embeds `committee_invite_uid` directly in the JWT when sending LFID invites. When this claim is present, the BFF has everything it needs in the token:

- It reads `organization_required` (string `"true"` / `"false"`) from the JWT.
- If the committee **does not require an organization**, it calls the committee service accept endpoint directly using both `resource_uid` (committee UID) and `committee_invite_uid`.
- If the committee **requires an organization** and `organization_name` is non-empty in the JWT (the invite was pre-filled with a suggested org), it calls accept with the full org payload (`name`, `id`, `website`) from the JWT claims.
- If the committee **requires an organization** but `organization_name` is empty or absent in the JWT (no org was pre-filled), it returns a `PendingCommitteeInviteForOrg` object to the client. The client is then responsible for collecting the organization from the user and calling the committee accept endpoint directly before redirecting.

No database or email-index lookup happens on this path.

**4. Legacy path — `committee_invite_uid` absent in JWT**
For JWTs issued before the committee service embedded `committee_invite_uid`, the BFF falls back to searching for the pending invite by email:

- If `resource_uid` (committee UID) is absent from the JWT, the legacy path is skipped — without it the search cannot be scoped to the correct committee.
- If `resource_type` is explicitly set to something other than `group`, the legacy path is skipped — the invite is not a committee invite.
- Otherwise, the BFF waits 3 seconds (to allow the FGA invitee tuple to propagate after LFID registration), then fetches all pending committee invites for the invited email address and filters to those matching the committee UID.
  - If no matching invite is visible yet, it waits another 3s and retries, up to 3 total attempts.
  - Once a matching invite is found, it checks the invite's `organization_required` field (read from the live invite record, not from a JWT claim):
    - If org **not required** — accepts directly.
    - If org **required and pre-filled** on the invite — accepts with the org payload.
    - If org **required but not pre-filled** — returns `PendingCommitteeInviteForOrg` to the client for manual org collection.
  - Any accept failure rethrows immediately; the controller does not retry after a real acceptance error.
- If all 3 attempts complete without finding a matching invite, a warning is logged and the user is redirected (committee membership may need to be reconciled separately).

**5. Committee auto-accept is best-effort**
If committee auto-accept throws at any point, the error is caught and logged as a warning. The LFID invite has already been accepted and `INVITE_ACCEPTED` already published — the committee failure does not affect the redirect or the downstream LFID invite processing.

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677) — Committee invites failing to auto-accept after LFID registration

## Upstream dependencies

This PR is the third leg of a three-repo fix and depends on all upstream PRs being deployed first:

- **Invite service** — [lfx-v2-invite-service#15](https://github.com/linuxfoundation/lfx-v2-invite-service/pull/15): adds \`CustomClaims map[string]string\` to \`SendInviteRequest\`, allowing any resource service to embed extra JWT claims
- **Committee service** — [lfx-v2-committee-service#154](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/154): embeds \`committee_invite_uid\` and the five new org-context claims in the custom claims when sending LFID invites

## Test plan

- [ ] Accept an LFID invite for a committee invitation — confirm the committee member is created and the user is redirected to the committee page without being prompted again
- [ ] Accept an LFID invite unrelated to any committee — confirm no committee invite acceptance is attempted (logs show no \`auto-accept\` line)
- [ ] Accept an LFID invite for a committee that requires organization with no pre-filled org — confirm the org-collection dialog is surfaced with correct \`committee_name\`
- [ ] Accept an LFID invite for a committee that requires organization with a pre-filled org — confirm accept fires with the org payload, no dialog
- [ ] Accept with an old JWT (no \`committee_invite_uid\` claim, but \`resource_uid\` present) — confirm legacy path fires: waits 3s then searches pending invites by email scoped to that committee UID, retrying up to 3 times
- [ ] Accept with an old JWT that has no \`committee_invite_uid\` and no \`resource_uid\` — confirm legacy path skips gracefully with a warning log (no accept attempted)
- [ ] Simulate a committee accept failure — confirm \`INVITE_ACCEPTED\` was already published and the user is still redirected (warning log present, no 500)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ