### PR TITLE
fix(dashboards): dissolve funnel-stage split in paid campaign table

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -277,7 +277,6 @@
             <!-- Table Header -->
             <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
               <span class="flex-[2] min-w-[120px]">Project / Campaign</span>
-              <span class="w-16 text-center">Funnel</span>
               <span class="flex-1 text-right">Spend</span>
               <span class="flex-1 text-right">Rev (last-touch)</span>
               <span class="w-14 text-right">ROAS</span>
@@ -300,11 +299,6 @@
                 (keydown.space)="$event.preventDefault(); toggleProject(project.projectName)"
                 data-testid="email-ctr-drawer-project-row">
                 <span class="flex-[2] min-w-[120px] text-sm font-semibold text-gray-900 truncate pr-2">{{ project.projectName }}</span>
-                <span class="w-16 flex justify-center">
-                  @if (formatFunnelLabel(project.funnelStage)) {
-                    <lfx-tag [value]="formatFunnelLabel(project.funnelStage)" severity="secondary" [rounded]="true" />
-                  }
-                </span>
                 <span class="flex-1 text-right text-sm font-semibold text-gray-900">${{ formatCompact(project.spend) }}</span>
                 <span class="flex-1 text-right text-sm font-semibold text-gray-900">${{ formatCompact(project.revenue) }}</span>
                 <span class="w-14 text-right text-sm font-semibold text-gray-900">{{ project.roas | number: '1.1-1' }}x</span>
@@ -318,14 +312,9 @@
 
               <!-- Expanded Campaign Rows -->
               @if (expandedProjects().has(project.projectName)) {
-                @for (campaign of project.campaigns; track campaign.campaignName + '|' + campaign.funnelStage) {
+                @for (campaign of project.campaigns; track campaign.campaignName) {
                   <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-paid-campaign-row">
                     <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="campaign.campaignName">{{ campaign.campaignName }}</span>
-                    <span class="w-16 flex justify-center">
-                      @if (formatFunnelLabel(campaign.funnelStage)) {
-                        <lfx-tag [value]="formatFunnelLabel(campaign.funnelStage)" severity="secondary" [rounded]="true" />
-                      }
-                    </span>
                     <span class="flex-1 text-right text-xs text-gray-600">${{ formatCompact(campaign.spend) }}</span>
                     <span class="flex-1 text-right text-xs text-gray-600">${{ formatCompact(campaign.revenue) }}</span>
                     <span class="w-14 text-right text-xs text-gray-600">{{ campaign.roas | number: '1.1-1' }}x</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -198,11 +198,6 @@ export class EmailCtrDrawerComponent {
     this.expandedProjects.set(next);
   }
 
-  protected formatFunnelLabel(stage: string): string {
-    const labels: Record<string, string> = { BoFU: 'BOTTOM', MoFU: 'MIDDLE', ToFU: 'TOP', ToFU2: 'TOP', Unknown: '' };
-    return labels[stage] ?? stage;
-  }
-
   protected toggleChannel(channel: string): void {
     const current = this.expandedChannels();
     const next = new Set(current);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2886,22 +2886,54 @@ export class ProjectService {
             impressions: data.impressions,
             clicks: data.clicks,
             performance: getPaidPerformance(projectRoas),
-            campaigns: [...data.campaigns]
-              .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
-              .slice(0, CAMPAIGN_TOP_N)
-              .map((c) => ({
-                campaignName: c.CAMPAIGN_NAME,
-                funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
-                spend: Math.round((c.SPEND ?? 0) * 100) / 100,
-                revenue: Math.round((c.REVENUE ?? 0) * 100) / 100,
-                roas: c.ROAS ?? 0,
-                conversions: c.CONVERSIONS ?? 0,
-                convRate: c.CONV_RATE ?? 0,
-                cpc: c.CPC ?? 0,
-                sessions: c.SESSIONS ?? 0,
-                impressions: c.IMPRESSIONS ?? 0,
-                clicks: c.CLICKS ?? 0,
-              })),
+            // The query's grain is campaign × funnel stage; the UI shows one
+            // row per campaign, so stages are dissolved here — sums first,
+            // then ratios recomputed from the sums (averaging per-stage
+            // ratios would be statistically incorrect), then the top-N cap
+            // so a multi-stage campaign consumes one slot, not three.
+            campaigns: (() => {
+              const byCampaign = new Map<
+                string,
+                { spend: number; revenue: number; conversions: number; sessions: number; impressions: number; clicks: number; stages: Set<string> }
+              >();
+              for (const c of data.campaigns) {
+                const agg = byCampaign.get(c.CAMPAIGN_NAME) ?? {
+                  spend: 0,
+                  revenue: 0,
+                  conversions: 0,
+                  sessions: 0,
+                  impressions: 0,
+                  clicks: 0,
+                  stages: new Set<string>(),
+                };
+                agg.spend += c.SPEND ?? 0;
+                agg.revenue += c.REVENUE ?? 0;
+                agg.conversions += c.CONVERSIONS ?? 0;
+                agg.sessions += c.SESSIONS ?? 0;
+                agg.impressions += c.IMPRESSIONS ?? 0;
+                agg.clicks += c.CLICKS ?? 0;
+                if (c.FUNNEL_STAGE) {
+                  agg.stages.add(c.FUNNEL_STAGE);
+                }
+                byCampaign.set(c.CAMPAIGN_NAME, agg);
+              }
+              return [...byCampaign.entries()]
+                .sort((a, b) => b[1].spend - a[1].spend)
+                .slice(0, CAMPAIGN_TOP_N)
+                .map(([campaignName, c]) => ({
+                  campaignName,
+                  funnelStage: formatFunnel(c.stages),
+                  spend: Math.round(c.spend * 100) / 100,
+                  revenue: Math.round(c.revenue * 100) / 100,
+                  roas: c.spend > 0 ? Math.round((c.revenue / c.spend) * 100) / 100 : 0,
+                  conversions: c.conversions,
+                  convRate: c.clicks > 0 ? Math.round((c.conversions / c.clicks) * 10000) / 100 : 0,
+                  cpc: c.clicks > 0 ? Math.round((c.spend / c.clicks) * 100) / 100 : 0,
+                  sessions: c.sessions,
+                  impressions: c.impressions,
+                  clicks: c.clicks,
+                }));
+            })(),
           };
         })
         .sort((a, b) => b.spend - a.spend);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2864,10 +2864,16 @@ export class ProjectService {
       // read ToFU, not BoFU. Ties fall back to a fixed priority for determinism.
       const formatFunnel = (stageSpend: Map<string, number>): string => {
         const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
+        // Unrecognized stages rank last so they lose spend ties to known stages,
+        // rather than winning them (indexOf would return -1, the lowest index).
+        const rank = (stage: string): number => {
+          const i = priority.indexOf(stage);
+          return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+        };
         let dominant = '';
         let maxSpend = -Infinity;
         for (const [stage, spend] of stageSpend) {
-          if (spend > maxSpend || (spend === maxSpend && priority.indexOf(stage) < priority.indexOf(dominant))) {
+          if (spend > maxSpend || (spend === maxSpend && rank(stage) < rank(dominant))) {
             dominant = stage;
             maxSpend = spend;
           }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2822,7 +2822,7 @@ export class ProjectService {
           impressions: number;
           clicks: number;
           sessions: number;
-          funnelStages: Set<string>;
+          funnelStages: Map<string, number>;
           campaigns: typeof projectPerfResult.rows;
         }
       >();
@@ -2834,7 +2834,7 @@ export class ProjectService {
           impressions: 0,
           clicks: 0,
           sessions: 0,
-          funnelStages: new Set<string>(),
+          funnelStages: new Map<string, number>(),
           campaigns: [] as typeof projectPerfResult.rows,
         };
         existing.spend += row.SPEND ?? 0;
@@ -2844,7 +2844,7 @@ export class ProjectService {
         existing.clicks += row.CLICKS ?? 0;
         existing.sessions += row.SESSIONS ?? 0;
         if (row.FUNNEL_STAGE) {
-          existing.funnelStages.add(row.FUNNEL_STAGE);
+          existing.funnelStages.set(row.FUNNEL_STAGE, (existing.funnelStages.get(row.FUNNEL_STAGE) ?? 0) + (row.SPEND ?? 0));
         }
         existing.campaigns.push(row);
         projectMap.set(row.PROJECT_NAME, existing);
@@ -2859,12 +2859,20 @@ export class ProjectService {
 
       const CAMPAIGN_TOP_N = 10;
 
-      const formatFunnel = (stages: Set<string>): string => {
+      // Picks the funnel stage that received the most spend. Presence alone is
+      // misleading: a campaign with 95% ToFU spend and a trace of BoFU should
+      // read ToFU, not BoFU. Ties fall back to a fixed priority for determinism.
+      const formatFunnel = (stageSpend: Map<string, number>): string => {
         const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
-        for (const p of priority) {
-          if (stages.has(p)) return p;
+        let dominant = '';
+        let maxSpend = -Infinity;
+        for (const [stage, spend] of stageSpend) {
+          if (spend > maxSpend || (spend === maxSpend && priority.indexOf(stage) < priority.indexOf(dominant))) {
+            dominant = stage;
+            maxSpend = spend;
+          }
         }
-        return [...stages][0] ?? 'Unknown';
+        return dominant || 'Unknown';
       };
 
       const projectBreakdown = Array.from(projectMap.entries())
@@ -2894,7 +2902,7 @@ export class ProjectService {
             campaigns: (() => {
               const byCampaign = new Map<
                 string,
-                { spend: number; revenue: number; conversions: number; sessions: number; impressions: number; clicks: number; stages: Set<string> }
+                { spend: number; revenue: number; conversions: number; sessions: number; impressions: number; clicks: number; stages: Map<string, number> }
               >();
               for (const c of data.campaigns) {
                 const agg = byCampaign.get(c.CAMPAIGN_NAME) ?? {
@@ -2904,7 +2912,7 @@ export class ProjectService {
                   sessions: 0,
                   impressions: 0,
                   clicks: 0,
-                  stages: new Set<string>(),
+                  stages: new Map<string, number>(),
                 };
                 agg.spend += c.SPEND ?? 0;
                 agg.revenue += c.REVENUE ?? 0;
@@ -2913,7 +2921,7 @@ export class ProjectService {
                 agg.impressions += c.IMPRESSIONS ?? 0;
                 agg.clicks += c.CLICKS ?? 0;
                 if (c.FUNNEL_STAGE) {
-                  agg.stages.add(c.FUNNEL_STAGE);
+                  agg.stages.set(c.FUNNEL_STAGE, (agg.stages.get(c.FUNNEL_STAGE) ?? 0) + (c.SPEND ?? 0));
                 }
                 byCampaign.set(c.CAMPAIGN_NAME, agg);
               }


### PR DESCRIPTION
## Summary
- "Performance by Project" in the ED Campaign Performance drawer showed one row per campaign per funnel stage (BoFU/MoFU/ToFU), fragmenting a single campaign's numbers across up to 3 rows and consuming multiple slots in the top-10 cap
- Campaigns now aggregate to a single row: spend/revenue/conversions/clicks are summed across stages first, then ROAS/Conv%/CPC are recomputed from those sums (never averaged across stages, which would be statistically incorrect)
- FUNNEL column removed from the table; the campaign's dominant funnel stage (by spend) is still tracked internally for other consumers of the same `projectBreakdown` payload

## Verification
Verified locally against `ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH` that dissolved per-campaign totals reconcile exactly with the sum of underlying per-stage rows (e.g. MCP Dev Summit NA 2026: $25.7K spend / $18.5K last-touch revenue matches BoFU+MoFU+ToFU sums).

LFXV2-2725