### PR TITLE
fix(committees): disable application-only join mode with coming soon notice

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -145,7 +145,8 @@
           <div class="flex flex-col gap-1">
             <span class="text-sm font-semibold text-gray-900">Apply to Join — Coming Soon</span>
             <p class="text-sm text-gray-600">
-              Reviewing and approving join requests is not yet available in LFX. Members who apply to join this group cannot currently be approved.
+              This group uses "Apply to Join" mode, but join request management is not yet available in LFX. New join requests are currently disabled and
+              existing applications cannot be reviewed or approved.
               @if (canEdit()) {
                 If you manage this group, consider changing the join mode to <strong>Open</strong>, <strong>Invite Only</strong>, or <strong>Closed</strong> in
                 the Settings tab below to continue letting members in while this feature is being built.
@@ -171,9 +172,9 @@
             @if (!committee()?.public) {
               <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
             }
-            <!-- Join / Request to Join / Contact Admin / Leave actions.
+            <!-- Join / Contact Admin / Leave actions.
                  Suppressed for an invited visitor — the Accept/Decline banner above is the action.
-                 Suppressed for invite-only groups — visitors must wait for an invitation. -->
+                 Suppressed for invite-only and application-only groups — visitors must wait for an invitation or admin add. -->
             <div class="ml-auto flex items-center gap-2">
               @if (isVisitor() && !pendingInvitation()) {
                 @if (committee()?.join_mode === 'open') {
@@ -185,16 +186,6 @@
                     [loading]="joiningOrLeaving()"
                     (onClick)="handleJoinRequest()"
                     data-testid="committee-view-join-btn" />
-                } @else if (committee()?.join_mode === 'application') {
-                  <lfx-button
-                    label="Request to Join"
-                    icon="fa-light fa-paper-plane"
-                    severity="secondary"
-                    [outlined]="true"
-                    size="small"
-                    [loading]="joiningOrLeaving()"
-                    (onClick)="handleJoinRequest()"
-                    data-testid="committee-view-request-to-join-btn" />
                 } @else if (committee()?.join_mode === 'closed') {
                   <lfx-button
                     label="Contact Admin"

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -134,6 +134,27 @@
           </div>
         </div>
       }
+      <!-- Application-only join mode coming soon notice -->
+      @if (committee()?.join_mode === 'application') {
+        <div
+          class="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-5 py-4"
+          role="region"
+          aria-label="Join mode notice"
+          data-testid="committee-view-application-mode-banner">
+          <i class="fa-light fa-triangle-exclamation mt-0.5 text-lg text-amber-600 shrink-0" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1">
+            <span class="text-sm font-semibold text-gray-900">Apply to Join — Coming Soon</span>
+            <p class="text-sm text-gray-600">
+              Reviewing and approving join requests is not yet available in LFX. Members who apply to join this group cannot currently be
+              approved.
+              @if (canEdit()) {
+                If you manage this group, consider changing the join mode to <strong>Open</strong>, <strong>Invite Only</strong>, or
+                <strong>Closed</strong> in the Settings tab below to continue letting members in while this feature is being built.
+              }
+            </p>
+          </div>
+        </div>
+      }
       <!-- Header Section -->
       <lfx-card styleClass="[&_.p-card-body]:!p-0" data-testid="committee-view-header">
         <div class="px-6 pt-5 pb-4 flex flex-col gap-4">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -145,11 +145,10 @@
           <div class="flex flex-col gap-1">
             <span class="text-sm font-semibold text-gray-900">Apply to Join — Coming Soon</span>
             <p class="text-sm text-gray-600">
-              Reviewing and approving join requests is not yet available in LFX. Members who apply to join this group cannot currently be
-              approved.
+              Reviewing and approving join requests is not yet available in LFX. Members who apply to join this group cannot currently be approved.
               @if (canEdit()) {
-                If you manage this group, consider changing the join mode to <strong>Open</strong>, <strong>Invite Only</strong>, or
-                <strong>Closed</strong> in the Settings tab below to continue letting members in while this feature is being built.
+                If you manage this group, consider changing the join mode to <strong>Open</strong>, <strong>Invite Only</strong>, or <strong>Closed</strong> in
+                the Settings tab below to continue letting members in while this feature is being built.
               }
             </p>
           </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -139,7 +139,7 @@ export class CommitteeOverviewComponent {
 
   public canJoin: Signal<boolean> = computed(() => {
     const mode = this.committee().join_mode;
-    return this.isVisitor() && (mode === 'open' || mode === 'application') && !this.hasPendingInvite();
+    return this.isVisitor() && mode === 'open' && !this.hasPendingInvite();
   });
 
   public showInviteOnlyNotice: Signal<boolean> = computed(() => {

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -498,7 +498,7 @@ export const JOIN_MODE_LABELS: Record<JoinMode, string> = {
 export const JOIN_MODE_OPTIONS = [
   { label: 'Open — anyone can join', value: 'open' },
   { label: 'Invite Only — members send invites', value: 'invite_only' },
-  { label: 'Apply & Review — Coming Soon', value: 'application', disabled: true },
+  { label: 'Apply to Join — Coming Soon', value: 'application', disabled: true },
   { label: 'Closed — admin adds members', value: 'closed' },
 ];
 

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -498,7 +498,7 @@ export const JOIN_MODE_LABELS: Record<JoinMode, string> = {
 export const JOIN_MODE_OPTIONS = [
   { label: 'Open — anyone can join', value: 'open' },
   { label: 'Invite Only — members send invites', value: 'invite_only' },
-  { label: 'Apply & Review — admin approves', value: 'application' },
+  { label: 'Apply & Review — Coming Soon', value: 'application', disabled: true },
   { label: 'Closed — admin adds members', value: 'closed' },
 ];
 


### PR DESCRIPTION
## Summary

- Grays out the **Apply to Join** option in the committee join mode dropdown (settings form) by adding \`disabled: true\` to the option — PrimeNG's select natively renders it as unselectable with a coming-soon label
- Adds an amber notice banner on the committee group view page when a group has \`join_mode: 'application'\`, explaining that reviewing join requests is not yet supported and guiding managers to change the join mode in Settings to keep the group functional
- Removes the "Request to Join" CTA for visitors on application-mode groups (both the header button and the Overview tab) so no new applications can be submitted to groups that cannot process them

## Ticket

[LFXV2-2690](https://linuxfoundation.atlassian.net/browse/LFXV2-2690)

## Screenshots

<img width="707" height="309" alt="Screenshot 2026-07-17 at 9 22 32 AM" src="https://github.com/user-attachments/assets/3621c09c-67de-425e-98d8-f5c41eb97606" />
<img width="1360" height="972" alt="Screenshot 2026-07-17 at 9 53 43 AM" src="https://github.com/user-attachments/assets/56b2d81c-7918-4d94-a3f7-733f3af2379c" />

## Test plan

- [ ] Create a new committee → Settings step: "Apply to Join" option is visually grayed out with "Coming Soon" label and cannot be selected
- [ ] Edit an existing group with \`join_mode: application\` → dropdown shows "Apply to Join — Coming Soon" as the current value (grayed out); other options remain selectable; saving without changing the mode is allowed (informational nudge, not a hard block)
- [ ] Visit view page of a group with \`join_mode: application\` → amber banner appears below the invitation slot and above the header card
- [ ] As a non-manager visitor on an application-mode group → no "Request to Join" button in the header or Overview tab
- [ ] As a non-manager visitor, banner appears but without the manager-specific sentence about changing the join mode
- [ ] Visit view page of an Open / Invite Only / Closed group → no banner shown
- [ ] \`yarn build\` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2690]: https://linuxfoundation.atlassian.net/browse/LFXV2-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ