### PR TITLE
feat(profile): unify transactions and settings into profile tabs

### DIFF
--- a/apps/lfx-one/e2e/persona-navigation.spec.ts
+++ b/apps/lfx-one/e2e/persona-navigation.spec.ts
@@ -23,6 +23,7 @@
  *   S11 Settings page — view-only banner shown to non-writer
  *   S12 Settings page — view-only banner hidden for writer
  *   S13 Settings lens redirect — me lens → /profile/settings (fragment preserved); foundation keeps prefixed route
+ *   S14 Legacy transactions redirect — /me/transactions → /profile/transactions, embedded in the Profile shell
  *
  * Failure messages include the persona × lens × page combination so CI output
  * pinpoints the exact regression without digging through traces.
@@ -629,5 +630,34 @@ test.describe('S13: Settings lens redirect — me lens → /profile/settings', (
       /\/foundation\/settings\?project=test-foundation/,
       { timeout: ELEMENT_TIMEOUT }
     );
+  });
+});
+
+// ─── S14: Legacy transactions redirect (/me/transactions → /profile/transactions) ──
+
+test.describe('S14: Legacy transactions redirect — /me/transactions → /profile/transactions', () => {
+  test('redirects the legacy path and renders the dashboard embedded in the Profile shell', async ({ page }) => {
+    await stubPersona(page, ['contributor']);
+    await setPersonaCookie(page, ['contributor']);
+
+    // Me lens is the default; establish it, then hit the legacy transactions path.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await page.goto('/me/transactions', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    // The route redirects the former /me/transactions page to the canonical Profile tab.
+    await expect(page, 'legacy /me/transactions should redirect to /profile/transactions').toHaveURL(/\/profile\/transactions$/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // The transactions dashboard renders inside the Profile shell, which owns the page header…
+    await expect(page.getByTestId('transactions-dashboard'), 'transactions dashboard should render').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('profile-page-title'), 'Profile shell header should own the page title').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    // …so the dashboard's own standalone header is suppressed in embedded mode.
+    await expect(page.getByTestId('transactions-title'), 'embedded dashboard should not render its standalone header').toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/persona-navigation.spec.ts
+++ b/apps/lfx-one/e2e/persona-navigation.spec.ts
@@ -22,6 +22,7 @@
  *   S10 Route guard — writerGuard passes for ED via synchronous fast path
  *   S11 Settings page — view-only banner shown to non-writer
  *   S12 Settings page — view-only banner hidden for writer
+ *   S13 Settings lens redirect — me lens → /profile/settings (fragment preserved); foundation keeps prefixed route
  *
  * Failure messages include the persona × lens × page combination so CI output
  * pinpoints the exact regression without digging through traces.
@@ -587,5 +588,45 @@ test.describe('S12: Settings / Permissions page — no banner for writer', () =>
       page.getByText('You have view-only access to this project'),
       'persona=contributor canWrite=true lens=project page=settings should NOT show view-only banner'
     ).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+  });
+});
+
+// ─── S13: Settings lens redirect (settingsLensRedirectGuard) ───────────────────
+
+test.describe('S13: Settings lens redirect — me lens → /profile/settings', () => {
+  test('me lens redirects /settings#developer-settings to /profile/settings with the fragment intact', async ({ page }) => {
+    await stubPersona(page, ['contributor']);
+    await setPersonaCookie(page, ['contributor']);
+
+    // Me lens is the default; no project context needed.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await page.goto('/settings#developer-settings', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    // settingsLensRedirectGuard maps me-lens /settings → /profile/settings, carrying the fragment
+    // through so the header's Developer Settings anchor link still lands on the right section.
+    await expect(page, 'me lens should redirect /settings to /profile/settings with #developer-settings preserved').toHaveURL(
+      /\/profile\/settings#developer-settings$/,
+      { timeout: ELEMENT_TIMEOUT }
+    );
+  });
+
+  test('foundation lens keeps the lens-prefixed /foundation/settings route', async ({ page }) => {
+    await stubPersona(page, ['executive-director']);
+    await stubNavLensItems(page, 'foundation');
+    await stubProjectApi(page, MOCK_FOUNDATION_SLUG, true);
+    await setPersonaCookie(page, ['executive-director']);
+
+    // Establish the foundation lens first, then hit the flat /settings route.
+    await gotoAndWaitForSidebar(page, `/foundation/overview?project=${MOCK_FOUNDATION_SLUG}`);
+
+    await page.goto(`/settings?project=${MOCK_FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await expect(page, 'foundation lens should redirect /settings to /foundation/settings').toHaveURL(/\/foundation\/settings/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
   });
 });

--- a/apps/lfx-one/e2e/persona-navigation.spec.ts
+++ b/apps/lfx-one/e2e/persona-navigation.spec.ts
@@ -594,7 +594,7 @@ test.describe('S12: Settings / Permissions page — no banner for writer', () =>
 // ─── S13: Settings lens redirect (settingsLensRedirectGuard) ───────────────────
 
 test.describe('S13: Settings lens redirect — me lens → /profile/settings', () => {
-  test('me lens redirects /settings#developer-settings to /profile/settings with the fragment intact', async ({ page }) => {
+  test('me lens redirects /settings?src=nav#developer-settings to /profile/settings preserving query + fragment', async ({ page }) => {
     await stubPersona(page, ['contributor']);
     await setPersonaCookie(page, ['contributor']);
 
@@ -602,13 +602,13 @@ test.describe('S13: Settings lens redirect — me lens → /profile/settings', (
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
-    await page.goto('/settings#developer-settings', { waitUntil: 'domcontentloaded' });
+    await page.goto('/settings?src=nav#developer-settings', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
-    // settingsLensRedirectGuard maps me-lens /settings → /profile/settings, carrying the fragment
-    // through so the header's Developer Settings anchor link still lands on the right section.
-    await expect(page, 'me lens should redirect /settings to /profile/settings with #developer-settings preserved').toHaveURL(
-      /\/profile\/settings#developer-settings$/,
+    // settingsLensRedirectGuard maps me-lens /settings → /profile/settings, carrying both the query
+    // param and the fragment through so the header's Developer Settings anchor link still lands right.
+    await expect(page, 'me lens should redirect /settings to /profile/settings with ?src=nav and #developer-settings preserved').toHaveURL(
+      /\/profile\/settings\?src=nav#developer-settings$/,
       { timeout: ELEMENT_TIMEOUT }
     );
   });
@@ -625,8 +625,9 @@ test.describe('S13: Settings lens redirect — me lens → /profile/settings', (
     await page.goto(`/settings?project=${MOCK_FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
-    await expect(page, 'foundation lens should redirect /settings to /foundation/settings').toHaveURL(/\/foundation\/settings/, {
-      timeout: ELEMENT_TIMEOUT,
-    });
+    await expect(page, 'foundation lens should redirect /settings to /foundation/settings with ?project preserved').toHaveURL(
+      /\/foundation\/settings\?project=test-foundation/,
+      { timeout: ELEMENT_TIMEOUT }
+    );
   });
 });

--- a/apps/lfx-one/e2e/profile-avatar.spec.ts
+++ b/apps/lfx-one/e2e/profile-avatar.spec.ts
@@ -56,7 +56,7 @@ function skipWhenAuthMissing(page: Page): void {
 test.describe('Profile header avatar', () => {
   test('renders user_metadata.picture as the avatar image when set', async ({ page }) => {
     await mockProfile(page, PNG_DATA_URI);
-    await page.goto('/profile/attribution', { waitUntil: 'domcontentloaded' });
+    await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });
@@ -68,7 +68,7 @@ test.describe('Profile header avatar', () => {
 
   test('falls back to initials when no picture is set', async ({ page }) => {
     await mockProfile(page, null);
-    await page.goto('/profile/attribution', { waitUntil: 'domcontentloaded' });
+    await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });
@@ -82,7 +82,7 @@ test.describe('Profile header avatar', () => {
     // Force the image request to fail so the (error) handler fires.
     await page.route(BROKEN_PICTURE_URL, (route) => route.abort());
 
-    await page.goto('/profile/attribution', { waitUntil: 'domcontentloaded' });
+    await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });

--- a/apps/lfx-one/e2e/profile-avatar.spec.ts
+++ b/apps/lfx-one/e2e/profile-avatar.spec.ts
@@ -56,10 +56,13 @@ function skipWhenAuthMissing(page: Page): void {
 test.describe('Profile header avatar', () => {
   test('renders user_metadata.picture as the avatar image when set', async ({ page }) => {
     await mockProfile(page, PNG_DATA_URI);
-    await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
+    // Enter via the legacy singular URL to also cover the backward-compat redirect.
+    await page.goto('/profile/attribution', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });
+    // The legacy /profile/attribution URL must redirect to the canonical /profile/attributions.
+    await expect(page).toHaveURL(/\/profile\/attributions$/, { timeout: 10000 });
 
     const image = page.getByTestId('profile-avatar-image');
     await expect(image).toBeVisible();

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -365,7 +365,7 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/badges/badges.routes').then((m) => m.BADGE_ROUTES),
       },
       {
-        // Transactions now live as a Profile & Account tab — redirect the legacy path.
+        // Transactions now live as a Profile tab — redirect the legacy path.
         path: 'me/transactions',
         redirectTo: 'profile/transactions',
         pathMatch: 'full',

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
 import { akritesEnabledGuard } from './shared/guards/akrites-enabled.guard';
 import { mktgOsAgentsEnabledGuard } from './shared/guards/mktg-os-agents-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
+import { settingsLensRedirectGuard } from './shared/guards/settings-lens-redirect.guard';
 
 const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
 
@@ -346,8 +347,9 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
       },
       {
+        // Me lens → /profile/settings (canonical); foundation/project → lens-prefixed settings.
         path: 'settings',
-        canActivate: [lensRedirectGuard],
+        canActivate: [settingsLensRedirectGuard],
         loadChildren: () => import('./modules/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
       },
       {
@@ -363,8 +365,10 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/badges/badges.routes').then((m) => m.BADGE_ROUTES),
       },
       {
+        // Transactions now live as a Profile & Account tab — redirect the legacy path.
         path: 'me/transactions',
-        loadChildren: () => import('./modules/transactions/transactions.routes').then((m) => m.TRANSACTION_ROUTES),
+        redirectTo: 'profile/transactions',
+        pathMatch: 'full',
       },
       {
         path: 'events',

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -178,7 +178,7 @@ export class ProfileLayoutComponent {
         this.messageService.add({
           severity: 'error',
           summary: 'Authorization Error',
-          detail: 'Profile authorization failed. Please try saving again.',
+          detail: 'Authorization failed. Please try again.',
         });
         this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
       }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -15,6 +15,7 @@ import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, filter, map, of, startWith, switchMap, take } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
+import { PENDING_PROFILE_SAVE_KEY } from '@app/shared/utils/pending-profile-save.util';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
 
 // Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
@@ -43,7 +44,7 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileLayoutComponent {
-  private static readonly formStateKey = 'lfx_profile_pending_save';
+  private static readonly formStateKey = PENDING_PROFILE_SAVE_KEY;
   // Discard a stored pending-save older than this. Prevents an abandoned profile-edit authorization
   // from being silently replayed by a later, unrelated profile-auth return (e.g. an email-delete
   // authorization that now lands on /profile/settings inside this shell).

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -71,7 +71,7 @@ export class ProfileLayoutComponent {
 
   // Form for mobile tab selection
   public readonly tabForm = this.fb.group({
-    selectedTab: ['attribution'],
+    selectedTab: ['attributions'],
   });
 
   // Profile data from the service (server-fetched). The profile GET is eventually consistent

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -171,7 +171,7 @@ export class ProfileLayoutComponent {
     this.route.queryParams.pipe(takeUntilDestroyed()).subscribe((params) => {
       if (params['success'] === 'profile_token_obtained') {
         this.handleProfileAuthReturn();
-        this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
+        this.clearAuthQueryParams();
       }
 
       if (PROFILE_AUTH_ERROR_CODES.has(params['error'])) {
@@ -180,7 +180,7 @@ export class ProfileLayoutComponent {
           summary: 'Authorization Error',
           detail: 'Authorization failed. Please try again.',
         });
-        this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
+        this.clearAuthQueryParams();
       }
     });
   }
@@ -307,6 +307,14 @@ export class ProfileLayoutComponent {
         });
       },
     });
+  }
+
+  // Strip the Flow C query params (success/error) while staying on the current tab.
+  // Navigating relative to this.route would resolve to the parent /profile route and
+  // bounce the user to the default tab — so re-navigate to the current path sans query.
+  private clearAuthQueryParams(): void {
+    const path = this.router.url.split('?')[0];
+    this.router.navigateByUrl(path, { replaceUrl: true });
   }
 
   // Private init functions

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { SelectComponent } from '@components/select/select.component';
-import { normalizeTShirtSize, PROFILE_TABS, TSHIRT_SIZES } from '@lfx-one/shared/constants';
+import { normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_TABS, TSHIRT_SIZES } from '@lfx-one/shared/constants';
 import { CombinedProfile, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -15,7 +15,6 @@ import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, filter, map, of, startWith, switchMap, take } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
-import { PENDING_PROFILE_SAVE_KEY } from '@app/shared/utils/pending-profile-save.util';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
 
 // Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -44,6 +44,10 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 })
 export class ProfileLayoutComponent {
   private static readonly formStateKey = 'lfx_profile_pending_save';
+  // Discard a stored pending-save older than this. Prevents an abandoned profile-edit authorization
+  // from being silently replayed by a later, unrelated profile-auth return (e.g. an email-delete
+  // authorization that now lands on /profile/settings inside this shell).
+  private static readonly pendingSaveTtlMs = 10 * 60 * 1000;
 
   // Private injections
   private readonly route = inject(ActivatedRoute);
@@ -253,9 +257,15 @@ export class ProfileLayoutComponent {
 
     sessionStorage.removeItem(ProfileLayoutComponent.formStateKey);
 
+    // Stored as { savedAt, form }. Discard if older than the TTL so an abandoned profile-edit
+    // authorization isn't silently replayed by a later, unrelated profile-auth return.
     let formData: Partial<UserMetadata>;
     try {
-      formData = JSON.parse(savedState);
+      const envelope = JSON.parse(savedState) as { savedAt?: unknown; form?: Partial<UserMetadata> };
+      if (typeof envelope?.savedAt !== 'number' || !envelope.form || Date.now() - envelope.savedAt > ProfileLayoutComponent.pendingSaveTtlMs) {
+        return;
+      }
+      formData = envelope.form;
     } catch {
       return;
     }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -13,6 +13,7 @@ import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata, WorkExp
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
+import { PENDING_PROFILE_SAVE_KEY } from '@app/shared/utils/pending-profile-save.util';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { finalize } from 'rxjs';
@@ -196,7 +197,7 @@ export class ProfileEditDialogComponent {
           if (error.status === 403 && error.error?.error === 'management_token_required') {
             // Stamp with a timestamp so the parent shell can discard a stale pending-save if this
             // authorization is abandoned (see ProfileLayoutComponent.handleProfileAuthReturn TTL guard).
-            sessionStorage.setItem('lfx_profile_pending_save', JSON.stringify({ savedAt: Date.now(), form: this.profileForm.value }));
+            sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify({ savedAt: Date.now(), form: this.profileForm.value }));
             window.location.href = error.error.authorize_url;
             return;
           }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -194,7 +194,9 @@ export class ProfileEditDialogComponent {
         error: (error: HttpErrorResponse) => {
           // Flow C: Management token required — save form state and redirect to authorize
           if (error.status === 403 && error.error?.error === 'management_token_required') {
-            sessionStorage.setItem('lfx_profile_pending_save', JSON.stringify(this.profileForm.value));
+            // Stamp with a timestamp so the parent shell can discard a stale pending-save if this
+            // authorization is abandoned (see ProfileLayoutComponent.handleProfileAuthReturn TTL guard).
+            sessionStorage.setItem('lfx_profile_pending_save', JSON.stringify({ savedAt: Date.now(), form: this.profileForm.value }));
             window.location.href = error.error.authorize_url;
             return;
           }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -8,12 +8,11 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { COUNTRIES, normalizeTShirtSize, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
+import { COUNTRIES, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata, WorkExperienceEntry } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
-import { PENDING_PROFILE_SAVE_KEY } from '@app/shared/utils/pending-profile-save.util';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { finalize } from 'rxjs';

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -8,12 +8,12 @@ export const PROFILE_ROUTES: Routes = [
     path: '',
     loadComponent: () => import('@app/layouts/profile-layout/profile-layout.component').then((m) => m.ProfileLayoutComponent),
     children: [
-      // Default redirect to attribution
-      { path: '', redirectTo: 'attribution', pathMatch: 'full' },
+      // Default redirect to attributions
+      { path: '', redirectTo: 'attributions', pathMatch: 'full' },
 
-      // Attribution tab (merges affiliations + work experience)
+      // Work history & Affiliations tab (merges affiliations + work experience)
       {
-        path: 'attribution',
+        path: 'attributions',
         loadComponent: () => import('./attribution/profile-attribution.component').then((m) => m.ProfileAttributionComponent),
       },
 
@@ -27,6 +27,22 @@ export const PROFILE_ROUTES: Routes = [
       {
         path: 'individual-enrollment',
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
+      },
+
+      // Transactions tab — canonical home for the former /me/transactions page.
+      // `embedded` suppresses the component's own page header inside the profile shell.
+      {
+        path: 'transactions',
+        data: { embedded: true },
+        loadComponent: () => import('../transactions/transactions-dashboard/transactions-dashboard.component').then((m) => m.TransactionsDashboardComponent),
+      },
+
+      // Settings tab — canonical home for the former me-context /settings page.
+      // `embedded` suppresses the component's own page header inside the profile shell.
+      {
+        path: 'settings',
+        data: { embedded: true },
+        loadComponent: () => import('../settings/account-settings/account-settings.component').then((m) => m.AccountSettingsComponent),
       },
 
       // linux-email is now embedded in the Identities tab — redirect for backward compat
@@ -43,15 +59,16 @@ export const PROFILE_ROUTES: Routes = [
       },
 
       // Backward-compat redirects for old URLs
-      { path: 'overview', redirectTo: 'attribution' },
-      { path: 'edit', redirectTo: 'attribution' },
-      { path: 'affiliations', redirectTo: 'attribution' },
-      { path: 'work-experience', redirectTo: 'attribution' },
+      { path: 'attribution', redirectTo: 'attributions' },
+      { path: 'overview', redirectTo: 'attributions' },
+      { path: 'edit', redirectTo: 'attributions' },
+      { path: 'affiliations', redirectTo: 'attributions' },
+      { path: 'work-experience', redirectTo: 'attributions' },
       { path: 'identity-services', redirectTo: 'identities' },
-      { path: 'badges', redirectTo: 'attribution' },
-      { path: 'certificates', redirectTo: 'attribution' },
-      { path: 'visibility', redirectTo: 'attribution' },
-      { path: 'manage', redirectTo: 'attribution' },
+      { path: 'badges', redirectTo: 'attributions' },
+      { path: 'certificates', redirectTo: 'attributions' },
+      { path: 'visibility', redirectTo: 'attributions' },
+      { path: 'manage', redirectTo: 'attributions' },
     ],
   },
 ];

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -10,8 +10,9 @@
     </div>
   }
 
-  <!-- Read-only notice while impersonating — account changes act on the real account and are disabled -->
-  @if (impersonating()) {
+  <!-- Read-only notice while impersonating — account changes act on the real account and are disabled.
+       Suppressed when embedded: the Profile & Account shell already renders this banner. -->
+  @if (impersonating() && !embedded) {
     <div
       class="mb-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
       role="status"

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="w-full" data-testid="account-settings">
-  <!-- Page Header — suppressed when embedded in the Profile & Account shell, which owns the header -->
+  <!-- Page Header — suppressed when embedded in the Profile shell, which owns the header -->
   @if (!embedded) {
     <div class="mb-6">
       <h1 class="font-display font-light text-2xl" data-testid="account-settings-title">Account Settings</h1>
@@ -11,7 +11,7 @@
   }
 
   <!-- Read-only notice while impersonating — account changes act on the real account and are disabled.
-       Suppressed when embedded: the Profile & Account shell already renders this banner. -->
+       Suppressed when embedded: the Profile shell already renders this banner. -->
   @if (impersonating() && !embedded) {
     <div
       class="mb-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -2,11 +2,13 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="w-full" data-testid="account-settings">
-  <!-- Page Header -->
-  <div class="mb-6">
-    <h1 class="font-display font-light text-2xl" data-testid="account-settings-title">Account Settings</h1>
-    <p class="mt-1 text-sm text-gray-500">Manage your account preferences, email addresses, and security settings.</p>
-  </div>
+  <!-- Page Header — suppressed when embedded in the Profile & Account shell, which owns the header -->
+  @if (!embedded) {
+    <div class="mb-6">
+      <h1 class="font-display font-light text-2xl" data-testid="account-settings-title">Account Settings</h1>
+      <p class="mt-1 text-sm text-gray-500">Manage your account preferences, email addresses, and security settings.</p>
+    </div>
+  }
 
   <!-- Read-only notice while impersonating — account changes act on the real account and are disabled -->
   @if (impersonating()) {

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -12,6 +12,7 @@ import { TokenRevealDialogComponent } from '@components/token-reveal-dialog/toke
 import { markFormControlsAsTouched } from '@lfx-one/shared';
 import { ActivatedRoute } from '@angular/router';
 import { useResendCooldown } from '@shared/utils/resend-cooldown';
+import { clearPendingProfileSave } from '@shared/utils/pending-profile-save.util';
 import { ChangePasswordRequest, EmailManagementData, PasswordStrength, UserEmail } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -244,7 +245,7 @@ export class AccountSettingsComponent {
         },
         error: (error) => {
           if (error.status === 403 && error.error?.error === 'management_token_required') {
-            window.location.href = error.error.authorize_url;
+            this.redirectToProfileAuth(error.error.authorize_url);
             return;
           }
           this.messageService.add({ severity: 'error', summary: 'Error', detail: error.error?.message || 'Verification failed. Please try again.' });
@@ -272,7 +273,7 @@ export class AccountSettingsComponent {
       },
       error: (err: HttpErrorResponse) => {
         if (err.error?.error === 'management_token_required' && err.error?.authorize_url) {
-          window.location.href = err.error.authorize_url;
+          this.redirectToProfileAuth(err.error.authorize_url);
           return;
         }
         this.messageService.add({ severity: 'error', summary: 'Error', detail: err.error?.message || 'Failed to update primary email' });
@@ -292,7 +293,7 @@ export class AccountSettingsComponent {
       .pipe(take(1))
       .subscribe((status) => {
         if (!status.authorized) {
-          window.location.href = '/api/profile/auth/start?returnTo=/profile/settings';
+          this.redirectToProfileAuth('/api/profile/auth/start?returnTo=/profile/settings');
           return;
         }
 
@@ -315,7 +316,7 @@ export class AccountSettingsComponent {
                 },
                 error: (err: HttpErrorResponse) => {
                   if (err.error?.error === 'management_token_required' && err.error?.authorize_url) {
-                    window.location.href = err.error.authorize_url;
+                    this.redirectToProfileAuth(err.error.authorize_url);
                     return;
                   }
                   this.messageService.add({ severity: 'error', summary: 'Error', detail: err.error?.message || 'Failed to delete email address' });
@@ -354,7 +355,7 @@ export class AccountSettingsComponent {
         },
         error: (error: HttpErrorResponse) => {
           if (error.error?.error === 'management_token_required' && error.error?.authorize_url) {
-            window.location.href = error.error.authorize_url;
+            this.redirectToProfileAuth(error.error.authorize_url);
             return;
           }
           this.messageService.add({
@@ -380,7 +381,7 @@ export class AccountSettingsComponent {
         },
         error: (error: HttpErrorResponse) => {
           if (error.error?.error === 'management_token_required' && error.error?.authorize_url) {
-            window.location.href = error.error.authorize_url;
+            this.redirectToProfileAuth(error.error.authorize_url);
             return;
           }
           this.resetResultSuccess.set(false);
@@ -443,6 +444,18 @@ export class AccountSettingsComponent {
   // ══════════════════════════════════════════
   // PRIVATE INITIALIZERS
   // ══════════════════════════════════════════
+
+  /**
+   * Redirect into a profile-auth (Flow C) flow for an email/password operation.
+   * Clears any stored profile-edit pending-save first so an abandoned edit
+   * authorization can't be silently replayed when this flow returns to the
+   * profile shell (these settings now live at /profile/settings).
+   */
+  private redirectToProfileAuth(url: string): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    clearPendingProfileSave();
+    window.location.href = url;
+  }
 
   private initEmailData(): Signal<EmailManagementData | null> {
     return toSignal(

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -10,6 +10,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { TokenRevealDialogComponent } from '@components/token-reveal-dialog/token-reveal-dialog.component';
 import { markFormControlsAsTouched } from '@lfx-one/shared';
+import { ActivatedRoute } from '@angular/router';
 import { useResendCooldown } from '@shared/utils/resend-cooldown';
 import { ChangePasswordRequest, EmailManagementData, PasswordStrength, UserEmail } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
@@ -48,6 +49,10 @@ export class AccountSettingsComponent {
   private readonly dialogService = inject(DialogService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly route = inject(ActivatedRoute);
+
+  // Hosted inside the Profile & Account shell (route data `embedded`), which owns the page header.
+  public readonly embedded = this.route.snapshot.data['embedded'] === true;
 
   // ── Refresh mechanisms ──
   private emailRefresh = new BehaviorSubject<void>(undefined);
@@ -287,7 +292,7 @@ export class AccountSettingsComponent {
       .pipe(take(1))
       .subscribe((status) => {
         if (!status.authorized) {
-          window.location.href = '/api/profile/auth/start?returnTo=/settings';
+          window.location.href = '/api/profile/auth/start?returnTo=/profile/settings';
           return;
         }
 

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -52,7 +52,7 @@ export class AccountSettingsComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly route = inject(ActivatedRoute);
 
-  // Hosted inside the Profile & Account shell (route data `embedded`), which owns the page header.
+  // Hosted inside the Profile shell (route data `embedded`), which owns the page header.
   public readonly embedded = this.route.snapshot.data['embedded'] === true;
 
   // ── Refresh mechanisms ──

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div [class]="embedded ? 'w-full' : 'container mx-auto px-4 sm:px-6 lg:px-8'" data-testid="transactions-dashboard">
-  <!-- Page Header — suppressed when embedded in the Profile & Account shell, which owns the header -->
+  <!-- Page Header — suppressed when embedded in the Profile shell, which owns the header -->
   @if (!embedded) {
     <div class="mb-6">
       <h1 class="font-display font-light text-2xl" data-testid="transactions-title">My Transactions</h1>

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -1,12 +1,14 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="transactions-dashboard">
-  <!-- Page Header -->
-  <div class="mb-6">
-    <h1 class="font-display font-light text-2xl" data-testid="transactions-title">My Transactions</h1>
-    <p class="mt-1 text-sm text-gray-500" data-testid="transactions-subtitle">{{ subtitle }}</p>
-  </div>
+<div [class]="embedded ? 'w-full' : 'container mx-auto px-4 sm:px-6 lg:px-8'" data-testid="transactions-dashboard">
+  <!-- Page Header — suppressed when embedded in the Profile & Account shell, which owns the header -->
+  @if (!embedded) {
+    <div class="mb-6">
+      <h1 class="font-display font-light text-2xl" data-testid="transactions-title">My Transactions</h1>
+      <p class="mt-1 text-sm text-gray-500" data-testid="transactions-subtitle">{{ subtitle }}</p>
+    </div>
+  }
 
   <!-- Tab switcher -->
   <div class="mb-6" data-testid="transactions-tabs">

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -59,7 +59,7 @@ export class TransactionsDashboardComponent {
   // ─── Configuration ─────────────────────────────────────────────────────────
   protected readonly subtitle = PAGE_SUBTITLE;
   protected readonly tabOptions = TAB_OPTIONS;
-  // Hosted inside the Profile & Account shell (route data `embedded`), which owns the page header.
+  // Hosted inside the Profile shell (route data `embedded`), which owns the page header.
   protected readonly embedded = this.route.snapshot.data['embedded'] === true;
 
   // ─── Writable Signals ──────────────────────────────────────────────────────

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -6,6 +6,7 @@
 import { CurrencyPipe, DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import {
   TRANSACTION_TYPE_BUNDLE,
   TRANSACTION_TYPE_CERTIFICATION,
@@ -53,10 +54,13 @@ const TAB_TYPE_MAP: Record<string, string> = {
 export class TransactionsDashboardComponent {
   // ─── Private Injections ────────────────────────────────────────────────────
   private readonly transactionService = inject(TransactionService);
+  private readonly route = inject(ActivatedRoute);
 
   // ─── Configuration ─────────────────────────────────────────────────────────
   protected readonly subtitle = PAGE_SUBTITLE;
   protected readonly tabOptions = TAB_OPTIONS;
+  // Hosted inside the Profile & Account shell (route data `embedded`), which owns the page header.
+  protected readonly embedded = this.route.snapshot.data['embedded'] === true;
 
   // ─── Writable Signals ──────────────────────────────────────────────────────
   protected readonly activeTab = signal<string>('all');

--- a/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { LensService } from '../services/lens.service';
+
+/**
+ * Route guard for the flat `/settings` route.
+ *
+ * - Foundation / project lens: redirect to the lens-prefixed equivalent
+ *   (`/foundation/settings`, `/project/settings`) — same behavior as `lensRedirectGuard`.
+ * - Me lens: redirect to `/profile/settings`, the canonical home for account settings
+ *   now that they live as a tab in the Profile & Account page.
+ * - Any other lens (e.g. org): let the request through unchanged.
+ *
+ * Reads `state.url` so query params and trailing segments survive the lens redirect.
+ */
+export const settingsLensRedirectGuard: CanActivateFn = (_route, state) => {
+  const lensService = inject(LensService);
+  const router = inject(Router);
+
+  const lens = lensService.activeLens();
+  if (lens === 'foundation' || lens === 'project') {
+    return router.parseUrl(`/${lens}${state.url}`);
+  }
+  if (lens === 'me') {
+    return router.parseUrl('/profile/settings');
+  }
+  return true;
+};

--- a/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
@@ -12,7 +12,7 @@ import { LensService } from '../services/lens.service';
  * - Foundation / project lens: redirect to the lens-prefixed equivalent
  *   (`/foundation/settings`, `/project/settings`) — same behavior as `lensRedirectGuard`.
  * - Me lens: redirect to `/profile/settings` (canonical home for account settings now
- *   that they live as a Profile & Account tab), carrying the query params and fragment
+ *   that they live as a Profile tab), carrying the query params and fragment
  *   through so the header's `/settings#developer-settings` anchor link still lands on
  *   the right section. `RouterStateSnapshot.url` omits the fragment, so build the tree
  *   from the snapshot's `queryParams`/`fragment` rather than string-prefixing `state.url`.

--- a/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
@@ -11,8 +11,10 @@ import { LensService } from '../services/lens.service';
  *
  * - Foundation / project lens: redirect to the lens-prefixed equivalent
  *   (`/foundation/settings`, `/project/settings`) — same behavior as `lensRedirectGuard`.
- * - Me lens: redirect to `/profile/settings`, the canonical home for account settings
- *   now that they live as a tab in the Profile & Account page.
+ * - Me lens: redirect under `/profile` (canonical home for account settings now that
+ *   they live as a Profile & Account tab). Prefixing `state.url` maps `/settings` →
+ *   `/profile/settings` while carrying query params and fragments (e.g. the header's
+ *   `/settings#developer-settings` anchor link) through the redirect.
  * - Any other lens (e.g. org): let the request through unchanged.
  *
  * Reads `state.url` so query params and trailing segments survive the lens redirect.
@@ -26,7 +28,7 @@ export const settingsLensRedirectGuard: CanActivateFn = (_route, state) => {
     return router.parseUrl(`/${lens}${state.url}`);
   }
   if (lens === 'me') {
-    return router.parseUrl('/profile/settings');
+    return router.parseUrl(`/profile${state.url}`);
   }
   return true;
 };

--- a/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/settings-lens-redirect.guard.ts
@@ -11,15 +11,14 @@ import { LensService } from '../services/lens.service';
  *
  * - Foundation / project lens: redirect to the lens-prefixed equivalent
  *   (`/foundation/settings`, `/project/settings`) — same behavior as `lensRedirectGuard`.
- * - Me lens: redirect under `/profile` (canonical home for account settings now that
- *   they live as a Profile & Account tab). Prefixing `state.url` maps `/settings` →
- *   `/profile/settings` while carrying query params and fragments (e.g. the header's
- *   `/settings#developer-settings` anchor link) through the redirect.
+ * - Me lens: redirect to `/profile/settings` (canonical home for account settings now
+ *   that they live as a Profile & Account tab), carrying the query params and fragment
+ *   through so the header's `/settings#developer-settings` anchor link still lands on
+ *   the right section. `RouterStateSnapshot.url` omits the fragment, so build the tree
+ *   from the snapshot's `queryParams`/`fragment` rather than string-prefixing `state.url`.
  * - Any other lens (e.g. org): let the request through unchanged.
- *
- * Reads `state.url` so query params and trailing segments survive the lens redirect.
  */
-export const settingsLensRedirectGuard: CanActivateFn = (_route, state) => {
+export const settingsLensRedirectGuard: CanActivateFn = (route, state) => {
   const lensService = inject(LensService);
   const router = inject(Router);
 
@@ -28,7 +27,10 @@ export const settingsLensRedirectGuard: CanActivateFn = (_route, state) => {
     return router.parseUrl(`/${lens}${state.url}`);
   }
   if (lens === 'me') {
-    return router.parseUrl(`/profile${state.url}`);
+    return router.createUrlTree(['/profile/settings'], {
+      queryParams: route.queryParams,
+      fragment: route.fragment ?? undefined,
+    });
   }
   return true;
 };

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -197,12 +197,12 @@ export class SidebarNavService {
         {
           label: 'Settings',
           icon: 'fa-light fa-gear',
-          routerLink: '/settings',
+          routerLink: '/profile/settings',
         },
         {
           label: 'Transactions',
           icon: 'fa-light fa-receipt',
-          routerLink: '/me/transactions',
+          routerLink: '/profile/transactions',
         },
       ],
     },

--- a/apps/lfx-one/src/app/shared/utils/pending-profile-save.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/pending-profile-save.util.ts
@@ -1,11 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * sessionStorage key for a profile-edit form that was interrupted by a Flow C
- * (management-token) authorization. ProfileLayoutComponent replays it on return.
- */
-export const PENDING_PROFILE_SAVE_KEY = 'lfx_profile_pending_save';
+import { PENDING_PROFILE_SAVE_KEY } from '@lfx-one/shared/constants';
 
 /**
  * Clear any stored profile-edit pending-save.

--- a/apps/lfx-one/src/app/shared/utils/pending-profile-save.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/pending-profile-save.util.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * sessionStorage key for a profile-edit form that was interrupted by a Flow C
+ * (management-token) authorization. ProfileLayoutComponent replays it on return.
+ */
+export const PENDING_PROFILE_SAVE_KEY = 'lfx_profile_pending_save';
+
+/**
+ * Clear any stored profile-edit pending-save.
+ *
+ * Called before initiating a NON-edit profile-auth flow (e.g. email or password
+ * management) so an abandoned edit authorization can't be silently replayed when
+ * that unrelated flow returns to the profile shell. SSR-safe: no-ops when
+ * sessionStorage is unavailable.
+ */
+export function clearPendingProfileSave(): void {
+  if (typeof sessionStorage === 'undefined') return;
+  sessionStorage.removeItem(PENDING_PROFILE_SAVE_KEY);
+}

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -88,6 +88,7 @@ export class ProfileController {
     '/profile/identities',
     '/profile/password',
     '/profile/linux-email',
+    '/profile/settings',
     '/settings',
   ]);
 

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -43,23 +43,23 @@ A user can carry both board and project roles simultaneously. In the sidebar len
 
 **Identical for all personas.** Static items — no runtime persona conditions.
 
-| Section       | Item                      | Route              |
-| ------------- | ------------------------- | ------------------ |
-| _(top-level)_ | My Dashboard              | `/`                |
-| My Engagement | My Meetings               | `/meetings`        |
-|               | My Events                 | `/events`          |
-|               | My Committees             | `/groups`          |
-|               | My Mailing Lists          | `/mailing-lists`   |
-|               | My Votes                  | `/votes`           |
-|               | My Surveys                | `/surveys`         |
-|               | My Documents              | `/documents`       |
-| My Growth     | Training & Certifications | `/me/training`     |
-|               | Mentorships               | _(external link)_  |
-|               | Crowdfunding              | _(external link)_  |
-|               | Badges                    | `/badges`          |
-| My Account    | Profile                   | `/profile`         |
-|               | Settings                  | `/settings`        |
-|               | Transactions              | `/me/transactions` |
+| Section       | Item                      | Route                   |
+| ------------- | ------------------------- | ----------------------- |
+| _(top-level)_ | My Dashboard              | `/`                     |
+| My Engagement | My Meetings               | `/meetings`             |
+|               | My Events                 | `/events`               |
+|               | My Committees             | `/groups`               |
+|               | My Mailing Lists          | `/mailing-lists`        |
+|               | My Votes                  | `/votes`                |
+|               | My Surveys                | `/surveys`              |
+|               | My Documents              | `/documents`            |
+| My Growth     | Training & Certifications | `/me/training`          |
+|               | Mentorships               | _(external link)_       |
+|               | Crowdfunding              | _(external link)_       |
+|               | Badges                    | `/badges`               |
+| My Account    | Profile                   | `/profile`              |
+|               | Settings                  | `/profile/settings`     |
+|               | Transactions              | `/profile/transactions` |
 
 ---
 

--- a/docs/user/profile/edit-profile/index.md
+++ b/docs/user/profile/edit-profile/index.md
@@ -13,11 +13,13 @@ Use the Profile section to keep your account information current. Your profile i
 
 ## Profile tabs
 
-The Profile page (`/profile`) has three tabs:
+The Profile page (`/profile`) has five tabs:
 
 - **Work history & Affiliations** — your work history and project affiliations
 - **Identities** — connected accounts used to identify you and attribute contributions
 - **Individual Enrollment** — enroll in the Linux Foundation Individual Supporter plan
+- **Transactions** — your Linux Foundation purchase history (`/profile/transactions`)
+- **Settings** — email addresses, password, and developer API token (`/profile/settings`)
 
 ## Edit your personal details
 
@@ -35,25 +37,25 @@ The Profile page (`/profile`) has three tabs:
 
 ## Manage email addresses
 
-Email address management is in **Settings** (`/profile/settings`), not on the Profile page.
+Email address management is in the **Settings** tab of your Profile (`/profile/settings`).
 
-1. Go to **Settings** (`/profile/settings`) > **Email Settings** > **Add New Email Address**.
+1. Go to the **Settings** tab (`/profile/settings`) > **Email Settings** > **Add New Email Address**.
 2. A 6-digit verification code will be sent to the new address.
 3. Enter the code to confirm the new address.
 
 ## Change your password
 
-Password management is in **Settings** (`/profile/settings`), not on the Profile page.
+Password management is in the **Settings** tab of your Profile (`/profile/settings`).
 
-1. Go to **Settings** (`/profile/settings`) > **Password** > **Change Password**.
+1. Go to the **Settings** tab (`/profile/settings`) > **Password** > **Change Password**.
 2. Fill in **Current Password**, **New Password**, and **Confirm New Password**.
 3. Select **Change Password** to apply.
 
 ## Developer settings (API token)
 
-Developer settings are in **Settings** (`/profile/settings`), not on the Profile page.
+Developer settings are in the **Settings** tab of your Profile (`/profile/settings`).
 
-1. Go to **Settings** (`/profile/settings`) > **Developer Settings**.
+1. Go to the **Settings** tab (`/profile/settings`) > **Developer Settings**.
 2. Your **Personal Access Token** is listed here.
 3. Use the **Show** button to reveal it and the **Copy** button to copy it.
 4. Never share this token publicly.

--- a/docs/user/profile/edit-profile/index.md
+++ b/docs/user/profile/edit-profile/index.md
@@ -35,25 +35,25 @@ The Profile page (`/profile`) has three tabs:
 
 ## Manage email addresses
 
-Email address management is in **Settings** (`/settings`), not on the Profile page.
+Email address management is in **Settings** (`/profile/settings`), not on the Profile page.
 
-1. Go to **Settings** (`/settings`) > **Email Settings** > **Add New Email Address**.
+1. Go to **Settings** (`/profile/settings`) > **Email Settings** > **Add New Email Address**.
 2. A 6-digit verification code will be sent to the new address.
 3. Enter the code to confirm the new address.
 
 ## Change your password
 
-Password management is in **Settings** (`/settings`), not on the Profile page.
+Password management is in **Settings** (`/profile/settings`), not on the Profile page.
 
-1. Go to **Settings** (`/settings`) > **Password** > **Change Password**.
+1. Go to **Settings** (`/profile/settings`) > **Password** > **Change Password**.
 2. Fill in **Current Password**, **New Password**, and **Confirm New Password**.
 3. Select **Change Password** to apply.
 
 ## Developer settings (API token)
 
-Developer settings are in **Settings** (`/settings`), not on the Profile page.
+Developer settings are in **Settings** (`/profile/settings`), not on the Profile page.
 
-1. Go to **Settings** (`/settings`) > **Developer Settings**.
+1. Go to **Settings** (`/profile/settings`) > **Developer Settings**.
 2. Your **Personal Access Token** is listed here.
 3. Use the **Show** button to reveal it and the **Copy** button to copy it.
 4. Never share this token publicly.

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -11,11 +11,11 @@ intercom_collection: Profile
 
 ## How do I change my email address?
 
-Email addresses are managed in **Settings** (`/profile/settings`), not on the Profile page. Go to Settings > **Email Settings** > **Add New Email Address**. A 6-digit verification code will be sent to the new address to confirm it.
+Email addresses are managed in the **Settings** tab of your Profile (`/profile/settings`). Go to the **Settings** tab > **Email Settings** > **Add New Email Address**. A 6-digit verification code will be sent to the new address to confirm it.
 
 ## How do I change my password?
 
-Go to **Settings** (`/profile/settings`) > **Password** > **Change Password**. Fill in **Current Password**, **New Password**, and **Confirm New Password**, then select **Change Password**.
+Go to the **Settings** tab of your Profile (`/profile/settings`) > **Password** > **Change Password**. Fill in **Current Password**, **New Password**, and **Confirm New Password**, then select **Change Password**.
 
 ## How do I update my profile photo?
 
@@ -27,7 +27,7 @@ Affiliations are the Linux Foundation projects you are associated with. They app
 
 ## Where are developer settings (API token)?
 
-Developer settings (API token) are in **Settings** (`/profile/settings`) > **Developer Settings**. Use the **Show** button to reveal your Personal Access Token and the **Copy** button to copy it.
+Developer settings (API token) are in the **Settings** tab of your Profile (`/profile/settings`) > **Developer Settings**. Use the **Show** button to reveal your Personal Access Token and the **Copy** button to copy it.
 
 ## My name is displaying incorrectly. How do I fix it?
 

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -11,11 +11,11 @@ intercom_collection: Profile
 
 ## How do I change my email address?
 
-Email addresses are managed in **Settings** (`/settings`), not on the Profile page. Go to Settings > **Email Settings** > **Add New Email Address**. A 6-digit verification code will be sent to the new address to confirm it.
+Email addresses are managed in **Settings** (`/profile/settings`), not on the Profile page. Go to Settings > **Email Settings** > **Add New Email Address**. A 6-digit verification code will be sent to the new address to confirm it.
 
 ## How do I change my password?
 
-Go to **Settings** (`/settings`) > **Password** > **Change Password**. Fill in **Current Password**, **New Password**, and **Confirm New Password**, then select **Change Password**.
+Go to **Settings** (`/profile/settings`) > **Password** > **Change Password**. Fill in **Current Password**, **New Password**, and **Confirm New Password**, then select **Change Password**.
 
 ## How do I update my profile photo?
 
@@ -27,7 +27,7 @@ Affiliations are the Linux Foundation projects you are associated with. They app
 
 ## Where are developer settings (API token)?
 
-Developer settings (API token) are in **Settings** (`/settings`) > **Developer Settings**. Use the **Show** button to reveal your Personal Access Token and the **Copy** button to copy it.
+Developer settings (API token) are in **Settings** (`/profile/settings`) > **Developer Settings**. Use the **Show** button to reveal your Personal Access Token and the **Copy** button to copy it.
 
 ## My name is displaying incorrectly. How do I fix it?
 

--- a/docs/user/profile/index.md
+++ b/docs/user/profile/index.md
@@ -17,12 +17,11 @@ The information below covers **your individual** LFX account — the profile tie
 
 ### What you can do
 
-- View your profile overview
-- Edit your name, photo, and personal details
-- Manage your email addresses
-- Change your password
-- View and update your project affiliations
-- Access developer settings
+- View and update your work history and project affiliations
+- Manage the identities used to attribute your contributions
+- Enroll in the Linux Foundation Individual Supporter plan
+- View your Linux Foundation purchase history
+- Manage your email addresses, password, and developer API token
 
 ### Who this applies to
 
@@ -32,14 +31,15 @@ All authenticated users have a profile. Every user can view and edit their own p
 
 Go to **app.lfx.dev** and select **Profile** from the left navigation sidebar, or navigate directly to `/profile`. The profile section uses a tabbed layout with the following tabs:
 
-| Tab          | Route                   | Description                                 |
-| ------------ | ----------------------- | ------------------------------------------- |
-| Overview     | `/profile`              | Summary of your profile and activity        |
-| Edit Profile | `/profile/manage`       | Edit your name, photo, and personal details |
-| Affiliations | `/profile/affiliations` | View and manage your project affiliations   |
-| Developer    | `/profile/developer`    | Developer-specific settings and API access  |
-| Email        | `/profile/email`        | Manage your email addresses                 |
-| Password     | `/profile/password`     | Change your account password                |
+| Tab                         | Route                            | Description                                                 |
+| --------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                  |
+| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work |
+| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan    |
+| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                      |
+| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token          |
+
+`/profile` opens the **Work history & Affiliations** tab by default.
 
 ## Your company's activity
 

--- a/docs/user/settings/faq/index.md
+++ b/docs/user/settings/faq/index.md
@@ -11,11 +11,11 @@ intercom_collection: Settings
 
 ## What is the difference between Settings and Profile?
 
-**Settings** (`/settings`) manages your account security and access credentials — email addresses, password, two-factor authentication, and your developer API token. **Profile** (`/profile`) manages your personal information — such as your name, work history, affiliations, and connected identities. Both are accessible from the left navigation.
+**Settings** is the tab of your **Profile** (`/profile/settings`) that manages your account security and access credentials — email addresses, password, two-factor authentication, and your developer API token. The other Profile tabs manage your personal information — such as your name, work history, affiliations, and connected identities. You can open Settings from its own item in the left navigation or from the Profile page tabs.
 
 ## Does LFX Self Serve have notification preferences?
 
-LFX Self Serve does not currently include a notification preferences section in Settings. Email and password settings are managed at `/settings`.
+LFX Self Serve does not currently include a notification preferences section in Settings. Email and password settings are managed in the Settings tab of your Profile (`/profile/settings`).
 
 ## Are my settings shared across devices?
 

--- a/docs/user/settings/index.md
+++ b/docs/user/settings/index.md
@@ -9,7 +9,7 @@ last_updated: 2026-05-22
 intercom_collection: Settings
 ---
 
-The Settings section lets you manage your account preferences within LFX Self Serve. Settings are separate from your profile information and cover email addresses, password and two-factor authentication, and developer API token settings.
+The Settings tab lets you manage your account preferences within LFX Self Serve. It lives within your Profile and covers email addresses, password and two-factor authentication, and developer API token settings.
 
 ## What you can do
 
@@ -23,7 +23,7 @@ All authenticated users have access to the Settings section.
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Settings** from the left navigation sidebar. The settings dashboard (route: `/settings`) shows all available configuration options.
+Go to **app.lfx.dev** and select **Settings** from the left navigation sidebar. The Settings tab of your Profile (route: `/profile/settings`) shows all available configuration options.
 
 ## Related sections
 

--- a/docs/user/settings/index.md
+++ b/docs/user/settings/index.md
@@ -27,5 +27,5 @@ Go to **app.lfx.dev** and select **Settings** from the left navigation sidebar. 
 
 ## Related sections
 
-- [Profile](../profile/) — for personal account information such as name, photo, and email
+- [Profile](../profile/) — for personal account information such as name, photo, work history, and affiliations
 - [Dashboard](../dashboards/) — lens and persona controls are in the top navigation, not Settings

--- a/docs/user/settings/manage-settings/index.md
+++ b/docs/user/settings/manage-settings/index.md
@@ -15,11 +15,11 @@ Use the Settings section to configure your application preferences in LFX Self S
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select **Settings** from the left navigation sidebar.
-3. The settings dashboard (route: `/settings`) displays your current configuration options.
+3. The Settings tab of your Profile (route: `/profile/settings`) displays your current configuration options.
 
 ## Available settings
 
-The Settings page (`/settings`) has three sections on one page:
+The Settings tab (`/profile/settings`) has three sections on one page:
 
 - **Email Settings** — add a new email address using the **Add New Email Address** button, then confirm with the **Send Code** button. A 6-digit verification code is sent to the new address.
 - **Password** — change your password using the **Current Password**, **New Password**, and **Confirm New Password** fields, then select **Change Password**. Use **Send Reset Link** if you have forgotten your current password. An **Account Recovery** section is also available.
@@ -32,4 +32,4 @@ Settings are NOT auto-saved. Each section has its own action button: **Add New E
 ## Related
 
 - [Settings overview](../) — an overview of the Settings section
-- [Profile](../../profile/) — personal account information is managed separately in Profile
+- [Profile](../../profile/) — personal account information such as name and photo is managed in the Profile tab, alongside Settings

--- a/docs/user/transactions/index.md
+++ b/docs/user/transactions/index.md
@@ -28,7 +28,7 @@ All authenticated users can view their own transactions. Each user sees only the
 
 ### Navigation
 
-Go to **app.lfx.dev**, open the **Profile & Account** page, and select the **Transactions** tab (route: `/profile/transactions`). The transactions page lists all your purchases associated with your LFX account.
+Go to **app.lfx.dev**, open the **Profile** page, and select the **Transactions** tab (route: `/profile/transactions`). The transactions page lists all your purchases associated with your LFX account.
 
 ## Your company's activity
 

--- a/docs/user/transactions/index.md
+++ b/docs/user/transactions/index.md
@@ -28,7 +28,7 @@ All authenticated users can view their own transactions. Each user sees only the
 
 ### Navigation
 
-Go to **app.lfx.dev** and select **My Transactions** from the left navigation sidebar (route: `/me/transactions`). The transactions page lists all your purchases associated with your LFX account.
+Go to **app.lfx.dev**, open the **Profile & Account** page, and select the **Transactions** tab (route: `/profile/transactions`). The transactions page lists all your purchases associated with your LFX account.
 
 ## Your company's activity
 

--- a/docs/user/transactions/view-transactions/index.md
+++ b/docs/user/transactions/view-transactions/index.md
@@ -14,7 +14,7 @@ Use the Transactions section to review your purchase and billing history on the 
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Open the **Profile & Account** page and select the **Transactions** tab (route: `/profile/transactions`).
+2. Open the **Profile** page and select the **Transactions** tab (route: `/profile/transactions`).
 3. Your transaction history appears in the main content area.
 4. Select a transaction to view its details.
 

--- a/docs/user/transactions/view-transactions/index.md
+++ b/docs/user/transactions/view-transactions/index.md
@@ -14,7 +14,7 @@ Use the Transactions section to review your purchase and billing history on the 
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Select **My Transactions** from the left navigation sidebar (route: `/me/transactions`).
+2. Open the **Profile & Account** page and select the **Transactions** tab (route: `/profile/transactions`).
 3. Your transaction history appears in the main content area.
 4. Select a transaction to view its details.
 

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -7,9 +7,11 @@ import { CdpIdentityType, IdentityProvider, IdentityProviderOption, ProfileTab }
  * Profile tab configuration
  */
 export const PROFILE_TABS: ProfileTab[] = [
-  { id: 'attribution', label: 'Work history & Affiliations', route: 'attribution' },
+  { id: 'attribution', label: 'Work history & Affiliations', route: 'attributions' },
   { id: 'identities', label: 'Identities', route: 'identities' },
   { id: 'individual-enrollment', label: 'Individual Enrollment', route: 'individual-enrollment' },
+  { id: 'transactions', label: 'Transactions', route: 'transactions' },
+  { id: 'settings', label: 'Settings', route: 'settings' },
 ];
 
 /**

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -4,6 +4,15 @@
 import { CdpIdentityType, IdentityProvider, IdentityProviderOption, ProfileTab } from '../interfaces';
 
 /**
+ * sessionStorage key for a profile-edit form interrupted by a Flow C
+ * (management-token) authorization. Written by the profile-edit dialog and
+ * replayed by ProfileLayoutComponent on return; cleared before unrelated
+ * profile-auth flows. Centralized here because it is shared across the profile
+ * layout, the profile-edit dialog, and the settings feature.
+ */
+export const PENDING_PROFILE_SAVE_KEY = 'lfx_profile_pending_save';
+
+/**
  * Profile tab configuration
  */
 export const PROFILE_TABS: ProfileTab[] = [


### PR DESCRIPTION
## Summary

- Consolidate the me-context **Settings** and **Transactions** pages into the Profile & Account page as bookmarkable tabs.
- Add `/profile/transactions` and `/profile/settings` routes that reuse the existing `TransactionsDashboardComponent` and `AccountSettingsComponent`; their standalone page headers are suppressed via an `embedded` route-data flag.
- Standardize the work-history route on the plural `/profile/attributions`; `/profile/attribution` and other legacy paths redirect.
- Redirect `/me/transactions` → `/profile/transactions`.
- Redirect me-context `/settings` → `/profile/settings` via a new `settingsLensRedirectGuard`; foundation/project lens behavior is unchanged.
- Update the Me lens "My Account" sidebar links to the new routes.

LFXV2-2739