### PR TITLE
feat(profile): reflow work-history and identities tab layouts

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.html
+++ b/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.html
@@ -97,8 +97,8 @@
       </div>
     </lfx-card>
   } @else if (compact()) {
-    <!-- Compact card-based list for narrow column -->
-    <div class="flex w-full flex-col gap-4" data-testid="project-affiliations-list">
+    <!-- Compact card grid — one card per project -->
+    <div class="grid w-full grid-cols-1 items-start gap-4 md:grid-cols-2 xl:grid-cols-3" data-testid="project-affiliations-list">
       @for (group of sortedProjectGroups(); track group.id) {
         <div class="group rounded-xl border border-slate-200 bg-white p-4" [attr.data-testid]="'project-card-' + group.id">
           <!-- Project Header -->

--- a/apps/lfx-one/src/app/modules/profile/attribution/profile-attribution.component.html
+++ b/apps/lfx-one/src/app/modules/profile/attribution/profile-attribution.component.html
@@ -2,8 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="w-full pb-12" data-testid="profile-attribution">
-  <div class="grid grid-cols-1 gap-8 lg:grid-cols-[3fr_1fr]">
-    <!-- Left Column: Work history -->
+  <div class="flex flex-col gap-10">
+    <!-- Work history -->
     <div class="flex flex-col gap-3">
       <div class="flex items-center justify-between">
         <h2>Work history</h2>
@@ -23,8 +23,8 @@
       <lfx-profile-work-experience [hideHeader]="true" (workExperienceChanged)="onWorkExperienceChanged()" />
     </div>
 
-    <!-- Right Column: Project Involvement -->
-    <div class="flex w-[360px] flex-col gap-3">
+    <!-- Project Involvement -->
+    <div class="flex flex-col gap-3">
       <h2>Project Involvement</h2>
       <lfx-profile-affiliations [hideHeader]="true" [compact]="true" (addWorkExperience)="onAddWorkExperience()" />
     </div>

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
@@ -23,8 +23,8 @@
     </lfx-message>
   }
 
-  <!-- Two-column layout: Identities (left) + Linux.com Email (right) -->
-  <div class="grid grid-cols-1 gap-8 items-start lg:grid-cols-[minmax(0,1fr)_360px]">
+  <!-- Stacked layout: Identities on top, Linux.com Email below -->
+  <div class="flex flex-col gap-10">
     <!-- Identities -->
     <div class="flex flex-col gap-5">
       <!-- Header with Add Button -->
@@ -173,7 +173,7 @@
     </div>
 
     <!-- Linux.com Email -->
-    <div class="flex flex-col gap-5">
+    <div class="flex w-full max-w-xl flex-col gap-5">
       <h2>Linux.com email</h2>
       <lfx-profile-linux-email [identities]="enrichedIdentities()" />
     </div>


### PR DESCRIPTION
## Summary

Layout reflow of three Profile & Account tabs per the redesign (LFXV2-2743) — presentation only, no data-flow or behavior changes.

- **Work history & Affiliations:** stack Work history above Project Involvement (full-width, 40px gap) instead of the previous `3fr/1fr` two-column split; Project Involvement cards now lay out in a responsive 3-column grid (1 / 2 / 3 columns at base / md / xl).
- **Identities:** stack Identities above the Linux.com email section (previously a two-column split); the email card is capped at `max-w-xl` so it doesn't over-stretch full-width.
- **Individual Enrollment:** no change — the LF Individual Supporter card already matches the design (logo, product name, price/year, benefits, and CTA are data-driven).

LFXV2-2743