### PR TITLE
feat(dashboards): add attribution channel tooltips, drop mom deltas

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -64,9 +64,12 @@
             <span class="truncate text-xs font-medium text-gray-700">{{ row.channel }}</span>
             @if (channelDescription(row.channel); as description) {
               <i
-                class="fa-light fa-circle-info cursor-help text-[11px] text-gray-400"
+                class="fa-light fa-circle-info cursor-help rounded-full text-[11px] text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                role="button"
+                tabindex="0"
                 [pTooltip]="description"
                 tooltipPosition="top"
+                tooltipEvent="both"
                 [attr.aria-label]="row.channel + ' definition: ' + description"
                 [attr.data-testid]="'attribution-channel-tooltip-' + row.channel"></i>
             }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.html
@@ -60,7 +60,17 @@
       <!-- Rows -->
       @for (row of channelRows(); track row.channel) {
         <div class="flex items-center gap-4 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'attribution-row-' + row.channel">
-          <span class="w-36 truncate text-xs font-medium text-gray-700" role="cell">{{ row.channel }}</span>
+          <div class="flex w-36 items-center gap-1.5" role="cell">
+            <span class="truncate text-xs font-medium text-gray-700">{{ row.channel }}</span>
+            @if (channelDescription(row.channel); as description) {
+              <i
+                class="fa-light fa-circle-info cursor-help text-[11px] text-gray-400"
+                [pTooltip]="description"
+                tooltipPosition="top"
+                [attr.aria-label]="row.channel + ' definition: ' + description"
+                [attr.data-testid]="'attribution-channel-tooltip-' + row.channel"></i>
+            }
+          </div>
           <div class="flex flex-1 items-center gap-2" role="cell">
             <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
               <div

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -7,9 +7,10 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
-import { ATTRIBUTION_MODEL_OPTIONS, FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
+import { ATTRIBUTION_CHANNEL_DESCRIPTIONS, ATTRIBUTION_MODEL_OPTIONS, FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, finalize, of, startWith, switchMap } from 'rxjs';
 
 import type {
@@ -22,7 +23,7 @@ import type {
 
 @Component({
   selector: 'lfx-attribution-section',
-  imports: [DecimalPipe, ReactiveFormsModule, SelectComponent, ButtonComponent],
+  imports: [DecimalPipe, ReactiveFormsModule, SelectComponent, ButtonComponent, TooltipModule],
   templateUrl: './attribution-section.component.html',
   styleUrl: './attribution-section.component.scss',
 })
@@ -60,6 +61,12 @@ export class AttributionSectionComponent {
   protected readonly channelRows: Signal<AttributionChannelRow[]> = this.initChannelRows();
   protected readonly totalRevenue: Signal<string> = this.initTotalRevenue();
   protected readonly hasData = computed(() => this.channelRows().length > 0);
+
+  // === Protected Methods ===
+  /** Tooltip text describing what a consolidated channel groups; empty when no definition exists (no tooltip shown). */
+  protected channelDescription(channel: string): string {
+    return ATTRIBUTION_CHANNEL_DESCRIPTIONS[channel] ?? '';
+  }
 
   // === Private Initializers ===
   private initAttributionData(): Signal<MarketingAttributionResponse | null> {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -48,6 +48,10 @@ export class AttributionSectionComponent {
   // Overview tab, which also renders this section), it passes it in so we reuse
   // it instead of issuing a duplicate request. `undefined` means "self-fetch".
   public readonly attributionOverride = input<MarketingAttributionResponse | null | undefined>(undefined);
+  // When using a parent override, the parent also passes its in-flight state so
+  // we show the skeleton (not the empty state) while the parent request runs and
+  // its override is still the initial/previous-period `null`.
+  public readonly loadingOverride = input<boolean>(false);
 
   // === Forms ===
   protected readonly modelForm = this.fb.nonNullable.group({
@@ -57,7 +61,9 @@ export class AttributionSectionComponent {
   protected readonly modelOptions: AttributionModelOption[] = ATTRIBUTION_MODEL_OPTIONS;
 
   // === WritableSignals ===
-  protected readonly loading = signal(false);
+  // Tracks the component's own fetch; the template reads `loading` (below), which
+  // also folds in the parent's loadingOverride when running in override mode.
+  private readonly selfLoading = signal(false);
 
   // === Computed Signals ===
   protected readonly attributionData: Signal<MarketingAttributionResponse | null> = this.initAttributionData();
@@ -65,6 +71,8 @@ export class AttributionSectionComponent {
   protected readonly channelRows: Signal<AttributionChannelRow[]> = this.initChannelRows();
   protected readonly totalRevenue: Signal<string> = this.initTotalRevenue();
   protected readonly hasData = computed(() => this.channelRows().length > 0);
+  // In override mode, defer to the parent's in-flight state; otherwise use our own.
+  protected readonly loading = computed(() => (this.attributionOverride() !== undefined ? this.loadingOverride() : this.selfLoading()));
 
   // === Protected Methods ===
   /** Tooltip text describing what a consolidated channel groups; empty when no definition exists (no tooltip shown). */
@@ -82,20 +90,21 @@ export class AttributionSectionComponent {
     return toSignal(
       combineLatest([override$, slug$, focus$, period$]).pipe(
         switchMap(([override, slug, focus, period]) => {
-          // A parent-supplied response short-circuits our own fetch (no duplicate query).
+          // A parent-supplied response short-circuits our own fetch (no duplicate
+          // query). Loading is driven by the parent's loadingOverride in this mode.
           if (override !== undefined) {
-            this.loading.set(false);
+            this.selfLoading.set(false);
             return of(override);
           }
           if (!slug) {
-            this.loading.set(false);
+            this.selfLoading.set(false);
             return of(null);
           }
-          this.loading.set(true);
+          this.selfLoading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
           return this.analyticsService.getMarketingAttribution(slug, classification, period || undefined).pipe(
             catchError(() => of(null)),
-            finalize(() => this.loading.set(false))
+            finalize(() => this.selfLoading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/attribution-section/attribution-section.component.ts
@@ -44,6 +44,10 @@ export class AttributionSectionComponent {
   public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
+  // When a parent has already fetched the same attribution response (e.g. the
+  // Overview tab, which also renders this section), it passes it in so we reuse
+  // it instead of issuing a duplicate request. `undefined` means "self-fetch".
+  public readonly attributionOverride = input<MarketingAttributionResponse | null | undefined>(undefined);
 
   // === Forms ===
   protected readonly modelForm = this.fb.nonNullable.group({
@@ -70,13 +74,19 @@ export class AttributionSectionComponent {
 
   // === Private Initializers ===
   private initAttributionData(): Signal<MarketingAttributionResponse | null> {
+    const override$ = toObservable(this.attributionOverride);
     const slug$ = toObservable(this.foundationSlug);
     const focus$ = toObservable(this.focusProgram);
     const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, focus$, period$]).pipe(
-        switchMap(([slug, focus, period]) => {
+      combineLatest([override$, slug$, focus$, period$]).pipe(
+        switchMap(([override, slug, focus, period]) => {
+          // A parent-supplied response short-circuits our own fetch (no duplicate query).
+          if (override !== undefined) {
+            this.loading.set(false);
+            return of(override);
+          }
           if (!slug) {
             this.loading.set(false);
             return of(null);

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -48,5 +48,6 @@
     [foundationName]="foundationName()"
     [focusProgram]="focusProgram()"
     [attributionOverride]="overviewKpiData().attribution"
+    [loadingOverride]="loading()"
     data-testid="overview-tab-attribution-section" />
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -47,5 +47,6 @@
     [selectedPeriod]="selectedPeriod()"
     [foundationName]="foundationName()"
     [focusProgram]="focusProgram()"
+    [attributionOverride]="overviewKpiData().attribution"
     data-testid="overview-tab-attribution-section" />
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -5,16 +5,7 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import {
-  computeMomPct,
-  formatChangePct,
-  formatCurrency,
-  formatNumber,
-  isPeriodMonth,
-  resolvePeriodRange,
-  trendColorClass,
-  trendDirection,
-} from '@lfx-one/shared/utils';
+import { formatChangePct, formatCurrency, formatNumber, isPeriodMonth, resolvePeriodRange, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rxjs';
 
@@ -59,7 +50,7 @@ export class OverviewTabComponent {
         switchMap(([slug, focus, period]) => {
           if (!slug) {
             this.loading.set(false);
-            return of({ revenueImpact: null, brandReach: null, emailCtr: null });
+            return of({ revenueImpact: null, brandReach: null, emailCtr: null, attribution: null });
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
@@ -71,10 +62,14 @@ export class OverviewTabComponent {
             // getBrandReach uses pre-computed _30D columns that cannot be period-filtered
             brandReach: this.analyticsService.getBrandReach(slug, classification).pipe(catchError(() => of(null))),
             emailCtr: isWebOnly ? of(null) : this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(catchError(() => of(null))),
+            // Attributed Revenue KPI reports Linear attribution to match the
+            // "Marketing attribution" table below (same source, same model),
+            // not pipeline-won CRM revenue which is a different metric.
+            attribution: this.analyticsService.getMarketingAttribution(slug, classification, period || undefined).pipe(catchError(() => of(null))),
           }).pipe(finalize(() => this.loading.set(false)));
         })
       ),
-      { initialValue: { revenueImpact: null, brandReach: null, emailCtr: null } }
+      { initialValue: { revenueImpact: null, brandReach: null, emailCtr: null, attribution: null } }
     );
   }
 
@@ -87,23 +82,26 @@ export class OverviewTabComponent {
 
       if (data.revenueImpact) {
         const ri = data.revenueImpact;
-        const yoyPct = isMonth ? ri.changePercentage : null;
-        const trend = ri.paidMedia?.monthlyTrend ?? [];
-        const revMomPct = computeMomPct(trend.map((m) => m.revenue));
-        const roasMomPct = computeMomPct(trend.map((m) => m.roas));
+        // Attributed Revenue reports Linear-attributed revenue from the same
+        // source as the "Marketing attribution" table below, so the headline
+        // agrees with that table. The attribution response carries no time
+        // dimension, so there is no honest period delta to show here — the
+        // prior wiring borrowed a paid-media monthly-trend delta that tracked
+        // a different metric than the value.
+        const attributedRevenue = (data.attribution?.channels ?? []).reduce((sum, ch) => sum + (ch.linearRevenue ?? 0), 0);
         cards.push(
           {
             id: 'attributed-revenue',
             label: 'Attributed Revenue',
             icon: 'fa-light fa-dollar-sign',
             iconClass: 'bg-green-100 text-green-600',
-            value: formatCurrency(ri.revenueAttributed),
-            momChange: formatChangePct(revMomPct, changeSuffix),
-            momTrend: trendDirection(revMomPct),
-            momTrendClass: trendColorClass(revMomPct),
-            yoyChange: formatChangePct(yoyPct, 'YoY'),
-            yoyTrend: trendDirection(yoyPct),
-            yoyTrendClass: trendColorClass(yoyPct),
+            value: formatCurrency(attributedRevenue),
+            momChange: null,
+            momTrend: 'neutral',
+            momTrendClass: 'text-gray-500',
+            yoyChange: null,
+            yoyTrend: 'neutral',
+            yoyTrendClass: 'text-gray-500',
           },
           {
             id: 'roas',
@@ -111,9 +109,14 @@ export class OverviewTabComponent {
             icon: 'fa-light fa-chart-line-up',
             iconClass: 'bg-blue-100 text-blue-600',
             value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
-            momChange: formatChangePct(roasMomPct, changeSuffix),
-            momTrend: trendDirection(roasMomPct),
-            momTrendClass: trendColorClass(roasMomPct),
+            // No MoM delta: paid spend is lumpy and event-driven, so a
+            // month-over-month ROAS swing mostly reflects a change in campaign
+            // volume/mix (e.g. fewer campaigns when events wind down), not a
+            // change in ad efficiency. Showing it as a performance delta
+            // misrepresents a volume shift as a decline.
+            momChange: null,
+            momTrend: 'neutral',
+            momTrendClass: 'text-gray-500',
             yoyChange: null,
             yoyTrend: 'neutral',
             yoyTrendClass: 'text-gray-500',
@@ -123,7 +126,12 @@ export class OverviewTabComponent {
 
       if (data.brandReach) {
         const br = data.brandReach;
-        const momPct = br.sessionMomChangePct;
+        // sessionMomChangePct defaults to 0 when there is no valid prior window
+        // to compare against (fewer than 8 weeks of trend, or an empty prior
+        // period), so a bare 0 is indistinguishable from "no comparison". Treat
+        // 0 as "nothing to report" and suppress the delta rather than show a
+        // misleading "0.0% MoM".
+        const momPct = br.sessionMomChangePct !== 0 ? br.sessionMomChangePct : null;
         cards.push({
           id: 'web-sessions',
           label: 'Total Web Sessions',
@@ -141,13 +149,17 @@ export class OverviewTabComponent {
 
       if (data.emailCtr) {
         const ec = data.emailCtr;
-        const momPct = ec.momChangePercentage;
+        // No email sent in the selected scope means CTR is undefined, not 0% —
+        // rendering 0.00% reads as poor performance rather than "no sends", so
+        // show a dash and suppress the delta/badge in that case.
+        const hasSends = (ec.monthlySends ?? []).some((s) => s > 0);
+        const momPct = hasSends ? ec.momChangePercentage : null;
         cards.push({
           id: 'email-ctr',
           label: 'Email CTR',
           icon: 'fa-light fa-envelope-open',
           iconClass: 'bg-amber-100 text-amber-600',
-          value: `${(ec.currentCtr ?? 0).toFixed(2)}%`,
+          value: hasSends ? `${(ec.currentCtr ?? 0).toFixed(2)}%` : '—',
           momChange: formatChangePct(momPct, changeSuffix),
           momTrend: trendDirection(momPct),
           momTrendClass: trendColorClass(momPct),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -160,17 +160,20 @@ export class OverviewTabComponent {
 
       if (data.emailCtr) {
         const ec = data.emailCtr;
-        // No email sent in the current month means CTR is undefined, not 0% —
-        // rendering 0.00% reads as poor performance rather than "no sends", so
-        // show a dash and suppress the delta/badge in that case. The series is
-        // calendar zero-filled, so only the trailing (current) month determines
-        // activity — matching the server's momChangePercentage contract and the
-        // sibling email-tab pattern (an earlier month with sends must not make
-        // a zero current month read as active).
+        // No sends in scope means CTR is undefined, not 0% — a 0.00% reads as
+        // poor performance rather than "no sends", so suppress the value in that
+        // case. What "in scope" means depends on the selection: the series is
+        // calendar zero-filled, so for a single-month view only the trailing
+        // (current) month counts, but for a preset range (last-3, YTD) currentCtr
+        // is a period aggregate that is valid if ANY month in the range had sends.
         const sends = ec.monthlySends ?? [];
         const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
-        const hasSends = lastSends !== undefined && lastSends > 0;
-        const momPct = hasSends ? ec.momChangePercentage : null;
+        const lastMonthActive = lastSends !== undefined && lastSends > 0;
+        const hasSends = isMonth ? lastMonthActive : sends.some((s) => s > 0);
+        // The MoM delta always requires the latest month to be active (the
+        // server's momChangePercentage compares the trailing two months), so it
+        // stays gated on lastMonthActive regardless of the selection type.
+        const momPct = lastMonthActive ? ec.momChangePercentage : null;
         cards.push({
           id: 'email-ctr',
           label: 'Email CTR',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -132,12 +132,14 @@ export class OverviewTabComponent {
 
       if (data.brandReach) {
         const br = data.brandReach;
-        // sessionMomChangePct defaults to 0 when there is no valid prior window
-        // to compare against (fewer than 8 weeks of trend, or an empty prior
-        // period), so a bare 0 is indistinguishable from "no comparison". Treat
-        // 0 as "nothing to report" and suppress the delta rather than show a
-        // misleading "0.0% MoM".
-        const momPct = br.sessionMomChangePct !== 0 ? br.sessionMomChangePct : null;
+        // sessionMomChangePct is 0 both for a genuine flat month AND when there is
+        // no valid prior window (the server needs recent-4 vs prior-4 weeks). Use
+        // the trend length to tell them apart: with a full comparison window (>= 8
+        // weeks) a 0 is a real "0.0% MoM"; without one, a 0 means "no comparison"
+        // and the delta is suppressed.
+        const hasComparisonWindow = (br.weeklyTrend?.length ?? 0) >= 8;
+        const noComparison = !hasComparisonWindow && br.sessionMomChangePct === 0;
+        const momPct = noComparison ? null : br.sessionMomChangePct;
         cards.push({
           id: 'web-sessions',
           label: 'Total Web Sessions',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -157,10 +157,16 @@ export class OverviewTabComponent {
 
       if (data.emailCtr) {
         const ec = data.emailCtr;
-        // No email sent in the selected scope means CTR is undefined, not 0% —
+        // No email sent in the current month means CTR is undefined, not 0% —
         // rendering 0.00% reads as poor performance rather than "no sends", so
-        // show a dash and suppress the delta/badge in that case.
-        const hasSends = (ec.monthlySends ?? []).some((s) => s > 0);
+        // show a dash and suppress the delta/badge in that case. The series is
+        // calendar zero-filled, so only the trailing (current) month determines
+        // activity — matching the server's momChangePercentage contract and the
+        // sibling email-tab pattern (an earlier month with sends must not make
+        // a zero current month read as active).
+        const sends = ec.monthlySends ?? [];
+        const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
+        const hasSends = lastSends !== undefined && lastSends > 0;
         const momPct = hasSends ? ec.momChangePercentage : null;
         cards.push({
           id: 'email-ctr',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -171,10 +171,12 @@ export class OverviewTabComponent {
         const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
         const lastMonthActive = lastSends !== undefined && lastSends > 0;
         const hasSends = isMonth ? lastMonthActive : sends.some((s) => s > 0);
-        // The MoM delta always requires the latest month to be active (the
-        // server's momChangePercentage compares the trailing two months), so it
-        // stays gated on lastMonthActive regardless of the selection type.
-        const momPct = lastMonthActive ? ec.momChangePercentage : null;
+        // The MoM delta only applies to the single-month view: momChangePercentage
+        // always compares the trailing two months, so pairing it with a range's
+        // period-aggregate value would place a monthly delta beside a period value
+        // — the exact metric mismatch this refinement removes. Show it only for a
+        // month selection with an active trailing month; suppress it for ranges.
+        const momPct = isMonth && lastMonthActive ? ec.momChangePercentage : null;
         cards.push({
           id: 'email-ctr',
           label: 'Email CTR',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -65,7 +65,10 @@ export class OverviewTabComponent {
             // Attributed Revenue KPI reports Linear attribution to match the
             // "Marketing attribution" table below (same source, same model),
             // not pipeline-won CRM revenue which is a different metric.
-            attribution: this.analyticsService.getMarketingAttribution(slug, classification, period || undefined).pipe(catchError(() => of(null))),
+            // No catchError here: getMarketingAttribution already swallows HTTP
+            // errors and emits { channels: [], projects: [] }, which the card
+            // renders as a dash — a component-level handler would be unreachable.
+            attribution: this.analyticsService.getMarketingAttribution(slug, classification, period || undefined),
           }).pipe(finalize(() => this.loading.set(false)));
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -136,13 +136,14 @@ export class OverviewTabComponent {
       if (data.brandReach) {
         const br = data.brandReach;
         // sessionMomChangePct is 0 both for a genuine flat month AND when there is
-        // no valid prior window (the server needs recent-4 vs prior-4 weeks). Use
-        // the trend length to tell them apart: with a full comparison window (>= 8
-        // weeks) a 0 is a real "0.0% MoM"; without one, a 0 means "no comparison"
-        // and the delta is suppressed.
-        const hasComparisonWindow = (br.weeklyTrend?.length ?? 0) >= 8;
-        const noComparison = !hasComparisonWindow && br.sessionMomChangePct === 0;
-        const momPct = noComparison ? null : br.sessionMomChangePct;
+        // no valid comparison (the server needs >= 8 weeks of trend AND a positive
+        // prior-4-week total — it leaves the pct at 0 on a zero prior window to
+        // avoid divide-by-zero). Replicate both server conditions so a 0 is only
+        // shown when it is a real "0.0% MoM"; otherwise suppress the delta.
+        const trend = br.weeklyTrend ?? [];
+        const priorWindowSessions = trend.length >= 8 ? trend.slice(-8, -4).reduce((sum, d) => sum + (d.sessions ?? 0), 0) : 0;
+        const hasComparison = priorWindowSessions > 0;
+        const momPct = hasComparison ? br.sessionMomChangePct : null;
         cards.push({
           id: 'web-sessions',
           label: 'Total Web Sessions',

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -80,48 +80,54 @@ export class OverviewTabComponent {
       const changeSuffix: 'MoM' | 'Period' = isMonth ? 'MoM' : 'Period';
       const cards: PerformanceSummaryKpi[] = [];
 
+      // Attributed Revenue is driven by the attribution response, not revenueImpact.
+      // They are fetched independently and revenueImpact is intentionally null for
+      // projectWebsites, so guarding this card on revenueImpact would hide it even
+      // when attribution data exists. An empty/unavailable channel list renders as a
+      // dash — matching the "No attribution data available" state of the table below —
+      // rather than a misleading $0.
+      if (data.attribution) {
+        const channels = data.attribution.channels ?? [];
+        // Linear-attributed revenue from the same source as the "Marketing
+        // attribution" table, so the headline agrees with that table. The
+        // attribution response carries no time dimension, so there is no honest
+        // period delta to show here.
+        const attributedRevenue = channels.reduce((sum, ch) => sum + (ch.linearRevenue ?? 0), 0);
+        cards.push({
+          id: 'attributed-revenue',
+          label: 'Attributed Revenue',
+          icon: 'fa-light fa-dollar-sign',
+          iconClass: 'bg-green-100 text-green-600',
+          value: channels.length ? formatCurrency(attributedRevenue) : '—',
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+        });
+      }
+
       if (data.revenueImpact) {
         const ri = data.revenueImpact;
-        // Attributed Revenue reports Linear-attributed revenue from the same
-        // source as the "Marketing attribution" table below, so the headline
-        // agrees with that table. The attribution response carries no time
-        // dimension, so there is no honest period delta to show here — the
-        // prior wiring borrowed a paid-media monthly-trend delta that tracked
-        // a different metric than the value.
-        const attributedRevenue = (data.attribution?.channels ?? []).reduce((sum, ch) => sum + (ch.linearRevenue ?? 0), 0);
-        cards.push(
-          {
-            id: 'attributed-revenue',
-            label: 'Attributed Revenue',
-            icon: 'fa-light fa-dollar-sign',
-            iconClass: 'bg-green-100 text-green-600',
-            value: formatCurrency(attributedRevenue),
-            momChange: null,
-            momTrend: 'neutral',
-            momTrendClass: 'text-gray-500',
-            yoyChange: null,
-            yoyTrend: 'neutral',
-            yoyTrendClass: 'text-gray-500',
-          },
-          {
-            id: 'roas',
-            label: 'Return on Ad Spend',
-            icon: 'fa-light fa-chart-line-up',
-            iconClass: 'bg-blue-100 text-blue-600',
-            value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
-            // No MoM delta: paid spend is lumpy and event-driven, so a
-            // month-over-month ROAS swing mostly reflects a change in campaign
-            // volume/mix (e.g. fewer campaigns when events wind down), not a
-            // change in ad efficiency. Showing it as a performance delta
-            // misrepresents a volume shift as a decline.
-            momChange: null,
-            momTrend: 'neutral',
-            momTrendClass: 'text-gray-500',
-            yoyChange: null,
-            yoyTrend: 'neutral',
-            yoyTrendClass: 'text-gray-500',
-          }
-        );
+        cards.push({
+          id: 'roas',
+          label: 'Return on Ad Spend',
+          icon: 'fa-light fa-chart-line-up',
+          iconClass: 'bg-blue-100 text-blue-600',
+          value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
+          // No MoM delta: paid spend is lumpy and event-driven, so a
+          // month-over-month ROAS swing mostly reflects a change in campaign
+          // volume/mix (e.g. fewer campaigns when events wind down), not a
+          // change in ad efficiency. Showing it as a performance delta
+          // misrepresents a volume shift as a decline.
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
+          yoyChange: null,
+          yoyTrend: 'neutral',
+          yoyTrendClass: 'text-gray-500',
+        });
       }
 
       if (data.brandReach) {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -2,21 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="performance-marketing-tab">
-  <!-- Header + funnel filter -->
-  <div class="flex flex-col gap-3">
-    <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
-      <div class="flex flex-col gap-0.5">
-        <h3 class="text-base font-semibold text-gray-900">Performance marketing</h3>
-        <p class="text-xs text-gray-500">Paid campaign metrics · {{ foundationName() || 'All foundations' }}</p>
-      </div>
-    </div>
-    <div class="flex items-center gap-3">
-      <span class="text-xs font-semibold tracking-wide text-gray-500">FUNNEL</span>
-      <lfx-filter-pills
-        [options]="funnelOptions"
-        [selectedFilter]="selectedFunnel()"
-        (filterChange)="onFunnelChange($event)"
-        data-testid="performance-marketing-funnel-pills" />
+  <!-- Header -->
+  <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-base font-semibold text-gray-900">Performance marketing</h3>
+      <p class="text-xs text-gray-500">Paid campaign metrics · {{ foundationName() || 'All foundations' }}</p>
     </div>
   </div>
 
@@ -47,7 +37,6 @@
           <!-- Table header -->
           <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
             <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
-            <span class="w-20 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">STAGE</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
             <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
             <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
@@ -56,8 +45,8 @@
           </div>
 
           <!-- Rows -->
-          @for (row of projectRows(); track row.funnelStage + '|' + row.name) {
-            @let projectKey = row.funnelStage + '|' + row.name;
+          @for (row of projectRows(); track row.name) {
+            @let projectKey = row.name;
             @let projectExpanded = expandedProjects().has(projectKey);
             <div
               class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
@@ -78,7 +67,6 @@
                 }
                 <span class="truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
               </div>
-              <span class="w-20 truncate text-[11px] text-gray-500" role="cell">{{ row.funnelStage }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
               <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.revenue }}</span>
               <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
@@ -99,7 +87,6 @@
                   [attr.data-testid]="'campaign-row-' + projectKey + '-' + $index">
                   <!-- w-40 (parent) minus pl-6 (indent) = 8.5rem -->
                   <span class="w-[8.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
-                  <span class="w-20 truncate text-[11px] text-gray-400" role="cell">{{ campaign.funnelStage }}</span>
                   <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
                   <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
                   <span class="w-16 text-right text-[11px] text-gray-500" role="cell">{{ campaign.roas }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -3,15 +3,12 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
-import { FOCUS_TO_CLASSIFICATION, FUNNEL_STAGE_OPTIONS } from '@lfx-one/shared/constants';
+import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
 import type {
-  FilterPillOption,
-  FunnelStage,
   KeywordPerformanceResponse,
   KeywordRow,
   MarketingImpactFocusProgram,
@@ -30,7 +27,7 @@ import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-c
 
 @Component({
   selector: 'lfx-performance-marketing-tab',
-  imports: [FilterPillsComponent, SparklineKpiCardComponent],
+  imports: [SparklineKpiCardComponent],
   templateUrl: './performance-marketing-tab.component.html',
   styleUrl: './performance-marketing-tab.component.scss',
 })
@@ -60,13 +57,9 @@ export class PerformanceMarketingTabComponent {
   public readonly foundationName = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
 
-  // === Constants ===
-  protected readonly funnelOptions: FilterPillOption[] = FUNNEL_STAGE_OPTIONS;
-
   // === WritableSignals ===
   protected readonly loading = signal(false);
   protected readonly keywordLoading = signal(false);
-  protected readonly selectedFunnel = signal<FunnelStage>('all');
   protected readonly expandedProjects = signal<Set<string>>(new Set());
   protected readonly expandedPlatforms = signal<Set<string>>(new Set());
   protected readonly expandedKeywords = signal<Set<string>>(new Set());
@@ -84,12 +77,6 @@ export class PerformanceMarketingTabComponent {
   protected readonly hasKeywords = computed(() => this.keywordRows().length > 0);
 
   // === Protected Methods ===
-  protected onFunnelChange(funnelId: string): void {
-    if (this.funnelOptions.some((o) => o.id === funnelId)) {
-      this.selectedFunnel.set(funnelId as FunnelStage);
-    }
-  }
-
   protected toggleProjectExpand(projectKey: string): void {
     this.expandedProjects.update((current) => {
       const next = new Set(current);
@@ -158,7 +145,6 @@ export class PerformanceMarketingTabComponent {
       const data = this.socialReachData();
       if (!data) return [];
 
-      const roasMomPct = data.changePercentage;
       const completedMonths = data.monthlyData?.slice(0, -1);
       const impressionsMomPct = computeMomPct(completedMonths);
 
@@ -208,9 +194,12 @@ export class PerformanceMarketingTabComponent {
           icon: 'fa-light fa-chart-line-up',
           iconClass: 'bg-violet-100 text-violet-600',
           value: `${(data.roas ?? 0).toFixed(2)}x`,
-          momChange: formatChangePct(roasMomPct, 'MoM'),
-          momTrend: trendDirection(roasMomPct),
-          momTrendClass: trendColorClass(roasMomPct),
+          // No MoM delta: paid spend is lumpy and event-driven, so a
+          // month-over-month ROAS swing mostly reflects a change in campaign
+          // volume/mix, not a change in ad efficiency.
+          momChange: null,
+          momTrend: 'neutral',
+          momTrendClass: 'text-gray-500',
           yoyChange: null,
           yoyTrend: 'neutral',
           yoyTrendClass: 'text-gray-500',
@@ -224,19 +213,9 @@ export class PerformanceMarketingTabComponent {
   private initProjectRows(): Signal<PaidProjectRow[]> {
     return computed(() => {
       const data = this.socialReachData();
-      const funnel = this.selectedFunnel();
       if (!data?.projectBreakdown?.length) return [];
 
       return data.projectBreakdown
-        .filter((p) => {
-          if (funnel === 'all') return true;
-          const stage = p.funnelStage?.toLowerCase() ?? '';
-          if (!stage || stage === 'unknown') return false;
-          if (funnel === 'tofu') return stage.startsWith('tofu');
-          if (funnel === 'mofu') return stage === 'mofu';
-          if (funnel === 'bofu') return stage === 'bofu';
-          return false;
-        })
         .map((p): PaidProjectRow => {
           const perf = this.normalizePerformance(p.performance);
           return {

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -39,6 +39,20 @@ export const ATTRIBUTION_MODEL_OPTIONS: AttributionModelOption[] = [
   { label: 'Time Decay', value: 'timeDecay' },
 ];
 
+/**
+ * Human-readable definitions for each consolidated attribution channel label, keyed by the UI
+ * label produced server-side (see mapChannel in project.service.ts). Surfaced as per-channel
+ * tooltips in the Marketing attribution table so viewers know what each grouping includes.
+ */
+export const ATTRIBUTION_CHANNEL_DESCRIPTIONS: Record<string, string> = {
+  'Paid Performance': 'Paid search and paid social campaigns.',
+  Email: 'Email and HubSpot marketing sends.',
+  'Internal & Banner': 'Internal cross-site links and on-site promotional banners.',
+  Organic: 'Unpaid organic search traffic.',
+  Other: 'Other tracked sources that do not fall into a primary channel.',
+  'Direct & Unknown': 'Direct visits plus sessions with no identifiable referring source.',
+};
+
 /** Maps MarketingImpactFocusProgram IDs to Snowflake LF_SUB_DOMAIN_CLASSIFICATION values. 'all' maps to undefined (no filter). */
 export const FOCUS_TO_CLASSIFICATION: Record<MarketingImpactFocusProgram, string | undefined> = {
   all: undefined,
@@ -58,11 +72,3 @@ export const FOCUS_VISIBLE_TABS: Record<MarketingImpactFocusProgram, ReadonlySet
   lfTraining: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
   projectWebsites: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'web-activity']),
 };
-
-/** Funnel stage filter options for the Performance Marketing tab. */
-export const FUNNEL_STAGE_OPTIONS: FilterPillOption[] = [
-  { id: 'all', label: 'All stages' },
-  { id: 'tofu', label: 'Top of funnel' },
-  { id: 'mofu', label: 'Middle of funnel' },
-  { id: 'bofu', label: 'Bottom of funnel' },
-];

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -5,6 +5,7 @@ import type {
   BrandReachResponse,
   EmailCtrResponse,
   MarketingAttributionChannel,
+  MarketingAttributionResponse,
   PaidProjectPerformance,
   RevenueImpactResponse,
 } from './analytics-data.interface';
@@ -40,6 +41,7 @@ export interface OverviewKpiData {
   revenueImpact: RevenueImpactResponse | null;
   brandReach: BrandReachResponse | null;
   emailCtr: EmailCtrResponse | null;
+  attribution: MarketingAttributionResponse | null;
 }
 
 /** Pre-formatted KPI card data for the Marketing Impact performance summary. */


### PR DESCRIPTION
## Summary

Marketing Impact dashboard refinements:

- **Attribution channel tooltips** — added per-channel info tooltips to the Marketing attribution table so viewers know what each consolidated channel groups. Notably clarifies that **Direct & Unknown** combines direct visits and sessions with no identifiable referring source. Definitions live in a shared constant (`ATTRIBUTION_CHANNEL_DESCRIPTIONS`).
- **Dropped noisy MoM deltas** — suppressed misleading month-over-month deltas on KPI cards where the delta tracked a different metric than the value, or had no honest prior window: Attributed Revenue, ROAS, Web Sessions, Email CTR.
- **Attributed Revenue → Linear attribution** — the headline now reports Linear-attributed revenue so it agrees with the attribution table below it.
- **Removed the redundant funnel filter / STAGE column** from the performance-marketing tab (and its now-dead `FUNNEL_STAGE_OPTIONS` constant).

## Notes

- **JIRA:** LFXV2-2023
- Splitting "Direct & Unknown" into separate Direct / Unknown rows was requested but is **blocked at the data layer**: the Snowflake `MARKETING_ATTRIBUTION` model already stores them as a single `Direct / Unknown` channel. The tooltip is an interim clarification; a true split requires an lf-dbt model change to emit them as distinct channels.

## Verification

- `yarn check-types` passes across both packages.
- Manually verified in-browser on the Marketing Impact page (Foundation lens, TLF).
