### PR TITLE
fix(campaigns): correct germany/uk linkedin geo urns

### DIFF
--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -204,8 +204,8 @@ export const LINKEDIN_GEO_RESOLVE_MAP: Readonly<Record<string, LinkedInGeoTarget
   'hong kong': { label: 'Hong Kong', urn: 'urn:li:geo:103291313' },
   'united states': { label: 'United States', urn: 'urn:li:geo:103644278' },
   usa: { label: 'United States', urn: 'urn:li:geo:103644278' },
-  germany: { label: 'Germany', urn: 'urn:li:geo:101165590' },
-  'united kingdom': { label: 'United Kingdom', urn: 'urn:li:geo:106693272' },
+  germany: { label: 'Germany', urn: 'urn:li:geo:101282230' },
+  'united kingdom': { label: 'United Kingdom', urn: 'urn:li:geo:101165590' },
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`LINKEDIN_GEO_RESOLVE_MAP` mapped **germany → `urn:li:geo:101165590`** and **united kingdom → `urn:li:geo:106693272`**. Verified against LinkedIn's geo reference:

| URN | Actual country |
|-----|----------------|
| `101282230` | Germany |
| `101165590` | United Kingdom |
| `106693272` | Switzerland |

So as written, **germany-targeted paid campaigns resolved to the UK, and UK campaigns to Switzerland**. This corrects germany → `101282230` and united kingdom → `101165590`.

## Scope

Two string-literal values in the shared constant. Consumers (`linkedin-ads.service.ts`, `implementation-tab.component.ts`) reference the map by `.urn` and pick up the correction automatically — no other changes needed.

## Related

This is the shared-constant source of truth for the **same defect already fixed in the `lfx-v2-campaign-service` Go client** (`internal/platform/linkedin` `geoResolveMap`, PR [#22](https://github.com/linuxfoundation/lfx-v2-campaign-service/pull/22)). Fixing it here keeps the TS client and Go port aligned. Tracked under LFXV2-2665.

## Verification

- `yarn lint:check`, `yarn check-types`, `yarn build` pass (pre-commit hook)
- License header check passes
- LinkedIn geo URNs verified against [LinkedIn's geography reference](https://learn.microsoft.com/en-us/linkedin/shared/references/reference-tables/geography-codes)