### PR TITLE
fix(create): derive lens access from writer grants, not persona alone

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -308,7 +308,7 @@ export const routes: Routes = [
       },
       {
         path: 'meetings',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/meetings/meetings.routes').then((m) => m.MEETING_ROUTES),
       },
       {
@@ -317,37 +317,37 @@ export const routes: Routes = [
       },
       {
         path: 'groups',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/committees/committees.routes').then((m) => m.COMMITTEE_ROUTES),
       },
       {
         path: 'mailing-lists',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then((m) => m.MAILING_LIST_ROUTES),
       },
       {
         path: 'votes',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/votes/votes.routes').then((m) => m.VOTE_ROUTES),
       },
       {
         path: 'surveys',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/surveys/surveys.routes').then((m) => m.SURVEY_ROUTES),
       },
       {
         path: 'newsletters',
-        canActivate: [lensRedirectGuard, newsletterAccessGuard],
+        canActivate: [lensRedirectGuard, newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
         path: 'documents',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
       },
       {
         path: 'settings',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
       },
       {
@@ -368,7 +368,7 @@ export const routes: Routes = [
       },
       {
         path: 'events',
-        canActivate: [lensRedirectGuard],
+        canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -12,6 +12,7 @@ import { ALL_LENSES } from '@lfx-one/shared/constants';
 import { Lens } from '@lfx-one/shared/interfaces';
 import { AppService } from '@services/app.service';
 import { LensService } from '@services/lens.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { SidebarNavService } from '@services/sidebar-nav.service';
 import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -29,6 +30,7 @@ export class MainLayoutComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly appService = inject(AppService);
   private readonly lensService = inject(LensService);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly sidebarNavService = inject(SidebarNavService);
   protected readonly userService = inject(UserService);
 
@@ -91,10 +93,12 @@ export class MainLayoutComponent {
       });
   }
 
+  /** Toggle the mobile sidebar drawer from the header control. */
   public toggleMobileSidebar(): void {
     this.appService.toggleMobileSidebar();
   }
 
+  /** Mirror the PrimeNG drawer's visibility back into app state when it closes itself (backdrop, Esc). */
   public onDrawerVisibilityChange(visible: boolean): void {
     if (!visible) {
       this.appService.closeMobileSidebar();
@@ -112,6 +116,15 @@ export class MainLayoutComponent {
       currentRoute = currentRoute.firstChild;
       lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
+    // Keep the context service's route-kind override in step with the route on *every* navigation.
+    // `projectQueryParamGuard` sets it earlier — before child components construct — but is not
+    // attached to every route (`/profile`, `/badges` and friends have none), so without this an
+    // override from a previous lens-prefixed route would leak into them. This runs on
+    // NavigationEnd, so on those unguarded routes there is a brief window during construction where
+    // the previous value is still visible; they are `me`-scoped pages that do not read the active
+    // context, and the guard already covers every route that does.
+    this.projectContextService.setRouteLensKind(lens === 'foundation' || lens === 'project' ? lens : null);
+
     // Assigned on every navigation, including routes that carry no lens, so a pending retry from an
     // earlier route can never outlive it. Without that, switching lens from the switcher (which
     // navigates to a route that may carry no lens data) would leave the old value armed, and the

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, model } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, effect, inject, model, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { ImpersonationBannerComponent } from '@components/impersonation-banner/impersonation-banner.component';
@@ -44,6 +44,17 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
+  /**
+   * A route lens that {@link LensService.setLens} refused, held for retry.
+   *
+   * The allowed lens set is partly derived from `writer` grants, which arrive after hydration
+   * (LFXV2-2754), so a deep link or hard refresh onto a lens-prefixed route can run before the
+   * grants land. Dropping the refusal there would strand the user on a `/foundation/...` URL with
+   * the lens still `me` — `activeContext` would then resolve the wrong slot and the page would act
+   * on the wrong project. Retried by the effect below once the set widens.
+   */
+  private readonly pendingRouteLens = signal<Lens | null>(null);
+
   public constructor() {
     // Close mobile sidebar and sync lens from route data on navigation
     this.router.events
@@ -56,6 +67,17 @@ export class MainLayoutComponent {
         this.selectorPanelOpen.set(false);
         this.syncLensFromRoute();
       });
+
+    // Re-assert a refused route lens when the allowed set widens. Reading `availableLenses`
+    // registers the dependency, so this re-runs exactly when the grants resolve. The set only
+    // ever widens, so this settles after one successful pass and cannot loop.
+    effect(() => {
+      this.lensService.availableLenses();
+      const pending = this.pendingRouteLens();
+      if (pending && this.lensService.setLens(pending)) {
+        this.pendingRouteLens.set(null);
+      }
+    });
   }
 
   public toggleMobileSidebar(): void {
@@ -80,7 +102,8 @@ export class MainLayoutComponent {
       lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
     if (lens && lens in ALL_LENSES) {
-      this.lensService.setLens(lens);
+      // Hold a refusal for retry rather than dropping it — the allowed set may still be widening.
+      this.pendingRouteLens.set(this.lensService.setLens(lens) ? null : lens);
     }
   }
 }

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, CUSTOM_ELEMENTS_SCHEMA, effect, inject, model, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, model, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { ImpersonationBannerComponent } from '@components/impersonation-banner/impersonation-banner.component';
 import { LensSwitcherComponent } from '@components/lens-switcher/lens-switcher.component';
@@ -15,7 +15,7 @@ import { LensService } from '@services/lens.service';
 import { SidebarNavService } from '@services/sidebar-nav.service';
 import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
-import { filter } from 'rxjs';
+import { distinctUntilChanged, filter, map } from 'rxjs';
 
 @Component({
   selector: 'lfx-main-layout',
@@ -51,7 +51,7 @@ export class MainLayoutComponent {
    * (LFXV2-2754), so a deep link or hard refresh onto a lens-prefixed route can run before the
    * grants land. Dropping the refusal there would strand the user on a `/foundation/...` URL with
    * the lens still `me` — `activeContext` would then resolve the wrong slot and the page would act
-   * on the wrong project. Retried by the effect below once the set widens.
+   * on the wrong project. Retried by the subscription below once the set widens.
    */
   private readonly pendingRouteLens = signal<Lens | null>(null);
 
@@ -68,16 +68,27 @@ export class MainLayoutComponent {
         this.syncLensFromRoute();
       });
 
-    // Re-assert a refused route lens when the allowed set widens. Reading `availableLenses`
-    // registers the dependency, so this re-runs exactly when the grants resolve. The set only
-    // ever widens, so this settles after one successful pass and cannot loop.
-    effect(() => {
-      this.lensService.availableLenses();
-      const pending = this.pendingRouteLens();
-      if (pending && this.lensService.setLens(pending)) {
-        this.pendingRouteLens.set(null);
-      }
-    });
+    // Re-assert a refused route lens when the allowed set changes, i.e. when the writer grants
+    // resolve. This terminates because `pendingRouteLens` is cleared on the successful pass and
+    // re-armed only by a later navigation — not because the set is monotonic. It isn't: the
+    // persona half can narrow when `PersonaService.refreshFromApi()` drops a cookie-claimed role.
+    //
+    // `availableLenses` is a computed returning a fresh array each recompute, so it re-emits on
+    // unrelated persona/flag churn with identical content. Comparing the projected lens ids keeps
+    // this to genuine changes — re-running on every churn would re-assert a lens the user may have
+    // since changed by another path.
+    toObservable(this.lensService.availableLenses)
+      .pipe(
+        map((lenses) => lenses.map((option) => option.id).join(',')),
+        distinctUntilChanged(),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => {
+        const pending = this.pendingRouteLens();
+        if (pending && this.lensService.setLens(pending)) {
+          this.pendingRouteLens.set(null);
+        }
+      });
   }
 
   public toggleMobileSidebar(): void {
@@ -101,9 +112,11 @@ export class MainLayoutComponent {
       currentRoute = currentRoute.firstChild;
       lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
-    if (lens && lens in ALL_LENSES) {
-      // Hold a refusal for retry rather than dropping it — the allowed set may still be widening.
-      this.pendingRouteLens.set(this.lensService.setLens(lens) ? null : lens);
-    }
+    // Assigned on every navigation, including routes that carry no lens, so a pending retry from an
+    // earlier route can never outlive it. Without that, switching lens from the switcher (which
+    // navigates to a route that may carry no lens data) would leave the old value armed, and the
+    // retry below would later clobber the user's explicit choice.
+    const pending = lens && lens in ALL_LENSES && !this.lensService.setLens(lens) ? lens : null;
+    this.pendingRouteLens.set(pending);
   }
 }

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -116,14 +116,24 @@ export class MainLayoutComponent {
       currentRoute = currentRoute.firstChild;
       lens = currentRoute.snapshot.data['lens'] ?? lens;
     }
-    // Keep the context service's route-kind override in step with the route on *every* navigation.
-    // `projectQueryParamGuard` sets it earlier — before child components construct — but is not
-    // attached to every route (`/profile`, `/badges` and friends have none), so without this an
-    // override from a previous lens-prefixed route would leak into them. This runs on
-    // NavigationEnd, so on those unguarded routes there is a brief window during construction where
-    // the previous value is still visible; they are `me`-scoped pages that do not read the active
-    // context, and the guard already covers every route that does.
-    this.projectContextService.setRouteLensKind(lens === 'foundation' || lens === 'project' ? lens : null);
+    const hasProjectParam = currentRoute.snapshot.queryParamMap.has('project');
+
+    // Clear the context service's route-kind override on routes the guard does not own, so a
+    // foundation/project override from a previous route cannot leak into them.
+    //
+    // `projectQueryParamGuard` is the authoritative setter: it runs on every lens-prefixed route
+    // AND every flat write route carrying a `?project=` param, and derives the kind from the route
+    // or from the resolved project. This handler runs on NavigationEnd — *after* the guard — so it
+    // must not overwrite what the guard just established. It therefore only acts on routes the guard
+    // does not touch: no declared lens and no `?project=` param (e.g. `/profile`, `/badges`), where
+    // it resets to `null`. On a lens route it re-asserts the value the guard set (idempotent); on a
+    // flat `?project=` route it leaves the guard's derived kind alone — clobbering it there is the
+    // bug that made a direct hit on `/meetings/create?project=<foundation>` resolve a null context.
+    if (lens === 'foundation' || lens === 'project') {
+      this.projectContextService.setRouteLensKind(lens);
+    } else if (!hasProjectParam) {
+      this.projectContextService.setRouteLensKind(null);
+    }
 
     // Assigned on every navigation, including routes that carry no lens, so a pending retry from an
     // earlier route can never outlive it. Without that, switching lens from the switcher (which

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
@@ -95,10 +95,15 @@ export class CreateArtifactDialogComponent {
 
     // `activeContext` is lens-gated: under `me`/`org` it reads the slot matching the user's
     // *persona*, not the kind picked here, so the create page would resolve the other slot.
-    // Aligning the lens first makes it read the slot seeded below. `setLens` refuses a lens the
-    // persona doesn't hold — `writer` and lens roles are independent grants — and there is no way
-    // to align the context in that case, so bail before mutating anything rather than create
-    // against a stale project (writerGuard's ED fast-path would not catch it).
+    // Aligning the lens first makes it read the slot seeded below.
+    //
+    // This should now always succeed: the options are exactly the user's `writer` grants, and
+    // `getAllowedLensIds` admits any lens they hold `writer` within (LFXV2-2754), so the lens
+    // for a listed project is available by construction. It previously failed for real users —
+    // the lens came from persona alone, which a writer grant does not imply — which is the bug
+    // this path was fixed for. Kept as a defensive bail because the alternative on an
+    // unexpected refusal is creating against a stale project, which `writerGuard`'s ED
+    // fast-path would not catch.
     if (!this.lensService.setLens(project.isFoundation ? 'foundation' : 'project')) {
       console.error('Cannot align lens to the selected project; aborting create navigation.', {
         slug: project.slug,

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -20,12 +20,17 @@ export const lensRedirectGuard: CanActivateFn = (_route, state) => {
   const router = inject(Router);
 
   // Reads `activeLens` synchronously, and the allowed lens set is partly derived from `writer`
-  // grants that resolve after hydration (LFXV2-2754). A user whose only route to a lens is a
-  // writer grant therefore gets no redirect on the first navigation after load, and the redirect
-  // on subsequent ones — the same URL resolving differently by timing. Accepted rather than fixed:
-  // gating this guard on a readiness signal would block every flat-route navigation on the grants
-  // request, and the un-redirected flat route is a correct, functional page rather than a wrong
-  // one. Revisit if the grants move into the SSR payload, which removes the asymmetry outright.
+  // grants that resolve after hydration (LFXV2-2754). A user whose only route to a lens is a writer
+  // grant therefore gets no redirect on the first navigation after load, and the redirect on
+  // subsequent ones — the same URL resolving differently by timing. Accepted rather than gated on a
+  // readiness signal, which would block every flat-route navigation on the grants request.
+  //
+  // The un-redirected flat route is a functional page, and — crucially — the create flows on it no
+  // longer resolve the wrong target while it is un-redirected: the flat write routes also run
+  // `projectQueryParamGuard`, which seeds the context slot from the `?project=` param (deriving
+  // foundation-vs-project from the project itself, not the lens), so `activeContextUid()` reflects
+  // the authorised target regardless of the active lens. This redirect is now cosmetic/navigational
+  // only. Revisit if the grants move into the SSR payload, which removes the timing asymmetry.
   const lens = lensService.activeLens();
   if (lens === 'foundation' || lens === 'project') {
     return router.parseUrl(`/${lens}${state.url}`);

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -19,6 +19,13 @@ export const lensRedirectGuard: CanActivateFn = (_route, state) => {
   const lensService = inject(LensService);
   const router = inject(Router);
 
+  // Reads `activeLens` synchronously, and the allowed lens set is partly derived from `writer`
+  // grants that resolve after hydration (LFXV2-2754). A user whose only route to a lens is a
+  // writer grant therefore gets no redirect on the first navigation after load, and the redirect
+  // on subsequent ones — the same URL resolving differently by timing. Accepted rather than fixed:
+  // gating this guard on a readiness signal would block every flat-route navigation on the grants
+  // request, and the un-redirected flat route is a correct, functional page rather than a wrong
+  // one. Revisit if the grants move into the SSR payload, which removes the asymmetry outright.
   const lens = lensService.activeLens();
   if (lens === 'foundation' || lens === 'project') {
     return router.parseUrl(`/${lens}${state.url}`);

--- a/apps/lfx-one/src/app/shared/guards/project-query-param.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/project-query-param.guard.ts
@@ -4,6 +4,7 @@
 import { inject } from '@angular/core';
 import { CanActivateFn } from '@angular/router';
 import { ProjectContext } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { catchError, map, of } from 'rxjs';
 
 import { ProjectContextService } from '../services/project-context.service';
@@ -20,15 +21,17 @@ export const projectQueryParamGuard: CanActivateFn = (route) => {
   const projectContextService = inject(ProjectContextService);
 
   const routeLens = route.data['lens'];
-  const routeKind = routeLens === 'foundation' || routeLens === 'project' ? routeLens : null;
+  const declaredKind = routeLens === 'foundation' || routeLens === 'project' ? routeLens : null;
 
-  // Record the route's declared kind before anything else, on every navigation this guard runs for
-  // — including the no-slug early return below. `activeContext` prefers this over the lens, which
-  // is clamped against a grant set that only resolves after hydration (LFXV2-2754); without it a
-  // deep link onto `/foundation/...` reads the project slot and create flows would build their
-  // payload from the wrong project. Writing `null` when the route declares no kind is what stops a
-  // previous route's override from leaking into this one.
-  projectContextService.setRouteLensKind(routeKind);
+  // Record the route's declared kind up front, before the async project fetch, so a route that
+  // declares one (the lens-prefixed routes) has `activeContext` resolving the right slot from the
+  // first render. `activeContext` prefers this over the lens, which is clamped against a grant set
+  // that only resolves after hydration (LFXV2-2754); without it a deep link onto `/foundation/...`
+  // reads the project slot and create flows would build their payload from the wrong project.
+  // Writing `null` when the route declares no kind stops a previous route's override from leaking
+  // in; the flat write routes (which declare no lens) get their kind from the resolved project
+  // below instead — see the `effectiveKind` note.
+  projectContextService.setRouteLensKind(declaredKind);
 
   const slug = route.queryParamMap.get('project');
   if (!slug) return true;
@@ -43,7 +46,18 @@ export const projectQueryParamGuard: CanActivateFn = (route) => {
         parent_uid: project.parent_uid,
         logoUrl: project.logo_url,
       };
-      if (routeKind === 'foundation') {
+      // When the route declares no lens (the flat write routes, e.g. `/meetings/create` reached by
+      // a direct URL rather than the lens-prefixed form the dialog redirects to), derive the kind
+      // from the project itself. `computeIsFoundation` reads the project's own attributes, so it is
+      // independent of the viewer's persona and of the post-hydration grant set — a foundation
+      // target lands in the foundation slot even when the active lens is still `me`. Without this,
+      // context would fall back to the lens and the create component would build its payload from
+      // the wrong slot (the target `writerGuard` authorised via `?project=` would be discarded).
+      const effectiveKind = declaredKind ?? (computeIsFoundation(project) ? 'foundation' : 'project');
+      if (effectiveKind !== declaredKind) {
+        projectContextService.setRouteLensKind(effectiveKind);
+      }
+      if (effectiveKind === 'foundation') {
         projectContextService.setFoundation(context);
       } else {
         projectContextService.setProject(context);

--- a/apps/lfx-one/src/app/shared/guards/project-query-param.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/project-query-param.guard.ts
@@ -16,11 +16,22 @@ import { ProjectService } from '../services/project.service';
  * and NavigationService.applyDefaultSelection handles the fallback selection.
  */
 export const projectQueryParamGuard: CanActivateFn = (route) => {
-  const slug = route.queryParamMap.get('project');
-  if (!slug) return true;
-
   const projectService = inject(ProjectService);
   const projectContextService = inject(ProjectContextService);
+
+  const routeLens = route.data['lens'];
+  const routeKind = routeLens === 'foundation' || routeLens === 'project' ? routeLens : null;
+
+  // Record the route's declared kind before anything else, on every navigation this guard runs for
+  // — including the no-slug early return below. `activeContext` prefers this over the lens, which
+  // is clamped against a grant set that only resolves after hydration (LFXV2-2754); without it a
+  // deep link onto `/foundation/...` reads the project slot and create flows would build their
+  // payload from the wrong project. Writing `null` when the route declares no kind is what stops a
+  // previous route's override from leaking into this one.
+  projectContextService.setRouteLensKind(routeKind);
+
+  const slug = route.queryParamMap.get('project');
+  if (!slug) return true;
 
   return projectService.getProject(slug, false).pipe(
     map((project) => {
@@ -32,7 +43,7 @@ export const projectQueryParamGuard: CanActivateFn = (route) => {
         parent_uid: project.parent_uid,
         logoUrl: project.logo_url,
       };
-      if (route.data['lens'] === 'foundation') {
+      if (routeKind === 'foundation') {
         projectContextService.setFoundation(context);
       } else {
         projectContextService.setProject(context);

--- a/apps/lfx-one/src/app/shared/services/create-permission.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-permission.service.ts
@@ -1,43 +1,42 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { computed, inject, Injectable, Signal } from '@angular/core';
 import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
-import { CreatableArtifactType, CreatableProject, Project } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation } from '@lfx-one/shared/utils';
-import { LensService } from '@services/lens.service';
-import { ProjectService } from '@services/project.service';
-import { map } from 'rxjs';
+import { CreatableArtifactType, CreatableProject } from '@lfx-one/shared/interfaces';
+import { WriterGrantsService } from '@services/writer-grants.service';
 
 /**
  * Decides whether the rail "Create" quick-link (and which artifact types) is
  * offered to the current user, and which projects/foundations they may target.
  *
- * Eligibility is the intersection of two independent grants:
- *  - the project `writer` grant — the same signal `writerGuard` enforces.
- *    `GET /api/projects` batch access-checks every visible project and returns
- *    `writer` per project, so this reflects real per-project authorization
- *    rather than inferring it from a persona.
- *  - a lens the user's persona holds. `ProjectContextService.activeContext` is
- *    lens-gated, so the create page can only resolve a selection whose lens can
- *    be aligned. Offering a project outside the user's lenses would dead-end at
- *    "Create". These grants are independent — a pure ED holds no `project` lens
- *    yet may hold `writer` on subprojects — so both must hold.
+ * Eligibility is the project `writer` grant, and nothing else — the same signal
+ * `writerGuard` enforces. `GET /api/projects` batch access-checks every visible
+ * project and returns `writer` per project, so this reflects real per-project
+ * authorization rather than inferring it from a persona.
+ *
+ * This list was previously intersected with the lenses the user's persona holds,
+ * on the reasoning that `ProjectContextService.activeContext` is lens-gated so an
+ * unreachable lens would dead-end at "Create". That was true, but it made the wrong
+ * side give way: it silently hid projects the user provably administers. A user
+ * holding `writer` on 81 foundations while detecting as `contributor` could target
+ * none of them (LFXV2-2754). The lens is now derived from the grant instead —
+ * `LensService.getAllowedLensIds` admits any lens the user holds `writer` within —
+ * so alignment succeeds for exactly the projects listed here and the intersection
+ * is redundant. Do not reintroduce a persona-derived filter on this list; persona
+ * and `writer` are independent, and `writer` is the one that confers authority.
  *
  * Everything resolves to `[]` while loading and on error, keeping the rail button
  * hidden until eligibility is proven — fail closed. The error half of that relies on
- * `ProjectService.getProjects()` catching internally and emitting `[]`; there is no
- * local `catchError` because one on this stream would be unreachable.
+ * `ProjectService.getProjects()` catching internally and emitting `[]`.
  *
  * Granularity note: `writer` is not the whole story upstream. Meetings are broader
  * (`meeting_coordinator` and committee-writer also qualify), so users holding only
- * those roles are under-shown, as are EDs whose only writable projects fall outside
- * their lenses. This is a UX affordance only — the create routes' `writerGuard`
- * remains authoritative for non-ED personas, so the button never grants access, it
- * only advertises it. A `GET /api/projects/creatable` endpoint encoding the per-type
- * grants would make the list exact and let the create flows resolve their target
- * without the lens, removing that constraint.
+ * those roles are still under-shown — they source no project `writer` at all, so the
+ * client cannot see them. This is a UX affordance only — the create routes'
+ * `writerGuard` remains authoritative for non-ED personas, so the button never grants
+ * access, it only advertises it. A `GET /api/projects/creatable` endpoint encoding the
+ * per-type grants (LFXV2-2753) is what closes that remaining gap.
  *
  * Persona note (ED): gating is purely the FGA `writer` relation, with NO ED fast-path —
  * unlike `writerGuard`, which synchronously allows the `executive-director` persona
@@ -53,22 +52,10 @@ import { map } from 'rxjs';
   providedIn: 'root',
 })
 export class CreatePermissionService {
-  private readonly projectService = inject(ProjectService);
-  private readonly lensService = inject(LensService);
-  private readonly destroyRef = inject(DestroyRef);
+  private readonly writerGrantsService = inject(WriterGrantsService);
 
-  /** Projects the user holds `writer` on, before the lens intersection. */
-  private readonly writerProjects = signal<CreatableProject[]>([]);
-
-  /**
-   * Projects the user may create on — `writer` intersected with lens reach (see class doc).
-   * A `computed` rather than a filter applied at fetch time, so it re-evaluates when persona
-   * data resolves and widens the available lenses.
-   */
-  public readonly creatableProjects: Signal<CreatableProject[]> = computed(() => {
-    const lenses = this.lensService.availableLenses();
-    return this.writerProjects().filter((project) => lenses.some((lens) => lens.id === (project.isFoundation ? 'foundation' : 'project')));
-  });
+  /** Projects the user may create on — exactly those they hold `writer` on (see class doc). */
+  public readonly creatableProjects: Signal<CreatableProject[]> = this.writerGrantsService.writerProjects;
 
   /**
    * Artifact types offered to the user — all types when they can create anywhere, else none.
@@ -86,35 +73,4 @@ export class CreatePermissionService {
 
   /** True when the user can create on at least one project. */
   public readonly canShowCreateButton: Signal<boolean> = computed(() => this.creatableProjects().length > 0);
-
-  public constructor() {
-    // Fetch after hydration, not at construction. Two reasons: the endpoint paginates every
-    // visible project and batch access-checks them, so a pending task would block SSR
-    // serialization on TTFB for every page; and `profile-affiliations` already issues this exact
-    // request during SSR, so the transfer cache would resolve it synchronously here and render
-    // the button on the client's first pass while the server rendered it absent — a hydration
-    // mismatch. `afterNextRender` runs browser-only, once the first render is committed.
-    afterNextRender(() => {
-      this.projectService
-        .getProjects()
-        .pipe(
-          map((projects) => projects.filter((project) => project.writer === true).map(toCreatableProject)),
-          takeUntilDestroyed(this.destroyRef)
-        )
-        .subscribe((projects) => this.writerProjects.set(projects));
-    });
-  }
-}
-
-function toCreatableProject(project: Project): CreatableProject {
-  return {
-    uid: project.uid,
-    slug: project.slug,
-    name: project.name,
-    // Derived from the project's own attributes, so it stays correct regardless of the
-    // viewer's persona — it dispatches the selection to the foundation vs project slot.
-    isFoundation: computeIsFoundation(project),
-    parent_uid: project.parent_uid,
-    logoUrl: project.logo_url,
-  };
 }

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -115,10 +115,16 @@ export class LensService {
    * Lenses the current user may use. Persona roles and `writer` grants each confer access
    * independently (LFXV2-2754) — see `deriveAllowedLenses` for why either suffices.
    *
-   * The `writer` half arrives after hydration (see {@link WriterGrantsService}), so this set
-   * only ever widens as grants land — it never narrows. A caller that acts on a lens before
-   * then must re-assert once it widens rather than treat a `false` from {@link setLens} as
-   * final; `MainLayoutComponent.syncLensFromRoute` is the one such caller.
+   * This set is not stable across a session, in two different ways:
+   *  - the `writer` half arrives after hydration (see {@link WriterGrantsService}) and only ever
+   *    widens as grants land;
+   *  - the persona half can *narrow*. It is seeded from a cookie and then replaced by
+   *    `PersonaService.refreshFromApi()`, which may drop a role the cookie claimed and clears
+   *    `isRootWriter` on its error path.
+   *
+   * So a caller must treat a `false` from {@link setLens} as provisional rather than final, and
+   * must not assume a lens it holds now will still be allowed later.
+   * `MainLayoutComponent.syncLensFromRoute` is the one caller that re-asserts.
    */
   private getAllowedLensIds(): readonly Lens[] {
     return deriveAllowedLenses({

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -13,11 +13,13 @@ import {
   ORG_LENS_ENABLED_FLAG,
 } from '@lfx-one/shared/constants';
 import { Lens, LensOption, NavLens } from '@lfx-one/shared/interfaces';
+import { deriveAllowedLenses } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
 import { PersonaService } from './persona.service';
+import { WriterGrantsService } from './writer-grants.service';
 
 @Injectable({
   providedIn: 'root',
@@ -27,6 +29,7 @@ export class LensService {
   private readonly cookieRegistry = inject(CookieRegistryService);
   private readonly personaService = inject(PersonaService);
   private readonly featureFlagService = inject(FeatureFlagService);
+  private readonly writerGrantsService = inject(WriterGrantsService);
   private readonly router = inject(Router);
 
   /** Dark-launch gate; off by default until the LaunchDarkly flag is flipped. */
@@ -108,26 +111,24 @@ export class LensService {
     });
   }
 
+  /**
+   * Lenses the current user may use. Persona roles and `writer` grants each confer access
+   * independently (LFXV2-2754) — see `deriveAllowedLenses` for why either suffices.
+   *
+   * The `writer` half arrives after hydration (see {@link WriterGrantsService}), so this set
+   * only ever widens as grants land — it never narrows. A caller that acts on a lens before
+   * then must re-assert once it widens rather than treat a `false` from {@link setLens} as
+   * final; `MainLayoutComponent.syncLensFromRoute` is the one such caller.
+   */
   private getAllowedLensIds(): readonly Lens[] {
-    const hasBoardRole = this.personaService.hasBoardRole();
-    const hasProjectRole = this.personaService.hasProjectRole();
-    const isRootWriter = this.personaService.isRootWriter();
-
-    // Root writers bypass persona filtering and see both foundation + project lenses.
-    const showFoundation = hasBoardRole || isRootWriter;
-    const showProject = hasProjectRole || isRootWriter;
-
-    const lenses: Lens[] = ['me'];
-    if (showFoundation) {
-      lenses.push('foundation');
-    }
-    if (showProject) {
-      lenses.push('project');
-    }
-    if (this.isOrgLensEnabled()) {
-      lenses.push('org');
-    }
-    return lenses;
+    return deriveAllowedLenses({
+      hasBoardRole: this.personaService.hasBoardRole(),
+      hasProjectRole: this.personaService.hasProjectRole(),
+      isRootWriter: this.personaService.isRootWriter(),
+      hasWriterFoundation: this.writerGrantsService.hasWriterFoundation(),
+      hasWriterProject: this.writerGrantsService.hasWriterProject(),
+      isOrgLensEnabled: this.isOrgLensEnabled(),
+    });
   }
 
   private persistToCookie(lens: Lens): void {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -34,6 +34,24 @@ export class ProjectContextService {
   private readonly foundationSelection: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
   private readonly projectSelection: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
 
+  /**
+   * The context kind declared by the current route (`route.data.lens`), when it declares one.
+   *
+   * Takes precedence over {@link LensService.activeLens} when resolving which slot is active. The
+   * route is a stronger statement of intent than the lens, and — unlike the lens — it does not
+   * depend on data that arrives after hydration. `activeLens` is clamped to the allowed set, and
+   * the writer-derived half of that set resolves post-hydration (LFXV2-2754), so on a deep link or
+   * hard refresh onto `/foundation/...` the lens can still read `me` while `projectQueryParamGuard`
+   * has already seeded the foundation slot. Resolving by lens there returns the *other* slot, and
+   * because create flows build their payload from `activeContextUid()`, the artifact would be
+   * created against a different project than the one `writerGuard` authorised. Honouring the route
+   * closes that window, and stays correct even if the grants request fails outright.
+   *
+   * Set by `projectQueryParamGuard` on every navigation it runs for — to the declared kind, or
+   * `null` where none is declared, so a stale override cannot outlive the route that set it.
+   */
+  private readonly routeLensKind: WritableSignal<'foundation' | 'project' | null> = signal<'foundation' | 'project' | null>(null);
+
   public readonly activeContext: Signal<ProjectContext | null> = this.initActiveContext();
   public readonly isFoundationContext: Signal<boolean> = this.initIsFoundationContext();
   public readonly activeContextUid: Signal<string> = computed(() => this.activeContext()?.uid || '');
@@ -73,6 +91,11 @@ export class ProjectContextService {
     if (syncUrl) {
       this.syncProjectQueryParam(project.slug);
     }
+  }
+
+  /** Records the kind the current route declares, so context resolution can prefer it over the lens. */
+  public setRouteLensKind(kind: 'foundation' | 'project' | null): void {
+    this.routeLensKind.set(kind);
   }
 
   public clearFoundation(): void {
@@ -139,6 +162,12 @@ export class ProjectContextService {
 
   private initActiveContext(): Signal<ProjectContext | null> {
     return computed(() => {
+      // The route wins when it declares a kind — see `routeLensKind`.
+      const routeKind = this.routeLensKind();
+      if (routeKind) {
+        return routeKind === 'foundation' ? this.foundationSelection() : this.projectSelection();
+      }
+
       const lens = this.lensService.activeLens();
 
       switch (lens) {
@@ -157,6 +186,12 @@ export class ProjectContextService {
 
   private initIsFoundationContext(): Signal<boolean> {
     return computed(() => {
+      // Kept in lockstep with `initActiveContext` — the two must never disagree about which slot is active.
+      const routeKind = this.routeLensKind();
+      if (routeKind) {
+        return routeKind === 'foundation';
+      }
+
       const lens = this.lensService.activeLens();
 
       switch (lens) {

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -1,0 +1,77 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CreatableProject, Project } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { ProjectService } from '@services/project.service';
+import { map } from 'rxjs';
+
+/**
+ * The user's per-project `writer` grants — the same signal `writerGuard` enforces.
+ *
+ * `GET /api/projects` batch access-checks every visible project and returns `writer` per
+ * project, so this reflects real authorization rather than inferring it from a persona.
+ * Owned here rather than in a consumer because two independent consumers need it and must
+ * not depend on each other:
+ *  - {@link LensService} widens the allowed lens set to cover projects the user can write
+ *    to (LFXV2-2754) — a `writer` grant is authority over that project, so the lens that
+ *    reaches it must be available regardless of which persona was detected.
+ *  - {@link CreatePermissionService} scopes the create quick-link to the same grants.
+ *
+ * Dependency direction matters: this service injects only `ProjectService` (which injects
+ * only `HttpClient`), so `LensService` can consume it without a cycle.
+ *
+ * Resolves to `[]` while loading and on error — callers fail closed. The error half relies
+ * on `ProjectService.getProjects()` catching internally and emitting `[]`; a local
+ * `catchError` here would be unreachable.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class WriterGrantsService {
+  private readonly projectService = inject(ProjectService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly grants = signal<CreatableProject[]>([]);
+
+  /** Projects the user holds `writer` on. Empty until the post-hydration fetch resolves. */
+  public readonly writerProjects: Signal<CreatableProject[]> = this.grants.asReadonly();
+
+  /** True once at least one writer-held project satisfies `computeIsFoundation`. */
+  public readonly hasWriterFoundation: Signal<boolean> = computed(() => this.grants().some((project) => project.isFoundation));
+
+  /** True once at least one writer-held project is a non-foundation project. */
+  public readonly hasWriterProject: Signal<boolean> = computed(() => this.grants().some((project) => !project.isFoundation));
+
+  public constructor() {
+    // Fetch after hydration, not at construction. The endpoint paginates every visible project
+    // and batch access-checks them, so a pending task would block SSR serialization on TTFB for
+    // every page. `afterNextRender` runs browser-only, once the first render is committed, so the
+    // server and the client's first pass agree and the widened lens set lands as a normal state
+    // update rather than a hydration mismatch.
+    afterNextRender(() => {
+      this.projectService
+        .getProjects()
+        .pipe(
+          map((projects) => projects.filter((project) => project.writer === true).map(toCreatableProject)),
+          takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe((projects) => this.grants.set(projects));
+    });
+  }
+}
+
+function toCreatableProject(project: Project): CreatableProject {
+  return {
+    uid: project.uid,
+    slug: project.slug,
+    name: project.name,
+    // Derived from the project's own attributes, so it stays correct regardless of the
+    // viewer's persona — it dispatches the selection to the foundation vs project slot.
+    isFoundation: computeIsFoundation(project),
+    parent_uid: project.parent_uid,
+    logoUrl: project.logo_url,
+  };
+}

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -63,6 +63,13 @@ export class WriterGrantsService {
   }
 }
 
+/**
+ * Project a raw `Project` down to the fields the create picker and lens derivation need.
+ *
+ * `isFoundation` is computed from the project's own attributes rather than read from any
+ * viewer-scoped field, so it stays correct regardless of the caller's persona — it decides both
+ * which lens the project requires and which slot a selection is dispatched to.
+ */
 function toCreatableProject(project: Project): CreatableProject {
   return {
     uid: project.uid,

--- a/packages/shared/src/interfaces/lens.interface.ts
+++ b/packages/shared/src/interfaces/lens.interface.ts
@@ -10,6 +10,25 @@ import type { LensItem } from './navigation.interface';
 export type Lens = 'me' | 'foundation' | 'project' | 'org';
 
 /**
+ * Inputs to `deriveAllowedLenses` — the persona roles and `writer` grants that
+ * independently confer lens access. See that function for why either source suffices.
+ */
+export interface LensGrantInputs {
+  /** Persona holds a board-scoped role (ED / Board Member). */
+  hasBoardRole: boolean;
+  /** Persona holds a project-scoped role (Maintainer / Contributor). */
+  hasProjectRole: boolean;
+  /** Root writer — bypasses persona filtering entirely. */
+  isRootWriter: boolean;
+  /** Holds `writer` on at least one project that computes as a foundation. */
+  hasWriterFoundation: boolean;
+  /** Holds `writer` on at least one non-foundation project. */
+  hasWriterProject: boolean;
+  /** Org lens dark-launch flag. */
+  isOrgLensEnabled: boolean;
+}
+
+/**
  * Configuration for a lens option displayed in the L1 Rail
  */
 export interface LensOption {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -38,5 +38,6 @@ export * from './org.utils';
 export * from './search.utils';
 export * from './email.utils';
 export * from './invitation.utils';
+export * from './lens.utils';
 export * from './crowdfunding.utils';
 export * from './persona.utils';

--- a/packages/shared/src/utils/lens.utils.spec.ts
+++ b/packages/shared/src/utils/lens.utils.spec.ts
@@ -1,0 +1,86 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { LensGrantInputs } from '../interfaces/lens.interface';
+import { deriveAllowedLenses } from './lens.utils';
+
+const NO_GRANTS: LensGrantInputs = {
+  hasBoardRole: false,
+  hasProjectRole: false,
+  isRootWriter: false,
+  hasWriterFoundation: false,
+  hasWriterProject: false,
+  isOrgLensEnabled: false,
+};
+
+const inputs = (overrides: Partial<LensGrantInputs>): LensGrantInputs => ({ ...NO_GRANTS, ...overrides });
+
+describe('deriveAllowedLenses', () => {
+  it('always includes the me lens', () => {
+    expect(deriveAllowedLenses(NO_GRANTS)).toEqual(['me']);
+  });
+
+  describe('persona-derived grants (pre-existing behaviour)', () => {
+    it('grants foundation for a board role', () => {
+      expect(deriveAllowedLenses(inputs({ hasBoardRole: true }))).toEqual(['me', 'foundation']);
+    });
+
+    it('grants project for a project role', () => {
+      expect(deriveAllowedLenses(inputs({ hasProjectRole: true }))).toEqual(['me', 'project']);
+    });
+
+    it('grants both for a root writer', () => {
+      expect(deriveAllowedLenses(inputs({ isRootWriter: true }))).toEqual(['me', 'foundation', 'project']);
+    });
+  });
+
+  describe('writer-derived grants (LFXV2-2754)', () => {
+    // The regression case: a contributor-only persona holding writer on foundations.
+    // Before this change the foundation lens was withheld, which made every foundation
+    // the user administers unreachable in the create flow.
+    it('grants foundation on a writer-held foundation despite no board role', () => {
+      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true }))).toEqual(['me', 'foundation']);
+    });
+
+    it('grants project on a writer-held project despite no project role', () => {
+      expect(deriveAllowedLenses(inputs({ hasWriterProject: true }))).toEqual(['me', 'project']);
+    });
+
+    it('grants both when the user holds writer on each kind', () => {
+      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true, hasWriterProject: true }))).toEqual(['me', 'foundation', 'project']);
+    });
+
+    it('does not grant foundation from a project-only writer grant', () => {
+      expect(deriveAllowedLenses(inputs({ hasWriterProject: true }))).not.toContain('foundation');
+    });
+
+    it('does not grant project from a foundation-only writer grant', () => {
+      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true }))).not.toContain('project');
+    });
+  });
+
+  describe('grant sources are additive, never subtractive', () => {
+    it('keeps persona-granted lenses when no writer grants have resolved yet', () => {
+      // Grants arrive after hydration; the set must not narrow while they are pending.
+      expect(deriveAllowedLenses(inputs({ hasBoardRole: true, hasProjectRole: true }))).toEqual(['me', 'foundation', 'project']);
+    });
+
+    it('does not duplicate a lens conferred by both sources', () => {
+      const result = deriveAllowedLenses(inputs({ hasBoardRole: true, hasWriterFoundation: true }));
+      expect(result).toEqual(['me', 'foundation']);
+      expect(result.filter((lens) => lens === 'foundation')).toHaveLength(1);
+    });
+  });
+
+  describe('org lens', () => {
+    it('appends org when the flag is on', () => {
+      expect(deriveAllowedLenses(inputs({ isOrgLensEnabled: true }))).toEqual(['me', 'org']);
+    });
+
+    it('orders org last alongside other grants', () => {
+      expect(deriveAllowedLenses(inputs({ isRootWriter: true, isOrgLensEnabled: true }))).toEqual(['me', 'foundation', 'project', 'org']);
+    });
+  });
+});

--- a/packages/shared/src/utils/lens.utils.ts
+++ b/packages/shared/src/utils/lens.utils.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Lens, LensGrantInputs } from '../interfaces/lens.interface';
+
+/**
+ * The lenses a user is authorised to use, from their persona roles and `writer` grants.
+ *
+ * Two independent sources confer a lens, and either is sufficient:
+ *  - a **persona role** — a board role reaches `foundation`, a project role reaches `project`,
+ *    and a root writer reaches both.
+ *  - a **`writer` grant** on a project of that kind (LFXV2-2754). Persona detection and FGA
+ *    grants are independent, so delegated staff commonly hold `writer` on foundations while
+ *    detecting as `contributor` only. Requiring the persona stranded them: every path that
+ *    resolves a create target reads the lens, so a lens they could never hold made projects
+ *    they demonstrably administer unreachable.
+ *
+ * `me` is always present. `org` is feature-flagged and independent of both sources.
+ *
+ * Extracted as a pure function so this authorisation-adjacent logic is unit-testable — the
+ * Angular app has no unit-test runner, and `LensService` consumes this rather than
+ * reimplementing it.
+ */
+export function deriveAllowedLenses(inputs: LensGrantInputs): Lens[] {
+  const { hasBoardRole, hasProjectRole, isRootWriter, hasWriterFoundation, hasWriterProject, isOrgLensEnabled } = inputs;
+
+  const showFoundation = hasBoardRole || isRootWriter || hasWriterFoundation;
+  const showProject = hasProjectRole || isRootWriter || hasWriterProject;
+
+  const lenses: Lens[] = ['me'];
+  if (showFoundation) {
+    lenses.push('foundation');
+  }
+  if (showProject) {
+    lenses.push('project');
+  }
+  if (isOrgLensEnabled) {
+    lenses.push('org');
+  }
+  return lenses;
+}


### PR DESCRIPTION
## What

Derives lens access from the user's `writer` grants instead of persona alone, so the create quick-link offers every project/foundation the user can actually write to.

Fixes LFXV2-2754.

## Why

`CreatePermissionService.creatableProjects` intersected `writer` grants with the lenses the user's *persona* holds. Persona detection and FGA grants are independent, so delegated staff routinely hold `writer` on foundations while detecting as `contributor` only — the intersection then hid every foundation they administer.

Measured on prod: `asalkever@linuxfoundation.org` resolves as `["contributor"]` (clean detection, `error: null`) while holding `writer` on 1159 projects, 81 of them foundations. His Foundations tab read "No foundations or projects available" and AAIF — where he holds the **Manage** role — was unsearchable.

Removing the intersection alone would not have worked: `ProjectContextService.activeContext` is lens-gated, so the create page would have resolved the wrong slot and acted on the wrong project. The lens is therefore derived from the grant, which makes alignment succeed for exactly the listed projects and leaves the intersection redundant.

## Changes

- **`WriterGrantsService`** (new) — owns the `writer` grant signal. Extracted so `LensService` and `CreatePermissionService` can share it; injects only `ProjectService` (which injects only `HttpClient`), so there is no DI cycle.
- **`deriveAllowedLenses`** (`@lfx-one/shared`) — lens derivation as a pure function, with 13 Vitest cases including the regression. The Angular app has no unit-test runner, so this is the only way the logic is testable.
- **`LensService`** — delegates to that function; `writer` grants confer a lens alongside persona roles.
- **`CreatePermissionService`** — intersection removed; `creatableProjects` is now exactly the writer grants. Class doc rewritten (it previously argued *for* the intersection).
- **`MainLayoutComponent`** — holds a route lens that `setLens` refused and re-asserts it when the allowed set widens, since grants land after hydration. Cleared on every navigation so a stale refusal cannot clobber a later explicit choice.

## Validation (prod, read-only)

| Persona | Before | After |
| --- | --- | --- |
| `asalkever@` — delegated staff, contributor-only, writer on 81 foundations | Foundations tab empty; AAIF unsearchable | 81 foundations listed; AAIF selects through to `/foundation/meetings/create?project=agentic-ai-foundation`; lens switches to Foundation; `writerGuard` admits; wizard loads |
| `mgilbert@` — foundation ED, board-scoped | worked | still works |
| `jzemlin@` — LF ED, board-scoped | worked | still works |

No writes performed — validation stopped at step 1 of the create wizard.

## Documented trade-offs

**1. `lensRedirectGuard` timing asymmetry.** The guard reads `activeLens()` synchronously, and the allowed set is now partly derived from grants that resolve after hydration. A user whose only route to a lens is a writer grant gets no redirect on the first navigation after load, and the redirect on subsequent ones — the same URL resolving differently by timing.

Accepted rather than fixed: gating the guard on a readiness signal would block every flat-route navigation on the grants request, and would hang under SSR (`afterNextRender` never fires server-side, so a readiness signal would never flip). The un-redirected flat route is a correct, functional page rather than a wrong one. Revisit if the grants move into the SSR payload, which removes the asymmetry outright.

**2. `WriterGrantsService` has no spec.** `apps/lfx-one` contains zero `*.spec.ts` files and has no unit-test runner, so a sibling spec is not executable. Mitigated by extracting the authorization logic into the tested `deriveAllowedLenses`; what remains uncovered is the fetch/filter/signal wiring. Repo-wide structural gap, not specific to this change.

**3. Icon latency extended to the lens set.** The grants come from `GET /api/projects` — 1.39 MB, ~5 s (measured). The create icon already waited on this; the lens set now does too, so a grant-derived Foundation entry appears ~5 s after the page is interactive. Pre-existing from LFXV2-2721, tracked separately in **LFXV2-2756** with measurements and options.

**4. `isHybridPersona` remains persona-only.** A user who now reaches both lenses via grants gets two switcher buttons rather than the merged "Projects" entry. Deriving hybrid from available lenses would fix the inconsistency but would also change behaviour for root writers, who would lose their separate Foundation button — not worth that blast radius here.

## Open question (see LFXV2-2754 comment)

`asalkever@` measures as `writer: true` on CNCF and FINOS while appearing in **neither** project's `writers` list (he *is* listed on AAIF, which works correctly). Not blanket over-granting — `mgilbert@` resolves as writer on only 5 projects — so the breadth likely comes from a team grant or model inheritance the stored permissions list does not surface.

This PR grants nothing: `writerGuard` uses the same access-check, so those grants are already honoured by the in-page create flows, Manage affordances and `canWrite`. But the persona-derived filter was incidentally masking them for contributor-persona users, and removing it makes them visible and one click away. Worth confirming with the FGA model owners (`lfx-v2-helm`) before merge; if the breadth is intentional, this is correct as-is.

## Not in scope

Committee/Group writers remain under-shown — they source no project `writer`. `GET /api/committees` does return a `writer` flag, but obtaining it costs an unscoped listing with an access-check over every committee (~35 s measured). Tracked in LFXV2-2753.

## Checks

`yarn lint`, `yarn build`, `./check-headers.sh` clean. 13 new Vitest cases pass. Pre-existing unrelated failure in `meeting-privacy.utils.spec.ts` (missing `vitest` import since #1093, red on `main` too) left untouched.
