### PR TITLE
fix(org-lens): mirror Insights 5-band project health classification

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -177,7 +177,7 @@
                     type="button"
                     class="flex items-center gap-1 whitespace-nowrap font-semibold"
                     (click)="toggleSort('health')"
-                    pTooltip="CHAOSS health classification from LFX Insights: Excellent, Healthy, or At Risk."
+                    pTooltip="LFX Insights project health classification: Excellent, Healthy, Stable, Unsteady, or Critical."
                     tooltipPosition="top"
                     tooltipStyleClass="lfx-tooltip-wide">
                     Health

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -936,16 +936,20 @@ export class OrgProjectsComponent {
   }
 
   private healthRank(health: OrgLensProject['health']): number {
-    if (health === 'excellent') {
-      return 2;
+    switch (health) {
+      case 'excellent':
+        return 5;
+      case 'healthy':
+        return 4;
+      case 'stable':
+        return 3;
+      case 'unsteady':
+        return 2;
+      case 'critical':
+        return 1;
+      default:
+        return 0;
     }
-    if (health === 'healthy') {
-      return 1;
-    }
-    if (health === 'at-risk') {
-      return 0;
-    }
-    return -1;
   }
 
   private buildRowMenu(project: OrgLensProject): MenuItem[] {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -19,7 +19,7 @@ import type {
   OrgLensProjectTrendSeries,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, classifyHealthScore } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { buildOrgCacheKey, valkeyService } from './valkey.service';
@@ -1140,8 +1140,7 @@ export class OrgLensProjectDetailService {
 
   private mapHealth(score: number | null): OrgLensProjectHealth | null {
     if (score === null || score === undefined) return null;
-    if (score >= 80) return 'excellent';
-    return score >= 60 ? 'healthy' : 'at-risk';
+    return classifyHealthScore(score);
   }
 
   private buildTechnicalCards(cards: CardsRow | null, index: SparklineIndex, axis: string[]): OrgLensProjectInfluenceCard[] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -13,6 +13,7 @@ import {
   ORG_PROJECTS_SEARCH_MIN_LENGTH,
   VALKEY_CACHE,
 } from '@lfx-one/shared/constants';
+import { classifyHealthScore } from '@lfx-one/shared/utils';
 import type {
   HealthScore,
   InfluenceBand,
@@ -447,10 +448,7 @@ export class OrgLensProjectsService {
   }
 
   private mapHealthScore(score: number): HealthScore {
-    if (score >= 80) {
-      return 'excellent';
-    }
-    return score >= 60 ? 'healthy' : 'at-risk';
+    return classifyHealthScore(score);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -27,11 +27,13 @@ export const PD_TIME_RANGE_TYPE: Record<OrgLensLeaderboardTimeRange, string> = {
   all: 'alltime',
 };
 
-/** Hero health badge → lfx-tag severity (green Excellent / blue Healthy / red At Risk), matching HEALTH_SCORE_SEVERITY on the Org Lens Projects page. */
+/** Hero health badge → lfx-tag severity (5 Insights bands), matching HEALTH_SCORE_LABELS / HEALTH_SCORE_SEVERITY on the Org Lens Projects page. */
 export const PD_HEALTH_TAG: Record<OrgLensProjectHealth, { label: string; severity: TagSeverity }> = {
   excellent: { label: 'Excellent', severity: 'success' },
   healthy: { label: 'Healthy', severity: 'info' },
-  'at-risk': { label: 'At Risk', severity: 'danger' },
+  stable: { label: 'Stable', severity: 'info' },
+  unsteady: { label: 'Unsteady', severity: 'warn' },
+  critical: { label: 'Critical', severity: 'danger' },
 };
 
 /** Leaderboard band chip → lfx-tag severity. */

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -86,19 +86,23 @@ export const INFLUENCE_BAND_BAR_FILL_CLASS_LIGHT: Record<InfluenceBand, string> 
   'non-lf': 'fill-gray-200',
 };
 
-/** Display labels for health scores. */
+/** Display labels for health scores (5 Insights bands + Unavailable). */
 export const HEALTH_SCORE_LABELS: Record<HealthScore, string> = {
   excellent: 'Excellent',
   healthy: 'Healthy',
-  'at-risk': 'At Risk',
+  stable: 'Stable',
+  unsteady: 'Unsteady',
+  critical: 'Critical',
   unavailable: 'Unavailable',
 };
 
-/** Tag/badge severity per health score (drives health-badge color). */
+/** Tag/badge severity per health score (drives health-badge color), matching the Insights health-score component intent. */
 export const HEALTH_SCORE_SEVERITY: Record<HealthScore, TagSeverity> = {
   excellent: 'success',
   healthy: 'info',
-  'at-risk': 'danger',
+  stable: 'info',
+  unsteady: 'warn',
+  critical: 'danger',
   unavailable: 'secondary',
 };
 

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -29,8 +29,8 @@ export interface InfluenceCardVm {
   testId: string;
 }
 
-/** CHAOSS-derived project health classification — drives the hero badge color token. */
-export type OrgLensProjectHealth = 'excellent' | 'healthy' | 'at-risk';
+/** LFX Insights project health classification — the 5 bands of the Insights project Health Score component; drives the hero badge color token. */
+export type OrgLensProjectHealth = 'excellent' | 'healthy' | 'stable' | 'unsteady' | 'critical';
 
 /**
  * Precomputed org-influence tier, read straight through from the warehouse level column.

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -6,8 +6,8 @@ import { TagSeverity } from './components.interface';
 /** Influence band per the markup-mu methodology (Boysel et al.). Declared strongest → weakest. */
 export type InfluenceBand = 'leading' | 'contributing' | 'participating' | 'silent' | 'non-lf';
 
-/** CHAOSS-derived project health classification (via LFX Insights). */
-export type HealthScore = 'excellent' | 'healthy' | 'at-risk' | 'unavailable';
+/** LFX Insights project health classification — the 5 bands of the Insights project Health Score component, plus `unavailable` when no score exists. */
+export type HealthScore = 'excellent' | 'healthy' | 'stable' | 'unsteady' | 'critical' | 'unavailable';
 
 /** Direction of a one-year influence trend, used for color-coding the sparkline + delta. */
 export type InfluenceTrendDirection = 'up' | 'down' | 'flat';

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LINKS_CONFIG } from '../constants/links.config';
+import type { HealthScore } from '../interfaces';
 
 /**
  * Builds an LFX Insights URL from an optional path and query params.
@@ -51,6 +52,29 @@ export function buildLensAwareInsightsUrl(
   }
   const path = opts.projectSubPath ? `/project/${slug}/${opts.projectSubPath}` : `/project/${slug}`;
   return buildInsightsUrl(path, opts.projectParams);
+}
+
+/**
+ * Classifies an LFX Insights project health score (0–100) into a band, matching the Insights
+ * primary project Health Score component (`health-score.vue`): `>= 80` Excellent, `>= 60` Healthy,
+ * `>= 40` Stable, `>= 20` Unsteady, else Critical. The `unavailable` state (no score) is handled by
+ * callers, so this returns only the five scored bands and is the single source both the Org Lens
+ * Projects table and the project-detail hero classify through (they must never disagree).
+ */
+export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
+  if (score >= 80) {
+    return 'excellent';
+  }
+  if (score >= 60) {
+    return 'healthy';
+  }
+  if (score >= 40) {
+    return 'stable';
+  }
+  if (score >= 20) {
+    return 'unsteady';
+  }
+  return 'critical';
 }
 
 function encodePathSegments(path: string): string {


### PR DESCRIPTION
## Summary
- Org Lens's Projects table and project-detail hero collapsed LFX Insights' 5 health bands (Excellent/Healthy/Stable/Unsteady/Critical) into an invented 3-band scheme with a non-existent "At Risk" label.
- Adds a single shared `classifyHealthScore()` helper matching Insights' primary Health Score component boundaries (`>=80/>=60/>=40/>=20/<20`), consumed by both BFF mappers (`org-lens-projects.service.ts`, `org-lens-project-detail.service.ts`) so the table and hero can never disagree.
- Extends the `HealthScore` / `OrgLensProjectHealth` unions and their label/severity/sort maps to the 5 bands + Unavailable, removes `at-risk` everywhere.
- Foundation lens health distribution is unchanged (out of scope, verified untouched).

Ref: LFXV2-2746
Spec/plan/tasks: `specs/032-org-lens-project-health-bands/` in the `lfx-workspace` umbrella repo.

## Test plan
- [x] `yarn check-types` / `yarn lint:check` / `yarn format:check` / `yarn build` all pass
- [x] `rg -n "at-risk|At Risk"` returns no matches in `apps/lfx-one` / `packages/shared`
- [x] Parity spot-check: sample projects across all five bands match Insights; score of exactly 80 shows "Excellent" in both the table and the hero
- [x] Foundation-lens regression: foundation-health card and project-health-scores drawer show identical band labels/counts (no code in those paths touched)
- [x] Pre-PR reviewer trio (general code review, repo-convention/checklist audit, empirical KB pattern match) — all three returned clean, zero Critical/Important findings