### PR TITLE
fix(org-lens): mirror Insights 5-band project health classification

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -97,7 +97,9 @@
             <span class="text-xs font-medium uppercase tracking-wide text-gray-500">Health score</span>
             @if (healthMeta(); as hm) {
               <span class="md:ml-auto" data-testid="project-detail-health-badge">
-                <lfx-tag [value]="hm.label" [severity]="hm.severity" />
+                <span class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold" [style.backgroundColor]="hm.bg" [style.color]="hm.text">{{
+                  hm.label
+                }}</span>
               </span>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -274,7 +274,12 @@
                     (mouseenter)="openHealth($event, project, healthPop)"
                     (mouseleave)="scheduleHealthHide(healthPop)"
                     [attr.data-testid]="'org-projects-health-' + project.slug">
-                    <lfx-tag [value]="project.healthLabel" [severity]="project.healthSeverity" />
+                    <span
+                      class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
+                      [style.backgroundColor]="project.healthBadge.bg"
+                      [style.color]="project.healthBadge.text"
+                      >{{ project.healthLabel }}</span
+                    >
                   </span>
                 </td>
                 <td>
@@ -373,7 +378,12 @@
           LFX Insights
         </a>
       </div>
-      <lfx-tag [value]="project.healthLabel" [severity]="project.healthSeverity" [dot]="true" />
+      <span
+        class="inline-flex w-fit px-2.5 py-1 rounded-full text-xs font-semibold"
+        [style.backgroundColor]="project.healthBadge.bg"
+        [style.color]="project.healthBadge.text"
+        >{{ project.healthLabel }}</span
+      >
       <p class="text-sm leading-relaxed text-gray-500">{{ project.description }}</p>
       <div class="flex flex-col gap-2.5">
         @for (metric of project.healthMetrics; track metric.label) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -177,7 +177,7 @@
                     type="button"
                     class="flex items-center gap-1 whitespace-nowrap font-semibold"
                     (click)="toggleSort('health')"
-                    pTooltip="CHAOSS health classification from LFX Insights: Excellent, Healthy, or At Risk."
+                    pTooltip="LFX Insights project health classification: Excellent, Healthy, Stable, Unsteady, or Critical."
                     tooltipPosition="top"
                     tooltipStyleClass="lfx-tooltip-wide">
                     Health

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -945,8 +945,8 @@ export class OrgProjectsComponent {
   }
 
   private compareHealthAvailability(a: OrgLensProject['health'], b: OrgLensProject['health']): number {
-    const aUnavailable = a === 'unavailable';
-    const bUnavailable = b === 'unavailable';
+    const aUnavailable = this.normalizeHealth(a) === 'unavailable';
+    const bUnavailable = this.normalizeHealth(b) === 'unavailable';
     if (aUnavailable === bUnavailable) {
       return 0;
     }
@@ -954,7 +954,7 @@ export class OrgProjectsComponent {
   }
 
   private healthRank(health: OrgLensProject['health']): number {
-    switch (health) {
+    switch (this.normalizeHealth(health)) {
       case 'excellent':
         return 5;
       case 'healthy':

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -936,16 +936,20 @@ export class OrgProjectsComponent {
   }
 
   private healthRank(health: OrgLensProject['health']): number {
-    if (health === 'excellent') {
-      return 2;
+    switch (health) {
+      case 'excellent':
+        return 5;
+      case 'healthy':
+        return 4;
+      case 'stable':
+        return 3;
+      case 'unsteady':
+        return 2;
+      case 'critical':
+        return 1;
+      default:
+        return 0;
     }
-    if (health === 'healthy') {
-      return 1;
-    }
-    if (health === 'at-risk') {
-      return 0;
-    }
-    return -1;
   }
 
   private buildRowMenu(project: OrgLensProject): MenuItem[] {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -12,8 +12,8 @@ import {
   DEFAULT_ORG_PROJECTS_WORKSPACE_ID,
   DEFAULT_ORG_PROJECTS_WORKSPACE_NAME,
   DEFAULT_ORG_PROJECTS_WORKSPACES,
+  HEALTH_SCORE_BADGE,
   HEALTH_SCORE_LABELS,
-  HEALTH_SCORE_SEVERITY,
   INFLUENCE_BAND_BAR_FILL_CLASS,
   INFLUENCE_BAND_BAR_FILL_CLASS_LIGHT,
   INFLUENCE_BAND_LABELS,
@@ -61,7 +61,6 @@ import { MenuComponent } from '@components/menu/menu.component';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
-import { TagComponent } from '@components/tag/tag.component';
 import { AccountContextService } from '@shared/services/account-context.service';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 import { OrgLensProjectsService } from '@shared/services/org-lens-projects.service';
@@ -85,7 +84,6 @@ import { PersonaService } from '@shared/services/persona.service';
     SelectComponent,
     SkeletonModule,
     TableComponent,
-    TagComponent,
     TooltipModule,
   ],
   templateUrl: './org-projects.component.html',
@@ -718,7 +716,7 @@ export class OrgProjectsComponent {
         technicalBandLabel: INFLUENCE_BAND_LABELS[project.technicalInfluence],
         ecosystemBandLabel: INFLUENCE_BAND_LABELS[project.ecosystemInfluence],
         healthLabel: HEALTH_SCORE_LABELS[project.health],
-        healthSeverity: HEALTH_SCORE_SEVERITY[project.health],
+        healthBadge: HEALTH_SCORE_BADGE[project.health],
         sparklineDataset: {
           labels: project.trend.series.map((_, i) => String(i)),
           datasets: [{ data: project.trend.series, borderColor: INFLUENCE_TREND_COLOR[project.trend.direction], fill: false }],

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -904,6 +904,12 @@ export class OrgProjectsComponent {
   }
 
   private compareProjects(a: OrgLensProject, b: OrgLensProject, field: OrgProjectsSortField, dir: SortDirection): number {
+    if (field === 'health') {
+      const availability = this.compareHealthAvailability(a.health, b.health);
+      if (availability !== 0) {
+        return availability;
+      }
+    }
     const primary = this.compareByField(a, b, field);
     const directed = dir === 'asc' ? primary : -primary;
     if (directed !== 0) {
@@ -933,6 +939,15 @@ export class OrgProjectsComponent {
       default:
         return 0;
     }
+  }
+
+  private compareHealthAvailability(a: OrgLensProject['health'], b: OrgLensProject['health']): number {
+    const aUnavailable = a === 'unavailable';
+    const bUnavailable = b === 'unavailable';
+    if (aUnavailable === bUnavailable) {
+      return 0;
+    }
+    return aUnavailable ? 1 : -1;
   }
 
   private healthRank(health: OrgLensProject['health']): number {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -29,6 +29,7 @@ import {
 } from '@lfx-one/shared/constants';
 import type {
   AddableProjectOption,
+  HealthScore,
   InfluenceBand,
   OrgLensProject,
   OrgLensProjectSearchResult,
@@ -482,7 +483,7 @@ export class OrgProjectsComponent {
     const header = ['Project', 'Health Score', 'Technical Influence', 'Ecosystem Influence', 'Influence Trend (1y) %', 'Our Contributors', 'Our Participants'];
     const body = rows.map((p) => [
       p.name,
-      HEALTH_SCORE_LABELS[p.health],
+      HEALTH_SCORE_LABELS[this.normalizeHealth(p.health)],
       INFLUENCE_BAND_LABELS[p.technicalInfluence],
       INFLUENCE_BAND_LABELS[p.ecosystemInfluence],
       p.trend.deltaPct,
@@ -555,7 +556,7 @@ export class OrgProjectsComponent {
   // Full health summary (rating + sub-scores) so keyboard/screen-reader users get the popover's content without a mouse.
   protected healthAriaLabel(project: OrgLensProject): string {
     const metrics = project.healthMetrics.map((m) => `${m.label} ${m.value}`).join(', ');
-    return `Health: ${HEALTH_SCORE_LABELS[project.health]}. ${metrics}.`;
+    return `Health: ${HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)]}. ${metrics}.`;
   }
   protected searchAddableProjects(query: string): void {
     if (this.addableProjectsSearchDebounceTimer) {
@@ -715,8 +716,8 @@ export class OrgProjectsComponent {
         ecosystemBars: this.bandBars(project.ecosystemInfluence),
         technicalBandLabel: INFLUENCE_BAND_LABELS[project.technicalInfluence],
         ecosystemBandLabel: INFLUENCE_BAND_LABELS[project.ecosystemInfluence],
-        healthLabel: HEALTH_SCORE_LABELS[project.health],
-        healthBadge: HEALTH_SCORE_BADGE[project.health],
+        healthLabel: HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)],
+        healthBadge: HEALTH_SCORE_BADGE[this.normalizeHealth(project.health)],
         sparklineDataset: {
           labels: project.trend.series.map((_, i) => String(i)),
           datasets: [{ data: project.trend.series, borderColor: INFLUENCE_TREND_COLOR[project.trend.direction], fill: false }],
@@ -937,6 +938,10 @@ export class OrgProjectsComponent {
       default:
         return 0;
     }
+  }
+
+  private normalizeHealth(health: HealthScore): HealthScore {
+    return Object.prototype.hasOwnProperty.call(HEALTH_SCORE_BADGE, health) ? health : 'unavailable';
   }
 
   private compareHealthAvailability(a: OrgLensProject['health'], b: OrgLensProject['health']): number {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DEFAULT_LFX_ONE_PLATINUM_SCHEMA, PD_TIME_RANGE_TYPE, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { DEFAULT_LFX_ONE_PLATINUM_SCHEMA, PD_HEALTH_TAG, PD_TIME_RANGE_TYPE, VALKEY_CACHE } from '@lfx-one/shared/constants';
 import type {
   OrgLensCardDetailCell,
   OrgLensCardDetailRow,
@@ -1519,7 +1519,9 @@ export class OrgLensProjectDetailService {
   private static isHeroBlock(value: unknown): value is OrgLensHeroBlock {
     if (value === null || typeof value !== 'object') return false;
     const candidate = value as OrgLensHeroBlock;
-    return !!candidate.hero && typeof candidate.hero === 'object' && typeof candidate.isNonLfProject === 'boolean';
+    if (!candidate.hero || typeof candidate.hero !== 'object' || typeof candidate.isNonLfProject !== 'boolean') return false;
+    const { health } = candidate.hero as OrgLensProjectHero;
+    return health === null || health in PD_HEALTH_TAG;
   }
 
   private static isInfluenceBlock(value: unknown): value is OrgLensInfluenceBlock {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -19,7 +19,7 @@ import type {
   OrgLensProjectTrendSeries,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, classifyHealthScore } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { buildOrgCacheKey, valkeyService } from './valkey.service';
@@ -1140,8 +1140,7 @@ export class OrgLensProjectDetailService {
 
   private mapHealth(score: number | null): OrgLensProjectHealth | null {
     if (score === null || score === undefined) return null;
-    if (score >= 80) return 'excellent';
-    return score >= 60 ? 'healthy' : 'at-risk';
+    return classifyHealthScore(score);
   }
 
   private buildTechnicalCards(cards: CardsRow | null, index: SparklineIndex, axis: string[]): OrgLensProjectInfluenceCard[] {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1521,7 +1521,7 @@ export class OrgLensProjectDetailService {
     const candidate = value as OrgLensHeroBlock;
     if (!candidate.hero || typeof candidate.hero !== 'object' || typeof candidate.isNonLfProject !== 'boolean') return false;
     const { health } = candidate.hero as OrgLensProjectHero;
-    return health === null || health in PD_HEALTH_TAG;
+    return health === null || Object.prototype.hasOwnProperty.call(PD_HEALTH_TAG, health);
   }
 
   private static isInfluenceBlock(value: unknown): value is OrgLensInfluenceBlock {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -448,7 +448,7 @@ export class OrgLensProjectsService {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
   }
 
-  private mapHealthScore(score: number): HealthScore {
+  private mapHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
     return classifyHealthScore(score);
   }
 

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_ALL_ACTIVITIES_PROJECT_LIMIT,
   DEFAULT_ORG_PROJECTS_WORKSPACE_ID,
   DEFAULT_ORG_PROJECTS_WORKSPACE_NAME,
+  HEALTH_SCORE_LABELS,
   ORG_PROJECTS_MEMBER_SERVICE_BULK_ADD_CHUNK_SIZE,
   ORG_PROJECTS_OUTSIDE_LF_WAREHOUSE_SLUG,
   ORG_PROJECTS_OUTSIDE_LF_WIRE_SLUG,
@@ -851,6 +852,7 @@ export class OrgLensProjectsService {
       (project) =>
         typeof project.slug === 'string' &&
         typeof project.name === 'string' &&
+        project.health in HEALTH_SCORE_LABELS &&
         Array.isArray(project.healthMetrics) &&
         Array.isArray(project.maintainers) &&
         Array.isArray(project.contributors)

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -852,7 +852,7 @@ export class OrgLensProjectsService {
       (project) =>
         typeof project.slug === 'string' &&
         typeof project.name === 'string' &&
-        project.health in HEALTH_SCORE_LABELS &&
+        Object.prototype.hasOwnProperty.call(HEALTH_SCORE_LABELS, project.health) &&
         Array.isArray(project.healthMetrics) &&
         Array.isArray(project.maintainers) &&
         Array.isArray(project.contributors)

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -13,6 +13,7 @@ import {
   ORG_PROJECTS_SEARCH_MIN_LENGTH,
   VALKEY_CACHE,
 } from '@lfx-one/shared/constants';
+import { classifyHealthScore } from '@lfx-one/shared/utils';
 import type {
   HealthScore,
   InfluenceBand,
@@ -447,10 +448,7 @@ export class OrgLensProjectsService {
   }
 
   private mapHealthScore(score: number): HealthScore {
-    if (score >= 80) {
-      return 'excellent';
-    }
-    return score >= 60 ? 'healthy' : 'at-risk';
+    return classifyHealthScore(score);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -27,11 +27,13 @@ export const PD_TIME_RANGE_TYPE: Record<OrgLensLeaderboardTimeRange, string> = {
   all: 'alltime',
 };
 
-/** Hero health badge → lfx-tag severity (green Excellent / blue Healthy / red At Risk), matching HEALTH_SCORE_SEVERITY on the Org Lens Projects page. */
+/** Hero health badge → lfx-tag severity (5 Insights bands), matching HEALTH_SCORE_LABELS / HEALTH_SCORE_SEVERITY on the Org Lens Projects page. */
 export const PD_HEALTH_TAG: Record<OrgLensProjectHealth, { label: string; severity: TagSeverity }> = {
   excellent: { label: 'Excellent', severity: 'success' },
   healthy: { label: 'Healthy', severity: 'info' },
-  'at-risk': { label: 'At Risk', severity: 'danger' },
+  stable: { label: 'Stable', severity: 'info' },
+  unsteady: { label: 'Unsteady', severity: 'warn' },
+  critical: { label: 'Critical', severity: 'danger' },
 };
 
 /** Leaderboard band chip → lfx-tag severity. */

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -10,6 +10,7 @@ import type {
   TagSeverity,
 } from '../interfaces';
 import { lfxColors } from './colors.constants';
+import { HEALTH_SCORE_BADGE } from './org-lens-projects.constants';
 
 export const PD_DEFAULT_TAB: OrgLensProjectDetailTab = 'pd-influence';
 export const PD_VALID_TABS: ReadonlySet<string> = new Set<OrgLensProjectDetailTab>(['pd-influence', 'pd-leaderboards']);
@@ -27,13 +28,12 @@ export const PD_TIME_RANGE_TYPE: Record<OrgLensLeaderboardTimeRange, string> = {
   all: 'alltime',
 };
 
-/** Hero health badge → lfx-tag severity (5 Insights bands), matching HEALTH_SCORE_LABELS / HEALTH_SCORE_SEVERITY on the Org Lens Projects page. */
-export const PD_HEALTH_TAG: Record<OrgLensProjectHealth, { label: string; severity: TagSeverity }> = {
-  excellent: { label: 'Excellent', severity: 'success' },
-  healthy: { label: 'Healthy', severity: 'info' },
-  stable: { label: 'Stable', severity: 'info' },
-  unsteady: { label: 'Unsteady', severity: 'warn' },
-  critical: { label: 'Critical', severity: 'danger' },
+export const PD_HEALTH_TAG: Record<OrgLensProjectHealth, { label: string; bg: string; text: string }> = {
+  excellent: { label: 'Excellent', ...HEALTH_SCORE_BADGE.excellent },
+  healthy: { label: 'Healthy', ...HEALTH_SCORE_BADGE.healthy },
+  stable: { label: 'Stable', ...HEALTH_SCORE_BADGE.stable },
+  unsteady: { label: 'Unsteady', ...HEALTH_SCORE_BADGE.unsteady },
+  critical: { label: 'Critical', ...HEALTH_SCORE_BADGE.critical },
 };
 
 /** Leaderboard band chip → lfx-tag severity. */

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -86,19 +86,23 @@ export const INFLUENCE_BAND_BAR_FILL_CLASS_LIGHT: Record<InfluenceBand, string> 
   'non-lf': 'fill-gray-200',
 };
 
-/** Display labels for health scores. */
+/** Display labels for health scores (5 Insights bands + Unavailable). */
 export const HEALTH_SCORE_LABELS: Record<HealthScore, string> = {
   excellent: 'Excellent',
   healthy: 'Healthy',
-  'at-risk': 'At Risk',
+  stable: 'Stable',
+  unsteady: 'Unsteady',
+  critical: 'Critical',
   unavailable: 'Unavailable',
 };
 
-/** Tag/badge severity per health score (drives health-badge color). */
+/** Tag/badge severity per health score (drives health-badge color), matching the Insights health-score component intent. */
 export const HEALTH_SCORE_SEVERITY: Record<HealthScore, TagSeverity> = {
   excellent: 'success',
   healthy: 'info',
-  'at-risk': 'danger',
+  stable: 'info',
+  unsteady: 'warn',
+  critical: 'danger',
   unavailable: 'secondary',
 };
 

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -9,7 +9,6 @@ import type {
   OrgProjectsWorkspace,
   OrgProjectsWorkspaceId,
   SortDirection,
-  TagSeverity,
 } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
@@ -96,14 +95,13 @@ export const HEALTH_SCORE_LABELS: Record<HealthScore, string> = {
   unavailable: 'Unavailable',
 };
 
-/** Tag/badge severity per health score (drives health-badge color), matching the Insights health-score component intent. */
-export const HEALTH_SCORE_SEVERITY: Record<HealthScore, TagSeverity> = {
-  excellent: 'success',
-  healthy: 'info',
-  stable: 'info',
-  unsteady: 'warn',
-  critical: 'danger',
-  unavailable: 'secondary',
+export const HEALTH_SCORE_BADGE: Record<HealthScore, { bg: string; text: string }> = {
+  excellent: { bg: lfxColors.emerald[100], text: lfxColors.emerald[700] },
+  healthy: { bg: lfxColors.blue[100], text: lfxColors.blue[700] },
+  stable: { bg: lfxColors.violet[100], text: lfxColors.violet[700] },
+  unsteady: { bg: lfxColors.amber[100], text: lfxColors.amber[700] },
+  critical: { bg: lfxColors.red[100], text: lfxColors.red[700] },
+  unavailable: { bg: lfxColors.gray[100], text: lfxColors.gray[600] },
 };
 
 /** Projects-table page sizes; 25 is the default. */

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -29,8 +29,8 @@ export interface InfluenceCardVm {
   testId: string;
 }
 
-/** CHAOSS-derived project health classification — drives the hero badge color token. */
-export type OrgLensProjectHealth = 'excellent' | 'healthy' | 'at-risk';
+/** LFX Insights project health classification — the 5 bands of the Insights project Health Score component; drives the hero badge color token. */
+export type OrgLensProjectHealth = 'excellent' | 'healthy' | 'stable' | 'unsteady' | 'critical';
 
 /**
  * Precomputed org-influence tier, read straight through from the warehouse level column.

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -6,8 +6,8 @@ import { TagSeverity } from './components.interface';
 /** Influence band per the markup-mu methodology (Boysel et al.). Declared strongest → weakest. */
 export type InfluenceBand = 'leading' | 'contributing' | 'participating' | 'silent' | 'non-lf';
 
-/** CHAOSS-derived project health classification (via LFX Insights). */
-export type HealthScore = 'excellent' | 'healthy' | 'at-risk' | 'unavailable';
+/** LFX Insights project health classification — the 5 bands of the Insights project Health Score component, plus `unavailable` when no score exists. */
+export type HealthScore = 'excellent' | 'healthy' | 'stable' | 'unsteady' | 'critical' | 'unavailable';
 
 /** Direction of a one-year influence trend, used for color-coding the sparkline + delta. */
 export type InfluenceTrendDirection = 'up' | 'down' | 'flat';

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -1,8 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { TagSeverity } from './components.interface';
-
 /** Influence band per the markup-mu methodology (Boysel et al.). Declared strongest → weakest. */
 export type InfluenceBand = 'leading' | 'contributing' | 'participating' | 'silent' | 'non-lf';
 
@@ -181,8 +179,7 @@ export interface OrgProjectsTableRow extends OrgLensProject {
   ecosystemBandLabel: string;
   /** Health badge display label (e.g. "Excellent"). */
   healthLabel: string;
-  /** Health badge severity token for lfx-tag. */
-  healthSeverity: TagSeverity;
+  healthBadge: { bg: string; text: string };
   /** Pre-built Chart.js dataset for the sparkline; stable reference avoids re-allocation on recompute. */
   sparklineDataset: { labels: string[]; datasets: { data: number[]; borderColor: string; fill: boolean }[] };
   /**

--- a/packages/shared/src/utils/insights.utils.spec.ts
+++ b/packages/shared/src/utils/insights.utils.spec.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyHealthScore } from './insights.utils';
+
+describe('classifyHealthScore', () => {
+  it.each([
+    [100, 'excellent'],
+    [80, 'excellent'],
+    [79, 'healthy'],
+    [60, 'healthy'],
+    [59, 'stable'],
+    [40, 'stable'],
+    [39, 'unsteady'],
+    [20, 'unsteady'],
+    [19, 'critical'],
+    [0, 'critical'],
+  ] as const)('classifies %i as %s', (score, band) => {
+    expect(classifyHealthScore(score)).toBe(band);
+  });
+
+  it('places the five bands in a strictly worsening order as the score drops', () => {
+    const order = [90, 70, 50, 30, 10].map(classifyHealthScore);
+    expect(order).toEqual(['excellent', 'healthy', 'stable', 'unsteady', 'critical']);
+  });
+});

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LINKS_CONFIG } from '../constants/links.config';
+import type { HealthScore } from '../interfaces';
 
 /**
  * Builds an LFX Insights URL from an optional path and query params.
@@ -51,6 +52,29 @@ export function buildLensAwareInsightsUrl(
   }
   const path = opts.projectSubPath ? `/project/${slug}/${opts.projectSubPath}` : `/project/${slug}`;
   return buildInsightsUrl(path, opts.projectParams);
+}
+
+/**
+ * Classifies an LFX Insights project health score (0–100) into a band, matching the Insights
+ * primary project Health Score component (`health-score.vue`): `>= 80` Excellent, `>= 60` Healthy,
+ * `>= 40` Stable, `>= 20` Unsteady, else Critical. The `unavailable` state (no score) is handled by
+ * callers, so this returns only the five scored bands and is the single source both the Org Lens
+ * Projects table and the project-detail hero classify through (they must never disagree).
+ */
+export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
+  if (score >= 80) {
+    return 'excellent';
+  }
+  if (score >= 60) {
+    return 'healthy';
+  }
+  if (score >= 40) {
+    return 'stable';
+  }
+  if (score >= 20) {
+    return 'unsteady';
+  }
+  return 'critical';
 }
 
 function encodePathSegments(path: string): string {


### PR DESCRIPTION
## Summary

Org Lens classified a project's LFX Insights health score into only **3 bands** (Excellent / Healthy / At Risk), collapsing Insights' Stable, Unsteady, and Critical grades into a single invented "At Risk" label that does not exist in Insights. This brings Org Lens to the **5-band** scheme used by the Insights project Health Score component, so Org Lens mirrors exactly what Insights shows for a project.

## What changed

- Added a shared `classifyHealthScore()` helper (`packages/shared/src/utils/insights.utils.ts`) implementing the Insights bands: `>= 80` Excellent, `>= 60` Healthy, `>= 40` Stable, `>= 20` Unsteady, `< 20` Critical.
- Both surfaces now classify through that single helper — the Projects table (`mapHealthScore`) and the project-detail hero (`mapHealth`) — so the two can never disagree.
- Extended the `HealthScore` / `OrgLensProjectHealth` unions and the `HEALTH_SCORE_LABELS` / `HEALTH_SCORE_SEVERITY` / `PD_HEALTH_TAG` maps to the 5 bands (+ `unavailable`); removed the legacy `at-risk`.
- Health-column sort (`healthRank`) now orders all five bands best → worst, with Unavailable last.
- Updated the Health-column header tooltip to list the 5 bands.

## Why `>= 80` (not `> 80`)

Matches the Insights project Health Score component (`health-score.vue`). The Insights docs list "60–79 Healthy" and "> 80 Excellent", leaving a score of exactly 80 unassigned — a documentation gap; the UI uses `>= 80`, which this change mirrors. The Foundation lens (which sources its 5-band category from the data warehouse) is intentionally unchanged.

## Testing

- `yarn check-types`, `yarn lint:check`, `yarn format:check`, and `yarn build` all pass.
- Verified live against the Development environment: the Org Lens → Projects Health column and the project-detail hero render the 5 bands, and the Foundation lens is unaffected.

Ref: LFXV2-2746
