### PR TITLE
feat(profile): add profile & account shell and right-hand panel

### DIFF
--- a/apps/lfx-one/e2e/profile-panel-github.spec.ts
+++ b/apps/lfx-one/e2e/profile-panel-github.spec.ts
@@ -1,0 +1,105 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, test } from '@playwright/test';
+
+// Mock GET /api/profile so the profile shell + panel render with a known display name.
+// PATCH /api/profile and nested /api/profile/* routes are matched separately below.
+async function mockProfile(page: Page): Promise<void> {
+  await page.route('**/api/profile', (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.continue();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 'e2e-user',
+          email: 'ada@example.com',
+          first_name: 'Ada',
+          last_name: 'Lovelace',
+          username: 'alovelace',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        profile: { given_name: 'Ada', family_name: 'Lovelace' },
+      }),
+    });
+  });
+}
+
+// Mock GET /api/profile/identities with a CDP-only (unowned) GitHub row listed BEFORE the
+// Auth0-owned one. This guards the panel's ownership filter: it must pick the owned identity
+// (inAuth0 === true), not simply the first GitHub row it encounters.
+async function mockIdentities(page: Page): Promise<void> {
+  await page.route('**/api/profile/identities', (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.continue();
+    }
+    const now = new Date().toISOString();
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'gh-cdp-only',
+          platform: 'github',
+          type: 'username',
+          value: 'not-my-github',
+          verified: false,
+          source: 'cdp',
+          icon: 'fa-brands fa-github',
+          createdAt: now,
+          updatedAt: now,
+          displayState: 'unverified',
+          inAuth0: false,
+        },
+        {
+          id: 'gh-owned',
+          platform: 'github',
+          type: 'username',
+          value: 'my-github',
+          verified: true,
+          source: 'auth0',
+          icon: 'fa-brands fa-github',
+          createdAt: now,
+          updatedAt: now,
+          displayState: 'verified',
+          inAuth0: true,
+          auth0UserId: 'github|123',
+        },
+      ]),
+    });
+  });
+}
+
+// Skip cleanly when Auth0 test credentials aren't configured (global-setup.ts only logs and
+// returns, leaving the app on the Auth0 login redirect). Hostname-exact matching avoids the
+// CodeQL substring-sanitization issue (e.g. `https://auth0.com.evil.com/`).
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — keep the test running rather than silently skip.
+  }
+}
+
+test.describe('Profile panel GitHub handle', () => {
+  test('renders only the Auth0-owned GitHub handle, not an unowned CDP-only row', async ({ page }) => {
+    await mockProfile(page);
+    await mockIdentities(page);
+    await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });
+
+    const github = page.getByTestId('profile-panel-github');
+    await expect(github).toBeVisible();
+    await expect(github).toContainText('my-github');
+    await expect(github).not.toContainText('not-my-github');
+  });
+});

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Two-column Profile & Account hub. Below xl the panel stacks full-width above the content
-  (the main-layout shell already claims 348px for its own fixed sidebar, so reserving another
-  320px at lg would crush the child pages). At xl the panel becomes a sticky in-flow right
-  column — it stays in view as the left column scrolls, and because it lives inside the content
-  flow it never overlays the shared footer.
+  Two-column Profile & Account hub. Below 2xl the panel stacks full-width above the content:
+  the main-layout shell already claims 348px for its own fixed sidebar, so reserving the panel's
+  width any earlier leaves child pages (e.g. /profile/settings' two-column cards) too narrow. At
+  2xl the panel becomes a sticky in-flow right column — it stays in view as the left column
+  scrolls, and because it lives inside the content flow it never overlays the shared footer.
 -->
-<div class="flex flex-col gap-6 xl:flex-row xl:items-start" data-testid="profile-layout">
-  <!-- Profile panel — first in the DOM so it stacks on top below xl; sticky right column at xl -->
-  <div class="xl:sticky xl:order-2 xl:w-80 xl:shrink-0" [class.xl:top-12]="impersonating()" [class.xl:top-6]="!impersonating()">
+<div class="flex flex-col gap-6 2xl:flex-row 2xl:items-start" data-testid="profile-layout">
+  <!-- Profile panel — first in the DOM so it stacks on top below 2xl; sticky right column at 2xl -->
+  <div class="2xl:sticky 2xl:order-2 2xl:w-80 2xl:shrink-0" [class.2xl:top-12]="impersonating()" [class.2xl:top-6]="!impersonating()">
     <lfx-profile-panel
       [loading]="loading()"
       [impersonating]="impersonating()"
@@ -29,7 +29,7 @@
   </div>
 
   <!-- Left column -->
-  <div class="min-w-0 flex-1 xl:order-1">
+  <div class="min-w-0 flex-1 2xl:order-1">
     <div class="mx-auto flex max-w-[1024px] flex-col gap-6">
       <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
       @if (impersonating()) {
@@ -49,7 +49,7 @@
       </div>
 
       <!-- Subtab navigation — horizontally scrollable on small screens -->
-      <div class="flex gap-1 overflow-x-auto border-b border-slate-200" data-testid="profile-tabs-desktop">
+      <nav aria-label="Profile sections" class="flex gap-1 overflow-x-auto border-b border-slate-200" data-testid="profile-tabs-desktop">
         @for (tab of tabs; track tab.id) {
           <a
             [routerLink]="tab.route"
@@ -63,7 +63,7 @@
             }
           </a>
         }
-      </div>
+      </nav>
 
       <!-- Router Outlet for child components -->
       <div class="pb-8" data-testid="profile-content">

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -1,164 +1,68 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="profile-layout">
-  <div class="flex flex-col gap-6">
-    <!-- Page Title -->
-    <h1 class="font-display font-light text-2xl mt-3" data-testid="profile-page-title">Profile</h1>
+<div class="relative" data-testid="profile-layout">
+  <!--
+    Right-hand profile panel. Placed first in the DOM so it stacks at the top on mobile;
+    on lg+ it is pinned to the viewport's right edge (see the component template) and the
+    left column reserves its width with lg:mr-80.
+  -->
+  <lfx-profile-panel
+    [loading]="loading()"
+    [impersonating]="impersonating()"
+    [avatarUrl]="avatarUrl()"
+    [displayName]="displayName()"
+    [initials]="initials()"
+    [username]="displayUsername() ?? ''"
+    [jobTitle]="jobTitle()"
+    [organization]="organization()"
+    [email]="emailInfo()"
+    [addressLines]="fullAddress()"
+    [phone]="phoneInfo()"
+    [tshirtSize]="tshirtSizeLabel()"
+    [githubHandle]="githubHandle()"
+    (editRequested)="openEditDialog()" />
 
-    <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
-    @if (impersonating()) {
-      <div
-        class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
-        role="status"
-        data-testid="profile-readonly-notice">
-        <i class="fa-light fa-eye"></i>
-        <span>You are viewing this profile while impersonating another user. Profile editing is disabled.</span>
+  <!-- Left column -->
+  <div class="lg:mr-80">
+    <div class="mx-auto flex max-w-[1024px] flex-col pt-6 lg:pt-0">
+      <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
+      @if (impersonating()) {
+        <div
+          class="mb-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          role="status"
+          data-testid="profile-readonly-notice">
+          <i class="fa-light fa-eye"></i>
+          <span>You are viewing this profile while impersonating another user. Profile editing is disabled.</span>
+        </div>
+      }
+
+      <!-- Page head -->
+      <div class="mb-6">
+        <h1 class="text-[22px] font-bold tracking-tight text-slate-900" data-testid="profile-page-title">Profile &amp; Account</h1>
+        <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
-    }
 
-    <!-- Profile Header Card + Tabs -->
-    <div class="relative overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm" data-testid="profile-header-card">
-      <!-- Profile Info Section -->
-      <div class="px-[18px] py-7">
-        @if (loading()) {
-          <div class="flex items-center justify-center py-8">
-            <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400"></i>
-          </div>
-        } @else {
-          <!-- Edit Button (visible but disabled while impersonating — profile edits act on the real account) -->
-          <button
-            (click)="openEditDialog()"
-            [disabled]="impersonating()"
-            [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
-            class="absolute right-5 top-5 flex h-8 w-8 items-center justify-center rounded-md text-gray-400 transition-colors enabled:hover:bg-blue-50 enabled:hover:text-blue-500 disabled:opacity-40 disabled:cursor-not-allowed"
-            data-testid="profile-edit-button">
-            <i class="fa-light fa-pencil text-sm"></i>
-          </button>
-
-          <div class="flex items-start gap-[18px]">
-            <!-- Avatar -->
-            <div
-              class="flex h-[42px] w-[42px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#cad5e2] text-base font-semibold text-white"
-              data-testid="profile-avatar">
-              @if (avatarUrl() && !avatarLoadError()) {
-                <img
-                  [src]="avatarUrl()"
-                  [alt]="displayName()"
-                  (error)="avatarLoadError.set(true)"
-                  class="h-full w-full rounded-full object-cover"
-                  data-testid="profile-avatar-image" />
-              } @else {
-                {{ initials() }}
-              }
-            </div>
-
-            <!-- 4-Column Grid -->
-            <div class="grid min-w-0 flex-1 grid-cols-1 gap-x-5 gap-y-2.5 sm:grid-cols-2 lg:grid-cols-4">
-              <!-- Column 1: Name -->
-              <div class="flex flex-col gap-0.5 min-w-0">
-                <h2 class="text-sm font-bold text-slate-900 truncate" data-testid="profile-display-name">
-                  {{ displayName() }}
-                </h2>
-                @if (jobTitle() || organization()) {
-                  <p class="text-xs text-slate-500" data-testid="profile-job-info">
-                    @if (jobTitle()) {
-                      <span>{{ jobTitle() }}</span>
-                    }
-                    @if (jobTitle() && organization()) {
-                      <br />
-                    }
-                    @if (organization()) {
-                      <span>{{ organization() }}</span>
-                    }
-                  </p>
-                }
-              </div>
-
-              <!-- Column 2: Username & Email -->
-              <div class="flex flex-col gap-2 text-xs text-slate-500">
-                @let username = displayUsername();
-                @if (username) {
-                  <div class="flex items-center gap-2" data-testid="profile-username">
-                    <i class="fa-light fa-user w-4 text-center text-slate-400"></i>
-                    <span class="truncate">&#64;{{ username }}</span>
-                  </div>
-                }
-                @if (emailInfo()) {
-                  <div class="flex items-center gap-2" data-testid="profile-email-info">
-                    <i class="fa-light fa-envelope w-4 text-center text-slate-400"></i>
-                    <span class="truncate">{{ emailInfo() }}</span>
-                  </div>
-                }
-              </div>
-
-              <!-- Column 3: Location -->
-              @if (fullAddress().length > 0) {
-                <div class="flex items-start gap-2 text-xs text-slate-500" data-testid="profile-location-info">
-                  <i class="fa-light fa-location-dot w-4 text-center text-slate-400 mt-0.5"></i>
-                  <div class="flex flex-col">
-                    @for (line of fullAddress(); track line) {
-                      <span>{{ line }}</span>
-                    }
-                  </div>
-                </div>
-              }
-
-              <!-- Column 4: Contact & Preferences -->
-              <div class="flex flex-col gap-2 text-xs text-slate-500">
-                @if (phoneInfo()) {
-                  <div class="flex items-center gap-2" data-testid="profile-phone-info">
-                    <i class="fa-light fa-phone w-4 text-center text-slate-400"></i>
-                    <span>{{ phoneInfo() }}</span>
-                  </div>
-                }
-                @if (tshirtSizeLabel()) {
-                  <div class="flex items-center gap-2" data-testid="profile-tshirt-info">
-                    <i class="fa-light fa-shirt w-4 text-center text-slate-400"></i>
-                    <span>{{ tshirtSizeLabel() }}</span>
-                  </div>
-                }
-              </div>
-            </div>
-          </div>
+      <!-- Subtab navigation — horizontally scrollable on small screens -->
+      <div class="mb-5 flex gap-1 overflow-x-auto border-b border-slate-200" data-testid="profile-tabs-desktop">
+        @for (tab of tabs; track tab.id) {
+          <a
+            [routerLink]="tab.route"
+            routerLinkActive="!border-blue-600 !text-blue-600"
+            class="-mb-px flex items-center gap-1.5 whitespace-nowrap border-b-2 border-transparent px-3 pb-3 pt-2 text-[13px] font-medium text-slate-500 transition-colors hover:text-slate-800"
+            [attr.data-testid]="'profile-tab-' + tab.id">
+            {{ tab.label }}
+            @if (tabNotifications().get(tab.id)) {
+              <span class="h-1.5 w-1.5 rounded-full bg-blue-500" role="status" aria-label="Action required"></span>
+            }
+          </a>
         }
       </div>
 
-      <!-- Tab Navigation -->
-      <div class="border-t border-slate-200" data-testid="profile-tabs-container">
-        <!-- Mobile: Dropdown -->
-        <div class="md:hidden px-5 py-3">
-          <lfx-select
-            [form]="tabForm"
-            control="selectedTab"
-            [options]="tabOptions"
-            placeholder="Select a tab"
-            styleClass="w-full"
-            size="small"
-            data-testid="profile-tabs-dropdown" />
-        </div>
-
-        <!-- Desktop: Horizontal text tabs with underline -->
-        <div class="hidden md:flex items-center gap-5 pl-5 h-14 overflow-x-auto" data-testid="profile-tabs-desktop">
-          @for (tab of tabs; track tab.id) {
-            <a
-              [routerLink]="tab.route"
-              routerLinkActive="text-slate-900 !border-blue-600"
-              class="flex items-center gap-1.5 h-14 text-sm font-medium transition-colors border-b-2 whitespace-nowrap text-slate-500 hover:text-slate-700 border-transparent"
-              [attr.data-testid]="'profile-tab-' + tab.id">
-              {{ tab.label }}
-              @if (tabNotifications().get(tab.id)) {
-                <span class="h-1.5 w-1.5 rounded-full bg-blue-500" role="status" aria-label="Action required"></span>
-              }
-            </a>
-          }
-        </div>
+      <!-- Router Outlet for child components -->
+      <div class="pb-8" data-testid="profile-content">
+        <router-outlet />
       </div>
-    </div>
-
-    <!-- Router Outlet for child components -->
-    <div class="pb-8" data-testid="profile-content">
-      <router-outlet />
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -10,7 +10,7 @@
 -->
 <div class="flex flex-col gap-6 xl:flex-row xl:items-start" data-testid="profile-layout">
   <!-- Profile panel — first in the DOM so it stacks on top below xl; sticky right column at xl -->
-  <div class="xl:sticky xl:order-2 xl:w-80 xl:shrink-0" [class.xl:top-16]="impersonating()" [class.xl:top-6]="!impersonating()">
+  <div class="xl:sticky xl:order-2 xl:w-80 xl:shrink-0" [class.xl:top-12]="impersonating()" [class.xl:top-6]="!impersonating()">
     <lfx-profile-panel
       [loading]="loading()"
       [impersonating]="impersonating()"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -25,11 +25,11 @@
 
   <!-- Left column -->
   <div class="lg:mr-80">
-    <div class="mx-auto flex max-w-[1024px] flex-col pt-6 lg:pt-0">
+    <div class="mx-auto flex max-w-[1024px] flex-col gap-6 pt-6 lg:pt-0">
       <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
       @if (impersonating()) {
         <div
-          class="mb-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
           role="status"
           data-testid="profile-readonly-notice">
           <i class="fa-light fa-eye"></i>
@@ -38,13 +38,13 @@
       }
 
       <!-- Page head -->
-      <div class="mb-6">
+      <div>
         <h1 class="text-[22px] font-bold tracking-tight text-slate-900" data-testid="profile-page-title">Profile &amp; Account</h1>
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
 
       <!-- Subtab navigation — horizontally scrollable on small screens -->
-      <div class="mb-5 flex gap-1 overflow-x-auto border-b border-slate-200" data-testid="profile-tabs-desktop">
+      <div class="flex gap-1 overflow-x-auto border-b border-slate-200" data-testid="profile-tabs-desktop">
         @for (tab of tabs; track tab.id) {
           <a
             [routerLink]="tab.route"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -1,31 +1,36 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="relative" data-testid="profile-layout">
-  <!--
-    Right-hand profile panel. Placed first in the DOM so it stacks at the top on mobile;
-    on lg+ it is pinned to the viewport's right edge (see the component template) and the
-    left column reserves its width with lg:mr-80.
-  -->
-  <lfx-profile-panel
-    [loading]="loading()"
-    [impersonating]="impersonating()"
-    [avatarUrl]="avatarUrl()"
-    [displayName]="displayName()"
-    [initials]="initials()"
-    [username]="displayUsername() ?? ''"
-    [jobTitle]="jobTitle()"
-    [organization]="organization()"
-    [email]="emailInfo()"
-    [addressLines]="fullAddress()"
-    [phone]="phoneInfo()"
-    [tshirtSize]="tshirtSizeLabel()"
-    [githubHandle]="githubHandle()"
-    (editRequested)="openEditDialog()" />
+<!--
+  Two-column Profile & Account hub. Below xl the panel stacks full-width above the content
+  (the main-layout shell already claims 348px for its own fixed sidebar, so reserving another
+  320px at lg would crush the child pages). At xl the panel becomes a sticky in-flow right
+  column — it stays in view as the left column scrolls, and because it lives inside the content
+  flow it never overlays the shared footer.
+-->
+<div class="flex flex-col gap-6 xl:flex-row xl:items-start" data-testid="profile-layout">
+  <!-- Profile panel — first in the DOM so it stacks on top below xl; sticky right column at xl -->
+  <div class="xl:sticky xl:order-2 xl:w-80 xl:shrink-0" [class.xl:top-16]="impersonating()" [class.xl:top-6]="!impersonating()">
+    <lfx-profile-panel
+      [loading]="loading()"
+      [impersonating]="impersonating()"
+      [avatarUrl]="avatarUrl()"
+      [displayName]="displayName()"
+      [initials]="initials()"
+      [username]="displayUsername() ?? ''"
+      [jobTitle]="jobTitle()"
+      [organization]="organization()"
+      [email]="emailInfo()"
+      [addressLines]="fullAddress()"
+      [phone]="phoneInfo()"
+      [tshirtSize]="tshirtSizeLabel()"
+      [githubHandle]="githubHandle()"
+      (editRequested)="openEditDialog()" />
+  </div>
 
   <!-- Left column -->
-  <div class="lg:mr-80">
-    <div class="mx-auto flex max-w-[1024px] flex-col gap-6 pt-6 lg:pt-0">
+  <div class="min-w-0 flex-1 xl:order-1">
+    <div class="mx-auto flex max-w-[1024px] flex-col gap-6">
       <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
       @if (impersonating()) {
         <div

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -49,6 +49,7 @@
           <a
             [routerLink]="tab.route"
             routerLinkActive="!border-blue-600 !text-blue-600"
+            ariaCurrentWhenActive="page"
             class="-mb-px flex items-center gap-1.5 whitespace-nowrap border-b-2 border-transparent px-3 pb-3 pt-2 text-[13px] font-medium text-slate-500 transition-colors hover:text-slate-800"
             [attr.data-testid]="'profile-tab-' + tab.id">
             {{ tab.label }}

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -132,9 +132,11 @@ export class ProfileLayoutComponent {
     return new Map<string, boolean>([['identities', hasUnverified]]);
   });
 
-  // GitHub username from a connected (non-hidden) GitHub identity; empty when GitHub isn't connected
+  // GitHub username from a GitHub account the user actually owns (linked in Auth0); empty otherwise.
+  // inAuth0 gates out CDP-only rows (inAuth0 === false) — unverified suggestions or identities that
+  // belong to another LFID merged into CDP — which could otherwise surface a stale/unowned handle.
   public readonly githubHandle: Signal<string> = computed(() => {
-    const github = this.identities().find((id) => id.platform === 'github' && id.displayState !== 'hidden');
+    const github = this.identities().find((id) => id.platform === 'github' && id.inAuth0);
     return github?.value ?? '';
   });
 

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -2,20 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { SelectComponent } from '@components/select/select.component';
+import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_TABS, TSHIRT_SIZES } from '@lfx-one/shared/constants';
-import { CombinedProfile, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
+import { CombinedProfile, EnrichedIdentity, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { BehaviorSubject, catchError, filter, map, of, startWith, switchMap, take } from 'rxjs';
+import { BehaviorSubject, catchError, filter, map, of, switchMap, take } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
+import { ProfilePanelComponent } from './profile-panel/profile-panel.component';
 
 // Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
 // Child routes (e.g. identities) handle their own error codes — do not swallow them here.
@@ -28,15 +27,18 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 ]);
 
 /**
- * ProfileLayoutComponent serves as the shell for all profile pages.
+ * ProfileLayoutComponent is the two-column shell for the Profile & Account hub.
  * It provides:
- * - Profile header card with user info
- * - Tab navigation (horizontal on desktop, dropdown on mobile)
- * - Router outlet for child components
+ * - Left column: page head, subtab navigation, and the router outlet for child pages
+ * - Right column: the fixed profile panel (lfx-profile-panel) bound to the user's CombinedProfile
+ *
+ * The layout owns the profile data fetch, optimistic updates, the edit dialog, and the
+ * Flow C (management-token) auth-return handling; the panel is presentational and emits
+ * `editRequested` back here to open the edit dialog.
  */
 @Component({
   selector: 'lfx-profile-layout',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, ReactiveFormsModule, SelectComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent],
   providers: [DialogService, MessageService],
   templateUrl: './profile-layout.component.html',
   styleUrl: './profile-layout.component.scss',
@@ -53,7 +55,6 @@ export class ProfileLayoutComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
-  private readonly fb = inject(NonNullableFormBuilder);
   private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
@@ -66,17 +67,6 @@ export class ProfileLayoutComponent {
 
   // Tab configuration
   public readonly tabs: ProfileTab[] = PROFILE_TABS;
-
-  // Tab options for dropdown (mobile)
-  public readonly tabOptions = this.tabs.map((tab) => ({
-    label: tab.label,
-    value: tab.route,
-  }));
-
-  // Form for mobile tab selection
-  public readonly tabForm = this.fb.group({
-    selectedTab: ['attributions'],
-  });
 
   // Profile data from the service (server-fetched). The profile GET is eventually consistent
   // (read-after-write lag in the auth-service), so after a save we apply an optimistic override
@@ -92,9 +82,6 @@ export class ProfileLayoutComponent {
   // but all profile mutations act on the real user's account server-side and are blocked. The edit
   // affordances render visible-but-disabled and a banner surfaces the read-only state.
   public readonly impersonating = this.userService.impersonating;
-
-  // Tracks failed avatar image loads so we can fall back to initials
-  public readonly avatarLoadError = signal<boolean>(false);
 
   // Computed signals
   public readonly displayUsername = computed(() => stripAuthPrefixOrNull(this.profileData()?.username));
@@ -136,37 +123,22 @@ export class ProfileLayoutComponent {
     return match?.label || data.tshirtSize;
   });
 
-  // Tab notification dots — show when work experiences need review or identities are unverified
-  public readonly tabNotifications: Signal<Map<string, boolean>> = this.initTabNotifications();
+  // Connected identities — fetched once and reused for the tab notification dots and the GitHub handle
+  private readonly identities: Signal<EnrichedIdentity[]> = this.initIdentities();
+
+  // Tab notification dots — show when identities are unverified
+  public readonly tabNotifications: Signal<Map<string, boolean>> = computed(() => {
+    const hasUnverified = this.identities().some((id) => id.platform !== 'lfid' && id.displayState !== 'hidden' && id.displayState !== 'verified');
+    return new Map<string, boolean>([['identities', hasUnverified]]);
+  });
+
+  // GitHub username from a connected (non-hidden) GitHub identity; empty when GitHub isn't connected
+  public readonly githubHandle: Signal<string> = computed(() => {
+    const github = this.identities().find((id) => id.platform === 'github' && id.displayState !== 'hidden');
+    return github?.value ?? '';
+  });
 
   public constructor() {
-    // Reset the avatar error flag whenever the picture URL changes so a newly-set
-    // (or refreshed) avatar re-attempts to load instead of staying on the initials fallback
-    effect(() => {
-      this.avatarUrl();
-      this.avatarLoadError.set(false);
-    });
-
-    // Subscribe to tab selection changes for mobile navigation
-    this.tabForm.controls.selectedTab.valueChanges.pipe(takeUntilDestroyed()).subscribe((route) => {
-      if (route) {
-        this.router.navigate(['/profile', route]);
-      }
-    });
-
-    // Sync mobile dropdown when route changes (back/forward, direct URL)
-    this.router.events
-      .pipe(
-        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
-        takeUntilDestroyed()
-      )
-      .subscribe((event) => {
-        const match = event.urlAfterRedirects.match(/\/profile\/([^?/]+)/);
-        if (match) {
-          this.tabForm.controls.selectedTab.setValue(match[1], { emitEvent: false });
-        }
-      });
-
     // Handle Flow C return — restore saved form state and auto-save
     this.route.queryParams.pipe(takeUntilDestroyed()).subscribe((params) => {
       if (params['success'] === 'profile_token_obtained') {
@@ -358,20 +330,8 @@ export class ProfileLayoutComponent {
     });
   }
 
-  private initTabNotifications(): Signal<Map<string, boolean>> {
-    return toSignal(
-      this.userService.getIdentities().pipe(
-        map((identities) => identities.some((id) => id.platform !== 'lfid' && id.displayState !== 'hidden' && id.displayState !== 'verified')),
-        catchError(() => of(false)),
-        startWith(false),
-        map((hasUnverified) => {
-          const notifications = new Map<string, boolean>();
-          notifications.set('identities', hasUnverified);
-          return notifications;
-        })
-      ),
-      { initialValue: new Map<string, boolean>() }
-    );
+  private initIdentities(): Signal<EnrichedIdentity[]> {
+    return toSignal(this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))), { initialValue: [] as EnrichedIdentity[] });
   }
 
   private mapToHeaderData(profile: CombinedProfile): ProfileHeaderData {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -30,7 +30,7 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
  * ProfileLayoutComponent is the two-column shell for the Profile & Account hub.
  * It provides:
  * - Left column: page head, subtab navigation, and the router outlet for child pages
- * - Right column: the fixed profile panel (lfx-profile-panel) bound to the user's CombinedProfile
+ * - Right column: the sticky profile panel (lfx-profile-panel) bound to the user's CombinedProfile
  *
  * The layout owns the profile data fetch, optimistic updates, the edit dialog, and the
  * Flow C (management-token) auth-return handling; the panel is presentational and emits

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -107,7 +107,7 @@
             <span>Location</span>
           </div>
           <div class="flex flex-col text-[12.5px] leading-relaxed text-slate-800">
-            @for (line of addressLines(); track line) {
+            @for (line of addressLines(); track $index) {
               <span>{{ line }}</span>
             }
           </div>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -9,6 +9,7 @@
   class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 lg:fixed lg:right-0 lg:bottom-0 lg:w-80 lg:overflow-y-auto lg:border-b-0 lg:border-l"
   [class.lg:top-12]="impersonating()"
   [class.lg:top-0]="!impersonating()"
+  aria-label="Profile summary"
   data-testid="profile-panel">
   @if (loading()) {
     <div class="flex items-center justify-center py-8">

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -63,9 +63,9 @@
     <div class="my-5 h-px bg-slate-200"></div>
 
     <!-- Fields — each renders only when its value is present -->
-    <div class="flex flex-col">
+    <div class="flex flex-col gap-5">
       @if (aboutMe()) {
-        <div class="mb-5" data-testid="profile-panel-about">
+        <div data-testid="profile-panel-about">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-file-lines"></i>
             <span>About me</span>
@@ -74,7 +74,7 @@
         </div>
       }
       @if (jobTitle()) {
-        <div class="mb-5" data-testid="profile-panel-job-title">
+        <div data-testid="profile-panel-job-title">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-briefcase"></i>
             <span>Job title</span>
@@ -83,7 +83,7 @@
         </div>
       }
       @if (organization()) {
-        <div class="mb-5" data-testid="profile-panel-organization">
+        <div data-testid="profile-panel-organization">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-building"></i>
             <span>Organization</span>
@@ -92,7 +92,7 @@
         </div>
       }
       @if (email()) {
-        <div class="mb-5" data-testid="profile-panel-email">
+        <div data-testid="profile-panel-email">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-envelope"></i>
             <span>Primary email</span>
@@ -101,7 +101,7 @@
         </div>
       }
       @if (addressLines().length > 0) {
-        <div class="mb-5" data-testid="profile-panel-location">
+        <div data-testid="profile-panel-location">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-location-dot"></i>
             <span>Location</span>
@@ -114,7 +114,7 @@
         </div>
       }
       @if (phone()) {
-        <div class="mb-5" data-testid="profile-panel-phone">
+        <div data-testid="profile-panel-phone">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-phone"></i>
             <span>Phone number</span>
@@ -123,7 +123,7 @@
         </div>
       }
       @if (tshirtSize()) {
-        <div class="mb-5" data-testid="profile-panel-tshirt">
+        <div data-testid="profile-panel-tshirt">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-shirt"></i>
             <span>T-shirt size</span>
@@ -133,7 +133,7 @@
       }
     </div>
 
-    <!-- Social rows — stubbed until wired from a real source; render only when present -->
+    <!-- Social rows — GitHub is wired from the user's connected identities; LinkedIn is stubbed. Each renders only when present. -->
     @if (githubHandle() || linkedinHandle()) {
       <div class="my-1 h-px bg-slate-200"></div>
       <div class="flex flex-col gap-2 pt-4">

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -20,11 +20,11 @@
       <div
         class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-blue-500 to-violet-600 text-xl font-semibold text-white"
         data-testid="profile-avatar">
-        @if (avatarUrl() && !avatarLoadError()) {
+        @if (showAvatarImage()) {
           <img
             [src]="avatarUrl()"
             [alt]="displayName()"
-            (error)="avatarLoadError.set(true)"
+            (error)="onAvatarError()"
             class="h-full w-full rounded-2xl object-cover"
             data-testid="profile-avatar-image" />
         } @else {
@@ -140,13 +140,13 @@
         @if (githubHandle()) {
           <div class="flex items-center gap-2 text-[12.5px] text-slate-700" data-testid="profile-panel-github">
             <i class="fa-brands fa-github text-slate-800"></i>
-            <span class="truncate">{{ githubHandle() }}</span>
+            <span class="break-all">{{ githubHandle() }}</span>
           </div>
         }
         @if (linkedinHandle()) {
           <div class="flex items-center gap-2 text-[12.5px] text-slate-700" data-testid="profile-panel-linkedin">
             <i class="fa-brands fa-linkedin text-blue-700"></i>
-            <span class="truncate">{{ linkedinHandle() }}</span>
+            <span class="break-all">{{ linkedinHandle() }}</span>
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,13 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Stacked full-width above the content on mobile; fixed to the viewport's right edge on lg+.
-  Top offset mirrors the main-layout sidebar so the fixed panel clears the impersonation banner.
+  Full-width separator card when stacked (below xl); at xl it fills the sticky right column
+  set up by the layout, with its own scroll if the content exceeds the viewport height.
 -->
 <aside
-  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 lg:fixed lg:right-0 lg:bottom-0 lg:w-80 lg:overflow-y-auto lg:border-b-0 lg:border-l"
-  [class.lg:top-12]="impersonating()"
-  [class.lg:top-0]="!impersonating()"
+  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 xl:max-h-[calc(100vh-4rem)] xl:overflow-y-auto xl:rounded-xl xl:border"
   aria-label="Profile summary"
   data-testid="profile-panel">
   @if (loading()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -10,8 +10,9 @@
   aria-label="Profile summary"
   data-testid="profile-panel">
   @if (loading()) {
-    <div class="flex items-center justify-center py-8">
-      <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400"></i>
+    <div class="flex items-center justify-center py-8" role="status" aria-live="polite">
+      <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400" aria-hidden="true"></i>
+      <span class="sr-only">Loading profile summary</span>
     </div>
   } @else {
     <!-- Avatar + edit-pencil badge (rounded, not circle) -->
@@ -42,7 +43,7 @@
     </div>
 
     <!-- Name + handle -->
-    <h2 class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</h2>
+    <p class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</p>
     @if (username()) {
       <p class="mb-4 text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
     }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,11 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Full-width separator card when stacked (below xl); at xl it fills the sticky right column
+  Full-width separator card when stacked (below 2xl); at 2xl it fills the sticky right column
   set up by the layout, with its own scroll if the content exceeds the viewport height.
 -->
 <aside
-  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 xl:max-h-[calc(100vh-4rem)] xl:overflow-y-auto xl:rounded-xl xl:border"
+  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 2xl:max-h-[calc(100vh-4rem)] 2xl:overflow-y-auto 2xl:rounded-xl 2xl:border"
   aria-label="Profile summary"
   data-testid="profile-panel">
   @if (loading()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -1,0 +1,155 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!--
+  Stacked full-width above the content on mobile; fixed to the viewport's right edge on lg+.
+  Top offset mirrors the main-layout sidebar so the fixed panel clears the impersonation banner.
+-->
+<aside
+  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 lg:fixed lg:right-0 lg:bottom-0 lg:w-80 lg:overflow-y-auto lg:border-b-0 lg:border-l"
+  [class.lg:top-12]="impersonating()"
+  [class.lg:top-0]="!impersonating()"
+  data-testid="profile-panel">
+  @if (loading()) {
+    <div class="flex items-center justify-center py-8">
+      <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400"></i>
+    </div>
+  } @else {
+    <!-- Avatar + edit-pencil badge (rounded, not circle) -->
+    <div class="relative mb-3.5 w-24">
+      <div
+        class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-blue-500 to-violet-600 text-xl font-semibold text-white"
+        data-testid="profile-avatar">
+        @if (avatarUrl() && !avatarLoadError()) {
+          <img
+            [src]="avatarUrl()"
+            [alt]="displayName()"
+            (error)="avatarLoadError.set(true)"
+            class="h-full w-full rounded-2xl object-cover"
+            data-testid="profile-avatar-image" />
+        } @else {
+          {{ initials() }}
+        }
+      </div>
+      <button
+        type="button"
+        (click)="onEdit()"
+        [disabled]="impersonating()"
+        [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : 'Edit profile'"
+        class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+        data-testid="profile-panel-edit-badge">
+        <i class="fa-light fa-pencil text-xs"></i>
+      </button>
+    </div>
+
+    <!-- Name + handle -->
+    <h2 class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</h2>
+    @if (username()) {
+      <p class="mb-4 text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
+    }
+
+    <!-- Edit profile pill -->
+    <button
+      type="button"
+      (click)="onEdit()"
+      [disabled]="impersonating()"
+      [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
+      class="mb-2.5 flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+      data-testid="profile-edit-button">
+      <i class="fa-light fa-pencil text-xs"></i>
+      Edit profile
+    </button>
+
+    <div class="my-5 h-px bg-slate-200"></div>
+
+    <!-- Fields — each renders only when its value is present -->
+    <div class="flex flex-col">
+      @if (aboutMe()) {
+        <div class="mb-5" data-testid="profile-panel-about">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-file-lines"></i>
+            <span>About me</span>
+          </div>
+          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ aboutMe() }}</div>
+        </div>
+      }
+      @if (jobTitle()) {
+        <div class="mb-5" data-testid="profile-panel-job-title">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-briefcase"></i>
+            <span>Job title</span>
+          </div>
+          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ jobTitle() }}</div>
+        </div>
+      }
+      @if (organization()) {
+        <div class="mb-5" data-testid="profile-panel-organization">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-building"></i>
+            <span>Organization</span>
+          </div>
+          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ organization() }}</div>
+        </div>
+      }
+      @if (email()) {
+        <div class="mb-5" data-testid="profile-panel-email">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-envelope"></i>
+            <span>Primary email</span>
+          </div>
+          <div class="break-words text-[12.5px] leading-relaxed text-slate-800">{{ email() }}</div>
+        </div>
+      }
+      @if (addressLines().length > 0) {
+        <div class="mb-5" data-testid="profile-panel-location">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-location-dot"></i>
+            <span>Location</span>
+          </div>
+          <div class="flex flex-col text-[12.5px] leading-relaxed text-slate-800">
+            @for (line of addressLines(); track line) {
+              <span>{{ line }}</span>
+            }
+          </div>
+        </div>
+      }
+      @if (phone()) {
+        <div class="mb-5" data-testid="profile-panel-phone">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-phone"></i>
+            <span>Phone number</span>
+          </div>
+          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ phone() }}</div>
+        </div>
+      }
+      @if (tshirtSize()) {
+        <div class="mb-5" data-testid="profile-panel-tshirt">
+          <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+            <i class="fa-light fa-shirt"></i>
+            <span>T-shirt size</span>
+          </div>
+          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ tshirtSize() }}</div>
+        </div>
+      }
+    </div>
+
+    <!-- Social rows — stubbed until wired from a real source; render only when present -->
+    @if (githubHandle() || linkedinHandle()) {
+      <div class="my-1 h-px bg-slate-200"></div>
+      <div class="flex flex-col gap-2 pt-4">
+        @if (githubHandle()) {
+          <div class="flex items-center gap-2 text-[12.5px] text-slate-700" data-testid="profile-panel-github">
+            <i class="fa-brands fa-github text-slate-800"></i>
+            <span class="truncate">{{ githubHandle() }}</span>
+          </div>
+        }
+        @if (linkedinHandle()) {
+          <div class="flex items-center gap-2 text-[12.5px] text-slate-700" data-testid="profile-panel-linkedin">
+            <i class="fa-brands fa-linkedin text-blue-700"></i>
+            <span class="truncate">{{ linkedinHandle() }}</span>
+          </div>
+        }
+      </div>
+    }
+  }
+</aside>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, effect, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 /**
  * ProfilePanelComponent is the fixed right-hand panel of the Profile & Account hub.
@@ -41,17 +41,16 @@ export class ProfilePanelComponent {
   // Outputs
   public readonly editRequested = output<void>();
 
-  // Tracks failed avatar image loads so we can fall back to initials
-  public readonly avatarLoadError = signal<boolean>(false);
+  // The avatar URL that failed to load, if any. Tracking the URL (rather than a plain boolean)
+  // lets a newly-set/refreshed picture re-attempt to load without an effect(): once avatarUrl
+  // changes, it no longer matches the errored URL, so showAvatarImage flips back to true.
+  private readonly avatarErrorUrl = signal<string | null>(null);
 
-  public constructor() {
-    // Reset the avatar error flag whenever the picture URL changes so a newly-set
-    // (or refreshed) avatar re-attempts to load instead of staying on the initials fallback
-    effect(() => {
-      this.avatarUrl();
-      this.avatarLoadError.set(false);
-    });
-  }
+  // Show the picture when we have a URL that hasn't errored; otherwise fall back to initials.
+  public readonly showAvatarImage = computed(() => {
+    const url = this.avatarUrl();
+    return !!url && this.avatarErrorUrl() !== url;
+  });
 
   // Editing acts on the real account and is blocked while impersonating.
   public onEdit(): void {
@@ -59,5 +58,10 @@ export class ProfilePanelComponent {
       return;
     }
     this.editRequested.emit();
+  }
+
+  // Called by the avatar <img> (error) handler — record the failed URL so we fall back to initials.
+  public onAvatarError(): void {
+    this.avatarErrorUrl.set(this.avatarUrl());
   }
 }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -10,9 +10,9 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
  * `editRequested` so the parent — which owns the profile data, edit dialog, and
  * optimistic-update logic — handles the actual edit flow.
  *
- * Rows render only when their value is present. About me, GitHub, and LinkedIn are
- * stubbed for now (no source on CombinedProfile yet) and therefore stay hidden until
- * wired in a follow-up.
+ * Rows render only when their value is present. GitHub is sourced from the user's
+ * connected identities (bound by the parent); About me and LinkedIn are stubbed for now
+ * (no source yet) and therefore stay hidden until wired in a follow-up.
  */
 @Component({
   selector: 'lfx-profile-panel',
@@ -52,7 +52,10 @@ export class ProfilePanelComponent {
     return !!url && this.avatarErrorUrl() !== url;
   });
 
-  // Editing acts on the real account and is blocked while impersonating.
+  /**
+   * Request the profile edit flow from the parent. No-op while impersonating, since
+   * profile edits act on the real account and are blocked server-side.
+   */
   public onEdit(): void {
     if (this.impersonating()) {
       return;
@@ -60,7 +63,10 @@ export class ProfilePanelComponent {
     this.editRequested.emit();
   }
 
-  // Called by the avatar <img> (error) handler — record the failed URL so we fall back to initials.
+  /**
+   * Handle a failed avatar image load: record the errored URL so `showAvatarImage`
+   * turns false and the initials fallback renders until the URL changes.
+   */
   public onAvatarError(): void {
     this.avatarErrorUrl.set(this.avatarUrl());
   }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -1,0 +1,63 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, effect, input, output, signal } from '@angular/core';
+
+/**
+ * ProfilePanelComponent is the fixed right-hand panel of the Profile & Account hub.
+ * It is purely presentational: all values arrive via signal inputs (sourced from the
+ * parent ProfileLayoutComponent's CombinedProfile) and the edit affordances emit
+ * `editRequested` so the parent — which owns the profile data, edit dialog, and
+ * optimistic-update logic — handles the actual edit flow.
+ *
+ * Rows render only when their value is present. About me, GitHub, and LinkedIn are
+ * stubbed for now (no source on CombinedProfile yet) and therefore stay hidden until
+ * wired in a follow-up.
+ */
+@Component({
+  selector: 'lfx-profile-panel',
+  imports: [],
+  templateUrl: './profile-panel.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfilePanelComponent {
+  // Inputs — sourced from the parent's CombinedProfile-derived signals
+  public readonly loading = input<boolean>(false);
+  public readonly impersonating = input<boolean>(false);
+  public readonly avatarUrl = input<string>('');
+  public readonly displayName = input<string>('');
+  public readonly initials = input<string>('U');
+  public readonly username = input<string>('');
+  public readonly aboutMe = input<string>('');
+  public readonly jobTitle = input<string>('');
+  public readonly organization = input<string>('');
+  public readonly email = input<string>('');
+  public readonly addressLines = input<string[]>([]);
+  public readonly phone = input<string>('');
+  public readonly tshirtSize = input<string>('');
+  public readonly githubHandle = input<string>('');
+  public readonly linkedinHandle = input<string>('');
+
+  // Outputs
+  public readonly editRequested = output<void>();
+
+  // Tracks failed avatar image loads so we can fall back to initials
+  public readonly avatarLoadError = signal<boolean>(false);
+
+  public constructor() {
+    // Reset the avatar error flag whenever the picture URL changes so a newly-set
+    // (or refreshed) avatar re-attempts to load instead of staying on the initials fallback
+    effect(() => {
+      this.avatarUrl();
+      this.avatarLoadError.set(false);
+    });
+  }
+
+  // Editing acts on the real account and is blocked while impersonating.
+  public onEdit(): void {
+    if (this.impersonating()) {
+      return;
+    }
+    this.editRequested.emit();
+  }
+}

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -4,7 +4,8 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 /**
- * ProfilePanelComponent is the fixed right-hand panel of the Profile & Account hub.
+ * ProfilePanelComponent is the sticky right-hand panel of the Profile & Account hub
+ * (a sticky side column at 2xl, stacked full-width above the content below that).
  * It is purely presentational: all values arrive via signal inputs (sourced from the
  * parent ProfileLayoutComponent's CombinedProfile) and the edit affordances emit
  * `editRequested` so the parent — which owns the profile data, edit dialog, and


### PR DESCRIPTION
## Summary

- Rework the profile layout into a two-column **Profile & Account** hub: left column
  with the page head, subtab navigation, and the router outlet; right column is a
  profile panel that stacks full-width at the top below `2xl` and becomes an in-flow
  sticky column at `2xl` (`2xl:sticky`).
- Add a new presentational `lfx-profile-panel` component — rounded avatar + edit-pencil
  badge, name, `@handle`, Edit-profile pill, and profile fields (About me, Job title,
  Organization, Primary email, Location, Phone, T-shirt size) plus GitHub/LinkedIn rows.
  The layout keeps ownership of the profile fetch, edit dialog, optimistic updates, and
  Flow C auth-return handling; the panel emits `editRequested`.
- Source the GitHub row from the user's connected identities (reusing the existing
  identities fetch — no extra request). About me and LinkedIn render only when present
  and stay hidden until a source is wired.
- Replace the mobile tab dropdown with a horizontally-scrollable subtab bar (one
  navigation UI across breakpoints), dropping the `ReactiveFormsModule`/`SelectComponent`/
  `tabForm` plumbing.

Jira: LFXV2-2740

