### PR TITLE
feat(newsletters): add opt-out tab showing unsubscribed emails

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -28,7 +28,14 @@
 
       <div class="px-5 py-5 flex flex-col gap-4">
         @if (statusTab() === 'optout') {
-          @if (!loading() && !hasOptOuts()) {
+          @if (optOutsLoadFailed()) {
+            <lfx-empty-state
+              [withCard]="false"
+              icon="fa-light fa-triangle-exclamation"
+              title="Could not load opt-outs"
+              subtitle="Something went wrong loading this list. Please try again later.">
+            </lfx-empty-state>
+          } @else if (!loading() && !hasOptOuts()) {
             <lfx-empty-state
               [withCard]="false"
               icon="fa-light fa-user-slash"

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -27,7 +27,36 @@
       </lfx-card-tabs-bar>
 
       <div class="px-5 py-5 flex flex-col gap-4">
-        @if (!loading() && !hasNewsletters()) {
+        @if (statusTab() === 'optout') {
+          @if (!loading() && !hasOptOuts()) {
+            <lfx-empty-state
+              [withCard]="false"
+              icon="fa-light fa-user-slash"
+              title="No opt-outs yet"
+              subtitle="People who unsubscribe from this newsletter will show up here.">
+            </lfx-empty-state>
+          } @else {
+            <lfx-table [value]="optOuts()" [loading]="loading()" dataKey="email" data-testid="newsletter-optout-table">
+              <ng-template #header>
+                <tr>
+                  <th class="w-[70%]">Email</th>
+                  <th class="w-[30%]">Unsubscribed</th>
+                </tr>
+              </ng-template>
+
+              <ng-template #body let-optOut>
+                <tr [attr.data-testid]="'newsletter-optout-row-' + optOut.email">
+                  <td>
+                    <span class="text-sm text-gray-900">{{ optOut.email }}</span>
+                  </td>
+                  <td>
+                    <span class="text-sm text-gray-700">{{ optOut.unsubscribed_at | date: 'MMM d, y' }}</span>
+                  </td>
+                </tr>
+              </ng-template>
+            </lfx-table>
+          }
+        } @else if (!loading() && !hasNewsletters()) {
           <lfx-empty-state
             [withCard]="false"
             icon="fa-light fa-paper-plane"

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -13,7 +13,16 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY } from '@lfx-one/shared/constants';
-import { FilterPillOption, NewsletterAnalytics, NewsletterListItem, NewsletterRow, NewsletterStatusTabId } from '@lfx-one/shared/interfaces';
+import {
+  FilterPillOption,
+  NewsletterAnalytics,
+  NewsletterListItem,
+  NewsletterListResponse,
+  NewsletterOptOut,
+  NewsletterOptOutListResponse,
+  NewsletterRow,
+  NewsletterStatusTabId,
+} from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -23,6 +32,11 @@ import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, distinctUntilChanged, EMPTY, finalize, from, map, mergeMap, of, switchMap, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
+
+// Discriminates the two list shapes the context/tab switchMap can resolve to,
+// so the single subscribe callback can route each response without a second
+// stream.
+type ListLoadResult = { kind: 'newsletters'; response: NewsletterListResponse } | { kind: 'optout'; response: NewsletterOptOutListResponse };
 
 @Component({
   selector: 'lfx-newsletter-list',
@@ -58,11 +72,13 @@ export class NewsletterListComponent {
   protected readonly statusTabOptions: FilterPillOption[] = [
     { id: 'draft', label: 'Drafts' },
     { id: 'sent', label: 'Sent' },
+    { id: 'optout', label: 'Opt-out' },
   ];
 
   // === Writable Signals ===
   protected readonly statusTab = signal<NewsletterStatusTabId>('draft');
   protected readonly newsletters = signal<NewsletterListItem[]>([]);
+  protected readonly optOuts = signal<NewsletterOptOut[]>([]);
   protected readonly loading = signal<boolean>(false);
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly nextPageToken = signal<string | undefined>(undefined);
@@ -93,20 +109,21 @@ export class NewsletterListComponent {
   public readonly projectUid: Signal<string> = this.projectContextService.activeContextUid;
   protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore() && !!this.projectUid());
   protected readonly hasNewsletters: Signal<boolean> = computed(() => this.newsletters().length > 0);
+  protected readonly hasOptOuts: Signal<boolean> = computed(() => this.optOuts().length > 0);
 
   // Pre-compute per-row labels so the template doesn't call functions-with-args.
   protected readonly rows: Signal<NewsletterRow[]> = this.initRows();
 
   public constructor() {
     const tabFromQuery = this.route.snapshot.queryParamMap.get('tab');
-    if (tabFromQuery === 'sent' || tabFromQuery === 'draft') {
+    if (tabFromQuery === 'sent' || tabFromQuery === 'draft' || tabFromQuery === 'optout') {
       this.statusTab.set(tabFromQuery);
     }
     this.initLoadOnContextOrTab();
   }
 
   protected onStatusTabChange(tab: string): void {
-    if (tab === 'draft' || tab === 'sent') {
+    if (tab === 'draft' || tab === 'sent' || tab === 'optout') {
       this.statusTab.set(tab);
     }
   }
@@ -133,7 +150,9 @@ export class NewsletterListComponent {
     const uid = this.projectUid();
     const status = this.statusTab();
     const generation = this.loadGeneration;
-    if (!token || this.loadingMore() || !uid) return;
+    // Opt-out has no pagination — canLoadMore() never yields true for it, so
+    // this is just the type guard that lets `status` narrow below.
+    if (!token || this.loadingMore() || !uid || status === 'optout') return;
     this.loadingMore.set(true);
     this.newsletterService
       .listNewsletters(uid, { status, page_token: token })
@@ -221,6 +240,7 @@ export class NewsletterListComponent {
           this.selectedNewsletter.set(null);
           this.nextPageToken.set(undefined);
           this.newsletters.set([]);
+          this.optOuts.set([]);
           if (uid !== this.lastLoadedUid) {
             this.lastLoadedUid = uid;
             this.analyticsCacheGeneration++;
@@ -232,7 +252,18 @@ export class NewsletterListComponent {
             return EMPTY;
           }
           this.loading.set(true);
+          if (status === 'optout') {
+            return this.newsletterService.listOptOuts(uid).pipe(
+              map((response): ListLoadResult => ({ kind: 'optout', response })),
+              catchError((err: HttpErrorResponse) => {
+                this.loading.set(false);
+                this.showLoadError(err);
+                return EMPTY;
+              })
+            );
+          }
           return this.newsletterService.listNewsletters(uid, { status }).pipe(
+            map((response): ListLoadResult => ({ kind: 'newsletters', response })),
             catchError((err: HttpErrorResponse) => {
               this.loading.set(false);
               this.showLoadError(err);
@@ -242,11 +273,15 @@ export class NewsletterListComponent {
         }),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((response) => {
+      .subscribe((result) => {
         this.loading.set(false);
-        this.newsletters.set(response.newsletters);
-        this.nextPageToken.set(response.next_page_token);
-        this.loadOpenRates(response.newsletters);
+        if (result.kind === 'optout') {
+          this.optOuts.set(result.response.opt_outs);
+          return;
+        }
+        this.newsletters.set(result.response.newsletters);
+        this.nextPageToken.set(result.response.next_page_token);
+        this.loadOpenRates(result.response.newsletters);
       });
   }
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -17,9 +17,8 @@ import {
   FilterPillOption,
   NewsletterAnalytics,
   NewsletterListItem,
-  NewsletterListResponse,
+  NewsletterListLoadResult,
   NewsletterOptOut,
-  NewsletterOptOutListResponse,
   NewsletterRow,
   NewsletterStatusTabId,
 } from '@lfx-one/shared/interfaces';
@@ -32,11 +31,6 @@ import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, distinctUntilChanged, EMPTY, finalize, from, map, mergeMap, of, switchMap, take } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
-
-// Discriminates the two list shapes the context/tab switchMap can resolve to,
-// so the single subscribe callback can route each response without a second
-// stream.
-type ListLoadResult = { kind: 'newsletters'; response: NewsletterListResponse } | { kind: 'optout'; response: NewsletterOptOutListResponse };
 
 @Component({
   selector: 'lfx-newsletter-list',
@@ -79,6 +73,7 @@ export class NewsletterListComponent {
   protected readonly statusTab = signal<NewsletterStatusTabId>('draft');
   protected readonly newsletters = signal<NewsletterListItem[]>([]);
   protected readonly optOuts = signal<NewsletterOptOut[]>([]);
+  protected readonly optOutsLoadFailed = signal<boolean>(false);
   protected readonly loading = signal<boolean>(false);
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly nextPageToken = signal<string | undefined>(undefined);
@@ -241,6 +236,7 @@ export class NewsletterListComponent {
           this.nextPageToken.set(undefined);
           this.newsletters.set([]);
           this.optOuts.set([]);
+          this.optOutsLoadFailed.set(false);
           if (uid !== this.lastLoadedUid) {
             this.lastLoadedUid = uid;
             this.analyticsCacheGeneration++;
@@ -254,16 +250,17 @@ export class NewsletterListComponent {
           this.loading.set(true);
           if (status === 'optout') {
             return this.newsletterService.listOptOuts(uid).pipe(
-              map((response): ListLoadResult => ({ kind: 'optout', response })),
+              map((response): NewsletterListLoadResult => ({ kind: 'optout', response })),
               catchError((err: HttpErrorResponse) => {
                 this.loading.set(false);
-                this.showLoadError(err);
+                this.optOutsLoadFailed.set(true);
+                this.showLoadError(err, 'Could not load opt-outs');
                 return EMPTY;
               })
             );
           }
           return this.newsletterService.listNewsletters(uid, { status }).pipe(
-            map((response): ListLoadResult => ({ kind: 'newsletters', response })),
+            map((response): NewsletterListLoadResult => ({ kind: 'newsletters', response })),
             catchError((err: HttpErrorResponse) => {
               this.loading.set(false);
               this.showLoadError(err);
@@ -365,10 +362,10 @@ export class NewsletterListComponent {
       });
   }
 
-  private showLoadError(err: HttpErrorResponse): void {
+  private showLoadError(err: HttpErrorResponse, summary = 'Could not load newsletters'): void {
     this.messageService.add({
       severity: 'error',
-      summary: 'Could not load newsletters',
+      summary,
       detail: err?.error?.message || err?.message || 'Please try again later.',
     });
   }

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -11,6 +11,7 @@ import {
   NewsletterAnalytics,
   NewsletterListParams,
   NewsletterListResponse,
+  NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
   NewsletterRecipientsResponse,
@@ -66,6 +67,10 @@ export class NewsletterService {
 
   public getAnalytics(projectUid: string, newsletterUid: string): Observable<NewsletterAnalytics> {
     return this.http.get<NewsletterAnalytics>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/analytics`).pipe(take(1));
+  }
+
+  public listOptOuts(projectUid: string): Observable<NewsletterOptOutListResponse> {
+    return this.http.get<NewsletterOptOutListResponse>(`/api/projects/${this.enc(projectUid)}/newsletters/opt-outs`).pipe(take(1));
   }
 
   public createNewsletter(projectUid: string, payload: CreateNewsletterRequest): Observable<Newsletter> {

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -265,6 +265,22 @@ export class NewsletterController {
   }
 
   /**
+   * GET /api/projects/:projectUid/newsletters/opt-outs
+   */
+  public async listOptOuts(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = this.requireProjectUid(req);
+    const startTime = logger.startOperation(req, 'newsletter_opt_outs_list', { project_uid: projectUid });
+
+    try {
+      const result = await this.newsletterService.listOptOuts(req, projectUid);
+      logger.success(req, 'newsletter_opt_outs_list', startTime, { count: result.opt_outs.length });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * POST /api/projects/:projectUid/newsletters/generate
    *
    * AI-assisted body generation. Doesn't touch the Go newsletter-service —

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -33,6 +33,11 @@ router.post('/test-send', (req, res, next) => newsletterController.testSend(req,
 router.get('/', (req, res, next) => newsletterController.listNewsletters(req, res, next));
 router.post('/', (req, res, next) => newsletterController.createNewsletter(req, res, next));
 
+// Opt-out (unsubscribe) list. Static segment, registered before the
+// `/:newsletterUid` catch-alls so Express doesn't parse `opt-outs` as a
+// newsletter UID.
+router.get('/opt-outs', (req, res, next) => newsletterController.listOptOuts(req, res, next));
+
 // Per-newsletter CRUD + send + analytics.
 router.get('/:newsletterUid', (req, res, next) => newsletterController.getNewsletter(req, res, next));
 router.put('/:newsletterUid', (req, res, next) => newsletterController.updateNewsletter(req, res, next));

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -8,6 +8,7 @@ import {
   NewsletterAnalytics,
   NewsletterListParams,
   NewsletterListResponse,
+  NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
   NewsletterRecipientsResponse,
@@ -143,5 +144,9 @@ export class NewsletterServiceClient {
       `/projects/${projectUid}/newsletters/${newsletterUid}/analytics`,
       'GET'
     );
+  }
+
+  public async listOptOuts(req: Request, projectUid: string): Promise<NewsletterOptOutListResponse> {
+    return this.microserviceProxy.proxyRequest<NewsletterOptOutListResponse>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletter-opt-outs`, 'GET');
   }
 }

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -7,6 +7,7 @@ import {
   NewsletterAnalytics,
   NewsletterListParams,
   NewsletterListResponse,
+  NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
   NewsletterRecipientsResponse,
@@ -79,5 +80,9 @@ export class NewsletterService {
 
   public getAnalytics(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterAnalytics> {
     return this.newsletterClient.getAnalytics(req, projectUid, newsletterUid);
+  }
+
+  public listOptOuts(req: Request, projectUid: string): Promise<NewsletterOptOutListResponse> {
+    return this.newsletterClient.listOptOuts(req, projectUid);
   }
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -185,6 +185,4 @@ export interface NewsletterOptOutListResponse {
 // Discriminates the two list shapes the newsletter list page's context/tab
 // switchMap can resolve to, so a single subscribe callback can route each
 // response without a second stream.
-export type NewsletterListLoadResult =
-  | { kind: 'newsletters'; response: NewsletterListResponse }
-  | { kind: 'optout'; response: NewsletterOptOutListResponse };
+export type NewsletterListLoadResult = { kind: 'newsletters'; response: NewsletterListResponse } | { kind: 'optout'; response: NewsletterOptOutListResponse };

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -181,3 +181,10 @@ export interface NewsletterOptOut {
 export interface NewsletterOptOutListResponse {
   opt_outs: NewsletterOptOut[];
 }
+
+// Discriminates the two list shapes the newsletter list page's context/tab
+// switchMap can resolve to, so a single subscribe callback can route each
+// response without a second stream.
+export type NewsletterListLoadResult =
+  | { kind: 'newsletters'; response: NewsletterListResponse }
+  | { kind: 'optout'; response: NewsletterOptOutListResponse };

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-export type NewsletterStatusTabId = 'draft' | 'sent';
+export type NewsletterStatusTabId = 'draft' | 'sent' | 'optout';
 
 /**
  * Newsletter lifecycle states.
@@ -171,4 +171,13 @@ export interface NewsletterChartDataset {
 export interface NewsletterChartData {
   labels: string[];
   datasets: NewsletterChartDataset[];
+}
+
+export interface NewsletterOptOut {
+  email: string;
+  unsubscribed_at: string;
+}
+
+export interface NewsletterOptOutListResponse {
+  opt_outs: NewsletterOptOut[];
 }


### PR DESCRIPTION
Adds an Opt-out tab next to Sent on the newsletter list page, showing everyone who has unsubscribed from a project's newsletter along with when they unsubscribed.

Depends on the new opt-outs endpoint added in linuxfoundation/lfx-v2-newsletter-service#52 — that PR should merge and deploy first.

LFXV2-2766