### PR TITLE
feat(profile): redesign me-lens user card and dock avatar menu

### DIFF
--- a/apps/lfx-one/e2e/me-profile-nav.spec.ts
+++ b/apps/lfx-one/e2e/me-profile-nav.spec.ts
@@ -1,0 +1,221 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Me-lens Profile Navigation E2E — LFXV2-2741.
+ *
+ * Covers the redesigned Me-lens profile entry points added in PR #1136:
+ *   1. Sidebar "me card" — a stretched-link card whose body navigates to /profile,
+ *      plus a ⋯ overflow trigger that opens a popover of the five PROFILE_TABS links.
+ *      Each tab link must navigate to its own route WITHOUT the stretched card's
+ *      /profile link winning (the layered pointer-events contract).
+ *   2. Dock avatar user menu — the "Settings" action (→ /profile/settings) and the
+ *      "Profile & Account" action (→ /profile), each of which also activates the Me lens.
+ *
+ * Both surfaces are desktop-shell affordances; the mobile shell exposes separate
+ * lens-mobile-* entries, so these specs skip on the narrow (mobile) viewport.
+ *
+ * The Me lens is the default (DEFAULT_LENS = 'me'), so a fresh context landing on a
+ * /profile route renders the me card. "Me lens active" is asserted via that card's
+ * presence, since showMeSelector() === (activeLens() === 'me') — the desktop lens rail
+ * buttons are hidden by every current caller and expose no active-state hook.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+// ─── Timeouts ───────────────────────────────────────────────────────────────
+test.setTimeout(60_000);
+
+const SIDEBAR_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+// PROFILE_TABS render order + testid (`me-card-tab-<id>`) → destination route.
+// Mirrors packages/shared/src/constants/profile.constants.ts (note id `attribution` → route `attributions`).
+const PROFILE_TAB_IDS = ['attribution', 'identities', 'individual-enrollment', 'transactions', 'settings'];
+
+const PROFILE_TABS: { id: string; route: string }[] = [
+  { id: 'attribution', route: 'attributions' },
+  { id: 'identities', route: 'identities' },
+  { id: 'individual-enrollment', route: 'individual-enrollment' },
+  { id: 'transactions', route: 'transactions' },
+  { id: 'settings', route: 'settings' },
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+// Hard skip when the auth-bootstrap failed — hostname-exact match so a crafted URL like
+// `https://auth0.com.evil.com/` can't fool the gate (mirrors org-selector.spec.ts).
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — keep running; a failure here is useful signal, not noise.
+  }
+}
+
+// The me card and dock user menu are desktop-shell affordances; the mobile shell exposes
+// separate lens-mobile-* entries. Skip on the narrow (mobile-chrome) viewport rather than
+// hard-coding a project name, which keeps the gate correct if the project list changes.
+function skipOnMobileViewport(page: Page): void {
+  const viewport = page.viewportSize();
+  if (viewport && viewport.width < 768) {
+    test.skip(true, 'Desktop-only profile affordance — mobile uses the lens-mobile-* entries');
+  }
+}
+
+/**
+ * Neutralize the Osano cookie-consent overlay. global-setup clears cookies, so the banner
+ * (.osano-cm-window) reappears in each fresh context and its bottom bar intercepts pointer events on
+ * the popover items these tests click. Registered via addInitScript so it runs on every navigation
+ * before page scripts — deterministic, unlike racing the banner's entrance animation to click Accept.
+ * The dialog is irrelevant to these navigation flows, so hiding it is sufficient.
+ */
+async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const hide = (): void => {
+      if (document.getElementById('e2e-hide-osano')) {
+        return;
+      }
+      const style = document.createElement('style');
+      style.id = 'e2e-hide-osano';
+      style.textContent = '.osano-cm-window { display: none !important; pointer-events: none !important; }';
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hide);
+    } else {
+      hide();
+    }
+  });
+}
+
+/** Navigate to a Me-lens route and wait for the sidebar (with the me card) to render. */
+async function gotoProfileAndWaitForCard(page: Page, url: string): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  await expect(page.getByTestId('sidebar'), `[${url}] sidebar should be visible`).toBeVisible({ timeout: SIDEBAR_LOAD_TIMEOUT });
+  await expect(page.getByTestId('me-selector'), `[${url}] me-lens card should render`).toBeVisible({ timeout: SIDEBAR_LOAD_TIMEOUT });
+}
+
+/**
+ * Open a popover by toggling its trigger, retrying until an expected item renders. The trigger can be
+ * painted (SSR) before Angular binds its (click) handler, so an early click is silently dropped;
+ * retrying self-heals that race. The guard only clicks when the menu is closed, so a slow-but-
+ * successful open is never toggled back shut. All popovers here append to <body>, so the item is
+ * queried on the page, not scoped to the trigger.
+ */
+async function openPopover(page: Page, triggerTestId: string, itemTestId: string): Promise<void> {
+  const trigger = page.getByTestId(triggerTestId);
+  await expect(trigger).toBeVisible({ timeout: SIDEBAR_LOAD_TIMEOUT });
+  const item = page.getByTestId(itemTestId);
+  await expect(async () => {
+    if (!(await item.isVisible())) {
+      await trigger.click();
+    }
+    await expect(item).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: SIDEBAR_LOAD_TIMEOUT });
+}
+
+/** Open the me-card ⋯ overflow popover and wait for the tab links to render. */
+async function openProfileTabsPopover(page: Page): Promise<void> {
+  await openPopover(page, 'me-card-more', 'me-card-tab-settings');
+}
+
+/** Open the dock avatar user menu and wait for its actions to render. */
+async function openUserMenu(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await openPopover(page, 'lens-user-avatar', 'lens-settings');
+}
+
+// ─── S1: Sidebar me-lens profile card ─────────────────────────────────────────
+
+test.describe('Me-lens profile card', () => {
+  test.beforeEach(async ({ page }) => {
+    skipOnMobileViewport(page);
+    await suppressCookieBanner(page);
+  });
+
+  test('S1: card body navigates to /profile (stretched link)', async ({ page }) => {
+    await gotoProfileAndWaitForCard(page, '/profile');
+
+    await page.getByTestId('me-card-link').click();
+
+    // /profile redirects to the first tab (attributions); assert we land in the Profile shell.
+    await expect(page, 'me-card body should navigate into the Profile shell').toHaveURL(/\/profile\b/, { timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('S2: the ⋯ overflow opens the five profile tabs, in order, each linking to its route', async ({ page }) => {
+    await gotoProfileAndWaitForCard(page, '/profile');
+    await openProfileTabsPopover(page);
+
+    for (const id of PROFILE_TAB_IDS) {
+      await expect(page.getByTestId(`me-card-tab-${id}`), `tab ${id} should be visible`).toBeVisible();
+    }
+
+    // Assert render order matches the PROFILE_TABS constant, not just presence.
+    const renderedOrder = await page
+      .locator('[data-testid^="me-card-tab-"]')
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('data-testid')?.replace('me-card-tab-', '')));
+    expect(renderedOrder).toEqual(PROFILE_TAB_IDS);
+
+    // Each tab links to its own /profile/<route> — the routing contract for all five, without the
+    // flaky per-tab re-open/click loop (one representative navigation is asserted in S3).
+    for (const tab of PROFILE_TABS) {
+      await expect(page.getByTestId(`me-card-tab-${tab.id}`), `tab ${tab.id} should link to /profile/${tab.route}`).toHaveAttribute(
+        'href',
+        new RegExp(`/profile/${tab.route}$`)
+      );
+    }
+  });
+
+  test('S3: clicking a tab link navigates to its route, not the stretched card', async ({ page }) => {
+    await gotoProfileAndWaitForCard(page, '/profile');
+    await openProfileTabsPopover(page);
+
+    // Settings resolves to /profile/settings, distinct from the card's /profile (→ /profile/attributions),
+    // so landing there proves the popover link won over the underlying stretched-link anchor.
+    await page.getByTestId('me-card-tab-settings').click();
+
+    await expect(page, 'the Settings tab should navigate to /profile/settings').toHaveURL(/\/profile\/settings\b/, { timeout: ELEMENT_TIMEOUT });
+  });
+});
+
+// ─── S4: Dock avatar user menu ────────────────────────────────────────────────
+
+test.describe('Dock avatar user menu', () => {
+  test.beforeEach(async ({ page }) => {
+    skipOnMobileViewport(page);
+    await suppressCookieBanner(page);
+  });
+
+  test('S4: Settings action navigates to /profile/settings and activates the Me lens', async ({ page }) => {
+    await openUserMenu(page);
+
+    await page.getByTestId('lens-settings').click();
+
+    await expect(page, 'dock Settings should navigate to /profile/settings').toHaveURL(/\/profile\/settings\b/, { timeout: ELEMENT_TIMEOUT });
+    // The Me lens is active iff the sidebar me card renders (showMeSelector === activeLens === 'me').
+    await expect(page.getByTestId('me-selector'), 'Me lens should be active after the Settings action').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('S5: Profile & Account action navigates to /profile', async ({ page }) => {
+    await openUserMenu(page);
+
+    await page.getByTestId('lens-profile').click();
+
+    await expect(page, 'dock Profile & Account should navigate into the Profile shell').toHaveURL(/\/profile\b/, { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('me-selector'), 'Me lens should be active after the Profile action').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+});

--- a/apps/lfx-one/e2e/me-profile-nav.spec.ts
+++ b/apps/lfx-one/e2e/me-profile-nav.spec.ts
@@ -15,16 +15,18 @@
  * Both surfaces are desktop-shell affordances; the mobile shell exposes separate
  * lens-mobile-* entries, so these specs skip on the narrow (mobile) viewport.
  *
- * The Me lens is the default (DEFAULT_LENS = 'me'), so a fresh context landing on a
- * /profile route renders the me card. "Me lens active" is asserted via that card's
- * presence, since showMeSelector() === (activeLens() === 'me') — the desktop lens rail
- * buttons are hidden by every current caller and expose no active-state hook.
+ * "Me lens active" is asserted via the me card's visibility: showMeSelector() === (activeLens()
+ * === 'me') toggles the card's `hidden` class, and the desktop lens rail exposes no active-state
+ * hook. Because a fresh context defaults to the Me lens (DEFAULT_LENS = 'me'), the dock tests first
+ * establish a non-Me (foundation) lens via stubbed persona/nav APIs — otherwise the card would
+ * already be visible and the assertion could not detect setLens('me') breaking.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
  *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
  */
 
+import type { LensItem } from '@lfx-one/shared/interfaces';
 import { expect, Page, test } from '@playwright/test';
 
 // ─── Timeouts ───────────────────────────────────────────────────────────────
@@ -45,6 +47,19 @@ const PROFILE_TABS: { id: string; route: string }[] = [
   { id: 'transactions', route: 'transactions' },
   { id: 'settings', route: 'settings' },
 ];
+
+// /profile redirects to its first tab, so this is the canonical landing route for any bare-/profile nav.
+const PROFILE_DEFAULT_URL = /\/profile\/attributions\b/;
+
+// Foundation-lens fixtures — used only to seed a non-Me lens as the precondition for the dock tests.
+const MOCK_FOUNDATION_SLUG = 'test-foundation';
+const MOCK_FOUNDATION_ITEM: LensItem = {
+  uid: 'f0000000-0000-0000-0000-000000000001',
+  slug: MOCK_FOUNDATION_SLUG,
+  name: 'Test Foundation',
+  logoUrl: null,
+  isFoundation: true,
+};
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -132,10 +147,59 @@ async function openProfileTabsPopover(page: Page): Promise<void> {
   await openPopover(page, 'me-card-more', 'me-card-tab-settings');
 }
 
-/** Open the dock avatar user menu and wait for its actions to render. */
-async function openUserMenu(page: Page): Promise<void> {
+// ─── Foundation-lens stubs (dock-test precondition) ──────────────────────────
+// Seed a non-Me lens so the post-action `me-selector` assertion proves the dock action switched the
+// lens back to Me, rather than passing trivially in the default-Me context. Mirrors the stub shape in
+// persona-navigation.spec.ts (hermetic: unmatched lens requests return empty items).
+
+async function stubPersona(page: Page, personas: string[]): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ personas, personaProjects: {}, projects: [], organizations: [], isRootWriter: false }),
+    })
+  );
+}
+
+async function stubFoundationNav(page: Page): Promise<void> {
+  await page.route('**/api/nav/lens-items*', (route) => {
+    const url = route.request().url();
+    const requestedLens = new URL(url).searchParams.get('lens') ?? 'foundation';
+    const items = requestedLens === 'foundation' ? [MOCK_FOUNDATION_ITEM] : [];
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: requestedLens }),
+    });
+  });
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ uid: MOCK_FOUNDATION_ITEM.uid, slug: MOCK_FOUNDATION_SLUG, name: 'Test Foundation', public: true, writer: true }),
+    })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+/** Put the app on the foundation lens (me card hidden) so a later switch to Me is observable. */
+async function establishFoundationLens(page: Page): Promise<void> {
+  await stubPersona(page, ['board-member']);
+  await stubFoundationNav(page);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
+  await page.goto(`/foundation/overview?project=${MOCK_FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page.getByTestId('sidebar'), 'sidebar should be visible on the foundation lens').toBeVisible({ timeout: SIDEBAR_LOAD_TIMEOUT });
+  // Precondition: not on the Me lens. The card stays in the DOM but is toggled off via a `hidden`
+  // class ([class.hidden]="!showMeSelector()"), so assert not-visible rather than not-attached.
+  await expect(page.getByTestId('me-selector'), 'me card should be hidden off the Me lens').toBeHidden({ timeout: SIDEBAR_LOAD_TIMEOUT });
+}
+
+/** Establish a non-Me lens, then open the dock avatar user menu and wait for its actions to render. */
+async function openUserMenu(page: Page): Promise<void> {
+  await establishFoundationLens(page);
   await openPopover(page, 'lens-user-avatar', 'lens-settings');
 }
 
@@ -148,12 +212,14 @@ test.describe('Me-lens profile card', () => {
   });
 
   test('S1: card body navigates to /profile (stretched link)', async ({ page }) => {
-    await gotoProfileAndWaitForCard(page, '/profile');
+    // Start on a different Me-lens tab so the assertion proves the click *changed* the route — not
+    // just that we were already somewhere under /profile.
+    await gotoProfileAndWaitForCard(page, '/profile/identities');
 
     await page.getByTestId('me-card-link').click();
 
-    // /profile redirects to the first tab (attributions); assert we land in the Profile shell.
-    await expect(page, 'me-card body should navigate into the Profile shell').toHaveURL(/\/profile\b/, { timeout: ELEMENT_TIMEOUT });
+    // The card links to /profile, which redirects to the canonical first tab.
+    await expect(page, 'me-card body should navigate to the default Profile tab').toHaveURL(PROFILE_DEFAULT_URL, { timeout: ELEMENT_TIMEOUT });
   });
 
   test('S2: the ⋯ overflow opens the five profile tabs, in order, each linking to its route', async ({ page }) => {
@@ -201,21 +267,25 @@ test.describe('Dock avatar user menu', () => {
   });
 
   test('S4: Settings action navigates to /profile/settings and activates the Me lens', async ({ page }) => {
+    // openUserMenu starts on the foundation lens (me card hidden), so the assertions below prove the
+    // action both navigated and switched the lens back to Me.
     await openUserMenu(page);
 
     await page.getByTestId('lens-settings').click();
 
     await expect(page, 'dock Settings should navigate to /profile/settings').toHaveURL(/\/profile\/settings\b/, { timeout: ELEMENT_TIMEOUT });
-    // The Me lens is active iff the sidebar me card renders (showMeSelector === activeLens === 'me').
-    await expect(page.getByTestId('me-selector'), 'Me lens should be active after the Settings action').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    // The Me lens is active iff the sidebar me card becomes visible (showMeSelector === activeLens === 'me').
+    await expect(page.getByTestId('me-selector'), 'Settings action should switch the lens to Me').toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
 
-  test('S5: Profile & Account action navigates to /profile', async ({ page }) => {
+  test('S5: Profile & Account action navigates to /profile and activates the Me lens', async ({ page }) => {
     await openUserMenu(page);
 
     await page.getByTestId('lens-profile').click();
 
-    await expect(page, 'dock Profile & Account should navigate into the Profile shell').toHaveURL(/\/profile\b/, { timeout: ELEMENT_TIMEOUT });
-    await expect(page.getByTestId('me-selector'), 'Me lens should be active after the Profile action').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    // /profile redirects to the canonical first tab; asserting it (not a bare /profile match) proves
+    // the action reached the Profile shell rather than merely staying on some /profile* URL.
+    await expect(page, 'dock Profile & Account should navigate to the default Profile tab').toHaveURL(PROFILE_DEFAULT_URL, { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('me-selector'), 'Profile action should switch the lens to Me').toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
 });

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -300,8 +300,16 @@
           data-testid="lens-profile"
           (click)="navigateToProfile()"
           class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-          <i class="fa-light fa-user w-4 text-gray-400"></i>
-          <span>My profile</span>
+          <i class="fa-light fa-circle-user w-4 text-gray-400"></i>
+          <span>Profile &amp; Account</span>
+        </button>
+        <button
+          type="button"
+          data-testid="lens-settings"
+          (click)="navigateToProfileSettings()"
+          class="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+          <i class="fa-light fa-gear w-4 text-gray-400"></i>
+          <span>Settings</span>
         </button>
         <button
           type="button"

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -114,6 +114,12 @@ export class LensSwitcherComponent {
     this.router.navigate(['/profile']);
   }
 
+  protected navigateToProfileSettings(): void {
+    this.userMenu()?.hide();
+    this.lensService.setLens('me');
+    this.router.navigate(['/profile/settings']);
+  }
+
   protected openImpersonationDialog(): void {
     this.dialogService.open(ImpersonationDialogComponent, {
       header: 'Impersonate User',

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -103,6 +103,8 @@
               type="button"
               (click)="toggleProfileMenu($event)"
               aria-label="Profile sections"
+              aria-haspopup="menu"
+              [attr.aria-expanded]="profileMenu.overlayVisible"
               data-testid="me-card-more"
               class="pointer-events-auto relative shrink-0 flex items-center justify-center size-8 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
               <i class="fa-light fa-ellipsis" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -103,7 +103,6 @@
               type="button"
               (click)="toggleProfileMenu($event)"
               aria-label="Profile sections"
-              aria-haspopup="menu"
               [attr.aria-expanded]="profileMenu.overlayVisible"
               data-testid="me-card-more"
               class="pointer-events-auto relative shrink-0 flex items-center justify-center size-8 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -43,17 +43,29 @@
 
       <!-- [class.hidden] avoids SSR hydration mismatch -->
       <div class="px-[12px] mb-[16px] w-full" [class.hidden]="!showMeSelector()">
-        <div data-testid="me-selector" class="box-border flex gap-3 items-start p-3 w-full rounded-lg">
-          <lfx-avatar [image]="user()?.picture ?? ''" [label]="user()?.name ?? ''" shape="circle" size="large" styleClass="shrink-0 size-10"></lfx-avatar>
-          <div class="flex flex-col gap-1 grow min-w-0">
-            <p class="font-semibold text-base text-gray-900 leading-5 tracking-tight line-clamp-2">{{ user()?.name }}</p>
-            @if (showPersonaBadge() && personaLabels().length > 0) {
-              @if (personaLabels().length === 1) {
-                <span class="inline-flex items-center text-xs font-normal text-gray-400 leading-none">
-                  <i [ngClass]="personaLabels()[0].icon" class="mr-1" aria-hidden="true"></i>{{ personaLabels()[0].label }}
-                </span>
-              } @else {
-                <div class="flex flex-wrap gap-1">
+        <div data-testid="me-selector" class="group relative box-border flex gap-3 items-center p-3 w-full rounded-lg hover:bg-gray-50 transition-colors">
+          <!--
+            Stretched link: the whole card navigates to /profile. Interactive children (persona
+            badges, the ⋯ button, the popover) re-enable pointer events and sit above so they keep
+            their own click/focus behaviour without nesting interactive elements inside the anchor.
+          -->
+          <a
+            [routerLink]="'/profile'"
+            aria-label="Profile & Account"
+            data-testid="me-card-link"
+            class="absolute inset-0 z-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"></a>
+
+          <div class="relative z-10 flex items-center gap-3 w-full pointer-events-none">
+            <!-- Avatar with persona badges anchored bottom-right -->
+            <div class="relative shrink-0">
+              <lfx-avatar
+                [image]="user()?.picture ?? ''"
+                [label]="user()?.name ?? ''"
+                shape="square"
+                size="large"
+                styleClass="size-12 rounded-xl overflow-hidden"></lfx-avatar>
+              @if (showPersonaBadge() && personaLabels().length > 0) {
+                <div class="absolute -bottom-1 -right-1 flex items-center gap-0.5">
                   @for (tag of personaLabels(); track $index) {
                     <ng-template #personaTooltipContent>
                       <div class="font-semibold">{{ tag.label }}</div>
@@ -72,14 +84,46 @@
                       [pTooltip]="personaTooltipContent"
                       tooltipPosition="top"
                       tooltipStyleClass="persona-tooltip"
-                      class="inline-flex items-center justify-center size-6 rounded-full bg-white border border-gray-200 text-gray-700 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
-                      <i [ngClass]="tag.icon" class="text-[10px]" aria-hidden="true"></i>
+                      class="pointer-events-auto inline-flex items-center justify-center size-[18px] rounded-md bg-white border border-gray-200 text-gray-700 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
+                      <i [ngClass]="tag.icon" class="text-[9px]" aria-hidden="true"></i>
                     </span>
                   }
                 </div>
               }
-            }
+            </div>
+
+            <!-- Name + label -->
+            <div class="flex flex-col gap-0.5 grow min-w-0">
+              <p class="font-semibold text-base text-gray-900 leading-5 tracking-tight line-clamp-2">{{ user()?.name }}</p>
+              <span class="text-sm font-medium text-blue-600">Profile &amp; Account</span>
+            </div>
+
+            <!-- Overflow (⋯) → profile tabs dropdown -->
+            <button
+              type="button"
+              (click)="toggleProfileMenu($event)"
+              aria-label="Profile sections"
+              data-testid="me-card-more"
+              class="pointer-events-auto relative shrink-0 flex items-center justify-center size-8 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
+              <i class="fa-light fa-ellipsis" aria-hidden="true"></i>
+            </button>
           </div>
+
+          <p-popover #profileMenu appendTo="body" styleClass="w-60 profile-tabs-popover">
+            <ng-template #content>
+              <nav aria-label="Profile sections" class="py-1">
+                @for (tab of profileTabs; track tab.id) {
+                  <a
+                    [routerLink]="['/profile', tab.route]"
+                    (click)="closeProfileMenu()"
+                    [attr.data-testid]="'me-card-tab-' + tab.id"
+                    class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                    {{ tab.label }}
+                  </a>
+                }
+              </nav>
+            </ng-template>
+          </p-popover>
         </div>
       </div>
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -146,8 +146,8 @@ export class SidebarComponent {
     this.expandedGroupOverrides.set({ itemsRef: items, overrides: { ...baseOverrides, [label]: !current } });
   }
 
-  // Toggle the me-lens card overflow dropdown. Stops propagation so the click doesn't also
-  // trigger the card's stretched link to /profile.
+  // Toggle the me-lens card overflow popover. stopPropagation keeps the click from
+  // reaching document-level outside-click handlers, not the (sibling) stretched link.
   protected toggleProfileMenu(event: Event): void {
     event.stopPropagation();
     this.profileMenu()?.toggle(event);

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, input, model, Signal, signal } from '@angular/core';
+import { Component, computed, inject, input, model, Signal, signal, viewChild } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -10,8 +10,8 @@ import { LensTabsComponent } from '@components/lens-tabs/lens-tabs.component';
 import { OrgSelectorComponent } from '@components/org-selector/org-selector.component';
 import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
 import { environment } from '@environments/environment';
-import { ORG_LENS_ENABLED_FLAG, PERSONA_OPTIONS, PERSONA_PRIORITY } from '@lfx-one/shared/constants';
-import { LensItem, NavLens, PersonaType, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { ORG_LENS_ENABLED_FLAG, PERSONA_OPTIONS, PERSONA_PRIORITY, PROFILE_TABS } from '@lfx-one/shared/constants';
+import { LensItem, NavLens, PersonaType, ProfileTab, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { lensItemToProjectContext, toTitleCase } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -20,6 +20,7 @@ import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
+import { Popover, PopoverModule } from 'primeng/popover';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 
@@ -41,6 +42,7 @@ const PERSONA_ICONS: Partial<Record<PersonaType, string>> = {
     LensTabsComponent,
     OrgSelectorComponent,
     ProjectSelectorComponent,
+    PopoverModule,
     SkeletonModule,
     TooltipModule,
   ],
@@ -85,6 +87,10 @@ export class SidebarComponent {
   protected readonly personaLabels: Signal<{ label: string; icon: string; names: string[]; ariaLabel: string }[]> = this.initPersonaLabels();
   // Hide the persona badge when the user is a root-writer — executive-director is spoofed, not naturally detected.
   protected readonly showPersonaBadge: Signal<boolean> = computed(() => !this.personaService.isRootWriter());
+
+  // Profile & Account tabs for the me-lens card overflow (⋯) dropdown → /profile/<route>
+  protected readonly profileTabs: ProfileTab[] = PROFILE_TABS;
+  protected readonly profileMenu = viewChild<Popover>('profileMenu');
 
   protected readonly itemsWithTestIds = computed(() =>
     this.items().map((item) => ({
@@ -138,6 +144,17 @@ export class SidebarComponent {
     const prev = this.expandedGroupOverrides();
     const baseOverrides = prev.itemsRef === items ? prev.overrides : {};
     this.expandedGroupOverrides.set({ itemsRef: items, overrides: { ...baseOverrides, [label]: !current } });
+  }
+
+  // Toggle the me-lens card overflow dropdown. Stops propagation so the click doesn't also
+  // trigger the card's stretched link to /profile.
+  protected toggleProfileMenu(event: Event): void {
+    event.stopPropagation();
+    this.profileMenu()?.toggle(event);
+  }
+
+  protected closeProfileMenu(): void {
+    this.profileMenu()?.hide();
   }
 
   protected onItemSelected(item: LensItem): void {

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -184,28 +184,6 @@ export class SidebarNavService {
         },
       ],
     },
-    {
-      label: 'My Account',
-      isSection: true,
-      expanded: true,
-      items: [
-        {
-          label: 'Profile',
-          icon: 'fa-light fa-user',
-          routerLink: '/profile',
-        },
-        {
-          label: 'Settings',
-          icon: 'fa-light fa-gear',
-          routerLink: '/profile/settings',
-        },
-        {
-          label: 'Transactions',
-          icon: 'fa-light fa-receipt',
-          routerLink: '/profile/transactions',
-        },
-      ],
-    },
   ];
 
   // Whether the currently selected foundation has project-level data in Snowflake.

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -43,23 +43,28 @@ A user can carry both board and project roles simultaneously. In the sidebar len
 
 **Identical for all personas.** Static items — no runtime persona conditions.
 
-| Section       | Item                      | Route                   |
-| ------------- | ------------------------- | ----------------------- |
-| _(top-level)_ | My Dashboard              | `/`                     |
-| My Engagement | My Meetings               | `/meetings`             |
-|               | My Events                 | `/events`               |
-|               | My Committees             | `/groups`               |
-|               | My Mailing Lists          | `/mailing-lists`        |
-|               | My Votes                  | `/votes`                |
-|               | My Surveys                | `/surveys`              |
-|               | My Documents              | `/documents`            |
-| My Growth     | Training & Certifications | `/me/training`          |
-|               | Mentorships               | _(external link)_       |
-|               | Crowdfunding              | _(external link)_       |
-|               | Badges                    | `/badges`               |
-| My Account    | Profile                   | `/profile`              |
-|               | Settings                  | `/profile/settings`     |
-|               | Transactions              | `/profile/transactions` |
+| Section           | Item                          | Route                            |
+| ----------------- | ----------------------------- | -------------------------------- |
+| _(top-level)_     | My Dashboard                  | `/`                              |
+| My Engagement     | My Meetings                   | `/meetings`                      |
+|                   | My Events                     | `/events`                        |
+|                   | My Committees                 | `/groups`                        |
+|                   | My Mailing Lists              | `/mailing-lists`                 |
+|                   | My Votes                      | `/votes`                         |
+|                   | My Surveys                    | `/surveys`                       |
+|                   | My Documents                  | `/documents`                     |
+| My Growth         | Training & Certifications     | `/me/training`                   |
+|                   | Mentorships                   | _(external link)_                |
+|                   | Crowdfunding                  | _(external link)_                |
+|                   | Badges                        | `/badges`                        |
+| Profile & Account | Profile & Account (user card) | `/profile`                       |
+|                   | Work history & Affiliations   | `/profile/attributions`          |
+|                   | Identities                    | `/profile/identities`            |
+|                   | Individual Enrollment         | `/profile/individual-enrollment` |
+|                   | Transactions                  | `/profile/transactions`          |
+|                   | Settings                      | `/profile/settings`              |
+
+> **Profile & Account** is not a nav section: it is the sidebar user card (the card links to `/profile`) with a trailing `⋯` overflow menu that exposes the profile tabs above. The lens-switcher dock avatar menu also links to Profile & Account (`/profile`) and Settings (`/profile/settings`).
 
 ---
 


### PR DESCRIPTION
## Summary

- Sidebar me-lens user card: relabel to **Profile & Account**, make the whole
  card a link to `/profile` (stretched-link so the persona badges + overflow
  button keep their own click/focus behaviour), enlarge the avatar to a rounded
  (non-circle) 48px, anchor the persona badges to the avatar's bottom-right with
  role tooltips, and add a trailing `⋯` button opening a popover of the five
  profile tabs (`PROFILE_TABS`) linking to `/profile/<tab>`.
- Remove the now-redundant "My Account" section from the me-lens sidebar nav.
- Dock avatar menu: replace "My profile" with **Profile & Account**
  (`fa-circle-user`) and add a **Settings** entry linking to `/profile/settings`.

Jira: LFXV2-2741
