### PR TITLE
fix(crowdfunding): add project fund type instead of general fund fallback

### DIFF
--- a/packages/shared/src/constants/crowdfunding.constants.ts
+++ b/packages/shared/src/constants/crowdfunding.constants.ts
@@ -21,6 +21,7 @@ import type {
 
 export const CROWDFUNDING_FUND_TYPE_LABELS: Record<FundType, string> = {
   [FundType.GENERAL_FUND]: 'General Fund',
+  [FundType.PROJECT]: 'Project',
   [FundType.SECURITY_AUDIT]: 'Security Audit',
   [FundType.MENTORSHIP]: 'Mentorship',
   [FundType.EVENT]: 'Event',
@@ -28,6 +29,7 @@ export const CROWDFUNDING_FUND_TYPE_LABELS: Record<FundType, string> = {
 
 export const CROWDFUNDING_FUND_TYPE_ICONS: Record<FundType, string> = {
   [FundType.GENERAL_FUND]: 'fa-light fa-piggy-bank',
+  [FundType.PROJECT]: 'fa-light fa-diagram-project',
   [FundType.SECURITY_AUDIT]: 'fa-light fa-shield-halved',
   [FundType.MENTORSHIP]: 'fa-light fa-user-group',
   [FundType.EVENT]: 'fa-light fa-calendar',
@@ -35,6 +37,7 @@ export const CROWDFUNDING_FUND_TYPE_ICONS: Record<FundType, string> = {
 
 export const CROWDFUNDING_FUND_TYPE_COLOR_CLASSES: Record<FundType, string> = {
   [FundType.GENERAL_FUND]: 'text-violet-600',
+  [FundType.PROJECT]: 'text-indigo-600',
   [FundType.SECURITY_AUDIT]: 'text-amber-600',
   [FundType.MENTORSHIP]: 'text-emerald-600',
   [FundType.EVENT]: 'text-blue-600',
@@ -42,6 +45,7 @@ export const CROWDFUNDING_FUND_TYPE_COLOR_CLASSES: Record<FundType, string> = {
 
 export const CROWDFUNDING_FUND_TYPE_AVATAR_CLASSES: Record<FundType, string> = {
   [FundType.GENERAL_FUND]: 'rounded-xl bg-violet-100 !text-violet-700',
+  [FundType.PROJECT]: 'rounded-xl bg-indigo-100 !text-indigo-700',
   [FundType.SECURITY_AUDIT]: 'rounded-xl bg-amber-100 !text-amber-700',
   [FundType.MENTORSHIP]: 'rounded-xl bg-emerald-100 !text-emerald-700',
   [FundType.EVENT]: 'rounded-xl bg-blue-100 !text-blue-700',

--- a/packages/shared/src/enums/crowdfunding.enum.ts
+++ b/packages/shared/src/enums/crowdfunding.enum.ts
@@ -3,6 +3,7 @@
 
 export enum FundType {
   GENERAL_FUND = 'general_fund',
+  PROJECT = 'project',
   SECURITY_AUDIT = 'security_audit',
   MENTORSHIP = 'mentorship',
   EVENT = 'event',


### PR DESCRIPTION
## Summary

- Initiatives with upstream `initiative_type: "project"` were displaying as "General Fund" in the initiatives list and detail views
- `FundType` only defined `general_fund`, `security_audit`, `mentorship`, `event`, so the mapper's fallback (`toValidFundType`) silently coerced the unrecognized `"project"` value to `general_fund`
- Added `FundType.PROJECT` as a real enum member with its own label ("Project"), icon, color, and avatar classes — no fallback coercion needed, and no other code changes required since the mapper and display components already read off the shared `FundType` maps

## Notes

- No JIRA ticket — bug was found visually, no ticket exists for this