### PR TITLE
feat(campaigns): rework ad channels and campaign selection flow

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -16,26 +16,25 @@
 
     <!-- Program & Delivery-Type Selectors -->
     <div class="flex items-center gap-3" data-testid="campaigns-selectors">
-      <select
-        class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        [value]="selectedProgramType()"
-        (change)="onProgramTypeChange($event)"
-        aria-label="Campaign program type"
-        data-testid="campaigns-program-select">
-        @for (pt of programTypes; track pt.id) {
-          <option [value]="pt.id">{{ pt.label }}</option>
-        }
-      </select>
-      <select
-        class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        [value]="selectedDeliveryType()"
-        (change)="onDeliveryTypeChange($event)"
-        aria-label="Campaign delivery type"
-        data-testid="campaigns-delivery-select">
-        @for (dt of deliveryTypes; track dt.id) {
-          <option [value]="dt.id" [disabled]="dt.disabled">{{ dt.label }}</option>
-        }
-      </select>
+      <lfx-select
+        [form]="selectorForm"
+        control="programType"
+        [options]="programTypeOptions"
+        optionLabel="label"
+        optionValue="id"
+        size="small"
+        ariaLabel="Campaign program type"
+        data-testid="campaigns-program-select" />
+      <lfx-select
+        [form]="selectorForm"
+        control="deliveryType"
+        [options]="deliveryTypeOptions"
+        optionLabel="label"
+        optionValue="id"
+        optionDisabled="disabled"
+        size="small"
+        ariaLabel="Campaign delivery type"
+        data-testid="campaigns-delivery-select" />
     </div>
   </div>
 
@@ -48,17 +47,8 @@
       data-testid="campaigns-email-placeholder">
       <i class="fa-light fa-envelope text-3xl text-gray-400" aria-hidden="true"></i>
       <h2 class="text-base font-semibold text-gray-900">Email campaigns are coming soon</h2>
-      <p class="max-w-md text-sm text-gray-500">
-        The Email delivery channel is under active development. Switch to
-        <button
-          type="button"
-          class="font-medium text-blue-600 hover:text-blue-700 hover:underline"
-          (click)="selectedDeliveryType.set('paid-marketing')"
-          data-testid="campaigns-email-switch-paid">
-          Paid Marketing
-        </button>
-        to plan and launch a campaign now.
-      </p>
+      <p class="max-w-md text-sm text-gray-500">The Email delivery channel is under active development.</p>
+      <lfx-button label="Switch to Paid Marketing" [link]="true" size="small" (onClick)="switchToPaidMarketing()" data-testid="campaigns-email-switch-paid" />
     </div>
   } @else {
     <!-- Tab Navigation -->

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -51,11 +51,14 @@
       <lfx-button label="Switch to Paid Marketing" [link]="true" size="small" (onClick)="switchToPaidMarketing()" data-testid="campaigns-email-switch-paid" />
     </div>
   }
-  <!-- Paid-marketing content stays MOUNTED (toggled via [hidden], not a structural @if)
+  <!-- Paid-marketing content stays MOUNTED (visibility-toggled, not a structural @if)
        while the Email placeholder shows. PlanningTabComponent owns the brief form +
        generation state locally, so destroying this subtree on an Email round-trip would
-       silently wipe the user's in-progress brief — hidden keeps the instance alive. -->
-  <div class="flex flex-col gap-6" [hidden]="selectedDeliveryType() === 'email'" data-testid="campaigns-paid-marketing">
+       silently wipe the user's in-progress brief — hiding it keeps the instance alive.
+       Uses an inline [style.display] rather than [hidden]: the `flex` utility sets
+       display:flex, which overrides Preflight's `[hidden]{display:none}` in the cascade,
+       so [hidden] alone would leave both views rendered. An inline style always wins. -->
+  <div class="flex flex-col gap-6" [style.display]="selectedDeliveryType() === 'email' ? 'none' : null" data-testid="campaigns-paid-marketing">
     <!-- Tab Navigation -->
     <div class="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Campaign tabs" data-testid="campaigns-tab-nav">
       @for (tab of tabs; track tab.id; let i = $index) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -50,7 +50,12 @@
       <p class="max-w-md text-sm text-gray-500">The Email delivery channel is under active development.</p>
       <lfx-button label="Switch to Paid Marketing" [link]="true" size="small" (onClick)="switchToPaidMarketing()" data-testid="campaigns-email-switch-paid" />
     </div>
-  } @else {
+  }
+  <!-- Paid-marketing content stays MOUNTED (toggled via [hidden], not a structural @if)
+       while the Email placeholder shows. PlanningTabComponent owns the brief form +
+       generation state locally, so destroying this subtree on an Email round-trip would
+       silently wipe the user's in-progress brief — hidden keeps the instance alive. -->
+  <div class="flex flex-col gap-6" [hidden]="selectedDeliveryType() === 'email'" data-testid="campaigns-paid-marketing">
     <!-- Tab Navigation -->
     <div class="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Campaign tabs" data-testid="campaigns-tab-nav">
       @for (tab of tabs; track tab.id; let i = $index) {
@@ -101,5 +106,5 @@
         </div>
       }
     }
-  }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -87,10 +87,16 @@
     @switch (selectedTab()) {
       @case ('planning') {
         <div role="tabpanel" id="panel-planning" aria-labelledby="tab-planning" data-testid="campaigns-planning-panel">
-          <lfx-planning-tab
-            [programTypeConfig]="activeProgramTypeConfig()"
-            (proceedToImplementation)="onProceedToImplementation($event)"
-            data-testid="campaigns-planning-tab" />
+          <!-- Keyed on the program type so a program change (Events <-> Education)
+               recreates PlanningTabComponent — it owns its brief/URL/copy/refinement
+               state locally and does not reset on input change, so without a fresh
+               instance a stale Events brief could show under Education. -->
+          @for (program of [selectedProgramType()]; track program) {
+            <lfx-planning-tab
+              [programTypeConfig]="activeProgramTypeConfig()"
+              (proceedToImplementation)="onProceedToImplementation($event)"
+              data-testid="campaigns-planning-tab" />
+          }
         </div>
       }
       @case ('implementation') {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -4,33 +4,36 @@
 <div class="flex flex-col gap-6 p-6" data-testid="campaigns-page">
   <!-- Header -->
   <div class="flex flex-col gap-3">
-    <h1 class="sr-only">{{ activeProgramTypeConfig().breadcrumbLabel }}</h1>
-    <!-- Breadcrumb -->
+    <h1 class="sr-only">{{ activeProgramTypeConfig().breadcrumbLabel }} — {{ activeDeliveryTypeConfig().breadcrumbLabel }}</h1>
+    <!-- Breadcrumb: Campaigns > {program} > {delivery type} -->
     <nav class="flex items-center gap-2 text-sm" aria-label="Breadcrumb" data-testid="campaigns-breadcrumb">
       <span class="text-gray-400">Campaigns</span>
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
-      <span class="text-gray-400">Paid Performance</span>
+      <span class="text-gray-400">{{ activeProgramTypeConfig().breadcrumbLabel }}</span>
       <i class="fa-solid fa-chevron-right text-[10px] text-gray-300" aria-hidden="true"></i>
-      <span class="font-semibold text-gray-900" aria-current="page">{{ activeProgramTypeConfig().breadcrumbLabel }}</span>
+      <span class="font-semibold text-gray-900" aria-current="page">{{ activeDeliveryTypeConfig().breadcrumbLabel }}</span>
     </nav>
 
-    <!-- Platform & Use Case Selectors -->
+    <!-- Program & Delivery-Type Selectors -->
     <div class="flex items-center gap-3" data-testid="campaigns-selectors">
-      <select
-        class="cursor-default rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600"
-        disabled
-        aria-label="Campaign platform"
-        data-testid="campaigns-platform-select">
-        <option>Paid Performance</option>
-      </select>
       <select
         class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         [value]="selectedProgramType()"
         (change)="onProgramTypeChange($event)"
         aria-label="Campaign program type"
-        data-testid="campaigns-usecase-select">
+        data-testid="campaigns-program-select">
         @for (pt of programTypes; track pt.id) {
           <option [value]="pt.id">{{ pt.label }}</option>
+        }
+      </select>
+      <select
+        class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        [value]="selectedDeliveryType()"
+        (change)="onDeliveryTypeChange($event)"
+        aria-label="Campaign delivery type"
+        data-testid="campaigns-delivery-select">
+        @for (dt of deliveryTypes; track dt.id) {
+          <option [value]="dt.id" [disabled]="dt.disabled">{{ dt.label }}</option>
         }
       </select>
     </div>
@@ -38,54 +41,75 @@
 
   <hr class="border-gray-200" />
 
-  <!-- Tab Navigation -->
-  <div class="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Campaign tabs" data-testid="campaigns-tab-nav">
-    @for (tab of tabs; track tab.id; let i = $index) {
-      <button
-        type="button"
-        role="tab"
-        [attr.aria-selected]="selectedTab() === tab.id"
-        [attr.aria-controls]="selectedTab() === tab.id ? 'panel-' + tab.id : null"
-        [attr.id]="'tab-' + tab.id"
-        [attr.tabindex]="selectedTab() === tab.id ? 0 : -1"
-        (click)="selectTab(tab.id)"
-        (keydown)="onTabKeydown($event, i)"
-        [class]="
-          selectedTab() === tab.id
-            ? 'flex items-center gap-2 rounded-md bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm'
-            : 'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700'
-        "
-        [attr.data-testid]="'campaigns-' + tab.id + '-tab'">
-        <i [class]="tab.icon" aria-hidden="true"></i>
-        {{ tab.label }}
-      </button>
-    }
-  </div>
+  @if (selectedDeliveryType() === 'email') {
+    <!-- Email delivery is under active development — placeholder until it ships. -->
+    <div
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-6 py-16 text-center"
+      data-testid="campaigns-email-placeholder">
+      <i class="fa-light fa-envelope text-3xl text-gray-400" aria-hidden="true"></i>
+      <h2 class="text-base font-semibold text-gray-900">Email campaigns are coming soon</h2>
+      <p class="max-w-md text-sm text-gray-500">
+        The Email delivery channel is under active development. Switch to
+        <button
+          type="button"
+          class="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+          (click)="selectedDeliveryType.set('paid-marketing')"
+          data-testid="campaigns-email-switch-paid">
+          Paid Marketing
+        </button>
+        to plan and launch a campaign now.
+      </p>
+    </div>
+  } @else {
+    <!-- Tab Navigation -->
+    <div class="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Campaign tabs" data-testid="campaigns-tab-nav">
+      @for (tab of tabs; track tab.id; let i = $index) {
+        <button
+          type="button"
+          role="tab"
+          [attr.aria-selected]="selectedTab() === tab.id"
+          [attr.aria-controls]="selectedTab() === tab.id ? 'panel-' + tab.id : null"
+          [attr.id]="'tab-' + tab.id"
+          [attr.tabindex]="selectedTab() === tab.id ? 0 : -1"
+          (click)="selectTab(tab.id)"
+          (keydown)="onTabKeydown($event, i)"
+          [class]="
+            selectedTab() === tab.id
+              ? 'flex items-center gap-2 rounded-md bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm'
+              : 'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700'
+          "
+          [attr.data-testid]="'campaigns-' + tab.id + '-tab'">
+          <i [class]="tab.icon" aria-hidden="true"></i>
+          {{ tab.label }}
+        </button>
+      }
+    </div>
 
-  <!-- Tab Content -->
-  @switch (selectedTab()) {
-    @case ('planning') {
-      <div role="tabpanel" id="panel-planning" aria-labelledby="tab-planning" data-testid="campaigns-planning-panel">
-        <lfx-planning-tab
-          [programTypeConfig]="activeProgramTypeConfig()"
-          (proceedToImplementation)="onProceedToImplementation($event)"
-          data-testid="campaigns-planning-tab" />
-      </div>
-    }
-    @case ('implementation') {
-      <div role="tabpanel" id="panel-implementation" aria-labelledby="tab-implementation" data-testid="campaigns-implementation-panel">
-        <lfx-implementation-tab [briefData]="briefOutput()" data-testid="campaigns-implementation-tab" />
-      </div>
-    }
-    @case ('insights') {
-      <div role="tabpanel" id="panel-insights" aria-labelledby="tab-insights" data-testid="campaigns-insights-panel">
-        <lfx-monitoring-tab data-testid="campaigns-insights-tab" />
-      </div>
-    }
-    @case ('optimization') {
-      <div role="tabpanel" id="panel-optimization" aria-labelledby="tab-optimization" data-testid="campaigns-optimization-panel">
-        <lfx-optimization-tab data-testid="campaigns-optimization-tab" />
-      </div>
+    <!-- Tab Content -->
+    @switch (selectedTab()) {
+      @case ('planning') {
+        <div role="tabpanel" id="panel-planning" aria-labelledby="tab-planning" data-testid="campaigns-planning-panel">
+          <lfx-planning-tab
+            [programTypeConfig]="activeProgramTypeConfig()"
+            (proceedToImplementation)="onProceedToImplementation($event)"
+            data-testid="campaigns-planning-tab" />
+        </div>
+      }
+      @case ('implementation') {
+        <div role="tabpanel" id="panel-implementation" aria-labelledby="tab-implementation" data-testid="campaigns-implementation-panel">
+          <lfx-implementation-tab [briefData]="briefOutput()" data-testid="campaigns-implementation-tab" />
+        </div>
+      }
+      @case ('insights') {
+        <div role="tabpanel" id="panel-insights" aria-labelledby="tab-insights" data-testid="campaigns-insights-panel">
+          <lfx-monitoring-tab data-testid="campaigns-insights-tab" />
+        </div>
+      }
+      @case ('optimization') {
+        <div role="tabpanel" id="panel-optimization" aria-labelledby="tab-optimization" data-testid="campaigns-optimization-panel">
+          <lfx-optimization-tab data-testid="campaigns-optimization-tab" />
+        </div>
+      }
     }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -48,7 +48,7 @@
       <i class="fa-light fa-envelope text-3xl text-gray-400" aria-hidden="true"></i>
       <h2 class="text-base font-semibold text-gray-900">Email campaigns are coming soon</h2>
       <p class="max-w-md text-sm text-gray-500">The Email delivery channel is under active development.</p>
-      <lfx-button label="Switch to Paid Marketing" [link]="true" size="small" (onClick)="switchToPaidMarketing()" data-testid="campaigns-email-switch-paid" />
+      <lfx-button label="Switch to Paid Marketing" [text]="true" size="small" (onClick)="switchToPaidMarketing()" data-testid="campaigns-email-switch-paid" />
     </div>
   }
   <!-- Paid-marketing content stays MOUNTED (visibility-toggled, not a structural @if)

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -67,15 +67,18 @@ export class CampaignsComponent {
       this.resetToPlanning();
     });
 
-    // Mirror the delivery-type control into the signal. Do NOT discard the brief here:
-    // Email is a placeholder ("coming soon"), so switching to it and back must preserve
-    // any in-progress Paid Marketing brief rather than silently wiping the user's work.
+    // Mirror the delivery-type control into the signal. Preserve ALL in-progress
+    // Paid Marketing state across an Email round-trip: Email is a "coming soon"
+    // placeholder, and the paid-marketing container stays mounted via [hidden], so we
+    // must NOT touch briefOutput OR selectedTab. Resetting selectedTab here would swap
+    // the inner @switch and destroy the currently-mounted tab component (e.g.
+    // ImplementationTabComponent with its own form/budget/creation state); leaving it
+    // alone means returning to Paid Marketing restores the same tab and its state.
     this.selectorForm.controls.deliveryType.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
       if (value === this.selectedDeliveryType()) {
         return;
       }
       this.selectedDeliveryType.set(value);
-      this.selectedTab.set('planning');
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -3,10 +3,14 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS } from '@lfx-one/shared/constants';
 import type { CampaignBriefOutput, CampaignDeliveryType, CampaignProgramType, CampaignTab } from '@lfx-one/shared/interfaces';
 
+import { ButtonComponent } from '../../../shared/components/button/button.component';
+import { SelectComponent } from '../../../shared/components/select/select.component';
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
 import { MonitoringTabComponent } from './components/monitoring-tab/monitoring-tab.component';
 import { OptimizationTabComponent } from './components/optimization-tab/optimization-tab.component';
@@ -14,7 +18,15 @@ import { PlanningTabComponent } from './components/planning-tab/planning-tab.com
 
 @Component({
   selector: 'lfx-campaigns',
-  imports: [PlanningTabComponent, ImplementationTabComponent, MonitoringTabComponent, OptimizationTabComponent],
+  imports: [
+    ReactiveFormsModule,
+    SelectComponent,
+    ButtonComponent,
+    PlanningTabComponent,
+    ImplementationTabComponent,
+    MonitoringTabComponent,
+    OptimizationTabComponent,
+  ],
   templateUrl: './campaigns.component.html',
   styleUrl: './campaigns.component.scss',
 })
@@ -24,6 +36,18 @@ export class CampaignsComponent {
   protected readonly tabs = CAMPAIGN_TABS;
   protected readonly programTypes = CAMPAIGN_PROGRAM_TYPES;
   protected readonly deliveryTypes = CAMPAIGN_DELIVERY_TYPES;
+  // lfx-select's `options` input is typed as a mutable `any[]`, so pass a shallow
+  // mutable copy of the readonly constants rather than the `readonly` arrays directly.
+  protected readonly programTypeOptions = [...CAMPAIGN_PROGRAM_TYPES];
+  protected readonly deliveryTypeOptions = [...CAMPAIGN_DELIVERY_TYPES];
+
+  // The two selectors are reactive-form controls so they can bind to the lfx-select
+  // wrapper (form-driven). nonNullable keeps the value typed to the union, never `| null`.
+  protected readonly selectorForm = new FormGroup({
+    programType: new FormControl<CampaignProgramType>('events', { nonNullable: true }),
+    deliveryType: new FormControl<CampaignDeliveryType>('paid-marketing', { nonNullable: true }),
+  });
+
   protected readonly selectedTab = signal<CampaignTab>('planning');
   protected readonly selectedProgramType = signal<CampaignProgramType>('events');
   protected readonly selectedDeliveryType = signal<CampaignDeliveryType>('paid-marketing');
@@ -31,6 +55,29 @@ export class CampaignsComponent {
 
   protected readonly activeProgramTypeConfig = computed(() => this.programTypes.find((pt) => pt.id === this.selectedProgramType()) ?? this.programTypes[0]);
   protected readonly activeDeliveryTypeConfig = computed(() => this.deliveryTypes.find((dt) => dt.id === this.selectedDeliveryType()) ?? this.deliveryTypes[0]);
+
+  constructor() {
+    // Mirror the program control into the signal. A program switch changes the whole
+    // brief context (URL scrape, copy), so it resets the brief + returns to planning.
+    this.selectorForm.controls.programType.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      if (value === this.selectedProgramType()) {
+        return;
+      }
+      this.selectedProgramType.set(value);
+      this.resetToPlanning();
+    });
+
+    // Mirror the delivery-type control into the signal. Do NOT discard the brief here:
+    // Email is a placeholder ("coming soon"), so switching to it and back must preserve
+    // any in-progress Paid Marketing brief rather than silently wiping the user's work.
+    this.selectorForm.controls.deliveryType.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      if (value === this.selectedDeliveryType()) {
+        return;
+      }
+      this.selectedDeliveryType.set(value);
+      this.selectedTab.set('planning');
+    });
+  }
 
   protected selectTab(tab: CampaignTab): void {
     this.selectedTab.set(tab);
@@ -59,26 +106,17 @@ export class CampaignsComponent {
     }
   }
 
-  protected onProgramTypeChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    if (this.programTypes.some((pt) => pt.id === value)) {
-      this.selectedProgramType.set(value as CampaignProgramType);
-      this.briefOutput.set(null);
-      this.selectedTab.set('planning');
-    }
-  }
-
-  protected onDeliveryTypeChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    if (this.deliveryTypes.some((dt) => dt.id === value && !dt.disabled)) {
-      this.selectedDeliveryType.set(value as CampaignDeliveryType);
-      this.briefOutput.set(null);
-      this.selectedTab.set('planning');
-    }
+  protected switchToPaidMarketing(): void {
+    this.selectorForm.controls.deliveryType.setValue('paid-marketing');
   }
 
   protected onProceedToImplementation(brief: CampaignBriefOutput): void {
     this.briefOutput.set(brief);
     this.selectedTab.set('implementation');
+  }
+
+  private resetToPlanning(): void {
+    this.briefOutput.set(null);
+    this.selectedTab.set('planning');
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -69,11 +69,13 @@ export class CampaignsComponent {
 
     // Mirror the delivery-type control into the signal. Preserve ALL in-progress
     // Paid Marketing state across an Email round-trip: Email is a "coming soon"
-    // placeholder, and the paid-marketing container stays mounted via [hidden], so we
-    // must NOT touch briefOutput OR selectedTab. Resetting selectedTab here would swap
-    // the inner @switch and destroy the currently-mounted tab component (e.g.
-    // ImplementationTabComponent with its own form/budget/creation state); leaving it
-    // alone means returning to Paid Marketing restores the same tab and its state.
+    // placeholder, and the paid-marketing container stays mounted (hidden via an inline
+    // [style.display] binding, which wins the cascade over the `flex` utility that
+    // otherwise overrides [hidden]), so we must NOT touch briefOutput OR selectedTab.
+    // Resetting selectedTab here would swap the inner @switch and destroy the
+    // currently-mounted tab component (e.g. ImplementationTabComponent with its own
+    // form/budget/creation state); leaving it alone means returning to Paid Marketing
+    // restores the same tab and its state.
     this.selectorForm.controls.deliveryType.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
       if (value === this.selectedDeliveryType()) {
         return;

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -4,8 +4,8 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID, signal } from '@angular/core';
 
-import { CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS } from '@lfx-one/shared/constants';
-import type { CampaignBriefOutput, CampaignProgramType, CampaignTab } from '@lfx-one/shared/interfaces';
+import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS } from '@lfx-one/shared/constants';
+import type { CampaignBriefOutput, CampaignDeliveryType, CampaignProgramType, CampaignTab } from '@lfx-one/shared/interfaces';
 
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
 import { MonitoringTabComponent } from './components/monitoring-tab/monitoring-tab.component';
@@ -23,11 +23,14 @@ export class CampaignsComponent {
 
   protected readonly tabs = CAMPAIGN_TABS;
   protected readonly programTypes = CAMPAIGN_PROGRAM_TYPES;
+  protected readonly deliveryTypes = CAMPAIGN_DELIVERY_TYPES;
   protected readonly selectedTab = signal<CampaignTab>('planning');
   protected readonly selectedProgramType = signal<CampaignProgramType>('events');
+  protected readonly selectedDeliveryType = signal<CampaignDeliveryType>('paid-marketing');
   protected readonly briefOutput = signal<CampaignBriefOutput | null>(null);
 
   protected readonly activeProgramTypeConfig = computed(() => this.programTypes.find((pt) => pt.id === this.selectedProgramType()) ?? this.programTypes[0]);
+  protected readonly activeDeliveryTypeConfig = computed(() => this.deliveryTypes.find((dt) => dt.id === this.selectedDeliveryType()) ?? this.deliveryTypes[0]);
 
   protected selectTab(tab: CampaignTab): void {
     this.selectedTab.set(tab);
@@ -60,6 +63,15 @@ export class CampaignsComponent {
     const value = (event.target as HTMLSelectElement).value;
     if (this.programTypes.some((pt) => pt.id === value)) {
       this.selectedProgramType.set(value as CampaignProgramType);
+      this.briefOutput.set(null);
+      this.selectedTab.set('planning');
+    }
+  }
+
+  protected onDeliveryTypeChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    if (this.deliveryTypes.some((dt) => dt.id === value && !dt.disabled)) {
+      this.selectedDeliveryType.set(value as CampaignDeliveryType);
       this.briefOutput.set(null);
       this.selectedTab.set('planning');
     }

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -32,8 +32,6 @@ export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'linkedin-ads', label: 'LinkedIn Ads', icon: 'fa-brands fa-linkedin' },
   { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta' },
   { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit' },
-  { id: 'brave-ads', label: 'Brave Ads', icon: 'fa-light fa-shield', disabled: true },
-  { id: 'feathr', label: 'Feathr', icon: 'fa-light fa-bullseye-arrow', disabled: true },
   { id: 'twitter-ads', label: 'X / Twitter Ads', icon: 'fa-brands fa-x-twitter', disabled: true },
 ] as const;
 
@@ -93,8 +91,6 @@ export const PLATFORM_BRAND_COLORS: Readonly<Record<CampaignPlatform, string>> =
   'reddit-ads': '#FF4500',
   'meta-ads': '#1877F2',
   'microsoft-ads': '#00A4EF',
-  'brave-ads': '#FB542B',
-  feathr: '#6366F1',
   'twitter-ads': '#000000',
 };
 

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  CampaignDeliveryTypeOption,
   CampaignGoalOption,
   CampaignPlatform,
   CampaignPlatformOption,
@@ -33,6 +34,15 @@ export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [
   { id: 'meta-ads', label: 'Meta Ads', icon: 'fa-brands fa-meta' },
   { id: 'reddit-ads', label: 'Reddit Ads', icon: 'fa-brands fa-reddit' },
   { id: 'twitter-ads', label: 'X / Twitter Ads', icon: 'fa-brands fa-x-twitter', disabled: true },
+] as const;
+
+/**
+ * Delivery types — the second campaign selector (after the program type). Both are
+ * selectable; the Email channel is under active parallel development.
+ */
+export const CAMPAIGN_DELIVERY_TYPES: readonly CampaignDeliveryTypeOption[] = [
+  { id: 'paid-marketing', label: 'Paid Marketing', breadcrumbLabel: 'Paid Marketing' },
+  { id: 'email', label: 'Email', breadcrumbLabel: 'Email' },
 ] as const;
 
 export const CAMPAIGN_PROGRAM_TYPES: readonly CampaignProgramTypeOption[] = [

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -28,6 +28,9 @@ export type CampaignGoal = 'conversions' | 'brand-awareness' | 'traffic' | 'lead
 
 export type CampaignProgramType = 'events' | 'education';
 
+/** How a campaign reaches its audience — the second selector after the program type. */
+export type CampaignDeliveryType = 'paid-marketing' | 'email';
+
 export type RedditObjective = 'awareness' | 'traffic' | 'conversions' | 'video_views';
 
 export interface RedditObjectiveParams {
@@ -37,6 +40,14 @@ export interface RedditObjectiveParams {
   readonly bidValue: number;
   readonly optimizationGoal: string;
   readonly viewThroughConversionType?: string;
+}
+
+export interface CampaignDeliveryTypeOption {
+  id: CampaignDeliveryType;
+  label: string;
+  breadcrumbLabel: string;
+  /** Disabled options render but can't be selected (e.g. a channel still in build). */
+  disabled?: boolean;
 }
 
 export interface CampaignProgramTypeOption {

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -5,7 +5,7 @@
 // Platform & Phase
 // ---------------------------------------------------------------------------
 
-export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'brave-ads' | 'feathr' | 'twitter-ads';
+export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'twitter-ads';
 
 export type CampaignPhase = 'planning' | 'implementation' | 'insights' | 'optimization';
 


### PR DESCRIPTION
## Summary

Two related campaigns-page changes (LFXV2-2023):

1. **Remove the Brave Ads and Feathr ad channels** — both were disabled "Coming soon" placeholders in the ad-channel selector. Drops the two `CAMPAIGN_PLATFORMS` entries, their `PLATFORM_BRAND_COLORS` values, and the `'brave-ads'`/`'feathr'` members from the `CampaignPlatform` union.

2. **Restructure the campaign selection flow** into two ordered dropdowns:
   `Campaigns > [Events / Education] > [Paid Marketing / Email]`
   - Program type (Events / Education) is now the **first** selector; the second is a new **delivery-type** selector (Paid Marketing / Email), replacing the disabled "Paid Performance" placeholder. Defaults to **Paid Marketing**.
   - Breadcrumb reflects the new order: `Campaigns > {program} > {delivery}`.
   - Selecting **Email** (under active parallel development) shows a "coming soon" placeholder panel with a shortcut back to Paid Marketing, rather than the paid-marketing tabs.
   - Adds `CampaignDeliveryType` + `CAMPAIGN_DELIVERY_TYPES` to `@lfx-one/shared`.

## Changes
- `packages/shared/src/interfaces/campaign.interface.ts` — shrink `CampaignPlatform` union; add `CampaignDeliveryType` + `CampaignDeliveryTypeOption`.
- `packages/shared/src/constants/campaign.constants.ts` — remove brave/feathr entries + brand colors; add `CAMPAIGN_DELIVERY_TYPES`.
- `apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts` — `selectedDeliveryType` signal + `onDeliveryTypeChange` handler + `activeDeliveryTypeConfig` computed.
- `apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html` — reorder selectors, restructure breadcrumb, gate content on delivery type (Email → placeholder).

## Notes
- Email is intentionally a selectable option with a placeholder view — the Email delivery channel is being built in parallel.
- Verified: `yarn check-types`, `yarn lint:check`, `yarn build` (SSR), and `./check-headers.sh` all pass. Both commits DCO-signed + GPG-signed, rebased on `main`.

## Design decisions (noted for reviewers)
- **"Paid Marketing" label** is a deliberate choice for the campaigns page. The ED/marketing-impact surfaces use "Paid Performance" for the analytics channel taxonomy; here the term names the campaign *delivery type* on the authoring flow. Kept intentionally distinct.
- **Email is selectable, not disabled** — it renders a "coming soon" placeholder (Email is being built in parallel). Switching to Email preserves any in-progress Paid Marketing brief rather than discarding it.
- **Breadcrumb is a custom `<nav>`** (not the PrimeNG `lfx-breadcrumb` wrapper) because it is a static, non-navigational label trail, not a router/MenuItem-driven breadcrumb.
- Selectors use the `lfx-select` design-system wrapper; the switch action uses `lfx-button`.