### PR TITLE
fix(crowdfunding): scope recurring charge history to subscription only

### DIFF
--- a/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/recurring-donation-detail/recurring-donation-detail.component.ts
@@ -111,9 +111,9 @@ export class RecurringDonationDetailComponent {
             startWith(undefined as void),
             scan((page) => page + 1, -1),
             concatMap((page) =>
-              this.crowdfundingService.getInitiativeTransactions(slug, {
+              this.crowdfundingService.getMyInitiativeTransactions(slug, {
                 type: 'donations',
-                kind: 'recurring',
+                subscriptionOnly: true,
                 size: DEFAULT_CROWDFUNDING_PAGE_SIZE,
                 from: page * DEFAULT_CROWDFUNDING_PAGE_SIZE,
               })

--- a/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/app/shared/services/crowdfunding.service.ts
@@ -157,6 +157,21 @@ export class CrowdfundingService {
       .pipe(catchError(this.handleCfError(EMPTY_TRANSACTION_LIST, 'getInitiativeTransactions')));
   }
 
+  public getMyInitiativeTransactions(
+    slug: string,
+    params?: { type?: 'donations' | 'expenses'; size?: number; from?: number; subscriptionOnly?: boolean }
+  ): Observable<CrowdfundingTransactionList> {
+    let httpParams = new HttpParams();
+    if (params?.type) httpParams = httpParams.set('type', params.type);
+    if (params?.size != null) httpParams = httpParams.set('size', String(params.size));
+    if (params?.from != null) httpParams = httpParams.set('from', String(params.from));
+    if (params?.subscriptionOnly) httpParams = httpParams.set('subscriptionOnly', 'true');
+
+    return this.http
+      .get<CrowdfundingTransactionList>(`/api/crowdfunding/initiatives/${encodeURIComponent(slug)}/my-transactions`, { params: httpParams })
+      .pipe(catchError(this.handleCfError(EMPTY_TRANSACTION_LIST, 'getMyInitiativeTransactions')));
+  }
+
   private handleCfError<T>(fallback: T, label: string) {
     return (err: HttpErrorResponse): Observable<T> => {
       if (err.status === 401 && (err.error as Record<string, unknown>)?.['code'] === 'CF_UNAUTHENTICATED') {

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -451,7 +451,10 @@ export class CrowdfundingController {
         throw new AuthenticationError('User authentication required', { operation: 'get_my_initiative_transactions' });
       }
 
-      const { slug } = req.params;
+      const slug = (req.params['slug'] ?? '').trim();
+      if (!slug) {
+        throw ServiceValidationError.forField('slug', 'Initiative slug is required', { operation: 'get_my_initiative_transactions' });
+      }
       const { type, size, from, subscriptionOnly } = req.query;
 
       const ALLOWED_TYPES = ['donations', 'expenses'] as const;

--- a/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
+++ b/apps/lfx-one/src/server/controllers/crowdfunding.controller.ts
@@ -442,6 +442,49 @@ export class CrowdfundingController {
     }
   }
 
+  /** GET /api/crowdfunding/initiatives/:slug/my-transactions — paginated list of the caller's own contributions to the initiative. */
+  public async getMyInitiativeTransactions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_my_initiative_transactions');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_my_initiative_transactions' });
+      }
+
+      const { slug } = req.params;
+      const { type, size, from, subscriptionOnly } = req.query;
+
+      const ALLOWED_TYPES = ['donations', 'expenses'] as const;
+      type AllowedType = (typeof ALLOWED_TYPES)[number];
+
+      const resolvedType = type ? String(type) : undefined;
+      if (resolvedType !== undefined && !ALLOWED_TYPES.includes(resolvedType as AllowedType)) {
+        res.status(400).json({ message: `Invalid type '${resolvedType}'. Allowed values: ${ALLOWED_TYPES.join(', ')}` });
+        return;
+      }
+
+      const transactions = await this.crowdfundingService.getMyInitiativeTransactions(
+        req,
+        slug,
+        resolvedType as AllowedType | undefined,
+        parseNonNegativeInt(size),
+        parseNonNegativeInt(from),
+        subscriptionOnly === 'true'
+      );
+
+      if (!transactions) {
+        res.status(404).json({ message: `Initiative '${slug}' not found` });
+        return;
+      }
+
+      logger.success(req, 'get_my_initiative_transactions', startTime, { slug, total: transactions.totalCount });
+
+      res.json(transactions);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   /** GET /api/crowdfunding/initiatives/:id/announcements — list announcements for an initiative. */
   public async getAnnouncements(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_announcements');

--- a/apps/lfx-one/src/server/routes/crowdfunding.route.ts
+++ b/apps/lfx-one/src/server/routes/crowdfunding.route.ts
@@ -28,6 +28,7 @@ router.post('/initiatives/:id/announcements', (req, res, next) => crowdfundingCo
 router.put('/initiatives/:id/announcements/:announcementId', (req, res, next) => crowdfundingController.updateAnnouncement(req, res, next));
 router.delete('/initiatives/:id/announcements/:announcementId', (req, res, next) => crowdfundingController.deleteAnnouncement(req, res, next));
 router.get('/initiatives/:slug/transactions', (req, res, next) => crowdfundingController.getInitiativeTransactions(req, res, next));
+router.get('/initiatives/:slug/my-transactions', (req, res, next) => crowdfundingController.getMyInitiativeTransactions(req, res, next));
 router.patch('/initiatives/:id', (req, res, next) => crowdfundingController.updateInitiative(req, res, next));
 router.get('/initiatives/:slug', (req, res, next) => crowdfundingController.getInitiativeBySlug(req, res, next));
 

--- a/apps/lfx-one/src/server/services/crowdfunding.service.ts
+++ b/apps/lfx-one/src/server/services/crowdfunding.service.ts
@@ -435,4 +435,44 @@ export class CrowdfundingService {
       size: raw.size,
     };
   }
+
+  public async getMyInitiativeTransactions(
+    req: Request,
+    slug: string,
+    type?: 'donations' | 'expenses',
+    size?: number,
+    from?: number,
+    subscriptionOnly?: boolean
+  ): Promise<CrowdfundingTransactionList | null> {
+    const startTime = logger.startOperation(req, 'cf_get_my_initiative_transactions', { slug, type, size, from, subscriptionOnly });
+
+    const params = new URLSearchParams();
+    if (type) params.set('type', type);
+    if (size != null) params.set('limit', String(size));
+    if (from != null) params.set('offset', String(from));
+    if (subscriptionOnly) params.set('subscriptionOnly', 'true');
+    const qs = params.toString();
+
+    // /v1/me/initiatives/{slug}/my-transactions — donor-scoped endpoint; returns the
+    // authenticated caller's own contributions to the (published) initiative, regardless
+    // of who owns it. Unlike the owner-scoped /transactions endpoint, this works for any donor.
+    const raw = await cfFetchNullable<BackendTransactionList>(
+      req,
+      'getMyInitiativeTransactions',
+      `/v1/me/initiatives/${encodeURIComponent(slug)}/my-transactions${qs ? `?${qs}` : ''}`
+    );
+    if (!raw) {
+      logger.warning(req, 'cf_get_my_initiative_transactions', 'Initiative not found', { slug });
+      return null;
+    }
+
+    logger.success(req, 'cf_get_my_initiative_transactions', startTime, { total: raw.total_count });
+
+    return {
+      data: raw.data.map(mapToTransaction),
+      totalCount: raw.total_count,
+      from: raw.from,
+      size: raw.size,
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- The recurring donation detail page's charge history was showing all of the caller's donations to an initiative instead of just the charges belonging to the specific recurring subscription being viewed.
- Adds a `subscriptionOnly` filter threaded through the frontend service, Express controller, and server service to the upstream ledger endpoint, matching [lfx-crowdfunding#233](https://github.com/linuxfoundation/lfx-crowdfunding/pull/233).

## Notes

- Depends on the upstream `subscriptionOnly` support already merged in lfx-crowdfunding#233.