### PR TITLE
feat(org-lens): drill into project detail from projects table counts

### DIFF
--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -129,6 +129,33 @@ test.describe('Org Project Detail — leaderboards', () => {
   });
 });
 
+test.describe('Org Project Detail — Contributors drawer deep-link', () => {
+  test('auto-opens the Contributors drawer from ?card=contributors', async ({ page }) => {
+    await page.goto(`${DETAIL_URL}?card=contributors`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('project-detail-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('project-detail-technical-card-contributors')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('influence-card-detail-title')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('influence-card-detail-title')).toHaveText('Contributors');
+  });
+
+  test('closing the auto-opened drawer stays on the detail page', async ({ page }) => {
+    await page.goto(`${DETAIL_URL}?card=contributors`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('influence-card-detail-title')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('influence-card-detail-title')).toBeHidden();
+    await expect(page.getByTestId('project-detail-page')).toBeVisible();
+    await expect(page).toHaveURL(/\/org\/projects\/k8s/);
+  });
+
+  test('ignores an unknown ?card= value and loads the page with no drawer', async ({ page }) => {
+    await page.goto(`${DETAIL_URL}?card=bogus-card`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('project-detail-technical-group')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('influence-card-detail-title')).toBeHidden();
+  });
+});
+
 test.describe('Org Project Detail — not found', () => {
   test('renders the 404 panel for an unknown slug', async ({ page }) => {
     await page.goto(DETAIL_URL_BOGUS, { waitUntil: 'domcontentloaded' });

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -169,7 +169,7 @@ test.describe('Org Projects', () => {
     await expect(page.getByTestId('org-projects-row-kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     const contributors = page.getByTestId('org-projects-contributors-kubernetes');
-    await expect(contributors).toHaveAttribute('aria-label', /contributors for Kubernetes/);
+    await expect(contributors).toHaveAttribute('aria-label', /View 1 contributor for Kubernetes/);
     await contributors.click();
 
     await expect(page).toHaveURL(/\/org\/projects\/kubernetes\?(?:.*&)?card=contributors/);

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -164,6 +164,27 @@ test.describe('Org Projects', () => {
     await expect(page).toHaveURL(/[?&]sort=name/);
   });
 
+  test('Contributors count links to the project detail page with the Contributors drawer param', async ({ page }) => {
+    await gotoOrgProjectsPage(page);
+    await expect(page.getByTestId('org-projects-row-kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    const contributors = page.getByTestId('org-projects-contributors-kubernetes');
+    await expect(contributors).toHaveAttribute('aria-label', /contributors for Kubernetes/);
+    await contributors.click();
+
+    await expect(page).toHaveURL(/\/org\/projects\/kubernetes\?(?:.*&)?card=contributors/);
+  });
+
+  test('Participants count links to the project detail page without a drawer param', async ({ page }) => {
+    await gotoOrgProjectsPage(page);
+    await expect(page.getByTestId('org-projects-row-kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('org-projects-participants-kubernetes').click();
+
+    await expect(page).toHaveURL(/\/org\/projects\/kubernetes(?:\?|$)/);
+    expect(page.url()).not.toContain('card=');
+  });
+
   test('opens the workspace dropdown and the add-workspace dialog', async ({ page }) => {
     await gotoOrgProjectsPage(page);
     await expect(page.getByTestId('org-projects-page')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -25,8 +25,10 @@ import {
   PD_DEFAULT_TAB,
   PD_VALID_TABS,
   PD_DEFAULT_TIME_RANGE,
+  PD_DRAWER_QUERY_PARAM,
   PD_HEALTH_TAG,
   PD_NON_LF_MARKER,
+  PD_VALID_DRAWER_CARD_KEYS,
   lfxColors,
   PD_METRIC_OPTIONS,
   PD_STACKED_PALETTE,
@@ -58,7 +60,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, map, type Observable, of, scan, skip, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, map, type Observable, of, scan, skip, startWith, switchMap, take } from 'rxjs';
 
 /**
  * Org Lens · Project Detail sub-page (LFXV2-1885), routed at `/org/projects/:projectSlug`.
@@ -138,6 +140,10 @@ export class OrgProjectDetailComponent {
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount().uid);
   private readonly orgName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
   protected readonly projectSlug = toSignal(this.route.paramMap.pipe(map((params) => params.get('projectSlug'))), { initialValue: null });
+  private readonly drawerCardParam = computed<string | null>(() => {
+    const raw = this.queryParamMap().get(PD_DRAWER_QUERY_PARAM);
+    return raw && PD_VALID_DRAWER_CARD_KEYS.has(raw) ? raw : null;
+  });
 
   // Fetch triggers. Hero is range-independent (drops range$); the tab-scoped blocks gate on an
   // "activated" flag that flips true the first time their tab is shown and stays true, so returning
@@ -288,6 +294,22 @@ export class OrgProjectDetailComponent {
         this.refreshArrows(this.techTrackRef()?.nativeElement, true);
         this.refreshArrows(this.ecoTrackRef()?.nativeElement, false);
       });
+
+    if (isPlatformBrowser(this.platformId)) {
+      toObservable(
+        computed(() => {
+          const key = this.drawerCardParam();
+          if (!key) return null;
+          return [...this.technicalCards(), ...this.ecosystemCards()].find((card) => card.key === key) ?? null;
+        })
+      )
+        .pipe(
+          filter((card): card is InfluenceCardVm => card !== null),
+          take(1),
+          takeUntilDestroyed()
+        )
+        .subscribe((card) => this.openCardDetail(card));
+    }
   }
 
   protected switchTab(tab: OrgLensProjectDetailTab): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -306,8 +306,8 @@ export class OrgProjectDetailComponent {
         })
       )
         .pipe(
-          distinctUntilChanged((a, b) => (a?.navToken ?? null) === (b?.navToken ?? null)),
           filter((match): match is { navToken: string; card: InfluenceCardVm } => match !== null),
+          distinctUntilChanged((a, b) => a.navToken === b.navToken),
           takeUntilDestroyed()
         )
         .subscribe(({ card }) => this.openCardDetail(card));

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -60,7 +60,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, map, type Observable, of, scan, skip, startWith, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, map, type Observable, of, scan, skip, startWith, switchMap } from 'rxjs';
 
 /**
  * Org Lens · Project Detail sub-page (LFXV2-1885), routed at `/org/projects/:projectSlug`.
@@ -298,17 +298,19 @@ export class OrgProjectDetailComponent {
     if (isPlatformBrowser(this.platformId)) {
       toObservable(
         computed(() => {
+          const slug = this.projectSlug();
           const key = this.drawerCardParam();
-          if (!key) return null;
-          return [...this.technicalCards(), ...this.ecosystemCards()].find((card) => card.key === key) ?? null;
+          if (!slug || !key) return null;
+          const card = [...this.technicalCards(), ...this.ecosystemCards()].find((c) => c.key === key) ?? null;
+          return card ? { navToken: `${slug}|${key}`, card } : null;
         })
       )
         .pipe(
-          filter((card): card is InfluenceCardVm => card !== null),
-          take(1),
+          distinctUntilChanged((a, b) => (a?.navToken ?? null) === (b?.navToken ?? null)),
+          filter((match): match is { navToken: string; card: InfluenceCardVm } => match !== null),
           takeUntilDestroyed()
         )
-        .subscribe((card) => this.openCardDetail(card));
+        .subscribe(({ card }) => this.openCardDetail(card));
     }
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -339,10 +339,23 @@
                   </div>
                 </td>
                 <td>
-                  <span class="text-sm font-medium text-gray-900">{{ project.contributors.length }}</span>
+                  <a
+                    [routerLink]="['/org/projects', project.slug]"
+                    [queryParams]="contributorsDrawerQueryParams"
+                    class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    [attr.aria-label]="'View ' + project.contributors.length + ' contributors for ' + project.name"
+                    [attr.data-testid]="'org-projects-contributors-' + project.slug"
+                    >{{ project.contributors.length }}</a
+                  >
                 </td>
                 <td>
-                  <span class="text-sm font-medium text-gray-900">{{ project.participants.length }}</span>
+                  <a
+                    [routerLink]="['/org/projects', project.slug]"
+                    class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    [attr.aria-label]="'View ' + project.name + ' project detail'"
+                    [attr.data-testid]="'org-projects-participants-' + project.slug"
+                    >{{ project.participants.length }}</a
+                  >
                 </td>
                 <td class="text-right">
                   <lfx-button

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -343,7 +343,7 @@
                     [routerLink]="['/org/projects', project.slug]"
                     [queryParams]="contributorsDrawerQueryParams"
                     class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    [attr.aria-label]="'View ' + project.contributors.length + ' contributors for ' + project.name"
+                    [attr.aria-label]="project.contributorsAriaLabel"
                     [attr.data-testid]="'org-projects-contributors-' + project.slug"
                     >{{ project.contributors.length }}</a
                   >
@@ -352,7 +352,7 @@
                   <a
                     [routerLink]="['/org/projects', project.slug]"
                     class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    [attr.aria-label]="'View ' + project.name + ' project detail'"
+                    [attr.aria-label]="project.participantsAriaLabel"
                     [attr.data-testid]="'org-projects-participants-' + project.slug"
                     >{{ project.participants.length }}</a
                   >

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -25,6 +25,8 @@ import {
   ORG_PROJECTS_ALL_FOUNDATIONS_FILTER,
   ORG_PROJECTS_PAGE_SIZE_OPTIONS,
   ORG_PROJECTS_SEARCH_MIN_LENGTH,
+  PD_CONTRIBUTORS_CARD_KEY,
+  PD_DRAWER_QUERY_PARAM,
   VALID_ORG_PROJECTS_SORT_FIELDS,
 } from '@lfx-one/shared/constants';
 import type {
@@ -105,6 +107,7 @@ export class OrgProjectsComponent {
 
   // Configuration
   protected readonly pageSizeOptions = [...ORG_PROJECTS_PAGE_SIZE_OPTIONS];
+  protected readonly contributorsDrawerQueryParams: Record<string, string> = { [PD_DRAWER_QUERY_PARAM]: PD_CONTRIBUTORS_CARD_KEY };
   // Static explanatory hover for the Technical / Ecosystem influence column headers.
   protected readonly influenceColumnTooltipHtml = `<ul class="flex list-disc flex-col gap-1.5 pl-4 text-left"><li>Technical influence examines code activities (commits, PRs) while ecosystem influence examines non-code collaboration activities (documentation, committees, meetings, events).</li><li>Comparing our company's share of these activities to the project total indicates greater influence in the project.</li></ul>`;
   // Minimal Chart.js line config for the Influence Trend sparkline (no axes, points, legend, or tooltip).

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -709,6 +709,10 @@ export class OrgProjectsComponent {
     return computed(() => this.buildSortedProjects());
   }
 
+  private countAriaLabel(count: number, singular: string, projectName: string): string {
+    return `View ${count} ${count === 1 ? singular : `${singular}s`} for ${projectName}`;
+  }
+
   // Enrich each sorted project with presentation values so the template only reads properties (no in-template logic).
   private initRows(): Signal<OrgProjectsTableRow[]> {
     return computed(() =>
@@ -733,6 +737,8 @@ export class OrgProjectsComponent {
         trendDeltaTextClass: INFLUENCE_TREND_TEXT_CLASS[project.trend.direction],
         trendArrowBadgeClass: INFLUENCE_TREND_ARROW_BADGE_CLASS[project.trend.direction],
         healthAriaLabel: this.healthAriaLabel(project),
+        contributorsAriaLabel: this.countAriaLabel(project.contributors.length, 'contributor', project.name),
+        participantsAriaLabel: this.countAriaLabel(project.participants.length, 'participant', project.name),
       }))
     );
   }

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -21,6 +21,10 @@ export const PD_VALID_METRICS: ReadonlySet<string> = new Set<OrgLensLeaderboardM
 export const PD_DEFAULT_TIME_RANGE: OrgLensLeaderboardTimeRange = '2y';
 export const PD_VALID_TIME_RANGES: ReadonlySet<string> = new Set<OrgLensLeaderboardTimeRange>(['1y', '2y', 'all']);
 
+export const PD_DRAWER_QUERY_PARAM = 'card';
+export const PD_CONTRIBUTORS_CARD_KEY = 'contributors';
+export const PD_VALID_DRAWER_CARD_KEYS: ReadonlySet<string> = new Set<string>([PD_CONTRIBUTORS_CARD_KEY]);
+
 /** Snowflake `time_range_type` value for each UI range toggle. */
 export const PD_TIME_RANGE_TYPE: Record<OrgLensLeaderboardTimeRange, string> = {
   '1y': 'last_365_days',

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -196,6 +196,10 @@ export interface OrgProjectsTableRow extends OrgLensProject {
   trendArrowBadgeClass: string;
   /** Plain-text health summary (rating + sub-scores) for screen readers / keyboard focus. */
   healthAriaLabel: string;
+  /** Plain-text, count-correlated label for the Contributors count link (screen readers / keyboard focus). */
+  contributorsAriaLabel: string;
+  /** Plain-text, count-correlated label for the Participants count link (screen readers / keyboard focus). */
+  participantsAriaLabel: string;
 }
 
 export interface OrgLensProjectRow {


### PR DESCRIPTION
## Summary
- On the Org Lens Projects table (`/org/projects`), the **Contributors** and **Participants** counts are now links (`org-projects.component.html`):
  - Contributors → `/org/projects/:slug?card=contributors`
  - Participants → `/org/projects/:slug`
- The project detail page (`org-project-detail.component.ts`) reads the new `?card=` query param and auto-opens the matching metric drawer once its influence card loads (browser-only, one-shot per navigation; unknown/absent keys are no-ops).
- New shared constants in `org-lens-project-detail.constants.ts`: `PD_DRAWER_QUERY_PARAM`, `PD_CONTRIBUTORS_CARD_KEY`, `PD_VALID_DRAWER_CARD_KEYS`.

## Why
Make the counts the entry point to the people they represent (agreed with design). Clicking a count now drills into the project detail — Contributors opens with the "Our Contributors" roster drawer.

## Implementation note
Counts use `!text-gray-900 hover:!text-gray-900` on purpose: the shared table SCSS (`table.component.scss`) forces `text-blue-500` on every `<a>` inside a `td`, so a plain utility class is overridden. The important override keeps the counts neutral while the project-name link keeps the default blue.

## Test plan
- [ ] `/org/projects` with a company selected → click a **Contributors** count → lands on the project detail with the Contributors drawer open.
- [ ] Click a **Participants** count → lands on the detail page with no drawer.
- [ ] `npx playwright test org-projects.spec.ts --project=chromium` passes.

[LFXV2-2785]: https://linuxfoundation.atlassian.net/browse/LFXV2-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ