### PR TITLE
feat(newsletters): add remove action to opt-out list

### DIFF
--- a/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
@@ -109,7 +109,7 @@ async function stubProjectApi(page: Page): Promise<void> {
   await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
 }
 
-async function stubOptOutApi(page: Page, optOuts: NewsletterOptOut[]): Promise<void> {
+async function stubOptOutApi(page: Page, optOuts: NewsletterOptOut[], deletedIds?: string[]): Promise<void> {
   const optOutsResponse: NewsletterOptOutListResponse = { opt_outs: optOuts };
 
   // GET /opt-outs — returns the full list. The DELETE goes to /opt-outs/:optOutId,
@@ -121,9 +121,17 @@ async function stubOptOutApi(page: Page, optOuts: NewsletterOptOut[]): Promise<v
     return route.fallback();
   });
 
-  // DELETE /opt-outs/:optOutId — succeed with no content
+  // DELETE /opt-outs/:optOutId — 204 only for ids that exist in the mock data,
+  // so a lost/mismatched id between the click handler and the delete call fails
+  // the test instead of slipping through. Requested ids are recorded so tests
+  // can assert exactly which opt-out was targeted.
   await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/opt-outs/*`, (route) => {
     if (route.request().method() === 'DELETE') {
+      const requestedId = new URL(route.request().url()).pathname.split('/').pop() ?? '';
+      deletedIds?.push(requestedId);
+      if (!optOuts.some((optOut) => optOut.id === requestedId)) {
+        return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'opt-out not found' }) });
+      }
       return route.fulfill({ status: 204 });
     }
     return route.fallback();
@@ -165,12 +173,15 @@ async function gotoOptOutListUrl(page: Page): Promise<void> {
 }
 
 test.describe('Newsletter opt-out list — Remove action', () => {
+  let deletedIds: string[];
+
   test.beforeEach(async ({ page }) => {
+    deletedIds = [];
     await setPersonaCookie(page, ['executive-director']);
     await stubPersona(page, ['executive-director']);
     await stubNavLensItems(page);
     await stubProjectApi(page);
-    await stubOptOutApi(page, MOCK_OPT_OUTS);
+    await stubOptOutApi(page, MOCK_OPT_OUTS, deletedIds);
   });
 
   test('displays opt-outs with remove buttons; clicking remove shows confirmation dialog', async ({ page }) => {
@@ -226,6 +237,37 @@ test.describe('Newsletter opt-out list — Remove action', () => {
     // Success toast should appear (PrimeNG toasts render role="alert", so
     // target the .p-toast container like the rest of the suite does)
     await expect(page.locator('.p-toast'), 'success toast should appear').toContainText('Opt-out removed', { timeout: ELEMENT_TIMEOUT });
+
+    // Exactly one DELETE, targeting alice's id — locks the id contract between
+    // the click handler and the delete call.
+    expect(deletedIds, 'DELETE should target the selected opt-out id').toEqual([MOCK_OPT_OUTS[0].id]);
+  });
+
+  test('failed removal keeps the row and shows error toast', async ({ page }) => {
+    // Later route registrations take precedence, so this overrides the
+    // beforeEach DELETE stub with a server error.
+    await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/opt-outs/*`, (route) => {
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'upstream unavailable' }) });
+      }
+      return route.fallback();
+    });
+
+    await gotoOptOutListUrl(page);
+
+    await expect(page.getByTestId('newsletter-optout-table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Click remove button for alice and accept the confirmation
+    await page.getByTestId('newsletter-optout-delete-alice@example.com').click();
+    const confirmDialog = page.locator('[role="dialog"]');
+    await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await confirmDialog.getByRole('button', { name: /remove/i }).click();
+
+    // Error toast should appear and the row must be retained
+    await expect(page.locator('.p-toast'), 'error toast should appear').toContainText('Remove failed', { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should be retained on failure').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
   });
 
   test('rejecting remove confirmation keeps the row', async ({ page }) => {

--- a/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
@@ -4,10 +4,12 @@
 /**
  * Newsletter Opt-out Remove Action — LFXV2-2766.
  *
- * Editors and Executive Directors can remove individual opt-outs from the opt-out tab,
- * restoring email delivery for that address. This spec locks in the remove flow: the
- * confirmation dialog appears with clear language about the consequence, and the row
- * disappears from the table and shows a success toast on completion.
+ * Project writers can remove individual opt-outs from the opt-out tab, restoring
+ * email delivery for that address (the upstream DELETE authorizes the writer
+ * relation only, and the UI hides the action from non-writers). This spec locks in
+ * the remove flow: the confirmation dialog appears with clear language about the
+ * consequence, and the row disappears from the table and shows a success toast on
+ * completion.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -268,6 +270,25 @@ test.describe('Newsletter opt-out list — Remove action', () => {
     await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should be retained on failure').toBeVisible({
       timeout: ELEMENT_TIMEOUT,
     });
+  });
+
+  test('non-writer sees the opt-out list without remove controls', async ({ page }) => {
+    // Later registrations take precedence: serve the project with writer: false
+    // so the writer-only visibility gate is exercised.
+    await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...buildProjectStub(), writer: false }) })
+    );
+
+    await gotoOptOutListUrl(page);
+
+    // The list still renders for the ED persona, but without remove buttons
+    await expect(page.getByTestId('newsletter-optout-table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should be visible').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-optout-delete-alice@example.com'), 'alice remove button should be hidden').toHaveCount(0);
+    await expect(page.getByTestId('newsletter-optout-delete-bob@example.com'), 'bob remove button should be hidden').toHaveCount(0);
+
+    // No DELETE can have been issued without a control to trigger it
+    expect(deletedIds, 'no DELETE should be issued').toEqual([]);
   });
 
   test('rejecting remove confirmation keeps the row', async ({ page }) => {

--- a/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
@@ -36,12 +36,12 @@ const MOCK_FOUNDATION_ITEM: LensItem = {
 
 const MOCK_OPT_OUTS: NewsletterOptOut[] = [
   {
-    id: 'o0000000-0000-0000-0000-000000000001',
+    id: 'a0000000-0000-0000-0000-000000000001',
     email: 'alice@example.com',
     unsubscribed_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
-    id: 'o0000000-0000-0000-0000-000000000002',
+    id: 'b0000000-0000-0000-0000-000000000002',
     email: 'bob@example.com',
     unsubscribed_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
   },
@@ -112,12 +112,17 @@ async function stubProjectApi(page: Page): Promise<void> {
 async function stubOptOutApi(page: Page, optOuts: NewsletterOptOut[]): Promise<void> {
   const optOutsResponse: NewsletterOptOutListResponse = { opt_outs: optOuts };
 
-  // GET /opt-outs — returns the full list
+  // GET /opt-outs — returns the full list. The DELETE goes to /opt-outs/:optOutId,
+  // one segment longer, so it needs its own route pattern below.
   await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/opt-outs`, (route) => {
     if (route.request().method() === 'GET') {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(optOutsResponse) });
     }
-    // DELETE /opt-outs/:optOutId — removes from mock list
+    return route.fallback();
+  });
+
+  // DELETE /opt-outs/:optOutId — succeed with no content
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/opt-outs/*`, (route) => {
     if (route.request().method() === 'DELETE') {
       return route.fulfill({ status: 204 });
     }
@@ -218,9 +223,9 @@ test.describe('Newsletter opt-out list — Remove action', () => {
       timeout: ELEMENT_TIMEOUT,
     });
 
-    // Success toast should appear
-    const successToast = page.locator('[role="status"]').filter({ has: page.locator('text=Opt-out removed') });
-    await expect(successToast, 'success toast should appear').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    // Success toast should appear (PrimeNG toasts render role="alert", so
+    // target the .p-toast container like the rest of the suite does)
+    await expect(page.locator('.p-toast'), 'success toast should appear').toContainText('Opt-out removed', { timeout: ELEMENT_TIMEOUT });
   });
 
   test('rejecting remove confirmation keeps the row', async ({ page }) => {

--- a/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-opt-out-remove.spec.ts
@@ -1,0 +1,251 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter Opt-out Remove Action — LFXV2-2766.
+ *
+ * Editors and Executive Directors can remove individual opt-outs from the opt-out tab,
+ * restoring email delivery for that address. This spec locks in the remove flow: the
+ * confirmation dialog appears with clear language about the consequence, and the row
+ * disappears from the table and shows a success toast on completion.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD
+ */
+
+import type { LensItem, NewsletterOptOut, NewsletterOptOutListResponse, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+import { PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+
+const MOCK_FOUNDATION_SLUG = 'test-foundation';
+const MOCK_FOUNDATION_UID = 'f0000000-0000-0000-0000-000000000001';
+
+const MOCK_FOUNDATION_ITEM: LensItem = {
+  uid: MOCK_FOUNDATION_UID,
+  slug: MOCK_FOUNDATION_SLUG,
+  name: 'Test Foundation',
+  logoUrl: null,
+  isFoundation: true,
+};
+
+const MOCK_OPT_OUTS: NewsletterOptOut[] = [
+  {
+    id: 'o0000000-0000-0000-0000-000000000001',
+    email: 'alice@example.com',
+    unsubscribed_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 'o0000000-0000-0000-0000-000000000002',
+    email: 'bob@example.com',
+    unsubscribed_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+function buildProjectStub() {
+  return {
+    uid: MOCK_FOUNDATION_UID,
+    slug: MOCK_FOUNDATION_SLUG,
+    name: 'Test Foundation',
+    description: 'Test foundation for newsletter opt-out remove specs',
+    public: true,
+    parent_uid: '',
+    stage: 'Active',
+    category: 'project',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: new Date().toISOString(),
+    mailing_list_count: 0,
+    writer: true,
+  };
+}
+
+async function stubPersona(page: Page, personas: string[]): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ personas, personaProjects: {}, projects: [], organizations: [], isRootWriter: true }),
+    })
+  );
+}
+
+async function stubNavLensItems(page: Page): Promise<void> {
+  await page.route('**/api/nav/lens-items*', (route) => {
+    const requestedLens = new URL(route.request().url()).searchParams.get('lens') ?? 'foundation';
+    if (requestedLens !== 'foundation') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], next_page_token: null, upstream_failed: false, lens: requestedLens }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [MOCK_FOUNDATION_ITEM], next_page_token: null, upstream_failed: false, lens: 'foundation' }),
+    });
+  });
+}
+
+async function stubProjectApi(page: Page): Promise<void> {
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(buildProjectStub()) })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+async function stubOptOutApi(page: Page, optOuts: NewsletterOptOut[]): Promise<void> {
+  const optOutsResponse: NewsletterOptOutListResponse = { opt_outs: optOuts };
+
+  // GET /opt-outs — returns the full list
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/opt-outs`, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(optOutsResponse) });
+    }
+    // DELETE /opt-outs/:optOutId — removes from mock list
+    if (route.request().method() === 'DELETE') {
+      return route.fulfill({ status: 204 });
+    }
+    return route.fallback();
+  });
+}
+
+async function setPersonaCookie(page: Page, personas: string[]): Promise<void> {
+  const state: PersistedPersonaState = {
+    primary: personas[0] as PersonaType,
+    all: personas as PersonaType[],
+  };
+  await page.context().addCookies([
+    {
+      name: PERSONA_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify(state)),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+async function gotoOptOutListUrl(page: Page): Promise<void> {
+  skipWhenAuthMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(`/foundation/newsletters/list?project=${MOCK_FOUNDATION_SLUG}&tab=optout`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+}
+
+test.describe('Newsletter opt-out list — Remove action', () => {
+  test.beforeEach(async ({ page }) => {
+    await setPersonaCookie(page, ['executive-director']);
+    await stubPersona(page, ['executive-director']);
+    await stubNavLensItems(page);
+    await stubProjectApi(page);
+    await stubOptOutApi(page, MOCK_OPT_OUTS);
+  });
+
+  test('displays opt-outs with remove buttons; clicking remove shows confirmation dialog', async ({ page }) => {
+    await gotoOptOutListUrl(page);
+
+    // Opt-out table should render with both rows visible
+    await expect(page.getByTestId('newsletter-optout-table'), 'opt-out table should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should be visible').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-optout-row-bob@example.com'), 'bob row should be visible').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Remove buttons should be visible
+    await expect(page.getByTestId('newsletter-optout-delete-alice@example.com'), 'alice remove button should be visible').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    await expect(page.getByTestId('newsletter-optout-delete-bob@example.com'), 'bob remove button should be visible').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // Click remove button for alice
+    await page.getByTestId('newsletter-optout-delete-alice@example.com').click();
+
+    // Confirmation dialog should appear
+    const confirmDialog = page.locator('[role="dialog"]');
+    await expect(confirmDialog, 'confirmation dialog should appear').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(confirmDialog, 'dialog should mention email').toContainText('alice@example.com');
+    await expect(confirmDialog, 'dialog should mention consequence').toContainText('will start receiving newsletters');
+  });
+
+  test('accepting remove confirmation removes the row and shows success toast', async ({ page }) => {
+    await gotoOptOutListUrl(page);
+
+    await expect(page.getByTestId('newsletter-optout-table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Click remove button for alice
+    await page.getByTestId('newsletter-optout-delete-alice@example.com').click();
+
+    // Accept the confirmation
+    const confirmDialog = page.locator('[role="dialog"]');
+    await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    const acceptButton = confirmDialog.getByRole('button', { name: /remove/i });
+    await acceptButton.click();
+
+    // Row should disappear after deletion
+    await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should be removed').not.toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // bob row should still be visible
+    await expect(page.getByTestId('newsletter-optout-row-bob@example.com'), 'bob row should still be visible').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // Success toast should appear
+    const successToast = page.locator('[role="status"]').filter({ has: page.locator('text=Opt-out removed') });
+    await expect(successToast, 'success toast should appear').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('rejecting remove confirmation keeps the row', async ({ page }) => {
+    await gotoOptOutListUrl(page);
+
+    await expect(page.getByTestId('newsletter-optout-table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Click remove button for alice
+    await page.getByTestId('newsletter-optout-delete-alice@example.com').click();
+
+    // Reject the confirmation
+    const confirmDialog = page.locator('[role="dialog"]');
+    await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    const rejectButton = confirmDialog.getByRole('button', { name: /cancel/i });
+    await rejectButton.click();
+
+    // Dialog should disappear
+    await expect(confirmDialog).not.toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Both rows should still be visible
+    await expect(page.getByTestId('newsletter-optout-row-alice@example.com'), 'alice row should still be visible').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    await expect(page.getByTestId('newsletter-optout-row-bob@example.com'), 'bob row should still be visible').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -43,12 +43,12 @@
               subtitle="People who unsubscribe from this newsletter will show up here.">
             </lfx-empty-state>
           } @else {
-            <lfx-table [value]="optOuts()" [loading]="loading()" dataKey="email" data-testid="newsletter-optout-table">
+            <lfx-table [value]="optOuts()" [loading]="loading()" dataKey="id" data-testid="newsletter-optout-table">
               <ng-template #header>
                 <tr>
                   <th class="w-[60%]">Email</th>
                   <th class="w-[25%]">Unsubscribed</th>
-                  <th class="w-[15%]"></th>
+                  <th class="w-[15%]"><span class="sr-only">Actions</span></th>
                 </tr>
               </ng-template>
 
@@ -61,16 +61,20 @@
                     <span class="text-sm text-gray-700">{{ optOut.unsubscribed_at | date: 'MMM d, y' }}</span>
                   </td>
                   <td class="text-right">
-                    <lfx-button
-                      icon="fa-light fa-trash-can"
-                      severity="danger"
-                      size="small"
-                      [text]="true"
-                      [ariaLabel]="'Remove opt-out for ' + optOut.email"
-                      (onClick)="onRemoveOptOut(optOut, $event)"
-                      [disabled]="removingOptOutId() === optOut.id"
-                      [attr.data-testid]="'newsletter-optout-delete-' + optOut.email">
-                    </lfx-button>
+                    @if (canWrite()) {
+                      <!-- Disabled while ANY removal is in flight: the single removingOptOutId
+                           signal can't track concurrent requests, so removals are serialized. -->
+                      <lfx-button
+                        icon="fa-light fa-trash-can"
+                        severity="danger"
+                        size="small"
+                        [text]="true"
+                        [ariaLabel]="'Remove opt-out for ' + optOut.email"
+                        (onClick)="onRemoveOptOut(optOut, $event)"
+                        [disabled]="removingOptOutId() !== null"
+                        [attr.data-testid]="'newsletter-optout-delete-' + optOut.email">
+                      </lfx-button>
+                    }
                   </td>
                 </tr>
               </ng-template>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -66,6 +66,7 @@
                       severity="danger"
                       size="small"
                       [text]="true"
+                      [ariaLabel]="'Remove opt-out for ' + optOut.email"
                       (onClick)="onRemoveOptOut(optOut, $event)"
                       [disabled]="removingOptOutId() === optOut.id"
                       [attr.data-testid]="'newsletter-optout-delete-' + optOut.email">

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.html
@@ -46,8 +46,9 @@
             <lfx-table [value]="optOuts()" [loading]="loading()" dataKey="email" data-testid="newsletter-optout-table">
               <ng-template #header>
                 <tr>
-                  <th class="w-[70%]">Email</th>
-                  <th class="w-[30%]">Unsubscribed</th>
+                  <th class="w-[60%]">Email</th>
+                  <th class="w-[25%]">Unsubscribed</th>
+                  <th class="w-[15%]"></th>
                 </tr>
               </ng-template>
 
@@ -58,6 +59,17 @@
                   </td>
                   <td>
                     <span class="text-sm text-gray-700">{{ optOut.unsubscribed_at | date: 'MMM d, y' }}</span>
+                  </td>
+                  <td class="text-right">
+                    <lfx-button
+                      icon="fa-light fa-trash-can"
+                      severity="danger"
+                      size="small"
+                      [text]="true"
+                      (onClick)="onRemoveOptOut(optOut, $event)"
+                      [disabled]="removingOptOutId() === optOut.id"
+                      [attr.data-testid]="'newsletter-optout-delete-' + optOut.email">
+                    </lfx-button>
                   </td>
                 </tr>
               </ng-template>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -198,6 +198,10 @@ export class NewsletterListComponent {
 
   protected onRemoveOptOut(optOut: NewsletterOptOut, event: Event): void {
     event.stopPropagation();
+    // Capture the project uid at dialog-open time: reading it on accept could
+    // target a different project if the context switches while the dialog is open.
+    const projectUid = this.projectUid();
+    if (!projectUid) return;
     this.confirmationService.confirm({
       key: 'newsletter-list',
       header: 'Remove opt-out?',
@@ -207,7 +211,7 @@ export class NewsletterListComponent {
       rejectLabel: 'Cancel',
       acceptButtonStyleClass: 'p-button-danger p-button-sm',
       rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
-      accept: () => this.runRemoveOptOut(optOut),
+      accept: () => this.runRemoveOptOut(projectUid, optOut),
     });
   }
 
@@ -326,11 +330,10 @@ export class NewsletterListComponent {
       });
   }
 
-  private runRemoveOptOut(optOut: NewsletterOptOut): void {
-    if (!this.projectUid()) return;
+  private runRemoveOptOut(projectUid: string, optOut: NewsletterOptOut): void {
     this.removingOptOutId.set(optOut.id);
     this.newsletterService
-      .deleteOptOut(this.projectUid(), optOut.id)
+      .deleteOptOut(projectUid, optOut.id)
       .pipe(
         take(1),
         finalize(() => this.removingOptOutId.set(null))

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -78,6 +78,7 @@ export class NewsletterListComponent {
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly nextPageToken = signal<string | undefined>(undefined);
   protected readonly deletingId = signal<string | null>(null);
+  protected readonly removingOptOutId = signal<string | null>(null);
   protected readonly previewVisible = signal<boolean>(false);
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
   // Analytics fetched lazily per sent row (the list endpoint intentionally omits
@@ -191,6 +192,21 @@ export class NewsletterListComponent {
     });
   }
 
+  protected onRemoveOptOut(optOut: NewsletterOptOut, event: Event): void {
+    event.stopPropagation();
+    this.confirmationService.confirm({
+      key: 'newsletter-list',
+      header: 'Remove opt-out?',
+      message: `Remove ${optOut.email} from the opt-out list? They will start receiving newsletters from this project again.`,
+      icon: 'pi pi-trash',
+      acceptLabel: 'Remove',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
+      accept: () => this.runRemoveOptOut(optOut),
+    });
+  }
+
   private initRows(): Signal<NewsletterRow[]> {
     return computed(() => {
       const analyticsMap = this.openRateAnalytics();
@@ -301,6 +317,30 @@ export class NewsletterListComponent {
             severity: 'error',
             summary: 'Delete failed',
             detail: err?.error?.message || err?.message || 'Could not delete the draft. Please try again.',
+          });
+        },
+      });
+  }
+
+  private runRemoveOptOut(optOut: NewsletterOptOut): void {
+    if (!this.projectUid()) return;
+    this.removingOptOutId.set(optOut.id);
+    this.newsletterService
+      .deleteOptOut(this.projectUid(), optOut.id)
+      .pipe(
+        take(1),
+        finalize(() => this.removingOptOutId.set(null))
+      )
+      .subscribe({
+        next: () => {
+          this.optOuts.update((current) => current.filter((o) => o.id !== optOut.id));
+          this.messageService.add({ severity: 'success', summary: 'Opt-out removed', detail: `${optOut.email} will receive newsletters again.` });
+        },
+        error: (err: HttpErrorResponse) => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Remove failed',
+            detail: err?.error?.message || err?.message || 'Could not remove the opt-out. Please try again.',
           });
         },
       });

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-list/newsletter-list.component.ts
@@ -81,6 +81,10 @@ export class NewsletterListComponent {
   protected readonly removingOptOutId = signal<string | null>(null);
   protected readonly previewVisible = signal<boolean>(false);
   protected readonly selectedNewsletter = signal<NewsletterListItem | null>(null);
+  // Upstream authorizes opt-out removal for the `writer` relation only, while the
+  // newsletters route guard also fast-paths the ED persona — gate the destructive
+  // action on writer permission so ED non-writers don't get a button that 403s.
+  protected readonly canWrite = this.projectContextService.canWrite;
   // Analytics fetched lazily per sent row (the list endpoint intentionally omits
   // open_rate/unique_opens). Kept in a side map keyed by newsletter id — never
   // written back into `newsletters` — so row identity stays stable and results

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -73,6 +73,10 @@ export class NewsletterService {
     return this.http.get<NewsletterOptOutListResponse>(`/api/projects/${this.enc(projectUid)}/newsletters/opt-outs`).pipe(take(1));
   }
 
+  public deleteOptOut(projectUid: string, optOutId: string): Observable<void> {
+    return this.http.delete<void>(`/api/projects/${this.enc(projectUid)}/newsletters/opt-outs/${this.enc(optOutId)}`).pipe(take(1));
+  }
+
   public createNewsletter(projectUid: string, payload: CreateNewsletterRequest): Observable<Newsletter> {
     return this.http.post<Newsletter>(`/api/projects/${this.enc(projectUid)}/newsletters`, payload).pipe(take(1));
   }

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -281,6 +281,23 @@ export class NewsletterController {
   }
 
   /**
+   * DELETE /api/projects/:projectUid/newsletters/opt-outs/:optOutId
+   */
+  public async deleteOptOut(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = this.requireProjectUid(req);
+    const optOutId = this.requireOptOutId(req);
+    const startTime = logger.startOperation(req, 'newsletter_opt_out_delete', { project_uid: projectUid, opt_out_id: optOutId });
+
+    try {
+      await this.newsletterService.deleteOptOut(req, projectUid, optOutId);
+      logger.success(req, 'newsletter_opt_out_delete', startTime, { opt_out_id: optOutId });
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * POST /api/projects/:projectUid/newsletters/generate
    *
    * AI-assisted body generation. Doesn't touch the Go newsletter-service —
@@ -376,6 +393,18 @@ export class NewsletterController {
       });
     }
     return newsletterUid;
+  }
+
+  private requireOptOutId(req: Request): string {
+    const optOutId = String(req.params['optOutId'] || '').trim();
+    if (!optOutId) {
+      throw ServiceValidationError.forField('optOutId', 'optOutId path parameter is required', {
+        operation: 'newsletter_controller',
+        service: 'newsletter_controller',
+        path: req.path,
+      });
+    }
+    return optOutId;
   }
 
   private validateCommonPayload(payload: { subject?: string; body_html?: string; ed_reply_email?: string }, path: string, operation: string): void {

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -285,11 +285,12 @@ export class NewsletterController {
    * DELETE /api/projects/:projectUid/newsletters/opt-outs/:optOutId
    */
   public async deleteOptOut(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const projectUid = this.requireProjectUid(req);
-    const optOutId = this.requireOptOutId(req);
-    const startTime = logger.startOperation(req, 'newsletter_opt_out_delete', { project_uid: projectUid, opt_out_id: optOutId });
-
+    // Validation must run inside the try: Express 4 doesn't forward async
+    // rejections, so a throw before the catch would hang the request.
     try {
+      const projectUid = this.requireProjectUid(req);
+      const optOutId = this.requireOptOutId(req);
+      const startTime = logger.startOperation(req, 'newsletter_opt_out_delete', { project_uid: projectUid, opt_out_id: optOutId });
       await this.newsletterService.deleteOptOut(req, projectUid, optOutId);
       logger.success(req, 'newsletter_opt_out_delete', startTime, { opt_out_id: optOutId });
       res.status(204).end();

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -11,6 +11,7 @@ import {
   NewsletterTestSendPayload,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
+import { isUuid } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -397,8 +398,10 @@ export class NewsletterController {
 
   private requireOptOutId(req: Request): string {
     const optOutId = String(req.params['optOutId'] || '').trim();
-    if (!optOutId) {
-      throw ServiceValidationError.forField('optOutId', 'optOutId path parameter is required', {
+    // Opt-out ids are always UUIDs; rejecting anything else keeps arbitrary
+    // strings out of the upstream path this value is interpolated into.
+    if (!isUuid(optOutId)) {
+      throw ServiceValidationError.forField('optOutId', 'optOutId path parameter must be a UUID', {
         operation: 'newsletter_controller',
         service: 'newsletter_controller',
         path: req.path,

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -33,10 +33,11 @@ router.post('/test-send', (req, res, next) => newsletterController.testSend(req,
 router.get('/', (req, res, next) => newsletterController.listNewsletters(req, res, next));
 router.post('/', (req, res, next) => newsletterController.createNewsletter(req, res, next));
 
-// Opt-out (unsubscribe) list. Static segment, registered before the
-// `/:newsletterUid` catch-alls so Express doesn't parse `opt-outs` as a
-// newsletter UID.
+// Opt-out (unsubscribe) list and individual opt-out deletion. Static segments
+// registered before the `/:newsletterUid` catch-alls so Express doesn't parse
+// them as newsletter UIDs.
 router.get('/opt-outs', (req, res, next) => newsletterController.listOptOuts(req, res, next));
+router.delete('/opt-outs/:optOutId', (req, res, next) => newsletterController.deleteOptOut(req, res, next));
 
 // Per-newsletter CRUD + send + analytics.
 router.get('/:newsletterUid', (req, res, next) => newsletterController.getNewsletter(req, res, next));

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -151,6 +151,13 @@ export class NewsletterServiceClient {
   }
 
   public async deleteOptOut(req: Request, projectUid: string, optOutId: string): Promise<void> {
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletter-opt-outs/${optOutId}`, 'DELETE');
+    // The controller already restricts optOutId to a UUID; encoding keeps this
+    // path segment safe even if a future caller skips that validation.
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletter-opt-outs/${encodeURIComponent(optOutId)}`,
+      'DELETE'
+    );
   }
 }

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -149,4 +149,8 @@ export class NewsletterServiceClient {
   public async listOptOuts(req: Request, projectUid: string): Promise<NewsletterOptOutListResponse> {
     return this.microserviceProxy.proxyRequest<NewsletterOptOutListResponse>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletter-opt-outs`, 'GET');
   }
+
+  public async deleteOptOut(req: Request, projectUid: string, optOutId: string): Promise<void> {
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletter-opt-outs/${optOutId}`, 'DELETE');
+  }
 }

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -85,4 +85,8 @@ export class NewsletterService {
   public listOptOuts(req: Request, projectUid: string): Promise<NewsletterOptOutListResponse> {
     return this.newsletterClient.listOptOuts(req, projectUid);
   }
+
+  public deleteOptOut(req: Request, projectUid: string, optOutId: string): Promise<void> {
+    return this.newsletterClient.deleteOptOut(req, projectUid, optOutId);
+  }
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -174,6 +174,7 @@ export interface NewsletterChartData {
 }
 
 export interface NewsletterOptOut {
+  id: string;
   email: string;
   unsubscribed_at: string;
 }


### PR DESCRIPTION
Adds a Remove button to each row of the newsletter Opt-out tab, behind a confirmation dialog that makes clear the address will start receiving the project's newsletters again.

Calls the new `DELETE /projects/{project_uid}/newsletter-opt-outs/{opt_out_id}` endpoint (linuxfoundation/lfx-v2-newsletter-service#55), which also adds the `id` field this uses. Until that service change is deployed the action fails gracefully with an error toast.

New Playwright spec covers the flow (runs in CI; skips locally without `TEST_USERNAME`/`TEST_PASSWORD`).

LFXV2-2766