### PR TITLE
fix(profile): refresh profile-shell identities after tab changes

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -9,7 +9,7 @@ import { normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_TABS, TSHIRT_SIZ
 import { CombinedProfile, EnrichedIdentity, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
-import { BehaviorSubject, catchError, filter, map, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, filter, map, of, startWith, switchMap } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDrawerComponent } from '../../modules/profile/components/profile-edit-drawer/profile-edit-drawer.component';
@@ -325,8 +325,17 @@ export class ProfileLayoutComponent {
     });
   }
 
+  // Re-fetch identities whenever the Identities tab signals a change (LFXV2-2767) so the panel's
+  // GitHub handle and the tab-notification dots stay current without a full reload. startWith drives
+  // the initial load; toSignal tears the subscription down when the layout is destroyed.
   private initIdentities(): Signal<EnrichedIdentity[]> {
-    return toSignal(this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))), { initialValue: [] as EnrichedIdentity[] });
+    return toSignal(
+      this.userService.identitiesRefresh$.pipe(
+        startWith(undefined),
+        switchMap(() => this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))))
+      ),
+      { initialValue: [] as EnrichedIdentity[] }
+    );
   }
 
   private mapToHeaderData(profile: CombinedProfile): ProfileHeaderData {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -9,7 +9,7 @@ import { normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_TABS, TSHIRT_SIZ
 import { CombinedProfile, EnrichedIdentity, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
-import { BehaviorSubject, catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, EMPTY, filter, map, of, startWith, switchMap } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDrawerComponent } from '../../modules/profile/components/profile-edit-drawer/profile-edit-drawer.component';
@@ -332,7 +332,10 @@ export class ProfileLayoutComponent {
     return toSignal(
       this.userService.identitiesRefresh$.pipe(
         startWith(undefined),
-        switchMap(() => this.userService.getIdentities().pipe(catchError(() => of([] as EnrichedIdentity[]))))
+        // Drop a failed refresh (EMPTY) rather than emitting [] — the shell has no error UI or retry,
+        // so a transient error must not wipe the last-good GitHub handle / notification dot. The
+        // initialValue below still covers an initial-load failure.
+        switchMap(() => this.userService.getIdentities().pipe(catchError(() => EMPTY)))
       ),
       { initialValue: [] as EnrichedIdentity[] }
     );

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -325,16 +325,14 @@ export class ProfileLayoutComponent {
     });
   }
 
-  // Re-fetch identities whenever the Identities tab signals a change (LFXV2-2767) so the panel's
-  // GitHub handle and the tab-notification dots stay current without a full reload. startWith drives
-  // the initial load; toSignal tears the subscription down when the layout is destroyed.
+  // Re-fetch identities on the Identities tab's refresh signal (LFXV2-2767) so the panel's GitHub
+  // handle and tab-notification dots stay current without a full reload.
   private initIdentities(): Signal<EnrichedIdentity[]> {
     return toSignal(
       this.userService.identitiesRefresh$.pipe(
         startWith(undefined),
-        // Drop a failed refresh (EMPTY) rather than emitting [] — the shell has no error UI or retry,
-        // so a transient error must not wipe the last-good GitHub handle / notification dot. The
-        // initialValue below still covers an initial-load failure.
+        // Drop a failed refresh (EMPTY) — the shell has no error UI, so a transient error must not
+        // wipe the last-good GitHub handle / dot. initialValue covers an initial-load failure.
         switchMap(() => this.userService.getIdentities().pipe(catchError(() => EMPTY)))
       ),
       { initialValue: [] as EnrichedIdentity[] }

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -22,7 +22,7 @@ import { UserService } from '@services/user.service';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { catchError, map, of, startWith, Subject, switchMap, take } from 'rxjs';
+import { catchError, map, of, startWith, switchMap, take } from 'rxjs';
 
 import { AddAccountDialogComponent } from '../components/add-account-dialog/add-account-dialog.component';
 import { ProfileLinuxEmailComponent } from '../linux-email/profile-linux-email.component';
@@ -79,7 +79,6 @@ export class ProfileIdentitiesComponent implements OnInit {
   public readonly hasUnverified: Signal<boolean> = computed(() => this.unverifiedIdentities().length > 0);
   public readonly menuItemsMap: Signal<Map<string, MenuItem[]>> = this.initMenuItemsMap();
 
-  private readonly refreshTrigger$ = new Subject<void>();
   private readonly identitiesState: Signal<IdentitiesState> = this.initIdentitiesState();
 
   public ngOnInit(): void {
@@ -87,7 +86,7 @@ export class ProfileIdentitiesComponent implements OnInit {
 
     if (params['success'] === 'identity_linked') {
       this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Identity linked successfully.' });
-      this.refreshTrigger$.next();
+      this.userService.refreshUserIdentities();
       this.clearQueryParams();
     } else if (params['error'] === 'already_linked') {
       this.conflictDetected.set(true);
@@ -124,7 +123,7 @@ export class ProfileIdentitiesComponent implements OnInit {
 
     dialogRef.onClose.pipe(take(1)).subscribe((result) => {
       if (result) {
-        this.refreshTrigger$.next();
+        this.userService.refreshUserIdentities();
       }
     });
   }
@@ -160,7 +159,7 @@ export class ProfileIdentitiesComponent implements OnInit {
 
     dialogRef.onClose.pipe(take(1)).subscribe((result) => {
       if (result) {
-        this.refreshTrigger$.next();
+        this.userService.refreshUserIdentities();
       }
     });
   }
@@ -188,7 +187,7 @@ export class ProfileIdentitiesComponent implements OnInit {
           .rejectIdentity(identity.id, identity.provider, identity.auth0UserId)
           .pipe(take(1))
           .subscribe({
-            next: () => this.refreshTrigger$.next(),
+            next: () => this.userService.refreshUserIdentities(),
             error: (err: HttpErrorResponse) => {
               if (err.error?.error === 'management_token_required' && err.error?.authorize_url) {
                 window.location.href = err.error.authorize_url;
@@ -232,7 +231,7 @@ export class ProfileIdentitiesComponent implements OnInit {
       return signal({ identities: [] as EnrichedIdentity[], loaded: false });
     }
     return toSignal(
-      this.refreshTrigger$.pipe(
+      this.userService.identitiesRefresh$.pipe(
         startWith(undefined),
         switchMap(() => {
           this.identitiesLoadError.set(false);

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -49,9 +49,8 @@ export class UserService {
 
   private readonly userMeetingsRefresh$ = new Subject<void>();
   private readonly userPastMeetingsRefresh$ = new Subject<void>();
-  // Shared identities refresh — lets the Identities tab notify the profile shell (and vice versa) so
-  // the shell's GitHub handle and tab-notification dots update after a link/verify/add/remove without
-  // a full reload (LFXV2-2767). Consumers each run their own getIdentities() fetch off this trigger.
+  // Shared identities refresh trigger — tab and shell each run their own getIdentities() fetch off
+  // this so the shell's GitHub handle / dots update after a link/verify/add/remove (LFXV2-2767).
   private readonly userIdentitiesRefresh$ = new Subject<void>();
   public readonly identitiesRefresh$: Observable<void> = this.userIdentitiesRefresh$.asObservable();
   // Per-chain destroy signals so that on user change we can tear down the old shareReplay

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -49,6 +49,11 @@ export class UserService {
 
   private readonly userMeetingsRefresh$ = new Subject<void>();
   private readonly userPastMeetingsRefresh$ = new Subject<void>();
+  // Shared identities refresh — lets the Identities tab notify the profile shell (and vice versa) so
+  // the shell's GitHub handle and tab-notification dots update after a link/verify/add/remove without
+  // a full reload (LFXV2-2767). Consumers each run their own getIdentities() fetch off this trigger.
+  private readonly userIdentitiesRefresh$ = new Subject<void>();
+  public readonly identitiesRefresh$: Observable<void> = this.userIdentitiesRefresh$.asObservable();
   // Per-chain destroy signals so that on user change we can tear down the old shareReplay
   // chain (which stays alive under refCount:false) instead of leaking abandoned subscriptions
   // to the refresh subjects. A fresh Subject is created for each new chain.
@@ -245,6 +250,15 @@ export class UserService {
    */
   public refreshUserPastMeetings(): void {
     this.userPastMeetingsRefresh$.next();
+  }
+
+  /**
+   * Signal that the user's connected identities changed (link / verify / add / remove). Consumers
+   * subscribed to {@link identitiesRefresh$} re-fetch, keeping the profile shell and the Identities
+   * tab in sync (LFXV2-2767).
+   */
+  public refreshUserIdentities(): void {
+    this.userIdentitiesRefresh$.next();
   }
 
   /**


### PR DESCRIPTION
## Summary

- `ProfileLayoutComponent` fetched connected identities once via `toSignal`, so
  the right-panel GitHub handle and the tab-notification dots went stale after a
  link/verify/add/remove on the Identities tab (which had its own local refresh)
  — until a full reload.
- Add a shared identities-refresh subject to `UserService` (`identitiesRefresh$`
  + `refreshUserIdentities()`), mirroring the existing meetings-refresh pattern.
- The profile shell and the Identities tab both fetch off `identitiesRefresh$`
  (via `startWith` + `switchMap`); the tab's mutation handlers now call
  `refreshUserIdentities()` instead of a local trigger, so the shell's handle
  and dots update live without a reload.
- Each consumer keeps its own fetch + error handling (no shared cache),
  preserving the tab's load-error / loaded UX.

JIRA: [LFXV2-2767](https://linuxfoundation.atlassian.net/browse/LFXV2-2767)

[LFXV2-2767]: https://linuxfoundation.atlassian.net/browse/LFXV2-2767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ