### PR TITLE
feat(create): drive create quick-link from server permissions

### DIFF
--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -21,7 +21,10 @@
  *       feeding the curated `creatableProjects` (verified in production-code review), not asserted here.
  * - S5: a single eligible project is auto-selected on open (Continue enabled without a pick); with
  *       multiple eligible projects nothing is pre-selected and Continue stays gated until the user picks
- * - S6: Continue routes into the create flow — lands on the lens-prefixed create URL carrying ?project=<slug>
+ * - S6: Continue routes into the create flow — lands on a create page carrying ?project=<slug>
+ * - S7: a committee-target type routes with both ?project= (owning project slug) and ?committee_uid=
+ * - S8: a committee-writer-only user (no project/foundation writer grant) sees the rail button with
+ *       only meeting/vote/survey offered
  *
  * Prerequisites:
  * - Dev server reachable at the Playwright baseURL
@@ -31,6 +34,11 @@
  *
  * Note: this suite stops at the dialog boundary. It does not assert the post-Continue
  * create page — that path is enforced by each route's writerGuard.
+ *
+ * LFXV2-2755: the dialog no longer aligns the navigation lens before navigating (removed the
+ * `LensService.setLens` coupling) — it navigates by explicit target selection, resolved by the
+ * create-route guards independently of the active lens. So Continue can legitimately land on a
+ * flat (non-lens-prefixed) create URL; S6 asserts the query param + successful load, not a URL prefix.
  */
 
 import { expect, Locator, Page, test } from '@playwright/test';
@@ -79,6 +87,18 @@ function continueButton(page: Page): Locator {
   return page.getByTestId('create-artifact-continue-button').locator('button');
 }
 
+// Scoped to the project/foundation selector specifically — the dialog can render a second,
+// independent `lfx-project-selector` instance for committees (LFXV2-2755), so an unscoped
+// `dialog.getByTestId('project-selector')` would violate Playwright strict mode whenever both
+// are visible for the same artifact type.
+function projectSelectorTrigger(dialog: Locator): Locator {
+  return dialog.getByTestId('create-artifact-project-select').getByTestId('project-selector');
+}
+
+function committeeSelectorTrigger(dialog: Locator): Locator {
+  return dialog.getByTestId('create-artifact-committee-select').getByTestId('project-selector');
+}
+
 test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
@@ -123,10 +143,11 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
   test('S3: picking "Meeting" opens the dialog and choosing a project enables Continue', async ({ page }) => {
     await openDialogForType(page, 'meeting');
 
-    // Open the reused project-selector (same UI as the sidebar). Scope the trigger to the dialog —
-    // the same `project-selector` testid is emitted by the sidebar's instance in project/foundation lens.
+    // Open the reused project-selector (same UI as the sidebar). Scope the trigger to the
+    // project/foundation selector specifically — the dialog can also render an independent
+    // committee selector carrying the same `project-selector` testid (LFXV2-2755).
     const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
+    await projectSelectorTrigger(dialog).click();
     const panel = page.getByTestId('project-selector-panel');
     await expect(panel).toBeVisible({ timeout: 5_000 });
     const firstItem = panel.locator('[data-testid^="lens-item-"]').first();
@@ -140,9 +161,9 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
   test('S4: the project selector reuses the search + tabs pattern and renders selectable projects', async ({ page }) => {
     await openDialogForType(page, 'meeting');
 
-    // Scope the trigger to the dialog — the sidebar renders the same `project-selector` testid in project/foundation lens.
+    // Scope to the project/foundation selector — see projectSelectorTrigger doc.
     const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
+    await projectSelectorTrigger(dialog).click();
     const panel = page.getByTestId('project-selector-panel');
     await expect(panel).toBeVisible({ timeout: 5_000 });
 
@@ -159,19 +180,31 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     await expect(panel.locator('[data-testid^="lens-item-"]').first()).toBeVisible({ timeout: 5_000 });
   });
 
-  // S5 — auto-select single: a lone eligible project is pre-selected so Continue is enabled without a pick
-  test('S5: a single eligible project is auto-selected; multiple require an explicit pick', async ({ page }) => {
+  // S5 — auto-select single: a lone eligible target (project OR committee, counted together — see
+  // CreateArtifactDialogComponent's constructor) is pre-selected so Continue is enabled without a pick.
+  test('S5: a single eligible target is auto-selected; multiple require an explicit pick', async ({ page }) => {
     await openDialogForType(page, 'meeting');
     const dialog = page.getByTestId('create-artifact-dialog');
-    const trigger = dialog.getByTestId('project-selector');
+    const trigger = projectSelectorTrigger(dialog);
 
-    // Count eligible options, then toggle the panel closed via the trigger (Escape could close the dialog).
+    // Count eligible project options, then toggle the panel closed via the trigger (Escape could close the dialog).
     await trigger.click();
     const panel = page.getByTestId('project-selector-panel');
     await expect(panel).toBeVisible({ timeout: 5_000 });
-    const itemCount = await panel.locator('[data-testid^="lens-item-"]').count();
+    let itemCount = await panel.locator('[data-testid^="lens-item-"]').count();
     await trigger.click();
     await expect(panel).toBeHidden();
+
+    // Meeting is a committee-eligible type — add the committee selector's count, if rendered, since
+    // auto-select fires when the two lists sum to exactly one (LFXV2-2755).
+    const committeeTrigger = committeeSelectorTrigger(dialog);
+    if (await committeeTrigger.isVisible().catch(() => false)) {
+      await committeeTrigger.click();
+      await expect(panel).toBeVisible({ timeout: 5_000 });
+      itemCount += await panel.locator('[data-testid^="lens-item-"]').count();
+      await committeeTrigger.click();
+      await expect(panel).toBeHidden();
+    }
 
     if (itemCount === 1) {
       // Auto-selected on open — no manual pick needed.
@@ -182,11 +215,11 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     }
   });
 
-  // S6 — Continue exercises the create-navigation path: lands on the lens-prefixed create URL carrying ?project=<slug>
+  // S6 — Continue exercises the create-navigation path: lands on a create page carrying ?project=<slug>
   test('S6: Continue navigates to the create page carrying the selected project slug', async ({ page }) => {
     await openDialogForType(page, 'meeting');
     const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
+    await projectSelectorTrigger(dialog).click();
     const panel = page.getByTestId('project-selector-panel');
     await expect(panel).toBeVisible({ timeout: 5_000 });
 
@@ -199,9 +232,64 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
 
     await continueButton(page).click();
 
-    // onContinue aligns the lens then navigates; lensRedirectGuard forwards to the lens-prefixed mount,
-    // preserving ?project=. Require the lens prefix explicitly (foundation|project) — a bare
-    // /meetings/create would mean setLens/lensRedirectGuard didn't run, so it must NOT match.
-    await expect(page).toHaveURL(new RegExp(`/(foundation|project)/meetings/create\\?.*project=${slug}`), { timeout: 15_000 });
+    // onContinue navigates by explicit selection (`?project=<slug>`), resolved by the create-route
+    // guards independently of the active lens (LFXV2-2755) — no lens-alignment step runs first, so a
+    // flat (non-lens-prefixed) URL is an expected, valid outcome here, not a bug. Assert the query
+    // param plus a successful landing on the create page rather than a URL prefix.
+    await expect(page).toHaveURL(new RegExp(`/meetings/create\\?.*project=${slug}`), { timeout: 15_000 });
+    await expect(page.getByTestId('create-artifact-dialog')).toBeHidden();
+  });
+
+  // S7 — a committee target carries both ?project= (owning project slug, for writerGuard + slot-seeding)
+  // and ?committee_uid= (the committee lock + committee-writer authorization) on navigation.
+  test('S7: Continue with a committee target carries both project and committee_uid', async ({ page }) => {
+    await openDialogForType(page, 'meeting');
+    const dialog = page.getByTestId('create-artifact-dialog');
+    const committeeTrigger = committeeSelectorTrigger(dialog);
+
+    const hasCommitteeSelector = await committeeTrigger.isVisible().catch(() => false);
+    test.skip(!hasCommitteeSelector, 'Test user holds no committee `writer` grant for a committee-eligible type — selector hidden by design.');
+
+    await committeeTrigger.click();
+    const panel = page.getByTestId('project-selector-panel');
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    const firstItem = panel.locator('[data-testid^="lens-item-"]').first();
+    await expect(firstItem).toBeVisible({ timeout: 5_000 });
+    await firstItem.click();
+
+    await expect(continueButton(page)).toBeEnabled();
+    await continueButton(page).click();
+
+    await expect(page).toHaveURL(/\/meetings\/create\?.*project=[^&]+.*committee_uid=[^&]+|\/meetings\/create\?.*committee_uid=[^&]+.*project=[^&]+/, {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('create-artifact-dialog')).toBeHidden();
+  });
+});
+
+// S8 — a committee-writer-only user (no project/foundation writer grant at all) still sees the rail
+// button, and only the committee-eligible types (meeting/vote/survey) are offered — never
+// newsletter/group/mailing-list, which are project-only (LFXV2-2755).
+test.describe('Create Quick-Link — committee-writer-only visibility', () => {
+  test('S8: a committee-writer-only user sees the rail button with only meeting/vote/survey offered', async ({ page }) => {
+    await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    const trigger = page.getByTestId('create-rail-button');
+    const visible = await trigger
+      .waitFor({ state: 'visible', timeout: RAIL_TIMEOUT })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!visible, 'Test user holds no writer grant of any kind — button hidden by design.');
+
+    await openCreateMenu(page);
+    const projectOnlyTypes: Array<'newsletter' | 'group' | 'mailing-list'> = ['newsletter', 'group', 'mailing-list'];
+    const anyProjectOnlyTypeVisible = await Promise.all(projectOnlyTypes.map((type) => page.getByTestId(`create-menu-option-${type}`).isVisible()));
+    test.skip(anyProjectOnlyTypeVisible.some(Boolean), 'Test user holds a project/foundation writer grant — not committee-writer-only.');
+
+    // Committee-writer-only: only the committee-eligible types are offered.
+    await expect(page.getByTestId('create-menu-option-meeting')).toBeVisible();
+    await expect(page.getByTestId('create-menu-option-vote')).toBeVisible();
+    await expect(page.getByTestId('create-menu-option-survey')).toBeVisible();
   });
 });

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -291,5 +291,8 @@ test.describe('Create Quick-Link — committee-writer-only visibility', () => {
     await expect(page.getByTestId('create-menu-option-meeting')).toBeVisible();
     await expect(page.getByTestId('create-menu-option-vote')).toBeVisible();
     await expect(page.getByTestId('create-menu-option-survey')).toBeVisible();
+    await expect(page.getByTestId('create-menu-option-newsletter')).toBeHidden();
+    await expect(page.getByTestId('create-menu-option-group')).toBeHidden();
+    await expect(page.getByTestId('create-menu-option-mailing-list')).toBeHidden();
   });
 });

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, model, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, model } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { ImpersonationBannerComponent } from '@components/impersonation-banner/impersonation-banner.component';
 import { LensSwitcherComponent } from '@components/lens-switcher/lens-switcher.component';
@@ -16,7 +16,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { SidebarNavService } from '@services/sidebar-nav.service';
 import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
-import { distinctUntilChanged, filter, map } from 'rxjs';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'lfx-main-layout',
@@ -46,17 +46,6 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
-  /**
-   * A route lens that {@link LensService.setLens} refused, held for retry.
-   *
-   * The allowed lens set is partly derived from `writer` grants, which arrive after hydration
-   * (LFXV2-2754), so a deep link or hard refresh onto a lens-prefixed route can run before the
-   * grants land. Dropping the refusal there would strand the user on a `/foundation/...` URL with
-   * the lens still `me` — `activeContext` would then resolve the wrong slot and the page would act
-   * on the wrong project. Retried by the subscription below once the set widens.
-   */
-  private readonly pendingRouteLens = signal<Lens | null>(null);
-
   public constructor() {
     // Close mobile sidebar and sync lens from route data on navigation
     this.router.events
@@ -68,28 +57,6 @@ export class MainLayoutComponent {
         this.appService.closeMobileSidebar();
         this.selectorPanelOpen.set(false);
         this.syncLensFromRoute();
-      });
-
-    // Re-assert a refused route lens when the allowed set changes, i.e. when the writer grants
-    // resolve. This terminates because `pendingRouteLens` is cleared on the successful pass and
-    // re-armed only by a later navigation — not because the set is monotonic. It isn't: the
-    // persona half can narrow when `PersonaService.refreshFromApi()` drops a cookie-claimed role.
-    //
-    // `availableLenses` is a computed returning a fresh array each recompute, so it re-emits on
-    // unrelated persona/flag churn with identical content. Comparing the projected lens ids keeps
-    // this to genuine changes — re-running on every churn would re-assert a lens the user may have
-    // since changed by another path.
-    toObservable(this.lensService.availableLenses)
-      .pipe(
-        map((lenses) => lenses.map((option) => option.id).join(',')),
-        distinctUntilChanged(),
-        takeUntilDestroyed()
-      )
-      .subscribe(() => {
-        const pending = this.pendingRouteLens();
-        if (pending && this.lensService.setLens(pending)) {
-          this.pendingRouteLens.set(null);
-        }
       });
   }
 
@@ -135,11 +102,8 @@ export class MainLayoutComponent {
       this.projectContextService.setRouteLensKind(null);
     }
 
-    // Assigned on every navigation, including routes that carry no lens, so a pending retry from an
-    // earlier route can never outlive it. Without that, switching lens from the switcher (which
-    // navigates to a route that may carry no lens data) would leave the old value armed, and the
-    // retry below would later clobber the user's explicit choice.
-    const pending = lens && lens in ALL_LENSES && !this.lensService.setLens(lens) ? lens : null;
-    this.pendingRouteLens.set(pending);
+    if (lens && lens in ALL_LENSES) {
+      this.lensService.setLens(lens);
+    }
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -532,7 +532,10 @@ export class MeetingManageComponent {
     }
 
     return {
-      project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid(),
+      // Falls back to the locked committee's own project_uid when the project slot isn't seeded —
+      // a committee-only writer (no direct project-viewer relation) has no project resolvable via
+      // `?project=`'s guard seeding, so `activeContextUid()` would otherwise be empty (LFXV2-2755).
+      project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid() || this.committeeContext()?.project_uid || '',
       title: formValue.title,
       description: formValue.description || '',
       start_time: startDateTime,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -368,6 +368,17 @@ export class MeetingManageComponent {
 
     // Prepare meeting data
     const meetingData = this.prepareMeetingData();
+
+    if (!meetingData.project_uid) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Project is required. Please select a project before saving.',
+      });
+      this.submitting.set(false);
+      return;
+    }
+
     const meetingId = this.meetingId()!;
     const updateMeeting$ = this.meetingService.updateMeeting(meetingId, meetingData as UpdateMeetingRequest, 'single');
 

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -150,7 +150,10 @@ export class VoteManageComponent {
       return;
     }
 
-    const projectUid = this.vote()?.project_uid || this.project()?.uid;
+    // Falls back to the locked committee's own project_uid when the project slot isn't seeded —
+    // a committee-only writer (no direct project-viewer relation) has no project resolvable via
+    // `?project=`'s guard seeding, so `this.project()` would otherwise be empty (LFXV2-2755).
+    const projectUid = this.vote()?.project_uid || this.project()?.uid || this.committeeContext()?.project_uid;
     if (!projectUid) {
       this.messageService.add({
         severity: 'error',
@@ -280,7 +283,10 @@ export class VoteManageComponent {
       return;
     }
 
-    const projectUid = this.vote()?.project_uid || this.project()?.uid;
+    // Falls back to the locked committee's own project_uid when the project slot isn't seeded —
+    // a committee-only writer (no direct project-viewer relation) has no project resolvable via
+    // `?project=`'s guard seeding, so `this.project()` would otherwise be empty (LFXV2-2755).
+    const projectUid = this.vote()?.project_uid || this.project()?.uid || this.committeeContext()?.project_uid;
     if (!projectUid) {
       this.messageService.add({
         severity: 'error',

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -14,23 +14,47 @@
   </div>
 
   <!-- Foundation / project — reuses the sidebar project-selector (search + All/Foundations/Projects tabs,
-       logos, role badges). Fed the writer-scoped `selectorItems` via the curated `items` input so the list
-       is only projects the user holds `writer` on, not the view-scoped nav catalog. -->
-  <div class="flex flex-col gap-1">
-    <label class="text-sm text-gray-900">
-      Select Foundation/Project
-      <span class="text-red-500">*</span>
-    </label>
-    <lfx-project-selector
-      [lens]="'project'"
-      [hybridMode]="true"
-      [items]="selectorItems()"
-      [selectedProject]="selectedContext()"
-      searchPlaceholder="Search foundations and projects..."
-      emptyMessage="No foundations or projects available"
-      (itemSelected)="onItemSelected($event)"
-      data-testid="create-artifact-project-select" />
-  </div>
+       logos, role badges). Fed the writer-scoped `projectSelectorItems` via the curated `items` input so
+       the list is only projects the user holds `writer` on, not the view-scoped nav catalog. -->
+  @if (showProjectSelector()) {
+    <div class="flex flex-col gap-1">
+      <label class="text-sm text-gray-900">
+        Select Foundation/Project
+        <span class="text-red-500">*</span>
+      </label>
+      <lfx-project-selector
+        [lens]="'project'"
+        [hybridMode]="true"
+        [items]="projectSelectorItems()"
+        [selectedProject]="selectedContext()"
+        searchPlaceholder="Search foundations and projects..."
+        emptyMessage="No foundations or projects available"
+        (itemSelected)="onProjectItemSelected($event)"
+        data-testid="create-artifact-project-select" />
+    </div>
+  }
+
+  <!-- Group / committee — same selector component in flat (non-hybrid) mode, since committees have
+       no Foundations/Projects split. Only rendered for artifact types that accept a committee target
+       and only when the user holds at least one committee `writer` grant.
+       Known cosmetic divergence: `lens="project"` is passed only to satisfy the selector's required
+       input (it has no `'group'`/`'committee'` lens); its "Project" subtext under the trigger is
+       therefore inaccurate for a committee selection. The "Select Group" label above disambiguates,
+       so this is accepted rather than threading a new lens kind through the shared selector. -->
+  @if (showCommitteeSelector()) {
+    <div class="flex flex-col gap-1">
+      <label class="text-sm text-gray-900">Select Group</label>
+      <lfx-project-selector
+        [lens]="'project'"
+        [hybridMode]="false"
+        [items]="committeeSelectorItems()"
+        [selectedProject]="selectedContext()"
+        searchPlaceholder="Search groups..."
+        emptyMessage="No groups available"
+        (itemSelected)="onCommitteeItemSelected($event)"
+        data-testid="create-artifact-committee-select" />
+    </div>
+  }
 
   <!-- Actions -->
   <div class="flex justify-end gap-3" data-testid="create-artifact-modal-actions">

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
@@ -7,10 +7,16 @@ import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
 import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
-import { CreatableArtifactConfig, CreatableArtifactType, CreatableProject, LensItem, ProjectContext } from '@lfx-one/shared/interfaces';
+import {
+  CreatableArtifactConfig,
+  CreatableArtifactType,
+  CreatableCommittee,
+  CreatableProject,
+  CreatableTarget,
+  LensItem,
+  ProjectContext,
+} from '@lfx-one/shared/interfaces';
 import { CreatePermissionService } from '@services/create-permission.service';
-import { LensService } from '@services/lens.service';
-import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -23,109 +29,110 @@ export class CreateArtifactDialogComponent {
   private readonly dialogRef = inject(DynamicDialogRef);
   private readonly config = inject(DynamicDialogConfig);
   private readonly router = inject(Router);
-  private readonly projectContextService = inject(ProjectContextService);
   private readonly createPermissionService = inject(CreatePermissionService);
-  private readonly lensService = inject(LensService);
   private readonly messageService = inject(MessageService);
 
   // The artifact type is chosen in the rail popover and handed to the dialog as data;
-  // this dialog only resolves the project/foundation for that fixed type.
+  // this dialog only resolves the target (project/foundation/committee) for that fixed type.
   protected readonly artifact: CreatableArtifactConfig = this.resolveArtifact();
 
   // Header + primary CTA copy, e.g. "Create Meeting".
   protected readonly createLabel = `Create ${this.artifact.label}`;
 
+  // Single control holding whichever target's uid is selected — project/foundation or committee.
+  // `selectedTarget` below carries the discriminated target the uid resolves to.
   protected readonly form = new FormGroup({
     project: new FormControl<string | null>(null, { validators: [Validators.required] }),
   });
 
-  // The picked project — drives the selector's trigger label/checkmark. Set on itemSelected.
-  protected readonly selectedContext: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
+  // The picked target — drives both selectors' trigger label/checkmark. Set on itemSelected.
+  protected readonly selectedTarget: WritableSignal<CreatableTarget | null> = signal<CreatableTarget | null>(null);
 
-  // Reactive by reference: the rail button only renders once this list is non-empty, so the
-  // dialog always opens populated — but reading the signal keeps it correct if it widens
-  // (e.g. persona data resolving and unlocking another lens) while the dialog is open.
-  protected readonly projectOptions: Signal<CreatableProject[]> = this.createPermissionService.creatableProjects;
-
-  // Writer-scoped options mapped to the selector's `LensItem` shape. Feeding this as the selector's
-  // curated `items` input keeps the list scoped to projects the user holds `writer` on — never the
-  // view-scoped NavigationService catalog the sidebar selector pulls by default.
-  protected readonly selectorItems: Signal<LensItem[]> = computed(() =>
-    this.projectOptions().map((project) => ({
-      uid: project.uid,
-      slug: project.slug,
-      name: project.name,
-      logoUrl: project.logoUrl ?? null,
-      isFoundation: project.isFoundation,
-    }))
+  // Reactive by reference: the rail button only renders once at least one list is non-empty, so
+  // the dialog always opens populated — but reading the signal keeps it correct if it widens
+  // while the dialog is open. Scoped to `artifact.targetKinds` — a project-only type (e.g. Group)
+  // never surfaces committee targets even if the user holds committee-writer grants.
+  protected readonly projectOptions: Signal<CreatableProject[]> = computed(() =>
+    this.artifact.targetKinds.includes('project') ? this.createPermissionService.creatableProjects() : []
+  );
+  protected readonly committeeOptions: Signal<CreatableCommittee[]> = computed(() =>
+    this.artifact.targetKinds.includes('committee') ? this.createPermissionService.creatableCommittees() : []
   );
 
+  protected readonly showProjectSelector: Signal<boolean> = computed(() => this.artifact.targetKinds.includes('project'));
+  protected readonly showCommitteeSelector: Signal<boolean> = computed(
+    () => this.artifact.targetKinds.includes('committee') && this.committeeOptions().length > 0
+  );
+
+  // Writer-scoped options mapped to the selector's `LensItem` shape. Feeding this as the selector's
+  // curated `items` input keeps each list scoped to targets the user holds `writer` on — never the
+  // view-scoped NavigationService catalog the sidebar selector pulls by default.
+  protected readonly projectSelectorItems: Signal<LensItem[]> = computed(() => this.projectOptions().map(projectToLensItem));
+  protected readonly committeeSelectorItems: Signal<LensItem[]> = computed(() => this.committeeOptions().map(committeeToLensItem));
+
+  // Drives the `[selectedProject]` checkmark binding on both selectors — a target selected in one
+  // selector simply won't match any uid in the other's item list, so only the active one highlights.
+  protected readonly selectedContext: Signal<ProjectContext | null> = computed(() => {
+    const target = this.selectedTarget();
+    if (!target) return null;
+    return target.kind === 'project'
+      ? { uid: target.uid, name: target.name, slug: target.slug, parent_uid: target.parent_uid, logoUrl: target.logoUrl }
+      : { uid: target.uid, name: target.name, slug: target.uid, logoUrl: target.logoUrl };
+  });
+
   public constructor() {
-    // Auto-select when the user can create on exactly one project/foundation: pre-fill the choice so the
-    // dialog opens with Continue enabled and the picker just shows the locked-in row — no redundant
-    // open-and-pick for a list of one. The rail button only renders once the list is non-empty, so this
-    // reflects the state the dialog opened in; if it later widens (persona data resolving), the user can
-    // still change the selection via the selector.
-    const options = this.projectOptions();
-    if (options.length === 1) {
-      this.applySelection(options[0]);
+    // Auto-select when the user can create against exactly one target across both lists: pre-fill
+    // the choice so the dialog opens with Continue enabled and the picker just shows the locked-in
+    // row — no redundant open-and-pick for a list of one. The rail button only renders once at
+    // least one list is non-empty, so this reflects the state the dialog opened in; if it later
+    // widens, the user can still change the selection via either selector.
+    const projects = this.projectOptions();
+    const committees = this.committeeOptions();
+    if (projects.length + committees.length === 1) {
+      if (projects.length === 1) {
+        this.applySelection({ kind: 'project', ...projects[0] });
+      } else {
+        this.applySelection({ kind: 'committee', ...committees[0] });
+      }
     }
   }
 
-  /** Bridge the selector's `itemSelected` output into the form control that gates the Continue CTA. */
-  public onItemSelected(item: LensItem): void {
-    this.applySelection(this.projectOptions().find((option) => option.uid === item.uid) ?? null);
+  /** Bridge the project/foundation selector's `itemSelected` output into the shared form control. */
+  public onProjectItemSelected(item: LensItem): void {
+    const project = this.projectOptions().find((option) => option.uid === item.uid);
+    this.applySelection(project ? { kind: 'project', ...project } : null);
+  }
+
+  /** Bridge the committee selector's `itemSelected` output into the shared form control. */
+  public onCommitteeItemSelected(item: LensItem): void {
+    const committee = this.committeeOptions().find((option) => option.uid === item.uid);
+    this.applySelection(committee ? { kind: 'committee', ...committee } : null);
   }
 
   public onContinue(): void {
-    const projectUid = this.form.controls.project.value;
-    if (!projectUid) {
+    const targetUid = this.form.controls.project.value;
+    if (!targetUid) {
       return;
     }
 
-    // The options are a live signal, so the selection can disappear mid-dialog if the list
-    // narrows (e.g. a persona refresh dropping a lens) while the form control keeps the old uid.
-    const project = this.projectOptions().find((option) => option.uid === projectUid);
-    if (!project) {
-      this.failWith('That project is no longer available. Please choose another.');
+    // The options are live signals, so the selection can disappear mid-dialog if a list narrows
+    // while the form control keeps the old uid.
+    const target = this.selectedTarget();
+    if (!target || target.uid !== targetUid || !this.isTargetStillAvailable(target)) {
+      this.failWith('That selection is no longer available. Please choose another.');
       return;
     }
 
-    const context: ProjectContext = this.toContext(project);
-
-    // `activeContext` is lens-gated: under `me`/`org` it reads the slot matching the user's
-    // *persona*, not the kind picked here, so the create page would resolve the other slot.
-    // Aligning the lens first makes it read the slot seeded below.
-    //
-    // This should now always succeed: the options are exactly the user's `writer` grants, and
-    // `getAllowedLensIds` admits any lens they hold `writer` within (LFXV2-2754), so the lens
-    // for a listed project is available by construction. It previously failed for real users —
-    // the lens came from persona alone, which a writer grant does not imply — which is the bug
-    // this path was fixed for. Kept as a defensive bail because the alternative on an
-    // unexpected refusal is creating against a stale project, which `writerGuard`'s ED
-    // fast-path would not catch.
-    if (!this.lensService.setLens(project.isFoundation ? 'foundation' : 'project')) {
-      console.error('Cannot align lens to the selected project; aborting create navigation.', {
-        slug: project.slug,
-        isFoundation: project.isFoundation,
-      });
-      this.failWith(`You don't have access to create in ${project.name}.`);
-      return;
-    }
-
-    // Seed the slot matching the selection's kind. `syncUrl: false` because the default rewrites
-    // the *current* page's history entry via replaceState — the dialog is global to the rail, so
-    // that would re-point whatever page the user opened it from. `router.navigate` carries the
-    // slug to the destination instead.
-    if (project.isFoundation) {
-      this.projectContextService.setFoundation(context, false);
+    // Navigate by explicit selection rather than aligning the active lens first — the create-route
+    // guards (`projectQueryParamGuard` + `writerGuard`) resolve the target from these query params
+    // independently of the active lens, so no lens alignment step is needed here (see LFXV2-2755).
+    if (target.kind === 'committee') {
+      // `?project=` keeps `writerGuard` + slot-seeding working on the owning project; `committee_uid`
+      // drives the committee lock + committee-writer authorization on the create page.
+      this.router.navigate([this.artifact.createRoute], { queryParams: { project: target.projectSlug, committee_uid: target.uid } });
     } else {
-      this.projectContextService.setProject(context, false);
+      this.router.navigate([this.artifact.createRoute], { queryParams: { project: target.slug } });
     }
-
-    // The slug keeps writerGuard authoritative on the chosen project and lets
-    // projectQueryParamGuard re-seed real project data on the lens-prefixed mounts.
-    this.router.navigate([this.artifact.createRoute], { queryParams: { project: project.slug } });
     this.dialogRef.close(true);
   }
 
@@ -133,16 +140,16 @@ export class CreateArtifactDialogComponent {
     this.dialogRef.close(false);
   }
 
-  /** Set (or clear) the current selection — drives the selector's display and the Continue-gating control. */
-  private applySelection(project: CreatableProject | null): void {
-    this.selectedContext.set(project ? this.toContext(project) : null);
-    this.form.controls.project.setValue(project?.uid ?? null);
+  /** Set (or clear) the current selection — drives both selectors' display and the Continue-gating control. */
+  private applySelection(target: CreatableTarget | null): void {
+    this.selectedTarget.set(target);
+    this.form.controls.project.setValue(target?.uid ?? null);
     this.form.controls.project.markAsTouched();
   }
 
-  /** Project a writer-scoped `CreatableProject` down to the `ProjectContext` the context service stores. */
-  private toContext(project: CreatableProject): ProjectContext {
-    return { uid: project.uid, name: project.name, slug: project.slug, parent_uid: project.parent_uid, logoUrl: project.logoUrl };
+  /** True while the selected target is still present in its corresponding live options list. */
+  private isTargetStillAvailable(target: CreatableTarget): boolean {
+    return target.kind === 'project' ? this.projectOptions().some((p) => p.uid === target.uid) : this.committeeOptions().some((c) => c.uid === target.uid);
   }
 
   /** Surface a dead-end to the user and close, rather than leaving the CTA silently inert. */
@@ -163,4 +170,19 @@ export class CreateArtifactDialogComponent {
     }
     return artifact;
   }
+}
+
+/** Project a writer-scoped `CreatableProject` down to the selector's curated `LensItem` shape. */
+function projectToLensItem(project: CreatableProject): LensItem {
+  return { uid: project.uid, slug: project.slug, name: project.name, logoUrl: project.logoUrl ?? null, isFoundation: project.isFoundation };
+}
+
+/**
+ * Project a writer-scoped `CreatableCommittee` down to the selector's curated `LensItem` shape.
+ * `slug` has no committee-native meaning (committees aren't slug-addressed) — the committee uid is
+ * reused there purely to satisfy the shape; navigation never reads it for committee targets, it
+ * reads `projectSlug`/`uid` off the resolved `CreatableCommittee` directly (see `onContinue`).
+ */
+function committeeToLensItem(committee: CreatableCommittee): LensItem {
+  return { uid: committee.uid, slug: committee.uid, name: committee.name, logoUrl: committee.logoUrl ?? null, isFoundation: false };
 }

--- a/apps/lfx-one/src/app/shared/services/committee-writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee-writer-grants.service.ts
@@ -1,0 +1,89 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { HttpParams } from '@angular/common/http';
+import { Committee, CreatableCommittee } from '@lfx-one/shared/interfaces';
+import { CommitteeService } from '@services/committee.service';
+import { map } from 'rxjs';
+
+/**
+ * The user's per-committee `writer` grants — the committee-side sibling of
+ * {@link WriterGrantsService}. Kept as a separate service (rather than folded into
+ * `WriterGrantsService`) so the committee-target grants list isn't entangled with
+ * {@link LensService}'s persona-only lens derivation — committees never affect which
+ * lens is available, only which create targets are offered.
+ *
+ * `GET /api/committees?include_project_metadata=true` batch access-checks every visible
+ * committee (returning `writer` per committee) and additionally enriches each with the
+ * owning project's `project_slug` / `is_foundation`, which the plain list call does not
+ * populate. The enrichment is required here: navigation seeds the create-flow's
+ * project/foundation slot from `?project=<slug>`, so a committee-only writer's target must
+ * carry a resolved slug rather than just the raw `project_uid`.
+ *
+ * Only {@link CreatePermissionService} consumes this — committee grants never widen the
+ * lens set (see LFXV2-2755, which also reverts the lens layer back to persona-only).
+ *
+ * Resolves to `[]` while loading and on error — callers fail closed, matching
+ * `CommitteeService.getCommittees()`'s internal `catchError(() => of([]))`.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CommitteeWriterGrantsService {
+  private readonly committeeService = inject(CommitteeService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly grants = signal<CreatableCommittee[]>([]);
+
+  /** Committees the user holds `writer` on. Empty until the post-hydration fetch resolves. */
+  public readonly writerCommittees: Signal<CreatableCommittee[]> = this.grants.asReadonly();
+
+  public constructor() {
+    // Fetch after hydration, mirroring WriterGrantsService — the enrichment costs an extra
+    // upstream project fetch per distinct project_uid, so it must not block SSR's TTFB.
+    afterNextRender(() => {
+      const params = new HttpParams().set('include_project_metadata', 'true');
+
+      this.committeeService
+        .getCommittees(params)
+        .pipe(
+          map((committees) =>
+            committees
+              .filter((committee) => committee.writer === true)
+              .map(toCreatableCommittee)
+              .filter(isResolvedCommittee)
+          ),
+          takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe((committees) => this.grants.set(committees));
+    });
+  }
+}
+
+/**
+ * Project a raw enriched `Committee` down to the fields the create picker needs.
+ * Returns `null` when `project_slug` didn't resolve (e.g. the owning project fetch failed
+ * during enrichment) — a committee target without a navigable project slug can't seed the
+ * create-flow's project slot, so it's dropped rather than offered as a broken option.
+ */
+function toCreatableCommittee(committee: Committee): CreatableCommittee | null {
+  if (!committee.project_slug) {
+    return null;
+  }
+
+  return {
+    uid: committee.uid,
+    name: committee.name,
+    logoUrl: undefined,
+    projectUid: committee.project_uid,
+    projectSlug: committee.project_slug,
+    projectName: committee.project_name ?? '',
+    isFoundation: committee.is_foundation ?? false,
+  };
+}
+
+function isResolvedCommittee(committee: CreatableCommittee | null): committee is CreatableCommittee {
+  return committee !== null;
+}

--- a/apps/lfx-one/src/app/shared/services/create-permission.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-permission.service.ts
@@ -3,40 +3,41 @@
 
 import { computed, inject, Injectable, Signal } from '@angular/core';
 import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
-import { CreatableArtifactType, CreatableProject } from '@lfx-one/shared/interfaces';
+import { CreatableArtifactType, CreatableCommittee, CreatableProject } from '@lfx-one/shared/interfaces';
+import { CommitteeWriterGrantsService } from '@services/committee-writer-grants.service';
 import { WriterGrantsService } from '@services/writer-grants.service';
 
 /**
  * Decides whether the rail "Create" quick-link (and which artifact types) is
- * offered to the current user, and which projects/foundations they may target.
+ * offered to the current user, and which projects/foundations/committees they may target.
  *
- * Eligibility is the project `writer` grant, and nothing else — the same signal
- * `writerGuard` enforces. `GET /api/projects` batch access-checks every visible
- * project and returns `writer` per project, so this reflects real per-project
- * authorization rather than inferring it from a persona.
+ * Eligibility is composed from two independent `writer` grants, and nothing else — the same
+ * signals `writerGuard` enforces:
+ *  - Project/foundation `writer`, via {@link WriterGrantsService} (`GET /api/projects`).
+ *  - Committee (Group) `writer`, via {@link CommitteeWriterGrantsService} (`GET /api/committees`).
  *
- * This list was previously intersected with the lenses the user's persona holds,
- * on the reasoning that `ProjectContextService.activeContext` is lens-gated so an
- * unreachable lens would dead-end at "Create". That was true, but it made the wrong
- * side give way: it silently hid projects the user provably administers. A user
- * holding `writer` on 81 foundations while detecting as `contributor` could target
- * none of them (LFXV2-2754). The lens is now derived from the grant instead —
- * `LensService.getAllowedLensIds` admits any lens the user holds `writer` within —
- * so alignment succeeds for exactly the projects listed here and the intersection
- * is redundant. Do not reintroduce a persona-derived filter on this list; persona
- * and `writer` are independent, and `writer` is the one that confers authority.
+ * This list was previously intersected with the lenses the user's persona holds, on the
+ * reasoning that `ProjectContextService.activeContext` is lens-gated so an unreachable lens
+ * would dead-end at "Create". That was true, but it made the wrong side give way: it silently
+ * hid projects the user provably administers. A user holding `writer` on 81 foundations while
+ * detecting as `contributor` could target none of them (LFXV2-2754). LFXV2-2755 removes the
+ * coupling at its root instead: the create dialog navigates by explicit selection
+ * (`?project=<slug>` / `?committee_uid=<uid>`), which the create-route guards resolve
+ * independently of the active lens — so `LensService` reverts to deriving lenses from persona
+ * alone, and this list no longer needs to align a lens at all. Do not reintroduce a
+ * persona-derived filter here; persona and `writer` are independent, and `writer` is the one
+ * that confers authority.
  *
- * Everything resolves to `[]` while loading and on error, keeping the rail button
- * hidden until eligibility is proven — fail closed. The error half of that relies on
- * `ProjectService.getProjects()` catching internally and emitting `[]`.
+ * Everything resolves to `[]` while loading and on error, keeping the rail button hidden until
+ * eligibility is proven — fail closed. The error half of that relies on the two grants services'
+ * upstream calls catching internally and emitting `[]`.
  *
- * Granularity note: `writer` is not the whole story upstream. Meetings are broader
- * (`meeting_coordinator` and committee-writer also qualify), so users holding only
- * those roles are still under-shown — they source no project `writer` at all, so the
- * client cannot see them. This is a UX affordance only — the create routes'
- * `writerGuard` remains authoritative for non-ED personas, so the button never grants
- * access, it only advertises it. A `GET /api/projects/creatable` endpoint encoding the
- * per-type grants (LFXV2-2753) is what closes that remaining gap.
+ * Granularity note: `writer` is not the whole story upstream. Meetings are broader still
+ * (`meeting_coordinator` also qualifies, beyond project-writer and committee-writer), so users
+ * holding only that role are still under-shown. This is a UX affordance only — the create
+ * routes' `writerGuard` remains authoritative for non-ED personas, so the button never grants
+ * access, it only advertises it. A `GET /api/projects/creatable` endpoint encoding the full
+ * per-type grants (LFXV2-2753) is what would close that remaining gap.
  *
  * Persona note (ED): gating is purely the FGA `writer` relation, with NO ED fast-path —
  * unlike `writerGuard`, which synchronously allows the `executive-director` persona
@@ -53,24 +54,32 @@ import { WriterGrantsService } from '@services/writer-grants.service';
 })
 export class CreatePermissionService {
   private readonly writerGrantsService = inject(WriterGrantsService);
+  private readonly committeeWriterGrantsService = inject(CommitteeWriterGrantsService);
 
   /** Projects the user may create on — exactly those they hold `writer` on (see class doc). */
   public readonly creatableProjects: Signal<CreatableProject[]> = this.writerGrantsService.writerProjects;
 
-  /**
-   * Artifact types offered to the user — all types when they can create anywhere, else none.
-   *
-   * All-or-nothing by design: a `writer` grant is not per-type, so every type is offered together.
-   * A new `CREATABLE_ARTIFACTS` entry therefore inherits visibility for free — it does NOT get
-   * independent gating. Do not assume adding a type here narrows who sees it. The per-type
-   * intersection this feeds (`lens-switcher`'s `creatableArtifacts` filter) is consequently a
-   * no-op today; it exists so the switcher stays correct if a future `GET /api/projects/creatable`
-   * endpoint makes this list a genuine per-type subset (see class doc).
-   */
-  public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() =>
-    this.creatableProjects().length > 0 ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
-  );
+  /** Committees (Groups) the user may create meetings/votes/surveys against. */
+  public readonly creatableCommittees: Signal<CreatableCommittee[]> = this.committeeWriterGrantsService.writerCommittees;
 
-  /** True when the user can create on at least one project. */
-  public readonly canShowCreateButton: Signal<boolean> = computed(() => this.creatableProjects().length > 0);
+  /**
+   * Artifact types offered to the user — a genuine per-target-kind subset, not all-or-nothing.
+   *
+   * A type is offered iff the user holds at least one target of a `kind` listed in that type's
+   * `targetKinds` (see `CREATABLE_ARTIFACTS`). A committee-only writer (no project/foundation
+   * `writer` grant at all) is offered meeting/vote/survey only; a project/foundation writer is
+   * offered all six. This is what makes `lens-switcher`'s `creatableArtifacts` filter meaningful
+   * rather than a no-op.
+   */
+  public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() => {
+    const hasProjectTarget = this.creatableProjects().length > 0;
+    const hasCommitteeTarget = this.creatableCommittees().length > 0;
+
+    return CREATABLE_ARTIFACTS.filter(
+      (artifact) => (hasProjectTarget && artifact.targetKinds.includes('project')) || (hasCommitteeTarget && artifact.targetKinds.includes('committee'))
+    ).map((artifact) => artifact.type);
+  });
+
+  /** True when the user can create on at least one project or committee. */
+  public readonly canShowCreateButton: Signal<boolean> = computed(() => this.creatableProjects().length > 0 || this.creatableCommittees().length > 0);
 }

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -19,7 +19,6 @@ import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
 import { PersonaService } from './persona.service';
-import { WriterGrantsService } from './writer-grants.service';
 
 @Injectable({
   providedIn: 'root',
@@ -29,7 +28,6 @@ export class LensService {
   private readonly cookieRegistry = inject(CookieRegistryService);
   private readonly personaService = inject(PersonaService);
   private readonly featureFlagService = inject(FeatureFlagService);
-  private readonly writerGrantsService = inject(WriterGrantsService);
   private readonly router = inject(Router);
 
   /** Dark-launch gate; off by default until the LaunchDarkly flag is flipped. */
@@ -112,27 +110,20 @@ export class LensService {
   }
 
   /**
-   * Lenses the current user may use. Persona roles and `writer` grants each confer access
-   * independently (LFXV2-2754) — see `deriveAllowedLenses` for why either suffices.
+   * Lenses the current user may use, derived from persona roles alone (LFXV2-2755 reverted the
+   * `writer`-grant widening LFXV2-2754 added — see `deriveAllowedLenses`).
    *
-   * This set is not stable across a session, in two different ways:
-   *  - the `writer` half arrives after hydration (see {@link WriterGrantsService}) and only ever
-   *    widens as grants land;
-   *  - the persona half can *narrow*. It is seeded from a cookie and then replaced by
-   *    `PersonaService.refreshFromApi()`, which may drop a role the cookie claimed and clears
-   *    `isRootWriter` on its error path.
-   *
-   * So a caller must treat a `false` from {@link setLens} as provisional rather than final, and
-   * must not assume a lens it holds now will still be allowed later.
-   * `MainLayoutComponent.syncLensFromRoute` is the one caller that re-asserts.
+   * This set can still *narrow* across a session: it is seeded from a cookie and then replaced by
+   * `PersonaService.refreshFromApi()`, which may drop a role the cookie claimed and clears
+   * `isRootWriter` on its error path. So a caller must treat a `false` from {@link setLens} as
+   * provisional rather than final, and must not assume a lens it holds now will still be allowed
+   * later. `MainLayoutComponent.syncLensFromRoute` is the one caller that re-asserts.
    */
   private getAllowedLensIds(): readonly Lens[] {
     return deriveAllowedLenses({
       hasBoardRole: this.personaService.hasBoardRole(),
       hasProjectRole: this.personaService.hasProjectRole(),
       isRootWriter: this.personaService.isRootWriter(),
-      hasWriterFoundation: this.writerGrantsService.hasWriterFoundation(),
-      hasWriterProject: this.writerGrantsService.hasWriterProject(),
       isOrgLensEnabled: this.isOrgLensEnabled(),
     });
   }

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
+import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CreatableProject, Project } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation } from '@lfx-one/shared/utils';
@@ -13,15 +13,11 @@ import { map } from 'rxjs';
  *
  * `GET /api/projects` batch access-checks every visible project and returns `writer` per
  * project, so this reflects real authorization rather than inferring it from a persona.
- * Owned here rather than in a consumer because two independent consumers need it and must
- * not depend on each other:
- *  - {@link LensService} widens the allowed lens set to cover projects the user can write
- *    to (LFXV2-2754) — a `writer` grant is authority over that project, so the lens that
- *    reaches it must be available regardless of which persona was detected.
- *  - {@link CreatePermissionService} scopes the create quick-link to the same grants.
  *
- * Dependency direction matters: this service injects only `ProjectService` (which injects
- * only `HttpClient`), so `LensService` can consume it without a cycle.
+ * Sole consumer today is {@link CreatePermissionService}, which scopes the create quick-link
+ * to these grants. `LensService` previously widened the allowed-lens set from this signal too
+ * (LFXV2-2754), but LFXV2-2755 reverted that — lens derivation is persona-only again since the
+ * create flow now resolves its target from an explicit selection rather than the active lens.
  *
  * Resolves to `[]` while loading and on error — callers fail closed. The error half relies
  * on `ProjectService.getProjects()` catching internally and emitting `[]`; a local
@@ -38,12 +34,6 @@ export class WriterGrantsService {
 
   /** Projects the user holds `writer` on. Empty until the post-hydration fetch resolves. */
   public readonly writerProjects: Signal<CreatableProject[]> = this.grants.asReadonly();
-
-  /** True once at least one writer-held project satisfies `computeIsFoundation`. */
-  public readonly hasWriterFoundation: Signal<boolean> = computed(() => this.grants().some((project) => project.isFoundation));
-
-  /** True once at least one writer-held project is a non-foundation project. */
-  public readonly hasWriterProject: Signal<boolean> = computed(() => this.grants().some((project) => !project.isFoundation));
 
   public constructor() {
     // Fetch after hydration, not at construction. The endpoint paginates every visible project

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -130,11 +130,20 @@ export class CommitteeService {
 
   /**
    * Fetches all committees based on query parameters
+   *
+   * @param query.include_project_metadata When `'true'`, enriches every returned committee with
+   *   `project_name`, `project_slug`, `is_foundation`, and `parent_project_uid` via
+   *   `ProjectService.enrichWithProjectData` (batched, de-duplicated across the result set).
+   *   Mirrors the `includeProjectMetadata` option on {@link getCommitteeById}. Opt-in because it
+   *   costs an extra upstream project fetch per distinct `project_uid` — enable only for callers
+   *   that need slug-based navigation (e.g. the committee-writer create-target grants list).
    */
   public async getCommittees(req: Request, query: Record<string, any> = {}): Promise<Committee[]> {
     const queryFilters = { ...query };
     delete queryFilters['page_token'];
     delete queryFilters['page_size'];
+    const includeProjectMetadata = queryFilters['include_project_metadata'] === 'true';
+    delete queryFilters['include_project_metadata'];
 
     const params = {
       ...queryFilters,
@@ -198,6 +207,10 @@ export class CommitteeService {
           total: totalBefore,
         });
       }
+    }
+
+    if (includeProjectMetadata) {
+      return this.projectService.enrichWithProjectData(req, committees);
     }
 
     return committees;

--- a/packages/shared/src/constants/create-artifact.constants.ts
+++ b/packages/shared/src/constants/create-artifact.constants.ts
@@ -22,6 +22,7 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-calendar',
     createRoute: '/meetings/create',
     group: 'engage',
+    targetKinds: ['project', 'committee'],
   },
   {
     type: 'newsletter',
@@ -30,6 +31,7 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-paper-plane',
     createRoute: '/newsletters/create',
     group: 'engage',
+    targetKinds: ['project'],
   },
   {
     type: 'vote',
@@ -38,6 +40,7 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-check-to-slot',
     createRoute: '/votes/create',
     group: 'decide',
+    targetKinds: ['project', 'committee'],
   },
   {
     type: 'survey',
@@ -46,6 +49,7 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-clipboard-list',
     createRoute: '/surveys/create',
     group: 'decide',
+    targetKinds: ['project', 'committee'],
   },
   {
     type: 'group',
@@ -54,6 +58,7 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-people-group',
     createRoute: '/groups/create',
     group: 'organize',
+    targetKinds: ['project'],
   },
   {
     type: 'mailing-list',
@@ -62,5 +67,6 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     icon: 'fa-light fa-envelope',
     createRoute: '/mailing-lists/create',
     group: 'organize',
+    targetKinds: ['project'],
   },
 ];

--- a/packages/shared/src/interfaces/create-artifact.interface.ts
+++ b/packages/shared/src/interfaces/create-artifact.interface.ts
@@ -36,6 +36,14 @@ export interface CreatableArtifactConfig {
   createRoute: string;
   /** Semantic group this entry belongs to; a change between adjacent entries draws a menu separator. */
   group: CreatableArtifactGroup;
+  /**
+   * Which target kinds this artifact type can be created against. A committee-writer-only
+   * user is only offered types whose `targetKinds` includes `'committee'` — mirrors the
+   * `writerGuard`'s `supportsCommitteeWriter` list (meetings/surveys/votes). Types not in
+   * that list (newsletter, group, mailing-list) require an actual project/foundation writer
+   * grant, since creating a *new* group is itself a project-writer operation.
+   */
+  targetKinds: CreatableTargetKind[];
 }
 
 /**
@@ -52,3 +60,35 @@ export interface CreatableProject extends ProjectContext {
    */
   isFoundation: boolean;
 }
+
+/** Discriminator for a create-target selector entry — a project/foundation or a committee. */
+export type CreatableTargetKind = 'project' | 'committee';
+
+/**
+ * A committee (Group) the current user is permitted to create meetings/votes/surveys
+ * against, sourced from a `writer === true` grant on `GET /api/committees`. Carries the
+ * owning project's slug/uid so navigation can seed `?project=<projectSlug>` alongside
+ * `?committee_uid=<uid>` — the create pages resolve `project_uid` from the seeded slot,
+ * falling back to `projectUid` directly when the caller has no independent project-viewer
+ * relation (see the committee-only writer fallback on the meeting/vote/survey create pages).
+ */
+export interface CreatableCommittee {
+  /** Committee UID. */
+  uid: string;
+  name: string;
+  logoUrl?: string;
+  /** Owning project's UID — used as a fallback when the project slot isn't seeded. */
+  projectUid: string;
+  /** Owning project's URL slug — carried as `?project=` to seed the create-flow slot. */
+  projectSlug: string;
+  projectName: string;
+  /** Whether the owning project is a foundation (top-level entity). */
+  isFoundation: boolean;
+}
+
+/**
+ * A create-target selector entry — either a project/foundation grant or a committee grant.
+ * `kind` discriminates which shape follows so the dialog and navigation code can branch
+ * without an `instanceof`/duck-typing check.
+ */
+export type CreatableTarget = ({ kind: 'project' } & CreatableProject) | ({ kind: 'committee' } & CreatableCommittee);

--- a/packages/shared/src/interfaces/lens.interface.ts
+++ b/packages/shared/src/interfaces/lens.interface.ts
@@ -10,8 +10,8 @@ import type { LensItem } from './navigation.interface';
 export type Lens = 'me' | 'foundation' | 'project' | 'org';
 
 /**
- * Inputs to `deriveAllowedLenses` — the persona roles and `writer` grants that
- * independently confer lens access. See that function for why either source suffices.
+ * Inputs to `deriveAllowedLenses` — the persona roles that confer lens access.
+ * See that function for the persona-only derivation (LFXV2-2755).
  */
 export interface LensGrantInputs {
   /** Persona holds a board-scoped role (ED / Board Member). */
@@ -20,10 +20,6 @@ export interface LensGrantInputs {
   hasProjectRole: boolean;
   /** Root writer — bypasses persona filtering entirely. */
   isRootWriter: boolean;
-  /** Holds `writer` on at least one project that computes as a foundation. */
-  hasWriterFoundation: boolean;
-  /** Holds `writer` on at least one non-foundation project. */
-  hasWriterProject: boolean;
   /** Org lens dark-launch flag. */
   isOrgLensEnabled: boolean;
 }

--- a/packages/shared/src/utils/lens.utils.spec.ts
+++ b/packages/shared/src/utils/lens.utils.spec.ts
@@ -10,8 +10,6 @@ const NO_GRANTS: LensGrantInputs = {
   hasBoardRole: false,
   hasProjectRole: false,
   isRootWriter: false,
-  hasWriterFoundation: false,
-  hasWriterProject: false,
   isOrgLensEnabled: false,
 };
 
@@ -22,7 +20,7 @@ describe('deriveAllowedLenses', () => {
     expect(deriveAllowedLenses(NO_GRANTS)).toEqual(['me']);
   });
 
-  describe('persona-derived grants (pre-existing behaviour)', () => {
+  describe('persona-derived grants', () => {
     it('grants foundation for a board role', () => {
       expect(deriveAllowedLenses(inputs({ hasBoardRole: true }))).toEqual(['me', 'foundation']);
     });
@@ -34,43 +32,9 @@ describe('deriveAllowedLenses', () => {
     it('grants both for a root writer', () => {
       expect(deriveAllowedLenses(inputs({ isRootWriter: true }))).toEqual(['me', 'foundation', 'project']);
     });
-  });
 
-  describe('writer-derived grants (LFXV2-2754)', () => {
-    // The regression case: a contributor-only persona holding writer on foundations.
-    // Before this change the foundation lens was withheld, which made every foundation
-    // the user administers unreachable in the create flow.
-    it('grants foundation on a writer-held foundation despite no board role', () => {
-      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true }))).toEqual(['me', 'foundation']);
-    });
-
-    it('grants project on a writer-held project despite no project role', () => {
-      expect(deriveAllowedLenses(inputs({ hasWriterProject: true }))).toEqual(['me', 'project']);
-    });
-
-    it('grants both when the user holds writer on each kind', () => {
-      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true, hasWriterProject: true }))).toEqual(['me', 'foundation', 'project']);
-    });
-
-    it('does not grant foundation from a project-only writer grant', () => {
-      expect(deriveAllowedLenses(inputs({ hasWriterProject: true }))).not.toContain('foundation');
-    });
-
-    it('does not grant project from a foundation-only writer grant', () => {
-      expect(deriveAllowedLenses(inputs({ hasWriterFoundation: true }))).not.toContain('project');
-    });
-  });
-
-  describe('grant sources are additive, never subtractive', () => {
-    it('keeps persona-granted lenses when no writer grants have resolved yet', () => {
-      // Grants arrive after hydration; the set must not narrow while they are pending.
+    it('keeps persona-granted lenses stable regardless of other inputs', () => {
       expect(deriveAllowedLenses(inputs({ hasBoardRole: true, hasProjectRole: true }))).toEqual(['me', 'foundation', 'project']);
-    });
-
-    it('does not duplicate a lens conferred by both sources', () => {
-      const result = deriveAllowedLenses(inputs({ hasBoardRole: true, hasWriterFoundation: true }));
-      expect(result).toEqual(['me', 'foundation']);
-      expect(result.filter((lens) => lens === 'foundation')).toHaveLength(1);
     });
   });
 

--- a/packages/shared/src/utils/lens.utils.ts
+++ b/packages/shared/src/utils/lens.utils.ts
@@ -4,28 +4,26 @@
 import { Lens, LensGrantInputs } from '../interfaces/lens.interface';
 
 /**
- * The lenses a user is authorised to use, from their persona roles and `writer` grants.
+ * The lenses a user is authorised to use, from their persona roles alone.
  *
- * Two independent sources confer a lens, and either is sufficient:
- *  - a **persona role** — a board role reaches `foundation`, a project role reaches `project`,
- *    and a root writer reaches both.
- *  - a **`writer` grant** on a project of that kind (LFXV2-2754). Persona detection and FGA
- *    grants are independent, so delegated staff commonly hold `writer` on foundations while
- *    detecting as `contributor` only. Requiring the persona stranded them: every path that
- *    resolves a create target reads the lens, so a lens they could never hold made projects
- *    they demonstrably administer unreachable.
+ * A board role reaches `foundation`, a project role reaches `project`, and a root writer
+ * reaches both. `writer` grants no longer factor in here (LFXV2-2754 introduced a
+ * `writer`-derived widening as a stopgap so delegated staff holding `writer` on a project their
+ * persona didn't cover weren't stranded; LFXV2-2755 removed the need for it by making the create
+ * flow navigate via explicit target selection, resolved independently of the active lens — see
+ * `CreatePermissionService` and `project-context.service.ts`'s `routeLensKind` precedence).
  *
- * `me` is always present. `org` is feature-flagged and independent of both sources.
+ * `me` is always present. `org` is feature-flagged and independent of persona.
  *
  * Extracted as a pure function so this authorisation-adjacent logic is unit-testable — the
  * Angular app has no unit-test runner, and `LensService` consumes this rather than
  * reimplementing it.
  */
 export function deriveAllowedLenses(inputs: LensGrantInputs): Lens[] {
-  const { hasBoardRole, hasProjectRole, isRootWriter, hasWriterFoundation, hasWriterProject, isOrgLensEnabled } = inputs;
+  const { hasBoardRole, hasProjectRole, isRootWriter, isOrgLensEnabled } = inputs;
 
-  const showFoundation = hasBoardRole || isRootWriter || hasWriterFoundation;
-  const showProject = hasProjectRole || isRootWriter || hasWriterProject;
+  const showFoundation = hasBoardRole || isRootWriter;
+  const showProject = hasProjectRole || isRootWriter;
 
   const lenses: Lens[] = ['me'];
   if (showFoundation) {


### PR DESCRIPTION
## Summary

- Removes the LFXV2-2754 writer-grant lens-widening stopgap: the create dialog now navigates by explicit target selection (`?project=<slug>` / `?committee_uid=<uid>`), which the create-route guards already resolve independently of the active lens — so `LensService` reverts to deriving lenses from persona alone.
- Brings the Group/committee create target into the picker: a committee-writer-only user now sees the create rail button, can select their committee, and lands in the create flow with `committee_uid` carried explicitly (backed by a new `CommitteeWriterGrantsService` and an opt-in `include_project_metadata` flag on `GET /api/committees`).
- Adds a defensive `project_uid` guard to the meeting combined-save path, matching the existing guard on the primary save path, to fail explicitly instead of silently sending an empty project.

## Test plan

- [x] `yarn build`, `yarn lint:check`, `yarn format:check`, `./check-headers.sh` all pass
- [x] `apps/lfx-one/e2e/create-quick-link.spec.ts` updated: S6 assertion relaxed (no lens-prefixed URL required post-decoupling), new S7 (committee-target navigation carries `committee_uid` + `project`), new S8 (committee-writer-only visibility — meeting/vote/survey shown, newsletter/group/mailing-list hidden)
- [x] `packages/shared/src/utils/lens.utils.spec.ts` updated for persona-only `deriveAllowedLenses`
- [ ] Manual impersonation smoke test recommended: a project/foundation writer with `me`-only persona should still land on their create flow; a committee-writer-only user should see only meeting/vote/survey offered

🤖 Generated with [Claude Code](https://claude.com/claude-code)