### PR TITLE
fix(sidebar): gate lens menu on hydration to fix stale org menu

### DIFF
--- a/apps/lfx-one/e2e/org-selector.spec.ts
+++ b/apps/lfx-one/e2e/org-selector.spec.ts
@@ -509,3 +509,32 @@ test.describe('Org Selector — zero-grants visibility gate (S9)', () => {
     await expect(page.getByTestId('org-selector')).not.toBeVisible();
   });
 });
+
+// S16 — org-route hard refresh must resolve to a clean org-lens sidebar with no stale
+// Me-lens sections (LFXV2-2789). The org lens is gated by a browser-only LaunchDarkly flag,
+// so SSR clamps to the me lens and used to emit a me-lens menu; hydrating that against the
+// client-resolved org menu left "My Engagement" / "My Growth" sections interleaved with org
+// items. The sidebar now withholds the concrete menu until afterNextRender, so the resolved
+// menu is built entirely from client state and must contain org items only.
+test.describe('Sidebar — org-route refresh has no stale Me-lens sections (S16)', () => {
+  test('S16: hard-refreshing /org/overview resolves to org-lens nav only, no Me-lens sections', async ({ page }) => {
+    await page.goto('/org/overview', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    // Flag off (or no org access) redirects away from /org/* — this regression only applies when
+    // the org lens is actually active, so skip otherwise (same gate as S14/S15).
+    if (!page.url().includes('/org/overview')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/overview redirected away');
+    }
+
+    // Wait for the sidebar to hydrate past the loading skeleton and render the resolved org menu.
+    await expect(page.getByTestId('sidebar'), 'sidebar should be visible').toBeVisible({ timeout: SIDEBAR_TIMEOUT });
+    await expect(page.getByTestId('sidebar-item-memberships'), 'org-lens Memberships item should render after hydration').toBeVisible({
+      timeout: SIDEBAR_TIMEOUT,
+    });
+
+    // The org lens tab and the resolved menu must be consistent: no Me-lens sections remain on screen.
+    await expect(page.getByTestId('sidebar-item-my-engagement'), 'Me-lens "My Engagement" must not leak into the org sidebar').toHaveCount(0);
+    await expect(page.getByTestId('sidebar-item-my-growth'), 'Me-lens "My Growth" must not leak into the org sidebar').toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -128,8 +128,13 @@
         </div>
       </div>
 
-      <!-- Hidden on foundation/project lens until nav API responds, since items are lens-scoped. -->
-      @if (lensLoaded()) {
+      <!--
+        Gated on hydrated() so the concrete lens menu is withheld until the browser commits its first
+        render (afterNextRender). Server + first client render both fall through to the skeleton branches
+        below, avoiding the SSR/CSR lens mismatch that left stale me-lens items on org routes. Also
+        hidden on foundation/project lens until the nav API responds, since items are lens-scoped.
+      -->
+      @if (hydrated() && lensLoaded()) {
         <div class="flex flex-col gap-1 items-start px-[12px] w-full">
           <!--
             Track by stable per-destination key (routerLink/url, falling back to the unique label for

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, input, model, Signal, signal, viewChild } from '@angular/core';
+import { afterNextRender, Component, computed, inject, input, model, Signal, signal, viewChild } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -82,6 +82,13 @@ export class SidebarComponent {
   protected readonly navLens: Signal<NavLens | null> = this.initNavLens();
   protected readonly lensLoaded: Signal<boolean> = this.initLensLoaded();
 
+  // Browser-only hydration gate. The org lens is enabled by a browser-only LaunchDarkly flag, so the
+  // server render always clamps to the me lens and would emit a me-lens menu; hydrating that against a
+  // client-resolved org menu leaves stale me-lens nodes on screen. Holding the concrete menu back until
+  // afterNextRender means the server and the first client render both show the loading skeleton
+  // (skeleton→skeleton reconciles cleanly), then the real menu is inserted as a post-hydration update.
+  protected readonly hydrated = signal(false);
+
   protected readonly user = this.userService.user;
   protected readonly userInitials = this.userService.userInitials;
   protected readonly personaLabels: Signal<{ label: string; icon: string; names: string[]; ariaLabel: string }[]> = this.initPersonaLabels();
@@ -137,6 +144,12 @@ export class SidebarComponent {
     scanForGroups(items);
     return states;
   });
+
+  public constructor() {
+    // Runs browser-only, after the first client render is committed — flips the menu from skeleton to
+    // the client-resolved lens menu once hydration is safely past the SSR/CSR reconciliation boundary.
+    afterNextRender(() => this.hydrated.set(true));
+  }
 
   protected toggleGroup(label: string): void {
     const items = this.items();


### PR DESCRIPTION
## Summary

On a hard refresh of an Organization-lens route (e.g. `/org/overview`), the sidebar kept rendering stale **Me-lens** sections ("My Engagement", "My Growth") interleaved with Organization items — the Organization tab was active while the menu was wrong.

Root cause is a server-vs-browser lens mismatch. The Organization lens is enabled by a **browser-only** LaunchDarkly flag (`org-lens-enabled`), so during SSR the allowed-lens set never includes `org`, the active lens clamps to `me`, and the server emits a fully-rendered Me-lens menu. On the client the flag resolves, the active lens becomes `org`, and the menu `@for` block — hydrated from the Me-lens server markup — fails to reconcile cleanly, leaving stale Me-lens DOM nodes on screen. The lens **tab** is a non-structural class binding, so it updates correctly, producing the "right tab, wrong menu" state.

## What changed

- `sidebar.component.ts`: added an `afterNextRender` browser-hydration gate (`hydrated` signal, defaults `false`).
- `sidebar.component.html`: gated the lens-specific menu block on `@if (hydrated() && lensLoaded())`; the existing org/generic loading skeletons serve as the pre-hydration fallback.

The server render and the first client render now both show the loading skeleton (skeleton→skeleton reconciles cleanly); the resolved lens menu is inserted as a normal post-hydration client update and tracks `activeLens()` reactively thereafter. Client-render-only — **no API, data, or backend changes**.

Trade-off: a brief menu skeleton on full page loads for all lenses, replacing today's behavior of rendering a possibly-wrong menu immediately.

## Test plan

- [x] `yarn check-types`, `yarn lint:check`, `yarn build` pass
- [x] License headers / Prettier format pass
- [x] Added e2e regression **S16** (`org-selector.spec.ts`): hard-refresh `/org/overview` asserts the org-lens Memberships item renders and no `My Engagement` / `My Growth` sections remain
- [ ] Manual: hard-refresh `/org/overview` with the org lens enabled → clean Organization menu, Organization tab active, no Me-lens sections
- [ ] Manual: Me-lens and Foundation/Project-lens refreshes still render their correct menus after the brief skeleton

Ref: [LFXV2-2789](https://linuxfoundation.atlassian.net/browse/LFXV2-2789)

[LFXV2-2789]: https://linuxfoundation.atlassian.net/browse/LFXV2-2789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ