### PR TITLE
fix(sidebar): differentiate profile menu aria-labels

### DIFF
--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -102,7 +102,7 @@
             <button
               type="button"
               (click)="toggleProfileMenu($event)"
-              aria-label="Profile sections"
+              aria-label="Open profile sections"
               [attr.aria-expanded]="profileMenu.overlayVisible"
               data-testid="me-card-more"
               class="pointer-events-auto relative shrink-0 flex items-center justify-center size-8 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">


### PR DESCRIPTION
## Summary

- The me-card overflow (⋯) trigger button in the sidebar and the `<nav>` inside
  the popover it opens both declared `aria-label="Profile sections"`, so screen
  readers announced the same label twice. Relabel the button to
  `Open profile sections` so the disclosure control and the navigation region
  read distinctly; the `<nav>` keeps `Profile sections`.
- Follow-up to the me-lens user-card redesign (#1136).

Jira: LFXV2-2741