### PR TITLE
docs(architecture): fix stale flat /settings route references

### DIFF
--- a/docs/architecture/frontend/component-architecture.md
+++ b/docs/architecture/frontend/component-architecture.md
@@ -410,8 +410,8 @@ AppComponent
         ├── /mailing-lists       → MailingListDashboardComponent (lazy loaded)
         ├── /votes               → VotesDashboardComponent (lazy loaded)
         ├── /surveys             → SurveysDashboardComponent (lazy loaded)
-        ├── /settings            → SettingsDashboardComponent (lazy loaded)
-        └── /profile             → ProfileOverviewComponent (lazy loaded)
+        ├── /settings            → redirects by lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings
+        └── /profile             → ProfileLayoutComponent (lazy loaded; tabs incl. settings → AccountSettingsComponent, transactions)
 
     Standalone routes (outside MainLayoutComponent):
     ├── /meetings/not-found      → MeetingNotFoundComponent

--- a/docs/architecture/frontend/component-architecture.md
+++ b/docs/architecture/frontend/component-architecture.md
@@ -410,7 +410,7 @@ AppComponent
         ├── /mailing-lists       → MailingListDashboardComponent (lazy loaded)
         ├── /votes               → VotesDashboardComponent (lazy loaded)
         ├── /surveys             → SurveysDashboardComponent (lazy loaded)
-        ├── /settings            → redirects by lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings
+        ├── /settings            → redirects by lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings; other lenses (e.g. org) fall through to SettingsDashboardComponent
         └── /profile             → ProfileLayoutComponent (lazy loaded; tabs incl. settings → AccountSettingsComponent, transactions)
 
     Standalone routes (outside MainLayoutComponent):

--- a/docs/architecture/frontend/lazy-loading-preloading-strategy.md
+++ b/docs/architecture/frontend/lazy-loading-preloading-strategy.md
@@ -45,8 +45,8 @@ All routes are flat children of `MainLayoutComponent` (no nested `project/:slug`
     { path: 'mailing-lists', loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then(m => m.MAILING_LIST_ROUTES) },
     { path: 'votes', loadChildren: () => import('./modules/votes/votes.routes').then(m => m.VOTE_ROUTES) },
     { path: 'surveys', loadChildren: () => import('./modules/surveys/surveys.routes').then(m => m.SURVEY_ROUTES) },
-    // `/settings` redirects by active lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings
-    { path: 'settings', canActivate: [settingsLensRedirectGuard], loadChildren: () => import('./modules/settings/settings.routes').then(m => m.SETTINGS_ROUTES) },
+    // `/settings` redirects by active lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings; any other lens (e.g. org) falls through to the flat SettingsDashboardComponent. projectQueryParamGuard preserves the active-project query param.
+    { path: 'settings', canActivate: [settingsLensRedirectGuard, projectQueryParamGuard], loadChildren: () => import('./modules/settings/settings.routes').then(m => m.SETTINGS_ROUTES) },
     { path: 'profile', loadChildren: () => import('./modules/profile/profile.routes').then(m => m.PROFILE_ROUTES) },
   ],
 }

--- a/docs/architecture/frontend/lazy-loading-preloading-strategy.md
+++ b/docs/architecture/frontend/lazy-loading-preloading-strategy.md
@@ -45,7 +45,8 @@ All routes are flat children of `MainLayoutComponent` (no nested `project/:slug`
     { path: 'mailing-lists', loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then(m => m.MAILING_LIST_ROUTES) },
     { path: 'votes', loadChildren: () => import('./modules/votes/votes.routes').then(m => m.VOTE_ROUTES) },
     { path: 'surveys', loadChildren: () => import('./modules/surveys/surveys.routes').then(m => m.SURVEY_ROUTES) },
-    { path: 'settings', loadChildren: () => import('./modules/settings/settings.routes').then(m => m.SETTINGS_ROUTES) },
+    // `/settings` redirects by active lens (settingsLensRedirectGuard): Me → /profile/settings; foundation/project → lens-prefixed settings
+    { path: 'settings', canActivate: [settingsLensRedirectGuard], loadChildren: () => import('./modules/settings/settings.routes').then(m => m.SETTINGS_ROUTES) },
     { path: 'profile', loadChildren: () => import('./modules/profile/profile.routes').then(m => m.PROFILE_ROUTES) },
   ],
 }


### PR DESCRIPTION
## Summary

- Update the `/settings` route entry in the lazy-loading strategy doc to show the `settingsLensRedirectGuard` redirect behavior instead of a plain lazy-loaded flat route
- Fix the route diagram in the component-architecture doc: `/settings` now redirects by lens (Me → `/profile/settings`, foundation/project → lens-prefixed settings), and `/profile` resolves to `ProfileLayoutComponent` with settings/transactions tabs rather than the removed `ProfileOverviewComponent`

Docs-only; no code changes.

LFXV2-2739