### PR TITLE
fix(profile): pin profile panel as fixed full-height right rail

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -75,11 +75,7 @@
 
   <!-- Main Content Area -->
   <!-- On the profile hub, reserve a right gutter (pr-[300px]) so content and the footer clear the fixed profile rail. -->
-  <!-- Transition is scoped to margin (not `all`) so the profile gutter applies instantly rather than animating over 300ms. -->
-  <main
-    class="flex-1 min-w-0 transition-[margin] duration-300 lg:ml-[348px] flex flex-col"
-    [ngClass]="{ 'pr-[300px]': isProfileHub() }"
-    data-testid="main-content">
+  <main class="flex-1 min-w-0 lg:ml-[348px] flex flex-col" [ngClass]="{ 'pr-[300px]': isProfileHub() }" data-testid="main-content">
     <!-- Mobile Menu Button -->
     <div
       class="lg:hidden sticky z-30 bg-white border-b border-gray-200 px-5 py-3"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -74,8 +74,12 @@
   }
 
   <!-- Main Content Area -->
-  <!-- On the profile hub, reserve a right gutter (pr-[300px]) so content and the footer clear the fixed profile rail -->
-  <main class="flex-1 min-w-0 transition-all duration-300 lg:ml-[348px] flex flex-col" [ngClass]="{ 'pr-[300px]': isProfileHub() }" data-testid="main-content">
+  <!-- On the profile hub, reserve a right gutter (pr-[300px]) so content and the footer clear the fixed profile rail. -->
+  <!-- Transition is scoped to margin (not `all`) so the profile gutter applies instantly rather than animating over 300ms. -->
+  <main
+    class="flex-1 min-w-0 transition-[margin] duration-300 lg:ml-[348px] flex flex-col"
+    [ngClass]="{ 'pr-[300px]': isProfileHub() }"
+    data-testid="main-content">
     <!-- Mobile Menu Button -->
     <div
       class="lg:hidden sticky z-30 bg-white border-b border-gray-200 px-5 py-3"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -74,7 +74,8 @@
   }
 
   <!-- Main Content Area -->
-  <main class="flex-1 min-w-0 transition-all duration-300 lg:ml-[348px] flex flex-col" data-testid="main-content">
+  <!-- On the profile hub, reserve a right gutter (pr-[300px]) so content and the footer clear the fixed profile rail -->
+  <main class="flex-1 min-w-0 transition-all duration-300 lg:ml-[348px] flex flex-col" [ngClass]="{ 'pr-[300px]': isProfileHub() }" data-testid="main-content">
     <!-- Mobile Menu Button -->
     <div
       class="lg:hidden sticky z-30 bg-white border-b border-gray-200 px-5 py-3"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -116,9 +116,10 @@ export class MainLayoutComponent {
     }
   }
 
-  /** Whether the current URL is under the /profile hub (drops any query string before matching). */
+  /** Whether the current URL is under the /profile hub (drops any query string, matches on segment boundary). */
   private computeIsProfileHub(): boolean {
-    return this.router.url.split('?')[0].startsWith('/profile');
+    const path = this.router.url.split('?')[0];
+    return path === '/profile' || path.startsWith('/profile/');
   }
 
   /**

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -46,6 +46,12 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
+  // True on the /profile hub, where the fixed profile rail is shown. Drives the right-side gutter
+  // (pr-[300px]) on <main> so page content and the shared footer stay clear of the rail. Only the
+  // me-lens /profile route uses ProfileLayoutComponent; org/foundation/project profile pages live
+  // under lens-prefixed paths (e.g. /org/...), so a /profile prefix match is exact enough here.
+  protected readonly isProfileHub = signal(false);
+
   /**
    * A route lens that {@link LensService.setLens} refused, held for retry.
    *
@@ -58,6 +64,10 @@ export class MainLayoutComponent {
   private readonly pendingRouteLens = signal<Lens | null>(null);
 
   public constructor() {
+    // Seed the profile-hub flag from the current URL so the right gutter is correct on the first
+    // paint / hard load, before the first NavigationEnd fires.
+    this.isProfileHub.set(this.computeIsProfileHub());
+
     // Close mobile sidebar and sync lens from route data on navigation
     this.router.events
       .pipe(
@@ -67,6 +77,7 @@ export class MainLayoutComponent {
       .subscribe(() => {
         this.appService.closeMobileSidebar();
         this.selectorPanelOpen.set(false);
+        this.isProfileHub.set(this.computeIsProfileHub());
         this.syncLensFromRoute();
       });
 
@@ -103,6 +114,11 @@ export class MainLayoutComponent {
     if (!visible) {
       this.appService.closeMobileSidebar();
     }
+  }
+
+  /** Whether the current URL is under the /profile hub (drops any query string before matching). */
+  private computeIsProfileHub(): boolean {
+    return this.router.url.split('?')[0].startsWith('/profile');
   }
 
   /**

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -10,6 +10,7 @@ import { LensSwitcherComponent } from '@components/lens-switcher/lens-switcher.c
 import { SidebarComponent } from '@components/sidebar/sidebar.component';
 import { ALL_LENSES } from '@lfx-one/shared/constants';
 import { Lens } from '@lfx-one/shared/interfaces';
+import { isProfileHubPath } from '@lfx-one/shared/utils';
 import { AppService } from '@services/app.service';
 import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -46,10 +47,8 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
-  // True on the /profile hub, where the fixed profile rail is shown. Drives the right-side gutter
-  // (pr-[300px]) on <main> so page content and the shared footer stay clear of the rail. Only the
-  // me-lens /profile route uses ProfileLayoutComponent; org/foundation/project profile pages live
-  // under lens-prefixed paths (e.g. /org/...), so a /profile prefix match is exact enough here.
+  // True on the /profile hub — drives the pr-[300px] right gutter on <main> so content/footer
+  // clear the fixed rail. Only the me-lens /profile route uses ProfileLayoutComponent.
   protected readonly isProfileHub = signal(false);
 
   /**
@@ -66,7 +65,7 @@ export class MainLayoutComponent {
   public constructor() {
     // Seed the profile-hub flag from the current URL so the right gutter is correct on the first
     // paint / hard load, before the first NavigationEnd fires.
-    this.isProfileHub.set(this.computeIsProfileHub());
+    this.isProfileHub.set(isProfileHubPath(this.router.url));
 
     // Close mobile sidebar and sync lens from route data on navigation
     this.router.events
@@ -77,7 +76,7 @@ export class MainLayoutComponent {
       .subscribe(() => {
         this.appService.closeMobileSidebar();
         this.selectorPanelOpen.set(false);
-        this.isProfileHub.set(this.computeIsProfileHub());
+        this.isProfileHub.set(isProfileHubPath(this.router.url));
         this.syncLensFromRoute();
       });
 
@@ -114,12 +113,6 @@ export class MainLayoutComponent {
     if (!visible) {
       this.appService.closeMobileSidebar();
     }
-  }
-
-  /** Whether the current URL is under the /profile hub (drops any query string, matches on segment boundary). */
-  private computeIsProfileHub(): boolean {
-    const path = this.router.url.split('?')[0];
-    return path === '/profile' || path.startsWith('/profile/');
   }
 
   /**

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Two-column Profile & Account hub. Below 2xl the panel stacks full-width above the content:
-  the main-layout shell already claims 348px for its own fixed sidebar, so reserving the panel's
-  width any earlier leaves child pages (e.g. /profile/settings' two-column cards) too narrow. At
-  2xl the panel becomes a sticky in-flow right column — it stays in view as the left column
-  scrolls, and because it lives inside the content flow it never overlays the shared footer.
+  Profile & Account hub. The profile panel is a fixed, full-height 300px rail pinned to the right
+  edge of the viewport at every screen size — mirroring the left menu. It never stacks above the
+  content, never changes width, and always sits above page content (z-40). MainLayoutComponent
+  reserves a matching right gutter (pr-[300px]) on the profile hub so the content and the shared
+  footer stay clear of the rail. The rail's `top` matches the impersonation banner offset.
 -->
-<div class="flex flex-col gap-6 2xl:flex-row 2xl:items-start" data-testid="profile-layout">
-  <!-- Profile panel — first in the DOM so it stacks on top below 2xl; sticky right column at 2xl -->
-  <div class="2xl:sticky 2xl:order-2 2xl:w-80 2xl:shrink-0" [class.2xl:top-12]="impersonating()" [class.2xl:top-6]="!impersonating()">
+<div class="flex flex-col" data-testid="profile-layout">
+  <!-- Profile panel — fixed full-height right rail at all widths (out of normal flow) -->
+  <div class="fixed bottom-0 right-0 z-40 w-[300px]" [class.top-12]="impersonating()" [class.top-0]="!impersonating()">
     <lfx-profile-panel
       [loading]="loading()"
       [impersonating]="impersonating()"
@@ -29,7 +29,7 @@
   </div>
 
   <!-- Left column -->
-  <div class="min-w-0 flex-1 2xl:order-1">
+  <div class="min-w-0 flex-1">
     <div class="mx-auto flex max-w-[1024px] flex-col gap-6">
       <!-- Read-only notice while impersonating — editing acts on the real account and is disabled -->
       @if (impersonating()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -27,10 +27,11 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 ]);
 
 /**
- * ProfileLayoutComponent is the two-column shell for the Profile & Account hub.
- * It provides:
- * - Left column: page head, subtab navigation, and the router outlet for child pages
- * - Right column: the sticky profile panel (lfx-profile-panel) bound to the user's CombinedProfile
+ * ProfileLayoutComponent is the shell for the Profile & Account hub. It provides:
+ * - Content column: page head, subtab navigation, and the router outlet for child pages
+ * - A fixed, full-height 300px profile rail (lfx-profile-panel) pinned to the right edge at every
+ *   screen size — never stacks above the content, never changes width, and sits above page content
+ *   (z-40); MainLayoutComponent reserves a matching right gutter so content/footer stay clear of it
  *
  * The layout owns the profile data fetch, optimistic updates, the edit drawer, and the
  * Flow C (management-token) auth-return handling; the panel is presentational and emits

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,13 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Full-width separator card when stacked (below 2xl); at 2xl it fills the sticky right column
-  set up by the layout, with its own scroll if the content exceeds the viewport height.
+  Presentational summary card. The layout wraps this in a fixed full-height right rail; here we
+  fill that rail (h-full) with a white, flush surface and a left border mirroring the left menu,
+  scrolling its own content independently (overflow-y-auto) when the viewport is short.
 -->
-<aside
-  class="flex flex-col border-b border-slate-200 bg-slate-50 px-6 py-7 2xl:max-h-[calc(100vh-4rem)] 2xl:overflow-y-auto 2xl:rounded-xl 2xl:border"
-  aria-label="Profile summary"
-  data-testid="profile-panel">
+<aside class="flex h-full flex-col overflow-y-auto border-l border-gray-200 bg-white px-6 py-7" aria-label="Profile summary" data-testid="profile-panel">
   @if (loading()) {
     <div class="flex items-center justify-center py-8" role="status" aria-live="polite">
       <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -4,12 +4,17 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 /**
- * ProfilePanelComponent is the sticky right-hand panel of the Profile & Account hub
- * (a sticky side column at 2xl, stacked full-width above the content below that).
+ * ProfilePanelComponent is the right-hand panel of the Profile & Account hub. The layout wraps it
+ * in a fixed, full-height 300px rail pinned to the right edge at every screen size; this component
+ * fills that rail and scrolls its own content independently when the viewport is short.
  * It is purely presentational: all values arrive via signal inputs (sourced from the
  * parent ProfileLayoutComponent's CombinedProfile) and the edit affordances emit
  * `editRequested` so the parent — which owns the profile data, edit dialog, and
  * optimistic-update logic — handles the actual edit flow.
+ *
+ * The host is `block h-full` so the inner `aside`'s `h-full`/`overflow-y-auto` resolves against
+ * the fixed rail's height (mirrors lfx-sidebar's `:host { height: 100% }`); without host sizing
+ * the height chain breaks and the rail cannot scroll independently.
  *
  * Rows render only when their value is present. GitHub is sourced from the user's
  * connected identities (bound by the parent); About me and LinkedIn are stubbed for now
@@ -18,6 +23,7 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
 @Component({
   selector: 'lfx-profile-panel',
   imports: [],
+  host: { class: 'block h-full' },
   templateUrl: './profile-panel.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/packages/shared/src/utils/url.utils.spec.ts
+++ b/packages/shared/src/utils/url.utils.spec.ts
@@ -1,0 +1,42 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { isProfileHubPath } from './url.utils';
+
+describe('isProfileHubPath', () => {
+  it('matches the exact /profile route', () => {
+    expect(isProfileHubPath('/profile')).toBe(true);
+  });
+
+  it('matches nested /profile/ routes', () => {
+    expect(isProfileHubPath('/profile/settings')).toBe(true);
+    expect(isProfileHubPath('/profile/badges')).toBe(true);
+  });
+
+  it('does not match sibling routes that share the /profile prefix', () => {
+    expect(isProfileHubPath('/profiles')).toBe(false);
+    expect(isProfileHubPath('/profile-old')).toBe(false);
+  });
+
+  it('strips the query string before matching', () => {
+    expect(isProfileHubPath('/profile?tab=account')).toBe(true);
+    expect(isProfileHubPath('/profiles?x=1')).toBe(false);
+  });
+
+  it('strips the fragment before matching', () => {
+    expect(isProfileHubPath('/profile#developer-settings')).toBe(true);
+    expect(isProfileHubPath('/profile/settings#developer-settings')).toBe(true);
+  });
+
+  it('strips both query and fragment before matching', () => {
+    expect(isProfileHubPath('/profile/settings?tab=account#developer-settings')).toBe(true);
+  });
+
+  it('does not match unrelated routes', () => {
+    expect(isProfileHubPath('/org/profile')).toBe(false);
+    expect(isProfileHubPath('/meetings')).toBe(false);
+    expect(isProfileHubPath('/')).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/url.utils.ts
+++ b/packages/shared/src/utils/url.utils.ts
@@ -163,3 +163,16 @@ export function normalizeToUrl(input: string): string | null {
 
   return null;
 }
+
+/**
+ * Whether a router URL is under the /profile hub, matching on the route-segment boundary.
+ * Strips both the query string and the fragment before matching, so a bare prefix
+ * check does not misclassify sibling routes (`/profiles`, `/profile-old`), and a fragment
+ * (e.g. `/profile/settings#developer-settings`) does not defeat the match.
+ * @param url - The router URL (may include `?query` and/or `#fragment`)
+ * @returns true when the path is exactly `/profile` or under `/profile/`
+ */
+export function isProfileHubPath(url: string): boolean {
+  const path = url.split(/[?#]/)[0];
+  return path === '/profile' || path.startsWith('/profile/');
+}


### PR DESCRIPTION
## Summary

- Convert the profile summary panel (`lfx-profile-panel`) from a 2xl-only sticky column — which dropped out of the column and stacked full-width on top of the content below 1440px — into a fixed, full-height **300px rail pinned to the right edge at every screen size**, mirroring the left menu (white background, left border, independently scrollable when the viewport is short).
- The rail never stacks above the content, never changes width, and sits above page content (`z-40`); its top offset follows the impersonation banner.
- Reserve a matching right gutter (`pr-[300px]`) on `<main>` for the profile hub so page content and the shared footer stay clear of the rail.
- Track the profile hub in `MainLayoutComponent` via an `isProfileHub` signal (seeded from the URL on init for first-paint correctness, updated on navigation).

JIRA: LFXV2-2738
