### PR TITLE
ci(build): add dev-cluster build config for preview and dev deploys

### DIFF
--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -64,5 +64,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            BUILD_ENV=development
+            BUILD_ENV=dev-cluster
             APP_VERSION=development

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -72,7 +72,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            BUILD_ENV=development
+            BUILD_ENV=dev-cluster
             APP_VERSION=pr-${{ github.event.pull_request.number }}
 
       - name: Comment deployment URL on PR

--- a/.github/workflows/feat-branch-deploy.yml
+++ b/.github/workflows/feat-branch-deploy.yml
@@ -85,7 +85,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            BUILD_ENV=development
+            BUILD_ENV=dev-cluster
 
       - name: Post preview URL to step summary
         env:

--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -120,6 +120,28 @@
                 }
               ]
             },
+            "dev-cluster": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "3MB",
+                  "maximumError": "4MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kB",
+                  "maximumError": "8kB"
+                }
+              ],
+              "outputHashing": "all",
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev.ts"
+                }
+              ]
+            },
             "local": {
               "optimization": false,
               "extractLicenses": false,

--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -6,6 +6,7 @@
     "start": "yarn docs:build && ng serve",
     "build": "yarn docs:build && ng build && cp -r src/server/pdf-templates dist/lfx-one/server/",
     "build:development": "yarn docs:build && ng build --configuration development",
+    "build:dev-cluster": "yarn docs:build && ng build --configuration dev-cluster",
     "build:production": "yarn docs:build && ng build --configuration production",
     "build:staging": "yarn docs:build && ng build --configuration staging",
     "watch": "yarn docs:build && ng build --watch --configuration development",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,6 +47,7 @@
   "scripts": {
     "build": "tsc",
     "build:development": "tsc",
+    "build:dev-cluster": "tsc",
     "build:production": "tsc",
     "build:staging": "tsc",
     "watch": "tsc --watch",


### PR DESCRIPTION
## Summary

Feature-branch, PR preview, and the persistent dev-cluster deployment all built with the unoptimized `development` Angular config — the same config used by local `yarn watch` builds. This produced a large unminified, un-tree-shaken SSR bundle that took several minutes to parse/JIT on cold start under the pods' constrained CPU limits, causing startup/liveness probe timeouts and restart loops (see LFXV2-2801).

- Add a new `dev-cluster` Angular build configuration: keeps `environment.dev.ts` URLs but enables `optimization`, `outputHashing`, and bundle budgets like `staging`/`production`
- Wire `build:dev-cluster` scripts into `apps/lfx-one/package.json` and `packages/shared/package.json`
- Repoint `docker-build-pr.yml`, `docker-build-main.yml`, and `feat-branch-deploy.yml` from `BUILD_ENV=development` to `BUILD_ENV=dev-cluster`
- `staging`/`production` configs and `docker-build-tag.yml` are untouched

The local-only `development` config remains as-is for `yarn watch`/`ng serve` fast iteration.

## Protected Files

- `apps/lfx-one/angular.json` — added the `dev-cluster` build configuration
- `apps/lfx-one/package.json` — added `build:dev-cluster` script
- `packages/shared/package.json` — added `build:dev-cluster` script (delegates to `tsc`, same as other configs)

Issue: LFXV2-2801