### PR TITLE
fix(header): opt logo button out of Angular event replay

### DIFF
--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -16,7 +16,12 @@
             <i class="fa-light fa-bars text-gray-600 text-xl"></i>
           </button>
 
-          <button type="button" jsaction="" class="flex items-center space-x-2 hover:opacity-80 transition-opacity p-2" routerLink="/" aria-label="Go to home page">
+          <button
+            type="button"
+            jsaction=""
+            class="flex items-center space-x-2 hover:opacity-80 transition-opacity p-2"
+            routerLink="/"
+            aria-label="Go to home page">
             <img src="/images/logo_lfx.svg" alt="LFX Logo" class="w-auto h-5" />
           </button>
         </div>

--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -16,7 +16,7 @@
             <i class="fa-light fa-bars text-gray-600 text-xl"></i>
           </button>
 
-          <button type="button" class="flex items-center space-x-2 hover:opacity-80 transition-opacity p-2" routerLink="/" aria-label="Go to home page">
+          <button type="button" jsaction="" class="flex items-center space-x-2 hover:opacity-80 transition-opacity p-2" routerLink="/" aria-label="Go to home page">
             <img src="/images/logo_lfx.svg" alt="LFX Logo" class="w-auto h-5" />
           </button>
         </div>

--- a/apps/lfx-one/src/app/shared/components/header/header.component.ts
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.ts
@@ -117,10 +117,6 @@ export class HeaderComponent {
     this.searchForm.get('search')?.setValue('');
   }
 
-  protected onLogoClick(): void {
-    this.router.navigate(['/']);
-  }
-
   protected onUserClick(): void {
     // TODO: Show user menu/dropdown or navigate to profile
     console.info('User avatar clicked');


### PR DESCRIPTION
## Summary

- Add `jsaction=""` to the header logo button to opt it out of Angular's `withEventReplay()` pre-hydration event capture
- Remove dead `onLogoClick()` method that was never called from the template
- Apply prettier formatting to the reformatted button element

## Root Cause

During SSR page load, Angular's `withEventReplay()` captures native DOM events that occur before hydration completes, then replays them once hydration finishes. If a click landed on the header logo button during that window, the replayed event triggered `routerLink="/"`, navigating the user away from the page they were on (in this case, a meeting detail page back to My Dashboards).

`jsaction=""` opts the button out of event replay capture while leaving normal post-hydration click behaviour (`routerLink="/"`) fully intact.

## Ticket

[LFXV2-2724](https://linuxfoundation.atlassian.net/browse/LFXV2-2724)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2724]: https://linuxfoundation.atlassian.net/browse/LFXV2-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ