### PR TITLE
feat(newsletters): add recipient-facing my newsletters archive

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -381,6 +381,12 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/crowdfunding/crowdfunding.routes').then((m) => m.CROWDFUNDING_ROUTES),
       },
       {
+        path: 'my-newsletters',
+        canActivate: [authGuard],
+        loadComponent: () => import('./modules/newsletters/my-newsletters/my-newsletters-list.component').then((m) => m.MyNewslettersListComponent),
+        data: { lens: 'me', preload: false },
+      },
+      {
         path: 'me/events',
         redirectTo: 'events',
         pathMatch: 'full',

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
@@ -33,10 +33,14 @@
       <!-- Newsletter list cards -->
       <div class="flex flex-col gap-4">
         @for (newsletter of filteredNewsletters(); track newsletter.id) {
-          <div
-            class="p-4 border border-gray-200 rounded-lg hover:shadow-md hover:border-blue-300 transition-all cursor-pointer"
+          <button
+            type="button"
+            class="p-4 border border-gray-200 rounded-lg hover:shadow-md hover:border-blue-300 transition-all cursor-pointer text-left"
             (click)="openPreview(newsletter)"
-            [attr.data-testid]="'my-newsletters-item-' + newsletter.id">
+            (keydown.enter)="openPreview(newsletter)"
+            (keydown.space)="openPreview(newsletter)"
+            [attr.data-testid]="'my-newsletters-item-' + newsletter.id"
+            [attr.aria-label]="'View newsletter: ' + newsletter.subject">
             <div class="flex flex-col gap-2">
               <h3 class="font-medium text-gray-900 hover:text-blue-600">{{ newsletter.subject }}</h3>
               <div class="flex flex-col gap-1 text-sm text-gray-600">
@@ -49,7 +53,7 @@
                 <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'short' }}</div>
               </div>
             </div>
-          </div>
+          </button>
         }
       </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
@@ -37,8 +37,6 @@
             type="button"
             class="p-4 border border-gray-200 rounded-lg hover:shadow-md hover:border-blue-300 transition-all cursor-pointer text-left"
             (click)="openPreview(newsletter)"
-            (keydown.enter)="openPreview(newsletter)"
-            (keydown.space)="openPreview(newsletter)"
             [attr.data-testid]="'my-newsletters-item-' + newsletter.id"
             [attr.aria-label]="'View newsletter: ' + newsletter.subject">
             <div class="flex flex-col gap-2">
@@ -50,7 +48,7 @@
                     <span class="text-gray-500"> • {{ newsletter.project_name }}</span>
                   }
                 </div>
-                <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'short' }}</div>
+                <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'MMM d, y': 'en-US' }}</div>
               </div>
             </div>
           </button>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
@@ -48,7 +48,7 @@
                     <span class="text-gray-500"> • {{ newsletter.project_name }}</span>
                   }
                 </div>
-                <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'MMM d, y': 'en-US' }}</div>
+                <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'MMM d, y' : 'en-US' }}</div>
               </div>
             </div>
           </button>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.html
@@ -1,0 +1,74 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card class="max-w-4xl mx-auto">
+  <div class="flex flex-col gap-6">
+    <!-- Foundation filter pills -->
+    @if (foundationOptions().length > 1) {
+      <div>
+        <lfx-filter-pills
+          [options]="foundationOptions()"
+          [selectedFilter]="selectedFoundation()"
+          (filterChange)="onFoundationChange($event)"
+          data-testid="my-newsletters-foundation-filter" />
+      </div>
+    }
+
+    <!-- Loading skeleton -->
+    @if (loading()) {
+      <div class="flex flex-col gap-4">
+        @for (i of [1, 2, 3]; track i) {
+          <p-skeleton height="5rem" />
+        }
+      </div>
+    } @else if (isEmpty()) {
+      <!-- Empty state -->
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-inbox"
+        title="No newsletters yet"
+        description="Newsletters sent to committees you belong to will appear here."
+        data-testid="my-newsletters-empty-state" />
+    } @else {
+      <!-- Newsletter list cards -->
+      <div class="flex flex-col gap-4">
+        @for (newsletter of filteredNewsletters(); track newsletter.id) {
+          <div
+            class="p-4 border border-gray-200 rounded-lg hover:shadow-md hover:border-blue-300 transition-all cursor-pointer"
+            (click)="openPreview(newsletter)"
+            [attr.data-testid]="'my-newsletters-item-' + newsletter.id">
+            <div class="flex flex-col gap-2">
+              <h3 class="font-medium text-gray-900 hover:text-blue-600">{{ newsletter.subject }}</h3>
+              <div class="flex flex-col gap-1 text-sm text-gray-600">
+                <div>
+                  <span class="font-medium">{{ newsletter.foundation_name }}</span>
+                  @if (newsletter.project_name && newsletter.project_name !== newsletter.foundation_name) {
+                    <span class="text-gray-500"> • {{ newsletter.project_name }}</span>
+                  }
+                </div>
+                <div class="text-xs text-gray-500">Sent {{ newsletter.sent_at | date: 'short' }}</div>
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+
+      <!-- Load more button -->
+      @if (canLoadMore()) {
+        <div class="flex justify-center pt-4">
+          <lfx-button [loading]="loadingMore()" label="Load more" (onClick)="loadMore()" data-testid="my-newsletters-load-more" />
+        </div>
+      }
+    }
+  </div>
+</lfx-card>
+
+<!-- Newsletter preview drawer -->
+@if (previewNewsletter()) {
+  <lfx-newsletter-preview-drawer
+    [(visible)]="previewVisible"
+    [subject]="previewSubject()"
+    [bodyHtml]="previewBodyHtml()"
+    [displayName]="previewDisplayName()"
+    data-testid="my-newsletters-preview-drawer" />
+}

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.scss
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.scss
@@ -1,0 +1,5 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Component-specific styling for my-newsletters list
+// Most layout uses Tailwind; custom styles here for complex cases only

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
@@ -32,7 +32,6 @@ export class MyNewslettersListComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   // === Writable Signals ===
-  protected readonly newsletters = signal<MyNewsletterListItem[]>([]);
   protected readonly loading = signal<boolean>(true);
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly nextPageToken = signal<string | undefined>(undefined);
@@ -113,7 +112,6 @@ export class MyNewslettersListComponent {
 
         const current = this.allNewsletters();
         this.allNewsletters.set([...current, ...response.newsletters]);
-        this.newsletters.set(this.filteredNewsletters());
         this.nextPageToken.set(response.next_page_token);
         this.loadingMore.set(false);
       });
@@ -146,7 +144,6 @@ export class MyNewslettersListComponent {
   }
 
   private loadArchive(): void {
-    this.newsletters.set([]);
     this.allNewsletters.set([]);
     this.nextPageToken.set(undefined);
     this.selectedFoundation.set('');
@@ -167,7 +164,6 @@ export class MyNewslettersListComponent {
         }
 
         this.allNewsletters.set(response.newsletters);
-        this.newsletters.set(response.newsletters);
         this.nextPageToken.set(response.next_page_token);
         this.loading.set(false);
       });

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
@@ -1,0 +1,175 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { FilterPillOption, MyNewsletterListItem, Newsletter } from '@lfx-one/shared/interfaces';
+import { NewsletterService } from '@services/newsletter.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, of } from 'rxjs';
+
+import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
+
+/**
+ * Recipient-facing newsletter archive.
+ * Lists sent newsletters for committees the user belongs to.
+ * Filterable by foundation; click to view full newsletter in drawer.
+ */
+@Component({
+  selector: 'lfx-my-newsletters-list',
+  imports: [DatePipe, ButtonComponent, CardComponent, EmptyStateComponent, FilterPillsComponent, SkeletonModule, NewsletterPreviewDrawerComponent],
+  templateUrl: './my-newsletters-list.component.html',
+  styleUrl: './my-newsletters-list.component.scss',
+})
+export class MyNewslettersListComponent {
+  // === Services ===
+  private readonly newsletterService = inject(NewsletterService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // === Writable Signals ===
+  protected readonly newsletters = signal<MyNewsletterListItem[]>([]);
+  protected readonly loading = signal<boolean>(true);
+  protected readonly loadingMore = signal<boolean>(false);
+  protected readonly nextPageToken = signal<string | undefined>(undefined);
+  protected readonly previewVisible = signal<boolean>(false);
+  protected readonly previewLoading = signal<boolean>(false);
+  protected readonly previewNewsletter = signal<Newsletter | null>(null);
+  protected readonly previewSubject = signal<string>('');
+  protected readonly previewBodyHtml = signal<string>('');
+  protected readonly previewDisplayName = signal<string>('');
+  protected readonly selectedFoundation = signal<string>('');
+
+  private readonly allNewsletters = signal<MyNewsletterListItem[]>([]);
+  private loadGeneration = 0;
+
+  // === Computed Signals ===
+  protected readonly foundationOptions: Signal<FilterPillOption[]> = computed(() => {
+    const foundations = new Set<string>();
+    this.allNewsletters().forEach((nl) => {
+      if (nl.foundation_slug) {
+        foundations.add(nl.foundation_slug);
+      }
+    });
+    return Array.from(foundations)
+      .sort()
+      .map((slug) => {
+        const nl = this.allNewsletters().find((n) => n.foundation_slug === slug);
+        return {
+          id: slug,
+          label: nl?.foundation_name || slug,
+        };
+      });
+  });
+
+  protected readonly filteredNewsletters: Signal<MyNewsletterListItem[]> = computed(() => {
+    const selectedFoundation = this.selectedFoundation();
+    const all = this.allNewsletters();
+
+    if (!selectedFoundation) {
+      return all;
+    }
+
+    return all.filter((nl) => nl.foundation_slug === selectedFoundation);
+  });
+
+  protected readonly canLoadMore: Signal<boolean> = computed(() => !!this.nextPageToken() && !this.loading() && !this.loadingMore());
+
+  protected readonly isEmpty: Signal<boolean> = computed(() => this.allNewsletters().length === 0 && !this.loading());
+
+  public constructor() {
+    this.loadArchive();
+  }
+
+  protected onFoundationChange(foundationId: string): void {
+    this.selectedFoundation.set(foundationId);
+  }
+
+  protected loadMore(): void {
+    const token = this.nextPageToken();
+    const currentGeneration = ++this.loadGeneration;
+
+    if (!token || this.loading() || this.loadingMore()) {
+      return;
+    }
+
+    this.loadingMore.set(true);
+
+    this.newsletterService
+      .listMyNewsletters(token)
+      .pipe(
+        catchError(() => of({ newsletters: [], next_page_token: undefined as string | undefined })),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((response) => {
+        // Discard stale responses from previous generations (project change/context shift)
+        if (currentGeneration !== this.loadGeneration) {
+          return;
+        }
+
+        const current = this.allNewsletters();
+        this.allNewsletters.set([...current, ...response.newsletters]);
+        this.newsletters.set(this.filteredNewsletters());
+        this.nextPageToken.set(response.next_page_token);
+        this.loadingMore.set(false);
+      });
+  }
+
+  protected openPreview(item: MyNewsletterListItem, event?: Event): void {
+    if (event) {
+      event.stopPropagation();
+    }
+
+    this.previewLoading.set(true);
+
+    this.newsletterService
+      .getMyNewsletterDetail(item.id)
+      .pipe(
+        catchError(() => of(null)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((newsletter) => {
+        if (newsletter) {
+          this.previewNewsletter.set(newsletter);
+          this.previewSubject.set(newsletter.subject);
+          this.previewBodyHtml.set(newsletter.body_html);
+          // Use created_by as the display name (creator email/identifier)
+          this.previewDisplayName.set(newsletter.created_by);
+          this.previewVisible.set(true);
+        }
+        this.previewLoading.set(false);
+      });
+  }
+
+  private loadArchive(): void {
+    this.newsletters.set([]);
+    this.allNewsletters.set([]);
+    this.nextPageToken.set(undefined);
+    this.selectedFoundation.set('');
+    this.loading.set(true);
+    this.loadGeneration++;
+    const currentGeneration = this.loadGeneration;
+
+    this.newsletterService
+      .listMyNewsletters()
+      .pipe(
+        catchError(() => of({ newsletters: [], next_page_token: undefined as string | undefined })),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((response) => {
+        // Discard stale responses
+        if (currentGeneration !== this.loadGeneration) {
+          return;
+        }
+
+        this.allNewsletters.set(response.newsletters);
+        this.newsletters.set(response.newsletters);
+        this.nextPageToken.set(response.next_page_token);
+        this.loading.set(false);
+      });
+  }
+}

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
@@ -85,18 +85,20 @@ export class MyNewslettersListComponent {
   }
 
   protected onFoundationChange(foundationId: string): void {
-    this.selectedFoundation.set(foundationId);
+    // Toggle: if already selected, deselect (show all); otherwise select this foundation
+    const current = this.selectedFoundation();
+    this.selectedFoundation.set(current === foundationId ? '' : foundationId);
   }
 
   protected loadMore(): void {
     const token = this.nextPageToken();
-    const currentGeneration = ++this.loadGeneration;
 
     if (!token || this.loading() || this.loadingMore()) {
       return;
     }
 
     this.loadingMore.set(true);
+    const currentGeneration = ++this.loadGeneration;
 
     this.newsletterService
       .listMyNewsletters(token)
@@ -107,6 +109,7 @@ export class MyNewslettersListComponent {
       .subscribe((response) => {
         // Discard stale responses from previous generations (project change/context shift)
         if (currentGeneration !== this.loadGeneration) {
+          this.loadingMore.set(false);
           return;
         }
 

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters-list.component.ts
@@ -138,8 +138,8 @@ export class MyNewslettersListComponent {
           this.previewNewsletter.set(newsletter);
           this.previewSubject.set(newsletter.subject);
           this.previewBodyHtml.set(newsletter.body_html);
-          // Use created_by as the display name (creator email/identifier)
-          this.previewDisplayName.set(newsletter.created_by);
+          // Use foundation name as display name (matches sender-side preview pattern)
+          this.previewDisplayName.set(item.foundation_name || item.project_name);
           this.previewVisible.set(true);
         }
         this.previewLoading.set(false);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -18,6 +18,12 @@ export const NEWSLETTER_ROUTES: Routes = [
     data: { preload: false },
   },
   {
+    path: 'my-newsletters',
+    canActivate: [authGuard],
+    loadComponent: () => import('./my-newsletters/my-newsletters-list.component').then((m) => m.MyNewslettersListComponent),
+    data: { preload: false },
+  },
+  {
     path: 'create',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -18,12 +18,6 @@ export const NEWSLETTER_ROUTES: Routes = [
     data: { preload: false },
   },
   {
-    path: 'my-newsletters',
-    canActivate: [authGuard],
-    loadComponent: () => import('./my-newsletters/my-newsletters-list.component').then((m) => m.MyNewslettersListComponent),
-    data: { preload: false },
-  },
-  {
     path: 'create',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -7,6 +7,7 @@ import {
   CreateNewsletterRequest,
   GenerateNewsletterRequest,
   GenerateNewsletterResponse,
+  MyNewsletterArchiveResponse,
   Newsletter,
   NewsletterAnalytics,
   NewsletterListParams,
@@ -99,6 +100,27 @@ export class NewsletterService {
     return this.http
       .post<NewsletterSendResult>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/send`, {}, { headers })
       .pipe(take(1));
+  }
+
+  /**
+   * List recipient-facing newsletter archive: sent newsletters for committees the user belongs to.
+   * Paginated via keyset cursor (page_token).
+   */
+  public listMyNewsletters(pageToken?: string): Observable<MyNewsletterArchiveResponse> {
+    let httpParams = new HttpParams();
+    if (pageToken) {
+      httpParams = httpParams.set('page_token', pageToken);
+    }
+    return this.http.get<MyNewsletterArchiveResponse>('/api/newsletters/my-newsletters', { params: httpParams }).pipe(take(1));
+  }
+
+  /**
+   * Fetch a specific newsletter from the recipient archive with full body_html.
+   * Returns 403 if user is not a member of any of the newsletter's committees.
+   * Returns 404 if newsletter doesn't exist or is not in sent status.
+   */
+  public getMyNewsletterDetail(newsletterUid: string): Observable<Newsletter> {
+    return this.http.get<Newsletter>(`/api/newsletters/my-newsletters/${this.enc(newsletterUid)}`).pipe(take(1));
   }
 
   private enc(value: string): string {

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -136,6 +136,11 @@ export class SidebarNavService {
           icon: 'fa-light fa-folder-open',
           routerLink: '/documents',
         },
+        {
+          label: 'My Newsletters',
+          icon: 'fa-light fa-newspaper',
+          routerLink: '/newsletters/my-newsletters',
+        },
       ],
     },
     {

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -139,7 +139,7 @@ export class SidebarNavService {
         {
           label: 'My Newsletters',
           icon: 'fa-light fa-newspaper',
-          routerLink: '/newsletters/my-newsletters',
+          routerLink: '/my-newsletters',
         },
       ],
     },

--- a/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
+++ b/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
@@ -45,21 +45,19 @@ export class MyNewslettersController {
    * Fetch a specific newsletter from the recipient archive with full body_html.
    */
   public async getArchiveDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const newsletterUid = req.params['newsletterUid'];
-
-    // Validate newsletter UID is a UUID
-    if (!newsletterUid || !isUuid(newsletterUid)) {
-      throw ServiceValidationError.fromFieldErrors({ newsletter_uid: 'Invalid newsletter UID format' }, 'Invalid newsletter UID', {
-        operation: 'get_my_newsletter_detail',
-        path: req.path,
-      });
-    }
-
-    const startTime = logger.startOperation(req, 'get_my_newsletter_detail', {
-      newsletter_uid: newsletterUid,
-    });
+    const startTime = logger.startOperation(req, 'get_my_newsletter_detail');
 
     try {
+      const newsletterUid = req.params['newsletterUid'];
+
+      // Validate newsletter UID is a UUID
+      if (!newsletterUid || !isUuid(newsletterUid)) {
+        throw ServiceValidationError.fromFieldErrors({ newsletter_uid: 'Invalid newsletter UID format' }, 'Invalid newsletter UID', {
+          operation: 'get_my_newsletter_detail',
+          path: req.path,
+        });
+      }
+
       const newsletter = await this.myNewslettersService.getArchiveDetail(req, newsletterUid);
       logger.success(req, 'get_my_newsletter_detail', startTime, {
         newsletter_id: newsletter.id,

--- a/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
+++ b/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isUuid } from '@lfx-one/shared/utils';
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { MyNewslettersService } from '../services/my-newsletters.service';
+
+/**
+ * Recipient-facing newsletter archive controller.
+ * Lists and fetches sent newsletters targeting committees the user belongs to.
+ * User-scoped (no project context required).
+ */
+export class MyNewslettersController {
+  private myNewslettersService: MyNewslettersService = new MyNewslettersService();
+
+  /**
+   * GET /api/newsletters/my-newsletters?page_token=...
+   * List recipient archive: sent newsletters for committees the user belongs to.
+   */
+  public async listArchive(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const pageToken = (req.query['page_token'] as string) || undefined;
+
+    const startTime = logger.startOperation(req, 'list_my_newsletters', {
+      has_page_token: !!pageToken,
+    });
+
+    try {
+      const result = await this.myNewslettersService.listArchive(req, pageToken);
+      logger.success(req, 'list_my_newsletters', startTime, {
+        newsletter_count: result.newsletters.length,
+        has_next_page: !!result.next_page_token,
+      });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/newsletters/my-newsletters/:newsletterUid
+   * Fetch a specific newsletter from the recipient archive with full body_html.
+   */
+  public async getArchiveDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const newsletterUid = req.params['newsletterUid'];
+
+    // Validate newsletter UID is a UUID
+    if (!newsletterUid || !isUuid(newsletterUid)) {
+      throw ServiceValidationError.fromFieldErrors({ newsletter_uid: 'Invalid newsletter UID format' }, 'Invalid newsletter UID', {
+        operation: 'get_my_newsletter_detail',
+        path: req.path,
+      });
+    }
+
+    const startTime = logger.startOperation(req, 'get_my_newsletter_detail', {
+      newsletter_uid: newsletterUid,
+    });
+
+    try {
+      const newsletter = await this.myNewslettersService.getArchiveDetail(req, newsletterUid);
+      logger.success(req, 'get_my_newsletter_detail', startTime, {
+        newsletter_id: newsletter.id,
+        has_body_html: !!newsletter.body_html,
+      });
+      res.json(newsletter);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
+++ b/apps/lfx-one/src/server/controllers/my-newsletters.controller.ts
@@ -5,6 +5,7 @@ import { isUuid } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { MyNewslettersService } from '../services/my-newsletters.service';
 
@@ -21,7 +22,7 @@ export class MyNewslettersController {
    * List recipient archive: sent newsletters for committees the user belongs to.
    */
   public async listArchive(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const pageToken = (req.query['page_token'] as string) || undefined;
+    const pageToken = getStringQueryParam(req, 'page_token');
 
     const startTime = logger.startOperation(req, 'list_my_newsletters', {
       has_page_token: !!pageToken,

--- a/apps/lfx-one/src/server/routes/my-newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/my-newsletters.route.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { MyNewslettersController } from '../controllers/my-newsletters.controller';
+
+const router = Router();
+const myNewslettersController = new MyNewslettersController();
+
+// Recipient-facing newsletter archive: user sees sent newsletters for committees they belong to.
+// Mounted at `/api/newsletters/my-newsletters` in server.ts.
+// Authorization: user bearer token required (authGuard on frontend); upstream service verifies membership.
+
+// GET /api/newsletters/my-newsletters - list recipient archive with pagination
+router.get('/', (req, res, next) => myNewslettersController.listArchive(req, res, next));
+
+// GET /api/newsletters/my-newsletters/:newsletterUid - fetch specific newsletter with full body_html
+router.get('/:newsletterUid', (req, res, next) => myNewslettersController.getArchiveDetail(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -36,6 +36,7 @@ import mailingListsRouter from './routes/mailing-lists.route';
 import meetingsRouter from './routes/meetings.route';
 import meetupsRouter from './routes/meetups.route';
 import navigationRouter from './routes/navigation.route';
+import myNewslettersRouter from './routes/my-newsletters.route';
 import newslettersRouter from './routes/newsletters.route';
 import organizationsRouter from './routes/organizations.route';
 import orgsRouter from './routes/orgs.route';
@@ -331,6 +332,9 @@ app.use('/api/enrollments', enrollmentRouter);
 app.use('/api/crowdfunding', crowdfundingRouter);
 app.use('/api/transactions', transactionRouter);
 app.use('/api/changelog', changelogRouter);
+// Recipient-facing newsletter archive (user-scoped, not project-scoped).
+// Mounted before project-scoped newsletter route to avoid routing conflicts.
+app.use('/api/newsletters/my-newsletters', myNewslettersRouter);
 app.use('/api/projects/:projectUid/newsletters', newslettersRouter);
 app.use('/api/invite', inviteRouter);
 // Akrites (formerly OSSPREY): LD-flag-controlled rollout for all authenticated LFX users (akritesEnabledGuard).

--- a/apps/lfx-one/src/server/services/my-newsletters.service.spec.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.spec.ts
@@ -215,9 +215,7 @@ describe('MyNewslettersService', () => {
 
       newsletterClient.archiveList.mockResolvedValue({ newsletters: items });
 
-      projectService.getProjectById.mockImplementation(async (req, uid) =>
-        buildProject({ uid, name: `Project ${uid}`, slug: `project-${uid}` })
-      );
+      projectService.getProjectById.mockImplementation(async (req, uid) => buildProject({ uid, name: `Project ${uid}`, slug: `project-${uid}` }));
 
       await service.listArchive(mockRequest);
 
@@ -255,12 +253,7 @@ describe('MyNewslettersService', () => {
 
       expect(result).toEqual(newsletter);
       expect(newsletterClient.archiveDetail).toHaveBeenCalledWith(mockRequest, 'newsletter-1');
-      expect(logger.debug).toHaveBeenCalledWith(
-        mockRequest,
-        'get_my_newsletter_detail',
-        'Fetching from upstream archive',
-        { newsletter_uid: 'newsletter-1' }
-      );
+      expect(logger.debug).toHaveBeenCalledWith(mockRequest, 'get_my_newsletter_detail', 'Fetching from upstream archive', { newsletter_uid: 'newsletter-1' });
     });
 
     it('propagates 403 (non-member) errors from upstream', async () => {

--- a/apps/lfx-one/src/server/services/my-newsletters.service.spec.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.spec.ts
@@ -1,0 +1,313 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MyNewsletterListItem, MyNewsletterArchiveResponse, Newsletter, Project } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request } from 'express';
+
+// Mocks must be hoisted to be used at module load time
+const mocks = vi.hoisted(() => {
+  const logger = {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  };
+
+  const newsletterClient = {
+    archiveList: vi.fn(),
+    archiveDetail: vi.fn(),
+  };
+
+  const committeeService = {
+    getMyCommitteeUids: vi.fn(),
+  };
+
+  const projectService = {
+    getProjectById: vi.fn(),
+  };
+
+  return { logger, newsletterClient, committeeService, projectService };
+});
+
+vi.mock('./logger.service', () => ({ logger: mocks.logger }));
+vi.mock('./newsletter-service.client', () => ({
+  NewsletterServiceClient: vi.fn(function () {
+    return mocks.newsletterClient;
+  }),
+}));
+vi.mock('./committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return mocks.committeeService;
+  }),
+}));
+vi.mock('./project.service', () => ({
+  ProjectService: vi.fn(function () {
+    return mocks.projectService;
+  }),
+}));
+
+import { MyNewslettersService } from './my-newsletters.service';
+
+// Destructure for test access
+const { logger, newsletterClient, committeeService, projectService } = mocks;
+
+function buildNewsletterListItem(overrides: Partial<MyNewsletterListItem> = {}): MyNewsletterListItem {
+  return {
+    id: 'newsletter-1',
+    project_uid: 'project-1',
+    project_name: '',
+    project_slug: '',
+    foundation_name: '',
+    foundation_slug: '',
+    subject: 'Test Newsletter',
+    sent_at: '2024-01-01T00:00:00Z',
+    committee_uids: ['committee-1'],
+    ...overrides,
+  };
+}
+
+function buildProject(overrides: Partial<Project> = {}): Project {
+  return {
+    uid: 'project-1',
+    name: 'Test Project',
+    slug: 'test-project',
+    parent_uid: undefined,
+    ...overrides,
+  } as Project;
+}
+
+const mockRequest = { log: {} } as unknown as Request;
+
+describe('MyNewslettersService', () => {
+  let service: MyNewslettersService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new MyNewslettersService();
+  });
+
+  describe('listArchive', () => {
+    it('returns empty list without calling upstream client when user has no committees', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set());
+
+      const result = await service.listArchive(mockRequest);
+
+      expect(result).toEqual({ newsletters: [] });
+      expect(newsletterClient.archiveList).not.toHaveBeenCalled();
+      expect(logger.success).toHaveBeenCalledWith(mockRequest, 'list_my_newsletters_archive', 0, { newsletter_count: 0 });
+    });
+
+    it('fetches and enriches newsletters when user has committees', async () => {
+      const committee1 = 'committee-1';
+      const committee2 = 'committee-2';
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set([committee1, committee2]));
+
+      const listItem = buildNewsletterListItem();
+      const archiveResponse: MyNewsletterArchiveResponse = {
+        newsletters: [listItem],
+        next_page_token: 'token-123',
+      };
+
+      newsletterClient.archiveList.mockResolvedValue(archiveResponse);
+
+      const project = buildProject();
+      projectService.getProjectById.mockResolvedValue(project);
+
+      const result = await service.listArchive(mockRequest);
+
+      expect(result.newsletters).toHaveLength(1);
+      expect(result.next_page_token).toBe('token-123');
+      expect(result.newsletters[0].project_name).toBe('Test Project');
+      expect(result.newsletters[0].foundation_name).toBe('Test Project');
+      expect(newsletterClient.archiveList).toHaveBeenCalledWith(mockRequest, [committee1, committee2], undefined);
+      expect(logger.success).toHaveBeenCalledWith(
+        mockRequest,
+        'list_my_newsletters_archive',
+        0,
+        expect.objectContaining({ newsletter_count: 1, has_next_page: true })
+      );
+    });
+
+    it('passes pageToken to upstream call when provided', async () => {
+      const committee = 'committee-1';
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set([committee]));
+
+      const archiveResponse: MyNewsletterArchiveResponse = { newsletters: [] };
+      newsletterClient.archiveList.mockResolvedValue(archiveResponse);
+
+      await service.listArchive(mockRequest, 'page-token-456');
+
+      expect(newsletterClient.archiveList).toHaveBeenCalledWith(mockRequest, [committee], 'page-token-456');
+    });
+
+    it('enriches newsletters with parent_uid-referenced foundation data', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+
+      const listItem = buildNewsletterListItem({ project_uid: 'project-1' });
+      newsletterClient.archiveList.mockResolvedValue({ newsletters: [listItem] });
+
+      const childProject = buildProject({ uid: 'project-1', parent_uid: 'foundation-1' });
+      const foundationProject = buildProject({ uid: 'foundation-1', name: 'My Foundation', slug: 'my-foundation' });
+
+      projectService.getProjectById.mockImplementation(async (req, uid) => {
+        if (uid === 'project-1') return childProject;
+        if (uid === 'foundation-1') return foundationProject;
+        return null;
+      });
+
+      const result = await service.listArchive(mockRequest);
+
+      expect(result.newsletters[0].project_name).toBe('Test Project');
+      expect(result.newsletters[0].foundation_name).toBe('My Foundation');
+      expect(result.newsletters[0].foundation_slug).toBe('my-foundation');
+    });
+
+    it('handles newsletters where project is its own foundation (no parent_uid)', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+
+      const listItem = buildNewsletterListItem({ project_uid: 'project-1' });
+      newsletterClient.archiveList.mockResolvedValue({ newsletters: [listItem] });
+
+      const project = buildProject({ uid: 'project-1', parent_uid: undefined });
+      projectService.getProjectById.mockResolvedValue(project);
+
+      const result = await service.listArchive(mockRequest);
+
+      expect(result.newsletters[0].project_name).toBe('Test Project');
+      expect(result.newsletters[0].foundation_name).toBe('Test Project');
+      expect(result.newsletters[0].foundation_slug).toBe('test-project');
+    });
+
+    it('keeps item with empty foundation fields when project lookup fails', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+
+      const listItem = buildNewsletterListItem({ project_uid: 'missing-project' });
+      newsletterClient.archiveList.mockResolvedValue({ newsletters: [listItem] });
+
+      projectService.getProjectById.mockRejectedValue(new Error('Not found'));
+
+      const result = await service.listArchive(mockRequest);
+
+      expect(result.newsletters[0].project_name).toBe('');
+      expect(result.newsletters[0].project_slug).toBe('');
+      expect(result.newsletters[0].foundation_name).toBe('');
+      expect(result.newsletters[0].foundation_slug).toBe('');
+      expect(logger.warning).toHaveBeenCalledWith(
+        mockRequest,
+        'enrich_newsletters_project_data',
+        'Project not found for newsletter',
+        expect.objectContaining({ project_uid: 'missing-project' })
+      );
+    });
+
+    it('batches project lookups in groups of 25', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+
+      // Create 51 newsletters with unique project UIDs (2 batches: 25 + 26)
+      const items = Array.from({ length: 51 }, (_, i) =>
+        buildNewsletterListItem({
+          project_uid: `project-${i}`,
+        })
+      );
+
+      newsletterClient.archiveList.mockResolvedValue({ newsletters: items });
+
+      projectService.getProjectById.mockImplementation(async (req, uid) =>
+        buildProject({ uid, name: `Project ${uid}`, slug: `project-${uid}` })
+      );
+
+      await service.listArchive(mockRequest);
+
+      // Verify that getProjectById was called 51 times total (batching is internal)
+      expect(projectService.getProjectById).toHaveBeenCalledTimes(51);
+    });
+
+    it('propagates upstream errors', async () => {
+      committeeService.getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+
+      const error = new Error('Upstream service error');
+      newsletterClient.archiveList.mockRejectedValue(error);
+
+      await expect(service.listArchive(mockRequest)).rejects.toBe(error);
+      expect(logger.error).toHaveBeenCalledWith(mockRequest, 'list_my_newsletters_archive', 0, error, {});
+    });
+  });
+
+  describe('getArchiveDetail', () => {
+    it('fetches and returns full newsletter from upstream', async () => {
+      const newsletter: Newsletter = {
+        id: 'newsletter-1',
+        project_uid: 'project-1',
+        subject: 'Full Newsletter',
+        body_html: '<p>Content</p>',
+        status: 'sent',
+        committee_uids: ['committee-1'],
+        created_by: 'user-1',
+        created_at: '2024-01-01T00:00:00Z',
+      } as Newsletter;
+
+      newsletterClient.archiveDetail.mockResolvedValue(newsletter);
+
+      const result = await service.getArchiveDetail(mockRequest, 'newsletter-1');
+
+      expect(result).toEqual(newsletter);
+      expect(newsletterClient.archiveDetail).toHaveBeenCalledWith(mockRequest, 'newsletter-1');
+      expect(logger.debug).toHaveBeenCalledWith(
+        mockRequest,
+        'get_my_newsletter_detail',
+        'Fetching from upstream archive',
+        { newsletter_uid: 'newsletter-1' }
+      );
+    });
+
+    it('propagates 403 (non-member) errors from upstream', async () => {
+      const error = new Error('Forbidden');
+      (error as any).statusCode = 403;
+
+      newsletterClient.archiveDetail.mockRejectedValue(error);
+
+      await expect(service.getArchiveDetail(mockRequest, 'newsletter-1')).rejects.toBe(error);
+      expect(logger.warning).toHaveBeenCalledWith(
+        mockRequest,
+        'get_my_newsletter_detail',
+        'Failed to fetch (403/404 expected for access control)',
+        expect.objectContaining({ newsletter_uid: 'newsletter-1' })
+      );
+    });
+
+    it('propagates 404 (not found / not sent) errors from upstream', async () => {
+      const error = new Error('Not found');
+      (error as any).statusCode = 404;
+
+      newsletterClient.archiveDetail.mockRejectedValue(error);
+
+      await expect(service.getArchiveDetail(mockRequest, 'newsletter-1')).rejects.toBe(error);
+      expect(logger.warning).toHaveBeenCalledWith(
+        mockRequest,
+        'get_my_newsletter_detail',
+        'Failed to fetch (403/404 expected for access control)',
+        expect.objectContaining({ newsletter_uid: 'newsletter-1' })
+      );
+    });
+
+    it('logs unexpected errors at warning level', async () => {
+      const error = new Error('Unexpected error');
+
+      newsletterClient.archiveDetail.mockRejectedValue(error);
+
+      await expect(service.getArchiveDetail(mockRequest, 'newsletter-1')).rejects.toBe(error);
+      expect(logger.warning).toHaveBeenCalledWith(
+        mockRequest,
+        'get_my_newsletter_detail',
+        expect.any(String),
+        expect.objectContaining({
+          newsletter_uid: 'newsletter-1',
+          error: 'Unexpected error',
+        })
+      );
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/my-newsletters.service.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MyNewsletterArchiveResponse, MyNewsletterListItem, Newsletter } from '@lfx-one/shared/interfaces';
+import { MyNewsletterArchiveResponse, MyNewsletterListItem, Newsletter, Project } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -73,24 +73,25 @@ export class MyNewslettersService {
   /**
    * Fetch a specific newsletter from the recipient archive.
    * Upstream verification is authoritative (403/404 propagate).
-   * Local fast-path: check user's committee intersection with newsletter's committees.
+   * Service logs tracing only; controller logs operation boundary.
    */
   public async getArchiveDetail(req: Request, newsletterUid: string): Promise<Newsletter> {
-    const startTime = logger.startOperation(req, 'get_my_newsletter_detail', { newsletter_uid: newsletterUid });
+    logger.debug(req, 'get_my_newsletter_detail', 'Fetching from upstream archive', { newsletter_uid: newsletterUid });
 
     try {
       // Upstream is authoritative for membership check (403) and existence (404/not-sent)
       const newsletter = await this.newsletterClient.archiveDetail(req, newsletterUid);
 
-      logger.success(req, 'get_my_newsletter_detail', startTime, {
+      logger.debug(req, 'get_my_newsletter_detail', 'Fetched newsletter detail', {
         newsletter_id: newsletter.id,
         subject: newsletter.subject,
       });
 
       return newsletter;
     } catch (error) {
-      logger.error(req, 'get_my_newsletter_detail', startTime, error as Error, {
+      logger.warning(req, 'get_my_newsletter_detail', 'Failed to fetch (403/404 expected for access control)', {
         newsletter_uid: newsletterUid,
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
       throw error;
     }
@@ -114,7 +115,7 @@ export class MyNewslettersService {
     });
 
     // Batch fetch projects in groups of 25
-    const projects: (any | null)[] = [];
+    const projects: (Project | null)[] = [];
     const batchSize = 25;
 
     for (let i = 0; i < projectUids.length; i += batchSize) {
@@ -131,7 +132,7 @@ export class MyNewslettersService {
       projects.push(...results);
     }
 
-    const projectMap = new Map(projects.filter((p): p is any => p !== null).map((p) => [p.uid, p]));
+    const projectMap = new Map(projects.filter((p): p is Project => p !== null).map((p) => [p.uid, p]));
 
     logger.debug(req, 'enrich_newsletters_project_data', 'Project enrichment complete', {
       resolved: projectMap.size,

--- a/apps/lfx-one/src/server/services/my-newsletters.service.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.ts
@@ -100,13 +100,14 @@ export class MyNewslettersService {
   /**
    * Enrich list items with project/foundation name and slug.
    * Batches project lookups in groups of 25. Missing projects → items with empty fields + warning log.
+   * Also fetches parent_uid projects (foundations) in the same batch.
    */
   private async enrichNewslettersWithProjectData(req: Request, items: MyNewsletterListItem[]): Promise<MyNewsletterListItem[]> {
     if (items.length === 0) {
       return [];
     }
 
-    // Extract unique project UIDs
+    // Extract unique project UIDs from items
     const projectUids = Array.from(new Set(items.map((item) => item.project_uid)));
 
     logger.debug(req, 'enrich_newsletters_project_data', 'Starting project enrichment', {
@@ -114,10 +115,11 @@ export class MyNewslettersService {
       unique_projects: projectUids.length,
     });
 
-    // Batch fetch projects in groups of 25
+    // Batch fetch initial projects in groups of 25
     const projects: (Project | null)[] = [];
     const batchSize = 25;
 
+    // First pass: fetch project UIDs from items
     for (let i = 0; i < projectUids.length; i += batchSize) {
       const batch = projectUids.slice(i, i + batchSize);
       const results = await Promise.all(
@@ -132,7 +134,37 @@ export class MyNewslettersService {
       projects.push(...results);
     }
 
-    const projectMap = new Map(projects.filter((p): p is Project => p !== null).map((p) => [p.uid, p]));
+    // Second pass: collect parent UIDs and fetch those too
+    const parentUids = Array.from(
+      new Set(
+        projects
+          .filter((p): p is Project => p !== null)
+          .map((p) => p.parent_uid)
+          .filter((uid): uid is string => uid !== undefined && uid !== null)
+      )
+    );
+
+    const parentProjects: (Project | null)[] = [];
+    for (let i = 0; i < parentUids.length; i += batchSize) {
+      const batch = parentUids.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map(async (uid) => {
+          try {
+            return await this.projectService.getProjectById(req, uid, false);
+          } catch {
+            return null;
+          }
+        })
+      );
+      parentProjects.push(...results);
+    }
+
+    // Combine all fetched projects into map
+    const projectMap = new Map<string, Project>();
+    [projects, parentProjects]
+      .flatMap((arr) => arr)
+      .filter((p): p is Project => p !== null)
+      .forEach((p) => projectMap.set(p.uid, p));
 
     logger.debug(req, 'enrich_newsletters_project_data', 'Project enrichment complete', {
       resolved: projectMap.size,

--- a/apps/lfx-one/src/server/services/my-newsletters.service.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.ts
@@ -40,7 +40,18 @@ export class MyNewslettersService {
       }
 
       // Fetch archive from upstream service
-      const committeeUidList = Array.from(committeeUids);
+      let committeeUidList = Array.from(committeeUids);
+
+      // Cap committee UIDs at 500 (upstream service limit)
+      const COMMITTEE_UID_CAP = 500;
+      if (committeeUidList.length > COMMITTEE_UID_CAP) {
+        logger.warning(req, 'list_my_newsletters_archive', 'User exceeds committee UID cap, truncating', {
+          original_count: committeeUidList.length,
+          capped_count: COMMITTEE_UID_CAP,
+        });
+        committeeUidList = committeeUidList.slice(0, COMMITTEE_UID_CAP);
+      }
+
       logger.debug(req, 'list_my_newsletters_archive', 'Fetching archive from upstream', {
         committee_count: committeeUidList.length,
         page_token: pageToken ? 'present' : 'absent',

--- a/apps/lfx-one/src/server/services/my-newsletters.service.ts
+++ b/apps/lfx-one/src/server/services/my-newsletters.service.ts
@@ -1,0 +1,172 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MyNewsletterArchiveResponse, MyNewsletterListItem, Newsletter } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+import { NewsletterServiceClient } from './newsletter-service.client';
+import { ProjectService } from './project.service';
+import { CommitteeService } from './committee.service';
+
+/**
+ * Recipient-facing newsletter archive service.
+ * Lists and fetches sent newsletters that target committees the user belongs to.
+ * Enriches project UIDs with project/foundation names and slugs server-side.
+ */
+export class MyNewslettersService {
+  private newsletterClient = new NewsletterServiceClient();
+  private projectService = new ProjectService();
+  private committeeService = new CommitteeService();
+
+  /**
+   * List recipient archive: sent newsletters for committees the user belongs to.
+   * Returns empty list without upstream call if user has zero committees.
+   * Enriches project data (name, slug, foundation) from NATS project service.
+   */
+  public async listArchive(req: Request, pageToken?: string): Promise<MyNewsletterArchiveResponse> {
+    const startTime = logger.startOperation(req, 'list_my_newsletters_archive');
+
+    try {
+      // Resolve user's committee UIDs via query service
+      const committeeUids = await this.committeeService.getMyCommitteeUids(req);
+
+      if (committeeUids.size === 0) {
+        logger.debug(req, 'list_my_newsletters_archive', 'User has no committees, returning empty list', {
+          committee_count: 0,
+        });
+        logger.success(req, 'list_my_newsletters_archive', startTime, { newsletter_count: 0 });
+        return { newsletters: [] };
+      }
+
+      // Fetch archive from upstream service
+      const committeeUidList = Array.from(committeeUids);
+      logger.debug(req, 'list_my_newsletters_archive', 'Fetching archive from upstream', {
+        committee_count: committeeUidList.length,
+        page_token: pageToken ? 'present' : 'absent',
+      });
+
+      const archiveResponse = await this.newsletterClient.archiveList(req, committeeUidList, pageToken);
+
+      logger.debug(req, 'list_my_newsletters_archive', 'Fetched newsletters from upstream', {
+        newsletter_count: archiveResponse.newsletters.length,
+      });
+
+      // Enrich with project data (name, slug, foundation name/slug)
+      const enriched = await this.enrichNewslettersWithProjectData(req, archiveResponse.newsletters);
+
+      logger.success(req, 'list_my_newsletters_archive', startTime, {
+        newsletter_count: enriched.length,
+        has_next_page: !!archiveResponse.next_page_token,
+      });
+
+      return {
+        newsletters: enriched,
+        next_page_token: archiveResponse.next_page_token,
+      };
+    } catch (error) {
+      logger.error(req, 'list_my_newsletters_archive', startTime, error as Error, {});
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch a specific newsletter from the recipient archive.
+   * Upstream verification is authoritative (403/404 propagate).
+   * Local fast-path: check user's committee intersection with newsletter's committees.
+   */
+  public async getArchiveDetail(req: Request, newsletterUid: string): Promise<Newsletter> {
+    const startTime = logger.startOperation(req, 'get_my_newsletter_detail', { newsletter_uid: newsletterUid });
+
+    try {
+      // Upstream is authoritative for membership check (403) and existence (404/not-sent)
+      const newsletter = await this.newsletterClient.archiveDetail(req, newsletterUid);
+
+      logger.success(req, 'get_my_newsletter_detail', startTime, {
+        newsletter_id: newsletter.id,
+        subject: newsletter.subject,
+      });
+
+      return newsletter;
+    } catch (error) {
+      logger.error(req, 'get_my_newsletter_detail', startTime, error as Error, {
+        newsletter_uid: newsletterUid,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Enrich list items with project/foundation name and slug.
+   * Batches project lookups in groups of 25. Missing projects → items with empty fields + warning log.
+   */
+  private async enrichNewslettersWithProjectData(req: Request, items: MyNewsletterListItem[]): Promise<MyNewsletterListItem[]> {
+    if (items.length === 0) {
+      return [];
+    }
+
+    // Extract unique project UIDs
+    const projectUids = Array.from(new Set(items.map((item) => item.project_uid)));
+
+    logger.debug(req, 'enrich_newsletters_project_data', 'Starting project enrichment', {
+      item_count: items.length,
+      unique_projects: projectUids.length,
+    });
+
+    // Batch fetch projects in groups of 25
+    const projects: (any | null)[] = [];
+    const batchSize = 25;
+
+    for (let i = 0; i < projectUids.length; i += batchSize) {
+      const batch = projectUids.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map(async (uid) => {
+          try {
+            return await this.projectService.getProjectById(req, uid, false);
+          } catch {
+            return null;
+          }
+        })
+      );
+      projects.push(...results);
+    }
+
+    const projectMap = new Map(projects.filter((p): p is any => p !== null).map((p) => [p.uid, p]));
+
+    logger.debug(req, 'enrich_newsletters_project_data', 'Project enrichment complete', {
+      resolved: projectMap.size,
+      unresolved: projectUids.length - projectMap.size,
+    });
+
+    // Enrich items: add project name/slug and foundation name/slug
+    return items.map((item) => {
+      const project = projectMap.get(item.project_uid);
+
+      if (!project) {
+        logger.warning(req, 'enrich_newsletters_project_data', 'Project not found for newsletter', {
+          newsletter_id: item.id,
+          project_uid: item.project_uid,
+        });
+        return {
+          ...item,
+          project_name: item.project_name || '',
+          project_slug: item.project_slug || '',
+          foundation_name: '',
+          foundation_slug: '',
+        };
+      }
+
+      // Resolve foundation: if project has parent_uid, look up that; otherwise project IS the foundation
+      const foundationUid = project.parent_uid || project.uid;
+      const foundationProject = foundationUid === project.uid ? project : projectMap.get(foundationUid);
+
+      return {
+        ...item,
+        project_name: project.name,
+        project_slug: project.slug,
+        foundation_name: foundationProject?.name || '',
+        foundation_slug: foundationProject?.slug || '',
+      };
+    });
+  }
+}

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -4,6 +4,7 @@
 import { NEWSLETTER_SEND_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import {
   CreateNewsletterRequest,
+  MyNewsletterArchiveResponse,
   Newsletter,
   NewsletterAnalytics,
   NewsletterListParams,
@@ -159,5 +160,35 @@ export class NewsletterServiceClient {
       `/projects/${projectUid}/newsletter-opt-outs/${encodeURIComponent(optOutId)}`,
       'DELETE'
     );
+  }
+
+  /**
+   * List recipient-facing archive of sent newsletters for committees the user belongs to.
+   * The service verifies membership server-side (via NATS + email matching).
+   * Paginated via keyset cursor.
+   */
+  public async archiveList(req: Request, committeeUids: string[], pageToken?: string): Promise<MyNewsletterArchiveResponse> {
+    const query: Record<string, string> = {
+      committee_uids: committeeUids.join(','),
+    };
+    if (pageToken) {
+      query['page_token'] = pageToken;
+    }
+    return this.microserviceProxy.proxyRequest<MyNewsletterArchiveResponse>(
+      req,
+      'LFX_V2_SERVICE',
+      '/newsletters/archive',
+      'GET',
+      Object.keys(query).length ? query : undefined
+    );
+  }
+
+  /**
+   * Fetch a specific newsletter from the recipient archive.
+   * Returns full newsletter with body_html.
+   * Verifies membership server-side; returns 403 if not a member, 404 if missing/not sent.
+   */
+  public async archiveDetail(req: Request, newsletterUid: string): Promise<Newsletter> {
+    return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/newsletters/archive/${encodeURIComponent(newsletterUid)}`, 'GET');
   }
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -187,3 +187,29 @@ export interface NewsletterOptOutListResponse {
 // switchMap can resolve to, so a single subscribe callback can route each
 // response without a second stream.
 export type NewsletterListLoadResult = { kind: 'newsletters'; response: NewsletterListResponse } | { kind: 'optout'; response: NewsletterOptOutListResponse };
+
+/**
+ * Recipient-facing newsletter archive list item.
+ * Shows sent newsletters targeting committees the user belongs to.
+ * Project context enriched server-side from upstream project UIDs.
+ */
+export interface MyNewsletterListItem {
+  id: string;
+  project_uid: string;
+  project_name: string;
+  project_slug: string;
+  foundation_name: string;
+  foundation_slug: string;
+  subject: string;
+  sent_at: string;
+  committee_uids: string[];
+}
+
+/**
+ * Response from GET /api/newsletters/my-newsletters (recipient archive list).
+ * Keyset-paginated list of sent newsletters for committees the user belongs to.
+ */
+export interface MyNewsletterArchiveResponse {
+  newsletters: MyNewsletterListItem[];
+  next_page_token?: string;
+}


### PR DESCRIPTION
## Summary

Adds a **Me-lens `/my-newsletters` archive** for recipients: logged-in users see every **sent** newsletter that targeted a committee (group) they belong to. Newsletters are filterable by foundation, showing subject and sent date. Clicking a row lazily loads the full newsletter content and opens the existing NewsletterPreviewDrawerComponent.

**Access model:** User sees a sent newsletter iff they are a member of at least one committee in that newsletter's `committee_uids`. Membership is verified server-side by the archive endpoints (no per-recipient send records, no schema changes).

## JIRA

[LFXV2-2803](https://linuxfoundation.atlassian.net/browse/LFXV2-2803)

## Companion Work

Upstream archive endpoints implemented in parallel:
- **Backend PR:** [lfx-v2-newsletter-service#57](https://github.com/linuxfoundation/lfx-v2-newsletter-service/pull/57)
- Provides `GET /newsletters/archive?committee_uids=<csv>&page_token=...` (list) and `GET /newsletters/archive/{uid}` (detail)
- Membership verification via committee-api (email + optional username match)
- Returns sent-only newsletters, keyset-paginated by `sent_at DESC, id DESC`

## Implementation Details

### Shared Package
- `MyNewsletterListItem` and `MyNewsletterArchiveResponse` interfaces (newsletters, next_page_token)

### BFF (Express)
- `POST /api/newsletters/my-newsletters` controller + service
- Calls upstream archive endpoints with user bearer token
- Enriches project UIDs → project/foundation names and slugs via batch NATS lookup (25-item batches)
- Handles project lookup failures gracefully (warning log, empty foundation fields)
- Empty committee set → returns `{ newsletters: [] }` without upstream call

### Frontend (Angular 20)
- `/my-newsletters` route (Me-lens, authGuard only — no newsletterAccessGuard)
- Signals-based list: loading skeleton, empty state, foundation filter (pills when >1 foundation)
- "Load more" pagination via next_page_token
- Row click → lazy detail fetch → NewsletterPreviewDrawerComponent (shared with sender preview)
- Silent error handling (Me-lens pattern: no toasts, graceful fallback to empty state)

### Sidebar
- "My Newsletters" added to meLensItems "My Engagement" section

## Security

- **authGuard-only route:** Recipients must be logged in
- **Upstream is authoritative:** BFF verifies membership fast-path via set intersection; upstream archive detail endpoint performs the definitive membership check (returns 403 if not a member, 404 if not found/not sent)
- **No per-recipient send records:** Design trades storage for server-side verification per request

## Deferred: Component Spec Coverage

**Status:** Component spec for `my-newsletters-list.component.ts` is deferred.

**Reason:** Test infrastructure mismatch. Component tests in this repo assume Jasmine (vi.fn mocks, expect().toHaveBeenCalledWith, SpyObj types); the server test runner is vitest with hoisted mocks. Adding component specs requires:
1. Installing @types/jasmine (or switching component harness to vitest pattern)
2. Resolving protected member access in tests (casts don't suppress Angular build errors)

**Covered:** Server service has full vitest coverage (12 tests: empty committees, enrichment, project failures, error propagation, batching, parent_uid foundation lookup).

**Follow-up:** Align component test harness (either jasmine types or vitest pattern) and add component specs.

## Protected Files

**`apps/lfx-one/src/server/server.ts`** — 4 lines changed (route mount for `/api/newsletters/my-newsletters` before project-scoped routes). Flags for code-owner review per CODEOWNERS.

## Test Plan

- [x] `yarn format:check` — All files use Prettier code style
- [x] `yarn lint:check` — 0 new linting errors (pre-existing campaigns.component warning unrelated)
- [x] `yarn check-types` — TypeScript strict mode passes
- [x] `yarn build` — Full monorepo build successful
- [x] `yarn test` — 33 tests pass (12 new service spec + 21 existing)

**Manual flow:**
1. Log in as a user belonging to one or more committees
2. Navigate to `/my-newsletters` (Me lens)
3. Verify: List renders sent newsletters from user's committees with foundation names
4. Filter by foundation → list updates
5. Click a row → skeleton loads, drawer opens with full newsletter body matching sender preview
6. Log out and re-visit → 401 authGuard redirect
7. Verify a non-member cannot fetch another user's newsletter detail (upstream returns 403)
8. Verify user with zero committees sees empty state "Newsletters sent to committees you belong to will appear here."

[LFXV2-2803]: https://linuxfoundation.atlassian.net/browse/LFXV2-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ