### PR TITLE
feat(meetings): show meeting organizer across meeting surfaces

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -100,6 +100,7 @@
           icon="fa-light fa-calendar-days"
           data-testid="meeting-datetime"></lfx-tag>
       }
+      <lfx-meeting-organizer [meeting]="meeting()"></lfx-meeting-organizer>
       @if (meeting().youtube_upload_enabled) {
         <lfx-tag value="YouTube Upload" severity="secondary" icon="fa-light fa-upload" styleClass="tag-feature-youtube"></lfx-tag>
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -100,7 +100,11 @@
           icon="fa-light fa-calendar-days"
           data-testid="meeting-datetime"></lfx-tag>
       }
-      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="drawerHosts()" [pastMeeting]="pastMeeting()"></lfx-meeting-organizer>
+      <lfx-meeting-organizer
+        [meeting]="meeting()"
+        [hosts]="drawerHosts()"
+        [pastMeeting]="pastMeeting()"
+        [startTime]="meetingStartTime()"></lfx-meeting-organizer>
       @if (meeting().youtube_upload_enabled) {
         <lfx-tag value="YouTube Upload" severity="secondary" icon="fa-light fa-upload" styleClass="tag-feature-youtube"></lfx-tag>
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -100,7 +100,7 @@
           icon="fa-light fa-calendar-days"
           data-testid="meeting-datetime"></lfx-tag>
       }
-      <lfx-meeting-organizer [meeting]="meeting()"></lfx-meeting-organizer>
+      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="drawerHosts()" [pastMeeting]="pastMeeting()"></lfx-meeting-organizer>
       @if (meeting().youtube_upload_enabled) {
         <lfx-tag value="YouTube Upload" severity="secondary" icon="fa-light fa-upload" styleClass="tag-feature-youtube"></lfx-tag>
       }
@@ -458,7 +458,8 @@
           [visible]="showRegistrants()"
           [showAddRegistrant]="!pastMeeting()"
           (registrantsCountChange)="additionalRegistrantsCount.set($event)"
-          (totalCountChange)="drawerGuestCount.set($event)">
+          (totalCountChange)="drawerGuestCount.set($event)"
+          (resolvedHostsChange)="drawerHosts.set($event)">
         </lfx-meeting-registrants-display>
       </p-drawer>
     }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -28,6 +28,7 @@ import {
   MeetingDeleteTypeResult,
   MeetingDeleteTypeSelectionComponent,
 } from '@app/modules/meetings/components/meeting-delete-type-selection/meeting-delete-type-selection.component';
+import { MeetingOrganizerComponent } from '@app/modules/meetings/components/meeting-organizer/meeting-organizer.component';
 import { MeetingRegistrantsDisplayComponent } from '@app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component';
 import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -101,6 +102,7 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
     MeetingRsvpDetailsComponent,
     MeetingRegistrantsDisplayComponent,
     MeetingMaterialsDrawerComponent,
+    MeetingOrganizerComponent,
   ],
   providers: [ConfirmationService],
   templateUrl: './meeting-card.component.html',

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -54,6 +54,7 @@ import {
   MeetingOccurrence,
   MeetingRecurrence,
   MEETING_TYPE_CONFIGS,
+  MeetingHostCandidate,
   PastMeeting,
   PastMeetingAttachment,
   PastMeetingRecording,
@@ -137,6 +138,9 @@ export class MeetingCardComponent implements OnInit {
   public transcript: WritableSignal<PastMeetingTranscript | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
   public drawerGuestCount: WritableSignal<number> = signal(0);
+  // Host-flagged people surfaced by the registrants drawer, fed to the organizer chip so it
+  // resolves the same organizer set the drawer badges (see resolvedHostsChange).
+  public drawerHosts: WritableSignal<MeetingHostCandidate[]> = signal<MeetingHostCandidate[]>([]);
   public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
   public materialsDrawerVisible = signal(false);
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
@@ -1,12 +1,52 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (display(); as organizer) {
-  <lfx-tag
-    [value]="organizer.label"
-    severity="secondary"
-    icon="fa-light fa-user"
-    [pTooltip]="organizer.count > 1 ? allNames() : ''"
+@if (chip(); as organizer) {
+  <span
+    class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 text-gray-600 text-xs font-medium px-2 py-1 whitespace-nowrap"
     data-testid="meeting-organizer">
-  </lfx-tag>
+    <i class="fa-light fa-user" aria-hidden="true"></i>
+    <span>Organized by</span>
+    <!-- Primary organizer: name is a mailto link unless it's "you" or has no email. -->
+    @if (organizer.primary.isYou) {
+      <span>you</span>
+    } @else if (organizer.primary.mailto) {
+      <a
+        [href]="organizer.primary.mailto"
+        class="text-gray-700 hover:underline"
+        [attr.title]="'Email ' + organizer.primary.name"
+        data-testid="organizer-mailto">
+        {{ organizer.primary.name }}
+      </a>
+    } @else {
+      <span>{{ organizer.primary.name }}</span>
+    }
+
+    <!-- Overflow: "+N" opens a popover listing every organizer with the same mailto treatment. -->
+    @if (organizer.count > 1) {
+      <button
+        type="button"
+        class="text-gray-500 hover:text-gray-700 hover:underline"
+        (click)="overflow.toggle($event)"
+        [attr.aria-label]="organizer.count - 1 + ' more organizers'"
+        data-testid="organizer-overflow-toggle">
+        +{{ organizer.count - 1 }}
+      </button>
+      <p-popover #overflow>
+        <div class="flex flex-col gap-1.5 py-1 min-w-[10rem]" data-testid="organizer-overflow-list">
+          @for (link of [organizer.primary].concat(organizer.overflow); track link.name) {
+            <div class="text-sm text-gray-700">
+              @if (link.isYou) {
+                <span>{{ link.name }} (you)</span>
+              } @else if (link.mailto) {
+                <a [href]="link.mailto" class="hover:underline" [attr.title]="'Email ' + link.name">{{ link.name }}</a>
+              } @else {
+                <span>{{ link.name }}</span>
+              }
+            </div>
+          }
+        </div>
+      </p-popover>
+    }
+  </span>
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
@@ -1,0 +1,12 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (display(); as organizer) {
+  <lfx-tag
+    [value]="organizer.label"
+    severity="secondary"
+    icon="fa-light fa-user"
+    [pTooltip]="organizer.count > 1 ? allNames() : ''"
+    data-testid="meeting-organizer">
+  </lfx-tag>
+}

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
@@ -27,13 +27,14 @@
         type="button"
         class="text-gray-500 hover:text-gray-700 hover:underline"
         (click)="overflow.toggle($event)"
+        [attr.aria-expanded]="overflow.overlayVisible"
         [attr.aria-label]="organizer.count - 1 + ' more organizers'"
         data-testid="organizer-overflow-toggle">
         +{{ organizer.count - 1 }}
       </button>
       <p-popover #overflow>
         <div class="flex flex-col gap-1.5 py-1 min-w-[10rem]" data-testid="organizer-overflow-list">
-          @for (link of allOrganizers(); track link.key) {
+          @for (link of organizer.overflow; track link.key) {
             <div class="text-sm text-gray-700">
               @if (link.isYou) {
                 <span>{{ link.name }} (you)</span>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.html
@@ -2,24 +2,23 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (chip(); as organizer) {
-  <span
-    class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 text-gray-600 text-xs font-medium px-2 py-1 whitespace-nowrap"
-    data-testid="meeting-organizer">
-    <i class="fa-light fa-user" aria-hidden="true"></i>
-    <span>Organized by</span>
-    <!-- Primary organizer: name is a mailto link unless it's "you" or has no email. -->
+  <span class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 text-gray-600 text-xs font-medium px-2 py-1 max-w-full" data-testid="meeting-organizer">
+    <i class="fa-light fa-user flex-shrink-0" aria-hidden="true"></i>
+    <span class="flex-shrink-0">Organized by</span>
+    <!-- Primary organizer: name is a mailto link unless it's "you" or has no email. Truncates on
+         narrow viewports (full name stays available via the title tooltip). -->
     @if (organizer.primary.isYou) {
-      <span>you</span>
+      <span class="truncate">you</span>
     } @else if (organizer.primary.mailto) {
       <a
         [href]="organizer.primary.mailto"
-        class="text-gray-700 hover:underline"
+        class="text-gray-700 hover:underline truncate"
         [attr.title]="'Email ' + organizer.primary.name"
         data-testid="organizer-mailto">
         {{ organizer.primary.name }}
       </a>
     } @else {
-      <span>{{ organizer.primary.name }}</span>
+      <span class="truncate" [attr.title]="organizer.primary.name">{{ organizer.primary.name }}</span>
     }
 
     <!-- Overflow: "+N" opens a popover listing every organizer with the same mailto treatment. -->
@@ -34,7 +33,7 @@
       </button>
       <p-popover #overflow>
         <div class="flex flex-col gap-1.5 py-1 min-w-[10rem]" data-testid="organizer-overflow-list">
-          @for (link of [organizer.primary].concat(organizer.overflow); track link.name) {
+          @for (link of allOrganizers(); track link.key) {
             <div class="text-sm text-gray-700">
               @if (link.isYou) {
                 <span>{{ link.name }} (you)</span>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -4,7 +4,7 @@
 import { Component, computed, inject, input, Signal } from '@angular/core';
 import { environment } from '@environments/environment';
 import { Meeting, MeetingHostCandidate, MeetingOrganizerChipModel, PastMeeting } from '@lfx-one/shared/interfaces';
-import { buildMeetingOrganizerChip, collectMeetingOrganizers, getPastMeetingResourceId } from '@lfx-one/shared/utils';
+import { buildMeetingOrganizerChip, collectMeetingOrganizers, getPastMeetingResourceId, getPastMeetingStartTimeMs } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { PopoverModule } from 'primeng/popover';
 
@@ -28,6 +28,9 @@ export class MeetingOrganizerComponent {
   public readonly meeting = input.required<Meeting | PastMeeting>();
   public readonly hosts = input<MeetingHostCandidate[]>([]);
   public readonly pastMeeting = input<boolean>(false);
+  // The surface's resolved display start time (recurring cards show the current/next occurrence,
+  // not the series origin). Used for the mailto subject date; falls back to the meeting's own start.
+  public readonly startTime = input<string | null>(null);
 
   public readonly chip: Signal<MeetingOrganizerChipModel | null> = this.initChip();
 
@@ -57,15 +60,32 @@ export class MeetingOrganizerComponent {
   }
 
   private formatMeetingDate(meeting: Meeting | PastMeeting): string {
-    const start = ('scheduled_start_time' in meeting && meeting.scheduled_start_time) || meeting.start_time;
-    if (!start) {
+    const ms = this.resolveStartMs(meeting);
+    if (ms === null) {
       return '';
     }
-    const date = new Date(start);
-    if (Number.isNaN(date.getTime())) {
-      return '';
+    return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(ms));
+  }
+
+  private resolveStartMs(meeting: Meeting | PastMeeting): number | null {
+    // Prefer the surface's resolved display start (the occurrence a recurring card actually shows).
+    const explicit = this.parseIso(this.startTime());
+    if (explicit !== null) {
+      return explicit;
     }
-    return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(date);
+    // Past meetings can carry a Go zero-date on scheduled_start_time — the shared helper falls back.
+    if (this.pastMeeting() || 'scheduled_start_time' in meeting) {
+      return getPastMeetingStartTimeMs(meeting as PastMeeting);
+    }
+    return this.parseIso(meeting.start_time);
+  }
+
+  private parseIso(iso: string | null | undefined): number | null {
+    if (!iso || iso.startsWith('0001-01-01')) {
+      return null;
+    }
+    const ms = new Date(iso).getTime();
+    return Number.isNaN(ms) ? null : ms;
   }
 
   private buildDetailUrl(meeting: Meeting | PastMeeting): string {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal } from '@angular/core';
+import { TagComponent } from '@components/tag/tag.component';
+import { buildMeetingOrganizerDisplay, collectMeetingOrganizers, Meeting, MeetingHostCandidate, MeetingOrganizerDisplay, PastMeeting } from '@lfx-one/shared';
+import { UserService } from '@services/user.service';
+import { TooltipModule } from 'primeng/tooltip';
+
+/**
+ * Shared "Organized by" chip reused across meeting cards, the join page, and past-meeting
+ * details. Resolves the organizer from `meeting.created_by` (with an optional host fallback),
+ * renders nothing when nothing resolves, and shows "Organized by you" when the viewer is the
+ * organizer. Multiple organizers collapse to "Organized by {first} +N" with a tooltip listing all.
+ */
+@Component({
+  selector: 'lfx-meeting-organizer',
+  imports: [TagComponent, TooltipModule],
+  templateUrl: './meeting-organizer.component.html',
+})
+export class MeetingOrganizerComponent {
+  private readonly userService = inject(UserService);
+
+  public readonly meeting = input.required<Meeting | PastMeeting>();
+  public readonly hosts = input<MeetingHostCandidate[]>([]);
+
+  public readonly display: Signal<MeetingOrganizerDisplay | null> = this.initDisplay();
+  public readonly allNames: Signal<string> = computed(() => {
+    const organizer = this.display();
+    if (!organizer) {
+      return '';
+    }
+    return [organizer.primaryName, ...organizer.overflowNames].filter(Boolean).join(', ');
+  });
+
+  private initDisplay(): Signal<MeetingOrganizerDisplay | null> {
+    return computed(() => {
+      const organizers = collectMeetingOrganizers(this.meeting(), this.hosts());
+      const viewerUsername = this.userService.user()?.username ?? null;
+      return buildMeetingOrganizerDisplay(organizers, viewerUsername);
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -35,6 +35,13 @@ export class MeetingOrganizerComponent {
 
   private initDisplay(): Signal<MeetingOrganizerDisplay | null> {
     return computed(() => {
+      // v1 privacy constraint (LFXV2-2802): the organizer is member-visible info, so it is
+      // never shown to unauthenticated visitors even on public meetings. Gated in this single
+      // component so the whole "Organized by" surface can be un-gated in one place once the
+      // data-privacy review clears it.
+      if (!this.userService.authenticated()) {
+        return null;
+      }
       const organizers = collectMeetingOrganizers(this.meeting(), this.hosts());
       const viewerUsername = this.userService.user()?.username ?? null;
       return buildMeetingOrganizerDisplay(organizers, viewerUsername);

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -2,20 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, input, Signal } from '@angular/core';
-import { TagComponent } from '@components/tag/tag.component';
-import { buildMeetingOrganizerDisplay, collectMeetingOrganizers, Meeting, MeetingHostCandidate, MeetingOrganizerDisplay, PastMeeting } from '@lfx-one/shared';
+import { environment } from '@environments/environment';
+import {
+  buildMeetingOrganizerChip,
+  collectMeetingOrganizers,
+  getPastMeetingResourceId,
+  Meeting,
+  MeetingHostCandidate,
+  MeetingOrganizerChipModel,
+  PastMeeting,
+} from '@lfx-one/shared';
 import { UserService } from '@services/user.service';
-import { TooltipModule } from 'primeng/tooltip';
+import { PopoverModule } from 'primeng/popover';
 
 /**
  * Shared "Organized by" chip reused across meeting cards, the join page, and past-meeting
- * details. Resolves the organizer from `meeting.created_by` (with an optional host fallback),
- * renders nothing when nothing resolves, and shows "Organized by you" when the viewer is the
- * organizer. Multiple organizers collapse to "Organized by {first} +N" with a tooltip listing all.
+ * details. Resolves organizers from the same host set the participants/registrants modal badges
+ * (with `meeting.created_by` folded in), so the two surfaces never disagree. Multiple organizers
+ * collapse to "Organized by {first} +N" with a popover listing all. Each organizer name is a
+ * pre-filled `mailto:` link (plain text when the record has no email, or for "you").
+ *
+ * Rendered only to authenticated users (v1 privacy constraint — see initChip).
  */
 @Component({
   selector: 'lfx-meeting-organizer',
-  imports: [TagComponent, TooltipModule],
+  imports: [PopoverModule],
   templateUrl: './meeting-organizer.component.html',
 })
 export class MeetingOrganizerComponent {
@@ -23,28 +34,46 @@ export class MeetingOrganizerComponent {
 
   public readonly meeting = input.required<Meeting | PastMeeting>();
   public readonly hosts = input<MeetingHostCandidate[]>([]);
+  public readonly pastMeeting = input<boolean>(false);
 
-  public readonly display: Signal<MeetingOrganizerDisplay | null> = this.initDisplay();
-  public readonly allNames: Signal<string> = computed(() => {
-    const organizer = this.display();
-    if (!organizer) {
-      return '';
-    }
-    return [organizer.primaryName, ...organizer.overflowNames].filter(Boolean).join(', ');
-  });
+  public readonly chip: Signal<MeetingOrganizerChipModel | null> = this.initChip();
 
-  private initDisplay(): Signal<MeetingOrganizerDisplay | null> {
+  private initChip(): Signal<MeetingOrganizerChipModel | null> {
     return computed(() => {
-      // v1 privacy constraint (LFXV2-2802): the organizer is member-visible info, so it is
+      // v1 privacy constraint (LFXV2-2802): the organizer is authenticated-visible info, so it is
       // never shown to unauthenticated visitors even on public meetings. Gated in this single
       // component so the whole "Organized by" surface can be un-gated in one place once the
       // data-privacy review clears it.
       if (!this.userService.authenticated()) {
         return null;
       }
-      const organizers = collectMeetingOrganizers(this.meeting(), this.hosts());
+
+      const meeting = this.meeting();
+      const organizers = collectMeetingOrganizers(meeting, this.hosts());
       const viewerUsername = this.userService.user()?.username ?? null;
-      return buildMeetingOrganizerDisplay(organizers, viewerUsername);
+
+      return buildMeetingOrganizerChip(organizers, viewerUsername, {
+        meetingTitle: meeting.title,
+        meetingDate: this.formatMeetingDate(meeting),
+        detailUrl: this.buildDetailUrl(meeting),
+      });
     });
+  }
+
+  private formatMeetingDate(meeting: Meeting | PastMeeting): string {
+    const start = ('scheduled_start_time' in meeting && meeting.scheduled_start_time) || meeting.start_time;
+    if (!start) {
+      return '';
+    }
+    const date = new Date(start);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(date);
+  }
+
+  private buildDetailUrl(meeting: Meeting | PastMeeting): string {
+    const id = this.pastMeeting() ? getPastMeetingResourceId(meeting) : meeting.id;
+    return `${environment.urls.home}/meetings/${id}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -3,15 +3,8 @@
 
 import { Component, computed, inject, input, Signal } from '@angular/core';
 import { environment } from '@environments/environment';
-import {
-  buildMeetingOrganizerChip,
-  collectMeetingOrganizers,
-  getPastMeetingResourceId,
-  Meeting,
-  MeetingHostCandidate,
-  MeetingOrganizerChipModel,
-  PastMeeting,
-} from '@lfx-one/shared';
+import { Meeting, MeetingHostCandidate, MeetingOrganizerChipModel, MeetingOrganizerLink, PastMeeting } from '@lfx-one/shared/interfaces';
+import { buildMeetingOrganizerChip, collectMeetingOrganizers, getPastMeetingResourceId } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { PopoverModule } from 'primeng/popover';
 
@@ -37,6 +30,12 @@ export class MeetingOrganizerComponent {
   public readonly pastMeeting = input<boolean>(false);
 
   public readonly chip: Signal<MeetingOrganizerChipModel | null> = this.initChip();
+  // Flattened [primary, ...overflow] for the "+N" popover — computed here so the template
+  // doesn't allocate a new array on every change-detection pass.
+  public readonly allOrganizers: Signal<MeetingOrganizerLink[]> = computed(() => {
+    const chip = this.chip();
+    return chip ? [chip.primary, ...chip.overflow] : [];
+  });
 
   private initChip(): Signal<MeetingOrganizerChipModel | null> {
     return computed(() => {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -49,7 +49,10 @@ export class MeetingOrganizerComponent {
 
       const meeting = this.meeting();
       const organizers = collectMeetingOrganizers(meeting, this.hosts());
-      const viewerUsername = this.userService.user()?.username ?? null;
+      // The optional `username` alias is often absent; the namespaced LFID claim is the canonical
+      // identity (matches the created_by/host username), so fall back to it for the "you" variant.
+      const user = this.userService.user();
+      const viewerUsername = user?.username || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
 
       return buildMeetingOrganizerChip(organizers, viewerUsername, {
         meetingTitle: meeting.title,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, computed, inject, input, Signal } from '@angular/core';
 import { environment } from '@environments/environment';
-import { Meeting, MeetingHostCandidate, MeetingOrganizerChipModel, MeetingOrganizerLink, PastMeeting } from '@lfx-one/shared/interfaces';
+import { Meeting, MeetingHostCandidate, MeetingOrganizerChipModel, PastMeeting } from '@lfx-one/shared/interfaces';
 import { buildMeetingOrganizerChip, collectMeetingOrganizers, getPastMeetingResourceId } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { PopoverModule } from 'primeng/popover';
@@ -30,12 +30,6 @@ export class MeetingOrganizerComponent {
   public readonly pastMeeting = input<boolean>(false);
 
   public readonly chip: Signal<MeetingOrganizerChipModel | null> = this.initChip();
-  // Flattened [primary, ...overflow] for the "+N" popover — computed here so the template
-  // doesn't allocate a new array on every change-detection pass.
-  public readonly allOrganizers: Signal<MeetingOrganizerLink[]> = computed(() => {
-    const chip = this.chip();
-    return chip ? [chip.primary, ...chip.overflow] : [];
-  });
 
   private initChip(): Signal<MeetingOrganizerChipModel | null> {
     return computed(() => {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -120,6 +120,15 @@
           <div class="flex flex-col min-w-0">
             <div class="flex items-center gap-2">
               <h3>{{ registrant.first_name }} {{ registrant.last_name }}</h3>
+              @if (registrant.host) {
+                <lfx-badge
+                  value="Organizer"
+                  severity="info"
+                  size="small"
+                  styleClass="inline-flex items-center flex-shrink-0"
+                  data-testid="registrant-organizer-badge">
+                </lfx-badge>
+              }
               @if (registrant.linkedin_profile) {
                 <a
                   [href]="registrant.linkedin_profile"
@@ -212,6 +221,15 @@
                 <div class="flex items-center gap-1 text-xs">
                   <i class="fa-light fa-user text-blue-500" pTooltip="Participant"></i>
                   <span class="text-sm text-gray-900 truncate">{{ participant.first_name }} {{ participant.last_name }}</span>
+                  @if (participant.host) {
+                    <lfx-badge
+                      value="Organizer"
+                      severity="info"
+                      size="small"
+                      styleClass="inline-flex items-center flex-shrink-0"
+                      data-testid="participant-organizer-badge">
+                    </lfx-badge>
+                  }
                 </div>
                 <span class="text-sm text-gray-500 truncate">{{ participant.email }}</span>
               </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -13,13 +13,14 @@ import {
   CommitteeMember,
   EnrichedPastMeetingParticipant,
   Meeting,
+  MeetingHostCandidate,
   MeetingRegistrant,
   PastMeeting,
   PastMeetingParticipant,
   PastParticipantAttendanceFilter,
   PastParticipantInvitationFilter,
 } from '@lfx-one/shared/interfaces';
-import { filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
+import { filterPastMeetingParticipants, isUnresolvableParticipantName, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -50,6 +51,9 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly registrantsCountChange: OutputEmitterRef<number> = output<number>();
   public readonly refreshRequested: OutputEmitterRef<number> = output<number>();
   public readonly totalCountChange: OutputEmitterRef<number> = output<number>();
+  // Emits the host-flagged people (the organizer set) whenever the list resolves, so a parent
+  // can feed the same set to the shared "Organized by" chip — keeping chip and modal in agreement.
+  public readonly resolvedHostsChange: OutputEmitterRef<MeetingHostCandidate[]> = output<MeetingHostCandidate[]>();
 
   private readonly internalLoading: WritableSignal<boolean> = signal(true);
   private readonly refresh$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -146,6 +150,13 @@ export class MeetingRegistrantsDisplayComponent {
 
   public constructor() {
     this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(false);
+
+    // Surface the host-flagged people to the parent so the "Organized by" chip and this modal
+    // resolve organizers from the same source.
+    effect(() => {
+      const people: MeetingHostCandidate[] = this.pastMeeting() ? this.pastMeetingParticipants() : this.registrants();
+      this.resolvedHostsChange.emit(people.filter((person) => person.host));
+    });
 
     effect(() => {
       if (!this.visible()) return;
@@ -454,11 +465,19 @@ export class MeetingRegistrantsDisplayComponent {
     );
   }
 
-  // Floats hosts (organizers) to the top of a people list, then orders by first name.
-  private compareByHostThenName<T extends { host?: boolean; first_name?: string | null }>(a: T, b: T): number {
-    const hostDelta = (b.host ? 1 : 0) - (a.host ? 1 : 0);
-    if (hostDelta !== 0) {
-      return hostDelta;
+  // Orders a people list into three tiers: hosts (organizers) first, then normally-named people,
+  // then unresolvable "[unknown]" records at the bottom — so broken rows never sit directly under
+  // the floated-to-top organizers. Within a tier, orders by first name.
+  private compareByHostThenName<T extends { host?: boolean; first_name?: string | null; last_name?: string | null }>(a: T, b: T): number {
+    const rank = (person: T): number => {
+      if (isUnresolvableParticipantName(person.first_name, person.last_name)) {
+        return 2;
+      }
+      return person.host ? 0 : 1;
+    };
+    const rankDelta = rank(a) - rank(b);
+    if (rankDelta !== 0) {
+      return rankDelta;
     }
     return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
   }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -20,7 +20,7 @@ import {
   PastParticipantAttendanceFilter,
   PastParticipantInvitationFilter,
 } from '@lfx-one/shared/interfaces';
-import { filterPastMeetingParticipants, isUnresolvableParticipantName, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
+import { compareMeetingPeopleByHostThenName, filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -148,15 +148,19 @@ export class MeetingRegistrantsDisplayComponent {
   // Filtered past meeting participants based on search
   public readonly filteredPastParticipants = this.initFilteredPastParticipants();
 
+  // Host-flagged people (the organizer set) derived from whichever list is active.
+  private readonly resolvedHosts: Signal<MeetingHostCandidate[]> = computed(() =>
+    (this.pastMeeting() ? this.pastMeetingParticipants() : this.registrants()).filter((person) => person.host)
+  );
+
   public constructor() {
     this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(false);
 
     // Surface the host-flagged people to the parent so the "Organized by" chip and this modal
     // resolve organizers from the same source.
-    effect(() => {
-      const people: MeetingHostCandidate[] = this.pastMeeting() ? this.pastMeetingParticipants() : this.registrants();
-      this.resolvedHostsChange.emit(people.filter((person) => person.host));
-    });
+    toObservable(this.resolvedHosts)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((hosts) => this.resolvedHostsChange.emit(hosts));
 
     effect(() => {
       if (!this.visible()) return;
@@ -292,7 +296,7 @@ export class MeetingRegistrantsDisplayComponent {
 
               return registrantsObservable.pipe(
                 catchError(() => of([])),
-                map((registrants) => registrants.sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[]),
+                map((registrants) => registrants.sort((a, b) => compareMeetingPeopleByHostThenName(a, b)) as MeetingRegistrant[]),
                 tap((registrants) => {
                   const meeting = this.meeting();
                   const resolvedBaseCount = resolveMeetingBaseCount(meeting);
@@ -364,7 +368,7 @@ export class MeetingRegistrantsDisplayComponent {
                   };
                   return enriched;
                 })
-                .sort((a, b) => this.compareByHostThenName(a, b));
+                .sort((a, b) => compareMeetingPeopleByHostThenName(a, b));
             }),
             finalize(() => this.internalLoading.set(false))
           );
@@ -379,13 +383,13 @@ export class MeetingRegistrantsDisplayComponent {
       let list: MeetingRegistrant[];
       if (this.externallyManaged()) {
         const seed = this.initialRegistrants() ?? [];
-        list = [...seed].sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[];
+        list = [...seed].sort((a, b) => compareMeetingPeopleByHostThenName(a, b)) as MeetingRegistrant[];
       } else {
         list = this.internalRegistrants();
       }
       const fetchedEmails = new Set(list.map((r) => r.email?.trim().toLowerCase()));
       const pending = this.optimisticRegistrants().filter((r) => !fetchedEmails.has(r.email?.trim().toLowerCase()));
-      return pending.length ? ([...pending, ...list].sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[]) : list;
+      return pending.length ? ([...pending, ...list].sort((a, b) => compareMeetingPeopleByHostThenName(a, b)) as MeetingRegistrant[]) : list;
     });
   }
 
@@ -463,22 +467,5 @@ export class MeetingRegistrantsDisplayComponent {
         group: this.groupFilter(),
       })
     );
-  }
-
-  // Orders a people list into three tiers: hosts (organizers) first, then normally-named people,
-  // then unresolvable "[unknown]" records at the bottom — so broken rows never sit directly under
-  // the floated-to-top organizers. Within a tier, orders by first name.
-  private compareByHostThenName<T extends { host?: boolean; first_name?: string | null; last_name?: string | null }>(a: T, b: T): number {
-    const rank = (person: T): number => {
-      if (isUnresolvableParticipantName(person.first_name, person.last_name)) {
-        return 2;
-      }
-      return person.host ? 0 : 1;
-    };
-    const rankDelta = rank(a) - rank(b);
-    if (rankDelta !== 0) {
-      return rankDelta;
-    }
-    return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -20,7 +20,13 @@ import {
   PastParticipantAttendanceFilter,
   PastParticipantInvitationFilter,
 } from '@lfx-one/shared/interfaces';
-import { compareMeetingPeopleByHostThenName, filterPastMeetingParticipants, markFormControlsAsTouched, resolveMeetingBaseCount } from '@lfx-one/shared/utils';
+import {
+  compareMeetingPeopleByHostThenName,
+  filterPastMeetingParticipants,
+  getPastMeetingResourceId,
+  markFormControlsAsTouched,
+  resolveMeetingBaseCount,
+} from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -336,7 +342,9 @@ export class MeetingRegistrantsDisplayComponent {
             : of([] as CommitteeMember[]);
 
           return combineLatest([
-            this.meetingService.getPastMeetingParticipants(meeting.id).pipe(catchError(() => of([] as PastMeetingParticipant[]))),
+            // Use the canonical occurrence resource id — project/foundation past cards can carry a
+            // distinct meeting.id, which would otherwise fail-soft to [] (empty organizer set).
+            this.meetingService.getPastMeetingParticipants(getPastMeetingResourceId(meeting)).pipe(catchError(() => of([] as PastMeetingParticipant[]))),
             committeeMembers$,
           ]).pipe(
             map(([participants, committeeMembers]) => {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -6,6 +6,7 @@ import { Component, computed, DestroyRef, effect, inject, input, InputSignal, ou
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { BadgeComponent } from '@components/badge/badge.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
@@ -29,7 +30,7 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 
 @Component({
   selector: 'lfx-meeting-registrants-display',
-  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgTemplateOutlet],
+  imports: [AvatarComponent, BadgeComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgTemplateOutlet],
   templateUrl: './meeting-registrants-display.component.html',
 })
 export class MeetingRegistrantsDisplayComponent {
@@ -280,7 +281,7 @@ export class MeetingRegistrantsDisplayComponent {
 
               return registrantsObservable.pipe(
                 catchError(() => of([])),
-                map((registrants) => registrants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]),
+                map((registrants) => registrants.sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[]),
                 tap((registrants) => {
                   const meeting = this.meeting();
                   const resolvedBaseCount = resolveMeetingBaseCount(meeting);
@@ -352,7 +353,7 @@ export class MeetingRegistrantsDisplayComponent {
                   };
                   return enriched;
                 })
-                .sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0);
+                .sort((a, b) => this.compareByHostThenName(a, b));
             }),
             finalize(() => this.internalLoading.set(false))
           );
@@ -367,13 +368,13 @@ export class MeetingRegistrantsDisplayComponent {
       let list: MeetingRegistrant[];
       if (this.externallyManaged()) {
         const seed = this.initialRegistrants() ?? [];
-        list = [...seed].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[];
+        list = [...seed].sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[];
       } else {
         list = this.internalRegistrants();
       }
       const fetchedEmails = new Set(list.map((r) => r.email?.trim().toLowerCase()));
       const pending = this.optimisticRegistrants().filter((r) => !fetchedEmails.has(r.email?.trim().toLowerCase()));
-      return pending.length ? ([...pending, ...list].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]) : list;
+      return pending.length ? ([...pending, ...list].sort((a, b) => this.compareByHostThenName(a, b)) as MeetingRegistrant[]) : list;
     });
   }
 
@@ -451,5 +452,14 @@ export class MeetingRegistrantsDisplayComponent {
         group: this.groupFilter(),
       })
     );
+  }
+
+  // Floats hosts (organizers) to the top of a people list, then orders by first name.
+  private compareByHostThenName<T extends { host?: boolean; first_name?: string | null }>(a: T, b: T): number {
+    const hostDelta = (b.host ? 1 : 0) - (a.host ? 1 : 0);
+    if (hostDelta !== 0) {
+      return hostDelta;
+    }
+    return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -171,7 +171,7 @@
                       } @else {
                         <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
                       }
-                      <lfx-meeting-organizer [meeting]="meeting()"></lfx-meeting-organizer>
+                      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="registrants()" [pastMeeting]="isPastMeeting()"></lfx-meeting-organizer>
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -171,7 +171,11 @@
                       } @else {
                         <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
                       }
-                      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="organizerChipHosts()" [pastMeeting]="isPastMeeting()"></lfx-meeting-organizer>
+                      <lfx-meeting-organizer
+                        [meeting]="meeting()"
+                        [hosts]="organizerChipHosts()"
+                        [pastMeeting]="isPastMeeting()"
+                        [startTime]="currentOccurrence()?.start_time || meeting().start_time"></lfx-meeting-organizer>
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -171,6 +171,7 @@
                       } @else {
                         <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
                       }
+                      <lfx-meeting-organizer [meeting]="meeting()"></lfx-meeting-organizer>
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -171,7 +171,7 @@
                       } @else {
                         <p-skeleton width="14rem" height="1.5rem" borderRadius="9999px" animation="wave" data-testid="meeting-badge-datetime-skeleton" />
                       }
-                      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="registrants()" [pastMeeting]="isPastMeeting()"></lfx-meeting-organizer>
+                      <lfx-meeting-organizer [meeting]="meeting()" [hosts]="organizerChipHosts()" [pastMeeting]="isPastMeeting()"></lfx-meeting-organizer>
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -34,6 +34,7 @@ import {
   getPastMeetingTranscriptUrl,
   MaterialsChangedEvent,
   MeetingAttachment,
+  MeetingHostCandidate,
   MeetingOccurrence,
   MeetingRecurrence,
   MeetingRegistrant,
@@ -249,6 +250,10 @@ export class MeetingJoinComponent implements OnInit {
   });
   // Past meeting participants (fetched from API for attendance stats)
   protected pastMeetingParticipants: Signal<PastMeetingParticipant[]>;
+  // Host source for the organizer chip: registrants for upcoming, participants for past (the
+  // upcoming registrants signal is empty on past join pages), so the chip and the participants
+  // drawer resolve organizers from the same people.
+  protected organizerChipHosts = computed<MeetingHostCandidate[]>(() => (this.isPastMeeting() ? this.pastMeetingParticipants() : this.registrants()));
   // Past meeting attendance stats (derived from participants)
   protected participantCount = computed(() => this.pastMeetingParticipants().length);
   protected attendedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_attended).length);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -7,6 +7,7 @@ import { afterNextRender, Component, computed, DestroyRef, inject, OnInit, PLATF
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MeetingOrganizerComponent } from '@app/modules/meetings/components/meeting-organizer/meeting-organizer.component';
 import { MeetingRegistrantsDisplayComponent } from '@app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component';
 import { MeetingSummaryModalComponent } from '@app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component';
 import { TranscriptModalComponent } from '@app/modules/meetings/components/transcript-modal/transcript-modal.component';
@@ -103,6 +104,7 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     RsvpButtonGroupComponent,
     MeetingRsvpDetailsComponent,
     MeetingRegistrantsDisplayComponent,
+    MeetingOrganizerComponent,
     GuestFormComponent,
     TooltipModule,
     DrawerModule,

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -107,6 +107,7 @@
               data-testid="badge-datetime">
             </lfx-tag>
           }
+          <lfx-meeting-organizer [meeting]="meeting" [hosts]="participants()"></lfx-meeting-organizer>
           @if (hasRecording()) {
             <lfx-tag value="Recording" severity="secondary" icon="fa-light fa-video" styleClass="tag-feature-recording" data-testid="badge-recording"></lfx-tag>
           }
@@ -397,7 +398,7 @@
                   <div class="flex items-center gap-1.5">
                     <span class="text-sm text-gray-900 truncate">{{ p.first_name }} {{ p.last_name }}</span>
                     @if (p.host) {
-                      <span class="text-xs font-medium text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded">Host</span>
+                      <span class="text-xs font-medium text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded" data-testid="participant-organizer-tag">Organizer</span>
                     }
                   </div>
                 </div>

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -107,7 +107,7 @@
               data-testid="badge-datetime">
             </lfx-tag>
           }
-          <lfx-meeting-organizer [meeting]="meeting" [hosts]="participants()" [pastMeeting]="true"></lfx-meeting-organizer>
+          <lfx-meeting-organizer [meeting]="meeting" [hosts]="participants()" [pastMeeting]="true" [startTime]="meeting.start_time"></lfx-meeting-organizer>
           @if (hasRecording()) {
             <lfx-tag value="Recording" severity="secondary" icon="fa-light fa-video" styleClass="tag-feature-recording" data-testid="badge-recording"></lfx-tag>
           }

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.html
@@ -107,7 +107,7 @@
               data-testid="badge-datetime">
             </lfx-tag>
           }
-          <lfx-meeting-organizer [meeting]="meeting" [hosts]="participants()"></lfx-meeting-organizer>
+          <lfx-meeting-organizer [meeting]="meeting" [hosts]="participants()" [pastMeeting]="true"></lfx-meeting-organizer>
           @if (hasRecording()) {
             <lfx-tag value="Recording" severity="secondary" icon="fa-light fa-video" styleClass="tag-feature-recording" data-testid="badge-recording"></lfx-tag>
           }

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -17,10 +17,10 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   DEFAULT_MEETING_TYPE_CONFIG,
   EnrichedPastMeetingParticipant,
+  compareMeetingPeopleByHostThenName,
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   isPastMeetingSummaryAwaitingApproval,
-  isUnresolvableParticipantName,
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
@@ -118,15 +118,7 @@ export class PastMeetingDetailsComponent {
       result = result.filter((p) => p.committee_voting_status === 'Voting Rep' || p.committee_voting_status === 'Alternate Voting Rep');
     }
     // Organizers (hosts) float to the top; unresolvable "[unknown]" rows sink to the bottom.
-    return [...result].sort((a, b) => {
-      const rank = (p: EnrichedPastMeetingParticipant): number => {
-        if (isUnresolvableParticipantName(p.first_name, p.last_name)) return 2;
-        return p.host ? 0 : 1;
-      };
-      const rankDelta = rank(a) - rank(b);
-      if (rankDelta !== 0) return rankDelta;
-      return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
-    });
+    return [...result].sort((a, b) => compareMeetingPeopleByHostThenName(a, b));
   });
   public meetingTypeBadge = this.initMeetingTypeBadge();
   public attendancePercentage = this.initAttendancePercentage();

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -20,6 +20,7 @@ import {
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   isPastMeetingSummaryAwaitingApproval,
+  isUnresolvableParticipantName,
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
@@ -116,7 +117,16 @@ export class PastMeetingDetailsComponent {
     if (this.votingOnly()) {
       result = result.filter((p) => p.committee_voting_status === 'Voting Rep' || p.committee_voting_status === 'Alternate Voting Rep');
     }
-    return result;
+    // Organizers (hosts) float to the top; unresolvable "[unknown]" rows sink to the bottom.
+    return [...result].sort((a, b) => {
+      const rank = (p: EnrichedPastMeetingParticipant): number => {
+        if (isUnresolvableParticipantName(p.first_name, p.last_name)) return 2;
+        return p.host ? 0 : 1;
+      };
+      const rankDelta = rank(a) - rank(b);
+      if (rankDelta !== 0) return rankDelta;
+      return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
+    });
   });
   public meetingTypeBadge = this.initMeetingTypeBadge();
   public attendancePercentage = this.initAttendancePercentage();

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -6,6 +6,7 @@ import { Component, computed, DestroyRef, inject, Signal, signal } from '@angula
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MeetingMaterialsDrawerComponent } from '@app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component';
+import { MeetingOrganizerComponent } from '@app/modules/meetings/components/meeting-organizer/meeting-organizer.component';
 import { MeetingSummaryModalComponent } from '@app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -56,6 +57,7 @@ import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filte
     AvatarComponent,
     TooltipModule,
     MeetingMaterialsDrawerComponent,
+    MeetingOrganizerComponent,
   ],
   templateUrl: './past-meeting-details.component.html',
 })

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -23,7 +23,7 @@ import { NatsSubjects } from '@lfx-one/shared/enums';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
-import { addInvitedStatusToMeeting } from '../helpers/meeting.helper';
+import { addInvitedStatusToMeeting, enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AiService } from '../services/ai.service';
 import { CommitteeService } from '../services/committee.service';
@@ -160,8 +160,12 @@ export class MeetingController {
         meetingWithInvitedStatus.committee_members_count = 0;
       }
 
+      // The ITX detail payload omits created_by — join back to the live v1_meeting index so
+      // the organizer name can be shown. Single meeting keyed on its own UID.
+      const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meetingWithInvitedStatus], (m) => m.id);
+
       // Send the meeting data to the client
-      res.json(meetingWithInvitedStatus);
+      res.json(enrichedMeeting);
     } catch (error) {
       // Send the error to the next middleware
       next(error);

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -18,6 +18,7 @@ import {
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
+import { enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
@@ -49,12 +50,16 @@ export class PastMeetingController {
         page_token?: string;
       };
 
+      // Past meetings are webhook-created (created_by = zoom.webhooks), so join back to the
+      // live v1_meeting index by meeting_id to resolve the real organizer name.
+      const enriched = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.meeting_id);
+
       logger.success(req, 'get_past_meetings', startTime, {
-        meeting_count: meetings.length,
+        meeting_count: enriched.length,
         has_more_pages: !!page_token,
       });
 
-      res.json({ data: meetings, page_token });
+      res.json({ data: enriched, page_token });
     } catch (error) {
       next(error);
     }
@@ -120,12 +125,16 @@ export class PastMeetingController {
       meeting.participant_count = counts.participant_count;
       meeting.attended_count = counts.attended_count;
 
+      // Webhook-created past meeting lacks a human created_by — join back to the live
+      // v1_meeting index by meeting_id to resolve the organizer name.
+      const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
+
       logger.success(req, 'get_past_meeting_by_id', startTime, {
         past_meeting_id: uid,
-        title: meeting.title,
+        title: enrichedMeeting.title,
       });
 
-      res.json(meeting);
+      res.json(enrichedMeeting);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { AuthorizationError } from '../errors/authentication.error';
-import { addInvitedStatusToMeeting, checkPastMeetingAccess } from '../helpers/meeting.helper';
+import { addInvitedStatusToMeeting, checkPastMeetingAccess, enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
@@ -127,6 +127,10 @@ export class PublicMeetingController {
       if (!isAuthenticated) {
         delete (meeting as Partial<Meeting>).host_key;
       }
+
+      // The ITX detail payload omits created_by — join back to the live v1_meeting index
+      // so the join page can show the organizer name.
+      [meeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.id);
 
       // Log the success
       logger.success(req, 'get_public_meeting_by_id', startTime, { meeting_id: id, project_uid: meeting.project_uid, title: meeting.title });
@@ -276,27 +280,33 @@ export class PublicMeetingController {
         delete (meeting as Partial<Meeting>).host_key;
       }
 
-      // For non-full-access users, return only the fields needed for the basic UI
+      // Webhook-created past meeting lacks a human created_by — join back to the live
+      // v1_meeting index by meeting_id to resolve the organizer name.
+      const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
+
+      // For non-full-access users, return only the fields needed for the basic UI.
+      // created_by is included so the basic view can still show the organizer name.
       const meetingResponse = fullAccess
-        ? meeting
+        ? enrichedMeeting
         : {
-            id: meeting.id,
-            title: meeting.title,
-            visibility: meeting.visibility,
-            meeting_type: meeting.meeting_type,
-            restricted: meeting.restricted,
-            start_time: meeting.start_time,
-            scheduled_start_time: meeting.scheduled_start_time,
-            scheduled_end_time: meeting.scheduled_end_time,
-            duration: meeting.duration,
-            recurrence: meeting.recurrence,
-            recording_enabled: meeting.recording_enabled,
-            transcript_enabled: meeting.transcript_enabled,
-            youtube_upload_enabled: meeting.youtube_upload_enabled,
-            show_meeting_attendees: meeting.show_meeting_attendees,
-            ai_summary_enabled: meeting.ai_summary_enabled,
-            project_uid: meeting.project_uid,
-            meeting_id: meeting.meeting_id,
+            id: enrichedMeeting.id,
+            title: enrichedMeeting.title,
+            visibility: enrichedMeeting.visibility,
+            meeting_type: enrichedMeeting.meeting_type,
+            restricted: enrichedMeeting.restricted,
+            start_time: enrichedMeeting.start_time,
+            scheduled_start_time: enrichedMeeting.scheduled_start_time,
+            scheduled_end_time: enrichedMeeting.scheduled_end_time,
+            duration: enrichedMeeting.duration,
+            recurrence: enrichedMeeting.recurrence,
+            recording_enabled: enrichedMeeting.recording_enabled,
+            transcript_enabled: enrichedMeeting.transcript_enabled,
+            youtube_upload_enabled: enrichedMeeting.youtube_upload_enabled,
+            show_meeting_attendees: enrichedMeeting.show_meeting_attendees,
+            ai_summary_enabled: enrichedMeeting.ai_summary_enabled,
+            project_uid: enrichedMeeting.project_uid,
+            meeting_id: enrichedMeeting.meeting_id,
+            created_by: enrichedMeeting.created_by,
           };
 
       res.json({

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -132,7 +132,7 @@ export class PublicMeetingController {
       // so the join page can show the organizer name.
       [meeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.id);
 
-      // The organizer is member-visible info (LFXV2-2802): never expose created_by (name/email/
+      // The organizer is authenticated-visible info (LFXV2-2802): never expose created_by (name/email/
       // username) to unauthenticated callers, mirroring the host_key strip above.
       if (!isAuthenticated) {
         delete (meeting as Partial<Meeting>).created_by;
@@ -290,7 +290,7 @@ export class PublicMeetingController {
       // v1_meeting index by meeting_id to resolve the organizer name.
       const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
 
-      // The organizer is member-visible info (LFXV2-2802): never expose created_by (name/email/
+      // The organizer is authenticated-visible info (LFXV2-2802): never expose created_by (name/email/
       // username) to unauthenticated callers. Stripping here covers both response branches below.
       if (!isAuthenticated) {
         delete (enrichedMeeting as Partial<Meeting>).created_by;

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -132,6 +132,12 @@ export class PublicMeetingController {
       // so the join page can show the organizer name.
       [meeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.id);
 
+      // The organizer is member-visible info (LFXV2-2802): never expose created_by (name/email/
+      // username) to unauthenticated callers, mirroring the host_key strip above.
+      if (!isAuthenticated) {
+        delete (meeting as Partial<Meeting>).created_by;
+      }
+
       // Log the success
       logger.success(req, 'get_public_meeting_by_id', startTime, { meeting_id: id, project_uid: meeting.project_uid, title: meeting.title });
 
@@ -284,8 +290,15 @@ export class PublicMeetingController {
       // v1_meeting index by meeting_id to resolve the organizer name.
       const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
 
+      // The organizer is member-visible info (LFXV2-2802): never expose created_by (name/email/
+      // username) to unauthenticated callers. Stripping here covers both response branches below.
+      if (!isAuthenticated) {
+        delete (enrichedMeeting as Partial<Meeting>).created_by;
+      }
+
       // For non-full-access users, return only the fields needed for the basic UI.
-      // created_by is included so the basic view can still show the organizer name.
+      // created_by is included (authenticated callers only, per the strip above) so the basic
+      // view can still show the organizer name.
       const meetingResponse = fullAccess
         ? enrichedMeeting
         : {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -128,13 +128,12 @@ export class PublicMeetingController {
         delete (meeting as Partial<Meeting>).host_key;
       }
 
-      // The ITX detail payload omits created_by — join back to the live v1_meeting index
-      // so the join page can show the organizer name.
-      [meeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.id);
-
-      // The organizer is authenticated-visible info (LFXV2-2802): never expose created_by (name/email/
-      // username) to unauthenticated callers, mirroring the host_key strip above.
-      if (!isAuthenticated) {
+      // The organizer is authenticated-visible info (LFXV2-2802). For authenticated callers, enrich
+      // created_by from the live v1_meeting index (the ITX detail payload omits it); for anonymous
+      // callers, skip that query and strip created_by so we neither expose nor waste a call on it.
+      if (isAuthenticated) {
+        [meeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.id);
+      } else {
         delete (meeting as Partial<Meeting>).created_by;
       }
 
@@ -286,14 +285,14 @@ export class PublicMeetingController {
         delete (meeting as Partial<Meeting>).host_key;
       }
 
-      // Webhook-created past meeting lacks a human created_by — join back to the live
-      // v1_meeting index by meeting_id to resolve the organizer name.
-      const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
-
-      // The organizer is authenticated-visible info (LFXV2-2802): never expose created_by (name/email/
-      // username) to unauthenticated callers. Stripping here covers both response branches below.
-      if (!isAuthenticated) {
-        delete (enrichedMeeting as Partial<Meeting>).created_by;
+      // The organizer is authenticated-visible info (LFXV2-2802). For authenticated callers, enrich
+      // created_by from the live v1_meeting index (webhook-created past meetings lack a human one);
+      // for anonymous callers, skip that query and strip created_by (present as zoom.webhooks).
+      let enrichedMeeting = meeting;
+      if (isAuthenticated) {
+        [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
+      } else {
+        delete (meeting as Partial<Meeting>).created_by;
       }
 
       // For non-full-access users, return only the fields needed for the basic UI.

--- a/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
@@ -1,0 +1,110 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Meeting, MeetingUserInfo, PastMeeting } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveCreatedByForMeetings } = vi.hoisted(() => ({
+  resolveCreatedByForMeetings: vi.fn<(req: unknown, uids: string[]) => Promise<Map<string, MeetingUserInfo>>>(),
+}));
+
+// This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
+// path alias isn't wired here, so runtime shared subpaths must be mocked (mirrors
+// session-store.service.spec.ts). resolveMeetingOrganizer's real behavior is exhaustively covered
+// in packages/shared/src/utils/meeting.utils.spec.ts; this faithful stand-in keeps the helper's
+// enrich/omit orchestration under test (human creator → skip; service-account/empty → enrich).
+const SKIP = ['zoom.webhooks', 'zoom.events'];
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolveMeetingOrganizer: (meeting: { created_by?: MeetingUserInfo } | null | undefined) => {
+    const createdBy = meeting?.created_by;
+    if (createdBy?.name && !SKIP.includes((createdBy.username ?? '').toLowerCase())) {
+      return createdBy;
+    }
+    return null;
+  },
+}));
+vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
+
+// Stub the services constructed at module load so importing the helper doesn't pull in the
+// microservice proxy / access-check / committee stack. Only resolveCreatedByForMeetings is exercised.
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: class {
+    public resolveCreatedByForMeetings = resolveCreatedByForMeetings;
+  },
+}));
+vi.mock('../services/committee.service', () => ({ CommitteeService: class {} }));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+
+import { enrichMeetingsWithCreatedBy } from './meeting.helper';
+
+const req = {} as any;
+const human: MeetingUserInfo = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
+
+function pastMeeting(overrides: Partial<PastMeeting>): PastMeeting {
+  return { id: 'pm-1', meeting_id: 'live-1', ...overrides } as PastMeeting;
+}
+
+describe('enrichMeetingsWithCreatedBy', () => {
+  beforeEach(() => {
+    resolveCreatedByForMeetings.mockReset();
+  });
+
+  it('joins past meetings to the live v1_meeting created_by by meeting_id', async () => {
+    resolveCreatedByForMeetings.mockResolvedValue(new Map([['live-1', human]]));
+    const meetings = [pastMeeting({ id: 'pm-1', meeting_id: 'live-1' })];
+
+    const result = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.meeting_id);
+
+    expect(resolveCreatedByForMeetings).toHaveBeenCalledWith(req, ['live-1']);
+    expect(result[0].created_by).toEqual(human);
+  });
+
+  it('omits created_by when the series meeting no longer exists (deleted series)', async () => {
+    resolveCreatedByForMeetings.mockResolvedValue(new Map());
+    const meetings = [pastMeeting({ id: 'pm-1', meeting_id: 'gone' })];
+
+    const result = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.meeting_id);
+
+    expect(result[0].created_by).toBeUndefined();
+  });
+
+  it('leaves meetings that already carry a human created_by untouched and does not query', async () => {
+    const meetings = [{ id: 'm-1', created_by: human } as Meeting];
+
+    const result = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.id);
+
+    expect(resolveCreatedByForMeetings).not.toHaveBeenCalled();
+    expect(result[0].created_by).toBe(human);
+  });
+
+  it('enriches a service-account created_by (zoom.webhooks) since it is not a human', async () => {
+    resolveCreatedByForMeetings.mockResolvedValue(new Map([['live-2', human]]));
+    const meetings = [pastMeeting({ id: 'pm-2', meeting_id: 'live-2', created_by: { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' } })];
+
+    const result = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.meeting_id);
+
+    expect(resolveCreatedByForMeetings).toHaveBeenCalledWith(req, ['live-2']);
+    expect(result[0].created_by).toEqual(human);
+  });
+
+  it('short-circuits with no query when nothing needs enrichment', async () => {
+    const result = await enrichMeetingsWithCreatedBy(req, [], (m: Meeting) => m.id);
+
+    expect(resolveCreatedByForMeetings).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('keys upcoming meetings on their own uid', async () => {
+    resolveCreatedByForMeetings.mockResolvedValue(new Map([['up-1', human]]));
+    const meetings = [{ id: 'up-1' } as Meeting];
+
+    const result = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.id);
+
+    expect(resolveCreatedByForMeetings).toHaveBeenCalledWith(req, ['up-1']);
+    expect(result[0].created_by).toEqual(human);
+  });
+});

--- a/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Meeting, MeetingUserInfo, PastMeeting } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { resolveCreatedByForMeetings } = vi.hoisted(() => ({
@@ -41,7 +42,7 @@ vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
 
 import { enrichMeetingsWithCreatedBy } from './meeting.helper';
 
-const req = {} as any;
+const req = {} as unknown as Request;
 const human: MeetingUserInfo = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
 
 function pastMeeting(overrides: Partial<PastMeeting>): PastMeeting {

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -3,6 +3,7 @@
 
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
+import { resolveMeetingOrganizer } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { CommitteeService } from '../services/committee.service';
@@ -75,6 +76,44 @@ export async function addInvitedStatusToMeetings(req: Request, meetings: Meeting
   // Check invitation status for all meetings, including organizer meetings
   // (organizers may also be invited to their own meetings)
   return Promise.all(meetings.map((meeting) => addInvitedStatusToMeeting(req, meeting, email, m2mToken)));
+}
+
+/**
+ * Enriches meetings that lack a human `created_by` by joining back to the live
+ * `v1_meeting` index (the only source that carries it). Upcoming meetings key on their
+ * own UID; past meetings key on `meeting_id` (the originating series meeting). Meetings
+ * that already carry a human creator, or whose series no longer exists, are left untouched
+ * so the organizer display is simply omitted.
+ *
+ * @param req - Express request object
+ * @param meetings - Meetings to enrich (mutated copies returned; input is not modified)
+ * @param keyOf - Extracts the live `v1_meeting` UID to look up for a given meeting
+ * @returns The meetings with `created_by` populated where it could be resolved
+ */
+export async function enrichMeetingsWithCreatedBy<T extends Meeting>(req: Request, meetings: T[], keyOf: (meeting: T) => string | undefined): Promise<T[]> {
+  if (meetings.length === 0) {
+    return meetings;
+  }
+
+  // Only meetings without a resolvable human creator need the join.
+  const needsEnrichment = (meeting: T): boolean => !resolveMeetingOrganizer(meeting) && !!keyOf(meeting);
+  const uids = meetings.filter(needsEnrichment).map((meeting) => keyOf(meeting)!);
+  if (uids.length === 0) {
+    return meetings;
+  }
+
+  const createdByMap = await meetingService.resolveCreatedByForMeetings(req, uids);
+  if (createdByMap.size === 0) {
+    return meetings;
+  }
+
+  return meetings.map((meeting) => {
+    if (!needsEnrichment(meeting)) {
+      return meeting;
+    }
+    const createdBy = createdByMap.get(keyOf(meeting)!);
+    return createdBy ? { ...meeting, created_by: createdBy } : meeting;
+  });
 }
 
 /**

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -35,9 +35,11 @@ vi.mock('./logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
 
+import type { Request } from 'express';
+
 import { MeetingService } from './meeting.service';
 
-const req = {} as any;
+const req = {} as unknown as Request;
 const human = (id: string): MeetingUserInfo => ({ name: `User ${id}`, username: `user${id}`, email: `${id}@example.com` });
 
 // Builds a single-page query-service response for the given meetings.
@@ -75,6 +77,18 @@ describe('MeetingService.resolveCreatedByForMeetings', () => {
     // Single chunk → single query; the tags param carries the batched OR list.
     expect(proxyRequest).toHaveBeenCalledTimes(1);
     expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'v1_meeting', tags: ['a', 'b'] });
+  });
+
+  it('falls back to the resource wrapper id when data.id is absent', async () => {
+    // Mirrors getMeetings normalization: uid = data.id || resource.id.split(":").pop().
+    proxyRequest.mockResolvedValueOnce({
+      resources: [{ id: 'v1_meeting:xyz', data: { created_by: human('xyz') } }],
+      page_token: undefined,
+    });
+
+    const result = await service.resolveCreatedByForMeetings(req, ['xyz']);
+
+    expect(result.get('xyz')).toEqual(human('xyz'));
   });
 
   it('dedupes repeated uids before querying', async () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Meeting, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
+// path alias isn't wired here, so runtime shared subpaths and the constructed collaborators must be
+// mocked (mirrors session-store.service.spec.ts / meeting.helper.spec.ts). Only the
+// microservice-proxy call path is exercised; the query-service pagination helper runs for real.
+const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
+
+vi.mock('@lfx-one/shared/enums', () => ({}));
+vi.mock('@lfx-one/shared/utils', () => ({
+  buildRecurrenceNeverEndDate: vi.fn(),
+  getPastMeetingTranscriptUrl: vi.fn(),
+  mapITXResponseToMeetingRsvp: vi.fn(),
+  normalizeIndexedMeetingAiSummary: vi.fn(),
+  selectPrimaryPastMeetingSummary: vi.fn(),
+}));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./access-check.service', () => ({ AccessCheckService: class {} }));
+vi.mock('./project.service', () => ({ ProjectService: class {} }));
+vi.mock('../utils/auth-helper', () => ({
+  getEffectiveEmail: vi.fn(),
+  getEffectiveUsername: vi.fn(),
+  getUsernameFromAuth: vi.fn(),
+  stripAuthPrefix: (v: string) => v,
+}));
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+}));
+
+import { MeetingService } from './meeting.service';
+
+const req = {} as any;
+const human = (id: string): MeetingUserInfo => ({ name: `User ${id}`, username: `user${id}`, email: `${id}@example.com` });
+
+// Builds a single-page query-service response for the given meetings.
+function pageOf(meetings: Partial<Meeting>[]): QueryServiceResponse<Meeting> {
+  return { resources: meetings.map((m) => ({ id: `v1_meeting:${m.id}`, data: m as Meeting })), page_token: undefined } as QueryServiceResponse<Meeting>;
+}
+
+describe('MeetingService.resolveCreatedByForMeetings', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('returns an empty map for an empty input without querying', async () => {
+    const result = await service.resolveCreatedByForMeetings(req, []);
+
+    expect(result.size).toBe(0);
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it('maps meeting uid → created_by from the v1_meeting index', async () => {
+    proxyRequest.mockResolvedValueOnce(
+      pageOf([
+        { id: 'a', created_by: human('a') },
+        { id: 'b', created_by: human('b') },
+      ])
+    );
+
+    const result = await service.resolveCreatedByForMeetings(req, ['a', 'b']);
+
+    expect(result.get('a')).toEqual(human('a'));
+    expect(result.get('b')).toEqual(human('b'));
+    // Single chunk → single query; the tags param carries the batched OR list.
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'v1_meeting', tags: ['a', 'b'] });
+  });
+
+  it('dedupes repeated uids before querying', async () => {
+    proxyRequest.mockResolvedValueOnce(pageOf([{ id: 'a', created_by: human('a') }]));
+
+    await service.resolveCreatedByForMeetings(req, ['a', 'a', 'a']);
+
+    expect(proxyRequest.mock.calls[0][4]).toMatchObject({ tags: ['a'] });
+  });
+
+  it('omits meetings that carry no created_by', async () => {
+    proxyRequest.mockResolvedValueOnce(pageOf([{ id: 'a', created_by: human('a') }, { id: 'b' }]));
+
+    const result = await service.resolveCreatedByForMeetings(req, ['a', 'b']);
+
+    expect(result.has('a')).toBe(true);
+    expect(result.has('b')).toBe(false);
+  });
+
+  it('batches at the 50-uid chunk boundary', async () => {
+    const first = Array.from({ length: 50 }, (_, i) => ({ id: `m${i}`, created_by: human(`m${i}`) }));
+    const second = [{ id: 'm50', created_by: human('m50') }];
+    proxyRequest.mockResolvedValueOnce(pageOf(first)).mockResolvedValueOnce(pageOf(second));
+
+    const result = await service.resolveCreatedByForMeetings(
+      req,
+      [...first, ...second].map((m) => m.id)
+    );
+
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
+    expect(proxyRequest.mock.calls[0][4].tags).toHaveLength(50);
+    expect(proxyRequest.mock.calls[1][4].tags).toEqual(['m50']);
+    expect(result.size).toBe(51);
+  });
+
+  it('skips a failing chunk and still returns results from the others', async () => {
+    const first = Array.from({ length: 50 }, (_, i) => ({ id: `m${i}`, created_by: human(`m${i}`) }));
+    proxyRequest.mockResolvedValueOnce(pageOf(first)).mockRejectedValueOnce(new Error('upstream 500'));
+
+    const result = await service.resolveCreatedByForMeetings(req, [...first.map((m) => m.id), 'm50']);
+
+    // First chunk resolved; second chunk failed and was skipped rather than throwing.
+    expect(result.size).toBe(50);
+    expect(result.has('m50')).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -296,35 +296,38 @@ export class MeetingService {
       chunks.push(uniqueUids.slice(i, i + CHUNK_SIZE));
     }
 
-    const fetchChunk = async (chunk: string[]): Promise<Meeting[]> => {
+    // Paginate manually (rather than via fetchAllQueryResources) so we keep each resource's wrapper
+    // id: the canonical UID is `data.id` when present, else the `type:uid` wrapper id split — the
+    // same normalization getMeetings uses. Keying on `data.id` alone would miss rows where it's
+    // absent, so meeting_id lookups would silently never hit the map.
+    const fetchChunk = async (chunk: string[]): Promise<void> => {
       try {
-        return await fetchAllQueryResources<Meeting>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        let pageToken: string | undefined;
+        do {
+          const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
             type: 'v1_meeting',
             tags: chunk,
             ...(pageToken && { page_token: pageToken }),
-          })
-        );
+          });
+          for (const resource of response.resources) {
+            const uid = resource.data?.id || resource.id?.split(':').pop() || resource.id;
+            if (uid && resource.data?.created_by) {
+              result.set(uid, resource.data.created_by);
+            }
+          }
+          pageToken = response.page_token;
+        } while (pageToken);
       } catch (error) {
         logger.warning(req, 'resolve_created_by_for_meetings', 'Failed to resolve created_by for a chunk, skipping', {
           chunk_size: chunk.length,
           err: error,
         });
-        return [];
       }
     };
 
     for (let i = 0; i < chunks.length; i += CONCURRENCY) {
       const wave = chunks.slice(i, i + CONCURRENCY);
-      const waveResults = await Promise.all(wave.map((chunk) => fetchChunk(chunk)));
-      for (const meetings of waveResults) {
-        for (const meeting of meetings) {
-          const uid = meeting.id;
-          if (uid && meeting.created_by) {
-            result.set(uid, meeting.created_by);
-          }
-        }
-      }
+      await Promise.all(wave.map((chunk) => fetchChunk(chunk)));
     }
 
     // Surface partial-failure completeness: a resolved count below requested means some chunks

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -284,31 +284,55 @@ export class MeetingService {
       unique: uniqueUids.length,
     });
 
+    // CHUNK_SIZE caps how many UIDs ride one tags-param query; CONCURRENCY caps how many of those
+    // chunk queries run at once. The Me-lens path can supply hundreds of past meetings, so running
+    // chunks in bounded-concurrency waves avoids serial latency proportional to meeting count while
+    // keeping per-chunk failure isolation (a failed chunk is skipped, not fatal).
     const CHUNK_SIZE = 50;
+    const CONCURRENCY = 5;
+
+    const chunks: string[][] = [];
     for (let i = 0; i < uniqueUids.length; i += CHUNK_SIZE) {
-      const chunk = uniqueUids.slice(i, i + CHUNK_SIZE);
+      chunks.push(uniqueUids.slice(i, i + CHUNK_SIZE));
+    }
+
+    const fetchChunk = async (chunk: string[]): Promise<Meeting[]> => {
       try {
-        const meetings = await fetchAllQueryResources<Meeting>(req, (pageToken) =>
+        return await fetchAllQueryResources<Meeting>(req, (pageToken) =>
           this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
             type: 'v1_meeting',
             tags: chunk,
             ...(pageToken && { page_token: pageToken }),
           })
         );
+      } catch (error) {
+        logger.warning(req, 'resolve_created_by_for_meetings', 'Failed to resolve created_by for a chunk, skipping', {
+          chunk_size: chunk.length,
+          err: error,
+        });
+        return [];
+      }
+    };
 
+    for (let i = 0; i < chunks.length; i += CONCURRENCY) {
+      const wave = chunks.slice(i, i + CONCURRENCY);
+      const waveResults = await Promise.all(wave.map((chunk) => fetchChunk(chunk)));
+      for (const meetings of waveResults) {
         for (const meeting of meetings) {
           const uid = meeting.id;
           if (uid && meeting.created_by) {
             result.set(uid, meeting.created_by);
           }
         }
-      } catch (error) {
-        logger.warning(req, 'resolve_created_by_for_meetings', 'Failed to resolve created_by for a chunk, skipping', {
-          chunk_size: chunk.length,
-          err: error,
-        });
       }
     }
+
+    // Surface partial-failure completeness: a resolved count below requested means some chunks
+    // failed and were skipped (those meetings render without an organizer rather than erroring).
+    logger.debug(req, 'resolve_created_by_for_meetings', 'Resolved created_by lookups', {
+      requested: uniqueUids.length,
+      resolved: result.size,
+    });
 
     return result;
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -17,6 +17,7 @@ import {
   MeetingJoinURL,
   MeetingRecurrence,
   MeetingRegistrant,
+  MeetingUserInfo,
   MeetingRsvp,
   PaginatedResponse,
   PastMeeting,
@@ -258,6 +259,58 @@ export class MeetingService {
     });
 
     return meeting;
+  }
+
+  /**
+   * Resolves the `created_by` (meeting creator) for a set of live `v1_meeting` UIDs by
+   * querying the indexed projection — the only source that carries it (the ITX detail
+   * payload and webhook-created past meetings do not).
+   *
+   * Batches the lookup with the query service's OR-semantics `tags` param so a page of
+   * meetings costs one call per chunk rather than N. UIDs that no longer resolve (deleted
+   * series) are simply absent from the returned map, so callers omit the organizer display.
+   *
+   * @returns Map of meeting UID → `created_by`, only for meetings that carry one.
+   */
+  public async resolveCreatedByForMeetings(req: Request, meetingUids: string[]): Promise<Map<string, MeetingUserInfo>> {
+    const result = new Map<string, MeetingUserInfo>();
+    const uniqueUids = [...new Set(meetingUids.filter(Boolean))];
+    if (uniqueUids.length === 0) {
+      return result;
+    }
+
+    logger.debug(req, 'resolve_created_by_for_meetings', 'Resolving created_by from v1_meeting index', {
+      requested: meetingUids.length,
+      unique: uniqueUids.length,
+    });
+
+    const CHUNK_SIZE = 50;
+    for (let i = 0; i < uniqueUids.length; i += CHUNK_SIZE) {
+      const chunk = uniqueUids.slice(i, i + CHUNK_SIZE);
+      try {
+        const meetings = await fetchAllQueryResources<Meeting>(req, (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'v1_meeting',
+            tags: chunk,
+            ...(pageToken && { page_token: pageToken }),
+          })
+        );
+
+        for (const meeting of meetings) {
+          const uid = meeting.id;
+          if (uid && meeting.created_by) {
+            result.set(uid, meeting.created_by);
+          }
+        }
+      } catch (error) {
+        logger.warning(req, 'resolve_created_by_for_meetings', 'Failed to resolve created_by for a chunk, skipping', {
+          chunk_size: chunk.length,
+          err: error,
+        });
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -38,6 +38,7 @@ import { buildInvitationActions, getCurrentOrNextOccurrence, hasMeetingEnded, no
 import { Request } from 'express';
 
 import { MicroserviceError, ResourceNotFoundError } from '../errors';
+import { enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
@@ -737,7 +738,11 @@ export class UserService {
 
     const enriched = await this.meetingService.getMeetingProjectName(req, pastOnly);
 
-    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_past_meeting', 'organizer');
+    // Webhook-created past meetings carry a service-account created_by — join back to the live
+    // v1_meeting index so the organizer chip resolves on Me-lens past cards.
+    const withCreatedBy = await enrichMeetingsWithCreatedBy(req, enriched, (m) => m.meeting_id);
+
+    return this.accessCheckService.addAccessToResources(req, withCreatedBy, 'v1_past_meeting', 'organizer');
   }
 
   /**
@@ -834,7 +839,10 @@ export class UserService {
     }
 
     const enriched = await this.meetingService.getMeetingProjectName(req, filtered);
-    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_past_meeting', 'organizer');
+    // Webhook-created past meetings carry a service-account created_by — join back to the live
+    // v1_meeting index so the organizer chip resolves on Me-lens latest-past cards.
+    const withCreatedBy = await enrichMeetingsWithCreatedBy(req, enriched, (m) => m.meeting_id);
+    return this.accessCheckService.addAccessToResources(req, withCreatedBy, 'v1_past_meeting', 'organizer');
   }
 
   /**

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -6,6 +6,13 @@ import type { CardSelectorOption, MeetingTypeConfig } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
 /**
+ * Service-account usernames/emails that own `created_by` on system-created meetings
+ * (e.g. Zoom webhook events). These are not real people and must never be shown as
+ * the meeting organizer — the organizer derivation skips them.
+ */
+export const MEETING_ORGANIZER_SKIP_IDENTIFIERS = ['zoom.webhooks', 'zoom.events'];
+
+/**
  * Available meeting platforms and their configurations
  * @description Defines the supported platforms for hosting meetings
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -150,19 +150,29 @@ export interface MeetingUserInfo {
 }
 
 /**
- * The resolved display model for a meeting's "Organized by" line.
+ * A single organizer entry for the "Organized by" chip — a display name plus an optional
+ * `mailto:` link (absent when the organizer record has no email → rendered as plain text).
  */
-export interface MeetingOrganizerDisplay {
-  /** Full label, e.g. "Organized by Ada Lovelace", "Organized by you", or "Organized by Ada +2". */
-  label: string;
-  /** Display name of the primary organizer. */
-  primaryName: string;
-  /** True when the primary organizer is the current viewer. */
+export interface MeetingOrganizerLink {
+  /** Display name (full name, falling back to username, then email). */
+  name: string;
+  /** True when this organizer is the current viewer (rendered as "you", never a mailto link). */
   isYou: boolean;
-  /** Display names of any additional organizers (for a "+N" popover). */
-  overflowNames: string[];
+  /** Pre-filled `mailto:` URL, or null when the organizer has no email. */
+  mailto: string | null;
+}
+
+/**
+ * The resolved view model for a meeting's "Organized by" chip: the primary organizer, any
+ * overflow (for the "+N" popover), and the total count.
+ */
+export interface MeetingOrganizerChipModel {
   /** Total number of organizers. */
   count: number;
+  /** The primary (first) organizer shown inline. */
+  primary: MeetingOrganizerLink;
+  /** Additional organizers listed in the "+N" popover. */
+  overflow: MeetingOrganizerLink[];
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -154,6 +154,8 @@ export interface MeetingUserInfo {
  * `mailto:` link (absent when the organizer record has no email → rendered as plain text).
  */
 export interface MeetingOrganizerLink {
+  /** Stable identity for `@for` tracking (username, else email, else name) — names can collide. */
+  key: string;
   /** Display name (full name, falling back to username, then email). */
   name: string;
   /** True when this organizer is the current viewer (rendered as "you", never a mailto link). */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -133,6 +133,51 @@ export interface MeetingCommittee {
   name?: string;
 }
 
+/**
+ * User info embedded in meeting responses (the meeting creator / organizer).
+ * @description Mirrors the upstream ITX `created_by` shape returned on the indexed
+ * `v1_meeting` projection. Used to display the meeting organizer's name.
+ */
+export interface MeetingUserInfo {
+  /** Display name of the user */
+  name: string;
+  /** LFID username of the user */
+  username: string;
+  /** Email address of the user */
+  email: string;
+  /** Profile picture URL */
+  profile_picture?: string;
+}
+
+/**
+ * The resolved display model for a meeting's "Organized by" line.
+ */
+export interface MeetingOrganizerDisplay {
+  /** Full label, e.g. "Organized by Ada Lovelace", "Organized by you", or "Organized by Ada +2". */
+  label: string;
+  /** Display name of the primary organizer. */
+  primaryName: string;
+  /** True when the primary organizer is the current viewer. */
+  isYou: boolean;
+  /** Display names of any additional organizers (for a "+N" popover). */
+  overflowNames: string[];
+  /** Total number of organizers. */
+  count: number;
+}
+
+/**
+ * Minimal host-candidate shape for the organizer host-fallback derivation.
+ * Satisfied structurally by both {@link MeetingRegistrant} and {@link PastMeetingParticipant}.
+ */
+export interface MeetingHostCandidate {
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  email?: string | null;
+  avatar_url?: string | null;
+  host?: boolean;
+}
+
 /** Indexed v1_meeting zoom_config; AI flags use ai_companion_enabled / ai_summary_require_approval vs top-level ai_summary_enabled / require_ai_summary_approval. */
 export interface MeetingZoomConfig {
   /** Zoom numeric meeting ID */
@@ -155,6 +200,14 @@ export interface Meeting {
   modified_at: string;
   /** Write access permission for current user (response only) */
   organizer?: boolean;
+  /**
+   * The meeting creator, used to display the organizer's name (response only).
+   * Present on the indexed `v1_meeting` list projection; the ITX detail payload and
+   * webhook-created past meetings omit it, so the BFF enriches those paths by joining
+   * back to the live `v1_meeting` record. Absent when the creator is a service account
+   * (e.g. `zoom.webhooks`) or the series meeting no longer exists.
+   */
+  created_by?: MeetingUserInfo;
 
   // Required API fields
   /** UUID of the LF project */

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -351,6 +351,9 @@ describe('buildMeetingOrganizerMailto', () => {
     expect(buildMeetingOrganizerMailto({ email: 'a&cc=x@b.com' })).toBeNull();
     expect(buildMeetingOrganizerMailto({ email: 'has space@b.com' })).toBeNull();
     expect(buildMeetingOrganizerMailto({ email: 'no-at-sign' })).toBeNull();
+    // Percent-encoded CRLF + Bcc header-injection attempt must not survive the allowlist.
+    expect(buildMeetingOrganizerMailto({ email: 'victim@example.com%0D%0ABcc:attacker@example.com' })).toBeNull();
+    expect(buildMeetingOrganizerMailto({ email: 'two@at@example.com' })).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -371,17 +371,19 @@ describe('buildMeetingOrganizerChip', () => {
     const chip = buildMeetingOrganizerChip([ada], null, ctx);
     expect(chip?.count).toBe(1);
     expect(chip?.primary.name).toBe('Ada Lovelace');
-    expect(chip?.primary.key).toBe('alovelace');
+    expect(chip?.primary.key).toBe('alovelace#0');
     expect(chip?.primary.mailto).toContain('mailto:ada@example.com?subject=Sync');
     expect(chip?.overflow).toEqual([]);
   });
 
-  it('gives same-named organizers distinct track keys (from username/email)', () => {
-    const dupeA = { name: 'Alex Kim', username: 'akim1', email: 'a1@x.com' };
-    const dupeB = { name: 'Alex Kim', username: 'akim2', email: 'a2@x.com' };
-    const chip = buildMeetingOrganizerChip([dupeA, dupeB]);
-    expect(chip?.primary.key).toBe('akim1');
-    expect(chip?.overflow[0].key).toBe('akim2');
+  it('gives same-named organizers distinct track keys even with no username/email', () => {
+    // Two host-only organizers with identical display names and no username/email must not collide.
+    const nameOnlyA = { name: 'Alex Kim', username: '', email: '' };
+    const nameOnlyB = { name: 'Alex Kim', username: '', email: '' };
+    const chip = buildMeetingOrganizerChip([nameOnlyA, nameOnlyB]);
+    expect(chip?.primary.key).toBe('Alex Kim#0');
+    expect(chip?.overflow[0].key).toBe('Alex Kim#1');
+    expect(chip?.primary.key).not.toBe(chip?.overflow[0].key);
   });
 
   it('marks the viewer as "you" and never links their name', () => {

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -15,6 +15,7 @@ import {
   buildMeetingOrganizerMailto,
   buildRecurrenceSummary,
   collectMeetingOrganizers,
+  compareMeetingPeopleByHostThenName,
   getMeetingOrganizerDisplayName,
   isUnresolvableParticipantName,
   normalizeIndexedMeetingAiSummary,
@@ -344,6 +345,13 @@ describe('buildMeetingOrganizerMailto', () => {
     expect(buildMeetingOrganizerMailto({ email: 'a@b.com', meetingTitle: 'Only Title' })).toBe('mailto:a@b.com?subject=Only%20Title');
     expect(buildMeetingOrganizerMailto({ email: 'a@b.com' })).toBe('mailto:a@b.com');
   });
+
+  it('rejects addresses that could inject mailto headers', () => {
+    expect(buildMeetingOrganizerMailto({ email: 'a?subject=evil@b.com', meetingTitle: 'T' })).toBeNull();
+    expect(buildMeetingOrganizerMailto({ email: 'a&cc=x@b.com' })).toBeNull();
+    expect(buildMeetingOrganizerMailto({ email: 'has space@b.com' })).toBeNull();
+    expect(buildMeetingOrganizerMailto({ email: 'no-at-sign' })).toBeNull();
+  });
 });
 
 describe('buildMeetingOrganizerChip', () => {
@@ -356,12 +364,21 @@ describe('buildMeetingOrganizerChip', () => {
     expect(buildMeetingOrganizerChip([])).toBeNull();
   });
 
-  it('builds a single-organizer chip with a mailto link on the name', () => {
+  it('builds a single-organizer chip with a mailto link and a stable track key on the name', () => {
     const chip = buildMeetingOrganizerChip([ada], null, ctx);
     expect(chip?.count).toBe(1);
     expect(chip?.primary.name).toBe('Ada Lovelace');
+    expect(chip?.primary.key).toBe('alovelace');
     expect(chip?.primary.mailto).toContain('mailto:ada@example.com?subject=Sync');
     expect(chip?.overflow).toEqual([]);
+  });
+
+  it('gives same-named organizers distinct track keys (from username/email)', () => {
+    const dupeA = { name: 'Alex Kim', username: 'akim1', email: 'a1@x.com' };
+    const dupeB = { name: 'Alex Kim', username: 'akim2', email: 'a2@x.com' };
+    const chip = buildMeetingOrganizerChip([dupeA, dupeB]);
+    expect(chip?.primary.key).toBe('akim1');
+    expect(chip?.overflow[0].key).toBe('akim2');
   });
 
   it('marks the viewer as "you" and never links their name', () => {
@@ -394,6 +411,23 @@ describe('isUnresolvableParticipantName', () => {
     expect(isUnresolvableParticipantName('Ada', '')).toBe(false);
     expect(isUnresolvableParticipantName('', 'Lovelace')).toBe(false);
     expect(isUnresolvableParticipantName('unknown', 'Lovelace')).toBe(false);
+  });
+});
+
+describe('compareMeetingPeopleByHostThenName', () => {
+  it('floats hosts to the top, sinks unresolvable rows to the bottom, sorts by first name within a tier', () => {
+    const people = [
+      { first_name: 'Zed', last_name: 'Zephyr', host: false },
+      { first_name: '', last_name: '', host: false }, // unresolvable → bottom
+      { first_name: 'Grace', last_name: 'Hopper', host: true }, // host → top
+      { first_name: 'Ada', last_name: 'Lovelace', host: false },
+      { first_name: 'Alan', last_name: 'Turing', host: true }, // host → top
+      { first_name: 'unknown', last_name: '[unknown]', host: false }, // unresolvable → bottom
+    ];
+
+    const ordered = [...people].sort(compareMeetingPeopleByHostThenName).map((p) => `${p.first_name} ${p.last_name}`.trim());
+
+    expect(ordered).toEqual(['Alan Turing', 'Grace Hopper', 'Ada Lovelace', 'Zed Zephyr', '', 'unknown [unknown]']);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -11,8 +11,12 @@ import { describe, expect, it } from 'vitest';
 import { RecurrenceType } from '../enums';
 import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
 import {
+  buildMeetingOrganizerDisplay,
   buildRecurrenceSummary,
+  collectMeetingOrganizers,
+  getMeetingOrganizerDisplayName,
   normalizeIndexedMeetingAiSummary,
+  resolveMeetingOrganizer,
   resolveOccurrenceRecurrence,
   selectPrimaryPastMeetingSummary,
   sortPastMeetingsDescending,
@@ -189,6 +193,141 @@ describe('normalizeIndexedMeetingAiSummary', () => {
     const result = normalizeIndexedMeetingAiSummary(meeting);
     expect(result.ai_summary_enabled).toBeUndefined();
     expect(result.require_ai_summary_approval).toBeUndefined();
+  });
+});
+
+describe('resolveMeetingOrganizer', () => {
+  it('returns created_by when it is a real human', () => {
+    const meeting = { created_by: { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com', profile_picture: 'https://x/a.jpg' } } as Meeting;
+
+    expect(resolveMeetingOrganizer(meeting)).toEqual({
+      name: 'Ada Lovelace',
+      username: 'alovelace',
+      email: 'ada@example.com',
+      profile_picture: 'https://x/a.jpg',
+    });
+  });
+
+  it('omits profile_picture when created_by has none', () => {
+    const meeting = { created_by: { name: 'Ada', username: 'ada', email: 'ada@example.com' } } as Meeting;
+
+    expect(resolveMeetingOrganizer(meeting)).toEqual({ name: 'Ada', username: 'ada', email: 'ada@example.com' });
+  });
+
+  it('skips zoom.webhooks / zoom.events service-account usernames', () => {
+    const webhooks = { created_by: { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: 'noreply@zoom.us' } } as Meeting;
+    const events = { created_by: { name: '', username: 'zoom.events', email: '' } } as Meeting;
+
+    expect(resolveMeetingOrganizer(webhooks)).toBeNull();
+    expect(resolveMeetingOrganizer(events)).toBeNull();
+  });
+
+  it('skips service accounts matched by email or email local-part', () => {
+    const byEmail = { created_by: { name: '', username: '', email: 'zoom.webhooks@zoom.us' } } as Meeting;
+
+    expect(resolveMeetingOrganizer(byEmail)).toBeNull();
+  });
+
+  it('returns null when created_by is empty and no hosts are given', () => {
+    expect(resolveMeetingOrganizer({ created_by: { name: '', username: '', email: '' } } as Meeting)).toBeNull();
+    expect(resolveMeetingOrganizer({} as Meeting)).toBeNull();
+    expect(resolveMeetingOrganizer(null)).toBeNull();
+  });
+
+  it('falls back to the first host when created_by is not a human', () => {
+    const meeting = { created_by: { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' } } as Meeting;
+    const hosts = [
+      { first_name: 'Not', last_name: 'Host', host: false },
+      { first_name: 'Grace', last_name: 'Hopper', username: 'ghopper', email: 'grace@example.com', avatar_url: 'https://x/g.jpg', host: true },
+    ];
+
+    expect(resolveMeetingOrganizer(meeting, hosts)).toEqual({
+      name: 'Grace Hopper',
+      username: 'ghopper',
+      email: 'grace@example.com',
+      profile_picture: 'https://x/g.jpg',
+    });
+  });
+
+  it('prefers a human created_by over host fallback', () => {
+    const meeting = { created_by: { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' } } as Meeting;
+    const hosts = [{ first_name: 'Grace', last_name: 'Hopper', host: true }];
+
+    expect(resolveMeetingOrganizer(meeting, hosts)?.name).toBe('Ada Lovelace');
+  });
+
+  it('returns null when hosts exist but none is flagged host', () => {
+    expect(resolveMeetingOrganizer({} as Meeting, [{ first_name: 'A', last_name: 'B', host: false }])).toBeNull();
+  });
+});
+
+describe('getMeetingOrganizerDisplayName', () => {
+  it('prefers name, then username, then email', () => {
+    expect(getMeetingOrganizerDisplayName({ name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' })).toBe('Ada Lovelace');
+    expect(getMeetingOrganizerDisplayName({ name: '   ', username: 'ada', email: 'ada@example.com' })).toBe('ada');
+    expect(getMeetingOrganizerDisplayName({ name: '', username: '', email: 'ada@example.com' })).toBe('ada@example.com');
+  });
+
+  it('returns an empty string for null or a fully empty organizer', () => {
+    expect(getMeetingOrganizerDisplayName(null)).toBe('');
+    expect(getMeetingOrganizerDisplayName({ name: '', username: '', email: '' })).toBe('');
+  });
+});
+
+describe('collectMeetingOrganizers', () => {
+  it('returns the human created_by as the sole organizer', () => {
+    const meeting = { created_by: { name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' } } as Meeting;
+
+    expect(collectMeetingOrganizers(meeting)).toEqual([{ name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' }]);
+  });
+
+  it('falls back to all host-flagged candidates when created_by is not a human', () => {
+    const meeting = { created_by: { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' } } as Meeting;
+    const hosts = [
+      { first_name: 'Grace', last_name: 'Hopper', username: 'ghopper', email: 'grace@example.com', host: true },
+      { first_name: 'Alan', last_name: 'Turing', username: 'aturing', email: 'alan@example.com', host: true },
+      { first_name: 'Not', last_name: 'Host', host: false },
+    ];
+
+    const organizers = collectMeetingOrganizers(meeting, hosts);
+    expect(organizers).toHaveLength(2);
+    expect(organizers.map((o) => o.name)).toEqual(['Grace Hopper', 'Alan Turing']);
+  });
+
+  it('returns an empty array when nothing resolves', () => {
+    expect(collectMeetingOrganizers({} as Meeting)).toEqual([]);
+    expect(collectMeetingOrganizers({} as Meeting, [{ first_name: 'A', last_name: 'B', host: false }])).toEqual([]);
+  });
+});
+
+describe('buildMeetingOrganizerDisplay', () => {
+  const ada = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
+  const grace = { name: 'Grace Hopper', username: 'ghopper', email: 'grace@example.com' };
+  const alan = { name: 'Alan Turing', username: 'aturing', email: 'alan@example.com' };
+
+  it('returns null when there are no organizers', () => {
+    expect(buildMeetingOrganizerDisplay([])).toBeNull();
+  });
+
+  it('labels a single organizer by name', () => {
+    expect(buildMeetingOrganizerDisplay([ada])?.label).toBe('Organized by Ada Lovelace');
+  });
+
+  it('uses the "you" variant when the primary organizer matches the viewer (case/prefix-insensitive)', () => {
+    expect(buildMeetingOrganizerDisplay([ada], 'ALOVELACE')?.label).toBe('Organized by you');
+    expect(buildMeetingOrganizerDisplay([ada], 'auth0|alovelace')?.isYou).toBe(true);
+    expect(buildMeetingOrganizerDisplay([ada], 'someone-else')?.isYou).toBe(false);
+  });
+
+  it('appends a "+N" overflow and exposes the overflow names for a popover', () => {
+    const display = buildMeetingOrganizerDisplay([grace, alan, ada]);
+    expect(display?.label).toBe('Organized by Grace Hopper +2');
+    expect(display?.count).toBe(3);
+    expect(display?.overflowNames).toEqual(['Alan Turing', 'Ada Lovelace']);
+  });
+
+  it('combines the "you" variant with the "+N" overflow', () => {
+    expect(buildMeetingOrganizerDisplay([grace, alan], 'ghopper')?.label).toBe('Organized by you +1');
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -434,6 +434,18 @@ describe('compareMeetingPeopleByHostThenName', () => {
 
     expect(ordered).toEqual(['Alan Turing', 'Grace Hopper', 'Ada Lovelace', 'Zed Zephyr', '', 'unknown [unknown]']);
   });
+
+  it('keeps an unnamed host at the top, not the bottom', () => {
+    const people = [
+      { first_name: 'Ada', last_name: 'Lovelace', host: false },
+      { first_name: '', last_name: '', host: true }, // unnamed host → still top
+      { first_name: 'unknown', last_name: '[unknown]', host: false }, // unresolvable non-host → bottom
+    ];
+
+    const ordered = [...people].sort(compareMeetingPeopleByHostThenName);
+    expect(ordered[0].host).toBe(true);
+    expect(`${ordered[2].first_name} ${ordered[2].last_name}`.trim()).toBe('unknown [unknown]');
+  });
 });
 
 function summaryResource(id: string, data: Partial<PastMeetingSummary> & { content?: string; edited_content?: string }): QueryServiceItem<PastMeetingSummary> {

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -11,10 +11,12 @@ import { describe, expect, it } from 'vitest';
 import { RecurrenceType } from '../enums';
 import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
 import {
-  buildMeetingOrganizerDisplay,
+  buildMeetingOrganizerChip,
+  buildMeetingOrganizerMailto,
   buildRecurrenceSummary,
   collectMeetingOrganizers,
   getMeetingOrganizerDisplayName,
+  isUnresolvableParticipantName,
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
   resolveOccurrenceRecurrence,
@@ -275,13 +277,13 @@ describe('getMeetingOrganizerDisplayName', () => {
 });
 
 describe('collectMeetingOrganizers', () => {
-  it('returns the human created_by as the sole organizer', () => {
+  it('returns the human created_by as the sole organizer when no hosts are supplied', () => {
     const meeting = { created_by: { name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' } } as Meeting;
 
     expect(collectMeetingOrganizers(meeting)).toEqual([{ name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' }]);
   });
 
-  it('falls back to all host-flagged candidates when created_by is not a human', () => {
+  it('uses the host set (sorted by name) as the authoritative organizers when hosts are present', () => {
     const meeting = { created_by: { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' } } as Meeting;
     const hosts = [
       { first_name: 'Grace', last_name: 'Hopper', username: 'ghopper', email: 'grace@example.com', host: true },
@@ -290,8 +292,27 @@ describe('collectMeetingOrganizers', () => {
     ];
 
     const organizers = collectMeetingOrganizers(meeting, hosts);
-    expect(organizers).toHaveLength(2);
-    expect(organizers.map((o) => o.name)).toEqual(['Grace Hopper', 'Alan Turing']);
+    expect(organizers.map((o) => o.name)).toEqual(['Alan Turing', 'Grace Hopper']);
+  });
+
+  it('does NOT short-circuit on created_by — hosts drive the set so chip and modal agree', () => {
+    // Regression: created_by (Christina) is one of two hosts; the chip must show BOTH, not just created_by.
+    const meeting = { created_by: { name: 'Christina Harter', username: 'charter', email: 'christina@example.com' } } as Meeting;
+    const hosts = [
+      { first_name: 'Christina', last_name: 'Harter', username: 'charter', email: 'christina@example.com', host: true },
+      { first_name: 'Grant', last_name: 'Miller', username: 'gmiller', email: 'grant@example.com', host: true },
+    ];
+
+    const organizers = collectMeetingOrganizers(meeting, hosts);
+    expect(organizers.map((o) => o.name)).toEqual(['Christina Harter', 'Grant Miller']);
+  });
+
+  it('folds a human created_by in when it is not among the hosts', () => {
+    const meeting = { created_by: { name: 'Ada Lovelace', username: 'ada', email: 'ada@example.com' } } as Meeting;
+    const hosts = [{ first_name: 'Grant', last_name: 'Miller', username: 'gmiller', email: 'grant@example.com', host: true }];
+
+    const organizers = collectMeetingOrganizers(meeting, hosts);
+    expect(organizers.map((o) => o.name)).toEqual(['Ada Lovelace', 'Grant Miller']);
   });
 
   it('returns an empty array when nothing resolves', () => {
@@ -300,34 +321,79 @@ describe('collectMeetingOrganizers', () => {
   });
 });
 
-describe('buildMeetingOrganizerDisplay', () => {
+describe('buildMeetingOrganizerMailto', () => {
+  it('returns null when there is no email (caller renders plain text)', () => {
+    expect(buildMeetingOrganizerMailto({ email: '', meetingTitle: 'Sync', detailUrl: 'https://x/m/1' })).toBeNull();
+    expect(buildMeetingOrganizerMailto({ email: null })).toBeNull();
+  });
+
+  it('builds a mailto with a percent-encoded subject and body, address left bare', () => {
+    const href = buildMeetingOrganizerMailto({
+      email: 'ada@example.com',
+      meetingTitle: 'Board & Strategy',
+      meetingDate: 'Jul 22, 2026',
+      detailUrl: 'https://lfx.dev/meetings/abc?x=1',
+    });
+
+    expect(href).toBe(
+      'mailto:ada@example.com?subject=Board%20%26%20Strategy%20%E2%80%94%20Jul%2022%2C%202026&body=https%3A%2F%2Flfx.dev%2Fmeetings%2Fabc%3Fx%3D1'
+    );
+  });
+
+  it('joins title and date with an em dash and omits empty parts', () => {
+    expect(buildMeetingOrganizerMailto({ email: 'a@b.com', meetingTitle: 'Only Title' })).toBe('mailto:a@b.com?subject=Only%20Title');
+    expect(buildMeetingOrganizerMailto({ email: 'a@b.com' })).toBe('mailto:a@b.com');
+  });
+});
+
+describe('buildMeetingOrganizerChip', () => {
   const ada = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
   const grace = { name: 'Grace Hopper', username: 'ghopper', email: 'grace@example.com' };
-  const alan = { name: 'Alan Turing', username: 'aturing', email: 'alan@example.com' };
+  const noEmail = { name: 'No Email', username: 'noemail', email: '' };
+  const ctx = { meetingTitle: 'Sync', meetingDate: 'Jul 22, 2026', detailUrl: 'https://x/m/1' };
 
   it('returns null when there are no organizers', () => {
-    expect(buildMeetingOrganizerDisplay([])).toBeNull();
+    expect(buildMeetingOrganizerChip([])).toBeNull();
   });
 
-  it('labels a single organizer by name', () => {
-    expect(buildMeetingOrganizerDisplay([ada])?.label).toBe('Organized by Ada Lovelace');
+  it('builds a single-organizer chip with a mailto link on the name', () => {
+    const chip = buildMeetingOrganizerChip([ada], null, ctx);
+    expect(chip?.count).toBe(1);
+    expect(chip?.primary.name).toBe('Ada Lovelace');
+    expect(chip?.primary.mailto).toContain('mailto:ada@example.com?subject=Sync');
+    expect(chip?.overflow).toEqual([]);
   });
 
-  it('uses the "you" variant when the primary organizer matches the viewer (case/prefix-insensitive)', () => {
-    expect(buildMeetingOrganizerDisplay([ada], 'ALOVELACE')?.label).toBe('Organized by you');
-    expect(buildMeetingOrganizerDisplay([ada], 'auth0|alovelace')?.isYou).toBe(true);
-    expect(buildMeetingOrganizerDisplay([ada], 'someone-else')?.isYou).toBe(false);
+  it('marks the viewer as "you" and never links their name', () => {
+    const chip = buildMeetingOrganizerChip([ada], 'auth0|alovelace', ctx);
+    expect(chip?.primary.isYou).toBe(true);
+    expect(chip?.primary.mailto).toBeNull();
   });
 
-  it('appends a "+N" overflow and exposes the overflow names for a popover', () => {
-    const display = buildMeetingOrganizerDisplay([grace, alan, ada]);
-    expect(display?.label).toBe('Organized by Grace Hopper +2');
-    expect(display?.count).toBe(3);
-    expect(display?.overflowNames).toEqual(['Alan Turing', 'Ada Lovelace']);
+  it('exposes overflow organizers for the "+N" popover, each with its own mailto', () => {
+    const chip = buildMeetingOrganizerChip([grace, ada, noEmail], null, ctx);
+    expect(chip?.count).toBe(3);
+    expect(chip?.primary.name).toBe('Grace Hopper');
+    expect(chip?.overflow.map((o) => o.name)).toEqual(['Ada Lovelace', 'No Email']);
+    expect(chip?.overflow[0].mailto).toContain('mailto:ada@example.com');
+    // No-email organizer → plain text (null mailto).
+    expect(chip?.overflow[1].mailto).toBeNull();
+  });
+});
+
+describe('isUnresolvableParticipantName', () => {
+  it('is true for empty or placeholder names', () => {
+    expect(isUnresolvableParticipantName('', '')).toBe(true);
+    expect(isUnresolvableParticipantName(null, undefined)).toBe(true);
+    expect(isUnresolvableParticipantName('unknown', 'unknown')).toBe(true);
+    expect(isUnresolvableParticipantName('[unknown]', '[unknown]')).toBe(true);
+    expect(isUnresolvableParticipantName('  Unknown  ', '')).toBe(true);
   });
 
-  it('combines the "you" variant with the "+N" overflow', () => {
-    expect(buildMeetingOrganizerDisplay([grace, alan], 'ghopper')?.label).toBe('Organized by you +1');
+  it('is false when at least one part is a real name', () => {
+    expect(isUnresolvableParticipantName('Ada', '')).toBe(false);
+    expect(isUnresolvableParticipantName('', 'Lovelace')).toBe(false);
+    expect(isUnresolvableParticipantName('unknown', 'Lovelace')).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -9,7 +9,8 @@ import {
   Meeting,
   MeetingHostCandidate,
   MeetingOccurrence,
-  MeetingOrganizerDisplay,
+  MeetingOrganizerChipModel,
+  MeetingOrganizerLink,
   MeetingRecurrence,
   MeetingUserInfo,
   PastMeeting,
@@ -746,14 +747,45 @@ export function getMeetingOrganizerDisplayName(organizer: MeetingUserInfo | null
   return organizer.name?.trim() || organizer.username?.trim() || organizer.email?.trim() || '';
 }
 
+/** Maps a host registrant/participant candidate to the organizer display shape. */
+function hostToOrganizer(host: MeetingHostCandidate): MeetingUserInfo {
+  const name = `${host.first_name ?? ''} ${host.last_name ?? ''}`.trim();
+  return {
+    name,
+    username: host.username?.trim() ?? '',
+    email: host.email?.trim() ?? '',
+    ...(host.avatar_url ? { profile_picture: host.avatar_url } : {}),
+  };
+}
+
+/** Whether two organizers refer to the same person (by username, then email, then name). */
+function sameOrganizer(a: MeetingUserInfo, b: MeetingUserInfo): boolean {
+  const usernameA = normalizeUsername(a.username);
+  const usernameB = normalizeUsername(b.username);
+  if (usernameA && usernameB) {
+    return usernameA === usernameB;
+  }
+  const emailA = a.email?.trim().toLowerCase();
+  const emailB = b.email?.trim().toLowerCase();
+  if (emailA && emailB) {
+    return emailA === emailB;
+  }
+  const nameA = a.name?.trim().toLowerCase();
+  const nameB = b.name?.trim().toLowerCase();
+  return !!nameA && nameA === nameB;
+}
+
 /**
- * Collects every person to attribute a meeting to, in priority order:
- *   - the human `created_by` as the sole organizer, else
- *   - all host-flagged candidates (multiple hosts → multiple organizers), else
- *   - an empty array (nothing to display).
+ * Collects every person to attribute a meeting to, from a single unified source so the
+ * "Organized by" chip and the participants/registrants modal never disagree:
+ *   - When host-flagged candidates are present, they ARE the organizer set (exactly what the
+ *     modal badges), sorted by name; the human `created_by` is folded in only if it isn't
+ *     already one of the hosts.
+ *   - When no hosts are supplied (e.g. summary cards that don't load the registrant list), the
+ *     human `created_by` is the sole organizer.
+ *   - Otherwise an empty array (nothing to display).
  *
- * The single-value {@link resolveMeetingOrganizer} drives the common (created_by) path;
- * this returns the full list so surfaces with host data can render a "+N" overflow.
+ * Surfaces that show BOTH the chip and the modal must pass the same host list to each.
  */
 export function collectMeetingOrganizers(
   meeting: Pick<Meeting, 'created_by'> | null | undefined,
@@ -761,22 +793,56 @@ export function collectMeetingOrganizers(
 ): MeetingUserInfo[] {
   const createdBy = meeting?.created_by;
   const humanCreatedBy = createdBy ? resolveMeetingOrganizer({ created_by: createdBy }) : null;
-  if (humanCreatedBy) {
-    return [humanCreatedBy];
+
+  const hostOrganizers = (hosts ?? [])
+    .filter((candidate) => candidate?.host)
+    .map((host) => hostToOrganizer(host))
+    .filter((organizer) => organizer.name || organizer.username || organizer.email)
+    .sort((a, b) => getMeetingOrganizerDisplayName(a).localeCompare(getMeetingOrganizerDisplayName(b)));
+
+  if (hostOrganizers.length === 0) {
+    return humanCreatedBy ? [humanCreatedBy] : [];
   }
 
-  return (hosts ?? [])
-    .filter((candidate) => candidate?.host)
-    .map((host) => {
-      const name = `${host.first_name ?? ''} ${host.last_name ?? ''}`.trim();
-      return {
-        name,
-        username: host.username?.trim() ?? '',
-        email: host.email?.trim() ?? '',
-        ...(host.avatar_url ? { profile_picture: host.avatar_url } : {}),
-      } as MeetingUserInfo;
-    })
-    .filter((organizer) => organizer.name || organizer.username || organizer.email);
+  if (humanCreatedBy && !hostOrganizers.some((organizer) => sameOrganizer(organizer, humanCreatedBy))) {
+    return [humanCreatedBy, ...hostOrganizers];
+  }
+  return hostOrganizers;
+}
+
+/**
+ * Builds a `mailto:` URL that pre-fills an email to a meeting organizer. Returns `null` when the
+ * organizer has no email (caller renders the name as plain text). Subject and body are
+ * percent-encoded; the address is left as a bare addr-spec.
+ *
+ * @param params.email - Organizer email (the mailto target).
+ * @param params.meetingTitle - Meeting title (subject prefix).
+ * @param params.meetingDate - Pre-formatted meeting date (subject suffix).
+ * @param params.detailUrl - Meeting details page URL (body).
+ */
+export function buildMeetingOrganizerMailto(params: {
+  email?: string | null;
+  meetingTitle?: string | null;
+  meetingDate?: string | null;
+  detailUrl?: string | null;
+}): string | null {
+  const email = params.email?.trim();
+  if (!email) {
+    return null;
+  }
+
+  const subject = [params.meetingTitle?.trim(), params.meetingDate?.trim()].filter(Boolean).join(' — ');
+  const body = params.detailUrl?.trim() ?? '';
+
+  const query: string[] = [];
+  if (subject) {
+    query.push(`subject=${encodeURIComponent(subject)}`);
+  }
+  if (body) {
+    query.push(`body=${encodeURIComponent(body)}`);
+  }
+
+  return `mailto:${email}${query.length ? `?${query.join('&')}` : ''}`;
 }
 
 /**
@@ -788,30 +854,48 @@ function normalizeUsername(username: string | null | undefined): string {
 }
 
 /**
- * Builds the "Organized by" display model from resolved organizers and the viewer's username.
- * Returns `null` when there are no organizers so the caller omits the line entirely.
+ * Builds the "Organized by" chip view model from resolved organizers, the viewer's username, and
+ * the meeting context needed to pre-fill a `mailto:` per organizer. Returns `null` when there are
+ * no organizers so the caller omits the chip entirely.
  *
  * @param organizers - Resolved organizers (see {@link collectMeetingOrganizers}).
- * @param viewerUsername - The current user's username, for the "Organized by you" variant.
+ * @param viewerUsername - The current user's username, for the "you" variant (never linked).
+ * @param mailtoContext - Meeting title / formatted date / details URL for the mailto subject+body.
  */
-export function buildMeetingOrganizerDisplay(organizers: ReadonlyArray<MeetingUserInfo>, viewerUsername?: string | null): MeetingOrganizerDisplay | null {
+export function buildMeetingOrganizerChip(
+  organizers: ReadonlyArray<MeetingUserInfo>,
+  viewerUsername?: string | null,
+  mailtoContext: { meetingTitle?: string | null; meetingDate?: string | null; detailUrl?: string | null } = {}
+): MeetingOrganizerChipModel | null {
   if (!organizers.length) {
     return null;
   }
 
-  const primary = organizers[0];
-  const primaryName = getMeetingOrganizerDisplayName(primary);
   const viewer = normalizeUsername(viewerUsername);
-  const isYou = !!viewer && normalizeUsername(primary.username) === viewer;
-  const overflowNames = organizers.slice(1).map((organizer) => getMeetingOrganizerDisplayName(organizer));
-  const extraCount = organizers.length - 1;
-  const base = `Organized by ${isYou ? 'you' : primaryName}`;
+  const toLink = (organizer: MeetingUserInfo): MeetingOrganizerLink => {
+    const isYou = !!viewer && normalizeUsername(organizer.username) === viewer;
+    return {
+      name: getMeetingOrganizerDisplayName(organizer),
+      isYou,
+      // "you" is never a mailto link (emailing yourself makes no sense); others link when they have an email.
+      mailto: isYou ? null : buildMeetingOrganizerMailto({ email: organizer.email, ...mailtoContext }),
+    };
+  };
 
   return {
-    label: extraCount > 0 ? `${base} +${extraCount}` : base,
-    primaryName,
-    isYou,
-    overflowNames,
     count: organizers.length,
+    primary: toLink(organizers[0]),
+    overflow: organizers.slice(1).map(toLink),
   };
+}
+
+/**
+ * Whether a participant/registrant has no meaningful name — empty or a placeholder like
+ * "unknown" / "[unknown]". Used to sink such rows to the BOTTOM of people lists (organizers
+ * float to top; broken records must not sit directly beneath them).
+ */
+export function isUnresolvableParticipantName(first?: string | null, last?: string | null): boolean {
+  const tokens = [first, last].map((token) => (token ?? '').trim().toLowerCase());
+  const meaningful = tokens.filter((token) => token && token !== 'unknown' && token !== '[unknown]');
+  return meaningful.length === 0;
 }

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -827,9 +827,10 @@ export function buildMeetingOrganizerMailto(params: {
   detailUrl?: string | null;
 }): string | null {
   const email = params.email?.trim();
-  // Require a plausible address and reject any header-injection characters (whitespace, `?`, `&`,
-  // `<`, `>`, `"`, control chars) so a malformed record can't smuggle extra mailto headers.
-  if (!email || !email.includes('@') || /[\s?&<>"]/.test(email)) {
+  // Only emit a mailto for a conservative single-recipient address. The positive allowlist rejects
+  // whitespace, separators (`,`/`;`), extra `@`, and — critically — percent escapes, so a record
+  // like `victim@x.com%0D%0ABcc:attacker@x.com` can't decode into a CRLF + injected mail header.
+  if (!email || !/^[A-Za-z0-9._+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(email)) {
     return null;
   }
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -917,10 +917,12 @@ export function isUnresolvableParticipantName(first?: string | null, last?: stri
  */
 export function compareMeetingPeopleByHostThenName<T extends { host?: boolean; first_name?: string | null; last_name?: string | null }>(a: T, b: T): number {
   const rank = (person: T): number => {
-    if (isUnresolvableParticipantName(person.first_name, person.last_name)) {
-      return 2;
+    // Hosts always float to the top, even when their upstream name is empty/[unknown];
+    // only non-host unresolvable rows sink to the bottom.
+    if (person.host) {
+      return 0;
     }
-    return person.host ? 0 : 1;
+    return isUnresolvableParticipantName(person.first_name, person.last_name) ? 2 : 1;
   };
   const rankDelta = rank(a) - rank(b);
   if (rankDelta !== 0) {

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -691,6 +691,8 @@ function isServiceOrEmptyCreatedBy(createdBy: MeetingUserInfo): boolean {
     return true;
   }
 
+  // `split('@')[0]` takes the local part; safe here because this only runs on trusted upstream
+  // created_by data (a malformed multi-`@` address would just not match a skip identifier).
   const emailLocalPart = email ? email.split('@')[0] : undefined;
   return MEETING_ORGANIZER_SKIP_IDENTIFIERS.some((skip) => username === skip || email === skip || emailLocalPart === skip || name?.toLowerCase() === skip);
 }
@@ -875,11 +877,13 @@ export function buildMeetingOrganizerChip(
   }
 
   const viewer = normalizeUsername(viewerUsername);
-  const toLink = (organizer: MeetingUserInfo): MeetingOrganizerLink => {
+  const toLink = (organizer: MeetingUserInfo, index: number): MeetingOrganizerLink => {
     const isYou = !!viewer && normalizeUsername(organizer.username) === viewer;
     const name = getMeetingOrganizerDisplayName(organizer);
     return {
-      key: organizer.username?.trim() || organizer.email?.trim() || name,
+      // Suffix the identity with its position so two name-only organizers sharing a display name
+      // still get distinct @for track keys (avoids Angular's duplicate-key diagnostic / DOM reuse).
+      key: `${organizer.username?.trim() || organizer.email?.trim() || name}#${index}`,
       name,
       isYou,
       // "you" is never a mailto link (emailing yourself makes no sense); others link when they have an email.
@@ -889,8 +893,8 @@ export function buildMeetingOrganizerChip(
 
   return {
     count: organizers.length,
-    primary: toLink(organizers[0]),
-    overflow: organizers.slice(1).map(toLink),
+    primary: toLink(organizers[0], 0),
+    overflow: organizers.slice(1).map((organizer, index) => toLink(organizer, index + 1)),
   };
 }
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -3,12 +3,15 @@
 
 import { HttpParams } from '@angular/common/http';
 
-import { RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
+import { MEETING_ORGANIZER_SKIP_IDENTIFIERS, RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
 import {
   CustomRecurrencePattern,
   Meeting,
+  MeetingHostCandidate,
   MeetingOccurrence,
+  MeetingOrganizerDisplay,
   MeetingRecurrence,
+  MeetingUserInfo,
   PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
@@ -670,5 +673,145 @@ export function normalizeIndexedMeetingAiSummary<T extends Pick<Meeting, 'ai_sum
     ...meeting,
     ai_summary_enabled: meeting.ai_summary_enabled ?? zoom.ai_companion_enabled,
     require_ai_summary_approval: meeting.require_ai_summary_approval ?? zoom.ai_summary_require_approval,
+  };
+}
+
+/**
+ * Returns true when a `created_by` value is a service account (e.g. `zoom.webhooks`)
+ * or carries no identifying information at all — either way it must not be shown as
+ * the meeting organizer.
+ */
+function isServiceOrEmptyCreatedBy(createdBy: MeetingUserInfo): boolean {
+  const name = createdBy.name?.trim();
+  const username = createdBy.username?.trim().toLowerCase();
+  const email = createdBy.email?.trim().toLowerCase();
+
+  if (!name && !username && !email) {
+    return true;
+  }
+
+  const emailLocalPart = email ? email.split('@')[0] : undefined;
+  return MEETING_ORGANIZER_SKIP_IDENTIFIERS.some((skip) => username === skip || email === skip || emailLocalPart === skip || name?.toLowerCase() === skip);
+}
+
+/**
+ * Resolves the person to display as a meeting's organizer, in priority order:
+ *   1. `meeting.created_by` when it's a real human (not a service account, not empty).
+ *   2. The first host among the supplied candidates (rare, but authoritative when present).
+ *   3. `null` — nothing resolvable, so the caller omits the organizer display entirely.
+ *
+ * @param meeting - Any object carrying an optional `created_by` (Meeting / PastMeeting).
+ * @param hosts - Optional registrant/participant candidates for the host fallback.
+ */
+export function resolveMeetingOrganizer(
+  meeting: Pick<Meeting, 'created_by'> | null | undefined,
+  hosts?: ReadonlyArray<MeetingHostCandidate>
+): MeetingUserInfo | null {
+  const createdBy = meeting?.created_by;
+  if (createdBy && !isServiceOrEmptyCreatedBy(createdBy)) {
+    return {
+      name: createdBy.name,
+      username: createdBy.username,
+      email: createdBy.email,
+      ...(createdBy.profile_picture ? { profile_picture: createdBy.profile_picture } : {}),
+    };
+  }
+
+  const host = hosts?.find((candidate) => candidate?.host);
+  if (host) {
+    const name = `${host.first_name ?? ''} ${host.last_name ?? ''}`.trim();
+    const username = host.username?.trim() ?? '';
+    const email = host.email?.trim() ?? '';
+    if (name || username || email) {
+      return {
+        name,
+        username,
+        email,
+        ...(host.avatar_url ? { profile_picture: host.avatar_url } : {}),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Display label for a resolved organizer: the full name, falling back to username,
+ * then email. Returns an empty string only when none are present.
+ */
+export function getMeetingOrganizerDisplayName(organizer: MeetingUserInfo | null | undefined): string {
+  if (!organizer) {
+    return '';
+  }
+  return organizer.name?.trim() || organizer.username?.trim() || organizer.email?.trim() || '';
+}
+
+/**
+ * Collects every person to attribute a meeting to, in priority order:
+ *   - the human `created_by` as the sole organizer, else
+ *   - all host-flagged candidates (multiple hosts → multiple organizers), else
+ *   - an empty array (nothing to display).
+ *
+ * The single-value {@link resolveMeetingOrganizer} drives the common (created_by) path;
+ * this returns the full list so surfaces with host data can render a "+N" overflow.
+ */
+export function collectMeetingOrganizers(
+  meeting: Pick<Meeting, 'created_by'> | null | undefined,
+  hosts?: ReadonlyArray<MeetingHostCandidate>
+): MeetingUserInfo[] {
+  const createdBy = meeting?.created_by;
+  const humanCreatedBy = createdBy ? resolveMeetingOrganizer({ created_by: createdBy }) : null;
+  if (humanCreatedBy) {
+    return [humanCreatedBy];
+  }
+
+  return (hosts ?? [])
+    .filter((candidate) => candidate?.host)
+    .map((host) => {
+      const name = `${host.first_name ?? ''} ${host.last_name ?? ''}`.trim();
+      return {
+        name,
+        username: host.username?.trim() ?? '',
+        email: host.email?.trim() ?? '',
+        ...(host.avatar_url ? { profile_picture: host.avatar_url } : {}),
+      } as MeetingUserInfo;
+    })
+    .filter((organizer) => organizer.name || organizer.username || organizer.email);
+}
+
+/**
+ * Normalizes a username for viewer-identity comparison — lowercased and stripped of any
+ * auth-provider prefix (e.g. `auth0|`), so an OIDC `sub` still matches a plain LFID.
+ */
+function normalizeUsername(username: string | null | undefined): string {
+  return (username ?? '').trim().toLowerCase().split('|').pop() ?? '';
+}
+
+/**
+ * Builds the "Organized by" display model from resolved organizers and the viewer's username.
+ * Returns `null` when there are no organizers so the caller omits the line entirely.
+ *
+ * @param organizers - Resolved organizers (see {@link collectMeetingOrganizers}).
+ * @param viewerUsername - The current user's username, for the "Organized by you" variant.
+ */
+export function buildMeetingOrganizerDisplay(organizers: ReadonlyArray<MeetingUserInfo>, viewerUsername?: string | null): MeetingOrganizerDisplay | null {
+  if (!organizers.length) {
+    return null;
+  }
+
+  const primary = organizers[0];
+  const primaryName = getMeetingOrganizerDisplayName(primary);
+  const viewer = normalizeUsername(viewerUsername);
+  const isYou = !!viewer && normalizeUsername(primary.username) === viewer;
+  const overflowNames = organizers.slice(1).map((organizer) => getMeetingOrganizerDisplayName(organizer));
+  const extraCount = organizers.length - 1;
+  const base = `Organized by ${isYou ? 'you' : primaryName}`;
+
+  return {
+    label: extraCount > 0 ? `${base} +${extraCount}` : base,
+    primaryName,
+    isYou,
+    overflowNames,
+    count: organizers.length,
   };
 }

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -827,7 +827,9 @@ export function buildMeetingOrganizerMailto(params: {
   detailUrl?: string | null;
 }): string | null {
   const email = params.email?.trim();
-  if (!email) {
+  // Require a plausible address and reject any header-injection characters (whitespace, `?`, `&`,
+  // `<`, `>`, `"`, control chars) so a malformed record can't smuggle extra mailto headers.
+  if (!email || !email.includes('@') || /[\s?&<>"]/.test(email)) {
     return null;
   }
 
@@ -874,8 +876,10 @@ export function buildMeetingOrganizerChip(
   const viewer = normalizeUsername(viewerUsername);
   const toLink = (organizer: MeetingUserInfo): MeetingOrganizerLink => {
     const isYou = !!viewer && normalizeUsername(organizer.username) === viewer;
+    const name = getMeetingOrganizerDisplayName(organizer);
     return {
-      name: getMeetingOrganizerDisplayName(organizer),
+      key: organizer.username?.trim() || organizer.email?.trim() || name,
+      name,
       isYou,
       // "you" is never a mailto link (emailing yourself makes no sense); others link when they have an email.
       mailto: isYou ? null : buildMeetingOrganizerMailto({ email: organizer.email, ...mailtoContext }),
@@ -898,4 +902,24 @@ export function isUnresolvableParticipantName(first?: string | null, last?: stri
   const tokens = [first, last].map((token) => (token ?? '').trim().toLowerCase());
   const meaningful = tokens.filter((token) => token && token !== 'unknown' && token !== '[unknown]');
   return meaningful.length === 0;
+}
+
+/**
+ * Orders a people list into three tiers so organizers stay at the top and broken rows at the bottom:
+ * hosts (organizers) first, then normally-named people, then unresolvable "[unknown]" records.
+ * Within a tier, orders by first name. Shared by the registrants/participants modal and the
+ * past-meeting details table so the ordering rule lives in one place.
+ */
+export function compareMeetingPeopleByHostThenName<T extends { host?: boolean; first_name?: string | null; last_name?: string | null }>(a: T, b: T): number {
+  const rank = (person: T): number => {
+    if (isUnresolvableParticipantName(person.first_name, person.last_name)) {
+      return 2;
+    }
+    return person.host ? 0 : 1;
+  };
+  const rankDelta = rank(a) - rank(b);
+  if (rankDelta !== 0) {
+    return rankDelta;
+  }
+  return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
 }


### PR DESCRIPTION
## What

Show the meeting **organizer's name** across meeting surfaces (LFXV2-2802): upcoming & past meeting cards, the public join page, and past-meeting details, plus an **Organizer** badge on host registrants/participants.

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-2802

## Why this is built on `created_by`

Production sampling + the upstream `lfx-v2-meeting-service` OpenAPI confirmed:

- `Meeting.organizers[]` is empty in prod (the field is written but ignored upstream — dead as a display source), and host registrants are near-nonexistent.
- `v1_meeting.created_by` (`{ name, username, email, profile_picture }`) is a real human on ~81–85% of meetings and is the display source.
- **Only the query-service `v1_meeting` list index carries `created_by`** — the ITX detail payload (`GET /itx/meetings/:id`, `/itx/past_meetings/:id`) omits it, and past meetings are webhook-created. So detail/join/past paths are **enriched** by joining back to the live `v1_meeting` index (batched via the OR-semantics `tags` param, cached per request, deleted-series → omitted).

## Privacy (v1 constraint)

The organizer is **authenticated-visible** info. Defense-in-depth:

- **Server:** public endpoints strip `created_by` for unauthenticated callers (and skip the enrichment query entirely for them).
- **Client:** the shared `lfx-meeting-organizer` chip renders only when authenticated — a single gate to lift once the data-privacy review clears it.

## Notable behavior

- **Chip and modal share one source.** `collectMeetingOrganizers` derives from the host set the participants/registrants modal badges (with `created_by` folded in), so the two never disagree. Multiple organizers → `Organized by {first} +N` with a popover.
- **mailto:** each organizer name is a pre-filled `mailto:` link (`{title} — {date}` subject, details-URL body, encoded; injection-guarded address); plain text when there's no email or for "you".
- **Sorting:** organizers float to top, unresolvable `[unknown]` rows sink to the bottom.
- **Card timing (accepted trade-off):** a card's host-derived `+N` populates after its Members/Guests drawer is opened once (reuses that fetch — no per-card N+1). Join & past-details show it immediately.

## Tests

Shared utils (organizer derivation, service-account skip list, `+N` chip model, mailto encoding + injection guard + no-email→plain, stable track key, three-tier sort), BFF enrichment (`meeting.helper.spec.ts`) and the batched `v1_meeting` lookup (`meeting.service.spec.ts`, incl. chunk boundary / dedup / per-chunk failure skip).

## Notes for reviewers

- **Diff size:** ~1.1k additions, but cohesive single-feature work — a large share is new `*.spec.ts` coverage plus the shared chip component.
- No upstream/other-repo changes required — uses the existing `v1_meeting.created_by` field.
- Opened as a **draft** pending integration validation.
