### PR TITLE
fix(committees): pre-resolve org before accept-invite dialog opens

### DIFF
--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -13,6 +13,7 @@
       [form]="form"
       nameControl="organization"
       domainControl="organization_url"
+      idControl="organization_id"
       [domainRequired]="isNewOrg()"
       placeholder="Search for organization..."
       styleClass="w-full"

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -27,7 +27,7 @@
     @if (isNewOrg()) {
       <p class="text-xs text-red-600" role="alert" data-testid="accept-invite-org-warning">
         <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
-        Organization not found. Search and select it from the results, or click "Enter manually" to provide a website URL.
+        Organization not found. Search and select it from the results, or click "I want to create" to provide a website URL.
       </p>
     }
   </div>
@@ -47,7 +47,7 @@
     severity="info"
     size="small"
     [loading]="submitting()"
-    [disabled]="submitting() || isNewOrg()"
+    [disabled]="!canConfirm()"
     (onClick)="onConfirm()"
     data-testid="accept-invite-organization-confirm"></lfx-button>
 </div>

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -28,7 +28,7 @@
     @if (showOrgWarning()) {
       <p class="text-xs text-red-600" role="alert" data-testid="accept-invite-org-warning">
         <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
-        Organization not found. Search and select it from the results, or click "I want to create" to provide a website URL.
+        Select an organization from the results, or click "I want to create" to provide a website URL.
       </p>
     }
   </div>

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -24,6 +24,12 @@
     @if (organizationControl.errors?.['trimmedRequired'] && organizationControl.touched) {
       <p class="text-xs text-red-600">Organization is required for this group</p>
     }
+    @if (isNewOrg()) {
+      <p class="text-xs text-red-600" role="alert" data-testid="accept-invite-org-warning">
+        <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
+        Organization not found. Search and select it from the results, or click "Enter manually" to provide a website URL.
+      </p>
+    }
   </div>
 </div>
 
@@ -41,7 +47,7 @@
     severity="info"
     size="small"
     [loading]="submitting()"
-    [disabled]="submitting()"
+    [disabled]="submitting() || isNewOrg()"
     (onClick)="onConfirm()"
     data-testid="accept-invite-organization-confirm"></lfx-button>
 </div>

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -25,7 +25,7 @@
     @if (organizationControl.errors?.['trimmedRequired'] && organizationControl.touched) {
       <p class="text-xs text-red-600">Organization is required for this group</p>
     }
-    @if (isNewOrg()) {
+    @if (showOrgWarning()) {
       <p class="text-xs text-red-600" role="alert" data-testid="accept-invite-org-warning">
         <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
         Organization not found. Search and select it from the results, or click "I want to create" to provide a website URL.

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -48,7 +48,32 @@ export class AcceptInviteOrganizationDialogComponent {
     return !value?.organization_id && !!value?.organization?.trim();
   });
 
-  protected readonly canConfirm = computed(() => !this.submitting() && (!this.isNewOrg() || this.urlStatus() === 'VALID'));
+  private readonly orgInvalid = computed(() => {
+    const search = this.organizationSearch();
+    if (search?.manualMode()) {
+      return this.urlStatus() !== 'VALID';
+    }
+    const vals = this.formValue();
+    const hasName = !!(vals?.organization ?? '').trim();
+    const pendingSearch = search?.searchTerm() ?? '';
+    if (!hasName && pendingSearch) return true;
+    if (!hasName) return false;
+    if (!vals?.organization_id) {
+      return this.urlStatus() !== 'VALID';
+    }
+    return false;
+  });
+
+  protected readonly showOrgWarning = computed(() => {
+    if (!this.orgInvalid()) return false;
+    if (this.organizationSearch()?.manualMode()) return false;
+    const vals = this.formValue();
+    const hasName = !!(vals?.organization ?? '').trim();
+    if (!hasName) return !!(this.organizationSearch()?.searchTerm() ?? '');
+    return true;
+  });
+
+  protected readonly canConfirm = computed(() => !this.submitting() && !this.orgInvalid());
 
   public constructor() {
     this.organizationControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((name) => {

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -23,7 +23,10 @@ export class AcceptInviteOrganizationDialogComponent {
   private readonly config = inject(DynamicDialogConfig<AcceptInviteOrganizationDialogData>);
 
   private readonly organizationSearch = viewChild(OrganizationSearchComponent);
-  private resolvedOrganizationName = '';
+  // Tracks the CDP-canonical name of the last resolved org so the valueChanges
+  // handler can distinguish a CDP-confirmed name from free text (and avoid
+  // clearing the pre-resolved id when the same name is re-set programmatically).
+  private resolvedOrganizationName = this.config.data?.organization?.id ? (this.config.data.organization.name ?? '') : '';
 
   public readonly committeeName = this.config.data?.committeeName ?? 'this group';
   public readonly form = new FormGroup({
@@ -38,11 +41,14 @@ export class AcceptInviteOrganizationDialogComponent {
   public readonly submitting = signal(false);
 
   private readonly formValue = this.initFormValue();
+  private readonly urlStatus = toSignal(this.urlControl.statusChanges.pipe(startWith(this.urlControl.status)));
 
   protected readonly isNewOrg = computed(() => {
     const value = this.formValue();
     return !value?.organization_id && !!value?.organization?.trim();
   });
+
+  protected readonly canConfirm = computed(() => !this.submitting() && (!this.isNewOrg() || this.urlStatus() === 'VALID'));
 
   public constructor() {
     this.organizationControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((name) => {

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -50,15 +50,19 @@ export class AcceptInviteOrganizationDialogComponent {
 
   private readonly orgInvalid = computed(() => {
     const search = this.organizationSearch();
+    const vals = this.formValue();
     if (search?.manualMode()) {
+      const urlValue = (vals?.organization_url ?? '').trim();
+      if (!urlValue) return true;
       return this.urlStatus() !== 'VALID';
     }
-    const vals = this.formValue();
     const hasName = !!(vals?.organization ?? '').trim();
     const pendingSearch = search?.searchTerm() ?? '';
     if (!hasName && pendingSearch) return true;
     if (!hasName) return true;
     if (!vals?.organization_id) {
+      const urlValue = (vals?.organization_url ?? '').trim();
+      if (!urlValue) return true;
       return this.urlStatus() !== 'VALID';
     }
     return false;

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormControlStatus, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { AcceptInviteOrganizationDialogData, AcceptInviteOrganizationDialogResult, OrganizationResolveResult } from '@lfx-one/shared/interfaces';
@@ -41,7 +41,7 @@ export class AcceptInviteOrganizationDialogComponent {
   public readonly submitting = signal(false);
 
   private readonly formValue = this.initFormValue();
-  private readonly urlStatus = toSignal(this.urlControl.statusChanges.pipe(startWith(this.urlControl.status)));
+  private readonly urlStatus = signal<FormControlStatus>(this.urlControl.status);
 
   protected readonly isNewOrg = computed(() => {
     const value = this.formValue();
@@ -58,6 +58,10 @@ export class AcceptInviteOrganizationDialogComponent {
       }
     });
 
+    this.urlControl.statusChanges.pipe(takeUntilDestroyed()).subscribe((status) => {
+      this.urlStatus.set(status);
+    });
+
     effect(() => {
       if (this.isNewOrg()) {
         this.urlControl.setValidators([trimmedRequired(), httpsUrlValidator()]);
@@ -65,6 +69,9 @@ export class AcceptInviteOrganizationDialogComponent {
         this.urlControl.clearValidators();
       }
       this.urlControl.updateValueAndValidity({ emitEvent: false });
+      // Manually sync after updateValueAndValidity({ emitEvent: false }) since
+      // suppressing the event means statusChanges won't fire for validator changes.
+      this.urlStatus.set(this.urlControl.status);
     });
   }
 

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -57,7 +57,7 @@ export class AcceptInviteOrganizationDialogComponent {
     const hasName = !!(vals?.organization ?? '').trim();
     const pendingSearch = search?.searchTerm() ?? '';
     if (!hasName && pendingSearch) return true;
-    if (!hasName) return false;
+    if (!hasName) return true;
     if (!vals?.organization_id) {
       return this.urlStatus() !== 'VALID';
     }
@@ -80,6 +80,9 @@ export class AcceptInviteOrganizationDialogComponent {
       const normalizedName = (name ?? '').trim();
       if (!normalizedName || normalizedName !== this.resolvedOrganizationName) {
         this.form.patchValue({ organization_id: null }, { emitEvent: false });
+      }
+      if (!normalizedName) {
+        this.organizationControl.markAsTouched();
       }
     });
 

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -52,19 +52,22 @@ export class AcceptInviteOrganizationDialogComponent {
     const search = this.organizationSearch();
     const vals = this.formValue();
     if (search?.manualMode()) {
+      if (!(vals?.organization ?? '').trim()) return true;
       const urlValue = (vals?.organization_url ?? '').trim();
       if (!urlValue) return true;
       return this.urlStatus() !== 'VALID';
     }
     const hasName = !!(vals?.organization ?? '').trim();
-    const pendingSearch = search?.searchTerm() ?? '';
-    if (!hasName && pendingSearch) return true;
     if (!hasName) return true;
     if (!vals?.organization_id) {
       const urlValue = (vals?.organization_url ?? '').trim();
       if (!urlValue) return true;
       return this.urlStatus() !== 'VALID';
     }
+    // Block if visible search term was edited without a new selection — confirmed name/id may be stale.
+    const searchTerm = search?.searchTerm() ?? '';
+    const orgName = (vals?.organization ?? '').trim();
+    if (searchTerm && searchTerm.toLowerCase() !== orgName.toLowerCase()) return true;
     return false;
   });
 
@@ -127,7 +130,8 @@ export class AcceptInviteOrganizationDialogComponent {
 
     this.submitting.set(true);
     const orgSearch = this.organizationSearch();
-    const resolve$ = orgSearch ? orgSearch.resolveCurrentEntry() : null;
+    const alreadyResolved = !!this.formValue()?.organization_id;
+    const resolve$ = orgSearch && !alreadyResolved ? orgSearch.resolveCurrentEntry() : null;
 
     const finish = (): void => {
       const raw = this.form.getRawValue();

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -12,6 +12,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { currentEmployerFromWorkExperiences, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationService } from '@services/invitation.service';
+import { OrganizationService } from '@services/organization.service';
 import { DialogService } from 'primeng/dynamicdialog';
 import { EMPTY, Observable, catchError, from, map, of, switchMap, take } from 'rxjs';
 
@@ -21,6 +22,7 @@ import { EMPTY, Observable, catchError, from, map, of, switchMap, take } from 'r
 export class InvitationAcceptFlowService {
   private readonly dialogService = inject(DialogService);
   private readonly invitationService = inject(InvitationService);
+  private readonly organizationService = inject(OrganizationService);
   private readonly http = inject(HttpClient);
 
   /**
@@ -49,6 +51,7 @@ export class InvitationAcceptFlowService {
         );
 
     return contextReady$.pipe(
+      switchMap((ctx) => this.preResolveOrganization(ctx)),
       switchMap((ctx) => from(this.openOrganizationDialog(ctx))),
       switchMap((result) => {
         if (!result?.organization) {
@@ -56,6 +59,26 @@ export class InvitationAcceptFlowService {
         }
         return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization);
       })
+    );
+  }
+
+  /**
+   * Attempts to resolve an org name to a CDP id before the dialog opens so a pre-filled
+   * name with no id is not treated as a brand-new org requiring a manual website entry.
+   * Silently passes context through on failure — the dialog handles the unresolved case.
+   */
+  private preResolveOrganization(ctx: InvitationAcceptContext): Observable<InvitationAcceptContext> {
+    const org = ctx.organization;
+    if (!org?.name?.trim() || org.id) {
+      return of(ctx);
+    }
+    return this.organizationService.resolveOrganization(org.name, org.website ?? '').pipe(
+      take(1),
+      map((resolved) => ({
+        ...ctx,
+        organization: { ...org, id: resolved.id || null, name: resolved.name },
+      })),
+      catchError(() => of(ctx))
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -94,7 +94,7 @@ export class InvitationAcceptFlowService {
               ...org,
               id: resolved.id || null,
               name: resolved.name || org.name,
-              website: normalizeToUrl(match.domain) ?? undefined,
+              website: normalizeToUrl(match.domain) ?? org.website,
             },
           }))
         );

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -14,7 +14,7 @@ import { currentEmployerFromWorkExperiences, invitationRequiresOrganization } fr
 import { InvitationService } from '@services/invitation.service';
 import { OrganizationService } from '@services/organization.service';
 import { DialogService } from 'primeng/dynamicdialog';
-import { EMPTY, Observable, catchError, from, map, of, switchMap, take } from 'rxjs';
+import { EMPTY, Observable, catchError, from, map, of, switchMap, take, timeout } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -65,19 +65,36 @@ export class InvitationAcceptFlowService {
   /**
    * Attempts to resolve an org name to a CDP id before the dialog opens so a pre-filled
    * name with no id is not treated as a brand-new org requiring a manual website entry.
-   * Silently passes context through on failure — the dialog handles the unresolved case.
+   *
+   * Uses a two-step read-only approach to avoid the find-or-create side effect of calling
+   * resolveOrganization directly with an empty or unverified domain:
+   *  1. Search by name (read-only GET) to find the CDP-canonical domain.
+   *  2. Resolve only on an exact name match, using the canonical domain so the CDP call
+   *     is almost certainly a find (not a create).
+   *
+   * Times out after 2 s and silently falls through — the dialog handles the unresolved case.
    */
   private preResolveOrganization(ctx: InvitationAcceptContext): Observable<InvitationAcceptContext> {
     const org = ctx.organization;
     if (!org?.name?.trim() || org.id) {
       return of(ctx);
     }
-    return this.organizationService.resolveOrganization(org.name, org.website ?? '').pipe(
+    return this.organizationService.searchOrganizations(org.name).pipe(
       take(1),
-      map((resolved) => ({
-        ...ctx,
-        organization: { ...org, id: resolved.id || null, name: resolved.name || org.name },
-      })),
+      switchMap((suggestions) => {
+        const match = suggestions.find((s) => s.name.toLowerCase() === org.name!.toLowerCase().trim());
+        if (!match) {
+          return of(ctx);
+        }
+        return this.organizationService.resolveOrganization(match.name, match.domain).pipe(
+          take(1),
+          map((resolved) => ({
+            ...ctx,
+            organization: { ...org, id: resolved.id || null, name: resolved.name || org.name },
+          }))
+        );
+      }),
+      timeout(2000),
       catchError((error) => {
         console.warn('[InvitationAcceptFlowService] Org pre-resolution failed; opening dialog with unresolved context', error);
         return of(ctx);

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -10,7 +10,7 @@ import {
   InvitationAcceptContext,
   WorkExperienceEntry,
 } from '@lfx-one/shared/interfaces';
-import { currentEmployerFromWorkExperiences, invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import { currentEmployerFromWorkExperiences, invitationRequiresOrganization, normalizeToUrl } from '@lfx-one/shared/utils';
 import { InvitationService } from '@services/invitation.service';
 import { OrganizationService } from '@services/organization.service';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -90,7 +90,12 @@ export class InvitationAcceptFlowService {
           take(1),
           map((resolved) => ({
             ...ctx,
-            organization: { ...org, id: resolved.id || null, name: resolved.name || org.name },
+            organization: {
+              ...org,
+              id: resolved.id || null,
+              name: resolved.name || org.name,
+              website: normalizeToUrl(match.domain) ?? undefined,
+            },
           }))
         );
       }),

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -76,7 +76,7 @@ export class InvitationAcceptFlowService {
       take(1),
       map((resolved) => ({
         ...ctx,
-        organization: { ...org, id: resolved.id || null, name: resolved.name },
+        organization: { ...org, id: resolved.id || null, name: resolved.name || org.name },
       })),
       catchError(() => of(ctx))
     );

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -78,7 +78,10 @@ export class InvitationAcceptFlowService {
         ...ctx,
         organization: { ...org, id: resolved.id || null, name: resolved.name || org.name },
       })),
-      catchError(() => of(ctx))
+      catchError((error) => {
+        console.warn('[InvitationAcceptFlowService] Org pre-resolution failed; opening dialog with unresolved context', error);
+        return of(ctx);
+      })
     );
   }
 


### PR DESCRIPTION
## Summary

- Pre-resolve the organization name against CDP in \`InvitationAcceptFlowService\` before opening the accept dialog, so a pre-filled org with a name but no CDP id is not treated as a brand-new org requiring manual website entry
- Fall back silently (with a \`console.warn\`) to the unresolved context on CDP failure — the dialog handles manual entry as before
- Guard against an empty/missing name in the CDP response with \`resolved.name || org.name\`

## Ticket

[LFXV2-2751](https://linuxfoundation.atlassian.net/browse/LFXV2-2751)

## Root cause

\`AcceptInviteOrganizationDialogComponent.isNewOrg()\` evaluates to \`true\` when \`organization_id\` is null and \`organization\` has a name. This triggers a required URL validator, making the form invalid and causing \`onConfirm()\` to silently bail before any network call. Users whose invite or work-experience employer had a name but no CDP id could not proceed without re-typing the org name and selecting from the autocomplete.

## Approach

Added a \`preResolveOrganization()\` step in the \`accept()\` observable chain, between the existing work-experience fallback and the dialog open. If CDP resolves the name to an id, the dialog opens with \`organization_id\` already populated, \`isNewOrg()\` stays false, and the user can confirm without entering a URL. On failure, context passes through unchanged.

## Trade-offs

- **Pre-resolution latency**: \`preResolveOrganization()\` runs two sequential HTTP calls (\`/organizations/search\` then \`/organizations/resolve\`) before the dialog opens. For the exact users this PR fixes (invite/work-experience org with a name but no CDP id), this adds up to 2 s of latency before the dialog appears. The 2 s \`timeout\` bounds the worst case and the fallthrough is silent. The trade-off was accepted to ensure the dialog always opens in a clean state (URL field not required, no transient validation error flash). A follow-up could open the dialog immediately and resolve in the background, patching the form once the id arrives.
- **No unit tests added**: no existing frontend service spec files exist in the codebase to pattern from; a follow-up should establish the pattern and cover this service

[LFXV2-2751]: https://linuxfoundation.atlassian.net/browse/LFXV2-2751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ