### PR TITLE
feat(dashboards): add lf events summary tiles to overview

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.html
@@ -1,0 +1,47 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="events-summary-section">
+  <!-- Header -->
+  <div class="flex flex-col gap-0.5">
+    <h3 class="text-base font-semibold text-gray-900">YTD Events summary</h3>
+    <p class="text-xs text-gray-500">Event reach and engagement · {{ foundationName() || 'All foundations' }}</p>
+  </div>
+
+  <!-- Tiles -->
+  @if (loading()) {
+    <div class="grid grid-cols-2 gap-x-6 gap-y-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7" data-testid="events-summary-skeleton">
+      @for (i of skeletons; track i) {
+        <div class="flex flex-col gap-2">
+          <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-7 w-16 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="grid grid-cols-2 gap-x-6 gap-y-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7" role="list" data-testid="events-summary-tiles">
+      @for (stat of stats(); track stat.id) {
+        <div class="flex flex-col gap-2" role="listitem" [attr.data-testid]="'events-summary-tile-' + stat.id">
+          <div class="flex items-center gap-1.5">
+            <span class="inline-flex h-6 w-6 items-center justify-center rounded-md" [ngClass]="stat.iconClass">
+              <i [class]="stat.icon + ' text-xs'" aria-hidden="true"></i>
+            </span>
+            <span class="text-xs font-medium text-gray-500">{{ stat.label }}</span>
+          </div>
+          <span class="text-2xl font-semibold text-gray-900">{{ stat.value }}</span>
+          @if (stat.delta) {
+            <span
+              class="text-xs font-medium"
+              [ngClass]="{
+                'text-emerald-600': stat.deltaTrend === 'up',
+                'text-red-600': stat.deltaTrend === 'down',
+                'text-gray-400': stat.deltaTrend === 'neutral',
+              }"
+              >{{ stat.delta }}</span
+            >
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.ts
@@ -1,0 +1,141 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { combineLatest, finalize, map, of, switchMap } from 'rxjs';
+
+import type { EventsOverviewSummary, EventsSummaryStat } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-events-summary-section',
+  imports: [NgClass],
+  templateUrl: './events-summary-section.component.html',
+})
+export class EventsSummarySectionComponent {
+  // Ordered tile definitions. `key` maps to EventsOverviewSummary; a null value
+  // renders a dash so metrics without a confirmed data source stay honest.
+  // `format` defaults to a plain count; 'currency' formats the value as dollars.
+  private static readonly tiles: readonly {
+    id: string;
+    key: keyof EventsOverviewSummary;
+    label: string;
+    icon: string;
+    iconClass: string;
+    format?: 'currency';
+  }[] = [
+    { id: 'events', key: 'events', label: 'Total Events', icon: 'fa-light fa-calendar-star', iconClass: 'bg-blue-100 text-blue-600' },
+    { id: 'registrations', key: 'registrations', label: 'Total Registrations', icon: 'fa-light fa-user-plus', iconClass: 'bg-violet-100 text-violet-600' },
+    { id: 'attendees', key: 'attendees', label: 'Total Attendees', icon: 'fa-light fa-users', iconClass: 'bg-green-100 text-green-600' },
+    { id: 'speakers', key: 'speakers', label: 'Total Speakers', icon: 'fa-light fa-microphone-lines', iconClass: 'bg-amber-100 text-amber-600' },
+    { id: 'organizations', key: 'organizations', label: 'Total Organizations', icon: 'fa-light fa-building', iconClass: 'bg-blue-100 text-blue-600' },
+    {
+      id: 'sponsorship',
+      key: 'sponsorship',
+      label: 'Sponsorship',
+      icon: 'fa-light fa-handshake',
+      iconClass: 'bg-green-100 text-green-600',
+      format: 'currency',
+    },
+    { id: 'countries', key: 'countries', label: 'Total Countries', icon: 'fa-light fa-earth-americas', iconClass: 'bg-violet-100 text-violet-600' },
+  ];
+
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+  public readonly selectedPeriod = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  protected readonly summary: Signal<EventsOverviewSummary | null> = this.initSummary();
+  protected readonly stats: Signal<EventsSummaryStat[]> = this.initStats();
+  protected readonly skeletons: readonly number[] = EventsSummarySectionComponent.tiles.map((_, i) => i);
+
+  // === Private Initializers ===
+  private initSummary(): Signal<EventsOverviewSummary | null> {
+    const slug$ = toObservable(this.foundationSlug);
+    const period$ = toObservable(this.selectedPeriod);
+
+    return toSignal(
+      combineLatest([slug$, period$]).pipe(
+        switchMap(([slug]) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          // All 7 tiles come from a single YTD-scoped endpoint over
+          // PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW + MARKETING_EVENT_SPONSORSHIPS. Each
+          // metric carries its value and a YoY change fraction (null when no prior baseline);
+          // a null response falls the whole block back to dashes.
+          return this.analyticsService.getEventsOverviewSummary(slug).pipe(
+            map((data) =>
+              data === null
+                ? null
+                : ({
+                    registrations: data.registrations,
+                    attendees: data.attendees,
+                    events: data.events,
+                    speakers: data.speakers,
+                    organizations: data.organizations,
+                    countries: data.countries,
+                    sponsorship: data.sponsorship,
+                  } satisfies EventsOverviewSummary)
+            ),
+            finalize(() => this.loading.set(false))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initStats(): Signal<EventsSummaryStat[]> {
+    return computed(() => {
+      const data = this.summary();
+      return EventsSummarySectionComponent.tiles.map((tile) => {
+        const metric = data ? data[tile.key] : null;
+        let value = '—';
+        if (metric) {
+          value = tile.format === 'currency' ? formatCurrency(metric.value) : formatNumber(metric.value);
+        }
+
+        // YoY delta from the change fraction (0.52 = +52%). Sponsorship has no modeled YoY
+        // (changeFraction null) so its tile shows no delta.
+        let delta: string | null = null;
+        let deltaTrend: 'up' | 'down' | 'neutral' = 'neutral';
+        const change = metric?.changeFraction;
+        if (change !== null && change !== undefined) {
+          const pct = Math.round(change * 100);
+          if (pct > 0) {
+            delta = `▲ ${pct}% YoY`;
+            deltaTrend = 'up';
+          } else if (pct < 0) {
+            delta = `▼ ${Math.abs(pct)}% YoY`;
+            deltaTrend = 'down';
+          } else {
+            delta = '— vs LY';
+          }
+        }
+
+        return {
+          id: tile.id,
+          label: tile.label,
+          icon: tile.icon,
+          iconClass: tile.iconClass,
+          value,
+          delta,
+          deltaTrend,
+        };
+      });
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -1,22 +1,16 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<lfx-events-summary-section
+  [foundationSlug]="foundationSlug()"
+  [foundationName]="foundationName()"
+  [selectedPeriod]="selectedPeriod()"
+  data-testid="overview-tab-events-summary" />
+
 <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-5" data-testid="overview-tab-summary-header">
-  <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
-    <div class="flex flex-col gap-0.5">
-      <h3 class="text-base font-semibold text-gray-900">{{ summaryTitle() }}</h3>
-      <p class="text-xs text-gray-500">{{ summarySubtitle() }}</p>
-    </div>
-    <div class="flex items-center gap-4">
-      <lfx-button
-        label="View executive summary"
-        icon="fa-light fa-arrow-up-right-from-square"
-        severity="secondary"
-        [outlined]="true"
-        [disabled]="true"
-        ariaLabel="View executive summary (coming soon)"
-        data-testid="overview-tab-exec-summary-btn" />
-    </div>
+  <div class="flex flex-col gap-0.5">
+    <h3 class="text-base font-semibold text-gray-900">{{ summaryTitle() }}</h3>
+    <p class="text-xs text-gray-500">{{ summarySubtitle() }}</p>
   </div>
 
   <div class="grid grid-cols-1 gap-4 pt-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="overview-tab-kpi-grid">
@@ -41,13 +35,11 @@
   </div>
 </div>
 
-@if (!isProjectWebsites()) {
-  <lfx-attribution-section
-    [foundationSlug]="foundationSlug()"
-    [selectedPeriod]="selectedPeriod()"
-    [foundationName]="foundationName()"
-    [focusProgram]="focusProgram()"
-    [attributionOverride]="overviewKpiData().attribution"
-    [loadingOverride]="loading()"
-    data-testid="overview-tab-attribution-section" />
-}
+<lfx-attribution-section
+  [foundationSlug]="foundationSlug()"
+  [selectedPeriod]="selectedPeriod()"
+  [foundationName]="foundationName()"
+  [focusProgram]="focusProgram()"
+  [attributionOverride]="overviewKpiData().attribution"
+  [loadingOverride]="loading()"
+  data-testid="overview-tab-attribution-section" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -3,7 +3,6 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ButtonComponent } from '@components/button/button.component';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { formatChangePct, formatCurrency, formatNumber, isPeriodMonth, resolvePeriodRange, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
@@ -12,11 +11,12 @@ import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rx
 import type { MarketingImpactFocusProgram, OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
+import { EventsSummarySectionComponent } from '../events-summary-section/events-summary-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [ButtonComponent, SparklineKpiCardComponent, AttributionSectionComponent],
+  imports: [SparklineKpiCardComponent, AttributionSectionComponent, EventsSummarySectionComponent],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {
@@ -33,7 +33,6 @@ export class OverviewTabComponent {
   protected readonly loading = signal(false);
 
   // === Computed Signals ===
-  protected readonly isProjectWebsites = computed(() => this.focusProgram() === 'projectWebsites');
   protected readonly overviewKpiData: Signal<OverviewKpiData> = this.initOverviewKpiData();
   protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
   protected readonly summaryTitle: Signal<string> = this.initSummaryTitle();
@@ -54,14 +53,11 @@ export class OverviewTabComponent {
           }
           this.loading.set(true);
           const classification = FOCUS_TO_CLASSIFICATION[focus];
-          const isWebOnly = focus === 'projectWebsites';
           return forkJoin({
-            revenueImpact: isWebOnly
-              ? of(null)
-              : this.analyticsService.getRevenueImpact(slug, classification, period || undefined).pipe(catchError(() => of(null))),
+            revenueImpact: this.analyticsService.getRevenueImpact(slug, classification, period || undefined).pipe(catchError(() => of(null))),
             // getBrandReach uses pre-computed _30D columns that cannot be period-filtered
             brandReach: this.analyticsService.getBrandReach(slug, classification).pipe(catchError(() => of(null))),
-            emailCtr: isWebOnly ? of(null) : this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(catchError(() => of(null))),
+            emailCtr: this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(catchError(() => of(null))),
             // Attributed Revenue KPI reports Linear attribution to match the
             // "Marketing attribution" table below (same source, same model),
             // not pipeline-won CRM revenue which is a different metric.
@@ -83,11 +79,10 @@ export class OverviewTabComponent {
       const changeSuffix: 'MoM' | 'Period' = isMonth ? 'MoM' : 'Period';
       const cards: PerformanceSummaryKpi[] = [];
 
-      // Attributed Revenue is driven by the attribution response, not revenueImpact.
-      // They are fetched independently and revenueImpact is intentionally null for
-      // projectWebsites, so guarding this card on revenueImpact would hide it even
-      // when attribution data exists. An empty/unavailable channel list renders as a
-      // dash — matching the "No attribution data available" state of the table below —
+      // Attributed Revenue is driven by the attribution response, not revenueImpact
+      // (they are fetched independently and can diverge), so this card is guarded on
+      // data.attribution. An empty/unavailable channel list renders as a dash —
+      // matching the "No attribution data available" state of the table below —
       // rather than a misleading $0.
       if (data.attribution) {
         const channels = data.attribution.channels ?? [];

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.html
@@ -12,14 +12,6 @@
       }
     </div>
     <div class="flex items-center gap-3">
-      <lfx-button
-        label="Export PDF"
-        icon="fa-light fa-file-pdf"
-        severity="secondary"
-        [outlined]="true"
-        [disabled]="true"
-        ariaLabel="Export report as PDF (coming soon)"
-        data-testid="marketing-impact-export-pdf" />
       <lfx-select
         [form]="headerForm"
         control="period"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/marketing-impact.component.ts
@@ -4,7 +4,6 @@
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { ButtonComponent } from '@components/button/button.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FOCUS_VISIBLE_TABS, MARKETING_IMPACT_FOCUS_OPTIONS, MARKETING_IMPACT_TABS } from '@lfx-one/shared/constants';
@@ -33,7 +32,6 @@ import { WebActivityTabComponent } from './components/web-activity-tab/web-activ
   imports: [
     ReactiveFormsModule,
     SelectComponent,
-    ButtonComponent,
     FilterPillsComponent,
     OverviewTabComponent,
     AttributionSectionComponent,

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   MembershipChurnPerTierSummaryResponse,
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
+  EventsOverviewSummaryResponse,
   EventsSummaryResponse,
   ParticipatingOrgsSummaryResponse,
   TrainingCertificationSummaryResponse,
@@ -1111,6 +1112,16 @@ export class AnalyticsService {
         });
       })
     );
+  }
+
+  /**
+   * Foundation-wide Events Summary tiles for the Marketing Impact Overview tab.
+   * Emits null on error so the tiles fall back to dashes rather than measured zeros.
+   */
+  public getEventsOverviewSummary(foundationSlug: string): Observable<EventsOverviewSummaryResponse | null> {
+    return this.http
+      .get<EventsOverviewSummaryResponse>('/api/analytics/events-overview-summary', { params: { foundationSlug } })
+      .pipe(catchError(() => of(null)));
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2705,6 +2705,42 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/events-overview-summary
+   * Foundation-wide Events Summary tiles for the Marketing Impact Overview tab
+   * (registrations, attendees, speakers, countries, organizations, events, sponsorship $).
+   */
+  public async getEventsOverviewSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_events_overview_summary');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_events_overview_summary',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_events_overview_summary',
+        });
+      }
+
+      const response = await this.projectService.getEventsOverviewSummary(foundationSlug);
+
+      logger.success(req, 'get_events_overview_summary', startTime, {
+        foundation_slug: foundationSlug,
+        project_id: response.projectId,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/brand-reach
    * Get brand reach metrics (total digital reach across social + owned sites)
    */

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -185,6 +185,7 @@ router.get('/board-meeting-participation-summary', (req, res, next) => analytics
 
 // ED dashboard marketing endpoints — backed by ANALYTICS.PLATINUM_LFX_ONE.* Snowflake views
 router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
+router.get('/events-overview-summary', (req, res, next) => analyticsController.getEventsOverviewSummary(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -29,6 +29,8 @@ import {
   EngagedCommunitySizeResponse,
   EventGrowthResponse,
   EventGrowthTopEvent,
+  EventsOverviewMetric,
+  EventsOverviewSummaryResponse,
   EventsSummaryResponse,
   FlywheelConversionResponse,
   FoundationActiveContributorsMonthlyResponse,
@@ -4763,6 +4765,111 @@ export class ProjectService {
       sponsorshipRevenue,
       sponsorshipGoal,
       sponsorshipProgressPct,
+    };
+  }
+
+  /**
+   * Get the foundation-wide Events Summary for the Marketing Impact Overview tab.
+   *
+   * Sourced from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW (one row per project,
+   * pre-computed period columns — no date-range filtering) plus MARKETING_EVENT_SPONSORSHIPS
+   * for the sponsorship dollar total. The foundation rollup (children included) is baked into
+   * the project spine, so a single row keyed on the resolved PROJECT_ID covers the foundation.
+   *
+   * Only YTD is modeled here (the table has no monthly grain); the *_PERCENT_CHANGE_YTD columns
+   * carry the YoY deltas as fractions (0.52 = +52%), surfaced unchanged as changeFraction.
+   */
+  public async getEventsOverviewSummary(foundationSlug: string): Promise<EventsOverviewSummaryResponse> {
+    logger.debug(undefined, 'get_events_overview_summary', 'Fetching events overview summary from Snowflake', {
+      foundation_slug: foundationSlug,
+    });
+
+    interface OverviewRow {
+      PROJECT_ID: string;
+      REGISTRATIONS_COUNT: number;
+      REGISTRATIONS_CHANGE: number | null;
+      ATTENDEES_COUNT: number;
+      ATTENDEES_CHANGE: number | null;
+      SPEAKERS_COUNT: number;
+      SPEAKERS_CHANGE: number | null;
+      COUNTRIES_COUNT: number;
+      COUNTRIES_CHANGE: number | null;
+      COMPANIES_COUNT: number;
+      COMPANIES_CHANGE: number | null;
+      EVENT_COUNT: number;
+    }
+
+    interface SponsorshipRow {
+      SPONSORSHIP_REVENUE: number;
+    }
+
+    // MARKETING_EVENT_OVERVIEW is one row per project; the *_PERCENT_CHANGE_YTD columns are
+    // passed through as-is (fractions). COMPANIES maps to the "Organizations" tile.
+    const overviewQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        eo.PROJECT_ID,
+        IFNULL(eo.REGISTRATIONS_COUNT_YTD, 0) AS REGISTRATIONS_COUNT,
+        eo.REGISTRATIONS_PERCENT_CHANGE_YTD AS REGISTRATIONS_CHANGE,
+        IFNULL(eo.ATTENDEES_COUNT_YTD, 0) AS ATTENDEES_COUNT,
+        eo.ATTENDEES_PERCENT_CHANGE_YTD AS ATTENDEES_CHANGE,
+        IFNULL(eo.SPEAKERS_COUNT_YTD, 0) AS SPEAKERS_COUNT,
+        eo.SPEAKERS_PERCENT_CHANGE_YTD AS SPEAKERS_CHANGE,
+        IFNULL(eo.COUNTRIES_COUNT_YTD, 0) AS COUNTRIES_COUNT,
+        eo.COUNTRIES_PERCENT_CHANGE_YTD AS COUNTRIES_CHANGE,
+        IFNULL(eo.COMPANIES_COUNT_YTD, 0) AS COMPANIES_COUNT,
+        eo.COMPANIES_PERCENT_CHANGE_YTD AS COMPANIES_CHANGE,
+        IFNULL(eo.EVENT_COUNT_YTD, 0) AS EVENT_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW eo
+      INNER JOIN slug_resolve sr ON eo.PROJECT_ID = sr.project_id
+      LIMIT 1
+    `;
+
+    const sponsorshipQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        IFNULL(SUM(es.SPONSORSHIP_REVENUE_YTD), 0) AS SPONSORSHIP_REVENUE
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS es
+      INNER JOIN slug_resolve sr ON es.PROJECT_ID = sr.project_id
+    `;
+
+    const [overviewResult, sponsorshipResult] = await Promise.all([
+      this.snowflakeService.execute<OverviewRow>(overviewQuery, [foundationSlug]),
+      this.snowflakeService.execute<SponsorshipRow>(sponsorshipQuery, [foundationSlug]),
+    ]);
+
+    const row = overviewResult.rows?.[0];
+    const sponsorshipRow = sponsorshipResult.rows?.[0];
+
+    if (!row) {
+      logger.warning(undefined, 'get_events_overview_summary', 'No events overview row for foundation', { foundation_slug: foundationSlug });
+    }
+
+    const metric = (value: number | undefined, change: number | null | undefined): EventsOverviewMetric => ({
+      value: value ?? 0,
+      changeFraction: change ?? null,
+    });
+
+    return {
+      projectId: row?.PROJECT_ID ?? '',
+      registrations: metric(row?.REGISTRATIONS_COUNT, row?.REGISTRATIONS_CHANGE),
+      attendees: metric(row?.ATTENDEES_COUNT, row?.ATTENDEES_CHANGE),
+      speakers: metric(row?.SPEAKERS_COUNT, row?.SPEAKERS_CHANGE),
+      countries: metric(row?.COUNTRIES_COUNT, row?.COUNTRIES_CHANGE),
+      organizations: metric(row?.COMPANIES_COUNT, row?.COMPANIES_CHANGE),
+      // MARKETING_EVENT_OVERVIEW has no EVENT_COUNT_PERCENT_CHANGE_YTD, so the
+      // events tile shows a value with no YoY delta.
+      events: metric(row?.EVENT_COUNT, null),
+      // No YoY change is modeled for sponsorship revenue.
+      sponsorship: metric(sponsorshipRow?.SPONSORSHIP_REVENUE, null),
     };
   }
 

--- a/packages/shared/src/constants/marketing-impact.constants.ts
+++ b/packages/shared/src/constants/marketing-impact.constants.ts
@@ -14,10 +14,9 @@ export const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'Jun
 /** Focus program filter options for the Marketing Impact FOCUS bar. Labels match Snowflake LF_SUB_DOMAIN_CLASSIFICATION values. */
 export const MARKETING_IMPACT_FOCUS_OPTIONS: FilterPillOption[] = [
   { id: 'all', label: 'All programs' },
-  { id: 'lfCorporate', label: 'LF Corporate' },
   { id: 'lfEvents', label: 'LF Events' },
+  { id: 'lfCorporate', label: 'LF Corporate' },
   { id: 'lfTraining', label: 'LF Training' },
-  { id: 'projectWebsites', label: 'Project Websites' },
 ];
 
 /** Tab definitions for the Marketing Impact section tabs. */
@@ -59,16 +58,14 @@ export const FOCUS_TO_CLASSIFICATION: Record<MarketingImpactFocusProgram, string
   lfCorporate: 'LF Corporate',
   lfEvents: 'LF Events',
   lfTraining: 'LF Training',
-  projectWebsites: 'Project Websites',
 };
 
 export const VALID_CLASSIFICATIONS: ReadonlySet<string> = new Set(Object.values(FOCUS_TO_CLASSIFICATION).filter((v): v is string => v !== undefined));
 
-/** Which tabs are visible for each focus area. Social tabs are hidden for non-"all" focuses (no classification filtering); Email is additionally hidden for projectWebsites (no email campaign data). */
+/** Which tabs are visible for each focus area. Social tabs are hidden for non-"all" focuses (no classification filtering). */
 export const FOCUS_VISIBLE_TABS: Record<MarketingImpactFocusProgram, ReadonlySet<MarketingImpactTab>> = {
   all: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity', 'social-accounts', 'social-listening']),
   lfCorporate: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
   lfEvents: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
   lfTraining: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'email', 'web-activity']),
-  projectWebsites: new Set<MarketingImpactTab>(['overview', 'attribution', 'performance-marketing', 'web-activity']),
 };

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -635,6 +635,36 @@ export interface EventsSummaryResponse {
   sponsorshipProgressPct: number;
 }
 
+/**
+ * A single Events Summary metric: its period value and the period-over-period change.
+ * `changeFraction` is a ratio from Snowflake (0.52 = +52%), not a percentage; null when
+ * there is no prior-period baseline to compare against.
+ */
+export interface EventsOverviewMetric {
+  value: number;
+  changeFraction: number | null;
+}
+
+/**
+ * Foundation-wide events summary for the Marketing Impact Overview tab, sourced from
+ * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW (per-project, pre-computed period
+ * columns) + MARKETING_EVENT_SPONSORSHIPS. One row per foundation slug (project spine rolls
+ * children up). Counts are for the selected period (YTD by default).
+ */
+export interface EventsOverviewSummaryResponse {
+  /** Snowflake PROJECT_ID echoed for PCC deep-link navigation; '' when the slug resolves to nothing. */
+  projectId: string;
+  registrations: EventsOverviewMetric;
+  attendees: EventsOverviewMetric;
+  speakers: EventsOverviewMetric;
+  countries: EventsOverviewMetric;
+  /** "Organizations" tile — COMPANIES_COUNT in the source model. */
+  organizations: EventsOverviewMetric;
+  events: EventsOverviewMetric;
+  /** Sponsorship revenue in dollars; no YoY change is modeled, so changeFraction is null. */
+  sponsorship: EventsOverviewMetric;
+}
+
 // ============================================
 // Training & Certification (Health Metrics Card)
 // ============================================

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -9,6 +9,7 @@ import type {
   PaidProjectPerformance,
   RevenueImpactResponse,
 } from './analytics-data.interface';
+import type { EventsOverviewMetric } from './dashboard-metric.interface';
 
 /** Period option for the Marketing Impact date range picker. */
 export interface MarketingImpactPeriodOption {
@@ -31,7 +32,7 @@ export interface MarketingImpactTabOption {
 }
 
 /** Focus program identifiers for the Marketing Impact FOCUS filter bar. Values map to Snowflake LF_SUB_DOMAIN_CLASSIFICATION via FOCUS_TO_CLASSIFICATION. */
-export type MarketingImpactFocusProgram = 'all' | 'lfCorporate' | 'lfEvents' | 'lfTraining' | 'projectWebsites';
+export type MarketingImpactFocusProgram = 'all' | 'lfCorporate' | 'lfEvents' | 'lfTraining';
 
 /** Tab identifiers for the Marketing Impact section tabs. */
 export type MarketingImpactTab = 'overview' | 'attribution' | 'performance-marketing' | 'email' | 'web-activity' | 'social-accounts' | 'social-listening';
@@ -42,6 +43,36 @@ export interface OverviewKpiData {
   brandReach: BrandReachResponse | null;
   emailCtr: EmailCtrResponse | null;
   attribution: MarketingAttributionResponse | null;
+}
+
+/**
+ * Foundation-wide events summary for the selected period, driving the Events Summary tile
+ * row at the top of the Overview tab. Each metric carries its value plus a YoY change
+ * fraction (0.52 = +52%; null when there is no prior baseline).
+ */
+export interface EventsOverviewSummary {
+  registrations: EventsOverviewMetric;
+  attendees: EventsOverviewMetric;
+  events: EventsOverviewMetric;
+  speakers: EventsOverviewMetric;
+  organizations: EventsOverviewMetric;
+  countries: EventsOverviewMetric;
+  /** Aggregate sponsorship revenue in dollars for the period. */
+  sponsorship: EventsOverviewMetric;
+}
+
+/** Pre-formatted view-model for a single Events Summary stat tile. */
+export interface EventsSummaryStat {
+  id: string;
+  label: string;
+  icon: string;
+  iconClass: string;
+  /** Formatted value string, or a dash when the underlying metric is null (no data yet). */
+  value: string;
+  /** Formatted YoY delta (e.g. "▲ 12% YoY"), or null when there is no baseline. */
+  delta: string | null;
+  /** Trend direction for coloring the delta. */
+  deltaTrend: 'up' | 'down' | 'neutral';
 }
 
 /** Pre-formatted KPI card data for the Marketing Impact performance summary. */


### PR DESCRIPTION
## Summary
Adds a 7-tile **Events Summary** block to the top of the Marketing Impact Overview tab, sourced from `ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW` (YTD columns) + `MARKETING_EVENT_SPONSORSHIPS`. Tiles: Events, Registrations, Attendees, Speakers, Organizations, Sponsorship ($), Countries — each with a YoY delta where the source models it. Foundation scope resolves slug→project via `ENGAGEMENT_SCORES_BY_CLASSIFICATION`.

Also cleans up the FOCUS bar (LF Events promoted, Project Websites removed) and drops the disabled "View executive summary" / "Export PDF" buttons.

**Part of a 6-PR stack for the LF Events dashboard (LFXV2-2768). This is PR 1/6 — base `main`.**

All queries validated live against Snowflake. Typecheck + lint pass.

LFXV2-2768
