### PR TITLE
feat(dashboards): add event roster with goal bars to overview

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
@@ -1,0 +1,137 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="event-roster-section">
+  <!-- Header -->
+  <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-base font-semibold text-gray-900">Events</h3>
+      <p class="text-xs text-gray-500">Registrations and sponsorship vs goal · click an event to open it</p>
+    </div>
+    <div class="flex items-center gap-3">
+      <div class="relative">
+        <i class="fa-light fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400" aria-hidden="true"></i>
+        <input
+          type="search"
+          [formControl]="search"
+          placeholder="Search events…"
+          aria-label="Search events"
+          class="w-56 rounded-md border border-gray-200 py-2 pl-8 pr-3 text-xs text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          data-testid="event-roster-search" />
+      </div>
+      <div class="flex items-center gap-1 rounded-full border border-gray-200 p-1" role="group" aria-label="Event scope">
+        <button
+          type="button"
+          class="rounded-full px-3 py-1 text-xs font-semibold"
+          [ngClass]="!includePast() ? 'bg-blue-500 text-white' : 'text-gray-500'"
+          (click)="toggleIncludePast(false)"
+          data-testid="event-roster-upcoming">
+          Upcoming
+        </button>
+        <button
+          type="button"
+          class="rounded-full px-3 py-1 text-xs font-semibold"
+          [ngClass]="includePast() ? 'bg-blue-500 text-white' : 'text-gray-500'"
+          (click)="toggleIncludePast(true)"
+          data-testid="event-roster-all">
+          All events
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Table -->
+  @if (loading()) {
+    <div class="flex flex-col gap-3" data-testid="event-roster-skeleton">
+      @for (i of skeletons; track i) {
+        <div class="flex items-center gap-4">
+          <div class="h-4 w-20 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-4 w-48 animate-pulse rounded bg-gray-100"></div>
+          <div class="h-4 flex-1 animate-pulse rounded bg-gray-100"></div>
+          <div class="h-4 flex-1 animate-pulse rounded bg-gray-100"></div>
+        </div>
+      }
+    </div>
+  } @else if (hasRows()) {
+    <div class="flex flex-col gap-0 overflow-x-auto" role="table" aria-label="Event roster" data-testid="event-roster-table">
+      <!-- Header row -->
+      <div class="flex items-center gap-4 border-b border-gray-200 pb-2 text-[11px] font-semibold tracking-wide text-gray-400" role="row">
+        <span class="w-24" role="columnheader">DATE</span>
+        <span class="flex-1 min-w-[180px]" role="columnheader">NAME</span>
+        <span class="w-52" role="columnheader">REGISTRATIONS</span>
+        <span class="w-52" role="columnheader">SPONSORSHIP REV.</span>
+        <span class="w-28 text-right" role="columnheader">CFP</span>
+      </div>
+
+      <!-- Rows -->
+      @for (row of rows(); track row.eventId) {
+        <div class="flex items-center gap-4 border-b border-gray-100 py-3" role="row" [attr.data-testid]="'event-roster-row-' + row.eventId">
+          <span class="w-24 text-xs text-gray-500 tabular-nums" role="cell">{{ row.dateLabel }}</span>
+
+          <div class="flex flex-1 min-w-[180px] items-center gap-2" role="cell">
+            @if (row.eventUrl) {
+              <a [href]="row.eventUrl" target="_blank" rel="noopener noreferrer" class="truncate text-xs font-semibold text-blue-600 hover:underline">{{
+                row.eventName
+              }}</a>
+            } @else {
+              <span class="truncate text-xs font-semibold text-gray-700">{{ row.eventName }}</span>
+            }
+            @if (row.atRisk) {
+              <i class="fa-solid fa-circle-exclamation text-xs text-red-500" aria-label="Behind registration goal" title="Behind registration goal"></i>
+            }
+          </div>
+
+          <!-- Registrations bar -->
+          <div class="w-52" role="cell">
+            <div class="flex items-baseline justify-between gap-2">
+              <span class="text-xs font-semibold text-blue-600 tabular-nums">{{ row.registrations.actual }}</span>
+              @if (row.registrations.hasGoal) {
+                <span class="text-[11px] text-gray-400 tabular-nums">{{ row.registrations.goal }}</span>
+              }
+            </div>
+            @if (row.registrations.hasGoal) {
+              <div class="mt-1 h-1.5 overflow-hidden rounded-full bg-gray-100">
+                <div
+                  class="h-full rounded-full"
+                  [ngClass]="{
+                    'bg-emerald-500': row.registrations.tone === 'good',
+                    'bg-amber-500': row.registrations.tone === 'warn',
+                    'bg-red-400': row.registrations.tone === 'critical',
+                  }"
+                  [style.width.%]="row.registrations.percent"></div>
+              </div>
+            }
+          </div>
+
+          <!-- Sponsorship revenue bar -->
+          <div class="w-52" role="cell">
+            <div class="flex items-baseline justify-between gap-2">
+              <span class="text-xs font-semibold text-gray-900 tabular-nums">{{ row.sponsorshipRevenue.actual }}</span>
+              @if (row.sponsorshipRevenue.hasGoal) {
+                <span class="text-[11px] text-gray-400 tabular-nums">{{ row.sponsorshipRevenue.goal }}</span>
+              }
+            </div>
+            @if (row.sponsorshipRevenue.hasGoal) {
+              <div class="mt-1 h-1.5 overflow-hidden rounded-full bg-gray-100">
+                <div
+                  class="h-full rounded-full"
+                  [ngClass]="{
+                    'bg-emerald-500': row.sponsorshipRevenue.tone === 'good',
+                    'bg-amber-500': row.sponsorshipRevenue.tone === 'warn',
+                    'bg-red-400': row.sponsorshipRevenue.tone === 'critical',
+                  }"
+                  [style.width.%]="row.sponsorshipRevenue.percent"></div>
+              </div>
+            }
+          </div>
+
+          <span class="w-28 truncate text-right text-[11px] text-gray-500" role="cell">{{ row.cfpStatus || '—' }}</span>
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="event-roster-empty">
+      <p class="text-sm text-gray-500">No events match your search.</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { combineLatest, finalize, of, startWith, switchMap } from 'rxjs';
+
+import type { EventRosterBar, EventRosterResponse, EventRosterRow, EventRosterRowView } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-event-roster-section',
+  imports: [NgClass, ReactiveFormsModule],
+  templateUrl: './event-roster-section.component.html',
+})
+export class EventRosterSectionComponent {
+  // === Services ===
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+
+  // === Controls ===
+  protected readonly search = new FormControl('', { nonNullable: true });
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+  protected readonly includePast = signal(false);
+  protected readonly skeletons: readonly number[] = [0, 1, 2, 3, 4];
+
+  // === Computed Signals ===
+  protected readonly roster: Signal<EventRosterResponse> = this.initRoster();
+  protected readonly searchTerm: Signal<string> = toSignal(this.search.valueChanges.pipe(startWith('')), { initialValue: '' });
+  protected readonly rows: Signal<EventRosterRowView[]> = this.initRows();
+  protected readonly hasRows = computed(() => this.rows().length > 0);
+
+  // === Protected Methods ===
+  protected toggleIncludePast(includePast: boolean): void {
+    this.includePast.set(includePast);
+  }
+
+  // === Private Initializers ===
+  private initRoster(): Signal<EventRosterResponse> {
+    const slug$ = toObservable(this.foundationSlug);
+    const past$ = toObservable(this.includePast);
+
+    return toSignal(
+      combineLatest([slug$, past$]).pipe(
+        switchMap(([slug, includePast]) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of({ projectId: '', events: [] });
+          }
+          this.loading.set(true);
+          return this.analyticsService.getEventRoster(slug, includePast).pipe(finalize(() => this.loading.set(false)));
+        })
+      ),
+      { initialValue: { projectId: '', events: [] } }
+    );
+  }
+
+  private initRows(): Signal<EventRosterRowView[]> {
+    return computed(() => {
+      const term = this.searchTerm().trim().toLowerCase();
+      const events = this.roster().events;
+      const filtered = term ? events.filter((e) => e.eventName.toLowerCase().includes(term)) : events;
+      return filtered.map((event) => this.toView(event));
+    });
+  }
+
+  // === Private Helpers ===
+  private toView(event: EventRosterRow): EventRosterRowView {
+    const registrations = this.toBar(event.registrations.actual, event.registrations.goal, false);
+    const sponsorshipRevenue = this.toBar(event.sponsorshipRevenue.actual, event.sponsorshipRevenue.goal, true);
+    // At-risk = a real registration goal the event is materially behind on, and a low pace vs last year.
+    const behindGoal = registrations.hasGoal && registrations.percent < 50;
+    const atRisk = behindGoal && event.compScore === 'low';
+
+    return {
+      eventId: event.eventId,
+      eventName: event.eventName,
+      dateLabel: this.formatDate(event.startDate),
+      eventUrl: event.eventUrl,
+      country: event.country,
+      registrations,
+      sponsorshipRevenue,
+      atRisk,
+      cfpStatus: event.cfpStatus,
+    };
+  }
+
+  private toBar(actual: number, goal: number, currency: boolean): EventRosterBar {
+    const fmt = (value: number): string => (currency ? formatCurrency(value) : formatNumber(value));
+    // Goal of 0/absent means "no goal required" — render no bar (matches PCC).
+    if (!goal || goal <= 0) {
+      return { actual: fmt(actual), goal: fmt(0), percent: 0, hasGoal: false, tone: 'none' };
+    }
+    const percent = Math.min(100, Math.round((actual / goal) * 100));
+    let tone: EventRosterBar['tone'] = 'critical';
+    if (percent >= 80) {
+      tone = 'good';
+    } else if (percent >= 50) {
+      tone = 'warn';
+    }
+    return { actual: fmt(actual), goal: fmt(goal), percent, hasGoal: true, tone };
+  }
+
+  private formatDate(iso: string): string {
+    const [year, month, day] = iso.split('-').map(Number);
+    if (!year || !month || !day) return iso;
+    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -7,6 +7,8 @@
   [selectedPeriod]="selectedPeriod()"
   data-testid="overview-tab-events-summary" />
 
+<lfx-event-roster-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-event-roster" />
+
 <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-5" data-testid="overview-tab-summary-header">
   <div class="flex flex-col gap-0.5">
     <h3 class="text-base font-semibold text-gray-900">{{ summaryTitle() }}</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -11,12 +11,13 @@ import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rx
 import type { MarketingImpactFocusProgram, OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
+import { EventRosterSectionComponent } from '../event-roster-section/event-roster-section.component';
 import { EventsSummarySectionComponent } from '../events-summary-section/events-summary-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [SparklineKpiCardComponent, AttributionSectionComponent, EventsSummarySectionComponent],
+  imports: [SparklineKpiCardComponent, AttributionSectionComponent, EventsSummarySectionComponent, EventRosterSectionComponent],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   MembershipChurnPerTierSummaryResponse,
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
+  EventRosterResponse,
   EventsOverviewSummaryResponse,
   EventsSummaryResponse,
   ParticipatingOrgsSummaryResponse,
@@ -1122,6 +1123,18 @@ export class AnalyticsService {
     return this.http
       .get<EventsOverviewSummaryResponse>('/api/analytics/events-overview-summary', { params: { foundationSlug } })
       .pipe(catchError(() => of(null)));
+  }
+
+  /**
+   * Foundation event roster (upcoming by default; pass includePast for the full history).
+   * Emits an empty roster on error so the table shows its empty state rather than breaking.
+   */
+  public getEventRoster(foundationSlug: string, includePast = false): Observable<EventRosterResponse> {
+    const params: Record<string, string> = { foundationSlug };
+    if (includePast) {
+      params['includePast'] = 'true';
+    }
+    return this.http.get<EventRosterResponse>('/api/analytics/event-roster', { params }).pipe(catchError(() => of({ projectId: '', events: [] })));
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2741,6 +2741,46 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/event-roster
+   * Foundation event roster — one row per event with registration/sponsorship
+   * actual-vs-goal, comparison rating, and CFP status. Defaults to upcoming events;
+   * pass includePast=true for the full history.
+   */
+  public async getEventRoster(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_roster');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_roster',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_roster',
+        });
+      }
+
+      const includePast = getStringQueryParam(req, 'includePast') === 'true';
+
+      const response = await this.projectService.getEventRoster(foundationSlug, includePast);
+
+      logger.success(req, 'get_event_roster', startTime, {
+        foundation_slug: foundationSlug,
+        include_past: includePast,
+        event_count: response.events.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/brand-reach
    * Get brand reach metrics (total digital reach across social + owned sites)
    */

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -186,6 +186,7 @@ router.get('/board-meeting-participation-summary', (req, res, next) => analytics
 // ED dashboard marketing endpoints — backed by ANALYTICS.PLATINUM_LFX_ONE.* Snowflake views
 router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
 router.get('/events-overview-summary', (req, res, next) => analyticsController.getEventsOverviewSummary(req, res, next));
+router.get('/event-roster', (req, res, next) => analyticsController.getEventRoster(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -27,8 +27,11 @@ import {
   CreateProjectDocumentRequest,
   EmailCtrResponse,
   EngagedCommunitySizeResponse,
+  EventCompScore,
   EventGrowthResponse,
   EventGrowthTopEvent,
+  EventRosterResponse,
+  EventRosterRow,
   EventsOverviewMetric,
   EventsOverviewSummaryResponse,
   EventsSummaryResponse,
@@ -4871,6 +4874,100 @@ export class ProjectService {
       // No YoY change is modeled for sponsorship revenue.
       sponsorship: metric(sponsorshipRow?.SPONSORSHIP_REVENUE, null),
     };
+  }
+
+  /**
+   * Get the Event Roster for a foundation — one row per event with registration and
+   * sponsorship actual-vs-goal, comparison rating, and CFP status.
+   *
+   * Sourced from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS (per event) left
+   * joined to sponsorship actuals aggregated from MARKETING_EVENT_SPONSORSHIPS_BY_TIER. A goal
+   * of 0 means "no goal required" for that event (the UI renders no progress bar). Defaults to
+   * upcoming events only; pass includePast to return the full history.
+   */
+  public async getEventRoster(foundationSlug: string, includePast = false): Promise<EventRosterResponse> {
+    logger.debug(undefined, 'get_event_roster', 'Fetching event roster from Snowflake', {
+      foundation_slug: foundationSlug,
+      include_past: includePast,
+    });
+
+    interface RosterRow {
+      EVENT_ID: string;
+      EVENT_NAME: string;
+      START_DATE: string;
+      EVENT_IS_PAST: boolean;
+      EVENT_COUNTRY: string | null;
+      EVENT_URL: string | null;
+      REG_ACTUAL: number | null;
+      REG_GOAL: number | null;
+      SPON_ACTUAL: number;
+      SPON_GOAL: number | null;
+      REGREV_ACTUAL: number | null;
+      REGREV_GOAL: number | null;
+      VS_LY: number | null;
+      COMP_SCORE: string | null;
+      CFP_STATUS: string | null;
+    }
+
+    const pastFilter = includePast ? '' : 'AND r.EVENT_IS_PAST = FALSE';
+
+    const query = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      ),
+      sponsorship AS (
+        SELECT EVENT_ID, SUM(IFNULL(SPONSORSHIP_REV_ALL_TIME, 0)) AS SPON_ACTUAL
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS_BY_TIER
+        GROUP BY EVENT_ID
+      )
+      SELECT
+        r.EVENT_ID,
+        r.EVENT_NAME,
+        TO_CHAR(r.EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
+        r.EVENT_IS_PAST,
+        r.EVENT_COUNTRY,
+        r.EVENT_URL,
+        r.COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
+        r.EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
+        IFNULL(sp.SPON_ACTUAL, 0) AS SPON_ACTUAL,
+        r.EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
+        NULL AS REGREV_ACTUAL,
+        r.EVENT_REGISTRATION_REVENUE_GOAL AS REGREV_GOAL,
+        r.PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
+        r.COMP_SCORE,
+        r.CFP_STATUS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS r
+      INNER JOIN slug_resolve sr ON r.PROJECT_ID = sr.project_id
+      LEFT JOIN sponsorship sp ON r.EVENT_ID = sp.EVENT_ID
+      WHERE 1 = 1 ${pastFilter}
+      ORDER BY r.EVENT_START_DATE
+    `;
+
+    const result = await this.snowflakeService.execute<RosterRow>(query, [foundationSlug]);
+
+    const normalizeScore = (score: string | null): EventCompScore => {
+      const s = (score ?? '').toLowerCase();
+      return s === 'high' || s === 'medium' || s === 'low' ? s : 'unknown';
+    };
+
+    const events: EventRosterRow[] = result.rows.map((row) => ({
+      eventId: row.EVENT_ID,
+      eventName: row.EVENT_NAME,
+      startDate: row.START_DATE,
+      isPast: row.EVENT_IS_PAST,
+      country: row.EVENT_COUNTRY ?? '',
+      eventUrl: row.EVENT_URL ?? '',
+      registrations: { actual: row.REG_ACTUAL ?? 0, goal: row.REG_GOAL ?? 0 },
+      sponsorshipRevenue: { actual: row.SPON_ACTUAL ?? 0, goal: row.SPON_GOAL ?? 0 },
+      registrationRevenue: { actual: row.REGREV_ACTUAL ?? 0, goal: row.REGREV_GOAL ?? 0 },
+      vsLastYear: row.VS_LY,
+      compScore: normalizeScore(row.COMP_SCORE),
+      cfpStatus: row.CFP_STATUS ?? '',
+    }));
+
+    return { projectId: '', events };
   }
 
   /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -645,6 +645,40 @@ export interface EventsOverviewMetric {
   changeFraction: number | null;
 }
 
+/** Comparison rating for an upcoming event's registration pace (from COMP_SCORE). */
+export type EventCompScore = 'high' | 'medium' | 'low' | 'unknown';
+
+/**
+ * One event row for the Event Roster table, sourced from
+ * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS joined to sponsorship actuals.
+ * Goals of 0 mean "no goal required" — the UI renders no progress bar in that case (matches PCC).
+ */
+export interface EventRosterRow {
+  eventId: string;
+  eventName: string;
+  /** Event start date, ISO (YYYY-MM-DD). */
+  startDate: string;
+  isPast: boolean;
+  country: string;
+  /** Public event URL (Cvent etc.) for the row link-out; '' when unknown. */
+  eventUrl: string;
+  registrations: { actual: number; goal: number };
+  /** Sponsorship revenue in dollars — actual summed from the tier table, goal from the event. */
+  sponsorshipRevenue: { actual: number; goal: number };
+  registrationRevenue: { actual: number; goal: number };
+  /** Ratio of this year's registrations to last year's (1.0 = on par); null when no baseline. */
+  vsLastYear: number | null;
+  compScore: EventCompScore;
+  /** CFP / speaking-proposal status text, e.g. "Review Complete"; '' when none. */
+  cfpStatus: string;
+}
+
+/** Event Roster response for a foundation: upcoming (default) or all events. */
+export interface EventRosterResponse {
+  projectId: string;
+  events: EventRosterRow[];
+}
+
 /**
  * Foundation-wide events summary for the Marketing Impact Overview tab, sourced from
  * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW (per-project, pre-computed period

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -61,6 +61,35 @@ export interface EventsOverviewSummary {
   sponsorship: EventsOverviewMetric;
 }
 
+/** A single actual-vs-goal progress bar in an event roster row. */
+export interface EventRosterBar {
+  /** Formatted actual value (e.g. "206", "$45.2K"). */
+  actual: string;
+  /** Formatted goal value (e.g. "700", "$195K"); shown as the grey target number. */
+  goal: string;
+  /** Fill percentage 0–100; only meaningful when hasGoal is true. */
+  percent: number;
+  /** False when goal is 0/absent — the UI renders no bar (matches PCC's "no goal required"). */
+  hasGoal: boolean;
+  /** Health tone driving the fill color. */
+  tone: 'good' | 'warn' | 'critical' | 'none';
+}
+
+/** Pre-formatted view-model for a single Event Roster table row. */
+export interface EventRosterRowView {
+  eventId: string;
+  eventName: string;
+  /** Display date (e.g. "Aug 11, 2026"). */
+  dateLabel: string;
+  eventUrl: string;
+  country: string;
+  registrations: EventRosterBar;
+  sponsorshipRevenue: EventRosterBar;
+  /** Whether to show the at-risk (⚠) flag — behind goal with a low comparison score. */
+  atRisk: boolean;
+  cfpStatus: string;
+}
+
 /** Pre-formatted view-model for a single Events Summary stat tile. */
 export interface EventsSummaryStat {
   id: string;


### PR DESCRIPTION
## Summary
Adds the **Events roster** table below the summary tiles, from `MARKETING_EVENT_REGISTRATIONS` joined to sponsorship actuals from `MARKETING_EVENT_SPONSORSHIPS_BY_TIER`. Each row shows registration and sponsorship actual-vs-goal as a health-colored bar (green/amber/red); a goal of 0 renders no bar (matches PCC's "no goal required"). Includes an at-risk flag, an upcoming/all toggle, and name search.

**PR 2/6 of the LF Events dashboard stack (LFXV2-2768). Base: `feat/LFXV2-2768-events-summary` (PR #1170).** Review/merge PR 1 first.

Queries validated live. Typecheck + lint pass.

LFXV2-2768
