### PR TITLE
feat(dashboards): add per-event detail drawer to roster

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
@@ -1,0 +1,120 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  styleClass="xl:!w-[45%] lg:!w-[55%] md:!w-[70%] sm:!w-[90%] !w-full"
+  [showCloseIcon]="true"
+  [dismissible]="true"
+  data-testid="event-detail-drawer">
+  <ng-template #header>
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-base font-semibold text-gray-900">{{ detail()?.eventName || 'Event detail' }}</h3>
+      @if (detail()) {
+        <p class="text-xs text-gray-500">
+          {{ dateLabel() }}
+          @if (detail()?.country) {
+            · {{ detail()?.country }}
+          }
+        </p>
+      }
+    </div>
+  </ng-template>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-4" data-testid="event-detail-skeleton">
+      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
+      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
+      <div class="h-40 animate-pulse rounded-lg bg-gray-100"></div>
+    </div>
+  } @else if (detail(); as d) {
+    <div class="flex flex-col gap-5">
+      <!-- Registrations vs goal -->
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-registrations">
+        <div class="flex items-baseline justify-between">
+          <span class="text-xs font-medium text-gray-500">Registrations</span>
+          @if (vsLastYearLabel(); as vs) {
+            <span class="text-[11px] font-medium text-gray-400">{{ vs }}</span>
+          }
+        </div>
+        <div class="flex items-baseline gap-2">
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ num(d.registrations.actual) }}</span>
+          @if (d.registrations.goal > 0) {
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ num(d.registrations.goal) }} goal</span>
+          }
+        </div>
+        @if (regProgress() !== null) {
+          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              class="h-full rounded-full"
+              [ngClass]="{
+                'bg-emerald-500': regProgress()! >= 80,
+                'bg-amber-500': regProgress()! >= 50 && regProgress()! < 80,
+                'bg-red-400': regProgress()! < 50,
+              }"
+              [style.width.%]="regProgress()"></div>
+          </div>
+        }
+      </div>
+
+      <!-- Sponsorship vs goal -->
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-sponsorship">
+        <span class="text-xs font-medium text-gray-500">Sponsorship revenue</span>
+        <div class="flex items-baseline gap-2">
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ money(d.sponsorshipRevenue.actual) }}</span>
+          @if (d.sponsorshipRevenue.goal > 0) {
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ money(d.sponsorshipRevenue.goal) }} goal</span>
+          }
+        </div>
+        @if (sponProgress() !== null) {
+          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              class="h-full rounded-full"
+              [ngClass]="{
+                'bg-emerald-500': sponProgress()! >= 80,
+                'bg-amber-500': sponProgress()! >= 50 && sponProgress()! < 80,
+                'bg-red-400': sponProgress()! < 50,
+              }"
+              [style.width.%]="sponProgress()"></div>
+          </div>
+        }
+      </div>
+
+      <!-- Sponsorship by tier -->
+      @if (d.sponsorshipTiers.length) {
+        <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-tiers">
+          <span class="text-xs font-medium text-gray-500">Sponsorship by tier</span>
+          <div class="flex flex-col gap-2.5">
+            @for (tier of d.sponsorshipTiers; track tier.tier) {
+              <div class="flex items-center justify-between gap-3" [attr.data-testid]="'event-detail-tier-' + tier.tier">
+                <span class="truncate text-xs font-medium text-gray-700">{{ tier.tier || 'Other' }}</span>
+                <div class="flex items-baseline gap-3">
+                  <span class="text-[11px] text-gray-400">{{ tier.sponsorCount }} sponsor{{ tier.sponsorCount === 1 ? '' : 's' }}</span>
+                  <span class="w-20 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ money(tier.revenue) }}</span>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Pacing lives in PCC (prediction service); deep-link out -->
+      @if (d.eventUrl) {
+        <a
+          [href]="d.eventUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center justify-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+          data-testid="event-detail-pcc-link">
+          <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+          View registration pacing &amp; prediction in PCC
+        </a>
+      }
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="event-detail-empty">
+      <p class="text-sm text-gray-500">No detail available for this event.</p>
+    </div>
+  }
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -1,0 +1,93 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { DrawerModule } from 'primeng/drawer';
+import { finalize, of, skip, switchMap } from 'rxjs';
+
+import type { EventDetailResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-event-detail-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgClass, DrawerModule],
+  templateUrl: './event-detail-drawer.component.html',
+})
+export class EventDetailDrawerComponent {
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  /** Event id to load when the drawer opens. */
+  public readonly eventId = input<string | null>(null);
+
+  // === Computed Signals ===
+  protected readonly detail: Signal<EventDetailResponse | null> = this.initDetail();
+  protected readonly loading = computed(() => this.visible() && this.detail() === null && this.eventId() !== null);
+
+  // Registration progress (0–100) when a real goal exists.
+  protected readonly regProgress = computed(() => {
+    const d = this.detail();
+    if (!d || d.registrations.goal <= 0) return null;
+    return Math.min(100, Math.round((d.registrations.actual / d.registrations.goal) * 100));
+  });
+  // Sponsorship progress (0–100) when a real goal exists.
+  protected readonly sponProgress = computed(() => {
+    const d = this.detail();
+    if (!d || d.sponsorshipRevenue.goal <= 0) return null;
+    return Math.min(100, Math.round((d.sponsorshipRevenue.actual / d.sponsorshipRevenue.goal) * 100));
+  });
+
+  // === Protected Helpers (template) ===
+  protected num(value: number): string {
+    return formatNumber(value);
+  }
+
+  protected money(value: number): string {
+    return formatCurrency(value);
+  }
+
+  /** Registration pace vs last year as a signed percent string, or null when no baseline. */
+  protected vsLastYearLabel(): string | null {
+    const d = this.detail();
+    if (!d || d.vsLastYear === null) return null;
+    const pct = Math.round((d.vsLastYear - 1) * 100);
+    if (pct > 0) return `+${pct}% vs last year`;
+    if (pct < 0) return `${pct}% vs last year`;
+    return 'On par with last year';
+  }
+
+  protected dateLabel(): string {
+    const iso = this.detail()?.startDate ?? '';
+    const [year, month, day] = iso.split('-').map(Number);
+    if (!year || !month || !day) return iso;
+    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+
+  // === Private Initializers ===
+  private initDetail(): Signal<EventDetailResponse | null> {
+    // Lazy-load on open: react to visibility flipping true (skip the initial value).
+    return toSignal(
+      toObservable(this.visible).pipe(
+        skip(1),
+        switchMap((open) => {
+          const id = this.eventId();
+          if (!open || !id) return of(null);
+          return this.analyticsService.getEventDetail(id).pipe(finalize(() => undefined));
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
@@ -65,17 +65,18 @@
 
       <!-- Rows -->
       @for (row of rows(); track row.eventId) {
-        <div class="flex items-center gap-4 border-b border-gray-100 py-3" role="row" [attr.data-testid]="'event-roster-row-' + row.eventId">
+        <div
+          class="flex cursor-pointer items-center gap-4 border-b border-gray-100 py-3 transition-colors hover:bg-blue-50/40"
+          role="row"
+          tabindex="0"
+          (click)="openEvent(row.eventId)"
+          (keydown.enter)="openEvent(row.eventId)"
+          (keydown.space)="openEvent(row.eventId)"
+          [attr.data-testid]="'event-roster-row-' + row.eventId">
           <span class="w-24 text-xs text-gray-500 tabular-nums" role="cell">{{ row.dateLabel }}</span>
 
           <div class="flex flex-1 min-w-[180px] items-center gap-2" role="cell">
-            @if (row.eventUrl) {
-              <a [href]="row.eventUrl" target="_blank" rel="noopener noreferrer" class="truncate text-xs font-semibold text-blue-600 hover:underline">{{
-                row.eventName
-              }}</a>
-            } @else {
-              <span class="truncate text-xs font-semibold text-gray-700">{{ row.eventName }}</span>
-            }
+            <span class="truncate text-xs font-semibold text-blue-600">{{ row.eventName }}</span>
             @if (row.atRisk) {
               <i class="fa-solid fa-circle-exclamation text-xs text-red-500" aria-label="Behind registration goal" title="Behind registration goal"></i>
             }
@@ -135,3 +136,5 @@
     </div>
   }
 </div>
+
+<lfx-event-detail-drawer [(visible)]="drawerVisible" [eventId]="selectedEventId()" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
@@ -11,9 +11,11 @@ import { combineLatest, finalize, of, startWith, switchMap } from 'rxjs';
 
 import type { EventRosterBar, EventRosterResponse, EventRosterRow, EventRosterRowView } from '@lfx-one/shared/interfaces';
 
+import { EventDetailDrawerComponent } from '../event-detail-drawer/event-detail-drawer.component';
+
 @Component({
   selector: 'lfx-event-roster-section',
-  imports: [NgClass, ReactiveFormsModule],
+  imports: [NgClass, ReactiveFormsModule, EventDetailDrawerComponent],
   templateUrl: './event-roster-section.component.html',
 })
 export class EventRosterSectionComponent {
@@ -30,6 +32,8 @@ export class EventRosterSectionComponent {
   protected readonly loading = signal(false);
   protected readonly includePast = signal(false);
   protected readonly skeletons: readonly number[] = [0, 1, 2, 3, 4];
+  protected readonly drawerVisible = signal(false);
+  protected readonly selectedEventId = signal<string | null>(null);
 
   // === Computed Signals ===
   protected readonly roster: Signal<EventRosterResponse> = this.initRoster();
@@ -40,6 +44,11 @@ export class EventRosterSectionComponent {
   // === Protected Methods ===
   protected toggleIncludePast(includePast: boolean): void {
     this.includePast.set(includePast);
+  }
+
+  protected openEvent(eventId: string): void {
+    this.selectedEventId.set(eventId);
+    this.drawerVisible.set(true);
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   MembershipChurnPerTierSummaryResponse,
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
+  EventDetailResponse,
   EventRosterResponse,
   EventsOverviewSummaryResponse,
   EventsSummaryResponse,
@@ -1135,6 +1136,14 @@ export class AnalyticsService {
       params['includePast'] = 'true';
     }
     return this.http.get<EventRosterResponse>('/api/analytics/event-roster', { params }).pipe(catchError(() => of({ projectId: '', events: [] })));
+  }
+
+  /**
+   * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
+   * Emits null on error so the drawer shows its empty state.
+   */
+  public getEventDetail(eventId: string): Observable<EventDetailResponse | null> {
+    return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId } }).pipe(catchError(() => of(null)));
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2781,6 +2781,41 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/event-detail
+   * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
+   */
+  public async getEventDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_detail');
+
+    try {
+      const eventId = getStringQueryParam(req, 'eventId');
+
+      if (!eventId) {
+        throw ServiceValidationError.forField('eventId', 'eventId query parameter is required', {
+          operation: 'get_event_detail',
+        });
+      }
+
+      if (!/^[A-Za-z0-9_-]{1,64}$/.test(eventId)) {
+        throw ServiceValidationError.forField('eventId', 'Invalid eventId format', {
+          operation: 'get_event_detail',
+        });
+      }
+
+      const response = await this.projectService.getEventDetail(eventId);
+
+      logger.success(req, 'get_event_detail', startTime, {
+        event_id: eventId,
+        found: response !== null,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/brand-reach
    * Get brand reach metrics (total digital reach across social + owned sites)
    */

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -187,6 +187,7 @@ router.get('/board-meeting-participation-summary', (req, res, next) => analytics
 router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
 router.get('/events-overview-summary', (req, res, next) => analyticsController.getEventsOverviewSummary(req, res, next));
 router.get('/event-roster', (req, res, next) => analyticsController.getEventRoster(req, res, next));
+router.get('/event-detail', (req, res, next) => analyticsController.getEventDetail(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -28,6 +28,7 @@ import {
   EmailCtrResponse,
   EngagedCommunitySizeResponse,
   EventCompScore,
+  EventDetailResponse,
   EventGrowthResponse,
   EventGrowthTopEvent,
   EventRosterResponse,
@@ -4968,6 +4969,103 @@ export class ProjectService {
     }));
 
     return { projectId: '', events };
+  }
+
+  /**
+   * Get per-event detail for the roster drawer — event meta, registration/sponsorship
+   * actual-vs-goal, comparison rating, and a sponsorship-by-tier breakdown.
+   *
+   * Meta comes from MARKETING_EVENT_REGISTRATIONS (one row per event) and the tier breakdown
+   * from MARKETING_EVENT_SPONSORSHIPS_BY_TIER. No daily-pacing time-series exists in these
+   * tables (that is PCC's prediction service); the drawer deep-links to eventUrl for pacing.
+   */
+  public async getEventDetail(eventId: string): Promise<EventDetailResponse | null> {
+    logger.debug(undefined, 'get_event_detail', 'Fetching event detail from Snowflake', { event_id: eventId });
+
+    interface EventRow {
+      EVENT_ID: string;
+      EVENT_NAME: string;
+      START_DATE: string;
+      EVENT_COUNTRY: string | null;
+      EVENT_URL: string | null;
+      REG_ACTUAL: number | null;
+      REG_GOAL: number | null;
+      SPON_GOAL: number | null;
+      VS_LY: number | null;
+      COMP_SCORE: string | null;
+      CFP_STATUS: string | null;
+    }
+
+    interface TierRow {
+      SPONSORSHIP_TIER: string | null;
+      REVENUE: number;
+      SPONSOR_COUNT: number;
+    }
+
+    const eventQuery = `
+      SELECT
+        EVENT_ID,
+        EVENT_NAME,
+        TO_CHAR(EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
+        EVENT_COUNTRY,
+        EVENT_URL,
+        COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
+        EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
+        EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
+        PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
+        COMP_SCORE,
+        CFP_STATUS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS
+      WHERE EVENT_ID = ?
+      LIMIT 1
+    `;
+
+    const tierQuery = `
+      SELECT
+        SPONSORSHIP_TIER,
+        SUM(IFNULL(SPONSORSHIP_REV_ALL_TIME, 0)) AS REVENUE,
+        SUM(IFNULL(SPONSORSHIP_COUNT_ALL_TIME, 0)) AS SPONSOR_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS_BY_TIER
+      WHERE EVENT_ID = ?
+      GROUP BY SPONSORSHIP_TIER
+      ORDER BY REVENUE DESC
+    `;
+
+    const [eventResult, tierResult] = await Promise.all([
+      this.snowflakeService.execute<EventRow>(eventQuery, [eventId]),
+      this.snowflakeService.execute<TierRow>(tierQuery, [eventId]),
+    ]);
+
+    const row = eventResult.rows?.[0];
+    if (!row) {
+      logger.warning(undefined, 'get_event_detail', 'No event row for id', { event_id: eventId });
+      return null;
+    }
+
+    const normalizeScore = (score: string | null): EventCompScore => {
+      const s = (score ?? '').toLowerCase();
+      return s === 'high' || s === 'medium' || s === 'low' ? s : 'unknown';
+    };
+
+    const sponsorshipActual = tierResult.rows.reduce((sum, t) => sum + (t.REVENUE ?? 0), 0);
+
+    return {
+      eventId: row.EVENT_ID,
+      eventName: row.EVENT_NAME,
+      startDate: row.START_DATE,
+      country: row.EVENT_COUNTRY ?? '',
+      eventUrl: row.EVENT_URL ?? '',
+      registrations: { actual: row.REG_ACTUAL ?? 0, goal: row.REG_GOAL ?? 0 },
+      sponsorshipRevenue: { actual: sponsorshipActual, goal: row.SPON_GOAL ?? 0 },
+      vsLastYear: row.VS_LY,
+      compScore: normalizeScore(row.COMP_SCORE),
+      cfpStatus: row.CFP_STATUS ?? '',
+      sponsorshipTiers: tierResult.rows.map((t) => ({
+        tier: t.SPONSORSHIP_TIER ?? '',
+        revenue: t.REVENUE ?? 0,
+        sponsorCount: t.SPONSOR_COUNT ?? 0,
+      })),
+    };
   }
 
   /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -679,6 +679,37 @@ export interface EventRosterResponse {
   events: EventRosterRow[];
 }
 
+/** One sponsorship tier row for the per-event detail drawer. */
+export interface EventSponsorshipTier {
+  /** Tier name (Diamond, Gold, Platinum, …); '' when unlabeled. */
+  tier: string;
+  /** Sponsorship revenue in dollars for this tier at this event. */
+  revenue: number;
+  /** Number of sponsors in this tier. */
+  sponsorCount: number;
+}
+
+/**
+ * Per-event detail for the roster drawer, sourced from
+ * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS (event meta + goals) and
+ * MARKETING_EVENT_SPONSORSHIPS_BY_TIER (tier breakdown). No daily-pacing time-series is
+ * available in these tables — that lives in PCC's prediction service, linked via eventUrl.
+ */
+export interface EventDetailResponse {
+  eventId: string;
+  eventName: string;
+  startDate: string;
+  country: string;
+  eventUrl: string;
+  registrations: { actual: number; goal: number };
+  sponsorshipRevenue: { actual: number; goal: number };
+  /** Ratio of this year's registrations to last year's (1.0 = on par); null when no baseline. */
+  vsLastYear: number | null;
+  compScore: EventCompScore;
+  cfpStatus: string;
+  sponsorshipTiers: EventSponsorshipTier[];
+}
+
 /**
  * Foundation-wide events summary for the Marketing Impact Overview tab, sourced from
  * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW (per-project, pre-computed period


### PR DESCRIPTION
## Summary
Adds a slide-in **per-event detail drawer** opened from an event roster row (`p-drawer`, lazy-loaded on open). Sourced from `MARKETING_EVENT_REGISTRATIONS` + `MARKETING_EVENT_SPONSORSHIPS_BY_TIER`.

**PR 3/6 of the LF Events dashboard stack (LFXV2-2768). Base: `feat/LFXV2-2768-event-roster` (PR).** Review/merge PRs 1–2 first.

LFXV2-2768
