### PR TITLE
feat(dashboards): add needs-attention strip for at-risk events

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-attention-section/events-attention-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-attention-section/events-attention-section.component.html
@@ -1,0 +1,59 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (hasItems()) {
+  <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="events-attention-section">
+    <!-- Header -->
+    <div class="flex items-center gap-2.5">
+      <span class="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-amber-100 text-amber-600">
+        <i class="fa-light fa-bolt text-sm" aria-hidden="true"></i>
+      </span>
+      <div class="flex flex-col gap-0.5">
+        <h3 class="text-sm font-semibold text-gray-900">Needs attention</h3>
+        <span class="text-xs text-gray-400">Upcoming events where marketing can move the needle</span>
+      </div>
+    </div>
+
+    <!-- Items -->
+    <div class="flex flex-col gap-2.5" role="list">
+      @for (item of items(); track item.id) {
+        <div
+          class="relative flex flex-col gap-3 rounded-lg border border-gray-200 py-3 pl-5 pr-4 md:flex-row md:items-center md:justify-between"
+          role="listitem"
+          [attr.data-testid]="'events-attention-item-' + item.id">
+          <span
+            class="absolute bottom-2 left-0 top-2 w-[3px] rounded-full"
+            [ngClass]="{ 'bg-red-500': item.severity === 'critical', 'bg-amber-500': item.severity === 'warning' }"
+            aria-hidden="true"></span>
+
+          <div class="flex flex-col gap-1">
+            <span
+              class="inline-flex w-fit rounded px-2 py-0.5 text-[10px] font-bold tracking-wide"
+              [ngClass]="{
+                'bg-red-100 text-red-600': item.severity === 'critical',
+                'bg-amber-100 text-amber-600': item.severity === 'warning',
+              }"
+              >{{ item.tag }}</span
+            >
+            <span class="text-sm font-semibold text-gray-900">{{ item.title }}</span>
+            <span class="text-xs text-gray-500">{{ item.detail }}</span>
+          </div>
+
+          <div class="flex flex-shrink-0 items-center gap-2">
+            @if (item.actionUrl) {
+              <a
+                [href]="item.actionUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1.5 rounded-lg bg-blue-500 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-600"
+                [attr.data-testid]="'events-attention-open-' + item.id">
+                <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+                Open event
+              </a>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-attention-section/events-attention-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-attention-section/events-attention-section.component.ts
@@ -1,0 +1,88 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { finalize, of, switchMap } from 'rxjs';
+
+import type { AttentionSeverity, EventAttentionItem, EventRosterResponse, EventRosterRow } from '@lfx-one/shared/interfaces';
+
+/** How many at-risk events to surface at most. */
+const MAX_ATTENTION_ITEMS = 3;
+/** Below this registration-to-goal percentage an event is considered behind. */
+const BEHIND_GOAL_THRESHOLD = 50;
+
+@Component({
+  selector: 'lfx-events-attention-section',
+  imports: [NgClass],
+  templateUrl: './events-attention-section.component.html',
+})
+export class EventsAttentionSectionComponent {
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+
+  // === Computed Signals ===
+  private readonly roster: Signal<EventRosterResponse> = this.initRoster();
+  protected readonly items: Signal<EventAttentionItem[]> = this.initItems();
+  protected readonly hasItems = computed(() => this.items().length > 0);
+
+  // === Private Initializers ===
+  private initRoster(): Signal<EventRosterResponse> {
+    const slug$ = toObservable(this.foundationSlug);
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of({ projectId: '', events: [] });
+          }
+          this.loading.set(true);
+          // Upcoming only — attention is about events we can still influence.
+          return this.analyticsService.getEventRoster(slug, false).pipe(finalize(() => this.loading.set(false)));
+        })
+      ),
+      { initialValue: { projectId: '', events: [] } }
+    );
+  }
+
+  private initItems(): Signal<EventAttentionItem[]> {
+    return computed(() => {
+      const atRisk = this.roster()
+        .events.map((event) => ({ event, percent: this.regPercent(event) }))
+        .filter((row) => row.percent !== null && (row.percent as number) < BEHIND_GOAL_THRESHOLD && row.event.compScore === 'low')
+        // Furthest behind first.
+        .sort((a, b) => (a.percent as number) - (b.percent as number))
+        .slice(0, MAX_ATTENTION_ITEMS);
+
+      return atRisk.map(({ event, percent }) => this.toItem(event, percent as number));
+    });
+  }
+
+  // === Private Helpers ===
+  private regPercent(event: EventRosterRow): number | null {
+    const goal = event.registrations.goal;
+    if (!goal || goal <= 0) return null;
+    return Math.round((event.registrations.actual / goal) * 100);
+  }
+
+  private toItem(event: EventRosterRow, percent: number): EventAttentionItem {
+    const severity: AttentionSeverity = percent < 25 ? 'critical' : 'warning';
+    const vsLy = event.vsLastYear !== null ? ` · pacing ${Math.round((event.vsLastYear - 1) * 100)}% vs last year` : '';
+    return {
+      id: event.eventId,
+      tag: 'BEHIND GOAL',
+      severity,
+      title: `${event.eventName} is ${percent}% to its registration goal`,
+      detail: `${formatNumber(event.registrations.actual)} / ${formatNumber(event.registrations.goal)} registrations${vsLy}. Email and paid are the fastest levers.`,
+      actionUrl: event.eventUrl,
+    };
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-geo-section/events-geo-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-geo-section/events-geo-section.component.html
@@ -1,0 +1,52 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="events-geo-section">
+  <!-- Header -->
+  <div class="flex flex-col gap-0.5">
+    <h3 class="text-base font-semibold text-gray-900">Geographic reach</h3>
+    <p class="text-xs text-gray-500">
+      Event registrations across
+      <span class="font-semibold text-gray-700">{{ totalCountriesLabel() }}</span> countries · {{ foundationName() || 'All foundations' }}
+    </p>
+  </div>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-3" data-testid="events-geo-skeleton">
+      @for (i of skeletons; track i) {
+        <div class="flex items-center gap-3">
+          <div class="h-4 w-28 animate-pulse rounded bg-gray-200"></div>
+          <div class="h-3 flex-1 animate-pulse rounded bg-gray-100"></div>
+          <div class="h-4 w-12 animate-pulse rounded bg-gray-200"></div>
+        </div>
+      }
+    </div>
+  } @else if (hasData()) {
+    <div class="flex flex-col gap-2.5" role="list" data-testid="events-geo-list">
+      @for (row of rows(); track row.code) {
+        <div class="flex items-center gap-3" role="listitem" [attr.data-testid]="'events-geo-row-' + row.code">
+          <div class="flex w-36 items-center gap-2">
+            <span class="inline-flex h-5 w-7 items-center justify-center rounded bg-gray-100 text-[10px] font-bold text-gray-500">{{ row.code || '—' }}</span>
+            <span class="truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
+          </div>
+          <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+            <div
+              class="h-full rounded-full bg-blue-500"
+              role="progressbar"
+              [attr.aria-valuenow]="row.sharePercent"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              [attr.aria-label]="row.name + ' registration share: ' + row.sharePercent + '%'"
+              [style.width.%]="row.barPercent"></div>
+          </div>
+          <span class="w-16 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ num(row.registrations) }}</span>
+          <span class="w-10 text-right text-[11px] text-gray-400 tabular-nums">{{ row.sharePercent }}%</span>
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="events-geo-empty">
+      <p class="text-sm text-gray-500">No registration geography available.</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-geo-section/events-geo-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-geo-section/events-geo-section.component.ts
@@ -1,0 +1,66 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { finalize, of, switchMap } from 'rxjs';
+
+import type { EventCountryReach, EventGeoReachResponse } from '@lfx-one/shared/interfaces';
+
+const EMPTY_GEO: EventGeoReachResponse = { projectId: '', totalRegistrations: 0, totalCountries: 0, countries: [] };
+
+@Component({
+  selector: 'lfx-events-geo-section',
+  templateUrl: './events-geo-section.component.html',
+})
+export class EventsGeoSectionComponent {
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Inputs ===
+  public readonly foundationSlug = input<string | undefined>();
+  public readonly foundationName = input<string>('');
+
+  // === WritableSignals ===
+  protected readonly loading = signal(false);
+  protected readonly skeletons: readonly number[] = [0, 1, 2, 3, 4, 5];
+
+  // === Computed Signals ===
+  protected readonly geo: Signal<EventGeoReachResponse> = this.initGeo();
+  protected readonly hasData = computed(() => this.geo().countries.length > 0);
+  protected readonly totalCountriesLabel = computed(() => formatNumber(this.geo().totalCountries));
+
+  // Widen each bar relative to the top country so the leader fills the track.
+  protected readonly rows: Signal<(EventCountryReach & { barPercent: number })[]> = computed(() => {
+    const countries = this.geo().countries;
+    const max = countries.length ? countries[0].registrations : 0;
+    return countries.map((country) => ({
+      ...country,
+      barPercent: max > 0 ? Math.max(2, Math.round((country.registrations / max) * 100)) : 0,
+    }));
+  });
+
+  // === Protected Helpers ===
+  protected num(value: number): string {
+    return formatNumber(value);
+  }
+
+  // === Private Initializers ===
+  private initGeo(): Signal<EventGeoReachResponse> {
+    const slug$ = toObservable(this.foundationSlug);
+    return toSignal(
+      slug$.pipe(
+        switchMap((slug) => {
+          if (!slug) {
+            this.loading.set(false);
+            return of(EMPTY_GEO);
+          }
+          this.loading.set(true);
+          return this.analyticsService.getEventGeoReach(slug).pipe(finalize(() => this.loading.set(false)));
+        })
+      ),
+      { initialValue: EMPTY_GEO }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -11,6 +11,8 @@
 
 <lfx-event-roster-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-event-roster" />
 
+<lfx-events-geo-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-events-geo" />
+
 <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-5" data-testid="overview-tab-summary-header">
   <div class="flex flex-col gap-0.5">
     <h3 class="text-base font-semibold text-gray-900">{{ summaryTitle() }}</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -1,6 +1,8 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<lfx-events-attention-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-events-attention" />
+
 <lfx-events-summary-section
   [foundationSlug]="foundationSlug()"
   [foundationName]="foundationName()"

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -13,6 +13,7 @@ import type { MarketingImpactFocusProgram, OverviewKpiData, PerformanceSummaryKp
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { EventRosterSectionComponent } from '../event-roster-section/event-roster-section.component';
 import { EventsAttentionSectionComponent } from '../events-attention-section/events-attention-section.component';
+import { EventsGeoSectionComponent } from '../events-geo-section/events-geo-section.component';
 import { EventsSummarySectionComponent } from '../events-summary-section/events-summary-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
@@ -24,6 +25,7 @@ import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-c
     EventsSummarySectionComponent,
     EventRosterSectionComponent,
     EventsAttentionSectionComponent,
+    EventsGeoSectionComponent,
   ],
   templateUrl: './overview-tab.component.html',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -12,12 +12,19 @@ import type { MarketingImpactFocusProgram, OverviewKpiData, PerformanceSummaryKp
 
 import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { EventRosterSectionComponent } from '../event-roster-section/event-roster-section.component';
+import { EventsAttentionSectionComponent } from '../events-attention-section/events-attention-section.component';
 import { EventsSummarySectionComponent } from '../events-summary-section/events-summary-section.component';
 import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [SparklineKpiCardComponent, AttributionSectionComponent, EventsSummarySectionComponent, EventRosterSectionComponent],
+  imports: [
+    SparklineKpiCardComponent,
+    AttributionSectionComponent,
+    EventsSummarySectionComponent,
+    EventRosterSectionComponent,
+    EventsAttentionSectionComponent,
+  ],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -57,6 +57,7 @@ import {
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
   EventDetailResponse,
+  EventGeoReachResponse,
   EventRosterResponse,
   EventsOverviewSummaryResponse,
   EventsSummaryResponse,
@@ -1144,6 +1145,16 @@ export class AnalyticsService {
    */
   public getEventDetail(eventId: string): Observable<EventDetailResponse | null> {
     return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId } }).pipe(catchError(() => of(null)));
+  }
+
+  /**
+   * Geographic registration reach for a foundation (top countries by YTD registrations).
+   * Emits an empty result on error so the panel shows its empty state.
+   */
+  public getEventGeoReach(foundationSlug: string): Observable<EventGeoReachResponse> {
+    return this.http
+      .get<EventGeoReachResponse>('/api/analytics/event-geo-reach', { params: { foundationSlug } })
+      .pipe(catchError(() => of({ projectId: '', totalRegistrations: 0, totalCountries: 0, countries: [] })));
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2816,6 +2816,41 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/event-geo-reach
+   * Geographic registration reach for a foundation (top countries by YTD registrations).
+   */
+  public async getEventGeoReach(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_geo_reach');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_geo_reach',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_geo_reach',
+        });
+      }
+
+      const response = await this.projectService.getEventGeoReach(foundationSlug);
+
+      logger.success(req, 'get_event_geo_reach', startTime, {
+        foundation_slug: foundationSlug,
+        country_count: response.totalCountries,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/brand-reach
    * Get brand reach metrics (total digital reach across social + owned sites)
    */

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -188,6 +188,7 @@ router.get('/event-growth', (req, res, next) => analyticsController.getEventGrow
 router.get('/events-overview-summary', (req, res, next) => analyticsController.getEventsOverviewSummary(req, res, next));
 router.get('/event-roster', (req, res, next) => analyticsController.getEventRoster(req, res, next));
 router.get('/event-detail', (req, res, next) => analyticsController.getEventDetail(req, res, next));
+router.get('/event-geo-reach', (req, res, next) => analyticsController.getEventGeoReach(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -28,7 +28,9 @@ import {
   EmailCtrResponse,
   EngagedCommunitySizeResponse,
   EventCompScore,
+  EventCountryReach,
   EventDetailResponse,
+  EventGeoReachResponse,
   EventGrowthResponse,
   EventGrowthTopEvent,
   EventRosterResponse,
@@ -5066,6 +5068,79 @@ export class ProjectService {
         sponsorCount: t.SPONSOR_COUNT ?? 0,
       })),
     };
+  }
+
+  /**
+   * Get geographic registration reach for a foundation — YTD registrations by country,
+   * ranked, from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATION_COUNTRY. Returns the
+   * top countries plus totals so the UI can render shares. Raw country slugs are title-cased.
+   */
+  public async getEventGeoReach(foundationSlug: string, limit = 12): Promise<EventGeoReachResponse> {
+    logger.debug(undefined, 'get_event_geo_reach', 'Fetching event geo reach from Snowflake', { foundation_slug: foundationSlug });
+
+    interface CountryRow {
+      COUNTRY: string | null;
+      COUNTRY_CODE: string | null;
+      REGS: number;
+    }
+    interface TotalRow {
+      TOTAL_REGS: number;
+      COUNTRY_COUNT: number;
+    }
+
+    const boundedLimit = Math.min(Math.max(Math.trunc(limit), 1), 50);
+
+    const countryQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT c.COUNTRY, c.COUNTRY_CODE, c.REGISTRATION_COUNT_YTD AS REGS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATION_COUNTRY c
+      INNER JOIN slug_resolve sr ON c.PROJECT_ID = sr.project_id
+      WHERE c.REGISTRATION_COUNT_YTD > 0
+      ORDER BY c.REGISTRATION_COUNT_YTD DESC
+      LIMIT ${boundedLimit}
+    `;
+
+    const totalQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        IFNULL(SUM(c.REGISTRATION_COUNT_YTD), 0) AS TOTAL_REGS,
+        COUNT(DISTINCT CASE WHEN c.REGISTRATION_COUNT_YTD > 0 THEN c.COUNTRY END) AS COUNTRY_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATION_COUNTRY c
+      INNER JOIN slug_resolve sr ON c.PROJECT_ID = sr.project_id
+    `;
+
+    const [countryResult, totalResult] = await Promise.all([
+      this.snowflakeService.execute<CountryRow>(countryQuery, [foundationSlug]),
+      this.snowflakeService.execute<TotalRow>(totalQuery, [foundationSlug]),
+    ]);
+
+    const total = totalResult.rows?.[0]?.TOTAL_REGS ?? 0;
+    const totalCountries = totalResult.rows?.[0]?.COUNTRY_COUNT ?? 0;
+
+    // Title-case a raw country slug ("republic_of_korea" -> "Republic Of Korea").
+    const titleCase = (slug: string): string =>
+      slug
+        .split('_')
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+
+    const countries: EventCountryReach[] = countryResult.rows.map((row) => ({
+      code: (row.COUNTRY_CODE ?? '').toUpperCase(),
+      name: row.COUNTRY ? titleCase(row.COUNTRY) : 'Unknown',
+      registrations: row.REGS ?? 0,
+      sharePercent: total > 0 ? Math.round(((row.REGS ?? 0) / total) * 1000) / 10 : 0,
+    }));
+
+    return { projectId: '', totalRegistrations: total, totalCountries, countries };
   }
 
   /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -679,6 +679,26 @@ export interface EventRosterResponse {
   events: EventRosterRow[];
 }
 
+/** One country's registration reach for the geographic panel. */
+export interface EventCountryReach {
+  /** Two-letter ISO code (e.g. "US"); '' when unknown. */
+  code: string;
+  /** Display name (title-cased). */
+  name: string;
+  /** YTD registrations from this country. */
+  registrations: number;
+  /** Share of total registrations, 0–100. */
+  sharePercent: number;
+}
+
+/** Geographic reach response: top countries by YTD registrations for a foundation. */
+export interface EventGeoReachResponse {
+  projectId: string;
+  totalRegistrations: number;
+  totalCountries: number;
+  countries: EventCountryReach[];
+}
+
 /** One sponsorship tier row for the per-event detail drawer. */
 export interface EventSponsorshipTier {
   /** Tier name (Diamond, Gold, Platinum, …); '' when unlabeled. */

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -61,6 +61,24 @@ export interface EventsOverviewSummary {
   sponsorship: EventsOverviewMetric;
 }
 
+/** Severity tone for a needs-attention item. */
+export type AttentionSeverity = 'critical' | 'warning';
+
+/** A single actionable item in the "Needs attention" strip. */
+export interface EventAttentionItem {
+  /** Stable id (the event id) for tracking. */
+  id: string;
+  /** Short severity tag, e.g. "BEHIND GOAL". */
+  tag: string;
+  severity: AttentionSeverity;
+  /** One-line headline, e.g. "Open Source Summit Korea is 29% to its registration goal". */
+  title: string;
+  /** Supporting detail line. */
+  detail: string;
+  /** Deep-link to act on the item (the event page); '' when unavailable. */
+  actionUrl: string;
+}
+
 /** A single actual-vs-goal progress bar in an event roster row. */
 export interface EventRosterBar {
   /** Formatted actual value (e.g. "206", "$45.2K"). */


### PR DESCRIPTION
## Summary
Adds a **Needs attention** strip at the top of the overview surfacing up to three upcoming events behind their registration goal with a low comparison pace, each with a deep-link to open the event. Derived from the existing roster data — no new query.

**PR 4/6 of the LF Events dashboard stack (LFXV2-2768). Base: `feat/LFXV2-2768-event-drawer` (PR).** Review/merge PRs 1–3 first.

LFXV2-2768
