### PR TITLE
feat(meetings): surface zoom host key and fix host_key leak

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -282,6 +282,45 @@
                       <span>{{ totalInvitees() }} invited</span>
                     </div>
                   }
+
+                  <!-- Host Key (upcoming meetings; organizer / project writer / committee writer only) -->
+                  @if (hostKeyVisible()) {
+                    <div class="flex flex-col gap-1.5" data-testid="meeting-host-key">
+                      <div class="flex items-center gap-1.5">
+                        <span class="text-sm font-medium text-gray-700">Host Key</span>
+                        <i
+                          class="fa-light fa-circle-info text-xs text-gray-400"
+                          pTooltip="Enter this key in Zoom to claim host privileges."
+                          tooltipPosition="top"
+                          aria-hidden="true"></i>
+                      </div>
+                      <div class="inline-flex items-center gap-2">
+                        <code
+                          class="font-mono text-sm text-gray-800 bg-gray-100 border border-gray-200 rounded px-2 py-1 tracking-widest"
+                          data-testid="host-key-value">
+                          {{ showHostKey() ? meeting().host_key : '••••••' }}
+                        </code>
+                        <lfx-button
+                          [icon]="showHostKey() ? 'fa-light fa-eye-slash' : 'fa-light fa-eye'"
+                          [text]="true"
+                          size="small"
+                          severity="secondary"
+                          [ariaLabel]="showHostKey() ? 'Hide host key' : 'Show host key'"
+                          [tooltip]="showHostKey() ? 'Hide host key' : 'Show host key'"
+                          (onClick)="toggleHostKey()"
+                          data-testid="host-key-toggle"></lfx-button>
+                        <lfx-button
+                          icon="fa-light fa-copy"
+                          [text]="true"
+                          size="small"
+                          severity="secondary"
+                          ariaLabel="Copy host key"
+                          tooltip="Copy host key"
+                          (onClick)="copyHostKey()"
+                          data-testid="host-key-copy"></lfx-button>
+                      </div>
+                    </div>
+                  }
                 </div>
 
                 <!-- Attendance Stats (past meetings) -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -255,6 +255,39 @@
                         styleClass="!text-purple-500"
                         data-testid="meeting-badge-ai-summary"></lfx-tag>
                     }
+
+                    <!-- Host Key Chip (upcoming; organizer / project writer / committee writer only). Click/Enter/Space toggles inline reveal. -->
+                    @if (hostKeyVisible()) {
+                      <div class="inline-flex items-center gap-1" data-testid="meeting-host-key">
+                        <button
+                          type="button"
+                          class="cursor-pointer hover:opacity-70 transition-opacity rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                          (click)="toggleHostKey()"
+                          [attr.aria-pressed]="showHostKey()"
+                          [attr.aria-label]="showHostKey() ? 'Hide host key' : 'Show host key'"
+                          pTooltip="Enter this key in Zoom to claim host privileges."
+                          tooltipPosition="top"
+                          data-testid="host-key-toggle">
+                          <lfx-tag
+                            [value]="showHostKey() ? 'Host Key: ' + meeting().host_key : 'Host Key'"
+                            severity="secondary"
+                            icon="fa-light fa-key"
+                            styleClass="!text-blue-600 cursor-pointer"
+                            data-testid="meeting-badge-host-key"></lfx-tag>
+                        </button>
+                        @if (showHostKey()) {
+                          <lfx-button
+                            icon="fa-light fa-copy"
+                            [text]="true"
+                            size="small"
+                            severity="secondary"
+                            ariaLabel="Copy host key"
+                            tooltip="Copy host key"
+                            (onClick)="copyHostKey()"
+                            data-testid="host-key-copy"></lfx-button>
+                        }
+                      </div>
+                    }
                   </div>
 
                   <!-- RSVP Summary -->
@@ -283,46 +316,6 @@
                     </div>
                   }
 
-                  <!-- Host Key (upcoming meetings; organizer / project writer / committee writer only) -->
-                  @if (hostKeyVisible()) {
-                    <div class="flex flex-col gap-1.5" data-testid="meeting-host-key">
-                      <div class="flex items-center gap-1.5">
-                        <span class="text-sm font-medium text-gray-700">Host Key</span>
-                        <i
-                          class="fa-light fa-circle-info text-xs text-gray-400 cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
-                          pTooltip="Enter this key in Zoom to claim host privileges."
-                          tooltipPosition="top"
-                          tabindex="0"
-                          role="img"
-                          aria-label="Enter this key in Zoom to claim host privileges."></i>
-                      </div>
-                      <div class="inline-flex items-center gap-2">
-                        <code
-                          class="font-mono text-sm text-gray-800 bg-gray-100 border border-gray-200 rounded px-2 py-1 tracking-widest"
-                          data-testid="host-key-value">
-                          {{ showHostKey() ? meeting().host_key : '••••••' }}
-                        </code>
-                        <lfx-button
-                          [icon]="showHostKey() ? 'fa-light fa-eye-slash' : 'fa-light fa-eye'"
-                          [text]="true"
-                          size="small"
-                          severity="secondary"
-                          [ariaLabel]="showHostKey() ? 'Hide host key' : 'Show host key'"
-                          [tooltip]="showHostKey() ? 'Hide host key' : 'Show host key'"
-                          (onClick)="toggleHostKey()"
-                          data-testid="host-key-toggle"></lfx-button>
-                        <lfx-button
-                          icon="fa-light fa-copy"
-                          [text]="true"
-                          size="small"
-                          severity="secondary"
-                          ariaLabel="Copy host key"
-                          tooltip="Copy host key"
-                          (onClick)="copyHostKey()"
-                          data-testid="host-key-copy"></lfx-button>
-                      </div>
-                    </div>
-                  }
                 </div>
 
                 <!-- Attendance Stats (past meetings) -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -318,7 +318,6 @@
                       <span>{{ totalInvitees() }} invited</span>
                     </div>
                   }
-
                 </div>
 
                 <!-- Attendance Stats (past meetings) -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -259,12 +259,14 @@
                     <!-- Host Key Chip (upcoming; organizer / project writer / committee writer only). Click/Enter/Space toggles inline reveal. -->
                     @if (hostKeyVisible()) {
                       <div class="inline-flex items-center gap-1" data-testid="meeting-host-key">
+                        <!-- On reveal, aria-label is dropped so the tag's visible "Host Key: <value>" becomes the accessible name (AT users get the digits). aria-describedby keeps the help text in the a11y tree (pTooltip alone is visual-only). -->
                         <button
                           type="button"
                           class="cursor-pointer hover:opacity-70 transition-opacity rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                           (click)="toggleHostKey()"
                           [attr.aria-pressed]="showHostKey()"
-                          [attr.aria-label]="showHostKey() ? 'Hide host key' : 'Show host key'"
+                          [attr.aria-label]="showHostKey() ? null : 'Show host key'"
+                          aria-describedby="host-key-help"
                           pTooltip="Enter this key in Zoom to claim host privileges."
                           tooltipPosition="top"
                           data-testid="host-key-toggle">
@@ -275,6 +277,7 @@
                             styleClass="!text-blue-600 cursor-pointer"
                             data-testid="meeting-badge-host-key"></lfx-tag>
                         </button>
+                        <span id="host-key-help" class="sr-only">Enter this key in Zoom to claim host privileges.</span>
                         @if (showHostKey()) {
                           <lfx-button
                             icon="fa-light fa-copy"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -289,10 +289,12 @@
                       <div class="flex items-center gap-1.5">
                         <span class="text-sm font-medium text-gray-700">Host Key</span>
                         <i
-                          class="fa-light fa-circle-info text-xs text-gray-400"
+                          class="fa-light fa-circle-info text-xs text-gray-400 cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                           pTooltip="Enter this key in Zoom to claim host privileges."
                           tooltipPosition="top"
-                          aria-hidden="true"></i>
+                          tabindex="0"
+                          role="img"
+                          aria-label="Enter this key in Zoom to claim host privileges."></i>
                       </div>
                       <div class="inline-flex items-center gap-2">
                         <code

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -50,7 +50,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
-import { getUserTimezone, isHostKeyVisible } from '@lfx-one/shared/utils';
+import { getUserTimezone, isHostKeyVisibleForJoinWindow } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -183,8 +183,10 @@ export class MeetingJoinComponent implements OnInit {
   protected showAllFiles = signal(false);
   // Host key is masked by default; the reveal toggle flips this.
   protected showHostKey = signal(false);
-  // Single gate for the host-key UI: upcoming meeting AND the BFF authorized this viewer and sent a key.
-  protected hostKeyVisible = computed(() => !this.isPastMeeting() && isHostKeyVisible(this.meeting()));
+  // Single gate for the host-key chip: the BFF authorized this viewer (and sent a key) AND the
+  // meeting is inside its join window (early-join → end) — the same window as the Join button.
+  // Host keys can rotate per occurrence, so we don't surface them before the meeting is joinable.
+  protected hostKeyVisible = computed(() => isHostKeyVisibleForJoinWindow(this.meeting(), this.currentOccurrence()));
   protected visibleFiles = computed(() => (this.showAllFiles() ? this.materialFiles() : this.materialFiles().slice(0, 5)));
   protected hasMoreFiles = computed(() => this.materialFiles().length > 5);
   // Authoritative "view as past" flag derived from the hyphenated occurrence ID URL pattern —

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -50,7 +50,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
-import { getUserTimezone } from '@lfx-one/shared/utils';
+import { getUserTimezone, isHostKeyVisible } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -181,6 +181,10 @@ export class MeetingJoinComponent implements OnInit {
   private optimisticAdditional = signal(0);
   public materialsDrawerVisible = signal(false);
   protected showAllFiles = signal(false);
+  // Host key is masked by default; the reveal toggle flips this.
+  protected showHostKey = signal(false);
+  // Single gate for the host-key UI: upcoming meeting AND the BFF authorized this viewer and sent a key.
+  protected hostKeyVisible = computed(() => !this.isPastMeeting() && isHostKeyVisible(this.meeting()));
   protected visibleFiles = computed(() => (this.showAllFiles() ? this.materialFiles() : this.materialFiles().slice(0, 5)));
   protected hasMoreFiles = computed(() => this.materialFiles().length > 5);
   // Authoritative "view as past" flag derived from the hyphenated occurrence ID URL pattern —
@@ -386,6 +390,32 @@ export class MeetingJoinComponent implements OnInit {
       summary: 'Meeting Link Copied',
       detail: 'The meeting link has been copied to your clipboard',
     });
+  }
+
+  public toggleHostKey(): void {
+    this.showHostKey.update((shown) => !shown);
+  }
+
+  public copyHostKey(): void {
+    const hostKey = this.meeting().host_key;
+    if (!hostKey) {
+      return;
+    }
+
+    const success = this.clipboard.copy(hostKey);
+    if (success) {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Host Key Copied',
+        detail: 'The host key has been copied to your clipboard',
+      });
+    } else {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy Failed',
+        detail: 'Unable to copy the host key. Please copy it manually.',
+      });
+    }
   }
 
   public onRegistrantsToggle(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -181,12 +181,15 @@ export class MeetingJoinComponent implements OnInit {
   private optimisticAdditional = signal(0);
   public materialsDrawerVisible = signal(false);
   protected showAllFiles = signal(false);
-  // Host key is masked by default; the reveal toggle flips this.
-  protected showHostKey = signal(false);
+  // Host key is masked by default. Reveal state is scoped to a specific meeting id so that
+  // navigating to a different meeting on the same component instance requires a fresh reveal and
+  // never renders another meeting's key unmasked once its response arrives.
+  private readonly revealedHostKeyMeetingId: WritableSignal<string | null> = signal<string | null>(null);
+  protected readonly showHostKey: Signal<boolean> = computed(() => !!this.meeting()?.id && this.revealedHostKeyMeetingId() === this.meeting().id);
   // Single gate for the host-key chip: the BFF authorized this viewer (and sent a key) AND the
   // meeting is inside its join window (early-join → end) — the same window as the Join button.
   // Host keys can rotate per occurrence, so we don't surface them before the meeting is joinable.
-  protected hostKeyVisible = computed(() => isHostKeyVisibleForJoinWindow(this.meeting(), this.currentOccurrence()));
+  protected readonly hostKeyVisible: Signal<boolean> = computed(() => isHostKeyVisibleForJoinWindow(this.meeting(), this.currentOccurrence()));
   protected visibleFiles = computed(() => (this.showAllFiles() ? this.materialFiles() : this.materialFiles().slice(0, 5)));
   protected hasMoreFiles = computed(() => this.materialFiles().length > 5);
   // Authoritative "view as past" flag derived from the hyphenated occurrence ID URL pattern —
@@ -394,10 +397,19 @@ export class MeetingJoinComponent implements OnInit {
     });
   }
 
+  /**
+   * Toggles the masked/revealed state of the host key for the currently loaded meeting.
+   * Reveal state is keyed to the meeting id, so it resets when a different meeting loads.
+   */
   public toggleHostKey(): void {
-    this.showHostKey.update((shown) => !shown);
+    const meetingId = this.meeting()?.id ?? null;
+    this.revealedHostKeyMeetingId.update((current) => (current === meetingId ? null : meetingId));
   }
 
+  /**
+   * Copies the raw host key to the clipboard, showing a success or failure toast.
+   * No-ops when the current meeting has no host key.
+   */
   public copyHostKey(): void {
     const hostKey = this.meeting().host_key;
     if (!hostKey) {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -23,8 +23,9 @@ import { NatsSubjects } from '@lfx-one/shared/enums';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
-import { addInvitedStatusToMeeting, enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
+import { addInvitedStatusToMeeting, applyHostKeyVisibility, enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
+import { AccessCheckService } from '../services/access-check.service';
 import { AiService } from '../services/ai.service';
 import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
@@ -43,6 +44,7 @@ export class MeetingController {
   private committeeService: CommitteeService = new CommitteeService();
   private natsService: NatsService = new NatsService();
   private userService: UserService = new UserService();
+  private accessCheckService: AccessCheckService = new AccessCheckService();
 
   /**
    * GET /meetings
@@ -70,7 +72,12 @@ export class MeetingController {
         this.userService.getUserRegisteredMeetingIds(req, userEmail),
       ]);
 
-      const result = meetings.map((m) => ({ ...m, invited: registeredMeetingIds.has(m.id) }));
+      // List cards never surface the host key — strip it from every item unconditionally.
+      const result = meetings.map((m) => {
+        const meeting = { ...m, invited: registeredMeetingIds.has(m.id) };
+        stripHostKey(meeting);
+        return meeting;
+      });
 
       logger.success(req, 'get_meetings', startTime, {
         meeting_count: result.length,
@@ -160,6 +167,10 @@ export class MeetingController {
         meetingWithInvitedStatus.committee_members_count = 0;
       }
 
+      // Gate the Zoom host key: expose it only to organizer / project writer / committee writer,
+      // stripped for everyone else. Runs on the authenticated user's token (active on this route).
+      await applyHostKeyVisibility(req, this.accessCheckService, meetingWithInvitedStatus);
+
       // The ITX detail payload omits created_by — join back to the live v1_meeting index so
       // the organizer name can be shown. Single meeting keyed on its own UID.
       const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meetingWithInvitedStatus], (m) => m.id);
@@ -196,6 +207,9 @@ export class MeetingController {
         project_uid: meeting.project_uid,
         title: meeting.title,
       });
+
+      // The create echo never carries the host key — the creator reads it via the detail endpoint.
+      stripHostKey(meeting);
 
       // Send the new meeting data to the client
       res.status(201).json(meeting);

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -18,7 +18,7 @@ import {
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
-import { enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
+import { enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
@@ -53,6 +53,9 @@ export class PastMeetingController {
       // Past meetings are webhook-created (created_by = zoom.webhooks), so join back to the
       // live v1_meeting index by meeting_id to resolve the real organizer name.
       const enriched = await enrichMeetingsWithCreatedBy(req, meetings, (m) => m.meeting_id);
+
+      // Past meetings never surface the host key.
+      enriched.forEach((meeting) => stripHostKey(meeting));
 
       logger.success(req, 'get_past_meetings', startTime, {
         meeting_count: enriched.length,
@@ -128,6 +131,9 @@ export class PastMeetingController {
       // Webhook-created past meeting lacks a human created_by — join back to the live
       // v1_meeting index by meeting_id to resolve the organizer name.
       const [enrichedMeeting] = await enrichMeetingsWithCreatedBy(req, [meeting], (m) => m.meeting_id);
+
+      // Past meetings never surface the host key.
+      stripHostKey(enrichedMeeting);
 
       logger.success(req, 'get_past_meeting_by_id', startTime, {
         past_meeting_id: uid,

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -1,0 +1,215 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MeetingVisibility } from '@lfx-one/shared/enums';
+import type { Meeting } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MEETING_ID = 'meeting-1111';
+const PROJECT_UID = 'project-2222';
+
+// Hoisted, per-test-controllable mocks. The controller (and the real meeting.helper it delegates
+// to for the host-key gate) reach these through the module mocks registered below.
+const {
+  checkAccessMock,
+  generateM2MTokenMock,
+  getEffectiveEmailMock,
+  getEffectiveUsernameMock,
+  validatePasswordMock,
+  meetingSvc,
+  projectSvc,
+  addInvitedStatusToMeetingMock,
+} = vi.hoisted(() => ({
+  checkAccessMock: vi.fn(),
+  generateM2MTokenMock: vi.fn(),
+  getEffectiveEmailMock: vi.fn(),
+  getEffectiveUsernameMock: vi.fn(),
+  validatePasswordMock: vi.fn(),
+  meetingSvc: {
+    getMeetingById: vi.fn(),
+    getMeetingRegistrants: vi.fn(),
+    getMeetingRegistrantsByEmail: vi.fn(),
+  },
+  projectSvc: { getProjectById: vi.fn() },
+  addInvitedStatusToMeetingMock: vi.fn(),
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into vitest; stub the one runtime shared import
+// the controller/gate use. validation.helper is mocked wholesale (see below) so its heavy
+// shared/constants + shared/utils module graph never loads.
+vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
+vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
+
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return meetingSvc;
+  }),
+}));
+vi.mock('../services/project.service', () => ({
+  ProjectService: vi.fn(function () {
+    return projectSvc;
+  }),
+}));
+vi.mock('../services/committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/access-check.service', () => ({
+  AccessCheckService: vi.fn(function () {
+    return { checkAccess: checkAccessMock };
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({
+  getEffectiveEmail: getEffectiveEmailMock,
+  getEffectiveUsername: getEffectiveUsernameMock,
+  getUsernameFromAuth: vi.fn(),
+}));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
+vi.mock('../utils/security.util', () => ({ validatePassword: validatePasswordMock }));
+
+// Keep the real host-key gate (applyHostKeyVisibility + stripHostKey); stub only the
+// registrant-lookup helpers so we don't need M2M/registrant plumbing.
+vi.mock('../helpers/meeting.helper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helpers/meeting.helper')>();
+  return { ...actual, addInvitedStatusToMeeting: addInvitedStatusToMeetingMock, checkPastMeetingAccess: vi.fn() };
+});
+
+import { PublicMeetingController } from './public-meeting.controller';
+
+function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: MEETING_ID,
+    project_uid: PROJECT_UID,
+    visibility: MeetingVisibility.PUBLIC,
+    restricted: false,
+    host_key: '123456',
+    committees: [],
+    ...overrides,
+  } as Meeting;
+}
+
+function buildProject() {
+  return { name: 'Proj', slug: 'proj', logo_url: 'logo', uid: PROJECT_UID, parent_uid: 'parent' };
+}
+
+function buildReqRes(authenticated: boolean) {
+  const req = {
+    params: { id: MEETING_ID },
+    query: {},
+    bearerToken: 'user-token',
+    oidc: { isAuthenticated: () => authenticated },
+    path: '/public/api/meetings/' + MEETING_ID,
+    log: {},
+  } as any;
+  const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+function accessMap(entries: Array<[string, boolean]>): Map<string, boolean> {
+  return new Map(entries);
+}
+
+describe('PublicMeetingController.getMeetingById host_key gating', () => {
+  let controller: PublicMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    getEffectiveUsernameMock.mockReturnValue('user');
+    projectSvc.getProjectById.mockResolvedValue(buildProject());
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+    // Default invited helper: not invited, host_key preserved on the returned object.
+    addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: false }));
+  });
+
+  it('strips host_key for an authenticated non-organizer on a PUBLIC non-restricted meeting (the leak regression)', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    checkAccessMock.mockResolvedValue(
+      accessMap([
+        [MEETING_ID, false],
+        [PROJECT_UID, false],
+      ])
+    );
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.host_key).toBeUndefined();
+    expect(payload.meeting.can_view_host_key).toBe(false);
+  });
+
+  it('keeps host_key for a meeting organizer', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    checkAccessMock.mockResolvedValue(accessMap([[MEETING_ID, true]]));
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingById(req, res, next);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.host_key).toBe('123456');
+    expect(payload.meeting.can_view_host_key).toBe(true);
+  });
+
+  it('keeps host_key for a project writer who is not the organizer', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    checkAccessMock.mockResolvedValue(
+      accessMap([
+        [MEETING_ID, false],
+        [PROJECT_UID, true],
+      ])
+    );
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingById(req, res, next);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.host_key).toBe('123456');
+    expect(payload.meeting.can_view_host_key).toBe(true);
+  });
+
+  it('strips host_key for an unauthenticated caller and never runs an access check', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(checkAccessMock).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.host_key).toBeUndefined();
+    expect(payload.meeting.can_view_host_key).toBe(false);
+  });
+
+  it('strips host_key for an invited non-organizer on a private restricted meeting', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE, restricted: true }));
+    addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: true }));
+    checkAccessMock.mockResolvedValue(
+      accessMap([
+        [MEETING_ID, false],
+        [PROJECT_UID, false],
+      ])
+    );
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingById(req, res, next);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.invited).toBe(true);
+    expect(payload.meeting.host_key).toBeUndefined();
+  });
+});

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -108,11 +108,12 @@ function buildProject() {
   return { name: 'Proj', slug: 'proj', logo_url: 'logo', uid: PROJECT_UID, parent_uid: 'parent' };
 }
 
-function buildReqRes(authenticated: boolean) {
+function buildReqRes(authenticated: boolean, hasUserToken = true) {
   const req = {
     params: { id: MEETING_ID },
     query: {},
-    bearerToken: 'user-token',
+    // Optional-auth routes can be authenticated with no user bearer token (refresh failure).
+    bearerToken: hasUserToken ? 'user-token' : undefined,
     oidc: { isAuthenticated: () => authenticated },
     path: '/public/api/meetings/' + MEETING_ID,
     log: {},
@@ -194,6 +195,20 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
 
     await controller.getMeetingById(req, res, next);
 
+    expect(checkAccessMock).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.meeting.host_key).toBeUndefined();
+    expect(payload.meeting.can_view_host_key).toBe(false);
+  });
+
+  it('fails closed when authenticated but no user token was captured (never checks access as the M2M identity)', async () => {
+    // Optional-auth refresh failure: isAuthenticated() true, but no user bearer token.
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    const { req, res, next } = buildReqRes(true, /* hasUserToken */ false);
+
+    await controller.getMeetingById(req, res, next);
+
+    // The access check must NOT run under the application (M2M) identity.
     expect(checkAccessMock).not.toHaveBeenCalled();
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBeUndefined();

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -29,6 +29,8 @@ const {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
     getMeetingRegistrantsByEmail: vi.fn(),
+    // Called by enrichMeetingsWithCreatedBy (#1155); empty map => enrich is a no-op.
+    resolveCreatedByForMeetings: vi.fn().mockResolvedValue(new Map()),
   },
   projectSvc: { getProjectById: vi.fn() },
   addInvitedStatusToMeetingMock: vi.fn(),
@@ -38,6 +40,9 @@ const {
 // the controller/gate use. validation.helper is mocked wholesale (see below) so its heavy
 // shared/constants + shared/utils module graph never loads.
 vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
+// meeting.helper (kept real via importOriginal) imports resolveMeetingOrganizer from shared/utils;
+// stub it so the real barrel (and its MeetingType enum dependency) isn't pulled into the mock graph.
+vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
 
 vi.mock('../services/meeting.service', () => ({

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -159,10 +159,13 @@ export class PublicMeetingController {
         return;
       }
 
-      // Authenticated registered participants and organizers can access private/restricted
-      // meeting details without a password in the URL — their registrant record is the gate.
+      // Authenticated registered participants, organizers, and project/committee writers can
+      // access private/restricted meeting details without a password in the URL — their
+      // registrant record or FGA writer/organizer relation is the gate. can_view_host_key is
+      // true only for organizer/project-writer/committee-writer, so it admits the writers who
+      // would otherwise fall through to the password gate despite managing the meeting.
       // host_key was already stripped above for anyone not authorized to view it.
-      if (meeting.invited || meeting.organizer) {
+      if (meeting.invited || meeting.organizer || meeting.can_view_host_key) {
         res.json({
           meeting,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { AuthorizationError } from '../errors/authentication.error';
-import { addInvitedStatusToMeeting, checkPastMeetingAccess, enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
+import { addInvitedStatusToMeeting, applyHostKeyVisibility, checkPastMeetingAccess, enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
@@ -78,7 +78,10 @@ export class PublicMeetingController {
         });
       }
 
-      // Check organizer status for authenticated users (needed for all meeting types)
+      // Resolve host-key visibility (organizer OR project writer OR committee writer) for
+      // authenticated users. This sets meeting.organizer (used for the registrant counts below)
+      // and meeting.can_view_host_key, and strips host_key when the user isn't authorized —
+      // the single source of truth for the gate across every response branch.
       if (isAuthenticated) {
         // Temporarily restore user's original token for the access check
         if (originalToken !== undefined) {
@@ -86,20 +89,24 @@ export class PublicMeetingController {
         }
 
         try {
-          meeting = await this.accessCheckService.addAccessToResource(req, meeting, 'v1_meeting', 'organizer');
+          await applyHostKeyVisibility(req, this.accessCheckService, meeting);
         } catch (error) {
-          // If organizer check fails, log but continue with organizer = false
-          logger.warning(req, 'get_public_meeting_by_id', 'Failed to check organizer status, continuing with organizer = false', {
+          // If the access check fails, log but fail closed (no organizer, no host key)
+          logger.warning(req, 'get_public_meeting_by_id', 'Failed to check host key access, continuing with no access', {
             err: error,
             meeting_id: id,
           });
           meeting.organizer = false;
+          meeting.can_view_host_key = false;
+          stripHostKey(meeting);
         }
 
         // Restore M2M token for subsequent operations (e.g., fetching public join URL)
         req.bearerToken = m2mToken;
       } else {
         meeting.organizer = false;
+        meeting.can_view_host_key = false;
+        stripHostKey(meeting);
       }
 
       // Fetch registrant counts for organizers, otherwise default to 0
@@ -120,12 +127,6 @@ export class PublicMeetingController {
       } else {
         meeting.individual_registrants_count = 0;
         meeting.committee_members_count = 0;
-      }
-
-      // The Zoom host key grants host privileges to whoever possesses it.
-      // Strip it from the response for unauthenticated callers.
-      if (!isAuthenticated) {
-        delete (meeting as Partial<Meeting>).host_key;
       }
 
       // The organizer is authenticated-visible info (LFXV2-2802). For authenticated callers, enrich
@@ -150,11 +151,8 @@ export class PublicMeetingController {
 
       // Authenticated registered participants and organizers can access private/restricted
       // meeting details without a password in the URL — their registrant record is the gate.
+      // host_key was already stripped above for anyone not authorized to view it.
       if (meeting.invited || meeting.organizer) {
-        // host_key grants Zoom host privileges — only organizers should receive it.
-        if (!meeting.organizer) {
-          delete (meeting as Partial<Meeting>).host_key;
-        }
         res.json({
           meeting,
           project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
@@ -175,7 +173,6 @@ export class PublicMeetingController {
                 email: userEmail,
               });
               meeting.invited = true;
-              delete (meeting as Partial<Meeting>).host_key;
               res.json({
                 meeting,
                 project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
@@ -280,10 +277,8 @@ export class PublicMeetingController {
         meeting.organizer = isOrganizer;
       }
 
-      // Strip the Zoom host key for unauthenticated callers (mirrors getMeetingById).
-      if (!isAuthenticated) {
-        delete (meeting as Partial<Meeting>).host_key;
-      }
+      // Past meetings never surface the Zoom host key — strip it unconditionally.
+      stripHostKey(meeting);
 
       // The organizer is authenticated-visible info (LFXV2-2802). For authenticated callers, enrich
       // created_by from the live v1_meeting index (webhook-created past meetings lack a human one);

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,7 +8,13 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { AuthorizationError } from '../errors/authentication.error';
-import { addInvitedStatusToMeeting, applyHostKeyVisibility, checkPastMeetingAccess, enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
+import {
+  addInvitedStatusToMeeting,
+  applyHostKeyVisibility,
+  checkPastMeetingAccess,
+  enrichMeetingsWithCreatedBy,
+  stripHostKey,
+} from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -84,15 +84,19 @@ export class PublicMeetingController {
         });
       }
 
-      // Resolve host-key visibility (organizer OR project writer OR committee writer) for
-      // authenticated users. This sets meeting.organizer (used for the registrant counts below)
-      // and meeting.can_view_host_key, and strips host_key when the user isn't authorized —
-      // the single source of truth for the gate across every response branch.
-      if (isAuthenticated) {
+      // Resolve host-key visibility (organizer OR project writer OR committee writer). This sets
+      // meeting.organizer (used for the registrant counts below) and meeting.can_view_host_key,
+      // and strips host_key when the user isn't authorized — the single source of truth for the
+      // gate across every response branch.
+      //
+      // Guard on originalToken, not just isAuthenticated: this is an optional-auth route, so a
+      // token-refresh failure can leave isAuthenticated() true with NO user token captured
+      // (originalToken === undefined) while req.bearerToken still holds the M2M token. Running the
+      // access check in that state would evaluate the application identity — which may hold writer
+      // relations — and leak the host key. Fail closed unless we hold the user's own token.
+      if (isAuthenticated && originalToken !== undefined) {
         // Temporarily restore user's original token for the access check
-        if (originalToken !== undefined) {
-          req.bearerToken = originalToken;
-        }
+        req.bearerToken = originalToken;
 
         try {
           await applyHostKeyVisibility(req, this.accessCheckService, meeting);

--- a/apps/lfx-one/src/server/controllers/user.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.spec.ts
@@ -1,0 +1,93 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks. stripHostKey is kept as a spy so we can assert every list item is sanitized;
+// its real behaviour (deleting host_key) is covered in meeting.helper.spec.ts.
+const { stripHostKeyMock, getStringQueryParamMock, getEffectiveEmailMock, userSvc } = vi.hoisted(() => ({
+  stripHostKeyMock: vi.fn(),
+  getStringQueryParamMock: vi.fn(() => undefined),
+  getEffectiveEmailMock: vi.fn(() => 'user@example.com'),
+  userSvc: {
+    getUserMeetings: vi.fn(),
+    getUserPastMeetings: vi.fn(),
+    getUserLatestPastMeetings: vi.fn(),
+  },
+}));
+
+vi.mock('../helpers/meeting.helper', () => ({ stripHostKey: stripHostKeyMock }));
+vi.mock('../helpers/validation.helper', () => ({ getStringQueryParam: getStringQueryParamMock }));
+vi.mock('../services/user.service', () => ({
+  UserService: vi.fn(function () {
+    return userSvc;
+  }),
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock }));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+import { UserController } from './user.controller';
+
+function buildRes() {
+  return { json: vi.fn(), set: vi.fn().mockReturnThis(), status: vi.fn().mockReturnThis() } as any;
+}
+
+const req = { query: {}, path: '/api/user/meetings', log: {} } as any;
+
+describe('UserController — host_key stripping on list endpoints', () => {
+  let controller: UserController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new UserController();
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+  });
+
+  it('strips host_key from every meeting in getUserMeetings', async () => {
+    const meetings = [
+      { id: 'm1', host_key: 'a' },
+      { id: 'm2', host_key: 'b' },
+    ];
+    userSvc.getUserMeetings.mockResolvedValue(meetings);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getUserMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(stripHostKeyMock).toHaveBeenCalledTimes(2);
+    expect(stripHostKeyMock).toHaveBeenCalledWith(meetings[0]);
+    expect(stripHostKeyMock).toHaveBeenCalledWith(meetings[1]);
+    expect(res.json).toHaveBeenCalledWith(meetings);
+  });
+
+  it('strips host_key from every meeting in getUserPastMeetings', async () => {
+    const meetings = [{ id: 'pm1', host_key: 'a' }];
+    userSvc.getUserPastMeetings.mockResolvedValue(meetings);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getUserPastMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(stripHostKeyMock).toHaveBeenCalledTimes(1);
+    expect(stripHostKeyMock).toHaveBeenCalledWith(meetings[0]);
+    expect(res.json).toHaveBeenCalledWith(meetings);
+  });
+
+  it('strips host_key from every meeting in getUserLatestPastMeetings', async () => {
+    const meetings = [{ id: 'lpm1', host_key: 'a' }];
+    userSvc.getUserLatestPastMeetings.mockResolvedValue(meetings);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getUserLatestPastMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(stripHostKeyMock).toHaveBeenCalledTimes(1);
+    expect(stripHostKeyMock).toHaveBeenCalledWith(meetings[0]);
+    expect(res.json).toHaveBeenCalledWith(meetings);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -4,6 +4,7 @@
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
+import { stripHostKey } from '../helpers/meeting.helper';
 import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { UserService } from '../services/user.service';
@@ -165,6 +166,9 @@ export class UserController {
       // server-side FGA lookup). Auth middleware has already ensured the user is authenticated.
       const meetings = await this.userService.getUserMeetings(req, projectUid, foundationUid);
 
+      // List cards never surface the Zoom host key — strip it from every item unconditionally.
+      meetings.forEach((meeting) => stripHostKey(meeting));
+
       logger.success(req, 'get_user_meetings', startTime, {
         project_uid: projectUid,
         foundation_uid: foundationUid,
@@ -215,6 +219,9 @@ export class UserController {
       // Get user's past meetings from service
       const pastMeetings = await this.userService.getUserPastMeetings(req, userEmail, projectUid, foundationUid);
 
+      // Past meetings never surface the Zoom host key.
+      pastMeetings.forEach((meeting) => stripHostKey(meeting));
+
       logger.success(req, 'get_user_past_meetings', startTime, {
         project_uid: projectUid,
         foundation_uid: foundationUid,
@@ -254,6 +261,9 @@ export class UserController {
       // No email extraction needed — the service uses req.bearerToken (via filter_grants=direct
       // server-side FGA lookup). Auth middleware has already ensured the user is authenticated.
       const pastMeetings = await this.userService.getUserLatestPastMeetings(req, projectUid, foundationUid);
+
+      // Past meetings never surface the Zoom host key.
+      pastMeetings.forEach((meeting) => stripHostKey(meeting));
 
       logger.success(req, 'get_user_latest_past_meetings', startTime, {
         count: pastMeetings.length,

--- a/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
@@ -5,6 +5,8 @@ import type { Meeting, MeetingUserInfo, PastMeeting } from '@lfx-one/shared/inte
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { AccessCheckService } from '../services/access-check.service';
+
 const { resolveCreatedByForMeetings } = vi.hoisted(() => ({
   resolveCreatedByForMeetings: vi.fn<(req: unknown, uids: string[]) => Promise<Map<string, MeetingUserInfo>>>(),
 }));
@@ -27,7 +29,9 @@ vi.mock('@lfx-one/shared/utils', () => ({
 vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
 
 // Stub the services constructed at module load so importing the helper doesn't pull in the
-// microservice proxy / access-check / committee stack. Only resolveCreatedByForMeetings is exercised.
+// microservice proxy / access-check / committee stack. enrichMeetingsWithCreatedBy exercises
+// resolveCreatedByForMeetings; the host-key gate uses an injected access-check service (not the
+// module), so a bare MeetingService stub with that one method covers both suites.
 vi.mock('../services/meeting.service', () => ({
   MeetingService: class {
     public resolveCreatedByForMeetings = resolveCreatedByForMeetings;
@@ -40,7 +44,7 @@ vi.mock('../services/logger.service', () => ({
 vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getUsernameFromAuth: vi.fn() }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
 
-import { enrichMeetingsWithCreatedBy } from './meeting.helper';
+import { applyHostKeyVisibility, enrichMeetingsWithCreatedBy, stripHostKey } from './meeting.helper';
 
 const req = {} as unknown as Request;
 const human: MeetingUserInfo = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
@@ -107,5 +111,148 @@ describe('enrichMeetingsWithCreatedBy', () => {
 
     expect(resolveCreatedByForMeetings).toHaveBeenCalledWith(req, ['up-1']);
     expect(result[0].created_by).toEqual(human);
+  });
+});
+
+const MEETING_ID = 'meeting-1111';
+const PROJECT_UID = 'project-2222';
+const COMMITTEE_A = 'committee-aaaa';
+const COMMITTEE_B = 'committee-bbbb';
+
+function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: MEETING_ID,
+    project_uid: PROJECT_UID,
+    host_key: '123456',
+    committees: [{ uid: COMMITTEE_A }],
+    // Only the fields the gate reads matter; cast the rest.
+    ...overrides,
+  } as Meeting;
+}
+
+function mockAccessCheck(results: Map<string, boolean>): { service: AccessCheckService; checkAccess: ReturnType<typeof vi.fn> } {
+  const checkAccess = vi.fn().mockResolvedValue(results);
+  return { service: { checkAccess } as unknown as AccessCheckService, checkAccess };
+}
+
+describe('applyHostKeyVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps host_key for a meeting organizer', async () => {
+    const meeting = buildMeeting();
+    const { service } = mockAccessCheck(
+      new Map([
+        [MEETING_ID, true],
+        [PROJECT_UID, false],
+        [COMMITTEE_A, false],
+      ])
+    );
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(meeting.organizer).toBe(true);
+    expect(meeting.can_view_host_key).toBe(true);
+    expect(meeting.host_key).toBe('123456');
+  });
+
+  it('keeps host_key for a project writer who is not the organizer', async () => {
+    const meeting = buildMeeting();
+    const { service } = mockAccessCheck(
+      new Map([
+        [MEETING_ID, false],
+        [PROJECT_UID, true],
+        [COMMITTEE_A, false],
+      ])
+    );
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(meeting.organizer).toBe(false);
+    expect(meeting.can_view_host_key).toBe(true);
+    expect(meeting.host_key).toBe('123456');
+  });
+
+  it('keeps host_key for a writer on any attached committee', async () => {
+    const meeting = buildMeeting({ committees: [{ uid: COMMITTEE_A }, { uid: COMMITTEE_B }] });
+    const { service } = mockAccessCheck(
+      new Map([
+        [MEETING_ID, false],
+        [PROJECT_UID, false],
+        [COMMITTEE_A, false],
+        [COMMITTEE_B, true],
+      ])
+    );
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(meeting.can_view_host_key).toBe(true);
+    expect(meeting.host_key).toBe('123456');
+  });
+
+  it('strips host_key when the user has none of the three relations (the leak regression)', async () => {
+    const meeting = buildMeeting();
+    const { service } = mockAccessCheck(
+      new Map([
+        [MEETING_ID, false],
+        [PROJECT_UID, false],
+        [COMMITTEE_A, false],
+      ])
+    );
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(meeting.organizer).toBe(false);
+    expect(meeting.can_view_host_key).toBe(false);
+    expect(meeting.host_key).toBeUndefined();
+  });
+
+  it('batches organizer + project + every committee into a single access-check call', async () => {
+    const meeting = buildMeeting({ committees: [{ uid: COMMITTEE_A }, { uid: COMMITTEE_B }] });
+    const { service, checkAccess } = mockAccessCheck(new Map());
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(checkAccess).toHaveBeenCalledTimes(1);
+    expect(checkAccess).toHaveBeenCalledWith(req, [
+      { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' },
+      { resource: 'project', id: PROJECT_UID, access: 'writer' },
+      { resource: 'committee', id: COMMITTEE_A, access: 'writer' },
+      { resource: 'committee', id: COMMITTEE_B, access: 'writer' },
+    ]);
+  });
+
+  it('handles a meeting with no committees (organizer + project only)', async () => {
+    const meeting = buildMeeting({ committees: [] });
+    const { service, checkAccess } = mockAccessCheck(new Map([[PROJECT_UID, true]]));
+
+    await applyHostKeyVisibility(req, service, meeting);
+
+    expect(checkAccess).toHaveBeenCalledWith(req, [
+      { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' },
+      { resource: 'project', id: PROJECT_UID, access: 'writer' },
+    ]);
+    expect(meeting.can_view_host_key).toBe(true);
+  });
+});
+
+describe('stripHostKey', () => {
+  it('removes host_key from a meeting', () => {
+    const meeting = buildMeeting();
+    stripHostKey(meeting);
+    expect(meeting.host_key).toBeUndefined();
+  });
+
+  it('leaves other fields intact', () => {
+    const meeting = buildMeeting();
+    stripHostKey(meeting);
+    expect(meeting.id).toBe(MEETING_ID);
+    expect(meeting.project_uid).toBe(PROJECT_UID);
+  });
+
+  it('no-ops on null/undefined', () => {
+    expect(() => stripHostKey(null)).not.toThrow();
+    expect(() => stripHostKey(undefined)).not.toThrow();
   });
 });

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingVisibility } from '@lfx-one/shared/enums';
-import { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
+import { AccessCheckAccessType, AccessCheckRequest, AccessCheckResourceType, Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
 import { resolveMeetingOrganizer } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
+import { AccessCheckService } from '../services/access-check.service';
 import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
@@ -114,6 +115,65 @@ export async function enrichMeetingsWithCreatedBy<T extends Meeting>(req: Reques
     const createdBy = createdByMap.get(keyOf(meeting)!);
     return createdBy ? { ...meeting, created_by: createdBy } : meeting;
   });
+}
+
+/**
+ * Removes the Zoom host key from a meeting response.
+ *
+ * The host key is a 6-digit credential that grants Zoom host privileges to whoever holds it,
+ * so it must never reach a client that isn't authorized to see it (see {@link applyHostKeyVisibility}).
+ * Used directly on response paths where the host key is never surfaced (list views, past meetings,
+ * anonymous callers, create echoes).
+ *
+ * @param meeting - The meeting (or partial) to strip; no-ops on null/undefined
+ */
+export function stripHostKey(meeting: Partial<Meeting> | null | undefined): void {
+  if (meeting) {
+    delete meeting.host_key;
+  }
+}
+
+/**
+ * Resolves whether the current user may view a meeting's Zoom host key and mutates the meeting
+ * accordingly. This is the single source of truth for host-key visibility on detail endpoints.
+ *
+ * The audience is any of three DISTINCT OpenFGA relations, OR-ed together:
+ *   - meeting organizer (`v1_meeting#organizer`)
+ *   - project writer (`project#writer`)
+ *   - writer on ANY committee attached to the meeting (`committee#writer`)
+ *
+ * All checks are batched into a single `/access-check` round-trip (no sequential per-committee
+ * calls). The check is fail-closed: on any upstream error the access-check service returns
+ * all-false, so the host key is stripped.
+ *
+ * Sets `meeting.organizer` (still consumed downstream for registrant-count gating) and
+ * `meeting.can_view_host_key` (the single gate the frontend reads), and deletes `host_key`
+ * when the user is not authorized.
+ *
+ * MUST be called with the user's own bearer token active on `req` — NOT an M2M token — or the
+ * access check evaluates against the application identity instead of the user.
+ *
+ * @param req - Express request object with the user's auth context
+ * @param accessCheckService - Access-check service instance
+ * @param meeting - The meeting to gate (mutated in place)
+ */
+export async function applyHostKeyVisibility(req: Request, accessCheckService: AccessCheckService, meeting: Meeting): Promise<void> {
+  const requests: AccessCheckRequest[] = [
+    { resource: 'v1_meeting', id: meeting.id, access: 'organizer' },
+    { resource: 'project', id: meeting.project_uid, access: 'writer' },
+    ...(meeting.committees ?? [])
+      .filter((committee) => committee?.uid)
+      .map((committee) => ({ resource: 'committee' as AccessCheckResourceType, id: committee.uid, access: 'writer' as AccessCheckAccessType })),
+  ];
+
+  const results = await accessCheckService.checkAccess(req, requests);
+
+  meeting.organizer = results.get(meeting.id) ?? false;
+  meeting.can_view_host_key = Array.from(results.values()).some(Boolean);
+
+  if (!meeting.can_view_host_key) {
+    stripHostKey(meeting);
+  }
 }
 
 /**

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -168,8 +168,14 @@ export async function applyHostKeyVisibility(req: Request, accessCheckService: A
 
   const results = await accessCheckService.checkAccess(req, requests);
 
-  meeting.organizer = results.get(meeting.id) ?? false;
-  meeting.can_view_host_key = Array.from(results.values()).some(Boolean);
+  // Derive the gate from the three named relations explicitly (not "any true in the batch"), so a
+  // future unrelated entry added to `requests` can't silently widen host-key visibility.
+  const isOrganizer = results.get(meeting.id) ?? false;
+  const isProjectWriter = results.get(meeting.project_uid) ?? false;
+  const isCommitteeWriter = (meeting.committees ?? []).some((committee) => !!committee?.uid && (results.get(committee.uid) ?? false));
+
+  meeting.organizer = isOrganizer;
+  meeting.can_view_host_key = isOrganizer || isProjectWriter || isCommitteeWriter;
 
   if (!meeting.can_view_host_key) {
     stripHostKey(meeting);

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -272,6 +272,8 @@ export interface Meeting {
 
   /** 6-digit Zoom host key */
   host_key?: string;
+  /** Whether the current user may view host_key (organizer OR project writer OR committee writer). Response-only. */
+  can_view_host_key?: boolean;
   /** Zoom meeting passcode */
   passcode?: string;
 

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -1,10 +1,16 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from 'vitest';
+// isHostKeyVisibleForJoinWindow pulls meeting.utils, which transitively imports
+// @angular/common/http (HttpParams) — its declarations need the Angular JIT compiler when loaded
+// outside an Angular bootstrap (as under Vitest). Importing the compiler first provides that facade.
+import '@angular/compiler';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingVisibility } from '../enums';
-import { getMeetingPrivacyIcon, getMeetingPrivacyLabel, isHostKeyVisible } from './meeting-privacy.utils';
+import type { Meeting } from '../interfaces';
+import { getMeetingPrivacyIcon, getMeetingPrivacyLabel, isHostKeyVisible, isHostKeyVisibleForJoinWindow } from './meeting-privacy.utils';
 
 describe('getMeetingPrivacyLabel', () => {
   it('returns "Public" for public + unrestricted', () => {
@@ -68,5 +74,65 @@ describe('isHostKeyVisible', () => {
   it('is false for null/undefined meetings', () => {
     expect(isHostKeyVisible(null)).toBe(false);
     expect(isHostKeyVisible(undefined)).toBe(false);
+  });
+});
+
+describe('isHostKeyVisibleForJoinWindow', () => {
+  // Fixed meeting: starts 12:00Z, 60 min long, 10 min early-join.
+  // Join window (per canJoinMeeting) = [11:50Z, 13:40Z] (end + 40 min buffer).
+  const START = '2026-01-01T12:00:00.000Z';
+
+  function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
+    return {
+      start_time: START,
+      duration: 60,
+      early_join_time_minutes: 10,
+      can_view_host_key: true,
+      host_key: '123456',
+      ...overrides,
+    } as Meeting;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is hidden before the early-join window opens', () => {
+    vi.setSystemTime(new Date('2026-01-01T11:00:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting())).toBe(false);
+  });
+
+  it('is visible during the early-join window (before start)', () => {
+    vi.setSystemTime(new Date('2026-01-01T11:55:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting())).toBe(true);
+  });
+
+  it('is visible while the meeting is in progress', () => {
+    vi.setSystemTime(new Date('2026-01-01T12:30:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting())).toBe(true);
+  });
+
+  it('is hidden after the meeting ends', () => {
+    vi.setSystemTime(new Date('2026-01-01T14:00:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting())).toBe(false);
+  });
+
+  it('is hidden inside the window when the viewer is not authorized', () => {
+    vi.setSystemTime(new Date('2026-01-01T12:30:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting({ can_view_host_key: false }))).toBe(false);
+  });
+
+  it('is hidden inside the window when no host_key was supplied', () => {
+    vi.setSystemTime(new Date('2026-01-01T12:30:00.000Z'));
+    expect(isHostKeyVisibleForJoinWindow(buildMeeting({ host_key: undefined }))).toBe(false);
+  });
+
+  it('is false for null/undefined meetings', () => {
+    expect(isHostKeyVisibleForJoinWindow(null)).toBe(false);
+    expect(isHostKeyVisibleForJoinWindow(undefined)).toBe(false);
   });
 });

--- a/packages/shared/src/utils/meeting-privacy.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { MeetingVisibility } from '../enums';
-import { getMeetingPrivacyIcon, getMeetingPrivacyLabel } from './meeting-privacy.utils';
+import { getMeetingPrivacyIcon, getMeetingPrivacyLabel, isHostKeyVisible } from './meeting-privacy.utils';
 
 describe('getMeetingPrivacyLabel', () => {
   it('returns "Public" for public + unrestricted', () => {
@@ -47,5 +47,26 @@ describe('getMeetingPrivacyIcon', () => {
 
   it('returns lock icon when public + restricted (edge case)', () => {
     expect(getMeetingPrivacyIcon(MeetingVisibility.PUBLIC, true)).toBe('fa-light fa-lock');
+  });
+});
+
+describe('isHostKeyVisible', () => {
+  it('is true when the viewer is authorized and a key is present', () => {
+    expect(isHostKeyVisible({ can_view_host_key: true, host_key: '123456' })).toBe(true);
+  });
+
+  it('is false when authorized but no key was supplied', () => {
+    expect(isHostKeyVisible({ can_view_host_key: true, host_key: undefined })).toBe(false);
+    expect(isHostKeyVisible({ can_view_host_key: true, host_key: '' })).toBe(false);
+  });
+
+  it('is false when a key is present but the viewer is not authorized (defense in depth)', () => {
+    expect(isHostKeyVisible({ can_view_host_key: false, host_key: '123456' })).toBe(false);
+    expect(isHostKeyVisible({ host_key: '123456' })).toBe(false);
+  });
+
+  it('is false for null/undefined meetings', () => {
+    expect(isHostKeyVisible(null)).toBe(false);
+    expect(isHostKeyVisible(undefined)).toBe(false);
   });
 });

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -49,7 +49,7 @@ export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, rest
  * (organizer OR project writer OR committee writer): it sets `can_view_host_key` and strips
  * `host_key` for anyone unauthorized. The UI must not re-derive that audience — it renders the
  * host key only when the BFF both marks the viewer authorized AND supplies a key. Callers gate
- * on meeting time (upcoming only) separately.
+ * on the meeting's join window separately (see {@link isHostKeyVisibleForJoinWindow}).
  */
 export function isHostKeyVisible(meeting: Pick<Meeting, 'host_key' | 'can_view_host_key'> | null | undefined): boolean {
   return !!meeting?.can_view_host_key && !!meeting?.host_key;

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingVisibility } from '../enums';
+import type { Meeting } from '../interfaces';
 
 /**
  * Returns a human-readable label for the combined meeting privacy state.
@@ -39,4 +40,16 @@ export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, rest
     return 'fa-light fa-shield';
   }
   return 'fa-light fa-globe';
+}
+
+/**
+ * Whether the current viewer may see a meeting's Zoom host key.
+ * @description The BFF is the single source of truth for the host-key audience
+ * (organizer OR project writer OR committee writer): it sets `can_view_host_key` and strips
+ * `host_key` for anyone unauthorized. The UI must not re-derive that audience — it renders the
+ * host key only when the BFF both marks the viewer authorized AND supplies a key. Callers gate
+ * on meeting time (upcoming only) separately.
+ */
+export function isHostKeyVisible(meeting: Pick<Meeting, 'host_key' | 'can_view_host_key'> | null | undefined): boolean {
+  return !!meeting?.can_view_host_key && !!meeting?.host_key;
 }

--- a/packages/shared/src/utils/meeting-privacy.utils.ts
+++ b/packages/shared/src/utils/meeting-privacy.utils.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingVisibility } from '../enums';
-import type { Meeting } from '../interfaces';
+import type { Meeting, MeetingOccurrence } from '../interfaces';
+import { canJoinMeeting } from './meeting.utils';
 
 /**
  * Returns a human-readable label for the combined meeting privacy state.
@@ -52,4 +53,19 @@ export function getMeetingPrivacyIcon(visibility: MeetingVisibility | null, rest
  */
 export function isHostKeyVisible(meeting: Pick<Meeting, 'host_key' | 'can_view_host_key'> | null | undefined): boolean {
   return !!meeting?.can_view_host_key && !!meeting?.host_key;
+}
+
+/**
+ * Whether the host-key chip should render on the meeting detail/join page.
+ * @description Combines the authorization gate ({@link isHostKeyVisible}) with the meeting's
+ * join window: the chip renders only from the early-join time (`start − early_join_time_minutes`)
+ * through the end of the meeting — the exact same window as the Join button and the early-join
+ * banner ({@link canJoinMeeting}), not merely "any upcoming meeting".
+ *
+ * Rationale: Zoom host keys belong to the shared license account and may be rotated per
+ * occurrence, so displaying the key before the meeting is joinable is both wider exposure and
+ * potentially stale. Gating on the join window mirrors PCC's posture.
+ */
+export function isHostKeyVisibleForJoinWindow(meeting: Meeting | null | undefined, occurrence?: MeetingOccurrence | null): boolean {
+  return !!meeting && canJoinMeeting(meeting, occurrence) && isHostKeyVisible(meeting);
 }


### PR DESCRIPTION
## Summary

Surfaces the Zoom **host key** on the meeting detail/join page for authorized users, and closes a set of `host_key` leaks across the meeting response paths.

Jira: [LFXV2-2805](https://linuxfoundation.atlassian.net/browse/LFXV2-2805)

### Security fix (the motivating bug)
`host_key` is a 6-digit credential that grants Zoom host privileges to whoever holds it. It was only partially protected:
- **Primary leak:** the public non-restricted branch of `public-meeting.controller.getMeetingById` returned early after stripping only for *unauthenticated* callers — so any **authenticated non-organizer viewing a public meeting** received `host_key`.
- The authenticated `meeting.controller` detail + list endpoints and `past-meeting.controller` never stripped it at all.

Now a single `applyHostKeyVisibility` helper is the source of truth: it batches **one** `/access-check` round-trip for **organizer OR project writer OR committee writer** (three distinct OpenFGA relations, OR-ed from their named results — not "any true in the batch"), sets `can_view_host_key`, and strips `host_key` for anyone else. Fail-closed on upstream error. List / past-meeting / create-echo paths strip unconditionally.

**Optional-auth fail-closed guard:** on the public route the check runs only when the caller's own bearer token is held (`originalToken !== undefined`), never as the application (M2M) identity. A token-refresh failure can leave `isAuthenticated()` true with no user token while `req.bearerToken` still holds the M2M token; evaluating the access check then would use the application identity (which may hold writer relations) and leak the key. In that state the gate fails closed.

### Feature
Organizer/writer-only **Host Key chip** in the meeting metadata row (alongside Recording / Transcripts / AI Summary), masked by default. Click / Enter / Space reveals inline (`Host Key: 123456`); a copy button appears when revealed. The UI never re-derives the audience — a single `can_view_host_key` gate from the BFF.

**Time gating:** the chip renders only within the meeting's **join window** — from the early-join time (`start − early_join_time_minutes`) through the end of the meeting — the same window as the Join button and the early-join banner (`canJoinMeeting`). Outside that window nothing renders, even for organizers/writers. Rationale: Zoom host keys belong to the shared license account and can rotate per occurrence, so pre-window display is wider exposure and possibly stale — this mirrors PCC's posture. The shared `isHostKeyVisibleForJoinWindow()` composes the existing window helper with the auth gate, so the time math is reused, not duplicated.

## Strip matrix (target state)

| Endpoint | anon | auth, not authorized | organizer / project-writer / committee-writer |
|---|---|---|---|
| `GET /public/api/meetings/:id` (join page) | 🚫 | 🚫 | ✅ |
| `GET /api/meetings/:uid` (auth detail) | n/a | 🚫 | ✅ |
| `GET /api/meetings` (list) | n/a | 🚫 | 🚫 |
| `POST /api/meetings` (create echo) | n/a | 🚫 | 🚫 |
| public/auth past-meeting (detail + list) | 🚫 | 🚫 | 🚫 |

## Changes
- **shared:** `Meeting.can_view_host_key` (response-only); `isHostKeyVisible()` (auth gate) and `isHostKeyVisibleForJoinWindow()` (auth gate ∧ join window) in `meeting-privacy.utils.ts`.
- **BFF:** `applyHostKeyVisibility` + `stripHostKey` in `meeting.helper.ts`; applied across `public-meeting`, `meeting`, and `past-meeting` controllers; optional-auth fail-closed guard on the public route.
- **UI:** host-key chip in `meeting-join` (join-window gated; reveal toggle, copy, tooltip, full keyboard/AT support).

## Tests
- `meeting.helper.spec.ts` — gate matrix (organizer / project-writer / committee-writer / none → strip), single-batch assertion.
- `public-meeting.controller.spec.ts` — controller strip matrix incl. the public-branch **leak regression** and the **no-user-token fail-closed** case.
- `meeting-privacy.utils.spec.ts` — `isHostKeyVisible`, plus `isHostKeyVisibleForJoinWindow` across before-window / early-join / in-progress / after-end / unauthorized states.
- `yarn lint && yarn format && yarn test && yarn build` all green (shared 279, ui 49).

## Notes for reviewers
- **Rebased onto #1155** (`feat(meetings): show meeting organizer across meeting surfaces`), which overlapped these files. Conflicts were hand-resolved so #1155's `created_by` enrichment and this branch's host-key gating coexist (host-key strip runs *before* the `created_by` spread, so a stripped key can't reappear). No dependency on any unmerged PR.
- **Branch name** keeps a descriptive suffix (`feat/LFXV2-2805-host-key-display`) vs the strict `feat/LFXV2-<n>` — noted, kept for traceability with the `ss-2805` worktree.
- **Trade-off:** the client reveal-state (`showHostKey`) isn't reset if the same component instance is reused for a different meeting. Harmless — the chip is gated on `can_view_host_key`/`host_key` + the join window, and the BFF remains the security boundary regardless of client reveal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LFXV2-2805]: https://linuxfoundation.atlassian.net/browse/LFXV2-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ