### PR TITLE
fix(org-lens): rank leaderboard rows, unpin viewing org [LFXV2-2799]

### DIFF
--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -132,12 +132,15 @@ test.describe('Org Project Detail — leaderboards', () => {
   });
 
   test('activity count mode also renders boards in rank order with the viewing org not pinned', async ({ page }) => {
-    // buildBoard() drops the pin in the Activity Count branch too (ordered by warehouse rank). Warehouse
-    // ranks can have gaps for a viewer-scoped set, so assert non-decreasing order (not contiguity) — a
-    // viewing row pinned out of order would still break a non-decreasing sequence.
+    // buildBoard() drops the pin in the Activity Count branch too, sorting by warehouse rank ascending
+    // (rows with no warehouse rank sort last and render a positional `i + 1` fallback). So each row's
+    // rank is non-decreasing versus the previous row EXCEPT for a trailing fallback row, whose rank
+    // equals its 1-based position. A viewing row pinned out of order would satisfy neither condition.
+    // Both boards load independently, so await each table before reading its rows to avoid a race.
     await page.getByTestId('project-detail-metric-activity').click();
     await expect(page).toHaveURL(/metric=activity/);
     await expect(page.getByTestId('project-detail-leaderboard-technical-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('project-detail-leaderboard-ecosystem-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     for (const board of ['technical', 'ecosystem'] as const) {
       const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
@@ -155,7 +158,9 @@ test.describe('Org Project Detail — leaderboards', () => {
       }
 
       for (let i = 1; i < ranks.length; i++) {
-        expect(ranks[i]).toBeGreaterThanOrEqual(ranks[i - 1]);
+        const nonDecreasing = ranks[i] >= ranks[i - 1];
+        const positionalFallback = ranks[i] === i + 1;
+        expect(nonDecreasing || positionalFallback).toBe(true);
       }
       expect(viewingIndex).toBeGreaterThanOrEqual(0);
     }

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -95,12 +95,38 @@ test.describe('Org Project Detail — leaderboards', () => {
     await expect(page.getByTestId('project-detail-leaderboard-technical-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
-  test('renders both side-by-side boards with the viewing-org row pinned', async ({ page }) => {
+  test('renders both side-by-side boards with the viewing-org row at its ranked position', async ({ page }) => {
     await expect(page.getByTestId('project-detail-leaderboard-technical')).toBeVisible();
     await expect(page.getByTestId('project-detail-leaderboard-ecosystem')).toBeVisible();
     await expect(page.getByTestId('project-detail-leaderboard-technical-viewing-row')).toBeVisible();
     await expect(page.getByTestId('project-detail-leaderboard-ecosystem-viewing-row')).toBeVisible();
     await expect(page.getByTestId('project-detail-trend-group')).toBeVisible();
+
+    // The viewing org is no longer pinned to the top: the default Calculated Influence view ranks
+    // rows 1..N contiguously, so ranks ascend in render order and the viewing row sits at the
+    // position matching its rank number. A pinned out-of-order row would break both invariants.
+    for (const board of ['technical', 'ecosystem'] as const) {
+      const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
+      const count = await rows.count();
+      expect(count).toBeGreaterThan(0);
+
+      const ranks: number[] = [];
+      let viewingIndex = -1;
+      for (let i = 0; i < count; i++) {
+        const row = rows.nth(i);
+        ranks.push(Number((await row.locator('td').first().innerText()).trim()));
+        if ((await row.getAttribute('data-testid')) === `project-detail-leaderboard-${board}-viewing-row`) {
+          viewingIndex = i;
+        }
+      }
+
+      expect(ranks[0]).toBe(1);
+      for (let i = 1; i < ranks.length; i++) {
+        expect(ranks[i]).toBeGreaterThan(ranks[i - 1]);
+      }
+      expect(viewingIndex).toBeGreaterThanOrEqual(0);
+      expect(ranks[viewingIndex]).toBe(viewingIndex + 1);
+    }
   });
 
   test('metric toggle persists in the URL and switches the score column', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -136,7 +136,9 @@ test.describe('Org Project Detail — leaderboards', () => {
     // (rows with no warehouse rank sort last and render a positional `i + 1` fallback). So each row's
     // rank is non-decreasing versus the previous row EXCEPT for a trailing fallback row, whose rank
     // equals its 1-based position. A viewing row pinned out of order would satisfy neither condition.
-    // Both boards load independently, so await each table before reading its rows to avoid a race.
+    // We assert only the rendered rank order — not the viewing row's presence — because unpinning
+    // explicitly allows the viewing org to fall onto a later paginator page. Both boards load
+    // independently, so await each table before reading its rows to avoid a race.
     await page.getByTestId('project-detail-metric-activity').click();
     await expect(page).toHaveURL(/metric=activity/);
     await expect(page.getByTestId('project-detail-leaderboard-technical-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
@@ -148,13 +150,8 @@ test.describe('Org Project Detail — leaderboards', () => {
       expect(count).toBeGreaterThan(0);
 
       const ranks: number[] = [];
-      let viewingIndex = -1;
       for (let i = 0; i < count; i++) {
-        const row = rows.nth(i);
-        ranks.push(Number((await row.locator('td').first().innerText()).trim()));
-        if ((await row.getAttribute('data-testid')) === `project-detail-leaderboard-${board}-viewing-row`) {
-          viewingIndex = i;
-        }
+        ranks.push(Number((await rows.nth(i).locator('td').first().innerText()).trim()));
       }
 
       for (let i = 1; i < ranks.length; i++) {
@@ -162,7 +159,6 @@ test.describe('Org Project Detail — leaderboards', () => {
         const positionalFallback = ranks[i] === i + 1;
         expect(nonDecreasing || positionalFallback).toBe(true);
       }
-      expect(viewingIndex).toBeGreaterThanOrEqual(0);
     }
   });
 

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -102,9 +102,12 @@ test.describe('Org Project Detail — leaderboards', () => {
     await expect(page.getByTestId('project-detail-leaderboard-ecosystem-viewing-row')).toBeVisible();
     await expect(page.getByTestId('project-detail-trend-group')).toBeVisible();
 
-    // The viewing org is no longer pinned to the top: the default Calculated Influence view ranks
-    // rows 1..N contiguously, so ranks ascend in render order and the viewing row sits at the
-    // position matching its rank number. A pinned out-of-order row would break both invariants.
+    // The viewing org is no longer pinned to the top. Calculated Influence assigns contiguous ranks,
+    // so within the rendered page each row's rank equals the first row's rank plus its offset, and the
+    // viewing row sits at its own rank position. Asserting contiguity relative to the first rendered
+    // rank (rather than a hardcoded 1) keeps this correct even if the board ever paginates; a pinned
+    // out-of-order row would break contiguity. The viewing-row visibility check above establishes that
+    // the viewing org renders on the current page.
     for (const board of ['technical', 'ecosystem'] as const) {
       const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
       const count = await rows.count();
@@ -120,12 +123,41 @@ test.describe('Org Project Detail — leaderboards', () => {
         }
       }
 
-      expect(ranks[0]).toBe(1);
-      for (let i = 1; i < ranks.length; i++) {
-        expect(ranks[i]).toBeGreaterThan(ranks[i - 1]);
+      for (let i = 0; i < ranks.length; i++) {
+        expect(ranks[i]).toBe(ranks[0] + i);
       }
       expect(viewingIndex).toBeGreaterThanOrEqual(0);
-      expect(ranks[viewingIndex]).toBe(viewingIndex + 1);
+      expect(ranks[viewingIndex]).toBe(ranks[0] + viewingIndex);
+    }
+  });
+
+  test('activity count mode also renders boards in rank order with the viewing org not pinned', async ({ page }) => {
+    // buildBoard() drops the pin in the Activity Count branch too (ordered by warehouse rank). Warehouse
+    // ranks can have gaps for a viewer-scoped set, so assert non-decreasing order (not contiguity) — a
+    // viewing row pinned out of order would still break a non-decreasing sequence.
+    await page.getByTestId('project-detail-metric-activity').click();
+    await expect(page).toHaveURL(/metric=activity/);
+    await expect(page.getByTestId('project-detail-leaderboard-technical-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    for (const board of ['technical', 'ecosystem'] as const) {
+      const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
+      const count = await rows.count();
+      expect(count).toBeGreaterThan(0);
+
+      const ranks: number[] = [];
+      let viewingIndex = -1;
+      for (let i = 0; i < count; i++) {
+        const row = rows.nth(i);
+        ranks.push(Number((await row.locator('td').first().innerText()).trim()));
+        if ((await row.getAttribute('data-testid')) === `project-detail-leaderboard-${board}-viewing-row`) {
+          viewingIndex = i;
+        }
+      }
+
+      for (let i = 1; i < ranks.length; i++) {
+        expect(ranks[i]).toBeGreaterThanOrEqual(ranks[i - 1]);
+      }
+      expect(viewingIndex).toBeGreaterThanOrEqual(0);
     }
   });
 

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -98,16 +98,19 @@ test.describe('Org Project Detail — leaderboards', () => {
   test('renders both side-by-side boards with the viewing-org row at its ranked position', async ({ page }) => {
     await expect(page.getByTestId('project-detail-leaderboard-technical')).toBeVisible();
     await expect(page.getByTestId('project-detail-leaderboard-ecosystem')).toBeVisible();
-    await expect(page.getByTestId('project-detail-leaderboard-technical-viewing-row')).toBeVisible();
-    await expect(page.getByTestId('project-detail-leaderboard-ecosystem-viewing-row')).toBeVisible();
     await expect(page.getByTestId('project-detail-trend-group')).toBeVisible();
 
     // The viewing org is no longer pinned to the top. Calculated Influence assigns contiguous ranks,
-    // so within the rendered page each row's rank equals the first row's rank plus its offset, and the
-    // viewing row sits at its own rank position. Asserting contiguity relative to the first rendered
-    // rank (rather than a hardcoded 1) keeps this correct even if the board ever paginates; a pinned
-    // out-of-order row would break contiguity. The viewing-row visibility check above establishes that
-    // the viewing org renders on the current page.
+    // so within the rendered page each row's rank equals the first row's rank plus its offset; a pinned
+    // out-of-order row would break that contiguity. This rank-order guard is asserted FIRST and is
+    // page-independent (it keys off the first rendered rank, not a hardcoded 1), so a genuine ordering
+    // regression surfaces on the rank assertion rather than being masked by a viewing-row precondition.
+    //
+    // Precondition for the viewing-row checks below: the test project returns a single page of orgs
+    // (<= the paginator page size), so the viewing org always renders on this page. If a future fixture
+    // pushed the viewing org past page 1 the viewing-row checks would need to step the paginator first;
+    // the rank-order guard above would still hold unchanged. The custom message keeps that failure mode
+    // legible instead of opaque.
     for (const board of ['technical', 'ecosystem'] as const) {
       const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
       const count = await rows.count();
@@ -126,7 +129,8 @@ test.describe('Org Project Detail — leaderboards', () => {
       for (let i = 0; i < ranks.length; i++) {
         expect(ranks[i]).toBe(ranks[0] + i);
       }
-      expect(viewingIndex).toBeGreaterThanOrEqual(0);
+
+      expect(viewingIndex, `viewing-org row expected on the first ${board} page for this fixture (rank <= page size)`).toBeGreaterThanOrEqual(0);
       expect(ranks[viewingIndex]).toBe(ranks[0] + viewingIndex);
     }
   });

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -100,6 +100,10 @@ test.describe('Org Project Detail — leaderboards', () => {
     await expect(page.getByTestId('project-detail-leaderboard-ecosystem')).toBeVisible();
     await expect(page.getByTestId('project-detail-trend-group')).toBeVisible();
 
+    // Each board loads on its own request. beforeEach awaits the technical table; await the ecosystem
+    // table too so the loop never reads zero rows or skeleton DOM from a board that hasn't resolved yet.
+    await expect(page.getByTestId('project-detail-leaderboard-ecosystem-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
     // The viewing org is no longer pinned to the top. Calculated Influence assigns contiguous ranks,
     // so within the rendered page each row's rank equals the first row's rank plus its offset; a pinned
     // out-of-order row would break that contiguity. This rank-order guard is asserted FIRST and is

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -554,7 +554,7 @@ export class OrgProjectDetailComponent {
           };
         });
       const query = search.trim().toLowerCase();
-      return this.pinViewingRow(query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked);
+      return query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked;
     }
 
     const valued = sourceRows.map((row) => {
@@ -591,12 +591,7 @@ export class OrgProjectDetailComponent {
       };
     });
     const query = search.trim().toLowerCase();
-    return this.pinViewingRow(query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked);
-  }
-
-  private pinViewingRow<T extends { isViewingOrg: boolean }>(rows: T[]): T[] {
-    const idx = rows.findIndex((r) => r.isViewingOrg);
-    return idx > 0 ? [rows[idx], ...rows.slice(0, idx), ...rows.slice(idx + 1)] : rows;
+    return query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked;
   }
 
   private initActiveTab(): OrgLensProjectDetailTab {

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -150,7 +150,7 @@ export interface OrgLensProjectLeaderboardRow {
   trendDeltaPct: number;
   /** Precomputed warehouse rank for Activity Count mode boards (org-dashboard parity). */
   warehouseRank?: number;
-  /** The viewing org's own row — always rendered and visually pinned. */
+  /** Marks the viewing org's own row — rendered at its rank-ordered position and visually highlighted (not pinned to the top). */
   isViewingOrg: boolean;
 }
 


### PR DESCRIPTION
Ticket: [LFXV2-2799](https://linuxfoundation.atlassian.net/browse/LFXV2-2799)

## Summary

- **What changed:** Removed the `pinViewingRow()` helper and its two call sites in `buildBoard()` (`org-project-detail.component.ts`) so the Org Lens Technical/Ecosystem influence leaderboards render rows in pure rank order; updated the `isViewingOrg` doc comment (`org-lens-project-detail.interface.ts`) and the `org-project-detail.spec.ts` E2E assertion from "viewing row pinned" to "viewing row at its ranked position".
- **Why:** LFXV2-2799 — the viewing org (e.g. Red Hat) was force-pinned to row 1 while still showing its real rank (#3/#4), so the visible order contradicted the rank column.
- **How to verify:** Org Lens → a project → Leaderboards tab; confirm rows ascend by rank and the viewing org sits at its true position with highlight + "You" badge. Verified live on Kubernetes as Red Hat (Technical #3 third row, Ecosystem #4 fourth row). `corepack yarn check-types` and `corepack yarn lint:check` pass.
- **Non-obvious:** BFF unchanged — it already returns rows `ORDER BY RANK ASC` with `isViewingOrg` flagged; the pin was purely client-side. Highlight + "You" badge are driven by `isViewingOrg` in the template, so no template change was needed.

## Test plan

- [x] `corepack yarn check-types` passes
- [x] `corepack yarn lint:check` passes
- [x] Live visual verification on the Kubernetes project as Red Hat: Technical influence # 3 renders in the 3rd row, Ecosystem influence # 4 renders in the 4th row, each with row highlight + "You" badge at its true ranked position.
- [ ] The `org-project-detail` Playwright spec requires an org-scoped test account — the local staff account hits the impersonation gate, so the spec is not exercisable with the default local credentials.

[LFXV2-2799]: https://linuxfoundation.atlassian.net/browse/LFXV2-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ