### PR TITLE
docs(runbooks): create feature branch deployment runbooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,6 +340,13 @@ the cleanup job, which posts a removal notice on the PR. The ArgoCD
 ApplicationSet automatically removes the namespace and all associated
 resources.
 
+**Verification:**
+
+Once the bot comment appears, open the URL in a browser and log in with a
+dev-environment account. The Angular app should load without a blank screen.
+Navigate to your feature and confirm expected behavior. If the URL is
+unreachable, wait 2–3 minutes for ArgoCD to finish reconciling, then reload.
+
 **Troubleshooting:**
 
 - **No bot comment after 10 minutes** — check the Actions tab on GitHub for
@@ -349,6 +356,10 @@ resources.
   the new commit; re-applying the label will force a fresh run if needed.
 - **Authentication errors in the preview** — the preview shares the dev
   cluster's Auth0 tenant; ensure your account has dev-environment access.
+
+For advanced scenarios (adding secrets, changing resource limits, pod-level
+debugging), see the full
+[Feature Branch Deployment Runbook](docs/runbooks/feature-branch-deployment.md).
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ label. The preview runs on the shared dev environment backends using the
 **Prerequisites:**
 
 - Write access to the repository (fork PRs are excluded)
-- An open, non-draft pull request
+- An open pull request
 
 **How it works:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,14 +308,47 @@ yarn e2e:headed      # visible browser
 
 ### Deploy Preview
 
-Contributors with write access to the repository have the option to add
-the **deploy-preview** label to their pull request. Adding this label will
-deploy the pull request to a hosted Kubernetes development cluster in an
-isolated namespace. A link to the hosted deployment will be added as a
-comment to the pull request.
+Contributors with write access to the repository can deploy a pull request
+to a live Kubernetes development cluster by adding the **deploy-preview**
+label. The preview runs on the shared dev environment backends using the
+`dev-cluster` Angular build configuration.
 
-When the pull request is closed or the **deploy-preview** label is
-removed, the deployment will be removed.
+**Prerequisites:**
+
+- Write access to the repository (fork PRs are excluded)
+- An open, non-draft pull request
+
+**How it works:**
+
+1. Add the **deploy-preview** label to your open PR.
+2. The `Deploy Branch to Development` GitHub Actions workflow triggers,
+   builds a Docker image tagged `ui-pr-<PR number>`, and pushes it to the
+   container registry.
+3. ArgoCD picks up the new image and deploys it to the isolated namespace
+   `ui-pr-<PR number>` on the dev cluster.
+4. The bot posts (or updates) a comment on the PR with the deployment URL:
+   `https://ui-pr-<PR number>.dev.v2.cluster.linuxfound.info`
+
+Builds typically complete within 5–10 minutes. Re-pushing commits to the
+branch while the label is applied will re-trigger the build and update the
+existing deployment.
+
+**Cleanup:**
+
+Removing the **deploy-preview** label or closing the pull request triggers
+the cleanup job, which posts a removal notice on the PR. The ArgoCD
+ApplicationSet automatically removes the namespace and all associated
+resources.
+
+**Troubleshooting:**
+
+- **No bot comment after 10 minutes** — check the Actions tab on GitHub for
+  workflow run failures. Confirm the label is applied and the PR is not from
+  a fork.
+- **Deployment not updating after a push** — verify the workflow triggered on
+  the new commit; re-applying the label will force a fresh run if needed.
+- **Authentication errors in the preview** — the preview shares the dev
+  cluster's Auth0 tenant; ensure your account has dev-environment access.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ The application is deployed via the in-repo Helm chart and the central GitOps re
   Self Serve service template, values, and Kubernetes resources.
 - **GitOps** — `lfx-v2-argocd` (sibling repo) owns environment values, chart pins,
   image tags, ExternalSecret references, and dev/staging/prod ApplicationSets.
+- **Preview** — add the `deploy-preview` label to any open PR (write access required)
+  to deploy it to an isolated dev-cluster namespace. See the
+  [Deploy Preview](CONTRIBUTING.md#deploy-preview) section in CONTRIBUTING.md.
 
 Runtime continues to use Node.js with PM2 (`apps/lfx-one/ecosystem.config.js`)
 inside the container. See the chart README and the `lfx-v2-argocd` repo for

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The application is deployed via the in-repo Helm chart and the central GitOps re
   Self Serve service template, values, and Kubernetes resources.
 - **GitOps** — `lfx-v2-argocd` (sibling repo) owns environment values, chart pins,
   image tags, ExternalSecret references, and dev/staging/prod ApplicationSets.
-- **Preview** — add the `deploy-preview` label to any open PR (write access required)
+- **Preview** — add the `deploy-preview` label to any open, non-fork PR (write access required)
   to deploy it to an isolated dev-cluster namespace. See the
   [Deploy Preview](CONTRIBUTING.md#deploy-preview) section in CONTRIBUTING.md.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -86,9 +86,10 @@ LFX One is a modern Angular 20 SSR application built with stable zoneless change
 
 1. **[Deployment Architecture](./deployment.md)** — Full CI/CD pipeline: build environments, main-branch dev deployment, PR branch previews, and the release (tag → staging/prod) flow. Start here.
 2. **[Deploy Preview](../../CONTRIBUTING.md#deploy-preview)** — Step-by-step guide: how to add the `deploy-preview` label, what the workflow does, cleanup, and troubleshooting.
-3. **[Helm Chart](../../charts/lfx-self-serve/README.md)** — Chart parameter reference, values schema, and local installation. Deployed values, environment promotion, and ApplicationSets live in the `lfx-v2-argocd` sibling repo.
-4. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
-5. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
+3. **[Feature Branch Deployment Runbook](../runbooks/feature-branch-deployment.md)** — Detailed runbook: branch selection, environment setup, verification, teardown, and common scenarios (adding secrets, changing resource limits).
+4. **[Helm Chart](../../charts/lfx-self-serve/README.md)** — Chart parameter reference, values schema, and local installation. Deployed values, environment promotion, and ApplicationSets live in the `lfx-v2-argocd` sibling repo.
+5. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
+6. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
 
 ## 🔧 Technology Stack Summary
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -84,10 +84,11 @@ LFX One is a modern Angular 20 SSR application built with stable zoneless change
 
 ### DevOps & Deployment
 
-1. **Deployment** — Chart source: `charts/lfx-self-serve/README.md` (in the repo root, outside this docs site). Deployed values, environment promotion, image tags, and ApplicationSets: `lfx-v2-argocd` (`values/dev/lfx-v2-ui.yaml`, staging, prod).
-2. **[Deploy Preview](../../CONTRIBUTING.md#deploy-preview)** — Add the `deploy-preview` label to any open PR to trigger a label → build → ArgoCD → isolated namespace → URL comment workflow on the shared dev cluster.
-3. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
-4. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
+1. **[Deployment Architecture](./deployment.md)** — Full CI/CD pipeline: build environments, main-branch dev deployment, PR branch previews, and the release (tag → staging/prod) flow. Start here.
+2. **[Deploy Preview](../../CONTRIBUTING.md#deploy-preview)** — Step-by-step guide: how to add the `deploy-preview` label, what the workflow does, cleanup, and troubleshooting.
+3. **[Helm Chart](../../charts/lfx-self-serve/README.md)** — Chart parameter reference, values schema, and local installation. Deployed values, environment promotion, and ApplicationSets live in the `lfx-v2-argocd` sibling repo.
+4. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
+5. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
 
 ## 🔧 Technology Stack Summary
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -85,8 +85,9 @@ LFX One is a modern Angular 20 SSR application built with stable zoneless change
 ### DevOps & Deployment
 
 1. **Deployment** — Chart source: `charts/lfx-self-serve/README.md` (in the repo root, outside this docs site). Deployed values, environment promotion, image tags, and ApplicationSets: `lfx-v2-argocd` (`values/dev/lfx-v2-ui.yaml`, staging, prod).
-2. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
-3. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
+2. **[Deploy Preview](../../CONTRIBUTING.md#deploy-preview)** — Add the `deploy-preview` label to any open PR to trigger a label → build → ArgoCD → isolated namespace → URL comment workflow on the shared dev cluster.
+3. **[Logging & Monitoring](./backend/logging-monitoring.md)** - Production monitoring
+4. **[Error Handling](./backend/error-handling-architecture.md)** - Error management
 
 ## 🔧 Technology Stack Summary
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -64,6 +64,53 @@ removal notice and ArgoCD tears down the namespace.
 Full workflow details — including prerequisites, step-by-step instructions,
 and troubleshooting — are in [CONTRIBUTING.md § Deploy Preview](../../CONTRIBUTING.md#deploy-preview).
 
+#### Orchestration diagram
+
+The label triggers two parallel tracks that must both complete before the URL
+is reachable. Bot comment arrival (~5 min) signals the image is ready; the URL
+becomes HTTPS-accessible once cert-manager finishes the Let's Encrypt challenge
+(~5–10 min total).
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant GH as GitHub PR
+    participant CI as GitHub Actions
+    participant GHCR as GHCR
+    participant AS as ArgoCD ApplicationSet
+    participant K8s as Kubernetes
+    participant CM as cert-manager
+    participant LE as Let's Encrypt
+    participant Traefik as Traefik
+    participant EDNS as external-dns
+
+    Dev->>GH: Add deploy-preview label
+
+    par Image build track
+        GH->>CI: Trigger docker-build-pr.yml
+        CI->>CI: Build image (BUILD_ENV=dev-cluster)
+        CI->>GHCR: Push image tagged ui-pr-N
+        CI->>GH: Post deployment URL comment
+    and ArgoCD provisioning track
+        GH-->>AS: pullRequest generator detects label
+        AS->>K8s: Create Application ui-pr-N
+        K8s->>K8s: Create namespace ui-pr-N
+        K8s->>K8s: Apply Helm chart (Deployment, Service, Ingress)
+        K8s->>CM: Ingress annotation cert-manager.io/cluster-issuer detected
+        CM->>CM: Create Certificate CR (ui-pr-N-tls)
+        CM->>LE: ACME HTTP-01 challenge
+        LE-->>CM: Challenge validated
+        CM->>K8s: Store TLS cert in Secret ui-pr-N-tls
+        K8s->>Traefik: Load TLS cert, expose HTTPS endpoint
+        K8s->>EDNS: Ingress created
+        EDNS->>EDNS: Create DNS record ui-pr-N.dev.v2.cluster.linuxfound.info
+    end
+
+    Note over Dev,EDNS: URL live once both tracks complete (~5–10 min)
+    Dev->>Traefik: HTTPS request to ui-pr-N.dev.v2.cluster.linuxfound.info
+    Traefik->>K8s: Route to lfx-self-serve pod
+```
+
 ### Release — staging and production
 
 **Trigger:** push of a `v*` tag (e.g. `v1.0.42`)

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -23,15 +23,19 @@ push v* tag       →    docker-build-tag.yml    →  <semver>        →  stagi
 The Dockerfile accepts a `BUILD_ENV` argument that selects the Angular build
 configuration. The mapping between workflow and build environment is:
 
-| Workflow           | `BUILD_ENV`   | Angular config | Backends                        |
-| ------------------ | ------------- | -------------- | ------------------------------- |
-| `docker-build-main` | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS   |
-| `docker-build-pr`   | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS   |
-| `docker-build-tag`  | `production`  | `production`   | Production Auth0 / API / NATS   |
+| Workflow           | `BUILD_ENV`   | Angular config | Runtime backends (from Helm/ArgoCD values) |
+| ------------------ | ------------- | -------------- | ------------------------------------------ |
+| `docker-build-main` | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS              |
+| `docker-build-pr`   | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS              |
+| `docker-build-tag`  | `production`  | `production`   | Production Auth0 / API / NATS              |
+
+`BUILD_ENV` selects the Angular compile-time configuration only — it does not
+control which backends the running container connects to. Runtime backend URLs,
+credentials, and feature flags come from Helm values and Kubernetes secrets
+managed by ArgoCD in `lfx-v2-argocd`.
 
 The `dev-cluster` Angular configuration is defined in
-`apps/lfx-one/angular.json` and targets the shared development-cluster
-environment.
+`apps/lfx-one/angular.json`.
 
 ## Workflow Details
 
@@ -96,14 +100,14 @@ sequenceDiagram
         AS->>K8s: Create Application ui-pr-N
         K8s->>K8s: Create namespace ui-pr-N
         K8s->>K8s: Apply Helm chart (Deployment, Service, Ingress)
+        K8s->>EDNS: Ingress created
+        EDNS->>EDNS: Create DNS record ui-pr-N.dev.v2.cluster.linuxfound.info
         K8s->>CM: Ingress annotation cert-manager.io/cluster-issuer detected
         CM->>CM: Create Certificate CR (ui-pr-N-tls)
         CM->>LE: ACME HTTP-01 challenge
         LE-->>CM: Challenge validated
         CM->>K8s: Store TLS cert in Secret ui-pr-N-tls
         K8s->>Traefik: Load TLS cert, expose HTTPS endpoint
-        K8s->>EDNS: Ingress created
-        EDNS->>EDNS: Create DNS record ui-pr-N.dev.v2.cluster.linuxfound.info
     end
 
     Note over Dev,EDNS: URL live once both tracks complete (~5–10 min)

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -10,7 +10,7 @@ images; ArgoCD (in the `lfx-v2-argocd` sibling repo) reconciles those images
 to the appropriate Kubernetes namespaces. There are three distinct deployment
 paths, each triggered by a different git event.
 
-```
+```text
 git event              workflow                   image tag          environment
 ─────────────────────────────────────────────────────────────────────────────────
 push to main      →    docker-build-main.yml   →  development     →  dev cluster (persistent)
@@ -54,7 +54,7 @@ Builds an isolated preview for a single PR. ArgoCD provisions a dedicated
 namespace (`ui-pr-<PR number>`) and the workflow bot posts the URL as a PR
 comment:
 
-```
+```text
 https://ui-pr-<PR number>.dev.v2.cluster.linuxfound.info
 ```
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -1,0 +1,105 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Deployment Architecture
+
+## Overview
+
+LFX One uses a GitOps deployment model. GitHub Actions builds and tags Docker
+images; ArgoCD (in the `lfx-v2-argocd` sibling repo) reconciles those images
+to the appropriate Kubernetes namespaces. There are three distinct deployment
+paths, each triggered by a different git event.
+
+```
+git event              workflow                   image tag          environment
+─────────────────────────────────────────────────────────────────────────────────
+push to main      →    docker-build-main.yml   →  development     →  dev cluster (persistent)
+PR + label        →    docker-build-pr.yml     →  ui-pr-<N>       →  dev cluster (isolated namespace)
+push v* tag       →    docker-build-tag.yml    →  <semver>        →  staging / production
+```
+
+## Build Environments
+
+The Dockerfile accepts a `BUILD_ENV` argument that selects the Angular build
+configuration. The mapping between workflow and build environment is:
+
+| Workflow           | `BUILD_ENV`   | Angular config | Backends                        |
+| ------------------ | ------------- | -------------- | ------------------------------- |
+| `docker-build-main` | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS   |
+| `docker-build-pr`   | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS   |
+| `docker-build-tag`  | `production`  | `production`   | Production Auth0 / API / NATS   |
+
+The `dev-cluster` Angular configuration is defined in
+`apps/lfx-one/angular.json` and targets the shared development-cluster
+environment.
+
+## Workflow Details
+
+### Main branch — persistent dev deployment
+
+**Trigger:** push to `main`
+**Workflow:** `.github/workflows/docker-build-main.yml`
+**Image tag:** `development` (floating)
+
+Every merged PR automatically rebuilds the image and ArgoCD rolls the dev
+environment forward. No manual action required.
+
+### PR branch preview — isolated namespace
+
+**Trigger:** `deploy-preview` label added to an open PR
+**Workflow:** `.github/workflows/docker-build-pr.yml`
+**Image tag:** `ui-pr-<PR number>`
+
+Builds an isolated preview for a single PR. ArgoCD provisions a dedicated
+namespace (`ui-pr-<PR number>`) and the workflow bot posts the URL as a PR
+comment:
+
+```
+https://ui-pr-<PR number>.dev.v2.cluster.linuxfound.info
+```
+
+Removing the label or closing the PR triggers the cleanup job, which posts a
+removal notice and ArgoCD tears down the namespace.
+
+Full workflow details — including prerequisites, step-by-step instructions,
+and troubleshooting — are in [CONTRIBUTING.md § Deploy Preview](../../CONTRIBUTING.md#deploy-preview).
+
+### Release — staging and production
+
+**Trigger:** push of a `v*` tag (e.g. `v1.0.42`)
+**Workflow:** `.github/workflows/docker-build-tag.yml`
+**Image tags:** semver (`1.0.42`, `1.0`)
+
+The release workflow:
+
+1. Builds the Docker image with `BUILD_ENV=production`.
+2. Publishes the Helm chart to the OCI registry at
+   `ghcr.io/linuxfoundation/lfx-self-serve/chart`.
+3. Signs the chart with Cosign.
+4. Generates a SLSA Level 3 provenance attestation.
+
+ArgoCD in `lfx-v2-argocd` pins the chart version for staging and production
+environments and promotes images through the standard GitOps promotion workflow.
+
+## ArgoCD & GitOps
+
+The `lfx-v2-argocd` sibling repo owns:
+
+- Environment-specific Helm values (`values/dev/lfx-v2-ui.yaml`, staging, prod)
+- Image tag pins and ApplicationSets for each environment
+- ExternalSecret references for runtime configuration
+
+This repo does not contain ArgoCD manifests — all promotion, rollback, and
+environment management happens in `lfx-v2-argocd`.
+
+## Container Registry
+
+All images are pushed to the GitHub Container Registry (GHCR) under
+`ghcr.io/linuxfoundation/lfx-self-serve`. Image visibility follows the
+repository's package settings.
+
+## Helm Chart
+
+The chart source lives at `charts/lfx-self-serve/` in this repo. See
+[charts/lfx-self-serve/README.md](../../charts/lfx-self-serve/README.md) for
+parameter reference, values schema, and local installation instructions.

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -23,8 +23,8 @@ push v* tag       →    docker-build-tag.yml    →  <semver>        →  stagi
 The Dockerfile accepts a `BUILD_ENV` argument that selects the Angular build
 configuration. The mapping between workflow and build environment is:
 
-| Workflow           | `BUILD_ENV`   | Angular config | Runtime backends (from Helm/ArgoCD values) |
-| ------------------ | ------------- | -------------- | ------------------------------------------ |
+| Workflow            | `BUILD_ENV`   | Angular config | Runtime backends (from Helm/ArgoCD values) |
+| ------------------- | ------------- | -------------- | ------------------------------------------ |
 | `docker-build-main` | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS              |
 | `docker-build-pr`   | `dev-cluster` | `dev-cluster`  | Shared dev Auth0 / API / NATS              |
 | `docker-build-tag`  | `production`  | `production`   | Production Auth0 / API / NATS              |
@@ -50,7 +50,7 @@ environment forward. No manual action required.
 
 ### PR branch preview — isolated namespace
 
-**Trigger:** `deploy-preview` label added to an open PR
+**Trigger:** `deploy-preview` label added to an open, non-fork PR
 **Workflow:** `.github/workflows/docker-build-pr.yml`
 **Image tag:** `ui-pr-<PR number>`
 

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -10,8 +10,9 @@ integration testing, stakeholder review, or debugging. Deployments are
 triggered by adding the `deploy-preview` label to a pull request — no manual
 `kubectl` or `helm` commands are required.
 
-For a high-level description of the CI/CD pipeline, see
-[Deployment Architecture](../architecture/deployment.md).
+For a high-level description of the CI/CD pipeline and an orchestration
+diagram showing the full label → image build → ArgoCD → cert-manager → DNS
+flow, see [Deployment Architecture](../architecture/deployment.md#orchestration-diagram).
 
 ---
 

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -156,32 +156,109 @@ have to function.
 
 **Secret values** (credentials, API keys):
 
-Secrets in the dev cluster are sourced from AWS Secrets Manager via
-ExternalSecret. The ExternalSecret fetches all secrets tagged
-`service: lfx-v2-ui` in `us-west-2`.
+Secrets flow through the following pipeline:
 
-To add a new secret for dev-cluster previews:
+```
+1Password (source of truth)
+    ↓  lfx-secrets-management sync
+AWS Secrets Manager
+    ↓  ExternalSecret controller
+Kubernetes Secret  →  Pod environment variable
+```
 
-1. Ask the platform team (or use your AWS access if you have it) to add the
-   secret to AWS Secrets Manager with the tag `service: lfx-v2-ui`.
-2. Add the corresponding environment variable reference to the Helm chart
-   `values.yaml`:
+The `lfx-secrets-management` repository is the authoritative tool for managing
+this pipeline. All secrets for the LFX platform are defined there as YAML and
+synced via GitHub Actions.
+
+**Step-by-step to add a new secret:**
+
+1. **Store the secret in 1Password.**
+   Add the credential to the appropriate vault in the `LFX` 1Password account:
+   - `lfx-development` for dev
+   - `lfx-staging` for staging
+   - `lfx-production` for production
+
+2. **Add a secret definition to `lfx-secrets-management`.**
+   Open a PR in the `lfx-secrets-management` repository. Add an entry to the
+   relevant file under `secrets/lfx/` (e.g. `cloud.yml` for general
+   credentials, `auth0_clients.yml` for Auth0 clients):
+
+   ```yaml
+   # secrets/lfx/cloud.yml
+   My LFX Self Serve Secret:
+     tags: [lfx_self_serve, pcc]
+     envs: [development, staging, production]
+     source:
+       onepassword:
+         vaults:
+           development: lfx-development
+           staging: lfx-staging
+           production: lfx-production
+         item: My Item Name in 1Password
+         fields: credential
+     destinations:
+       - aws_secretsmanager:
+           path: cloud/lfx_self_serve/my_secret
+           tags:
+             service: pcc
+   ```
+
+   The `service: pcc` AWS tag is what the dev-cluster ExternalSecret uses to
+   discover which secrets to sync into the preview namespace.
+
+3. **Validate the definition locally:**
+
+   ```bash
+   cd ~/lfx-secrets-management
+   make validate TAGS="lfx_self_serve"
+   ```
+
+4. **Merge the PR and deploy.**
+   After the `lfx-secrets-management` PR merges, trigger the GitHub Actions
+   deploy workflow (or ask the platform team to run it):
+
+   ```bash
+   gh workflow run deploy.yml \
+     --repo linuxfoundation/lfx-secrets-management \
+     --field tags="lfx_self_serve" \
+     --field envs="development"
+   ```
+
+   This syncs the secret from 1Password into AWS Secrets Manager. The
+   ExternalSecret controller picks it up within ~1 minute and creates the
+   Kubernetes Secret in the preview namespace.
+
+5. **Reference the secret in the Helm chart.**
+   Add the environment variable reference to `charts/lfx-self-serve/values.yaml`
+   and open a PR in this repo:
 
    ```yaml
    environment:
      MY_NEW_SECRET:
        valueFrom:
          secretKeyRef:
-           name: pcc-secret-store   # ExternalSecret target name
-           key: MY_NEW_SECRET
+           name: pcc-secret-store   # ExternalSecret target secret name
+           key: my_secret           # Key as stored in AWS Secrets Manager
    ```
 
-3. Update `lfx-v2-argocd` dev values to reference the secret key, then open
-   the preview as normal.
+6. **Set the value in `lfx-v2-argocd`** for the dev environment so the preview
+   namespace picks it up. Open a PR in `lfx-v2-argocd`:
 
-> **Note:** If you need the secret only in a single preview (not in all dev
-> namespaces), create a Kubernetes `Secret` manually in the preview namespace
-> via the platform team; this is unusual and should be a short-term workaround.
+   ```yaml
+   # values/dev/lfx-v2-ui.yaml
+   environment:
+     MY_NEW_SECRET:
+       valueFrom:
+         secretKeyRef:
+           name: pcc-secret-store
+           key: my_secret
+   ```
+
+> **Single-preview workaround:** If the secret is only needed for one specific
+> preview (not all dev namespaces), coordinate with the platform team to patch
+> the Kubernetes Secret directly in the `ui-pr-<N>` namespace. This is a
+> short-term workaround — the secret should still be added to
+> `lfx-secrets-management` for permanence.
 
 ---
 

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -180,9 +180,9 @@ synced via GitHub Actions.
 
 1. **Store the secret in 1Password.**
    Add the credential to the appropriate vault in the `LFX` 1Password account:
-   - `lfx-development` for dev
-   - `lfx-staging` for staging
-   - `lfx-production` for production
+   - `LFX V2 - Development` for dev
+   - `LFX V2 - Staging` for staging
+   - `LFX V2 - Production` for production
 
 2. **Add a secret definition to `lfx-secrets-management`.**
    Open a PR in the `lfx-secrets-management` repository. Add an entry to the
@@ -192,14 +192,14 @@ synced via GitHub Actions.
    ```yaml
    # secrets/lfx/cloud.yml
    My LFX Self Serve Secret:
-     tags: [lfx_self_serve, pcc]
+     tags: [lfx_v2, pcc]
      envs: [development, staging, production]
      source:
        onepassword:
          vaults:
-           development: lfx-development
-           staging: lfx-staging
-           production: lfx-production
+           development: LFX V2 - Development
+           staging: LFX V2 - Staging
+           production: LFX V2 - Production
          item: My Item Name in 1Password
          fields: credential
      destinations:

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -22,7 +22,7 @@ Before proceeding, verify:
 
 - **Write access** to the `linuxfoundation/lfx-self-serve` GitHub repository.
   Fork PRs cannot trigger preview deployments.
-- **An open pull request** — the PR must not be in draft state.
+- **An open pull request** — the workflow triggers on any open, non-fork PR with the label, including drafts.
 - **GitHub Actions enabled** — check under _Settings → Actions_ that workflows
   are not disabled for your fork or the repo.
 - **No merge conflicts** — the branch must be buildable. A red CI status does
@@ -231,8 +231,8 @@ synced via GitHub Actions.
    ```
 
    This syncs the secret from 1Password into AWS Secrets Manager. The
-   ExternalSecret controller picks it up within ~1 minute and creates the
-   Kubernetes Secret in the preview namespace.
+   ExternalSecret controller refreshes every 10 minutes (the chart default),
+   so a new key may take up to 10 minutes to appear in the preview namespace.
 
 5. **Reference the secret in the Helm chart.**
    Add the environment variable reference to `charts/lfx-self-serve/values.yaml`
@@ -243,8 +243,8 @@ synced via GitHub Actions.
      MY_NEW_SECRET:
        valueFrom:
          secretKeyRef:
-           name: pcc-secret-store   # ExternalSecret target secret name
-           key: my_secret           # Key as stored in AWS Secrets Manager
+           name: pcc-secrets   # Kubernetes Secret created by ExternalSecret
+           key: credential     # Field name as defined in the 1Password source
    ```
 
 6. **Set the value in `lfx-v2-argocd`** for the dev environment so the preview
@@ -256,8 +256,8 @@ synced via GitHub Actions.
      MY_NEW_SECRET:
        valueFrom:
          secretKeyRef:
-           name: pcc-secret-store
-           key: my_secret
+           name: pcc-secrets
+           key: credential
    ```
 
 > **Single-preview workaround:** If the secret is only needed for one specific

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -36,8 +36,9 @@ Before proceeding, verify:
 Choose the branch to deploy:
 
 - Use the branch associated with the PR you want to preview. The workflow
-  always builds the PR's `HEAD` commit at the time the label is applied (or
-  re-applied after a push).
+  builds GitHub's synthetic merge commit of the PR branch against the base
+  branch (standard `pull_request` event behaviour for `actions/checkout@v4`).
+  In most cases this is equivalent to the PR's latest commit.
 - If you need to preview a stack of changes, open a PR against a feature
   integration branch rather than `main`, and apply the label there.
 
@@ -51,6 +52,7 @@ Choose the branch to deploy:
    progress in the **Actions** tab of the repository.
 
 The workflow:
+
 - Checks out the PR branch.
 - Builds a Docker image with `BUILD_ENV=dev-cluster` tagged `ui-pr-<N>`.
 - Pushes the image to `ghcr.io/linuxfoundation/lfx-self-serve`.
@@ -89,10 +91,13 @@ Pod logs surface Express/Node.js errors that do not appear in the browser:
 
 ```bash
 # Requires kubectl access to the dev cluster
-kubectl logs -n ui-pr-<N> -l app=lfx-self-serve --tail=100
+kubectl logs -n ui-pr-<N> \
+  -l app.kubernetes.io/name=lfx-self-serve \
+  --tail=100
 ```
 
 Common errors to look for:
+
 - Missing environment variable warnings (see [Adding a New Secret](#adding-a-new-secret) below)
 - NATS connection failures (usually transient; the app retries automatically)
 - Auth0 configuration mismatches
@@ -159,7 +164,7 @@ have to function.
 
 Secrets flow through the following pipeline:
 
-```
+```text
 1Password (source of truth)
     ↓  lfx-secrets-management sync
 AWS Secrets Manager

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -91,7 +91,8 @@ Pod logs surface Express/Node.js errors that do not appear in the browser:
 
 ```bash
 # Requires kubectl access to the dev cluster
-kubectl logs -n ui-pr-<N> \
+# Replace 123 with your PR number
+kubectl logs -n ui-pr-123 \
   -l app.kubernetes.io/name=lfx-self-serve \
   --tail=100
 ```

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -193,7 +193,7 @@ synced via GitHub Actions.
    ```yaml
    # secrets/lfx/cloud.yml
    My LFX Self Serve Secret:
-     tags: [lfx_v2, pcc]
+     tags: [lfx_v2, pcc, lfx_self_serve]
      envs: [development, staging, production]
      source:
        onepassword:

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -1,0 +1,241 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Runbook: Feature Branch Deployment
+
+## Overview
+
+This runbook covers deploying a feature branch to the shared dev cluster for
+integration testing, stakeholder review, or debugging. Deployments are
+triggered by adding the `deploy-preview` label to a pull request — no manual
+`kubectl` or `helm` commands are required.
+
+For a high-level description of the CI/CD pipeline, see
+[Deployment Architecture](../architecture/deployment.md).
+
+---
+
+## Prerequisites and Access Requirements
+
+Before proceeding, verify:
+
+- **Write access** to the `linuxfoundation/lfx-self-serve` GitHub repository.
+  Fork PRs cannot trigger preview deployments.
+- **An open pull request** — the PR must not be in draft state.
+- **GitHub Actions enabled** — check under _Settings → Actions_ that workflows
+  are not disabled for your fork or the repo.
+- **No merge conflicts** — the branch must be buildable. A red CI status does
+  not block the label, but a failed build will leave the previous deployment
+  (or no deployment) in place.
+
+---
+
+## Step 1: Branch Selection
+
+Choose the branch to deploy:
+
+- Use the branch associated with the PR you want to preview. The workflow
+  always builds the PR's `HEAD` commit at the time the label is applied (or
+  re-applied after a push).
+- If you need to preview a stack of changes, open a PR against a feature
+  integration branch rather than `main`, and apply the label there.
+
+---
+
+## Step 2: Trigger the Deployment
+
+1. Open the pull request on GitHub.
+2. In the right-hand sidebar, click **Labels → deploy-preview**.
+3. The `Deploy Branch to Development` workflow starts immediately. Monitor
+   progress in the **Actions** tab of the repository.
+
+The workflow:
+- Checks out the PR branch.
+- Builds a Docker image with `BUILD_ENV=dev-cluster` tagged `ui-pr-<N>`.
+- Pushes the image to `ghcr.io/linuxfoundation/lfx-self-serve`.
+- Posts a comment on the PR with the deployment URL once the image push
+  succeeds. ArgoCD picks up the image and reconciles the namespace within
+  ~1 minute of the image appearing in the registry.
+
+Typical end-to-end time from label to live URL: **5–10 minutes**.
+
+---
+
+## Step 3: Verification
+
+Once the bot posts the deployment URL (`https://ui-pr-<N>.dev.v2.cluster.linuxfound.info`):
+
+### 3.1 Basic health check
+
+- Open the URL in a browser. The Angular app should load without a blank screen
+  or error page.
+- Log in with a dev-environment account (Auth0 dev tenant). If login fails,
+  confirm your account has access to the dev Auth0 tenant.
+- Navigate to the feature or page being tested and confirm expected behavior.
+
+### 3.2 Check pod status (optional)
+
+If the URL is not reachable or returns errors, check pod health via the ArgoCD
+UI (access requires cluster credentials managed by the platform team):
+
+- Application name: `ui-pr-<N>`
+- Namespace: `ui-pr-<N>`
+- All pods should be in `Running` state with `1/1` containers ready.
+
+### 3.3 Check application logs (optional)
+
+Pod logs surface Express/Node.js errors that do not appear in the browser:
+
+```bash
+# Requires kubectl access to the dev cluster
+kubectl logs -n ui-pr-<N> -l app=lfx-self-serve --tail=100
+```
+
+Common errors to look for:
+- Missing environment variable warnings (see [Adding a New Secret](#adding-a-new-secret) below)
+- NATS connection failures (usually transient; the app retries automatically)
+- Auth0 configuration mismatches
+
+---
+
+## Step 4: Iterating on the Branch
+
+Re-pushing commits to the PR branch while the `deploy-preview` label is active
+will re-trigger the build workflow automatically (on the `synchronize` event).
+The existing deployment is updated in-place; no need to remove and re-add the
+label.
+
+---
+
+## Step 5: Teardown
+
+Deployments are removed in two ways:
+
+| Action | Result |
+|--------|--------|
+| Remove the `deploy-preview` label | Cleanup job runs; bot posts a removal notice on the PR |
+| Close or merge the PR | Cleanup job runs automatically |
+
+The ArgoCD ApplicationSet removes the namespace and all associated Kubernetes
+resources. Container images tagged `ui-pr-<N>` remain in GHCR and are subject
+to the registry's retention policy.
+
+---
+
+## Common Scenarios
+
+### Adding a New Environment Variable or Secret
+
+**When to use:** Your feature branch introduces a new configuration value
+(API key, service URL, feature flag, etc.) that the dev-cluster preview must
+have to function.
+
+**Non-secret values** (URLs, flags, non-sensitive config):
+
+1. Add the variable to the Helm chart's `values.yaml` schema in
+   `charts/lfx-self-serve/`:
+
+   ```yaml
+   # charts/lfx-self-serve/values.yaml
+   environment:
+     MY_NEW_VAR:
+       value: "default-value"
+   ```
+
+2. Open a PR in `lfx-v2-argocd` to set the dev-cluster value:
+
+   ```yaml
+   # values/dev/lfx-v2-ui.yaml
+   environment:
+     MY_NEW_VAR:
+       value: "dev-value"
+   ```
+
+3. The preview namespace inherits the dev-cluster values. No per-PR override
+   is needed unless the value must differ per preview.
+
+**Secret values** (credentials, API keys):
+
+Secrets in the dev cluster are sourced from AWS Secrets Manager via
+ExternalSecret. The ExternalSecret fetches all secrets tagged
+`service: lfx-v2-ui` in `us-west-2`.
+
+To add a new secret for dev-cluster previews:
+
+1. Ask the platform team (or use your AWS access if you have it) to add the
+   secret to AWS Secrets Manager with the tag `service: lfx-v2-ui`.
+2. Add the corresponding environment variable reference to the Helm chart
+   `values.yaml`:
+
+   ```yaml
+   environment:
+     MY_NEW_SECRET:
+       valueFrom:
+         secretKeyRef:
+           name: pcc-secret-store   # ExternalSecret target name
+           key: MY_NEW_SECRET
+   ```
+
+3. Update `lfx-v2-argocd` dev values to reference the secret key, then open
+   the preview as normal.
+
+> **Note:** If you need the secret only in a single preview (not in all dev
+> namespaces), create a Kubernetes `Secret` manually in the preview namespace
+> via the platform team; this is unusual and should be a short-term workaround.
+
+---
+
+### Changing Kubernetes Resource Limits
+
+**When to use:** The app OOMKills under load, or you need to reduce resource
+consumption for a cost experiment.
+
+Resource limits and requests are set via the Helm chart in `lfx-v2-argocd`.
+Preview namespaces inherit the dev-cluster defaults.
+
+1. Locate the dev values file in `lfx-v2-argocd`:
+   `values/dev/lfx-v2-ui.yaml`
+
+2. Override the resources block:
+
+   ```yaml
+   resources:
+     requests:
+       cpu: "100m"
+       memory: "256Mi"
+     limits:
+       cpu: "500m"
+       memory: "512Mi"
+   ```
+
+3. Open a PR in `lfx-v2-argocd`. ArgoCD reconciles the change within ~2 minutes
+   of merge. All active preview namespaces pick up the new limits because they
+   use the same ApplicationSet template.
+
+> For a one-off resource change on a single preview namespace (e.g., load
+> testing), coordinate with the platform team to patch the deployment directly
+> — do not merge a temporary resource change to the ArgoCD repo.
+
+---
+
+### Updating a Base Dependency (npm package, Angular, Node)
+
+**When to use:** Your branch updates a major dependency and you want to confirm
+the build and runtime behavior before merging.
+
+No special steps are needed — `docker-build-pr.yml` runs a full production
+build inside the Docker image. Dependency changes are picked up automatically
+from `package.json` / `yarn.lock`. Apply the `deploy-preview` label as normal.
+
+---
+
+## Known Gotchas
+
+| Symptom | Likely Cause | Resolution |
+|---------|-------------|------------|
+| No bot comment after 10 minutes | Workflow failed or never triggered | Check the Actions tab; confirm the label is applied and the PR is not from a fork |
+| Bot comment posted but URL returns 502/503 | ArgoCD not yet synced, or pod CrashLoopBackOff | Wait 2–3 minutes; check pod status via ArgoCD or kubectl |
+| Login redirects to wrong callback | Auth0 dev tenant callback not registered for this namespace | Contact the platform team to register `https://ui-pr-<N>.dev.v2.cluster.linuxfound.info/callback` |
+| Re-push doesn't update the deployment | Workflow did not re-trigger | Confirm `synchronize` event fired in Actions; re-add the label to force a fresh run |
+| Missing environment variable at runtime | New env var not present in dev-cluster ExternalSecret or values | Follow the [Adding a New Secret](#adding-a-new-secret) steps above |
+| Preview works but prod does not | `dev-cluster` vs `production` build config difference | Check Angular environment files in `apps/lfx-one/src/environments/` |

--- a/docs/runbooks/feature-branch-deployment.md
+++ b/docs/runbooks/feature-branch-deployment.md
@@ -98,7 +98,7 @@ kubectl logs -n ui-pr-<N> \
 
 Common errors to look for:
 
-- Missing environment variable warnings (see [Adding a New Secret](#adding-a-new-secret) below)
+- Missing environment variable warnings (see [Adding a New Environment Variable or Secret](#adding-a-new-environment-variable-or-secret) below)
 - NATS connection failures (usually transient; the app retries automatically)
 - Auth0 configuration mismatches
 
@@ -117,10 +117,10 @@ label.
 
 Deployments are removed in two ways:
 
-| Action | Result |
-|--------|--------|
+| Action                            | Result                                                 |
+| --------------------------------- | ------------------------------------------------------ |
 | Remove the `deploy-preview` label | Cleanup job runs; bot posts a removal notice on the PR |
-| Close or merge the PR | Cleanup job runs automatically |
+| Close or merge the PR             | Cleanup job runs automatically                         |
 
 The ArgoCD ApplicationSet removes the namespace and all associated Kubernetes
 resources. Container images tagged `ui-pr-<N>` remain in GHCR and are subject
@@ -145,7 +145,7 @@ have to function.
    # charts/lfx-self-serve/values.yaml
    environment:
      MY_NEW_VAR:
-       value: "default-value"
+       value: 'default-value'
    ```
 
 2. Open a PR in `lfx-v2-argocd` to set the dev-cluster value:
@@ -154,7 +154,7 @@ have to function.
    # values/dev/lfx-v2-ui.yaml
    environment:
      MY_NEW_VAR:
-       value: "dev-value"
+       value: 'dev-value'
    ```
 
 3. The preview namespace inherits the dev-cluster values. No per-PR override
@@ -243,8 +243,8 @@ synced via GitHub Actions.
      MY_NEW_SECRET:
        valueFrom:
          secretKeyRef:
-           name: pcc-secrets   # Kubernetes Secret created by ExternalSecret
-           key: credential     # Field name as defined in the 1Password source
+           name: pcc-secrets # Kubernetes Secret created by ExternalSecret
+           key: credential # Field name as defined in the 1Password source
    ```
 
 6. **Set the value in `lfx-v2-argocd`** for the dev environment so the preview
@@ -284,11 +284,11 @@ Preview namespaces inherit the dev-cluster defaults.
    ```yaml
    resources:
      requests:
-       cpu: "100m"
-       memory: "256Mi"
+       cpu: '100m'
+       memory: '256Mi'
      limits:
-       cpu: "500m"
-       memory: "512Mi"
+       cpu: '500m'
+       memory: '512Mi'
    ```
 
 3. Open a PR in `lfx-v2-argocd`. ArgoCD reconciles the change within ~2 minutes
@@ -306,19 +306,19 @@ Preview namespaces inherit the dev-cluster defaults.
 **When to use:** Your branch updates a major dependency and you want to confirm
 the build and runtime behavior before merging.
 
-No special steps are needed — `docker-build-pr.yml` runs a full production
-build inside the Docker image. Dependency changes are picked up automatically
+No special steps are needed — `docker-build-pr.yml` runs a full
+`dev-cluster` build inside the Docker image. Dependency changes are picked up automatically
 from `package.json` / `yarn.lock`. Apply the `deploy-preview` label as normal.
 
 ---
 
 ## Known Gotchas
 
-| Symptom | Likely Cause | Resolution |
-|---------|-------------|------------|
-| No bot comment after 10 minutes | Workflow failed or never triggered | Check the Actions tab; confirm the label is applied and the PR is not from a fork |
-| Bot comment posted but URL returns 502/503 | ArgoCD not yet synced, or pod CrashLoopBackOff | Wait 2–3 minutes; check pod status via ArgoCD or kubectl |
-| Login redirects to wrong callback | Auth0 dev tenant callback not registered for this namespace | Contact the platform team to register `https://ui-pr-<N>.dev.v2.cluster.linuxfound.info/callback` |
-| Re-push doesn't update the deployment | Workflow did not re-trigger | Confirm `synchronize` event fired in Actions; re-add the label to force a fresh run |
-| Missing environment variable at runtime | New env var not present in dev-cluster ExternalSecret or values | Follow the [Adding a New Secret](#adding-a-new-secret) steps above |
-| Preview works but prod does not | `dev-cluster` vs `production` build config difference | Check Angular environment files in `apps/lfx-one/src/environments/` |
+| Symptom                                    | Likely Cause                                                    | Resolution                                                                                                         |
+| ------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| No bot comment after 10 minutes            | Workflow failed or never triggered                              | Check the Actions tab; confirm the label is applied and the PR is not from a fork                                  |
+| Bot comment posted but URL returns 502/503 | ArgoCD not yet synced, or pod CrashLoopBackOff                  | Wait 2–3 minutes; check pod status via ArgoCD or kubectl                                                           |
+| Login redirects to wrong callback          | Auth0 dev tenant callback not registered for this namespace     | Contact the platform team to register `https://ui-pr-<N>.dev.v2.cluster.linuxfound.info/callback`                  |
+| Re-push doesn't update the deployment      | Workflow did not re-trigger                                     | Confirm `synchronize` event fired in Actions; re-add the label to force a fresh run                                |
+| Missing environment variable at runtime    | New env var not present in dev-cluster ExternalSecret or values | Follow the [Adding a New Environment Variable or Secret](#adding-a-new-environment-variable-or-secret) steps above |
+| Preview works but prod does not            | `dev-cluster` vs `production` build config difference           | Check Angular environment files in `apps/lfx-one/src/environments/`                                                |


### PR DESCRIPTION
## Summary

- Expands the `CONTRIBUTING.md` Deploy Preview section with full step-by-step instructions, prerequisites, build config explanation, verification steps, and troubleshooting
- Adds a `Preview` bullet to the `README.md` Deployment section
- Creates `docs/architecture/deployment.md` — a new deployment architecture overview covering all three CI/CD paths (main→dev, PR preview, tag→release) with a Mermaid orchestration diagram showing the full label → build → ArgoCD → cert-manager → Let's Encrypt → Traefik → external-dns flow
- Creates `docs/runbooks/feature-branch-deployment.md` — a full operational runbook covering branch selection, environment setup, deployment steps, verification, teardown, and common scenarios (adding secrets via `lfx-secrets-management`, changing resource limits, updating dependencies)
- Updates `docs/architecture/README.md` DevOps section to surface all new docs

## JIRA

[LFXV2-2078](https://linuxfoundation.atlassian.net/browse/LFXV2-2078) — Create runbooks and documentation for feature branch deployments in self-serve

[LFXV2-2078]: https://linuxfoundation.atlassian.net/browse/LFXV2-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ