### PR TITLE
feat(committees): add newsletter committee category

### DIFF
--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -97,6 +97,12 @@ export const COMMITTEE_CATEGORY_CONFIGS: Record<string, CommitteeCategoryInfo> =
     examples: 'Project maintainers, release managers, core team',
     color: lfxColors.blue[500],
   },
+  Newsletter: {
+    icon: 'fa-light fa-newspaper',
+    description: 'Communication channel for newsletters and regular updates',
+    examples: 'Project newsletter, announcement digest, community updates',
+    color: lfxColors.violet[500],
+  },
   'Marketing Committee/Sub Committee': {
     icon: 'fa-light fa-chart-line-up',
     description: 'Drives marketing initiatives and community growth',
@@ -180,6 +186,7 @@ export const COMMITTEE_CATEGORIES = [
   { label: 'Government Advisory Council', value: 'Government Advisory Council' },
   { label: 'Legal Committee', value: 'Legal Committee' },
   { label: 'Maintainers', value: 'Maintainers' },
+  { label: 'Newsletter', value: 'Newsletter' },
   { label: 'Marketing Committee/Sub Committee', value: 'Marketing Committee/Sub Committee' },
   { label: 'Marketing Mailing List', value: 'Marketing Mailing List' },
   { label: 'Marketing Oversight Committee/Marketing Advisory Committee', value: 'Marketing Oversight Committee/Marketing Advisory Committee' },
@@ -305,6 +312,9 @@ const COMMITTEE_TYPE_COLORS = {
   // Technical roles
   Maintainers: 'bg-blue-100 text-blue-800',
   Committers: 'bg-blue-100 text-blue-800',
+
+  // Newsletters
+  Newsletter: 'bg-blue-100 text-blue-700',
 
   // Marketing and outreach
   'Marketing Oversight Committee/Marketing Advisory Committee': 'bg-violet-100 text-violet-700',
@@ -537,6 +547,7 @@ export const CATEGORY_BEHAVIORAL_CLASS: Record<string, GroupBehavioralClass> = {
   // ── special-interest-group (community / discussion / marketing outreach) ──
   'Special Interest Group': 'special-interest-group',
   'Technical Mailing List': 'special-interest-group',
+  Newsletter: 'special-interest-group',
   'Marketing Committee/Sub Committee': 'special-interest-group',
   'Marketing Mailing List': 'special-interest-group',
   'Marketing Oversight Committee/Marketing Advisory Committee': 'special-interest-group',

--- a/packages/shared/src/constants/tag.constants.ts
+++ b/packages/shared/src/constants/tag.constants.ts
@@ -61,6 +61,7 @@ export const COMMITTEE_CATEGORY_SEVERITY: Record<string, TagSeverity> = {
   'Technical Steering Committee': 'secondary',
   'Technical Oversight Committee/Technical Advisory Committee': 'secondary',
   'Technical Mailing List': 'secondary',
+  Newsletter: 'secondary',
   Maintainers: 'info',
   Committers: 'info',
 


### PR DESCRIPTION
## Summary
- Adds `Newsletter` as a new committee category, fast-following the existing Mailing List categories.
- Updates `COMMITTEE_CATEGORY_CONFIGS`, `COMMITTEE_CATEGORIES`, `COMMITTEE_TYPE_COLORS`, and `CATEGORY_BEHAVIORAL_CLASS` in `packages/shared/src/constants/committees.constants.ts`.
- Updates `COMMITTEE_CATEGORY_SEVERITY` in `packages/shared/src/constants/tag.constants.ts`.
- Not added to `FILTERED_COMMITTEE_CATEGORIES` (maintainer-only subset), matching how Mailing List categories are handled.

This is part of a coordinated 4-repo change introducing `Newsletter` as a committee/group category across `lfx-self-serve`, `lfx-v2-committee-service`, `lfx-pcc`, and `project-management`. The exact string value `Newsletter` is kept consistent across all four repos.

## Test plan
- [x] `yarn lint:check` passes (no new warnings/errors introduced)
- [x] `yarn build` passes
- [ ] Manually verify Newsletter appears in committee category selection UI with correct icon/color