### PR TITLE
feat(newsletters): restrict audience picker to newsletter groups

### DIFF
--- a/apps/lfx-one/e2e/newsletter-reopen-review-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review-robust.spec.ts
@@ -149,7 +149,7 @@ async function stubBackend(page: Page, draft: Newsletter): Promise<void> {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify([{ uid: MOCK_COMMITTEE_UID, name: 'Technical Steering Committee', category: 'Technical' }]),
+      body: JSON.stringify([{ uid: MOCK_COMMITTEE_UID, name: 'Community Newsletter', category: 'Newsletter' }]),
     })
   );
 }

--- a/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
@@ -33,6 +33,7 @@ const MOCK_FOUNDATION_SLUG = 'test-foundation';
 const MOCK_FOUNDATION_UID = 'f0000000-0000-0000-0000-000000000001';
 const MOCK_NEWSLETTER_ID = 'n0000000-0000-0000-0000-000000000aaa';
 const MOCK_COMMITTEE_UID = 'c0000000-0000-0000-0000-000000000bbb';
+const MOCK_INELIGIBLE_COMMITTEE_UID = 'c0000000-0000-0000-0000-000000000ccc';
 
 const MOCK_FOUNDATION_ITEM: LensItem = {
   uid: MOCK_FOUNDATION_UID,
@@ -122,7 +123,11 @@ async function stubProjectApi(page: Page): Promise<void> {
   await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
 }
 
-async function stubNewsletterApis(page: Page, draft: Newsletter): Promise<void> {
+async function stubNewsletterApis(
+  page: Page,
+  draft: Newsletter,
+  committees: { uid: string; name: string; category: string }[] = [{ uid: MOCK_COMMITTEE_UID, name: 'Community Newsletter', category: 'Newsletter' }]
+): Promise<void> {
   await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/${MOCK_NEWSLETTER_ID}`, (route) => {
     if (route.request().method() === 'GET') {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(draft) });
@@ -146,13 +151,7 @@ async function stubNewsletterApis(page: Page, draft: Newsletter): Promise<void> 
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify([
-        {
-          uid: MOCK_COMMITTEE_UID,
-          name: 'Community Newsletter',
-          category: 'Newsletter',
-        },
-      ]),
+      body: JSON.stringify(committees),
     })
   );
 }
@@ -275,6 +274,30 @@ test.describe('Newsletter reopen — empty-state coverage', () => {
     await expect(page.getByTestId('newsletter-review-content-incomplete'), 'subject-only blank copy should call out the subject').toContainText(
       'Add a subject before sending'
     );
+  });
+});
+
+test.describe('Newsletter reopen — audience normalization with mixed committee eligibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await setPersonaCookie(page, ['executive-director']);
+    await stubPersona(page, ['executive-director']);
+    await stubNavLensItems(page);
+    await stubProjectApi(page);
+  });
+
+  test('a saved ineligible committee UID is pruned from the audience and does not count toward recipients', async ({ page }) => {
+    await stubNewsletterApis(page, buildDraft({ committee_uids: [MOCK_COMMITTEE_UID, MOCK_INELIGIBLE_COMMITTEE_UID] }), [
+      { uid: MOCK_COMMITTEE_UID, name: 'Community Newsletter', category: 'Newsletter' },
+      { uid: MOCK_INELIGIBLE_COMMITTEE_UID, name: 'Legal Committee', category: 'Legal' },
+    ]);
+    await gotoEditUrl(page);
+
+    await expect(page.getByTestId('newsletter-review'), 'review screen should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // The draft was saved with 2 committee_uids, but only 1 is Newsletter-eligible —
+    // normalization must prune the ineligible one before the audience is ever sent,
+    // otherwise a stale non-Newsletter uid could be delivered to on a later Send.
+    await expect(page.getByTestId('newsletter-review-audience-summary'), 'audience summary should only count the eligible group').toContainText('1 group');
   });
 });
 

--- a/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
@@ -149,8 +149,8 @@ async function stubNewsletterApis(page: Page, draft: Newsletter): Promise<void> 
       body: JSON.stringify([
         {
           uid: MOCK_COMMITTEE_UID,
-          name: 'Technical Steering Committee',
-          category: 'Technical',
+          name: 'Community Newsletter',
+          category: 'Newsletter',
         },
       ]),
     })

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -27,7 +27,7 @@
       }
     </div>
 
-    @if (loadingCommittees()) {
+    @if (committeesLoading()) {
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
     } @else if (committeesError(); as error) {
       <div role="alert" class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -30,8 +30,18 @@
     @if (committeesLoading()) {
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
     } @else if (committeesError(); as error) {
-      <div role="alert" class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">
+      <div
+        role="alert"
+        class="flex items-center justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        data-testid="newsletter-audience-committees-error">
         {{ error }}
+        <button
+          type="button"
+          (click)="retryCommittees.emit()"
+          class="shrink-0 font-medium text-red-800 hover:underline"
+          data-testid="newsletter-audience-committees-retry-btn">
+          Retry
+        </button>
       </div>
     } @else if (!hasCommittees() && projectUid()) {
       <div class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" data-testid="newsletter-audience-no-committees">

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -30,7 +30,7 @@
     @if (loadingCommittees()) {
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
     } @else if (committeesError(); as error) {
-      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">
+      <div role="alert" class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">
         {{ error }}
       </div>
     } @else if (!hasCommittees() && projectUid()) {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -29,6 +29,8 @@
 
     @if (loadingCommittees()) {
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
+    } @else if (committeesError(); as error) {
+      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">{{ error }}</div>
     } @else if (!hasCommittees() && projectUid()) {
       <div class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" data-testid="newsletter-audience-no-committees">
         No newsletter groups available. Create a group with the Newsletter category first.

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -30,7 +30,9 @@
     @if (loadingCommittees()) {
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
     } @else if (committeesError(); as error) {
-      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">{{ error }}</div>
+      <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" data-testid="newsletter-audience-committees-error">
+        {{ error }}
+      </div>
     } @else if (!hasCommittees() && projectUid()) {
       <div class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" data-testid="newsletter-audience-no-committees">
         No newsletter groups available. Create a group with the Newsletter category first.

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -31,7 +31,7 @@
       <div class="text-sm text-gray-500 px-3 py-2 rounded-md border border-gray-200 bg-gray-50">Loading groups…</div>
     } @else if (!hasCommittees() && projectUid()) {
       <div class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" data-testid="newsletter-audience-no-committees">
-        No groups exist here yet. Create one first.
+        No newsletter groups available. Create a group with the Newsletter category first.
       </div>
     } @else {
       <lfx-multi-select

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -7,11 +7,10 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
 import { Committee, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-one/shared/interfaces';
-import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { catchError, distinctUntilChanged, EMPTY, finalize, map, of, startWith, switchMap, take } from 'rxjs';
+import { EMPTY, finalize, map, startWith, switchMap, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-newsletter-audience-step',
@@ -20,26 +19,29 @@ import { catchError, distinctUntilChanged, EMPTY, finalize, map, of, startWith, 
 })
 export class NewsletterAudienceStepComponent {
   // === Services ===
-  private readonly committeeService = inject(CommitteeService);
   private readonly newsletterService = inject(NewsletterService);
   private readonly destroyRef = inject(DestroyRef);
 
   // === Inputs ===
+  // Committees are fetched once by the parent (NewsletterManageComponent) and
+  // passed down here rather than re-fetched — the upstream endpoint fans out
+  // through fetchAllQueryResources, so a second full traversal per mount is wasteful
+  // and can produce inconsistent loading/error states between parent and child.
   public readonly form = input.required<FormGroup>();
   public readonly projectUid = input.required<string>();
+  public readonly committees = input<Committee[]>([]);
+  public readonly committeesLoading = input<boolean>(false);
+  public readonly committeesError = input<string | null>(null);
   public readonly recipientCount = input<number | null>(null);
   public readonly recipientCountLoading = input<boolean>(false);
 
   // === Signals ===
-  protected readonly loadingCommittees = signal<boolean>(false);
-  protected readonly committeesError = signal<string | null>(null);
   protected readonly recipients = signal<NewsletterRecipient[]>([]);
   protected readonly recipientsLoading = signal<boolean>(false);
   protected readonly recipientsError = signal<string | null>(null);
   protected readonly recipientsPopover = viewChild<Popover>('recipientsPopover');
 
   // === Reactive data ===
-  protected readonly committees: Signal<Committee[]> = this.initCommittees();
   protected readonly committeeUidsValue: Signal<string[]> = this.initCommitteeUidsValue();
 
   protected readonly committeeOptions = computed<NewsletterCommitteeOption[]>(() =>
@@ -83,28 +85,6 @@ export class NewsletterAudienceStepComponent {
           this.recipientsError.set('Could not load recipients. Please try again.');
         },
       });
-  }
-
-  private initCommittees(): Signal<Committee[]> {
-    return toSignal(
-      toObservable(this.projectUid).pipe(
-        distinctUntilChanged(),
-        switchMap((uid) => {
-          this.committeesError.set(null);
-          if (!uid) return of([] as Committee[]);
-          this.loadingCommittees.set(true);
-          return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
-            catchError(() => {
-              this.committeesError.set('Could not load groups. Please try again.');
-              return of([] as Committee[]);
-            }),
-            finalize(() => this.loadingCommittees.set(false))
-          );
-        }),
-        takeUntilDestroyed(this.destroyRef)
-      ),
-      { initialValue: [] as Committee[] }
-    );
   }
 
   private initCommitteeUidsValue(): Signal<string[]> {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -57,7 +57,7 @@ export class NewsletterAudienceStepComponent {
 
   public constructor() {
     effect(() => {
-      if (!this.committeesLoaded()) return;
+      if (!this.committeesLoaded() || this.committeesError()) return;
 
       const eligibleUids = new Set(this.committeeOptions().map((option) => option.value));
       const current = this.committeeUidsValue();

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, input, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, output, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
@@ -34,6 +34,9 @@ export class NewsletterAudienceStepComponent {
   public readonly committeesError = input<string | null>(null);
   public readonly recipientCount = input<number | null>(null);
   public readonly recipientCountLoading = input<boolean>(false);
+
+  // === Outputs ===
+  public readonly retryCommittees = output<void>();
 
   // === Signals ===
   protected readonly recipients = signal<NewsletterRecipient[]>([]);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, DestroyRef, inject, input, Signal, signal, viewChi
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
+import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
 import { Committee, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
@@ -41,11 +42,13 @@ export class NewsletterAudienceStepComponent {
   protected readonly committeeUidsValue: Signal<string[]> = this.initCommitteeUidsValue();
 
   protected readonly committeeOptions = computed<NewsletterCommitteeOption[]>(() =>
-    this.committees().map((c) => ({
-      label: c.name || 'Unnamed group',
-      value: c.uid,
-      category: c.category || 'Other',
-    }))
+    this.committees()
+      .filter((c) => c.category === NEWSLETTER_COMMITTEE_CATEGORY)
+      .map((c) => ({
+        label: c.name || 'Unnamed group',
+        value: c.uid,
+        category: c.category || 'Other',
+      }))
   );
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -111,7 +111,7 @@ export class NewsletterAudienceStepComponent {
           }
           this.loadingCommittees.set(true);
           this.committeesLoaded.set(false);
-          return this.committeeService.getCommitteesByProject(uid).pipe(
+          return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
             catchError(() => {
               this.committeesError.set('Could not load groups. Please try again.');
               return of([] as Committee[]);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, effect, inject, input, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
@@ -32,7 +32,6 @@ export class NewsletterAudienceStepComponent {
 
   // === Signals ===
   protected readonly loadingCommittees = signal<boolean>(false);
-  protected readonly committeesLoaded = signal<boolean>(false);
   protected readonly committeesError = signal<string | null>(null);
   protected readonly recipients = signal<NewsletterRecipient[]>([]);
   protected readonly recipientsLoading = signal<boolean>(false);
@@ -54,19 +53,6 @@ export class NewsletterAudienceStepComponent {
   );
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);
-
-  public constructor() {
-    effect(() => {
-      if (!this.committeesLoaded() || this.committeesError()) return;
-
-      const eligibleUids = new Set(this.committeeOptions().map((option) => option.value));
-      const current = this.committeeUidsValue();
-      const filtered = current.filter((uid) => eligibleUids.has(uid));
-      if (filtered.length !== current.length) {
-        this.form().get('committeeUids')?.setValue(filtered);
-      }
-    });
-  }
 
   protected onShowRecipients(event: Event): void {
     const popover = this.recipientsPopover();
@@ -105,21 +91,14 @@ export class NewsletterAudienceStepComponent {
         distinctUntilChanged(),
         switchMap((uid) => {
           this.committeesError.set(null);
-          if (!uid) {
-            this.committeesLoaded.set(true);
-            return of([] as Committee[]);
-          }
+          if (!uid) return of([] as Committee[]);
           this.loadingCommittees.set(true);
-          this.committeesLoaded.set(false);
           return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
             catchError(() => {
               this.committeesError.set('Could not load groups. Please try again.');
               return of([] as Committee[]);
             }),
-            finalize(() => {
-              this.loadingCommittees.set(false);
-              this.committeesLoaded.set(true);
-            })
+            finalize(() => this.loadingCommittees.set(false))
           );
         }),
         takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, input, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
@@ -32,6 +32,8 @@ export class NewsletterAudienceStepComponent {
 
   // === Signals ===
   protected readonly loadingCommittees = signal<boolean>(false);
+  protected readonly committeesLoaded = signal<boolean>(false);
+  protected readonly committeesError = signal<string | null>(null);
   protected readonly recipients = signal<NewsletterRecipient[]>([]);
   protected readonly recipientsLoading = signal<boolean>(false);
   protected readonly recipientsError = signal<string | null>(null);
@@ -52,6 +54,19 @@ export class NewsletterAudienceStepComponent {
   );
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);
+
+  public constructor() {
+    effect(() => {
+      if (!this.committeesLoaded()) return;
+
+      const eligibleUids = new Set(this.committeeOptions().map((option) => option.value));
+      const current = this.committeeUidsValue();
+      const filtered = current.filter((uid) => eligibleUids.has(uid));
+      if (filtered.length !== current.length) {
+        this.form().get('committeeUids')?.setValue(filtered);
+      }
+    });
+  }
 
   protected onShowRecipients(event: Event): void {
     const popover = this.recipientsPopover();
@@ -89,11 +104,22 @@ export class NewsletterAudienceStepComponent {
       toObservable(this.projectUid).pipe(
         distinctUntilChanged(),
         switchMap((uid) => {
-          if (!uid) return of([] as Committee[]);
+          this.committeesError.set(null);
+          if (!uid) {
+            this.committeesLoaded.set(true);
+            return of([] as Committee[]);
+          }
           this.loadingCommittees.set(true);
+          this.committeesLoaded.set(false);
           return this.committeeService.getCommitteesByProject(uid).pipe(
-            catchError(() => of([] as Committee[])),
-            finalize(() => this.loadingCommittees.set(false))
+            catchError(() => {
+              this.committeesError.set('Could not load groups. Please try again.');
+              return of([] as Committee[]);
+            }),
+            finalize(() => {
+              this.loadingCommittees.set(false);
+              this.committeesLoaded.set(true);
+            })
           );
         }),
         takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
@@ -50,7 +50,7 @@
           }
         </div>
       </div>
-      @if (committeesError()) {
+      @if (committeesError() || committeesLoading()) {
         <lfx-button
           label="Retry"
           icon="fa-light fa-rotate-right"

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
@@ -34,7 +34,9 @@
         </span>
         <div class="flex flex-col gap-1 min-w-0">
           <h3 class="text-base font-semibold text-gray-900">Audience</h3>
-          @if (audienceEmpty()) {
+          @if (committeesError(); as error) {
+            <p class="text-sm text-red-600" role="alert" data-testid="newsletter-review-audience-error">{{ error }}</p>
+          } @else if (audienceEmpty()) {
             <p class="text-sm text-amber-600" data-testid="newsletter-review-audience-empty">No groups selected yet — add at least one to send.</p>
           } @else {
             <p class="text-sm text-gray-700" data-testid="newsletter-review-audience-summary">
@@ -48,16 +50,30 @@
           }
         </div>
       </div>
-      <lfx-button
-        label="Edit"
-        icon="fa-light fa-pen"
-        severity="secondary"
-        [outlined]="true"
-        size="small"
-        (onClick)="editAudience.emit()"
-        ariaLabel="Edit audience"
-        data-testid="newsletter-review-audience-edit-btn">
-      </lfx-button>
+      @if (committeesError()) {
+        <lfx-button
+          label="Retry"
+          icon="fa-light fa-rotate-right"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          [loading]="committeesLoading()"
+          (onClick)="retryCommittees.emit()"
+          ariaLabel="Retry loading groups"
+          data-testid="newsletter-review-audience-retry-btn">
+        </lfx-button>
+      } @else {
+        <lfx-button
+          label="Edit"
+          icon="fa-light fa-pen"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          (onClick)="editAudience.emit()"
+          ariaLabel="Edit audience"
+          data-testid="newsletter-review-audience-edit-btn">
+        </lfx-button>
+      }
     </div>
   </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.ts
@@ -31,6 +31,8 @@ export class NewsletterReviewComponent {
   public readonly sending = input<boolean>(false);
   public readonly testSending = input<boolean>(false);
   public readonly deleting = input<boolean>(false);
+  public readonly committeesError = input<string | null>(null);
+  public readonly committeesLoading = input<boolean>(false);
 
   // === Outputs ===
   public readonly editAudience = output<void>();
@@ -40,6 +42,7 @@ export class NewsletterReviewComponent {
   public readonly sendTest = output<void>();
   public readonly preview = output<void>();
   public readonly delete = output<void>();
+  public readonly retryCommittees = output<void>();
 
   // === Reactive form mirrors ===
   protected readonly committeeUids: Signal<string[]> = this.initControlValue<string[]>('committeeUids', []);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -171,7 +171,8 @@
                     [committeesLoading]="committeesLoading()"
                     [committeesError]="committeesError()"
                     [recipientCount]="recipientCount()"
-                    [recipientCountLoading]="recipientCountLoading()">
+                    [recipientCountLoading]="recipientCountLoading()"
+                    (retryCommittees)="retryCommittees()">
                   </lfx-newsletter-audience-step>
                 </ng-template>
               </p-step-panel>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -41,13 +41,16 @@
         [sending]="submitting()"
         [testSending]="testSending()"
         [deleting]="deletingDraft()"
+        [committeesError]="committeesError()"
+        [committeesLoading]="committeesLoading()"
         (editAudience)="enterStep(1)"
         (editContent)="enterStep(2)"
         (editSend)="enterStep(3)"
         (send)="onSend()"
         (sendTest)="onSendTest()"
         (preview)="openPreviewDrawer()"
-        (delete)="onDeleteDraft()">
+        (delete)="onDeleteDraft()"
+        (retryCommittees)="retryCommittees()">
       </lfx-newsletter-review>
     }
   } @else {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -164,6 +164,9 @@
                   <lfx-newsletter-audience-step
                     [form]="form"
                     [projectUid]="projectUid()"
+                    [committees]="committees()"
+                    [committeesLoading]="committeesLoading()"
+                    [committeesError]="committeesError()"
                     [recipientCount]="recipientCount()"
                     [recipientCountLoading]="recipientCountLoading()">
                   </lfx-newsletter-audience-step>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, DestroyRef, effect, inject, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, Injector, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -76,6 +76,7 @@ export class NewsletterManageComponent {
   protected readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly injector = inject(Injector);
   private readonly newsletterService = inject(NewsletterService);
   private readonly committeeService = inject(CommitteeService);
   private readonly projectContextService = inject(ProjectContextService);
@@ -499,7 +500,9 @@ export class NewsletterManageComponent {
     // and one of the two would 409. canSend also disables Send while
     // savingDraft() is true; this is defense-in-depth for the click that
     // slips in during the flip.
-    const ensureSaved$ = toObservable(this.savingDraft).pipe(
+    // toObservable requires an injection context; runSend is invoked from the confirm-dialog's
+    // accept callback (a plain event handler), so the injector must be passed explicitly here.
+    const ensureSaved$ = toObservable(this.savingDraft, { injector: this.injector }).pipe(
       filter((saving) => !saving),
       take(1),
       switchMap(() => (this.snapshotMatchesLastSaved() ? of(true) : this.saveDraft(true).pipe(map((draft) => draft !== null))))

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -196,7 +196,14 @@ export class NewsletterManageComponent {
   public readonly canGoPrevious = computed(() => this.currentStep() > 1);
   public readonly canGoNext = computed(() => this.currentStep() < this.totalSteps && this.canProceed());
   public readonly canSaveDraft = computed(
-    () => this.hasContext() && this.audienceFilled() && this.subjectFilled() && this.bodyFilled() && this.edEmail().length > 0 && !this.savingDraft()
+    () =>
+      this.hasContext() &&
+      this.audienceFilled() &&
+      this.audienceNormalized() &&
+      this.subjectFilled() &&
+      this.bodyFilled() &&
+      this.edEmail().length > 0 &&
+      !this.savingDraft()
   );
   public readonly isLastStep = computed(() => this.currentStep() === this.totalSteps);
   public readonly currentStepTitle = computed(() => NEWSLETTER_STEP_TITLES[this.currentStep()] ?? '');
@@ -359,7 +366,7 @@ export class NewsletterManageComponent {
   private computeCanProceed(step: number): boolean {
     switch (step) {
       case 1:
-        return this.audienceFilled();
+        return this.audienceFilled() && this.audienceNormalized();
       case 2:
         return this.subjectFilled() && this.bodyFilled();
       case 3:
@@ -759,7 +766,7 @@ export class NewsletterManageComponent {
   }
 
   private hasAnythingToSave(): boolean {
-    return this.audienceFilled() && this.subjectFilled() && this.bodyFilled();
+    return this.audienceFilled() && this.audienceNormalized() && this.subjectFilled() && this.bodyFilled();
   }
 
   private saveDraft(isManual = false) {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -186,7 +186,8 @@ export class NewsletterManageComponent {
       this.bodyFilled() &&
       this.hasContext() &&
       !this.submitting() &&
-      !this.resolvingSend()
+      !this.resolvingSend() &&
+      !this.savingDraft()
   );
   public readonly canSendTest = computed(
     () => this.subjectFilled() && this.bodyFilled() && this.hasContext() && this.edEmail().length > 0 && !this.testSending()
@@ -463,11 +464,21 @@ export class NewsletterManageComponent {
     // newsletter by id/version, so a normalized-but-unsaved committee_uids value
     // would otherwise still deliver to the stale, un-normalized audience on the
     // server. Force a save first whenever the form has drifted from what's saved.
-    const ensureSaved$ = this.snapshotMatchesLastSaved() ? of(true) : this.saveDraft(true).pipe(map((draft) => draft !== null));
+    //
+    // Wait out any autosave already in flight first — saveDraft isn't routed
+    // through the saveTrigger$/concatMap channel here, so firing it directly
+    // while autosave's own PUT is still pending would race the same version
+    // and one of the two would 409. canSend also disables Send while
+    // savingDraft() is true; this is defense-in-depth for the click that
+    // slips in during the flip.
+    const ensureSaved$ = toObservable(this.savingDraft).pipe(
+      filter((saving) => !saving),
+      take(1),
+      switchMap(() => (this.snapshotMatchesLastSaved() ? of(true) : this.saveDraft(true).pipe(map((draft) => draft !== null))))
+    );
 
     ensureSaved$
       .pipe(
-        take(1),
         switchMap((saved) => {
           if (!saved) return EMPTY;
           return this.newsletterService.sendNewsletter(this.projectUid(), id, this.version());

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -38,6 +38,7 @@ import {
   filter,
   finalize,
   map,
+  merge,
   of,
   Subject,
   switchMap,
@@ -150,12 +151,20 @@ export class NewsletterManageComponent {
   // === Recipient summary ===
   protected readonly recipientCount = signal<number | null>(null);
   protected readonly recipientCountLoading = signal<boolean>(false);
+  // Draft-load fires an immediate count request for the (possibly unfiltered)
+  // saved uids; audience normalization can follow shortly after with a
+  // setValue for the filtered uids. Routing both through one switchMap-based
+  // pipeline (rather than each firing its own independent subscription)
+  // cancels the stale in-flight request instead of letting it race the
+  // normalized one and clobber the displayed count.
+  private readonly recipientCountTrigger$ = new Subject<string[]>();
 
   // === Newsletter-eligible committees ===
   // Fetched once here (not duplicated in the audience-step child) and passed down
   // via inputs, since the upstream endpoint fans out through fetchAllQueryResources.
   protected readonly committeesLoading = signal<boolean>(false);
   protected readonly committeesError = signal<string | null>(null);
+  private readonly retryCommittees$ = new Subject<void>();
   protected readonly committees: Signal<Committee[]> = this.initCommittees();
 
   // null means "not yet loaded, or the fetch failed" — pruning is skipped in both
@@ -356,6 +365,10 @@ export class NewsletterManageComponent {
     });
   }
 
+  protected retryCommittees(): void {
+    this.retryCommittees$.next();
+  }
+
   private goToList(tab?: 'draft' | 'sent'): void {
     this.router.navigate(['list'], {
       relativeTo: this.route.parent,
@@ -383,42 +396,50 @@ export class NewsletterManageComponent {
   }
 
   private initRecipientCount(): void {
-    this.form.controls.committeeUids.valueChanges
-      .pipe(debounceTime(300), distinctUntilChanged(this.uidsEqual), takeUntilDestroyed(this.destroyRef))
-      .subscribe((uids) => this.fetchRecipientCountFor(uids ?? []));
+    merge(this.form.controls.committeeUids.valueChanges.pipe(debounceTime(300), distinctUntilChanged(this.uidsEqual)), this.recipientCountTrigger$)
+      .pipe(
+        switchMap((uids) => this.fetchRecipientCount$(uids ?? [])),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe();
   }
 
   private fetchRecipientCountFor(uids: string[]): void {
+    this.recipientCountTrigger$.next(uids);
+  }
+
+  private fetchRecipientCount$(uids: string[]) {
     if (!uids || uids.length === 0) {
       this.recipientCount.set(0);
-      return;
+      return EMPTY;
     }
     if (!this.hasContext()) {
-      return;
+      return EMPTY;
     }
     this.recipientCountLoading.set(true);
-    this.newsletterService
-      .getRecipientCount(this.projectUid(), { committee_uids: uids })
-      .pipe(
-        take(1),
-        finalize(() => this.recipientCountLoading.set(false))
-      )
-      .subscribe({
+    return this.newsletterService.getRecipientCount(this.projectUid(), { committee_uids: uids }).pipe(
+      finalize(() => this.recipientCountLoading.set(false)),
+      tap({
         next: (res) => this.recipientCount.set(res.count),
         error: () => this.recipientCount.set(null),
-      });
+      }),
+      catchError(() => EMPTY)
+    );
   }
 
   private initCommittees(): Signal<Committee[]> {
     return toSignal(
-      toObservable(this.projectUid).pipe(
-        distinctUntilChanged(),
+      merge(toObservable(this.projectUid).pipe(distinctUntilChanged()), this.retryCommittees$.pipe(map(() => this.projectUid()))).pipe(
         switchMap((uid) => {
           this.committeesError.set(null);
           if (!uid) return of([] as Committee[]);
           this.committeesLoading.set(true);
           return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
             catchError(() => {
+              // A single transient failure otherwise leaves eligibleCommitteeUids()
+              // null forever — Send, save, and step-1 proceed all stay blocked with
+              // no way to recover short of navigating away. retryCommittees() gives
+              // users (surfaced on the Review screen) an explicit way back in.
               this.committeesError.set('Could not load groups. Please try again.');
               return of([] as Committee[]);
             }),

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -173,8 +173,20 @@ export class NewsletterManageComponent {
   public readonly subjectFilled = computed(() => (this.subjectValue() ?? '').trim().length > 0);
   public readonly bodyFilled = computed(() => stripHtml(this.bodyValue() ?? '').length > 0);
   public readonly audienceFilled = computed(() => (this.committeeUidsValue() ?? []).length > 0);
+  // Gates Send on eligibility having actually resolved — while committees are
+  // still loading (or the fetch failed), eligibleCommitteeUids() is null and
+  // initAudienceNormalization() deliberately skips pruning, so a stale/legacy
+  // non-Newsletter audience could otherwise be sent before it's ever checked.
+  public readonly audienceNormalized = computed(() => this.eligibleCommitteeUids() !== null);
   public readonly canSend = computed(
-    () => this.audienceFilled() && this.subjectFilled() && this.bodyFilled() && this.hasContext() && !this.submitting() && !this.resolvingSend()
+    () =>
+      this.audienceFilled() &&
+      this.audienceNormalized() &&
+      this.subjectFilled() &&
+      this.bodyFilled() &&
+      this.hasContext() &&
+      !this.submitting() &&
+      !this.resolvingSend()
   );
   public readonly canSendTest = computed(
     () => this.subjectFilled() && this.bodyFilled() && this.hasContext() && this.edEmail().length > 0 && !this.testSending()

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY, NEWSLETTER_STEP_TITLES, NEWSLETTER_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import {
+  Committee,
   CreateNewsletterRequest,
   GenerateNewsletterResponse,
   Newsletter,
@@ -151,9 +152,22 @@ export class NewsletterManageComponent {
   protected readonly recipientCountLoading = signal<boolean>(false);
 
   // === Newsletter-eligible committees ===
+  // Fetched once here (not duplicated in the audience-step child) and passed down
+  // via inputs, since the upstream endpoint fans out through fetchAllQueryResources.
+  protected readonly committeesLoading = signal<boolean>(false);
+  protected readonly committeesError = signal<string | null>(null);
+  protected readonly committees: Signal<Committee[]> = this.initCommittees();
+
   // null means "not yet loaded, or the fetch failed" — pruning is skipped in both
   // cases so a transient error or in-flight load never wipes a valid selection.
-  private readonly eligibleCommitteeUids: Signal<Set<string> | null> = this.initEligibleCommitteeUids();
+  private readonly eligibleCommitteeUids: Signal<Set<string> | null> = computed(() => {
+    if (this.committeesLoading() || this.committeesError()) return null;
+    return new Set(
+      this.committees()
+        .filter((c) => c.category === NEWSLETTER_COMMITTEE_CATEGORY)
+        .map((c) => c.uid)
+    );
+  });
 
   // === Validation gates ===
   public readonly subjectFilled = computed(() => (this.subjectValue() ?? '').trim().length > 0);
@@ -375,20 +389,25 @@ export class NewsletterManageComponent {
       });
   }
 
-  private initEligibleCommitteeUids(): Signal<Set<string> | null> {
+  private initCommittees(): Signal<Committee[]> {
     return toSignal(
       toObservable(this.projectUid).pipe(
         distinctUntilChanged(),
         switchMap((uid) => {
-          if (!uid) return of(null as Set<string> | null);
+          this.committeesError.set(null);
+          if (!uid) return of([] as Committee[]);
+          this.committeesLoading.set(true);
           return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
-            map((committees) => new Set(committees.filter((c) => c.category === NEWSLETTER_COMMITTEE_CATEGORY).map((c) => c.uid))),
-            catchError(() => of(null as Set<string> | null))
+            catchError(() => {
+              this.committeesError.set('Could not load groups. Please try again.');
+              return of([] as Committee[]);
+            }),
+            finalize(() => this.committeesLoading.set(false))
           );
         }),
         takeUntilDestroyed(this.destroyRef)
       ),
-      { initialValue: null }
+      { initialValue: [] as Committee[] }
     );
   }
 
@@ -428,10 +447,19 @@ export class NewsletterManageComponent {
     }
     this.submitting.set(true);
 
-    this.newsletterService
-      .sendNewsletter(this.projectUid(), id, this.version())
+    // Audience normalization only mutates the form; runSend sends the *persisted*
+    // newsletter by id/version, so a normalized-but-unsaved committee_uids value
+    // would otherwise still deliver to the stale, un-normalized audience on the
+    // server. Force a save first whenever the form has drifted from what's saved.
+    const ensureSaved$ = this.snapshotMatchesLastSaved() ? of(true) : this.saveDraft(true).pipe(map((draft) => draft !== null));
+
+    ensureSaved$
       .pipe(
         take(1),
+        switchMap((saved) => {
+          if (!saved) return EMPTY;
+          return this.newsletterService.sendNewsletter(this.projectUid(), id, this.version());
+        }),
         finalize(() => this.submitting.set(false))
       )
       .subscribe({

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { NEWSLETTER_STEP_TITLES, NEWSLETTER_TOTAL_STEPS } from '@lfx-one/shared/constants';
+import { NEWSLETTER_COMMITTEE_CATEGORY, NEWSLETTER_STEP_TITLES, NEWSLETTER_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import {
   CreateNewsletterRequest,
   GenerateNewsletterResponse,
@@ -18,6 +18,7 @@ import {
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { formatRelativeTime, stripHtml } from '@lfx-one/shared/utils';
+import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
@@ -74,6 +75,7 @@ export class NewsletterManageComponent {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly newsletterService = inject(NewsletterService);
+  private readonly committeeService = inject(CommitteeService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
   private readonly userService = inject(UserService);
@@ -148,6 +150,11 @@ export class NewsletterManageComponent {
   protected readonly recipientCount = signal<number | null>(null);
   protected readonly recipientCountLoading = signal<boolean>(false);
 
+  // === Newsletter-eligible committees ===
+  // null means "not yet loaded, or the fetch failed" — pruning is skipped in both
+  // cases so a transient error or in-flight load never wipes a valid selection.
+  private readonly eligibleCommitteeUids: Signal<Set<string> | null> = this.initEligibleCommitteeUids();
+
   // === Validation gates ===
   public readonly subjectFilled = computed(() => (this.subjectValue() ?? '').trim().length > 0);
   public readonly bodyFilled = computed(() => stripHtml(this.bodyValue() ?? '').length > 0);
@@ -179,6 +186,7 @@ export class NewsletterManageComponent {
     this.initSaveChannel();
     this.initAutosave();
     this.initRecipientCount();
+    this.initAudienceNormalization();
   }
 
   protected goToStep(step: number | undefined): void {
@@ -365,6 +373,42 @@ export class NewsletterManageComponent {
         next: (res) => this.recipientCount.set(res.count),
         error: () => this.recipientCount.set(null),
       });
+  }
+
+  private initEligibleCommitteeUids(): Signal<Set<string> | null> {
+    return toSignal(
+      toObservable(this.projectUid).pipe(
+        distinctUntilChanged(),
+        switchMap((uid) => {
+          if (!uid) return of(null as Set<string> | null);
+          return this.committeeService.getCommitteesByProjectOrThrow(uid).pipe(
+            map((committees) => new Set(committees.filter((c) => c.category === NEWSLETTER_COMMITTEE_CATEGORY).map((c) => c.uid))),
+            catchError(() => of(null as Set<string> | null))
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      ),
+      { initialValue: null }
+    );
+  }
+
+  /**
+   * Owns audience normalization at the form level so it applies regardless of which
+   * step/view is mounted — the audience step's own picker only renders while the
+   * stepper is on step 1, but save/send can happen from the Review view.
+   */
+  private initAudienceNormalization(): void {
+    effect(() => {
+      const eligible = this.eligibleCommitteeUids();
+      if (!eligible) return;
+
+      const control = this.form.controls.committeeUids;
+      const current = control.value ?? [];
+      const filtered = current.filter((uid) => eligible.has(uid));
+      if (filtered.length !== current.length) {
+        control.setValue(filtered);
+      }
+    });
   }
 
   private runSend(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -395,18 +395,20 @@ export class NewsletterManageComponent {
   /**
    * Owns audience normalization at the form level so it applies regardless of which
    * step/view is mounted — the audience step's own picker only renders while the
-   * stepper is on step 1, but save/send can happen from the Review view.
+   * stepper is on step 1, but save/send can happen from the Review view. Tracks
+   * `committeeUidsValue` (not just `eligibleCommitteeUids`) so a draft loaded via
+   * `patchValue({ emitEvent: false })` after eligibility has already resolved still
+   * gets re-checked.
    */
   private initAudienceNormalization(): void {
     effect(() => {
       const eligible = this.eligibleCommitteeUids();
+      const current = this.committeeUidsValue();
       if (!eligible) return;
 
-      const control = this.form.controls.committeeUids;
-      const current = control.value ?? [];
       const filtered = current.filter((uid) => eligible.has(uid));
       if (filtered.length !== current.length) {
-        control.setValue(filtered);
+        this.form.controls.committeeUids.setValue(filtered);
       }
     });
   }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -38,6 +38,17 @@ export class CommitteeService {
     return this.getCommittees(params);
   }
 
+  /**
+   * Same request as `getCommitteesByProject`, but propagates HTTP errors instead of
+   * swallowing them to `[]`. Use when the caller needs to distinguish a fetch failure
+   * from a genuinely empty result.
+   */
+  public getCommitteesByProjectOrThrow(uid: string): Observable<Committee[]> {
+    const params = new HttpParams().set('tags', `project_uid:${uid}`);
+
+    return this.http.get<Committee[]>('/api/committees', { params });
+  }
+
   public getCommitteesCountByProject(uid: string): Observable<number> {
     const params = new HttpParams().set('tags', `project_uid:${uid}`);
     return this.http

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -201,6 +201,13 @@ export const COMMITTEE_CATEGORIES = [
 ];
 
 /**
+ * Committee category value used to identify newsletter-eligible groups
+ * @description Only committees tagged with this category should be selectable as a newsletter's audience
+ * @readonly
+ */
+export const NEWSLETTER_COMMITTEE_CATEGORY = 'Newsletter';
+
+/**
  * Filtered committee categories for specific UI contexts
  * @description Subset of categories for restricted selection (e.g., forms, dashboards)
  */


### PR DESCRIPTION
## Summary
- Only show committees tagged with the Newsletter category in the newsletter audience picker

LFXV2-2818