### PR TITLE
fix(mailing-lists): minor ui issues in create and edit flows

### DIFF
--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.html
@@ -57,7 +57,7 @@
         @if (form().get('group_name')?.errors?.['pattern'] && form().get('group_name')?.touched) {
           <p class="mt-1 text-sm text-red-600">Name can only contain lowercase letters and numbers, with hyphens allowed between characters</p>
         }
-        @if (form().get('group_name')?.errors?.['duplicateName'] && form().get('group_name')?.touched) {
+        @if (duplicateNameError()) {
           <p class="mt-1 text-sm text-red-600">A mailing list with this name already exists</p>
         }
       }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.html
@@ -57,6 +57,9 @@
         @if (form().get('group_name')?.errors?.['pattern'] && form().get('group_name')?.touched) {
           <p class="mt-1 text-sm text-red-600">Name can only contain lowercase letters and numbers, with hyphens allowed between characters</p>
         }
+        @if (form().get('group_name')?.errors?.['duplicateName'] && form().get('group_name')?.touched) {
+          <p class="mt-1 text-sm text-red-600">A mailing list with this name already exists</p>
+        }
       }
     </div>
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-basic-info/mailing-list-basic-info.component.ts
@@ -23,6 +23,7 @@ export class MailingListBasicInfoComponent {
   public readonly prefix = input<string>('');
   public readonly maxGroupNameLength = input<number>(34);
   public readonly isEditMode = input<boolean>(false);
+  public readonly duplicateNameError = input<boolean>(false);
 
   public readonly projectName = computed(() => {
     return this.service()?.project_name || this.projectContextService.activeContext()?.name || '';

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.html
@@ -4,9 +4,9 @@
 <div class="container px-8" data-testid="mailing-list-manage">
   <!-- Back Navigation -->
   <div class="mb-4">
-    <a routerLink="/mailing-lists" class="inline-flex items-center text-gray-500 hover:text-gray-700 transition-colors">
+    <a [routerLink]="backLink()" class="inline-flex items-center text-gray-500 hover:text-gray-700 transition-colors">
       <i class="fa-light fa-arrow-left mr-2"></i>
-      Back to Mailing Lists
+      {{ isEditMode() ? 'Back to Mailing List' : 'Back to Mailing Lists' }}
     </a>
   </div>
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.html
@@ -85,7 +85,8 @@
                 [service]="selectedService()"
                 [prefix]="servicePrefix()"
                 [maxGroupNameLength]="maxGroupNameLength()"
-                [isEditMode]="isEditMode()">
+                [isEditMode]="isEditMode()"
+                [duplicateNameError]="hasDuplicateNameError()">
               </lfx-mailing-list-basic-info>
             </ng-template>
           </p-step-panel>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -62,6 +62,7 @@ export class MailingListManageComponent {
   public readonly parentService = signal<GroupsIOService | null>(null);
   private readonly internalStep = signal<number>(1);
   private readonly createdService = signal<GroupsIOService | null>(null);
+  public readonly hasDuplicateNameError = signal<boolean>(false);
 
   // Complex computed/toSignal signals
   public readonly isEditMode: Signal<boolean> = this.initIsEditMode();
@@ -83,6 +84,9 @@ export class MailingListManageComponent {
 
   public constructor() {
     evictOnWriteAccessLoss();
+    this.form()
+      .get('group_name')
+      ?.valueChanges.subscribe(() => this.hasDuplicateNameError.set(false));
   }
 
   public nextStep(): void {
@@ -169,6 +173,7 @@ export class MailingListManageComponent {
             const groupNameControl = this.form().get('group_name');
             groupNameControl?.setErrors({ ...groupNameControl.errors, duplicateName: true });
             groupNameControl?.markAsTouched();
+            this.hasDuplicateNameError.set(true);
             this.internalStep.set(1);
             this.messageService.add({
               severity: 'error',
@@ -267,6 +272,7 @@ export class MailingListManageComponent {
           this.servicesLoaded.set(false);
           this.parentService.set(null);
           this.createdService.set(null);
+          this.hasDuplicateNameError.set(false);
         }),
         filter((project): project is NonNullable<typeof project> => project !== null),
         switchMap((project) =>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -86,7 +86,8 @@ export class MailingListManageComponent {
     evictOnWriteAccessLoss();
     this.form()
       .get('group_name')
-      ?.valueChanges.subscribe(() => this.hasDuplicateNameError.set(false));
+      ?.valueChanges.pipe(takeUntilDestroyed())
+      .subscribe(() => this.hasDuplicateNameError.set(false));
   }
 
   public nextStep(): void {
@@ -273,6 +274,7 @@ export class MailingListManageComponent {
           this.parentService.set(null);
           this.createdService.set(null);
           this.hasDuplicateNameError.set(false);
+          this.form().get('group_name')?.updateValueAndValidity();
         }),
         filter((project): project is NonNullable<typeof project> => project !== null),
         switchMap((project) =>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -170,6 +170,11 @@ export class MailingListManageComponent {
             groupNameControl?.setErrors({ ...groupNameControl.errors, duplicateName: true });
             groupNameControl?.markAsTouched();
             this.internalStep.set(1);
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: 'A mailing list with this name already exists',
+            });
           } else {
             const isServiceError = isCreatingService && !serviceWasCreated;
             this.messageService.add({

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -60,6 +60,7 @@ export class MailingListManageComponent {
   public readonly servicesLoaded = signal<boolean>(false);
   public readonly parentService = signal<GroupsIOService | null>(null);
   private readonly internalStep = signal<number>(1);
+  private readonly createdService = signal<GroupsIOService | null>(null);
 
   // Complex computed/toSignal signals
   public readonly isEditMode: Signal<boolean> = this.initIsEditMode();
@@ -132,10 +133,15 @@ export class MailingListManageComponent {
     // Determine if we need to create a shared service first
     const isCreatingService = this.needsSharedServiceCreation() && !this.isEditMode();
     const serviceCreation$: Observable<GroupsIOService | null> = isCreatingService ? this.createSharedService() : of(null);
+    let serviceWasCreated = false;
 
     serviceCreation$
       .pipe(
         switchMap((newService: GroupsIOService | null) => {
+          if (newService) {
+            this.createdService.set(newService);
+            serviceWasCreated = true;
+          }
           const service = newService ?? this.selectedService();
           if (!service?.uid) {
             return throwError(() => new Error('Parent service is required'));
@@ -152,11 +158,11 @@ export class MailingListManageComponent {
             summary: 'Success',
             detail: `Mailing list ${this.isEditMode() ? 'updated' : 'created'} successfully`,
           });
-          this.router.navigate(['/mailing-lists']);
+          this.router.navigate(this.backLink());
         },
         error: (error: Error) => {
           const httpStatus = (error as any).status as number | undefined;
-          const isDuplicateName = !this.isEditMode() && httpStatus === 409;
+          const isDuplicateName = !this.isEditMode() && httpStatus === 409 && (!isCreatingService || serviceWasCreated);
 
           if (isDuplicateName) {
             const groupNameControl = this.form().get('group_name');
@@ -164,7 +170,7 @@ export class MailingListManageComponent {
             groupNameControl?.markAsTouched();
             this.internalStep.set(1);
           } else {
-            const isServiceError = isCreatingService && error?.message?.includes('service');
+            const isServiceError = isCreatingService && !serviceWasCreated;
             this.messageService.add({
               severity: 'error',
               summary: 'Error',
@@ -254,6 +260,7 @@ export class MailingListManageComponent {
         tap(() => {
           this.servicesLoaded.set(false);
           this.parentService.set(null);
+          this.createdService.set(null);
         }),
         filter((project): project is NonNullable<typeof project> => project !== null),
         switchMap((project) =>
@@ -298,12 +305,15 @@ export class MailingListManageComponent {
   }
 
   private initSelectedService(): Signal<GroupsIOService | null> {
-    return computed(() => this.availableServices()[0] ?? null);
+    return computed(() => this.createdService() ?? this.availableServices()[0] ?? null);
   }
 
   private initNeedsSharedServiceCreation(): Signal<boolean> {
     return computed(
-      () => this.parentService() !== null && this.availableServices().filter((service) => service.type === GroupsIOServiceType.SHARED).length === 0
+      () =>
+        this.createdService() === null &&
+        this.parentService() !== null &&
+        this.availableServices().filter((service) => service.type === GroupsIOServiceType.SHARED).length === 0
     );
   }
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -155,14 +155,24 @@ export class MailingListManageComponent {
           this.router.navigate(['/mailing-lists']);
         },
         error: (error: Error) => {
-          const isServiceError = isCreatingService && error?.message?.includes('service');
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Error',
-            detail: isServiceError
-              ? 'Failed to create mailing list service for this project'
-              : `Failed to ${this.isEditMode() ? 'update' : 'create'} mailing list`,
-          });
+          const httpStatus = (error as any).status as number | undefined;
+          const isDuplicateName = !this.isEditMode() && httpStatus === 409;
+
+          if (isDuplicateName) {
+            const groupNameControl = this.form().get('group_name');
+            groupNameControl?.setErrors({ ...groupNameControl.errors, duplicateName: true });
+            groupNameControl?.markAsTouched();
+            this.internalStep.set(1);
+          } else {
+            const isServiceError = isCreatingService && error?.message?.includes('service');
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: isServiceError
+                ? 'Failed to create mailing list service for this project'
+                : `Failed to ${this.isEditMode() ? 'update' : 'create'} mailing list`,
+            });
+          }
           this.submitting.set(false);
         },
       });

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -134,7 +134,7 @@ export class MailingListManageComponent {
     // Determine if we need to create a shared service first
     const isCreatingService = this.needsSharedServiceCreation() && !this.isEditMode();
     const serviceCreation$: Observable<GroupsIOService | null> = isCreatingService ? this.createSharedService() : of(null);
-    let serviceWasCreated = false;
+    let serviceWasCreated: boolean = false;
 
     serviceCreation$
       .pipe(

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, inject, Signal, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ButtonComponent } from '@components/button/button.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { COMMITTEE_LABEL, MAILING_LIST_TOTAL_STEPS } from '@lfx-one/shared/constants';
@@ -160,8 +161,8 @@ export class MailingListManageComponent {
           });
           this.router.navigate(this.backLink());
         },
-        error: (error: Error) => {
-          const httpStatus = (error as any).status as number | undefined;
+        error: (error: unknown) => {
+          const httpStatus = error instanceof HttpErrorResponse ? error.status : undefined;
           const isDuplicateName = !this.isEditMode() && httpStatus === 409 && (!isCreatingService || serviceWasCreated);
 
           if (isDuplicateName) {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -77,6 +77,7 @@ export class MailingListManageComponent {
   public readonly isLastStep: Signal<boolean> = this.initIsLastStep();
   public readonly initialPublicValue: Signal<boolean | null> = this.initInitialPublicValue();
   public currentStep: Signal<number> = this.initCurrentStep();
+  public readonly backLink: Signal<string[]> = this.initBackLink();
 
   public constructor() {
     evictOnWriteAccessLoss();
@@ -117,7 +118,7 @@ export class MailingListManageComponent {
   }
 
   public onCancel(): void {
-    this.router.navigate(['/mailing-lists']);
+    this.router.navigate(this.backLink());
   }
 
   public onSubmit(): void {
@@ -342,6 +343,13 @@ export class MailingListManageComponent {
 
   private initInitialPublicValue(): Signal<boolean | null> {
     return computed(() => this.mailingList()?.public ?? null);
+  }
+
+  private initBackLink(): Signal<string[]> {
+    return computed(() => {
+      const id = this.mailingListId();
+      return this.isEditMode() && id ? ['/mailing-lists', id] : ['/mailing-lists'];
+    });
   }
 
   private initCurrentStep(): Signal<number> {

--- a/apps/lfx-one/src/app/shared/components/committee-selector/committee-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/committee-selector/committee-selector.component.html
@@ -21,7 +21,7 @@
     <!-- Loading State -->
     <div class="flex items-center gap-2 p-3 bg-gray-50 rounded-lg">
       <i class="fa-light fa-circle-notch fa-spin text-blue-600"></i>
-      <span class="text-sm text-gray-500">Loading committees...</span>
+      <span class="text-sm text-gray-500">Loading groups...</span>
     </div>
   } @else {
     <!-- Search Autocomplete -->
@@ -59,7 +59,7 @@
 
       <!-- Empty template -->
       <ng-template #empty>
-        <div class="p-3 text-center text-sm text-gray-500">No committees found</div>
+        <div class="p-3 text-center text-sm text-gray-500">No groups found</div>
       </ng-template>
     </lfx-autocomplete>
 


### PR DESCRIPTION
## Summary

- Show inline field error when a duplicate mailing list name is submitted (409 → navigate to step 1, set `duplicateName` error on the name control, clears automatically on edit)
- Fix group selector loading/empty states to say "groups" instead of "committees"
- In edit mode, cancel and the back link now return to the mailing list detail page (`/mailing-lists/:id`) instead of the list page; back link label updates to "Back to Mailing List" (singular)

## Ticket

[LFXV2-2816 — Mailing list: fix minor UI issues in create and edit flows](https://linuxfoundation.atlassian.net/browse/LFXV2-2816)

## Test plan

- [x] Create a mailing list, then try creating another with the same name — should navigate back to step 1 and show "A mailing list with this name already exists" inline under the name field
- [x] Edit the name field after the error appears — error should clear immediately
- [x] On the create/edit form step 3, verify the group selector shows "Loading groups..." and "No groups found" (not "committees")
- [x] Edit an existing mailing list, click Cancel — should return to the detail page (`/mailing-lists/:id`), not the list
- [x] Edit an existing mailing list, click the back link — same, should return to the detail page with label "Back to Mailing List"
- [x] Create a new mailing list, click Cancel — should still return to `/mailing-lists` (list page)

🤖 Generated with [Claude Code](https://claude.ai/code)