### PR TITLE
fix(meetings): use DST-aware offset in timezone dropdown

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
@@ -239,7 +239,7 @@
           [filter]="true"
           [form]="form()"
           control="timezone"
-          [options]="timezoneOptions"
+          [options]="timezoneOptions()"
           placeholder="Select timezone"
           styleClass="w-full"
           id="timezone"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -427,9 +427,12 @@ export class MeetingDetailsComponent implements OnInit {
   }
 
   private buildTimezoneOptions(date: Date): { label: string; value: string }[] {
-    return TIMEZONES.map((tz) => ({
-      label: `${tz.label} (${getTimezoneUtcOffsetString(tz.value, date)})`,
-      value: tz.value,
-    }));
+    return TIMEZONES.map((tz) => {
+      const offset = getTimezoneUtcOffsetString(tz.value, date);
+      return {
+        label: offset ? `${tz.label} (${offset})` : tz.label,
+        value: tz.value,
+      };
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -15,7 +15,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { TimePickerComponent } from '@components/time-picker/time-picker.component';
 import { GenerateAgendaRequest, MeetingTemplate } from '@lfx-one/shared';
 import { MEETING_DURATION_OPTIONS, RECURRING_MEETING_FEATURE, TIMEZONES, YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
-import { getWeekOfMonth } from '@lfx-one/shared/utils';
+import { getTimezoneUtcOffsetString, getWeekOfMonth } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -94,11 +94,8 @@ export class MeetingDetailsComponent implements OnInit {
   // Recurrence options (dynamically updated based on selected date)
   public recurrenceOptions = signal<{ label: string; value: string }[]>([]);
 
-  // Timezone options from shared constants
-  public readonly timezoneOptions = TIMEZONES.map((tz) => ({
-    label: `${tz.label} (${tz.offset})`,
-    value: tz.value,
-  }));
+  // Timezone options — rebuilt whenever the meeting date changes so DST offsets are correct
+  public readonly timezoneOptions = signal<{ label: string; value: string }[]>(this.buildTimezoneOptions(new Date()));
 
   // Minimum date (yesterday)
   public readonly minDate = computed(() => {
@@ -109,10 +106,11 @@ export class MeetingDetailsComponent implements OnInit {
   });
 
   public ngOnInit(): void {
-    // Initialize recurrence options with current start date
+    // Initialize recurrence and timezone options with current start date
     const initialStartDate = this.form().get('startDate')?.value;
     if (initialStartDate) {
       this.generateRecurrenceOptions(initialStartDate);
+      this.timezoneOptions.set(this.buildTimezoneOptions(initialStartDate as Date));
     } else {
       this.recurrenceOptions.set([{ label: 'Does not repeat', value: 'none' }]);
     }
@@ -137,6 +135,7 @@ export class MeetingDetailsComponent implements OnInit {
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((newDate) => {
         this.handleStartDateChange(newDate as Date);
+        this.timezoneOptions.set(this.buildTimezoneOptions(newDate as Date));
       });
 
     // Watch for isRecurring changes to reset recurrence
@@ -425,5 +424,12 @@ export class MeetingDetailsComponent implements OnInit {
         // For custom, the recurrence pattern component will handle the values
         break;
     }
+  }
+
+  private buildTimezoneOptions(date: Date): { label: string; value: string }[] {
+    return TIMEZONES.map((tz) => ({
+      label: `${tz.label} (${getTimezoneUtcOffsetString(tz.value, date)})`,
+      value: tz.value,
+    }));
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -135,7 +135,7 @@ export class MeetingDetailsComponent implements OnInit {
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((newDate) => {
         this.handleStartDateChange(newDate as Date);
-        this.timezoneOptions.set(this.buildTimezoneOptions(newDate as Date));
+        this.timezoneOptions.set(this.buildTimezoneOptions((newDate as Date) ?? new Date()));
       });
 
     // Watch for isRecurring changes to reset recurrence

--- a/packages/shared/src/interfaces/timezones.interface.ts
+++ b/packages/shared/src/interfaces/timezones.interface.ts
@@ -10,6 +10,6 @@ export interface TimezoneOption {
   label: string;
   /** IANA timezone identifier value */
   value: string;
-  /** UTC offset string representation */
+  /** Standard-time UTC offset string (e.g. "-08:00"). Not DST-aware — use getTimezoneUtcOffsetString() for display labels. */
   offset: string;
 }

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import { fromZonedTime, getTimezoneOffset, toZonedTime } from 'date-fns-tz';
 
 import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, TIMEZONES, WEEKDAY_CODES } from '../constants';
 import { RecurrenceType } from '../enums';
@@ -225,6 +225,23 @@ export function parseTime12Hour(time: string): { hours: number; minutes: number 
 // ============================================================================
 // Timezone Utilities
 // ============================================================================
+
+/**
+ * Returns the UTC offset string for a timezone at a given date, reflecting DST.
+ * e.g. 'America/Los_Angeles' on a July date → '-07:00'; on a January date → '-08:00'
+ */
+export function getTimezoneUtcOffsetString(timezone: string, date: Date): string {
+  try {
+    const offsetMs = getTimezoneOffset(timezone, date);
+    const sign = offsetMs >= 0 ? '+' : '-';
+    const absMs = Math.abs(offsetMs);
+    const hours = Math.floor(absMs / 3_600_000);
+    const minutes = Math.floor((absMs % 3_600_000) / 60_000);
+    return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  } catch {
+    return '';
+  }
+}
 
 /**
  * Helper function to get timezone by value

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -233,6 +233,7 @@ export function parseTime12Hour(time: string): { hours: number; minutes: number 
 export function getTimezoneUtcOffsetString(timezone: string, date: Date): string {
   try {
     const offsetMs = getTimezoneOffset(timezone, date);
+    if (!Number.isFinite(offsetMs)) return '';
     const sign = offsetMs >= 0 ? '+' : '-';
     const absMs = Math.abs(offsetMs);
     const hours = Math.floor(absMs / 3_600_000);


### PR DESCRIPTION
## Summary

- The Create Meeting timezone dropdown showed hard-coded standard-time offsets (e.g. `-08:00` for `America/Los_Angeles`) regardless of the selected meeting date, misleading users about the real UTC time of their meeting
- Added `getTimezoneUtcOffsetString(timezone, date)` to `date-time.utils.ts` using `date-fns-tz`'s `getTimezoneOffset` to compute the actual UTC offset for a given IANA timezone + date, correctly reflecting DST
- Converted `timezoneOptions` in `MeetingDetailsComponent` from a static readonly array to a `signal` that rebuilds whenever `startDate` changes — July meetings now show `-07:00`, January meetings show `-08:00`

## Ticket

[LFXV2-2811](https://linuxfoundation.atlassian.net/browse/LFXV2-2811)

## Test plan

- [x] Open Create Meeting wizard → Step 2, set a July/August date → confirm Pacific Time shows `-07:00`
- [x] Switch to a January date → confirm Pacific Time shows `-08:00`
- [x] Confirm the dropdown initializes with today's correct offset when no date is pre-selected
- [x] `yarn build` passes (SSR bundle clean)
- [x] `yarn check-types` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2811]: https://linuxfoundation.atlassian.net/browse/LFXV2-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ