### PR TITLE
fix(meetings): use display name in auto-generated title

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -1032,8 +1032,8 @@ export class MeetingManageComponent {
         year: 'numeric',
       });
 
-      const projectSlug = project?.slug?.toUpperCase() || '';
-      const generatedTitle = `${projectSlug} ${meetingType} Meeting - ${formattedDate}`;
+      const projectName = project?.name || '';
+      const generatedTitle = `${projectName} ${meetingType} Meeting - ${formattedDate}`;
       form.get('title')?.setValue(generatedTitle);
     }
   }


### PR DESCRIPTION
## Summary

- `generateMeetingTitle()` was using `project?.slug?.toUpperCase()` to build the auto-populated Meeting Title in Step 2 of the Create Meeting wizard
- This produced an all-caps slug (e.g. "ENERGNN Board Meeting - 07/30/2026") instead of the project's display name
- Fixed to use `project?.name`, which is already present on `ProjectContext` and carries the correct display name (e.g. "EnerGNN Board Meeting - 07/30/2026")

## Ticket

[LFXV2-2812](https://linuxfoundation.atlassian.net/browse/LFXV2-2812)

## Test plan

- [ ] Navigate to `/project/meetings/create?project=<mixed-case-slug>` (e.g. EnerGNN)
- [ ] Select a meeting type and start date in Step 1, advance to Step 2
- [ ] Confirm the pre-filled Meeting Title uses the display name (e.g. "EnerGNN Board Meeting - MM/DD/YYYY"), not the uppercased slug

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2812]: https://linuxfoundation.atlassian.net/browse/LFXV2-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ