### PR TITLE
feat(newsletters): restrict audience picker to a single group

### DIFF
--- a/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
@@ -359,8 +359,21 @@ test.describe('Newsletter reopen — single-group audience picker', () => {
     await expect(picker, 'selecting a second group should replace the first, not add to it').toContainText('Security Newsletter');
     await expect(picker, 'the prior selection should no longer be shown').not.toContainText('Community Newsletter');
 
+    await page.getByTestId('newsletter-manage-back-to-review').click();
+    await expect(
+      page.getByTestId('newsletter-review-audience-summary'),
+      'the shared committeeUids control should reflect the replacement, not just the local display'
+    ).toContainText('1 group');
+
+    await page.getByTestId('newsletter-review-audience-edit-btn').click();
     await picker.locator('.p-select-clear-icon').click();
     await expect(picker, 'Clear should empty the selection').toContainText('Pick a group');
+
+    await page.getByTestId('newsletter-manage-back-to-review').click();
+    await expect(
+      page.getByTestId('newsletter-review-audience-empty'),
+      'the shared committeeUids control should reflect the clear, not just the local display'
+    ).toBeVisible();
   });
 });
 

--- a/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
@@ -250,7 +250,7 @@ test.describe('Newsletter reopen — empty-state coverage', () => {
     await gotoEditUrl(page);
 
     await expect(page.getByTestId('newsletter-review'), 'review screen should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByTestId('newsletter-review-audience-empty'), 'audience empty-state copy should appear').toContainText('No groups selected yet');
+    await expect(page.getByTestId('newsletter-review-audience-empty'), 'audience empty-state copy should appear').toContainText('No group selected yet');
     // The summary line should NOT render when the empty-state branch is active.
     await expect(page.getByTestId('newsletter-review-audience-summary')).toHaveCount(0);
   });

--- a/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reopen-review.spec.ts
@@ -301,6 +301,69 @@ test.describe('Newsletter reopen — audience normalization with mixed committee
   });
 });
 
+test.describe('Newsletter reopen — single-group audience picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await setPersonaCookie(page, ['executive-director']);
+    await stubPersona(page, ['executive-director']);
+    await stubNavLensItems(page);
+    await stubProjectApi(page);
+  });
+
+  test('reopening a saved draft hydrates the selected group in the picker', async ({ page }) => {
+    await stubNewsletterApis(page, buildDraft());
+    await gotoEditUrl(page);
+
+    await expect(page.getByTestId('newsletter-review'), 'review screen should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('newsletter-review-audience-edit-btn').click();
+
+    await expect(page.getByTestId('newsletter-audience-committees'), 'picker should hydrate the saved group').toContainText('Community Newsletter', {
+      timeout: ELEMENT_TIMEOUT,
+    });
+  });
+
+  test('a legacy multi-group draft is narrowed to a single selection in the picker', async ({ page }) => {
+    const secondEligibleUid = 'c0000000-0000-0000-0000-000000000ddd';
+    await stubNewsletterApis(page, buildDraft({ committee_uids: [MOCK_COMMITTEE_UID, secondEligibleUid] }), [
+      { uid: MOCK_COMMITTEE_UID, name: 'Community Newsletter', category: 'Newsletter' },
+      { uid: secondEligibleUid, name: 'Security Newsletter', category: 'Newsletter' },
+    ]);
+    await gotoEditUrl(page);
+
+    await expect(page.getByTestId('newsletter-review'), 'review screen should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    // Both uids are Newsletter-eligible, so this exercises the picker's own narrowing
+    // (not the host's eligibility pruning), and the review card must agree.
+    await expect(page.getByTestId('newsletter-review-audience-summary'), 'review summary should reflect the narrowed selection').toContainText('1 group');
+
+    await page.getByTestId('newsletter-review-audience-edit-btn').click();
+    await expect(page.getByTestId('newsletter-audience-committees'), 'picker should show exactly one selected group').toContainText('Community Newsletter', {
+      timeout: ELEMENT_TIMEOUT,
+    });
+  });
+
+  test('selecting a different group replaces the prior selection, and Clear empties it', async ({ page }) => {
+    const secondEligibleUid = 'c0000000-0000-0000-0000-000000000ddd';
+    await stubNewsletterApis(page, buildDraft(), [
+      { uid: MOCK_COMMITTEE_UID, name: 'Community Newsletter', category: 'Newsletter' },
+      { uid: secondEligibleUid, name: 'Security Newsletter', category: 'Newsletter' },
+    ]);
+    await gotoEditUrl(page);
+
+    await expect(page.getByTestId('newsletter-review'), 'review screen should render').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('newsletter-review-audience-edit-btn').click();
+
+    const picker = page.getByTestId('newsletter-audience-committees');
+    await expect(picker, 'picker should hydrate the saved group first').toContainText('Community Newsletter', { timeout: ELEMENT_TIMEOUT });
+
+    await picker.click();
+    await page.getByRole('option', { name: 'Security Newsletter', exact: true }).click();
+    await expect(picker, 'selecting a second group should replace the first, not add to it').toContainText('Security Newsletter');
+    await expect(picker, 'the prior selection should no longer be shown').not.toContainText('Community Newsletter');
+
+    await picker.locator('.p-select-clear-icon').click();
+    await expect(picker, 'Clear should empty the selection').toContainText('Pick a group');
+  });
+});
+
 test.describe('Newsletter list — Draft tag parity', () => {
   test.beforeEach(async ({ page }) => {
     await setPersonaCookie(page, ['executive-director']);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -4,12 +4,12 @@
 <div class="flex flex-col gap-4" data-testid="newsletter-audience-step">
   <div>
     <h2 class="text-base font-semibold text-gray-900">Who's this for?</h2>
-    <p class="text-sm text-gray-500 mt-1">Pick the groups that should receive this newsletter. Members in multiple groups only get one email.</p>
+    <p class="text-sm text-gray-500 mt-1">Pick the group that should receive this newsletter.</p>
   </div>
 
   <div class="flex flex-col gap-2">
     <div class="flex items-center justify-between">
-      <label class="text-sm font-medium text-gray-700">Groups</label>
+      <label class="text-sm font-medium text-gray-700">Group</label>
       @if (selectedCount() > 0 && recipientCount() !== null) {
         @if (recipientCountLoading()) {
           <span class="text-xs text-gray-500" data-testid="newsletter-audience-recipient-pill">Calculating recipients…</span>
@@ -48,19 +48,19 @@
         No newsletter groups available. Create a group with the Newsletter category first.
       </div>
     } @else {
-      <lfx-multi-select
-        [form]="form()"
-        control="committeeUids"
+      <lfx-select
+        [form]="audienceForm"
+        control="committeeUid"
         [options]="committeeOptions()"
         optionLabel="label"
         optionValue="value"
-        optionSubLabel="category"
-        placeholder="Pick the groups that should receive this newsletter"
+        placeholder="Pick a group"
         [filter]="true"
-        filterPlaceHolder="Search groups"
+        filterPlaceholder="Search groups"
+        [showClear]="true"
         styleClass="w-full"
         data-testid="newsletter-audience-committees">
-      </lfx-multi-select>
+      </lfx-select>
     }
   </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -9,7 +9,7 @@
 
   <div class="flex flex-col gap-2">
     <div class="flex items-center justify-between">
-      <label class="text-sm font-medium text-gray-700">Group</label>
+      <label class="text-sm font-medium text-gray-700" for="newsletter-audience-committee">Group</label>
       @if (selectedCount() > 0 && recipientCount() !== null) {
         @if (recipientCountLoading()) {
           <span class="text-xs text-gray-500" data-testid="newsletter-audience-recipient-pill">Calculating recipients…</span>
@@ -58,6 +58,7 @@
         [filter]="true"
         filterPlaceholder="Search groups"
         [showClear]="true"
+        inputId="newsletter-audience-committee"
         styleClass="w-full"
         data-testid="newsletter-audience-committees">
       </lfx-select>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, input, output, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, output, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { SelectComponent } from '@components/select/select.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
 import { Committee, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
@@ -14,7 +14,7 @@ import { EMPTY, finalize, map, startWith, switchMap, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-newsletter-audience-step',
-  imports: [ReactiveFormsModule, MultiSelectComponent, PopoverModule, ProgressSpinnerModule],
+  imports: [ReactiveFormsModule, SelectComponent, PopoverModule, ProgressSpinnerModule],
   templateUrl: './newsletter-audience-step.component.html',
 })
 export class NewsletterAudienceStepComponent {
@@ -38,6 +38,15 @@ export class NewsletterAudienceStepComponent {
   // === Outputs ===
   public readonly retryCommittees = output<void>();
 
+  // === Forms ===
+  // The shared `form` input carries `committeeUids: string[]` end-to-end — recipient
+  // count, save payload, review/list counts, and server validation all expect an
+  // array. The picker is constrained to one group at a time, so this local form holds
+  // the scalar selection; it's bridged to the shared array control in initSync().
+  protected readonly audienceForm = new FormGroup({
+    committeeUid: new FormControl<string | null>(null),
+  });
+
   // === Signals ===
   protected readonly recipients = signal<NewsletterRecipient[]>([]);
   protected readonly recipientsLoading = signal<boolean>(false);
@@ -58,6 +67,10 @@ export class NewsletterAudienceStepComponent {
   );
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);
+
+  public constructor() {
+    this.initSync();
+  }
 
   protected onShowRecipients(event: Event): void {
     const popover = this.recipientsPopover();
@@ -88,6 +101,27 @@ export class NewsletterAudienceStepComponent {
           this.recipientsError.set('Could not load recipients. Please try again.');
         },
       });
+  }
+
+  // Bridges the local single-value `audienceForm` control to the shared array
+  // control both directions: incoming committeeUids (draft hydration, audience
+  // normalization) mirror into the local control with emitEvent: false so the
+  // write-back below doesn't re-fire; user selections write back as a 1-element
+  // array (or [] when cleared).
+  private initSync(): void {
+    effect(() => {
+      const uid = this.committeeUidsValue()[0] ?? null;
+      const control = this.audienceForm.controls.committeeUid;
+      if (control.value !== uid) {
+        control.setValue(uid, { emitEvent: false });
+      }
+    });
+
+    this.audienceForm.controls.committeeUid.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((uid) => {
+      this.form()
+        .get('committeeUids')
+        ?.setValue(uid ? [uid] : []);
+    });
   }
 
   private initCommitteeUidsValue(): Signal<string[]> {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, effect, inject, input, output, Signal, signal, viewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, output, Signal, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { SelectComponent } from '@components/select/select.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
@@ -114,19 +114,20 @@ export class NewsletterAudienceStepComponent {
   // first uid in the shared control too, not just in the local display, so
   // send/review/recipient counts can't stay out of sync with what the picker shows.
   private initSync(): void {
-    effect(() => {
-      const committeeUids = this.committeeUidsValue();
-      const uid = committeeUids[0] ?? null;
-      const control = this.audienceForm.controls.committeeUid;
-      if (control.value !== uid) {
-        control.setValue(uid, { emitEvent: false });
-      }
-      if (committeeUids.length > 1) {
-        this.form()
-          .get('committeeUids')
-          ?.setValue(uid ? [uid] : []);
-      }
-    });
+    toObservable(this.committeeUidsValue)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((committeeUids) => {
+        const uid = committeeUids[0] ?? null;
+        const control = this.audienceForm.controls.committeeUid;
+        if (control.value !== uid) {
+          control.setValue(uid, { emitEvent: false });
+        }
+        if (committeeUids.length > 1) {
+          this.form()
+            .get('committeeUids')
+            ?.setValue(uid ? [uid] : []);
+        }
+      });
 
     this.audienceForm.controls.committeeUid.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((uid) => {
       this.form()

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, DestroyRef, effect, inject, input, output, Signal, signal, viewChild } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { SelectComponent } from '@components/select/select.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
@@ -10,7 +10,7 @@ import { Committee, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-
 import { NewsletterService } from '@services/newsletter.service';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { EMPTY, finalize, map, startWith, switchMap, take } from 'rxjs';
+import { finalize, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-newsletter-audience-step',
@@ -32,6 +32,11 @@ export class NewsletterAudienceStepComponent {
   public readonly committees = input<Committee[]>([]);
   public readonly committeesLoading = input<boolean>(false);
   public readonly committeesError = input<string | null>(null);
+  // Mirrors the host's `committeeUidsValue` signal rather than re-deriving one from
+  // `committeeUids.valueChanges` — the host's is kept in sync even through
+  // `patchValue({ emitEvent: false })` draft hydration, which a local valueChanges-based
+  // signal here would miss entirely.
+  public readonly committeeUidsValue = input<string[]>([]);
   public readonly recipientCount = input<number | null>(null);
   public readonly recipientCountLoading = input<boolean>(false);
 
@@ -54,8 +59,6 @@ export class NewsletterAudienceStepComponent {
   protected readonly recipientsPopover = viewChild<Popover>('recipientsPopover');
 
   // === Reactive data ===
-  protected readonly committeeUidsValue: Signal<string[]> = this.initCommitteeUidsValue();
-
   protected readonly committeeOptions = computed<NewsletterCommitteeOption[]>(() =>
     this.committees()
       .filter((c) => c.category === NEWSLETTER_COMMITTEE_CATEGORY)
@@ -107,13 +110,21 @@ export class NewsletterAudienceStepComponent {
   // control both directions: incoming committeeUids (draft hydration, audience
   // normalization) mirror into the local control with emitEvent: false so the
   // write-back below doesn't re-fire; user selections write back as a 1-element
-  // array (or [] when cleared).
+  // array (or [] when cleared). A legacy multi-group draft is narrowed to its
+  // first uid in the shared control too, not just in the local display, so
+  // send/review/recipient counts can't stay out of sync with what the picker shows.
   private initSync(): void {
     effect(() => {
-      const uid = this.committeeUidsValue()[0] ?? null;
+      const committeeUids = this.committeeUidsValue();
+      const uid = committeeUids[0] ?? null;
       const control = this.audienceForm.controls.committeeUid;
       if (control.value !== uid) {
         control.setValue(uid, { emitEvent: false });
+      }
+      if (committeeUids.length > 1) {
+        this.form()
+          .get('committeeUids')
+          ?.setValue(uid ? [uid] : []);
       }
     });
 
@@ -122,20 +133,5 @@ export class NewsletterAudienceStepComponent {
         .get('committeeUids')
         ?.setValue(uid ? [uid] : []);
     });
-  }
-
-  private initCommitteeUidsValue(): Signal<string[]> {
-    return toSignal(
-      toObservable(this.form).pipe(
-        switchMap((fg) => {
-          const control = fg.get('committeeUids');
-          if (!control) return EMPTY;
-          return control.valueChanges.pipe(startWith(control.value));
-        }),
-        map((v): string[] => (Array.isArray(v) ? (v as string[]) : [])),
-        takeUntilDestroyed(this.destroyRef)
-      ),
-      { initialValue: [] as string[] }
-    );
   }
 }

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -110,9 +110,9 @@ export class NewsletterAudienceStepComponent {
   // control both directions: incoming committeeUids (draft hydration, audience
   // normalization) mirror into the local control with emitEvent: false so the
   // write-back below doesn't re-fire; user selections write back as a 1-element
-  // array (or [] when cleared). A legacy multi-group draft is narrowed to its
-  // first uid in the shared control too, not just in the local display, so
-  // send/review/recipient counts can't stay out of sync with what the picker shows.
+  // array (or [] when cleared). Narrowing a legacy multi-group draft to a single
+  // uid is the host's job (NewsletterManageComponent.initAudienceNormalization),
+  // not this component's — Review can be mounted instead of this step on reopen.
   private initSync(): void {
     toObservable(this.committeeUidsValue)
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -121,11 +121,6 @@ export class NewsletterAudienceStepComponent {
         const control = this.audienceForm.controls.committeeUid;
         if (control.value !== uid) {
           control.setValue(uid, { emitEvent: false });
-        }
-        if (committeeUids.length > 1) {
-          this.form()
-            .get('committeeUids')
-            ?.setValue(uid ? [uid] : []);
         }
       });
 

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-review/newsletter-review.component.html
@@ -37,7 +37,7 @@
           @if (committeesError(); as error) {
             <p class="text-sm text-red-600" role="alert" data-testid="newsletter-review-audience-error">{{ error }}</p>
           } @else if (audienceEmpty()) {
-            <p class="text-sm text-amber-600" data-testid="newsletter-review-audience-empty">No groups selected yet — add at least one to send.</p>
+            <p class="text-sm text-amber-600" data-testid="newsletter-review-audience-empty">No group selected yet — pick one to send.</p>
           } @else {
             <p class="text-sm text-gray-700" data-testid="newsletter-review-audience-summary">
               {{ groupsLabel() }}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -170,6 +170,7 @@
                     [committees]="committees()"
                     [committeesLoading]="committeesLoading()"
                     [committeesError]="committeesError()"
+                    [committeeUidsValue]="committeeUidsValue()"
                     [recipientCount]="recipientCount()"
                     [recipientCountLoading]="recipientCountLoading()"
                     (retryCommittees)="retryCommittees()">

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -462,7 +462,8 @@ export class NewsletterManageComponent {
    * stepper is on step 1, but save/send can happen from the Review view. Tracks
    * `committeeUidsValue` (not just `eligibleCommitteeUids`) so a draft loaded via
    * `patchValue({ emitEvent: false })` after eligibility has already resolved still
-   * gets re-checked.
+   * gets re-checked. Also narrows a legacy multi-group draft to its first uid here
+   * (not just in the audience step), since Review is what's mounted on reopen.
    */
   private initAudienceNormalization(): void {
     effect(() => {
@@ -471,8 +472,9 @@ export class NewsletterManageComponent {
       if (!eligible) return;
 
       const filtered = current.filter((uid) => eligible.has(uid));
-      if (filtered.length !== current.length) {
-        this.form.controls.committeeUids.setValue(filtered);
+      const narrowed = filtered.length > 1 ? filtered.slice(0, 1) : filtered;
+      if (narrowed.length !== current.length || narrowed.some((uid, i) => uid !== current[i])) {
+        this.form.controls.committeeUids.setValue(narrowed);
       }
     });
   }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -141,7 +141,10 @@ export class NewsletterManageComponent {
   public readonly edEmail: Signal<string> = computed(() => this.userService.user()?.email ?? '');
 
   // === Form mirrors ===
-  private readonly committeeUidsValue = signal<string[]>([]);
+  // Public: the audience step consumes this directly rather than re-deriving its own
+  // valueChanges-based signal, since patchValue({ emitEvent: false }) on draft hydration
+  // (see populateFormFromDraft) would otherwise leave a child-owned signal stale forever.
+  public readonly committeeUidsValue = signal<string[]>([]);
   private readonly subjectValue = signal<string>('');
   private readonly bodyValue = signal<string>('');
 


### PR DESCRIPTION
## Summary
- Converts the newsletter audience picker from a multi-select checkbox UI to a single-select searchable dropdown (`lfx-select`), so only one group/committee can be targeted per newsletter.
- Wire format stays `committee_uids: string[]` end-to-end (shared interfaces, save payload, server validation, upstream contract) — the audience step bridges a local scalar form control to the shared array control internally, writing back a 1-element array (or `[]` when cleared).
- Updates copy on the audience step and review empty-state to reflect single-group semantics.

Builds on top of #1182 (merged), which introduced the `committees` input, category filtering, and loading/error/retry states on this same component.

LFXV2-2820

## Test plan
- [x] `yarn build` succeeds
- [x] `yarn lint` clean (no new warnings)
- [x] `./check-headers.sh` passes
- [ ] Manually verify in newsletter create: Group field is single-select searchable dropdown, selecting replaces prior selection, clear button empties it
- [ ] Confirm recipient-count pill updates on selection
- [ ] Save draft, reload, confirm dropdown re-selects saved group from `committee_uids[0]`
- [ ] Confirm review card shows "1 group" and Send is enabled only with a group selected