### PR TITLE
feat(meetings): add organized by me filter

### DIFF
--- a/apps/lfx-one/e2e/meetings-organized-by-me.spec.ts
+++ b/apps/lfx-one/e2e/meetings-organized-by-me.spec.ts
@@ -1,0 +1,219 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const MEETINGS_URL = '/meetings';
+const LENS_COOKIE = 'lfx-active-lens';
+
+// Deterministic, far-future start so `hasMeetingEnded` never drops the upcoming fixtures.
+const FUTURE_START = '2099-03-04T15:00:00Z';
+const PAST_START = '2020-03-04T15:00:00Z';
+
+const OTHER_ORGANIZER = { name: 'Grace Hopper', username: 'ghopper-e2e', email: 'grace-e2e@example.com' };
+const SERVICE_ACCOUNT = { name: 'Zoom Webhooks', username: 'zoom.webhooks', email: 'noreply@zoom.us' };
+
+test.setTimeout(120_000);
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+async function seedMeLensCookie(page: Page): Promise<void> {
+  await page.context().addCookies([{ name: LENS_COOKIE, value: 'me', domain: 'localhost', path: '/' }]);
+}
+
+/**
+ * The signed-in user's LFID comes from the SSR auth context (TransferState), not an API the test
+ * can stub — so the fixtures have to be built around whoever is actually logged in. Reads it back
+ * out of the serialized state the same way the app does (`username`, then the namespaced claim).
+ */
+async function readViewerLfid(page: Page): Promise<string | null> {
+  const raw = await page.locator('#ng-state').textContent();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const state = JSON.parse(raw) as Record<string, { user?: Record<string, string> }>;
+    const user = state['auth']?.user;
+    return user?.['username'] || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
+  } catch {
+    return null;
+  }
+}
+
+async function stubMeLensContext(page: Page): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: [],
+      isRootWriter: false,
+    })
+  );
+
+  // Per-card lookups (materials, recordings, summaries, transcripts) are irrelevant here and each
+  // component already degrades on error — 404 keeps them off the real backend.
+  await page.route('**/api/meetings/*/attachments*', (route) => route.fulfill({ status: 404, body: '{}' }));
+  await page.route('**/api/past-meetings/**', (route) => route.fulfill({ status: 404, body: '{}' }));
+}
+
+function upcomingMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    uid: id,
+    title,
+    description: title,
+    start_time: FUTURE_START,
+    duration: 60,
+    timezone: 'UTC',
+    meeting_type: 'Board',
+    visibility: 'public',
+    restricted: false,
+    project_uid: 'proj-e2e',
+    project_name: 'E2E Project',
+    is_foundation: false,
+    committees: [],
+    occurrences: [],
+    recurrence: null,
+    created_by: createdBy,
+    ...extra,
+  };
+}
+
+function pastMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+  return {
+    ...upcomingMeeting(id, title, createdBy, extra),
+    start_time: PAST_START,
+    scheduled_start_time: PAST_START,
+    meeting_and_occurrence_id: id,
+    meeting_id: `series-${id}`,
+  };
+}
+
+/**
+ * Stubs both Me-lens meeting lists. Each list gets one meeting created by the viewer, one created
+ * by someone else, and one webhook-created meeting the viewer merely has an `organizer` (FGA
+ * manage) grant on — the case that must NOT survive the "Organized by me" filter.
+ */
+async function stubMeetingLists(page: Page, viewerLfid: string): Promise<void> {
+  const viewer = { name: 'E2E Viewer', username: viewerLfid, email: 'viewer-e2e@example.com' };
+
+  await page.route('**/api/user/meetings*', (route) =>
+    fulfillJson(route, [
+      upcomingMeeting('up-mine', 'Upcoming Mine', viewer, { organizer: true }),
+      upcomingMeeting('up-theirs', 'Upcoming Theirs', OTHER_ORGANIZER),
+      upcomingMeeting('up-granted', 'Upcoming Granted', SERVICE_ACCOUNT, { organizer: true }),
+    ])
+  );
+
+  await page.route('**/api/user/past-meetings*', (route) =>
+    fulfillJson(route, [
+      pastMeeting('past-mine', 'Past Mine', viewer, { organizer: true }),
+      pastMeeting('past-theirs', 'Past Theirs', OTHER_ORGANIZER),
+      pastMeeting('past-granted', 'Past Granted', SERVICE_ACCOUNT, { organizer: true }),
+    ])
+  );
+}
+
+/** Loads the Me-lens meetings page with fixtures keyed to the signed-in user. */
+async function gotoMyMeetings(page: Page): Promise<void> {
+  await seedMeLensCookie(page);
+  await stubMeLensContext(page);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  const viewerLfid = await readViewerLfid(page);
+  if (!viewerLfid) {
+    test.skip(true, 'Could not resolve the signed-in LFID from the SSR auth state');
+    return;
+  }
+
+  await stubMeetingLists(page, viewerLfid);
+  await page.goto(MEETINGS_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  if (!page.url().includes('/meetings')) {
+    test.skip(true, 'Me lens is not available for this user — /meetings redirected away');
+  }
+}
+
+const organizerPill = (page: Page) => page.getByTestId('organizer-filter-pills').getByTestId('filter-pill-organizer');
+const pastTab = (page: Page) => page.getByTestId('time-filter-tabs').getByTestId('filter-pill-past');
+const upcomingTab = (page: Page) => page.getByTestId('time-filter-tabs').getByTestId('filter-pill-upcoming');
+const card = (page: Page, id: string) => page.locator(`#meeting-${id}`);
+
+test.describe('My Meetings — "Organized by me" filter', () => {
+  test('is offered on both time tabs, unlike the upcoming-only Pending RSVP pill', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    await expect(organizerPill(page)).toBeVisible();
+    await expect(page.getByTestId('pending-rsvp-filter-pills')).toBeVisible();
+
+    await pastTab(page).click();
+    await expect(organizerPill(page)).toBeVisible();
+    await expect(page.getByTestId('pending-rsvp-filter-pills')).toHaveCount(0);
+  });
+
+  test('keeps only meetings the viewer created — an inherited organizer grant is not enough', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    await expect(card(page, 'up-mine')).toBeVisible();
+    await expect(card(page, 'up-theirs')).toBeVisible();
+    await expect(card(page, 'up-granted')).toBeVisible();
+
+    await organizerPill(page).click();
+
+    await expect(card(page, 'up-mine')).toBeVisible();
+    await expect(card(page, 'up-theirs')).toHaveCount(0);
+    // `organizer: true` is an FGA manage grant, not authorship — it must not survive the filter.
+    await expect(card(page, 'up-granted')).toHaveCount(0);
+  });
+
+  test('persists across Upcoming ↔ Past and filters the past list too', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    await organizerPill(page).click();
+    await pastTab(page).click();
+
+    // Still active after the tab switch — the filter is meaningful on both tabs.
+    await expect(card(page, 'past-mine')).toBeVisible();
+    await expect(card(page, 'past-theirs')).toHaveCount(0);
+    await expect(card(page, 'past-granted')).toHaveCount(0);
+
+    await upcomingTab(page).click();
+    await expect(card(page, 'up-mine')).toBeVisible();
+    await expect(card(page, 'up-theirs')).toHaveCount(0);
+  });
+
+  test('shows the filtered empty state with a working reset when nothing matches', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    // Search that matches nothing, combined with the pill, drives the list to zero.
+    await page.getByTestId('meetings-search-input').getByRole('textbox').fill('zzz-no-such-meeting');
+    await organizerPill(page).click();
+
+    const emptyState = page.getByTestId('meetings-empty-state-filtered');
+    await expect(emptyState).toBeVisible();
+    await expect(page.getByTestId('meetings-empty-state')).toHaveCount(0);
+
+    await emptyState.getByRole('button', { name: 'Reset filters' }).click();
+
+    // Reset clears the pill along with the search — the full list is back.
+    await expect(card(page, 'up-theirs')).toBeVisible();
+    await expect(card(page, 'up-granted')).toBeVisible();
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -46,12 +46,8 @@ export class MeetingOrganizerComponent {
 
       const meeting = this.meeting();
       const organizers = collectMeetingOrganizers(meeting, this.hosts());
-      // The optional `username` alias is often absent; the namespaced LFID claim is the canonical
-      // identity (matches the created_by/host username), so fall back to it for the "you" variant.
-      const user = this.userService.user();
-      const viewerUsername = user?.username || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
 
-      return buildMeetingOrganizerChip(organizers, viewerUsername, {
+      return buildMeetingOrganizerChip(organizers, this.userService.viewerUsername(), {
         meetingTitle: meeting.title,
         meetingDate: this.formatMeetingDate(meeting),
         detailUrl: this.buildDetailUrl(meeting),

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
@@ -14,6 +14,15 @@
       data-testid="pending-rsvp-filter-pills" />
   }
 
+  <!-- Organized by me Filter Pills (Me lens, upcoming + past) -->
+  @if (showOrganizerFilter()) {
+    <lfx-filter-pills
+      [options]="organizerPillOptions"
+      [selectedFilter]="organizerOnly() ? 'organizer' : ''"
+      (filterChange)="onOrganizerPillChange()"
+      data-testid="organizer-filter-pills" />
+  }
+
   <!-- Search Input -->
   <div class="flex-1">
     <lfx-input-text

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
@@ -23,6 +23,8 @@ export class MeetingsTopBarComponent {
   public readonly timeFilter = input<'upcoming' | 'past'>('upcoming');
   public readonly pendingRsvpOnly = input<boolean>(false);
   public readonly showPendingRsvpFilter = input<boolean>(false);
+  public readonly organizerOnly = input<boolean>(false);
+  public readonly showOrganizerFilter = input<boolean>(false);
   public readonly meetingTypeChange = output<string | null>();
   public readonly foundationFilterChange = output<string | null>();
   public readonly projectFilterChange = output<string | null>();
@@ -30,6 +32,7 @@ export class MeetingsTopBarComponent {
   public readonly searchQueryChange = output<string>();
   public readonly timeFilterChange = output<'upcoming' | 'past'>();
   public readonly pendingRsvpOnlyChange = output<boolean>();
+  public readonly organizerOnlyChange = output<boolean>();
 
   public readonly timeTabOptions: FilterPillOption[] = [
     { id: 'upcoming', label: 'Upcoming' },
@@ -40,6 +43,9 @@ export class MeetingsTopBarComponent {
   // and the pill highlights; when inactive, selectedFilter doesn't match any option so the pill
   // renders gray. Clicking always fires 'pending', and the handler inverts the current state.
   public readonly pendingRsvpPillOptions: FilterPillOption[] = [{ id: 'pending', label: 'Pending RSVP' }];
+
+  // Same single-pill toggle mechanics as pendingRsvpPillOptions above.
+  public readonly organizerPillOptions: FilterPillOption[] = [{ id: 'organizer', label: 'Organized by me' }];
 
   public searchForm: FormGroup = new FormGroup({
     search: new FormControl(''),
@@ -85,5 +91,10 @@ export class MeetingsTopBarComponent {
   public onPendingRsvpPillChange(): void {
     // Single pill — clicking always toggles the current state.
     this.pendingRsvpOnlyChange.emit(!this.pendingRsvpOnly());
+  }
+
+  public onOrganizerPillChange(): void {
+    // Single pill — clicking always toggles the current state.
+    this.organizerOnlyChange.emit(!this.organizerOnly());
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -181,13 +181,16 @@
             [timeFilter]="timeFilter()"
             [pendingRsvpOnly]="pendingRsvpOnly()"
             [showPendingRsvpFilter]="activeLens() === 'me' && timeFilter() === 'upcoming'"
+            [organizerOnly]="organizerOnly()"
+            [showOrganizerFilter]="activeLens() === 'me'"
             (meetingTypeChange)="onMeetingTypeChange($event)"
             (foundationFilterChange)="onFoundationFilterChange($event)"
             (projectFilterChange)="onProjectFilterChange($event)"
             [searchQuery]="searchQuery()"
             (searchQueryChange)="searchQuery.set($event)"
             (timeFilterChange)="onTimeFilterChange($event)"
-            (pendingRsvpOnlyChange)="pendingRsvpOnly.set($event)" />
+            (pendingRsvpOnlyChange)="pendingRsvpOnly.set($event)"
+            (organizerOnlyChange)="organizerOnly.set($event)" />
         }
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -14,7 +14,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { CANCELLED_COLOR, MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
-import { Lens, Meeting, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
+import { Lens, MeLensMeetingFilters, Meeting, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
   addMinutesToDate,
   getCurrentOrNextOccurrence,
@@ -22,6 +22,7 @@ import {
   getPastMeetingResourceId,
   getPastMeetingStartTimeMs,
   hasMeetingEnded,
+  isMeetingOrganizedByViewer,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
@@ -115,6 +116,7 @@ export class MeetingsDashboardComponent {
   public foundationFilter: WritableSignal<string | null>;
   public projectFilter: WritableSignal<string | null>;
   public pendingRsvpOnly: WritableSignal<boolean>;
+  public organizerOnly: WritableSignal<boolean>;
   public showFoundationFilter: Signal<boolean>;
   public showProjectFilter: Signal<boolean>;
   public foundationOptions: Signal<{ label: string; value: string | null }[]>;
@@ -185,6 +187,7 @@ export class MeetingsDashboardComponent {
     this.foundationFilter = signal<string | null>(null);
     this.projectFilter = signal<string | null>(null);
     this.pendingRsvpOnly = signal<boolean>(false);
+    this.organizerOnly = signal<boolean>(false);
     this.hasMore = computed(() => this.activeLens() !== 'me' && (this.timeFilter() === 'past' ? !!this.pastPageToken() : !!this.upcomingPageToken()));
 
     // Initialize meeting type options
@@ -310,6 +313,8 @@ export class MeetingsDashboardComponent {
     this.timeFilter.set(value);
     this.foundationFilter.set(null);
     this.projectFilter.set(null);
+    // Pending RSVP is an upcoming-only concept, so it resets on tab switch. "Organized by me" is
+    // valid on both tabs and deliberately persists across them.
     this.pendingRsvpOnly.set(false);
     this.router.navigate([], {
       relativeTo: this.route,
@@ -325,6 +330,7 @@ export class MeetingsDashboardComponent {
     this.foundationFilter.set(null);
     this.projectFilter.set(null);
     this.pendingRsvpOnly.set(false);
+    this.organizerOnly.set(false);
   }
 
   public loadMore(): void {
@@ -369,12 +375,35 @@ export class MeetingsDashboardComponent {
     const foundationFilter$ = toObservable(this.foundationFilter);
     const projectFilter$ = toObservable(this.projectFilter);
     const pendingRsvpOnly$ = toObservable(this.pendingRsvpOnly);
-    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserMeetings$, foundationFilter$, projectFilter$, pendingRsvpOnly$]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project, pendingRsvpOnly]) => {
+    const organizerOnly$ = toObservable(this.organizerOnly);
+    // The viewer LFID backs the "Organized by me" predicate and can resolve after the meetings do,
+    // so it participates in the stream — otherwise the first filtered emission would use a null viewer.
+    const viewerUsername$ = toObservable(this.userService.viewerUsername);
+    const meLens$ = combineLatest([
+      lens$,
+      timeFilter$,
+      searchQuery$,
+      meetingType$,
+      rawUserMeetings$,
+      foundationFilter$,
+      projectFilter$,
+      pendingRsvpOnly$,
+      organizerOnly$,
+      viewerUsername$,
+    ]).pipe(
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername]) => {
         if (lens !== 'me' || timeFilter !== 'upcoming') {
           return of<PageResult<Meeting>>({ data: [], page_token: undefined, reset: true });
         }
-        const filtered = this.filterMeLensMeetings(rawMeetings, searchQuery, meetingType, foundation, project, pendingRsvpOnly);
+        const filtered = this.filterMeLensMeetings(rawMeetings, {
+          searchQuery,
+          meetingType,
+          foundation,
+          project,
+          pendingRsvpOnly,
+          organizerOnly,
+          viewerUsername,
+        });
         return of<PageResult<Meeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -450,13 +479,33 @@ export class MeetingsDashboardComponent {
     const rawUserPastMeetings$ = toObservable(this.rawUserPastMeetings);
     const pastFoundationFilter$ = toObservable(this.foundationFilter);
     const pastProjectFilter$ = toObservable(this.projectFilter);
-    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserPastMeetings$, pastFoundationFilter$, pastProjectFilter$]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings, foundation, project]) => {
+    const pastOrganizerOnly$ = toObservable(this.organizerOnly);
+    const pastViewerUsername$ = toObservable(this.userService.viewerUsername);
+    const meLens$ = combineLatest([
+      lens$,
+      timeFilter$,
+      searchQuery$,
+      meetingType$,
+      rawUserPastMeetings$,
+      pastFoundationFilter$,
+      pastProjectFilter$,
+      pastOrganizerOnly$,
+      pastViewerUsername$,
+    ]).pipe(
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings, foundation, project, organizerOnly, viewerUsername]) => {
         if (lens !== 'me' || timeFilter !== 'past') {
           return of<PageResult<PastMeeting>>({ data: [], page_token: undefined, reset: true });
         }
-        // Pending-RSVP chip is upcoming-only, so past-meeting filtering always passes `false`.
-        const filtered = this.filterMeLensMeetings(rawPastMeetings, searchQuery, meetingType, foundation, project, false);
+        const filtered = this.filterMeLensMeetings(rawPastMeetings, {
+          searchQuery,
+          meetingType,
+          foundation,
+          project,
+          // Pending-RSVP chip is upcoming-only, so past-meeting filtering always passes `false`.
+          pendingRsvpOnly: false,
+          organizerOnly,
+          viewerUsername,
+        });
         return of<PageResult<PastMeeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -616,14 +665,8 @@ export class MeetingsDashboardComponent {
     });
   }
 
-  private filterMeLensMeetings<T extends Meeting>(
-    items: T[],
-    searchQuery: string,
-    meetingType: string | null,
-    foundation: string | null,
-    project: string | null,
-    pendingRsvpOnly: boolean
-  ): T[] {
+  private filterMeLensMeetings<T extends Meeting>(items: T[], filters: MeLensMeetingFilters): T[] {
+    const { searchQuery, meetingType, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername } = filters;
     let filtered = items;
 
     if (project) {
@@ -638,6 +681,12 @@ export class MeetingsDashboardComponent {
     if (pendingRsvpOnly) {
       // Pending = no RSVP recorded. accepted, declined, and maybe are all valid responses.
       filtered = filtered.filter((m) => !m.my_rsvp);
+    }
+
+    if (organizerOnly) {
+      // Matches the card's "Organized by you" chip (created_by-derived), NOT meeting.organizer —
+      // that FGA flag includes inherited grants, so it would surface meetings the user never created.
+      filtered = filtered.filter((m) => isMeetingOrganizedByViewer(m, viewerUsername));
     }
 
     return this.filterBySearchAndType(filtered, searchQuery, meetingType);
@@ -912,7 +961,13 @@ export class MeetingsDashboardComponent {
 
   private initIsFiltered(): Signal<boolean> {
     return computed(
-      () => !!this.debouncedSearchQuery() || !!this.meetingTypeFilter() || !!this.foundationFilter() || !!this.projectFilter() || this.pendingRsvpOnly()
+      () =>
+        !!this.debouncedSearchQuery() ||
+        !!this.meetingTypeFilter() ||
+        !!this.foundationFilter() ||
+        !!this.projectFilter() ||
+        this.pendingRsvpOnly() ||
+        this.organizerOnly()
     );
   }
 
@@ -924,14 +979,15 @@ export class MeetingsDashboardComponent {
       // Me lens: apply the same filters as the list view (foundation/project/pendingRsvp); FP lens raw signals are already scoped, only search+type apply.
       const filtered =
         lens === 'me'
-          ? this.filterMeLensMeetings(
-              [...this.rawUserMeetings(), ...this.rawUserPastMeetings()],
-              search,
+          ? this.filterMeLensMeetings([...this.rawUserMeetings(), ...this.rawUserPastMeetings()], {
+              searchQuery: search,
               meetingType,
-              this.foundationFilter(),
-              this.projectFilter(),
-              this.pendingRsvpOnly()
-            )
+              foundation: this.foundationFilter(),
+              project: this.projectFilter(),
+              pendingRsvpOnly: this.pendingRsvpOnly(),
+              organizerOnly: this.organizerOnly(),
+              viewerUsername: this.userService.viewerUsername(),
+            })
           : this.filterBySearchAndType([...this.rawFpUpcomingMeetings(), ...this.rawFpPastMeetings()], search, meetingType);
       return filtered.flatMap((m) => this.meetingToEvents(m));
     });

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -686,6 +686,15 @@ export class MeetingsDashboardComponent {
     if (organizerOnly) {
       // Matches the card's "Organized by you" chip (created_by-derived), NOT meeting.organizer —
       // that FGA flag includes inherited grants, so it would surface meetings the user never created.
+      //
+      // Deliberately called without a `hosts` list, so this only ever matches on created_by — the
+      // same basis the chip uses before a card's registrants drawer has been opened. Once opened,
+      // collectMeetingOrganizers folds real Zoom co-hosts into the chip's organizer set too (see its
+      // JSDoc), so a co-host who isn't the creator can see "Organized by you" on their own card yet
+      // not match this filter. Accepted: host data only exists via the per-card registrants fetch
+      // (MeetingRegistrantsDisplayComponent → resolvedHostsChange), so matching it here would mean
+      // fetching registrants for every meeting in the list up front — real new API cost this
+      // client-side filter (LFXV2-2824) doesn't take on.
       filtered = filtered.filter((m) => isMeetingOrganizedByViewer(m, viewerUsername));
     }
 

--- a/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
+++ b/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
@@ -15,6 +15,7 @@
       [tooltipDisabled]="!option.fullLabel || option.fullLabel === option.label"
       tooltipPosition="top"
       [attr.aria-label]="option.fullLabel || option.label"
+      [attr.aria-pressed]="selectedFilter() === option.id"
       [attr.data-testid]="'filter-pill-' + option.id">
       {{ option.label }}
     </button>

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -44,6 +44,12 @@ export class UserService {
   public impersonator: WritableSignal<Impersonator | null> = signal<Impersonator | null>(null);
   public canImpersonate: WritableSignal<boolean> = signal<boolean>(false);
   public readonly userInitials: Signal<string> = this.initUserInitials();
+  /**
+   * The viewer's LFID as it appears on meeting `created_by` / host records — null when unresolved.
+   * Single source for viewer-identity comparisons (e.g. the "Organized by you" chip and the
+   * "Organized by me" meetings filter), so those surfaces can never resolve identity differently.
+   */
+  public readonly viewerUsername: Signal<string | null> = this.initViewerUsername();
   /** Cached Salesforce user ID from the API Gateway — null until first fetch */
   public readonly apiGatewayUserId = signal<string | null>(null);
 
@@ -368,6 +374,15 @@ export class UserService {
    */
   public getSalesforceId(): Observable<SalesforceIdResponse> {
     return this.http.get<SalesforceIdResponse>('/api/user/salesforce-id').pipe(take(1));
+  }
+
+  private initViewerUsername(): Signal<string | null> {
+    return computed(() => {
+      const user = this.user();
+      // The optional `username` alias is often absent; the namespaced LFID claim is the canonical
+      // identity (it matches meeting created_by/host usernames), so fall back to it.
+      return user?.username || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
+    });
   }
 
   private initUserInitials(): Signal<string> {

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1267,3 +1267,24 @@ export interface MeetingTypeBadge {
  * Derived from the {@link PAST_MEETING_SORT} constant so the union stays in sync with it.
  */
 export type PastMeetingSort = (typeof PAST_MEETING_SORT)[keyof typeof PAST_MEETING_SORT];
+
+/**
+ * Client-side filter criteria applied to the Me lens meeting lists (My Meetings), which are
+ * fetched once and filtered in the browser rather than re-queried per filter change.
+ */
+export interface MeLensMeetingFilters {
+  /** Case-insensitive substring matched against the meeting title. */
+  searchQuery: string;
+  /** Exact `meeting_type` match; null means all types. */
+  meetingType: string | null;
+  /** Foundation project UID — matches the foundation itself and its non-foundation children. */
+  foundation: string | null;
+  /** Project UID; takes precedence over `foundation` when both are set. */
+  project: string | null;
+  /** Keep only meetings with no RSVP recorded (upcoming only). */
+  pendingRsvpOnly: boolean;
+  /** Keep only meetings the viewer organized (created), matching the "Organized by you" chip. */
+  organizerOnly: boolean;
+  /** Viewer username/LFID used by the `organizerOnly` predicate; null disables matching. */
+  viewerUsername: string | null;
+}

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -17,6 +17,7 @@ import {
   collectMeetingOrganizers,
   compareMeetingPeopleByHostThenName,
   getMeetingOrganizerDisplayName,
+  isMeetingOrganizedByViewer,
   isUnresolvableParticipantName,
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
@@ -400,6 +401,68 @@ describe('buildMeetingOrganizerChip', () => {
     expect(chip?.overflow[0].mailto).toContain('mailto:ada@example.com');
     // No-email organizer → plain text (null mailto).
     expect(chip?.overflow[1].mailto).toBeNull();
+  });
+});
+
+describe('isMeetingOrganizedByViewer', () => {
+  const meetingBy = (createdBy: { name: string; username: string; email: string }, extra: Partial<Meeting> = {}): Meeting =>
+    ({ created_by: createdBy, ...extra }) as Meeting;
+
+  const ada = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
+  const grace = { name: 'Grace Hopper', username: 'ghopper', email: 'grace@example.com' };
+
+  it('matches when created_by is the viewer', () => {
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), 'alovelace')).toBe(true);
+  });
+
+  it('ignores case and any auth-provider prefix on the viewer username', () => {
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), 'auth0|ALovelace')).toBe(true);
+  });
+
+  it('does not match a meeting created by someone else', () => {
+    expect(isMeetingOrganizedByViewer(meetingBy(grace), 'alovelace')).toBe(false);
+  });
+
+  it('ignores the organizer FGA flag — inherited manage grants must not widen the filter', () => {
+    // Staff regression: `organizer: true` means "can manage", not "created". Matching on it would
+    // surface every meeting a staff member has an inherited grant on.
+    expect(isMeetingOrganizedByViewer(meetingBy(grace, { organizer: true }), 'alovelace')).toBe(false);
+  });
+
+  it('does not match service-account or empty created_by', () => {
+    expect(isMeetingOrganizedByViewer(meetingBy({ name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' }), 'zoom.webhooks')).toBe(false);
+    expect(isMeetingOrganizedByViewer(meetingBy({ name: '', username: '', email: '' }), 'alovelace')).toBe(false);
+    expect(isMeetingOrganizedByViewer({} as Meeting, 'alovelace')).toBe(false);
+    expect(isMeetingOrganizedByViewer(null, 'alovelace')).toBe(false);
+  });
+
+  it('never matches when the viewer is unresolved — an empty viewer must not select every meeting', () => {
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), null)).toBe(false);
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), '')).toBe(false);
+    expect(isMeetingOrganizedByViewer(meetingBy({ name: 'No Username', username: '', email: 'x@example.com' }), '')).toBe(false);
+  });
+
+  it('matches a host-flagged viewer when the surface supplies hosts', () => {
+    const hosts = [{ first_name: 'Grace', last_name: 'Hopper', username: 'ghopper', email: 'grace@example.com', host: true }];
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), 'ghopper', hosts)).toBe(true);
+    expect(isMeetingOrganizedByViewer(meetingBy(ada), 'alovelace', hosts)).toBe(true);
+  });
+
+  it('agrees with the chip: the filter matches exactly when the chip renders an "Organized by you" entry', () => {
+    const cases: { meeting: Meeting; viewer: string | null }[] = [
+      { meeting: meetingBy(ada), viewer: 'alovelace' },
+      { meeting: meetingBy(ada), viewer: 'auth0|alovelace' },
+      { meeting: meetingBy(grace), viewer: 'alovelace' },
+      { meeting: meetingBy(grace, { organizer: true }), viewer: 'alovelace' },
+      { meeting: meetingBy({ name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' }), viewer: 'zoom.webhooks' },
+      { meeting: meetingBy(ada), viewer: null },
+    ];
+
+    for (const { meeting, viewer } of cases) {
+      const chip = buildMeetingOrganizerChip(collectMeetingOrganizers(meeting), viewer);
+      const chipSaysYou = !!chip && [chip.primary, ...chip.overflow].some((link) => link.isYou);
+      expect(isMeetingOrganizedByViewer(meeting, viewer)).toBe(chipSaysYou);
+    }
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -859,6 +859,36 @@ function normalizeUsername(username: string | null | undefined): string {
 }
 
 /**
+ * Whether a resolved organizer IS the current viewer — the single comparison behind both the
+ * chip's "you" variant and the "Organized by me" list filter, so the two can never disagree.
+ * An absent/empty viewer never matches (a logged-out or unresolved viewer must not match every
+ * meeting).
+ */
+function isViewerOrganizer(organizer: MeetingUserInfo, viewerUsername?: string | null): boolean {
+  const viewer = normalizeUsername(viewerUsername);
+  return !!viewer && normalizeUsername(organizer.username) === viewer;
+}
+
+/**
+ * Whether the viewer is one of the meeting's organizers — the predicate behind the "Organized by
+ * me" filter on My Meetings (LFXV2-2824). Deliberately derived from `created_by` (via
+ * {@link collectMeetingOrganizers}) and NOT from `meeting.organizer`: that flag is a per-viewer FGA
+ * access check ("can I manage this") that includes inherited grants, so staff would match meetings
+ * they never created — contradicting the "Organized by you" chip on the same card.
+ *
+ * @param meeting - Any object carrying an optional `created_by` (Meeting / PastMeeting).
+ * @param viewerUsername - The current user's username/LFID (prefix-tolerant, case-insensitive).
+ * @param hosts - Optional host candidates, when the surface has them (see collectMeetingOrganizers).
+ */
+export function isMeetingOrganizedByViewer(
+  meeting: Pick<Meeting, 'created_by'> | null | undefined,
+  viewerUsername?: string | null,
+  hosts?: ReadonlyArray<MeetingHostCandidate>
+): boolean {
+  return collectMeetingOrganizers(meeting, hosts).some((organizer) => isViewerOrganizer(organizer, viewerUsername));
+}
+
+/**
  * Builds the "Organized by" chip view model from resolved organizers, the viewer's username, and
  * the meeting context needed to pre-fill a `mailto:` per organizer. Returns `null` when there are
  * no organizers so the caller omits the chip entirely.
@@ -876,9 +906,8 @@ export function buildMeetingOrganizerChip(
     return null;
   }
 
-  const viewer = normalizeUsername(viewerUsername);
   const toLink = (organizer: MeetingUserInfo, index: number): MeetingOrganizerLink => {
-    const isYou = !!viewer && normalizeUsername(organizer.username) === viewer;
+    const isYou = isViewerOrganizer(organizer, viewerUsername);
     const name = getMeetingOrganizerDisplayName(organizer);
     return {
       // Suffix the identity with its position so two name-only organizers sharing a display name

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -876,6 +876,12 @@ function isViewerOrganizer(organizer: MeetingUserInfo, viewerUsername?: string |
  * access check ("can I manage this") that includes inherited grants, so staff would match meetings
  * they never created — contradicting the "Organized by you" chip on the same card.
  *
+ * Callers without a `hosts` list (e.g. the My Meetings list filter, which filters ahead of any
+ * per-card registrants fetch) only ever match on `created_by`. A real Zoom co-host who isn't the
+ * creator therefore won't match here even though the chip on their own card would recognize them
+ * as "you" once that card's registrants drawer resolves hosts — an accepted gap, since matching
+ * it at list-filter time would mean fetching registrants for every meeting up front.
+ *
  * @param meeting - Any object carrying an optional `created_by` (Meeting / PastMeeting).
  * @param viewerUsername - The current user's username/LFID (prefix-tolerant, case-insensitive).
  * @param hosts - Optional host candidates, when the surface has them (see collectMeetingOrganizers).


### PR DESCRIPTION
## Summary

- Adds an "Organized by me" filter pill to My Meetings (Me lens), visible on both the Upcoming and Past tabs (unlike Pending RSVP, which is upcoming-only).
- The predicate is deliberately `created_by`-derived — the same logic the card's "Organized by you" chip already uses — and NOT `meeting.organizer` (a per-viewer FGA "can manage" grant that includes inherited access and would surface meetings the user never created, especially for staff-like accounts).
- Extracted the chip's viewer-identity comparison into a shared `isMeetingOrganizedByViewer` util so the chip and the filter can never disagree; moved viewer-LFID resolution into `UserService.viewerUsername` as the single source both consume.
- Pill state persists across Upcoming ↔ Past tab switches (the filter is meaningful on both) and resets via the existing "Reset filters" / clear-filters flow, reusing the existing filtered-empty-state UI.
- No backend changes — both `/api/user/meetings` and `/api/user/past-meetings` already carry (or are enriched with) `created_by`.

## Test plan

- [x] `packages/shared/src/utils/meeting.utils.spec.ts` — 8 new cases for `isMeetingOrganizedByViewer`, including a staff regression (`organizer: true` + foreign `created_by` → must not match) and a chip/filter parity check.
- [x] New `apps/lfx-one/e2e/meetings-organized-by-me.spec.ts` — pill visible on both tabs, filters correctly (excluding an FGA-manage-only meeting), persists across tab switch, resets via "Reset filters", and drives the filtered empty state on zero matches.
- [x] `yarn lint && yarn format && yarn test && yarn build` — all pass.
- [ ] Manual validation in the integration worktree against prod data (pending).

Reviewed pre-PR by the `lfx-general-code-reviewer`, `lfx-self-serve-code-reviewer`, and `lfx-self-serve-learnings-reviewer` trio — all clean. One Important finding from the general reviewer is a known trade-off, documented rather than fixed: `organizerOnly` (like the pre-existing `pendingRsvpOnly`) isn't reset on lens switch, only on tab switch/Reset — a pre-existing papercut shared with the Pending RSVP filter, not a regression introduced here.

JIRA: https://linuxfoundation.atlassian.net/browse/LFXV2-2824