### PR TITLE
feat(dashboards): add monthly-distinct active contributors chart

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -63,7 +63,7 @@
           <div class="flex items-baseline gap-2">
             @if (momDelta(); as delta) {
               <span class="text-xl font-semibold text-gray-900" data-testid="active-contributors-drawer-mom-metric">
-                {{ delta.latest.toLocaleString() }}
+                {{ delta.latest.toLocaleString('en-US') }}
               </span>
               @if (delta.deltaPercent !== null) {
                 <span
@@ -73,9 +73,13 @@
                   [class.text-gray-500]="delta.direction === 'flat'"
                   data-testid="active-contributors-drawer-mom-delta">
                   @if (delta.direction === 'up') {
-                    ▲
+                    <span aria-hidden="true">▲</span>
+                    <span class="sr-only">Increased </span>
                   } @else if (delta.direction === 'down') {
-                    ▼
+                    <span aria-hidden="true">▼</span>
+                    <span class="sr-only">Decreased </span>
+                  } @else {
+                    <span class="sr-only">No change </span>
                   }
                   {{ formatMomDelta(delta.deltaPercent) }}% vs last month
                 </span>
@@ -149,10 +153,10 @@
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-          pTooltip="Share of total contributions made by each contributor tier over the last 12 months. The Top 10% drives most of the activity; the Bottom 50% contributes very little."
+          pTooltip="Share of total contributions made by each contributor tier over the last 12 months."
           tooltipPosition="top"
           tooltipEvent="both"
-          aria-label="Share of total contributions made by each contributor tier over the last 12 months. The Top 10% drives most of the activity; the Bottom 50% contributes very little.">
+          aria-label="Share of total contributions made by each contributor tier over the last 12 months.">
           <i class="fa-light fa-circle-info"></i>
         </button>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -43,20 +43,78 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="active-contributors-drawer-content">
+    <!-- Monthly Distinct (MoM) Section -->
+    <div class="flex flex-col gap-3" data-testid="active-contributors-drawer-mom-section">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <h3 class="text-sm font-medium text-gray-900">Active Contributors (Monthly Distinct)</h3>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Unique people who contributed at any point in each month. Each person is counted once per month, so someone active on many days still counts as one."
+            tooltipPosition="top"
+            tooltipEvent="both"
+            aria-label="Unique people who contributed at any point in each month. Each person is counted once per month, so someone active on many days still counts as one.">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
+        </div>
+
+        @if (hasMomData()) {
+          <div class="flex items-baseline gap-2">
+            @if (momDelta(); as delta) {
+              <span class="text-xl font-semibold text-gray-900" data-testid="active-contributors-drawer-mom-metric">
+                {{ delta.latest.toLocaleString() }}
+              </span>
+              @if (delta.deltaPercent !== null) {
+                <span
+                  class="text-sm font-medium"
+                  [class.text-emerald-600]="delta.direction === 'up'"
+                  [class.text-red-600]="delta.direction === 'down'"
+                  [class.text-gray-500]="delta.direction === 'flat'"
+                  data-testid="active-contributors-drawer-mom-delta">
+                  @if (delta.direction === 'up') {
+                    ▲
+                  } @else if (delta.direction === 'down') {
+                    ▼
+                  }
+                  {{ formatMomDelta(delta.deltaPercent) }}% vs last month
+                </span>
+              }
+            }
+          </div>
+        }
+      </div>
+
+      @if (drawerLoading()) {
+        <div class="flex items-center justify-center py-12" data-testid="active-contributors-drawer-mom-loading">
+          <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+        </div>
+      } @else if (hasMomData()) {
+        <div class="h-[240px]" data-testid="active-contributors-drawer-mom-chart">
+          <lfx-chart type="line" [data]="momChartData()" [options]="momChartOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="active-contributors-drawer-mom-empty">
+          <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+          <p class="text-sm text-gray-500">No monthly contributor data available for this foundation.</p>
+        </div>
+      }
+    </div>
+
     <!-- Monthly Trend Section -->
     <div class="flex flex-col gap-3" data-testid="active-contributors-drawer-trend-section">
       <!-- Section Header -->
       <div class="flex items-center justify-between">
         <!-- Title + Tooltip -->
         <div class="flex items-center gap-2">
-          <h3 class="text-sm font-medium text-gray-900">Active Contributors</h3>
+          <h3 class="text-sm font-medium text-gray-900">Active Contributors (Monthly Average)</h3>
           <button
             type="button"
             class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-            pTooltip="Monthly average unique contributors across the foundation over the last 12 months"
+            pTooltip="Average number of unique contributors active on a typical day in each month. Lower than the monthly-distinct count because the same person on multiple days is averaged, not stacked."
             tooltipPosition="top"
             tooltipEvent="both"
-            aria-label="Monthly average unique contributors across the foundation over the last 12 months">
+            aria-label="Average number of unique contributors active on a typical day in each month. Lower than the monthly-distinct count because the same person on multiple days is averaged, not stacked.">
             <i class="fa-light fa-circle-info"></i>
           </button>
         </div>
@@ -74,7 +132,7 @@
         </div>
       } @else if (hasTrendData()) {
         <div class="h-[240px]" data-testid="active-contributors-drawer-trend-chart">
-          <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+          <lfx-chart type="bar" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
         </div>
       } @else {
         <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="active-contributors-drawer-trend-empty">
@@ -91,10 +149,10 @@
         <button
           type="button"
           class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-          pTooltip="Share of total contributions made by each percentile group of contributors over the last 12 months"
+          pTooltip="Share of total contributions made by each contributor tier over the last 12 months. The Top 10% drives most of the activity; the Bottom 50% contributes very little."
           tooltipPosition="top"
           tooltipEvent="both"
-          aria-label="Share of total contributions made by each percentile group of contributors over the last 12 months">
+          aria-label="Share of total contributions made by each contributor tier over the last 12 months. The Top 10% drives most of the activity; the Bottom 50% contributes very little.">
           <i class="fa-light fa-circle-info"></i>
         </button>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -63,7 +63,7 @@
           <div class="flex items-baseline gap-2">
             @if (momDelta(); as delta) {
               <span class="text-xl font-semibold text-gray-900" data-testid="active-contributors-drawer-mom-metric">
-                {{ delta.latest.toLocaleString('en-US') }}
+                {{ delta.latestLabel }}
               </span>
               @if (delta.deltaPercent !== null) {
                 <span
@@ -81,7 +81,7 @@
                   } @else {
                     <span class="sr-only">No change </span>
                   }
-                  {{ formatMomDelta(delta.deltaPercent) }}% vs last month
+                  {{ delta.deltaLabel }}% vs last month
                 </span>
               }
             }

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -7,7 +7,12 @@ import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
-import { DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY, DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION, lfxColors } from '@lfx-one/shared/constants';
+import {
+  DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY,
+  DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT,
+  DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -17,6 +22,8 @@ import { catchError, forkJoin, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
 import type {
+  ActiveContributorsMoMDelta,
+  FoundationActiveContributorsMonthlyDistinctResponse,
   FoundationActiveContributorsMonthlyResponse,
   FoundationContributorsDistributionResponse,
   UniqueContributorsDailyResponse,
@@ -36,10 +43,9 @@ export class ActiveContributorsDrawerComponent {
   // === Static Options ===
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
-  protected readonly trendChartOptions: ChartOptions<'line'> = {
+  protected readonly trendChartOptions: ChartOptions<'bar'> = {
     responsive: true,
     maintainAspectRatio: false,
-    interaction: { mode: 'index', intersect: false },
     plugins: {
       legend: { display: false },
       tooltip: {
@@ -70,7 +76,7 @@ export class ActiveContributorsDrawerComponent {
         beginAtZero: true,
       },
     },
-    datasets: { line: { tension: 0.4, borderWidth: 2, pointRadius: 0, pointHoverRadius: 4 } },
+    datasets: { bar: { barPercentage: 0.6, categoryPercentage: 0.7 } },
   };
 
   protected readonly distributionChartOptions: ChartOptions<'bar'> = {
@@ -113,6 +119,43 @@ export class ActiveContributorsDrawerComponent {
     datasets: { bar: { barPercentage: 0.6, categoryPercentage: 0.7 } },
   };
 
+  protected readonly momChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(255, 255, 255, 0.98)',
+        titleColor: lfxColors.gray[900],
+        bodyColor: lfxColors.gray[600],
+        borderColor: lfxColors.gray[200],
+        borderWidth: 1,
+        padding: 10,
+        cornerRadius: 6,
+        callbacks: {
+          label: (ctx) => ` ${(ctx.parsed.y as number).toLocaleString()} contributors`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        border: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, maxRotation: 0 },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false, dash: [3, 3] },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, callback: (v) => (v as number).toLocaleString() },
+        beginAtZero: true,
+      },
+    },
+    datasets: { line: { tension: 0.4, borderWidth: 2, pointRadius: 0, pointHoverRadius: 4 } },
+  };
+
   // === Forms ===
   protected readonly headerForm: FormGroup = this.fb.group({
     timeRange: [{ value: 'last-12-months', disabled: true }],
@@ -141,20 +184,37 @@ export class ActiveContributorsDrawerComponent {
   private readonly drawerData = this.initDrawerData();
   protected readonly monthlyTrendData: Signal<FoundationActiveContributorsMonthlyResponse> = computed(() => this.drawerData().monthly);
   protected readonly distributionData: Signal<FoundationContributorsDistributionResponse> = computed(() => this.drawerData().distribution);
+  protected readonly momData: Signal<FoundationActiveContributorsMonthlyDistinctResponse> = computed(() => this.drawerData().mom);
   protected readonly hasTrendData: Signal<boolean> = computed(() => this.monthlyTrendData().monthlyData.length > 0);
   protected readonly hasDistributionData: Signal<boolean> = computed(() => this.distributionData().distribution.length > 0);
+  protected readonly hasMomData: Signal<boolean> = computed(() => this.momData().monthlyData.length > 0);
 
-  protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
+  protected readonly trendChartData: Signal<ChartData<'bar'>> = this.initTrendChartData();
   protected readonly distributionChartData: Signal<ChartData<'bar'>> = this.initDistributionChartData();
+  protected readonly momDelta: Signal<ActiveContributorsMoMDelta> = this.initMomDelta();
+  protected readonly momChartData: Signal<ChartData<'line'>> = this.initMomChartData();
 
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
   }
 
+  // Magnitude only — the up/down arrow already conveys direction
+  protected formatMomDelta(value: number): string {
+    return Math.abs(value).toFixed(1);
+  }
+
   // === Private Initializers ===
-  private initDrawerData(): Signal<{ monthly: FoundationActiveContributorsMonthlyResponse; distribution: FoundationContributorsDistributionResponse }> {
-    const defaultValue = { monthly: DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY, distribution: DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION };
+  private initDrawerData(): Signal<{
+    monthly: FoundationActiveContributorsMonthlyResponse;
+    distribution: FoundationContributorsDistributionResponse;
+    mom: FoundationActiveContributorsMonthlyDistinctResponse;
+  }> {
+    const defaultValue = {
+      monthly: DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY,
+      distribution: DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION,
+      mom: DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT,
+    };
     return toSignal(
       toObservable(this.visible).pipe(
         skip(1),
@@ -172,6 +232,7 @@ export class ActiveContributorsDrawerComponent {
           return forkJoin({
             monthly: this.analyticsService.getFoundationActiveContributorsMonthly(slug),
             distribution: this.analyticsService.getFoundationContributorsDistribution(slug),
+            mom: this.analyticsService.getFoundationActiveContributorsMonthlyDistinct(slug),
           }).pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
@@ -185,7 +246,7 @@ export class ActiveContributorsDrawerComponent {
     );
   }
 
-  private initTrendChartData(): Signal<ChartData<'line'>> {
+  private initTrendChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
       const { monthlyData, monthlyLabels } = this.monthlyTrendData();
       return {
@@ -193,9 +254,8 @@ export class ActiveContributorsDrawerComponent {
         datasets: [
           {
             data: monthlyData,
-            borderColor: lfxColors.blue[500],
-            backgroundColor: hexToRgba(lfxColors.blue[400], 0.2),
-            fill: true,
+            backgroundColor: lfxColors.blue[500],
+            borderRadius: 4,
           },
         ],
       };
@@ -218,6 +278,42 @@ export class ActiveContributorsDrawerComponent {
             backgroundColor: distribution.map((d) => bandColors[d.band] ?? lfxColors.gray[400]),
             borderRadius: 4,
             borderSkipped: 'start',
+          },
+        ],
+      };
+    });
+  }
+
+  private initMomDelta(): Signal<ActiveContributorsMoMDelta> {
+    return computed(() => {
+      const data = this.momData().monthlyData;
+      const latest = data.length ? data[data.length - 1] : 0;
+      const prior = data.length > 1 ? data[data.length - 2] : null;
+      if (prior === null || prior === 0) {
+        return { latest, deltaPercent: null, direction: 'flat' };
+      }
+      const deltaPercent = ((latest - prior) / prior) * 100;
+      let direction: ActiveContributorsMoMDelta['direction'] = 'flat';
+      if (deltaPercent > 0) {
+        direction = 'up';
+      } else if (deltaPercent < 0) {
+        direction = 'down';
+      }
+      return { latest, deltaPercent, direction };
+    });
+  }
+
+  private initMomChartData(): Signal<ChartData<'line'>> {
+    return computed(() => {
+      const { monthlyData, monthlyLabels } = this.momData();
+      return {
+        labels: monthlyLabels,
+        datasets: [
+          {
+            data: monthlyData,
+            borderColor: lfxColors.blue[500],
+            backgroundColor: hexToRgba(lfxColors.blue[400], 0.2),
+            fill: true,
           },
         ],
       };

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -178,17 +178,15 @@ export class ActiveContributorsDrawerComponent {
     })
   );
 
-  // Headline mirrors the chart's own monthly averages (mean of the per-month
-  // daily-unique averages) so summary and bars share one SQL source and reconcile.
+  // Headline uses the canonical 12-month daily average supplied by the parent
+  // (UniqueContributorsDailyResponse.avgContributors) rather than a recomputed
+  // unweighted mean of per-month averages, so the summary matches the value
+  // shown elsewhere and the daily-data request is not fetched and discarded.
   protected readonly metricValue: Signal<string> = computed(() => {
-    const values = this.monthlyTrendData().monthlyData;
-    if (values.length === 0) {
-      return '';
-    }
-    const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
-    return Math.round(avg).toLocaleString('en-US');
+    const avg = this.data().avgContributors;
+    return avg > 0 ? Math.round(avg).toLocaleString('en-US') : '';
   });
-  protected readonly hasData: Signal<boolean> = computed(() => this.monthlyTrendData().monthlyData.length > 0);
+  protected readonly hasData: Signal<boolean> = computed(() => this.data().avgContributors > 0);
 
   private readonly drawerData = this.initDrawerData();
   protected readonly monthlyTrendData: Signal<FoundationActiveContributorsMonthlyResponse> = computed(() => this.drawerData().monthly);
@@ -316,6 +314,10 @@ export class ActiveContributorsDrawerComponent {
             borderColor: lfxColors.blue[500],
             backgroundColor: hexToRgba(lfxColors.blue[400], 0.2),
             fill: true,
+            // A single-point line dataset has no segment, so the sole point
+            // must be visible or the chart renders blank for new foundations.
+            pointRadius: monthlyData.length === 1 ? 3 : 0,
+            pointHoverRadius: 4,
           },
         ],
       };

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -178,8 +178,17 @@ export class ActiveContributorsDrawerComponent {
     })
   );
 
-  protected readonly metricValue: Signal<string> = computed(() => this.data().avgContributors.toLocaleString());
-  protected readonly hasData: Signal<boolean> = computed(() => this.data().avgContributors > 0);
+  // Headline mirrors the chart's own monthly averages (mean of the per-month
+  // daily-unique averages) so summary and bars share one SQL source and reconcile.
+  protected readonly metricValue: Signal<string> = computed(() => {
+    const values = this.monthlyTrendData().monthlyData;
+    if (values.length === 0) {
+      return '';
+    }
+    const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
+    return Math.round(avg).toLocaleString('en-US');
+  });
+  protected readonly hasData: Signal<boolean> = computed(() => this.monthlyTrendData().monthlyData.length > 0);
 
   private readonly drawerData = this.initDrawerData();
   protected readonly monthlyTrendData: Signal<FoundationActiveContributorsMonthlyResponse> = computed(() => this.drawerData().monthly);

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -134,7 +134,7 @@ export class ActiveContributorsDrawerComponent {
         padding: 10,
         cornerRadius: 6,
         callbacks: {
-          label: (ctx) => ` ${(ctx.parsed.y as number).toLocaleString()} contributors`,
+          label: (ctx) => ` ${(ctx.parsed.y as number).toLocaleString('en-US')} contributors`,
         },
       },
     },
@@ -149,7 +149,7 @@ export class ActiveContributorsDrawerComponent {
         display: true,
         grid: { color: lfxColors.gray[200], lineWidth: 1 },
         border: { display: false, dash: [3, 3] },
-        ticks: { color: lfxColors.gray[500], font: { size: 12 }, callback: (v) => (v as number).toLocaleString() },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, callback: (v) => (v as number).toLocaleString('en-US') },
         beginAtZero: true,
       },
     },
@@ -286,20 +286,13 @@ export class ActiveContributorsDrawerComponent {
 
   private initMomDelta(): Signal<ActiveContributorsMoMDelta> {
     return computed(() => {
-      const data = this.momData().monthlyData;
-      const latest = data.length ? data[data.length - 1] : 0;
-      const prior = data.length > 1 ? data[data.length - 2] : null;
-      if (prior === null || prior === 0) {
-        return { latest, deltaPercent: null, direction: 'flat' };
-      }
-      const deltaPercent = ((latest - prior) / prior) * 100;
-      let direction: ActiveContributorsMoMDelta['direction'] = 'flat';
-      if (deltaPercent > 0) {
-        direction = 'up';
-      } else if (deltaPercent < 0) {
-        direction = 'down';
-      }
-      return { latest, deltaPercent, direction };
+      const mom = this.momData();
+      // delta + direction are validated server-side for adjacent, current months.
+      return {
+        latest: mom.latest,
+        deltaPercent: mom.momDeltaPercent,
+        direction: mom.momDirection,
+      };
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -178,14 +178,8 @@ export class ActiveContributorsDrawerComponent {
     })
   );
 
-  // Headline uses the canonical 12-month daily average supplied by the parent
-  // (UniqueContributorsDailyResponse.avgContributors) rather than a recomputed
-  // unweighted mean of per-month averages, so the summary matches the value
-  // shown elsewhere and the daily-data request is not fetched and discarded.
-  protected readonly metricValue: Signal<string> = computed(() => {
-    const avg = this.data().avgContributors;
-    return avg > 0 ? Math.round(avg).toLocaleString('en-US') : '';
-  });
+  // Headline reuses the parent's canonical 12-month daily average instead of recomputing it.
+  protected readonly metricValue: Signal<string> = this.initMetricValue();
   protected readonly hasData: Signal<boolean> = computed(() => this.data().avgContributors > 0);
 
   private readonly drawerData = this.initDrawerData();
@@ -212,6 +206,13 @@ export class ActiveContributorsDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initMetricValue(): Signal<string> {
+    return computed(() => {
+      const avg = this.data().avgContributors;
+      return avg > 0 ? Math.round(avg).toLocaleString('en-US') : '';
+    });
+  }
+
   private initDrawerData(): Signal<{
     monthly: FoundationActiveContributorsMonthlyResponse;
     distribution: FoundationContributorsDistributionResponse;

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -200,11 +200,6 @@ export class ActiveContributorsDrawerComponent {
     this.visible.set(false);
   }
 
-  // Magnitude only — the up/down arrow already conveys direction
-  protected formatMomDelta(value: number): string {
-    return Math.abs(value).toFixed(1);
-  }
-
   // === Private Initializers ===
   private initMetricValue(): Signal<string> {
     return computed(() => {
@@ -298,7 +293,9 @@ export class ActiveContributorsDrawerComponent {
       // delta + direction are validated server-side for adjacent, current months.
       return {
         latest: mom.latest,
+        latestLabel: mom.latest.toLocaleString('en-US'),
         deltaPercent: mom.momDeltaPercent,
+        deltaLabel: mom.momDeltaPercent === null ? '' : Math.abs(mom.momDeltaPercent).toFixed(1),
         direction: mom.momDirection,
       };
     });

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -175,6 +175,8 @@
                 [chartOptions]="card.chartOptions"
                 [value]="card.value"
                 [subtitle]="card.subtitle"
+                [trend]="card.trend"
+                [changePercentage]="card.changePercentage"
                 [loading]="card.loading"
                 [clickable]="!!card.drawerType"
                 (cardClick)="handleCardClick(card.drawerType!)"></lfx-metric-card>

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -221,7 +221,7 @@
 <lfx-active-contributors-drawer
   [visible]="activeDrawer() === DashboardDrawerType.ActiveContributors"
   (visibleChange)="handleDrawerClose()"
-  [data]="activeContributorsData()"></lfx-active-contributors-drawer>
+  [data]="reconciledActiveContributorsData()"></lfx-active-contributors-drawer>
 
 <lfx-maintainers-drawer
   [visible]="activeDrawer() === DashboardDrawerType.Maintainers"

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -35,6 +35,7 @@ import { TotalValueDrawerComponent } from '../total-value-drawer/total-value-dra
 import type {
   CompanyBusFactor,
   DashboardMetricCard,
+  FoundationActiveContributorsMonthlyDistinctResponse,
   FoundationCompanyBusFactorResponse,
   FoundationHealthScoreDistributionResponse,
   FoundationMaintainersResponse,
@@ -78,6 +79,7 @@ export class FoundationHealthComponent {
   private readonly maintainersLoading = signal(true);
   protected readonly healthScoresLoading = signal(true);
   private readonly activeContributorsLoading = signal(true);
+  private readonly activeContributorsMonthlyDistinctLoading = signal(true);
   private readonly eventsLoading = signal(true);
 
   private readonly selectedFoundationSlug$ = toObservable(this.projectContextService.selectedFoundation).pipe(
@@ -94,6 +96,7 @@ export class FoundationHealthComponent {
   protected readonly maintainersData = this.initializeMaintainersData();
   protected readonly healthScoresData = this.initializeHealthScoresData();
   protected readonly activeContributorsData = this.initializeActiveContributorsData();
+  protected readonly activeContributorsMonthlyDistinctData = this.initializeActiveContributorsMonthlyDistinctData();
   protected readonly eventsData = this.initializeEventsData();
 
   // totalProjectsData retains the prior foundation's total until the next request
@@ -399,26 +402,38 @@ export class FoundationHealthComponent {
   }
 
   private transformActiveContributors(metric: DashboardMetricCard): DashboardMetricCard {
-    const data = this.activeContributorsData();
+    const data = this.activeContributorsMonthlyDistinctData();
+    const values = data.monthlyData;
+    const labels = data.monthlyLabels;
 
-    // Reverse the data to show oldest to newest for chart rendering
-    const chartData = [...data.data].reverse();
-    const contributorValues = chartData.map((row) => row.DAILY_UNIQUE_CONTRIBUTORS);
-    const chartLabels = chartData.map((row) => {
-      const date = new Date(row.ACTIVITY_DATE);
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    });
+    const latest = values.length ? values[values.length - 1] : 0;
+    const prior = values.length > 1 ? values[values.length - 2] : null;
+
+    let trend: DashboardMetricCard['trend'] = 'neutral';
+    let changePercentage: string | undefined;
+    if (prior !== null && prior !== 0) {
+      const deltaPercent = ((latest - prior) / prior) * 100;
+      if (deltaPercent > 0) {
+        trend = 'up';
+      } else if (deltaPercent < 0) {
+        trend = 'down';
+      }
+      const sign = deltaPercent > 0 ? '+' : '';
+      changePercentage = `${sign}${deltaPercent.toFixed(1)}% vs last month`;
+    }
 
     return {
       ...metric,
-      loading: this.activeContributorsLoading(),
-      value: data.avgContributors.toLocaleString(),
-      subtitle: 'Average active contributors over the past year',
+      loading: this.activeContributorsMonthlyDistinctLoading(),
+      value: values.length ? latest.toLocaleString() : '',
+      subtitle: 'Monthly distinct active contributors',
+      trend,
+      changePercentage,
       chartData: {
-        labels: chartLabels,
+        labels,
         datasets: [
           {
-            data: contributorValues,
+            data: values,
             borderColor: lfxColors.blue[500],
             backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
             fill: true,
@@ -729,6 +744,29 @@ export class FoundationHealthComponent {
             tap(() => this.activeContributorsLoading.set(false)),
             catchError(() => {
               this.activeContributorsLoading.set(false);
+              return of(defaultValue);
+            })
+          )
+        )
+      ),
+      { initialValue: defaultValue }
+    );
+  }
+
+  private initializeActiveContributorsMonthlyDistinctData() {
+    const defaultValue: FoundationActiveContributorsMonthlyDistinctResponse = {
+      monthlyData: [],
+      monthlyLabels: [],
+    };
+
+    return toSignal(
+      this.selectedFoundationSlug$.pipe(
+        tap(() => this.activeContributorsMonthlyDistinctLoading.set(true)),
+        switchMap((foundationSlug) =>
+          this.analyticsService.getFoundationActiveContributorsMonthlyDistinct(foundationSlug).pipe(
+            tap(() => this.activeContributorsMonthlyDistinctLoading.set(false)),
+            catchError(() => {
+              this.activeContributorsMonthlyDistinctLoading.set(false);
               return of(defaultValue);
             })
           )

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -412,14 +412,20 @@ export class FoundationHealthComponent {
     let changePercentage: string | undefined;
     if (data.momDeltaPercent !== null) {
       const sign = data.momDeltaPercent > 0 ? '+' : '';
-      const arrow = data.momDeltaPercent > 0 ? '▲' : '▼';
-      changePercentage = `${arrow} ${sign}${data.momDeltaPercent.toFixed(1)}% vs last month`;
+      let arrow = '';
+      if (data.momDirection === 'up') {
+        arrow = '▲';
+      } else if (data.momDirection === 'down') {
+        arrow = '▼';
+      }
+      const prefix = arrow ? `${arrow} ` : '';
+      changePercentage = `${prefix}${sign}${data.momDeltaPercent.toFixed(1)}% vs last month`;
     }
 
     return {
       ...metric,
       loading: this.activeContributorsMonthlyDistinctLoading(),
-      value: data.latest ? data.latest.toLocaleString('en-US') : '',
+      value: data.monthlyData.length > 0 ? data.latest.toLocaleString('en-US') : '',
       subtitle: 'Monthly distinct active contributors',
       trend,
       changePercentage,

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -439,7 +439,9 @@ export class FoundationHealthComponent {
             fill: true,
             tension: 0.4,
             borderWidth: 2,
-            pointRadius: 0,
+            // A single-point line dataset has no segment, so the sole point
+            // must be visible or the sparkline renders blank for new foundations.
+            pointRadius: values.length === 1 ? 3 : 0,
           },
         ],
       },

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -78,7 +78,6 @@ export class FoundationHealthComponent {
   private readonly companyBusFactorLoading = signal(true);
   private readonly maintainersLoading = signal(true);
   protected readonly healthScoresLoading = signal(true);
-  private readonly activeContributorsLoading = signal(true);
   private readonly activeContributorsMonthlyDistinctLoading = signal(true);
   private readonly eventsLoading = signal(true);
 
@@ -406,26 +405,21 @@ export class FoundationHealthComponent {
     const values = data.monthlyData;
     const labels = data.monthlyLabels;
 
-    const latest = values.length ? values[values.length - 1] : 0;
-    const prior = values.length > 1 ? values[values.length - 2] : null;
-
-    let trend: DashboardMetricCard['trend'] = 'neutral';
+    // MoM (delta + direction) is validated server-side for adjacent, current
+    // months; render it directly instead of re-deriving from the last two
+    // array entries (which may be non-adjacent when a month is missing).
+    const trend: DashboardMetricCard['trend'] = data.momDirection === 'flat' ? 'neutral' : data.momDirection;
     let changePercentage: string | undefined;
-    if (prior !== null && prior !== 0) {
-      const deltaPercent = ((latest - prior) / prior) * 100;
-      if (deltaPercent > 0) {
-        trend = 'up';
-      } else if (deltaPercent < 0) {
-        trend = 'down';
-      }
-      const sign = deltaPercent > 0 ? '+' : '';
-      changePercentage = `${sign}${deltaPercent.toFixed(1)}% vs last month`;
+    if (data.momDeltaPercent !== null) {
+      const sign = data.momDeltaPercent > 0 ? '+' : '';
+      const arrow = data.momDeltaPercent > 0 ? '▲' : '▼';
+      changePercentage = `${arrow} ${sign}${data.momDeltaPercent.toFixed(1)}% vs last month`;
     }
 
     return {
       ...metric,
       loading: this.activeContributorsMonthlyDistinctLoading(),
-      value: values.length ? latest.toLocaleString() : '',
+      value: data.latest ? data.latest.toLocaleString('en-US') : '',
       subtitle: 'Monthly distinct active contributors',
       trend,
       changePercentage,
@@ -738,16 +732,7 @@ export class FoundationHealthComponent {
 
     return toSignal(
       this.selectedFoundationSlug$.pipe(
-        tap(() => this.activeContributorsLoading.set(true)),
-        switchMap((foundationSlug) =>
-          this.analyticsService.getUniqueContributorsDaily(foundationSlug, 'foundation').pipe(
-            tap(() => this.activeContributorsLoading.set(false)),
-            catchError(() => {
-              this.activeContributorsLoading.set(false);
-              return of(defaultValue);
-            })
-          )
-        )
+        switchMap((foundationSlug) => this.analyticsService.getUniqueContributorsDaily(foundationSlug, 'foundation').pipe(catchError(() => of(defaultValue))))
       ),
       { initialValue: defaultValue }
     );
@@ -757,6 +742,9 @@ export class FoundationHealthComponent {
     const defaultValue: FoundationActiveContributorsMonthlyDistinctResponse = {
       monthlyData: [],
       monthlyLabels: [],
+      latest: 0,
+      momDeltaPercent: null,
+      momDirection: 'flat',
     };
 
     return toSignal(

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -116,9 +116,7 @@ export class FoundationHealthComponent {
   // default while loading so the drawer headline never flashes the previous
   // foundation's average against the newly loaded chart.
   protected readonly reconciledActiveContributorsData = computed<UniqueContributorsDailyResponse>(() =>
-    this.activeContributorsLoading()
-      ? { data: [], avgContributors: 0, totalDays: 0 }
-      : this.activeContributorsData()
+    this.activeContributorsLoading() ? { data: [], avgContributors: 0, totalDays: 0 } : this.activeContributorsData()
   );
 
   public readonly selectedFilter = signal<string>('all');

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -111,10 +111,7 @@ export class FoundationHealthComponent {
     this.healthScoresLoading() ? DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION : this.healthScoresData()
   );
 
-  // activeContributorsData (the daily average feeding the drawer headline) retains
-  // the prior foundation's avgContributors during a switch; surface the zeroed
-  // default while loading so the drawer headline never flashes the previous
-  // foundation's average against the newly loaded chart.
+  // Surface a zeroed default while loading so the drawer headline never shows the prior foundation's average.
   protected readonly reconciledActiveContributorsData = computed<UniqueContributorsDailyResponse>(() =>
     this.activeContributorsLoading() ? { data: [], avgContributors: 0, totalDays: 0 } : this.activeContributorsData()
   );
@@ -414,9 +411,7 @@ export class FoundationHealthComponent {
     const values = data.monthlyData;
     const labels = data.monthlyLabels;
 
-    // MoM (delta + direction) is validated server-side for adjacent, current
-    // months; render it directly instead of re-deriving from the last two
-    // array entries (which may be non-adjacent when a month is missing).
+    // MoM is server-validated for adjacent current months; render it directly.
     const trend: DashboardMetricCard['trend'] = data.momDirection === 'flat' ? 'neutral' : data.momDirection;
     let changePercentage: string | undefined;
     if (data.momDeltaPercent !== null) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -79,6 +79,7 @@ export class FoundationHealthComponent {
   private readonly maintainersLoading = signal(true);
   protected readonly healthScoresLoading = signal(true);
   private readonly activeContributorsMonthlyDistinctLoading = signal(true);
+  private readonly activeContributorsLoading = signal(true);
   private readonly eventsLoading = signal(true);
 
   private readonly selectedFoundationSlug$ = toObservable(this.projectContextService.selectedFoundation).pipe(
@@ -108,6 +109,16 @@ export class FoundationHealthComponent {
   // never renders the previous foundation's buckets for the newly selected one.
   protected readonly reconciledHealthScoresData = computed(() =>
     this.healthScoresLoading() ? DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION : this.healthScoresData()
+  );
+
+  // activeContributorsData (the daily average feeding the drawer headline) retains
+  // the prior foundation's avgContributors during a switch; surface the zeroed
+  // default while loading so the drawer headline never flashes the previous
+  // foundation's average against the newly loaded chart.
+  protected readonly reconciledActiveContributorsData = computed<UniqueContributorsDailyResponse>(() =>
+    this.activeContributorsLoading()
+      ? { data: [], avgContributors: 0, totalDays: 0 }
+      : this.activeContributorsData()
   );
 
   public readonly selectedFilter = signal<string>('all');
@@ -740,7 +751,16 @@ export class FoundationHealthComponent {
 
     return toSignal(
       this.selectedFoundationSlug$.pipe(
-        switchMap((foundationSlug) => this.analyticsService.getUniqueContributorsDaily(foundationSlug, 'foundation').pipe(catchError(() => of(defaultValue))))
+        tap(() => this.activeContributorsLoading.set(true)),
+        switchMap((foundationSlug) =>
+          this.analyticsService.getUniqueContributorsDaily(foundationSlug, 'foundation').pipe(
+            tap(() => this.activeContributorsLoading.set(false)),
+            catchError(() => {
+              this.activeContributorsLoading.set(false);
+              return of(defaultValue);
+            })
+          )
+        )
       ),
       { initialValue: defaultValue }
     );

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -74,7 +74,7 @@ import {
   MarketingAttributionResponse,
   MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
-import { HEALTH_METRICS_NPS_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
+import { DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT, HEALTH_METRICS_NPS_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
 import { catchError, Observable, of, shareReplay } from 'rxjs';
 
 /**
@@ -351,7 +351,7 @@ export class AnalyticsService {
       .get<FoundationActiveContributorsMonthlyDistinctResponse>('/api/analytics/foundation-active-contributors-monthly-distinct', {
         params: { foundationSlug },
       })
-      .pipe(catchError(() => of({ monthlyData: [], monthlyLabels: [] })));
+      .pipe(catchError(() => of(DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT)));
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -8,6 +8,7 @@ import {
   ActiveWeeksStreakResponse,
   CertifiedEmployeesResponse,
   CodeCommitsDailyResponse,
+  FoundationActiveContributorsMonthlyDistinctResponse,
   FoundationActiveContributorsMonthlyResponse,
   FoundationCompanyBusFactorResponse,
   FoundationContributorsMentoredResponse,
@@ -338,6 +339,18 @@ export class AnalyticsService {
   public getFoundationActiveContributorsMonthly(foundationSlug: string): Observable<FoundationActiveContributorsMonthlyResponse> {
     return this.http
       .get<FoundationActiveContributorsMonthlyResponse>('/api/analytics/foundation-active-contributors-monthly', { params: { foundationSlug } })
+      .pipe(catchError(() => of({ monthlyData: [], monthlyLabels: [] })));
+  }
+
+  /**
+   * Get monthly DISTINCT active contributors for a foundation (last 12 months)
+   * @param foundationSlug - Required foundation slug (e.g., 'cncf', 'tlf')
+   */
+  public getFoundationActiveContributorsMonthlyDistinct(foundationSlug: string): Observable<FoundationActiveContributorsMonthlyDistinctResponse> {
+    return this.http
+      .get<FoundationActiveContributorsMonthlyDistinctResponse>('/api/analytics/foundation-active-contributors-monthly-distinct', {
+        params: { foundationSlug },
+      })
       .pipe(catchError(() => of({ monthlyData: [], monthlyLabels: [] })));
   }
 

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -739,6 +739,42 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/foundation-active-contributors-monthly-distinct
+   * Get monthly DISTINCT active contributors for a foundation (last 12 months)
+   * Query params: foundationSlug (required)
+   */
+  public async getFoundationActiveContributorsMonthlyDistinct(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_foundation_active_contributors_monthly_distinct');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_foundation_active_contributors_monthly_distinct',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_foundation_active_contributors_monthly_distinct',
+        });
+      }
+
+      const response = await this.projectService.getFoundationActiveContributorsMonthlyDistinct(foundationSlug);
+
+      logger.success(req, 'get_foundation_active_contributors_monthly_distinct', startTime, {
+        foundation_slug: foundationSlug,
+        monthly_data_points: response.monthlyData.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/foundation-contributors-distribution
    * Get contributor distribution by percentile band for a foundation
    * Query params: foundationSlug (required)

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -52,6 +52,11 @@ router.get('/foundation-total-members', (req, res, next) => analyticsController.
 // Foundation active contributors monthly endpoint (active contributors drill-down)
 router.get('/foundation-active-contributors-monthly', (req, res, next) => analyticsController.getFoundationActiveContributorsMonthly(req, res, next));
 
+// Foundation active contributors monthly-distinct endpoint (active contributors drill-down)
+router.get('/foundation-active-contributors-monthly-distinct', (req, res, next) =>
+  analyticsController.getFoundationActiveContributorsMonthlyDistinct(req, res, next)
+);
+
 // Foundation contributors distribution endpoint (active contributors drill-down)
 router.get('/foundation-contributors-distribution', (req, res, next) => analyticsController.getFoundationContributorsDistribution(req, res, next));
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -110,6 +110,7 @@ import {
   ProjectUniqueContributorsDailyRow,
   QueryServiceResponse,
   RevenueImpactResponse,
+  SnowflakeQueryResult,
   SocialMediaMonthlyResponse,
   SocialMediaPlatformMonthly,
   SocialMediaPlatformMonthlyRow,
@@ -1358,7 +1359,20 @@ export class ProjectService {
       ORDER BY MONTH_START_DATE ASC
     `;
 
-    const result = await this.snowflakeService.execute<FoundationActiveContributorsMonthlyDistinctRow>(query, [foundationSlug]);
+    let result: SnowflakeQueryResult<FoundationActiveContributorsMonthlyDistinctRow>;
+    try {
+      result = await this.snowflakeService.execute<FoundationActiveContributorsMonthlyDistinctRow>(query, [foundationSlug], {
+        expectMissingObject: true,
+      });
+    } catch (error) {
+      // Pre-dbt deploy the monthly table is absent; degrade to the empty
+      // response the PR description promises instead of 5xx per dashboard load.
+      if (!SnowflakeService.isMissingObjectError(error)) throw error;
+      logger.warning(undefined, 'get_foundation_active_contributors_monthly_distinct', 'Monthly distinct table not deployed yet; returning empty response', {
+        foundation_slug: foundationSlug,
+      });
+      return { monthlyData: [], monthlyLabels: [], latest: 0, momDeltaPercent: null, momDirection: 'flat' };
+    }
 
     logger.debug(undefined, 'get_foundation_active_contributors_monthly_distinct', 'Fetched monthly distinct active contributors', {
       row_count: result.rows.length,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -31,6 +31,8 @@ import {
   EventGrowthTopEvent,
   EventsSummaryResponse,
   FlywheelConversionResponse,
+  FoundationActiveContributorsMonthlyDistinctResponse,
+  FoundationActiveContributorsMonthlyDistinctRow,
   FoundationActiveContributorsMonthlyResponse,
   FoundationActiveContributorsMonthlyRow,
   FoundationCodeCommitsDailyRow,
@@ -1329,6 +1331,42 @@ export class ProjectService {
     const monthlyData = result.rows.map((row) => row.MONTHLY_AVG_CONTRIBUTORS);
     const monthlyLabels = result.rows.map((row) => {
       const date = new Date(row.MONTH_START);
+      return date.toLocaleDateString('en-US', { month: 'short' });
+    });
+
+    return { monthlyData, monthlyLabels };
+  }
+
+  /**
+   * Get monthly DISTINCT active contributors for a foundation (last 12 months)
+   * Queries FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY (COUNT DISTINCT member_id per month)
+   * @param foundationSlug - Foundation slug to filter by
+   * @returns Monthly distinct contributor counts with short month labels
+   */
+  public async getFoundationActiveContributorsMonthlyDistinct(foundationSlug: string): Promise<FoundationActiveContributorsMonthlyDistinctResponse> {
+    logger.debug(undefined, 'get_foundation_active_contributors_monthly_distinct', 'Fetching monthly distinct active contributors', {
+      foundation_slug: foundationSlug,
+    });
+
+    const query = `
+      SELECT
+        MONTH_START_DATE,
+        MONTHLY_ACTIVE_CONTRIBUTORS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY
+      WHERE FOUNDATION_SLUG = ?
+        AND MONTH_START_DATE >= DATE_TRUNC('MONTH', DATEADD('month', -11, CURRENT_DATE()))
+      ORDER BY MONTH_START_DATE ASC
+    `;
+
+    const result = await this.snowflakeService.execute<FoundationActiveContributorsMonthlyDistinctRow>(query, [foundationSlug]);
+
+    logger.debug(undefined, 'get_foundation_active_contributors_monthly_distinct', 'Fetched monthly distinct active contributors', {
+      row_count: result.rows.length,
+    });
+
+    const monthlyData = result.rows.map((row) => row.MONTHLY_ACTIVE_CONTRIBUTORS);
+    const monthlyLabels = result.rows.map((row) => {
+      const date = new Date(row.MONTH_START_DATE);
       return date.toLocaleDateString('en-US', { month: 'short' });
     });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1364,10 +1364,20 @@ export class ProjectService {
       row_count: result.rows.length,
     });
 
-    const monthlyData = result.rows.map((row) => row.MONTHLY_ACTIVE_CONTRIBUTORS);
-    const monthlyLabels = result.rows.map((row) => {
+    // Drop future-materialized rows so a row dated past the current month can't
+    // become the displayed headline or skew the MoM pair; mirrors the date-only
+    // UTC handling used elsewhere in this service.
+    const now = new Date();
+    const currentMonthOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth();
+    const rows = result.rows.filter((row) => {
       const date = new Date(row.MONTH_START_DATE);
-      return date.toLocaleDateString('en-US', { month: 'short' });
+      return date.getUTCFullYear() * 12 + date.getUTCMonth() <= currentMonthOrdinal;
+    });
+
+    const monthlyData = rows.map((row) => row.MONTHLY_ACTIVE_CONTRIBUTORS);
+    const monthlyLabels = rows.map((row) => {
+      const date = new Date(row.MONTH_START_DATE);
+      return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
     });
 
     // MoM is only meaningful when the two most recent rows are ADJACENT calendar
@@ -1378,20 +1388,18 @@ export class ProjectService {
     let latest = 0;
     let momDeltaPercent: number | null = null;
     let momDirection: 'up' | 'down' | 'flat' = 'flat';
-    if (result.rows.length > 0) {
-      const newest = result.rows[result.rows.length - 1];
+    if (rows.length > 0) {
+      const newest = rows[rows.length - 1];
       latest = newest.MONTHLY_ACTIVE_CONTRIBUTORS ?? 0;
-      if (result.rows.length >= 2) {
-        const prior = result.rows[result.rows.length - 2];
+      if (rows.length >= 2) {
+        const prior = rows[rows.length - 2];
         const rowOrdinal = (value: string | Date): number => {
           const date = new Date(value);
           return date.getUTCFullYear() * 12 + date.getUTCMonth();
         };
-        const now = new Date();
-        const currentMonthOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth();
         const newestOrdinal = rowOrdinal(newest.MONTH_START_DATE);
         const priorOrdinal = rowOrdinal(prior.MONTH_START_DATE);
-        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= currentMonthOrdinal - 1;
+        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= currentMonthOrdinal - 1 && newestOrdinal <= currentMonthOrdinal;
         const previous = prior.MONTHLY_ACTIVE_CONTRIBUTORS ?? 0;
         if (validPair && previous > 0) {
           momDeltaPercent = Number((((latest - previous) / previous) * 100).toFixed(1));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1370,7 +1370,41 @@ export class ProjectService {
       return date.toLocaleDateString('en-US', { month: 'short' });
     });
 
-    return { monthlyData, monthlyLabels };
+    // MoM is only meaningful when the two most recent rows are ADJACENT calendar
+    // months and the newest row is current (or one month stale, tolerating a
+    // monthly materialization lag). Otherwise a missing month would silently
+    // compare non-adjacent months and label it "vs last month". Mirrors the
+    // adjacency+recency guard used for mention MoM above.
+    let latest = 0;
+    let momDeltaPercent: number | null = null;
+    let momDirection: 'up' | 'down' | 'flat' = 'flat';
+    if (result.rows.length > 0) {
+      const newest = result.rows[result.rows.length - 1];
+      latest = newest.MONTHLY_ACTIVE_CONTRIBUTORS ?? 0;
+      if (result.rows.length >= 2) {
+        const prior = result.rows[result.rows.length - 2];
+        const rowOrdinal = (value: string | Date): number => {
+          const date = new Date(value);
+          return date.getUTCFullYear() * 12 + date.getUTCMonth();
+        };
+        const now = new Date();
+        const currentMonthOrdinal = now.getUTCFullYear() * 12 + now.getUTCMonth();
+        const newestOrdinal = rowOrdinal(newest.MONTH_START_DATE);
+        const priorOrdinal = rowOrdinal(prior.MONTH_START_DATE);
+        const validPair = newestOrdinal - priorOrdinal === 1 && newestOrdinal >= currentMonthOrdinal - 1;
+        const previous = prior.MONTHLY_ACTIVE_CONTRIBUTORS ?? 0;
+        if (validPair && previous > 0) {
+          momDeltaPercent = Number((((latest - previous) / previous) * 100).toFixed(1));
+          if (momDeltaPercent > 0) {
+            momDirection = 'up';
+          } else if (momDeltaPercent < 0) {
+            momDirection = 'down';
+          }
+        }
+      }
+    }
+
+    return { monthlyData, monthlyLabels, latest, momDeltaPercent, momDirection };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1394,11 +1394,8 @@ export class ProjectService {
       return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
     });
 
-    // MoM is only meaningful when the two most recent rows are ADJACENT calendar
-    // months and the newest row is current (or one month stale, tolerating a
-    // monthly materialization lag). Otherwise a missing month would silently
-    // compare non-adjacent months and label it "vs last month". Mirrors the
-    // adjacency+recency guard used for mention MoM above.
+    // MoM requires the two newest rows to be adjacent calendar months and the newest
+    // to be current (or one stale); otherwise a missing month would mislabel the delta.
     let latest = 0;
     let momDeltaPercent: number | null = null;
     let momDirection: 'up' | 'down' | 'flat' = 'flat';

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -125,6 +125,7 @@ import {
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
 import type { PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
+import type { MoMDirection } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
@@ -1398,7 +1399,7 @@ export class ProjectService {
     // to be current (or one stale); otherwise a missing month would mislabel the delta.
     let latest = 0;
     let momDeltaPercent: number | null = null;
-    let momDirection: 'up' | 'down' | 'flat' = 'flat';
+    let momDirection: MoMDirection = 'flat';
     if (rows.length > 0) {
       const newest = rows[rows.length - 1];
       latest = newest.MONTHLY_ACTIVE_CONTRIBUTORS ?? 0;

--- a/packages/shared/src/constants/active-contributors-drawer.constants.ts
+++ b/packages/shared/src/constants/active-contributors-drawer.constants.ts
@@ -1,8 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { FoundationActiveContributorsMonthlyResponse, FoundationContributorsDistributionResponse } from '../interfaces';
+import type {
+  FoundationActiveContributorsMonthlyDistinctResponse,
+  FoundationActiveContributorsMonthlyResponse,
+  FoundationContributorsDistributionResponse,
+} from '../interfaces';
 
 export const DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY: FoundationActiveContributorsMonthlyResponse = { monthlyData: [], monthlyLabels: [] };
+
+export const DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT: FoundationActiveContributorsMonthlyDistinctResponse = {
+  monthlyData: [],
+  monthlyLabels: [],
+};
 
 export const DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION: FoundationContributorsDistributionResponse = { distribution: [] };

--- a/packages/shared/src/constants/active-contributors-drawer.constants.ts
+++ b/packages/shared/src/constants/active-contributors-drawer.constants.ts
@@ -12,6 +12,9 @@ export const DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY: FoundationActiveCon
 export const DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT: FoundationActiveContributorsMonthlyDistinctResponse = {
   monthlyData: [],
   monthlyLabels: [],
+  latest: 0,
+  momDeltaPercent: null,
+  momDirection: 'flat',
 };
 
 export const DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION: FoundationContributorsDistributionResponse = { distribution: [] };

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -699,6 +699,31 @@ export interface FoundationActiveContributorsMonthlyResponse {
 }
 
 /**
+ * Single month row from FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY (distinct per month)
+ */
+export interface FoundationActiveContributorsMonthlyDistinctRow {
+  MONTH_START_DATE: string;
+  MONTHLY_ACTIVE_CONTRIBUTORS: number;
+}
+
+/**
+ * API response for foundation monthly-distinct active contributors
+ */
+export interface FoundationActiveContributorsMonthlyDistinctResponse {
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * Latest-month headline count + month-over-month delta for the monthly-distinct chart
+ */
+export interface ActiveContributorsMoMDelta {
+  latest: number;
+  deltaPercent: number | null; // null when there is no prior month to compare
+  direction: 'up' | 'down' | 'flat';
+}
+
+/**
  * Single percentile band row from FOUNDATION_CONTRIBUTORS_DISTRIBUTION
  */
 export interface FoundationContributorsDistributionRow {

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -707,11 +707,20 @@ export interface FoundationActiveContributorsMonthlyDistinctRow {
 }
 
 /**
- * API response for foundation monthly-distinct active contributors
+ * API response for foundation monthly-distinct active contributors.
+ * `latest`, `momDeltaPercent`, and `momDirection` are computed server-side so
+ * both consumers render a pre-validated month-over-month delta rather than
+ * re-deriving it from the last two array entries (which may be non-adjacent
+ * when a month is absent from the materialized table).
  */
 export interface FoundationActiveContributorsMonthlyDistinctResponse {
   monthlyData: number[];
   monthlyLabels: string[];
+  /** Most recent month's distinct contributor count (0 when no rows). */
+  latest: number;
+  /** MoM delta percent; null when no valid adjacent prior month exists. */
+  momDeltaPercent: number | null;
+  momDirection: 'up' | 'down' | 'flat';
 }
 
 /**

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -706,6 +706,9 @@ export interface FoundationActiveContributorsMonthlyDistinctRow {
   MONTHLY_ACTIVE_CONTRIBUTORS: number;
 }
 
+/** Month-over-month direction for the active-contributors metric. */
+export type MoMDirection = 'up' | 'down' | 'flat';
+
 /**
  * API response for foundation monthly-distinct active contributors.
  * `latest`, `momDeltaPercent`, and `momDirection` are computed server-side so
@@ -720,16 +723,20 @@ export interface FoundationActiveContributorsMonthlyDistinctResponse {
   latest: number;
   /** MoM delta percent; null when no valid adjacent prior month exists. */
   momDeltaPercent: number | null;
-  momDirection: 'up' | 'down' | 'flat';
+  momDirection: MoMDirection;
 }
 
 /**
- * Latest-month headline count + month-over-month delta for the monthly-distinct chart
+ * Latest-month headline count + month-over-month delta for the monthly-distinct chart.
+ * `latestLabel` / `deltaLabel` are pre-formatted display strings so the template
+ * reads plain props instead of re-running toLocaleString / toFixed each pass.
  */
 export interface ActiveContributorsMoMDelta {
   latest: number;
+  latestLabel: string;
   deltaPercent: number | null; // null when there is no prior month to compare
-  direction: 'up' | 'down' | 'flat';
+  deltaLabel: string; // '' when deltaPercent is null
+  direction: MoMDirection;
 }
 
 /**


### PR DESCRIPTION
# Summary

Adds a **monthly-distinct** active-contributors view to the foundation dashboard. Previously the "Active Contributors" surfaces showed a *daily-average* number, which understates real reach because a contributor active on many days is averaged down rather than counted once. This PR introduces a distinct-per-month metric (`COUNT(DISTINCT member_id)` per month) alongside the existing average, so EDs and maintainers can see how many unique people actually contributed each month and the month-over-month trend.

# Before / After

**Before:** The active-contributors drawer opened with a single line chart of *monthly-average* daily unique contributors, and the foundation-health card showed the yearly average with no trend indicator. There was no view of how many distinct people contributed in a given month.

**After:** The drawer now leads with a **Monthly Distinct** section — a headline count of the latest month plus a month-over-month delta (▲/▼ % vs last month) and a 12-month line chart — above the existing average view (now relabeled **Monthly Average** and rendered as bars to visually distinguish the two metrics). The foundation-health card now shows the latest monthly-distinct count with a trend arrow and "% vs last month" instead of the flat yearly average.

# Changes

## Shared (`@lfx-one/shared`)
- Add `FoundationActiveContributorsMonthlyDistinctRow`, `FoundationActiveContributorsMonthlyDistinctResponse`, and `ActiveContributorsMoMDelta` interfaces.
- Add `DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY_DISTINCT` constant.

## Backend (Express)
- New endpoint `GET /api/analytics/foundation-active-contributors-monthly-distinct` (route + controller with `foundationSlug` validation via `SLUG_PATTERN`).
- New `ProjectService.getFoundationActiveContributorsMonthlyDistinct()` — parameterized Snowflake query against `ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY` (last 12 months, `COUNT(DISTINCT member_id)` per month), returning `{ monthlyData, monthlyLabels }`.

## Frontend
- `AnalyticsService.getFoundationActiveContributorsMonthlyDistinct()` HTTP gateway with graceful empty-array fallback.
- **Active contributors drawer**: new Monthly Distinct section (headline count, MoM delta signal/computed, line chart, loading/empty states, tooltip); relabels the existing section to "Monthly Average" and switches it from a filled line to a bar chart; clarified tooltip copy across sections. Data now loaded via a three-way `forkJoin` (monthly, distribution, mom).
- **Foundation-health card**: active-contributors card now sourced from the monthly-distinct data with a `trend` + `changePercentage` ("% vs last month") derived from the latest two months.

## Tests
- No automated E2E tests added — acceptance criteria (AC-1–AC-4) for this feature are verified manually per the LFXV2-2687 spec. `data-testid` hooks were added to the new drawer markup to support future E2E targeting.

# Deploy ordering (cross-repo dependency)

This PR consumes a new dbt model, `platinum_lfx_one_foundation_active_contributors_monthly.sql`, materialized to `ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY`. That model must be built and populated in Snowflake **before** this app deploys. If the app ships first, the endpoint returns empty arrays and the UI shows a graceful empty state (no error), but not the intended data. Sequence: merge/deploy dbt → verify table populated → merge this PR.
