### PR TITLE
perf(profile): collapse duplicate user_emails.read on linux-email tab

### DIFF
--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -2,17 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Linux.com email tab — partial-claim-failure recovery.
+ * Linux.com email tab.
  *
- * Covers the fix for the non-atomic claim flow: `add_alias` (auth-service) succeeds
- * but `set_target` (forwards-service) fails, so the server returns
- * `502 FORWARD_SET_FAILED`. The alias is immutable once claimed, so the component
- * must recover into the claimed/edit view (where the user can set forwarding)
- * instead of leaving them stuck on the claim form, where a retry would fail with
- * `already_claimed`.
+ * Covers:
+ * - Partial-claim-failure recovery: `add_alias` (auth-service) succeeds but
+ *   `set_target` (forwards-service) fails, so the server returns
+ *   `502 FORWARD_SET_FAILED`. The alias is immutable once claimed, so the
+ *   component must recover into the claimed/edit view instead of leaving the
+ *   user stuck on the claim form (where a retry would fail with `already_claimed`).
+ * - Forwarding-target visibility across the claimed states.
+ * - The whole-tab retry panel when the alias service is unavailable.
+ *
+ * The tab reads its state from a single `GET /api/profile/linux-email` call —
+ * the server resolves `user_emails.read` and returns the primary email inline as
+ * `primaryEmail`, so these stubs set it on the alias body rather than mocking a
+ * separate `/api/profile/emails` fetch.
  */
 
-import type { EmailManagementData, LinuxAliasData } from '@lfx-one/shared/interfaces';
+import type { LinuxAliasData } from '@lfx-one/shared/interfaces';
 import { expect, Page, test } from '@playwright/test';
 
 const DOMAIN = 'example.org';
@@ -30,14 +37,8 @@ function skipWhenAuthMissing(page: Page): void {
   }
 }
 
-/** Stub the sibling fetches the tab needs to render deterministically. */
-async function stubProfileContext(page: Page): Promise<void> {
-  await page.route('**/api/profile/emails', (route) => {
-    if (route.request().method() !== 'GET') return route.fallback();
-    const body: EmailManagementData = { primary_email: PRIMARY_EMAIL, alternate_emails: [] };
-    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-  });
-
+/** Stub the identities fetch the tab needs to render deterministically. */
+async function stubIdentities(page: Page): Promise<void> {
   await page.route('**/api/profile/identities', (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
@@ -55,8 +56,8 @@ async function stubPartialClaimFailure(page: Page): Promise<void> {
   await page.route('**/api/profile/linux-email', (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     const body: LinuxAliasData = claimed
-      ? { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: `${ALIAS}@${DOMAIN}`, forwardTo: null }
-      : { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null };
+      ? { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: `${ALIAS}@${DOMAIN}`, forwardTo: null, primaryEmail: PRIMARY_EMAIL }
+      : { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: PRIMARY_EMAIL };
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
   });
 
@@ -80,7 +81,7 @@ async function stubPartialClaimFailure(page: Page): Promise<void> {
 
 test.describe('Linux.com email — partial claim failure recovery', () => {
   test('recovers into the claimed/edit view after a FORWARD_SET_FAILED response', async ({ page }) => {
-    await stubProfileContext(page);
+    await stubIdentities(page);
     await stubPartialClaimFailure(page);
 
     await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
@@ -112,10 +113,17 @@ test.describe('Linux.com email — partial claim failure recovery', () => {
 
 test.describe('Linux.com email — forwarding target visibility', () => {
   test('keeps the forward dropdown visible with a hint when the saved target is the only verified option', async ({ page }) => {
-    await stubProfileContext(page);
+    await stubIdentities(page);
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: `${ALIAS}@${DOMAIN}`, forwardTo: PRIMARY_EMAIL };
+      const body: LinuxAliasData = {
+        state: 'claimed',
+        domain: DOMAIN,
+        alias: ALIAS,
+        email: `${ALIAS}@${DOMAIN}`,
+        forwardTo: PRIMARY_EMAIL,
+        primaryEmail: PRIMARY_EMAIL,
+      };
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
@@ -138,18 +146,10 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     // forwardTo-preservation branch, with the primary excluded because it equals the alias.
     const aliasEmail = `${ALIAS}@${DOMAIN}`;
     const externalForward = 'someone@external.com';
-    await page.route('**/api/profile/emails', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      const body: EmailManagementData = { primary_email: aliasEmail, alternate_emails: [] };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
-    await page.route('**/api/profile/identities', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
-    });
+    await stubIdentities(page);
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: aliasEmail, forwardTo: externalForward };
+      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: aliasEmail, forwardTo: externalForward, primaryEmail: aliasEmail };
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
@@ -169,18 +169,10 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     // Genuine-empty case: the only verified email is the claimed alias itself (so it's
     // excluded from forwardOptions) and no external forwardTo is saved — zero options.
     const aliasEmail = `${ALIAS}@${DOMAIN}`;
-    await page.route('**/api/profile/emails', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      const body: EmailManagementData = { primary_email: aliasEmail, alternate_emails: [] };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
-    await page.route('**/api/profile/identities', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
-    });
+    await stubIdentities(page);
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: aliasEmail, forwardTo: null };
+      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: aliasEmail, forwardTo: null, primaryEmail: aliasEmail };
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
@@ -194,10 +186,10 @@ test.describe('Linux.com email — forwarding target visibility', () => {
   });
 
   test('shows the normal hint on a first-time claim with a single verified email', async ({ page }) => {
-    await stubProfileContext(page);
+    await stubIdentities(page);
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null };
+      const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: PRIMARY_EMAIL };
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
@@ -211,19 +203,15 @@ test.describe('Linux.com email — forwarding target visibility', () => {
   });
 });
 
-test.describe('Linux.com email — verified emails fetch failure', () => {
-  test('shows a retry panel instead of the empty-state message on the claim form', async ({ page }) => {
-    await page.route('**/api/profile/emails', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'upstream unavailable' }) });
-    });
-    await page.route('**/api/profile/identities', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
-    });
+test.describe('Linux.com email — service unavailable', () => {
+  test('renders the whole-tab retry panel when the alias service is unavailable', async ({ page }) => {
+    // getLinuxAlias reads user_emails.read server-side; when that (or any downstream
+    // read) fails, the endpoint returns service_unavailable. The tab must render the
+    // whole-tab retry panel rather than any of the claim/claimed forms.
+    await stubIdentities(page);
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null };
+      const body: LinuxAliasData = { state: 'service_unavailable', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: null };
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
@@ -231,38 +219,8 @@ test.describe('Linux.com email — verified emails fetch failure', () => {
     skipWhenAuthMissing(page);
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('linux-email-claim-forward-load-error')).toBeVisible();
-    await expect(page.getByTestId('linux-email-claim-forward-empty')).not.toBeAttached();
-    await expect(page.getByTestId('linux-email-claim-forward-retry-button')).toBeVisible();
-  });
-
-  test('shows a retry panel instead of the empty-state message on the edit form', async ({ page }) => {
-    await page.route('**/api/profile/emails', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'upstream unavailable' }) });
-    });
-    await page.route('**/api/profile/identities', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
-    });
-    await page.route('**/api/profile/linux-email', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      // A preserved forwardTo (from before the emails fetch started failing) would make
-      // forwardOptions() non-empty even though emails failed — the retry panel must still
-      // win over the select in that case.
-      const body: LinuxAliasData = { state: 'claimed', domain: DOMAIN, alias: ALIAS, email: `${ALIAS}@${DOMAIN}`, forwardTo: PRIMARY_EMAIL };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
-
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('linux-email-forward-load-error')).toBeVisible();
-    await expect(page.getByTestId('linux-email-forward-empty')).not.toBeAttached();
-    await expect(page.getByTestId('linux-email-forward-select')).not.toBeAttached();
-    await expect(page.getByTestId('linux-email-forward-retry-button')).toBeVisible();
+    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
+    await expect(page.getByTestId('linux-email-claimed-panel')).not.toBeAttached();
   });
 });

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -187,6 +187,16 @@ test.describe('Linux.com email — forwarding target visibility', () => {
 
   test('shows the normal hint on a first-time claim with a single verified email', async ({ page }) => {
     await stubIdentities(page);
+
+    // Regression guard for the perf goal of this tab: the primary email now arrives inline on
+    // the linux-email response, so the tab must not make a second /api/profile/emails round-trip.
+    // Count GET hits (fulfilling so the assertion fails loudly rather than hanging if reintroduced).
+    let emailsFetchCount = 0;
+    await page.route('**/api/profile/emails', (route) => {
+      if (route.request().method() === 'GET') emailsFetchCount++;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ primary_email: PRIMARY_EMAIL, alternate_emails: [] }) });
+    });
+
     await page.route('**/api/profile/linux-email', (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
       const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: PRIMARY_EMAIL };
@@ -200,6 +210,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-claim-forward-select')).toBeVisible();
     await expect(page.getByText('Choose one of your verified email addresses.')).toBeVisible();
+    expect(emailsFetchCount).toBe(0);
   });
 });
 

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -107,27 +107,7 @@
 
               <div class="flex flex-col gap-1">
                 <label class="block text-sm font-medium text-gray-700">Forward to</label>
-                @if (emailsLoadFailed()) {
-                  <lfx-message severity="warn" styleClass="!p-3" data-testid="linux-email-claim-forward-load-error">
-                    <ng-template #content>
-                      <div class="flex flex-col gap-3 items-start">
-                        <div class="flex items-center gap-2">
-                          <i class="fa-light fa-triangle-exclamation shrink-0"></i>
-                          <span class="text-sm font-semibold">Couldn't load your verified emails</span>
-                        </div>
-                        <p class="text-sm font-normal text-gray-900">We couldn't check your verified email addresses. Please try again.</p>
-                        <lfx-button
-                          size="small"
-                          label="Retry"
-                          icon="fa-light fa-rotate-right"
-                          severity="secondary"
-                          variant="outlined"
-                          (onClick)="retry()"
-                          data-testid="linux-email-claim-forward-retry-button"></lfx-button>
-                      </div>
-                    </ng-template>
-                  </lfx-message>
-                } @else if (forwardOptions().length) {
+                @if (forwardOptions().length) {
                   <lfx-select
                     [form]="claimForm"
                     control="forwardTo"
@@ -156,7 +136,7 @@
                 icon="fa-light fa-check"
                 severity="info"
                 size="small"
-                [disabled]="claimForm.invalid || claiming() || impersonating() || emailsLoadFailed()"
+                [disabled]="claimForm.invalid || claiming() || impersonating()"
                 [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
                 [loading]="claiming()"
                 data-testid="linux-email-claim-button"></lfx-button>
@@ -190,7 +170,7 @@
             <form [formGroup]="editForm" (ngSubmit)="updateForward()" class="flex flex-col gap-3 pt-5" data-testid="linux-email-forward-form">
               <div class="flex flex-col gap-0.5">
                 <span class="text-sm font-medium text-gray-700">Forward to</span>
-                @if (!emailsLoadFailed() && forwardOptions().length) {
+                @if (forwardOptions().length) {
                   <p class="text-xs text-gray-500">
                     @if (hasForwardOptions()) {
                       Choose one of your verified email addresses.
@@ -200,27 +180,7 @@
                   </p>
                 }
               </div>
-              @if (emailsLoadFailed()) {
-                <lfx-message severity="warn" styleClass="!p-3" data-testid="linux-email-forward-load-error">
-                  <ng-template #content>
-                    <div class="flex flex-col gap-3 items-start">
-                      <div class="flex items-center gap-2">
-                        <i class="fa-light fa-triangle-exclamation shrink-0"></i>
-                        <span class="text-sm font-semibold">Couldn't load your verified emails</span>
-                      </div>
-                      <p class="text-sm font-normal text-gray-900">We couldn't check your verified email addresses. Please try again.</p>
-                      <lfx-button
-                        size="small"
-                        label="Retry"
-                        icon="fa-light fa-rotate-right"
-                        severity="secondary"
-                        variant="outlined"
-                        (onClick)="retry()"
-                        data-testid="linux-email-forward-retry-button"></lfx-button>
-                    </div>
-                  </ng-template>
-                </lfx-message>
-              } @else if (forwardOptions().length) {
+              @if (forwardOptions().length) {
                 <lfx-select
                   [form]="editForm"
                   control="forwardTo"

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -13,12 +13,12 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MessageComponent } from '@components/message/message.component';
 import { SelectComponent } from '@components/select/select.component';
-import { EmailManagementData, EnrichedIdentity, LinuxAliasData, LinuxEmailData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
+import { EnrichedIdentity, LinuxAliasData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
 import { linuxAliasValidator } from '@lfx-one/shared/validators';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
-import { BehaviorSubject, catchError, finalize, forkJoin, map, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, finalize, map, of, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-profile-linux-email',
@@ -65,12 +65,12 @@ export class ProfileLinuxEmailComponent {
   private readonly savedForwardTo = signal<string>('');
 
   // Data signals
-  public data: Signal<LinuxEmailData> = this.initData();
+  public data: Signal<LinuxAliasData | null> = this.initData();
 
   // Derived view state
-  public state = computed(() => this.data().alias?.state ?? null);
-  public domain = computed(() => this.data().alias?.domain ?? '');
-  public email = computed(() => this.data().alias?.email ?? null);
+  public state = computed(() => this.data()?.state ?? null);
+  public domain = computed(() => this.data()?.domain ?? '');
+  public email = computed(() => this.data()?.email ?? null);
 
   // True only when the user has changed the forward-to selection from its saved value.
   public forwardDirty: Signal<boolean> = this.initForwardDirty();
@@ -81,14 +81,14 @@ export class ProfileLinuxEmailComponent {
   // GitHub) are excluded since you can't forward email to them, and the claimed
   // alias is excluded since you can't forward an address to itself.
   public forwardOptions = computed((): LinuxForwardOption[] => {
-    const { alias, emails } = this.data();
+    const alias = this.data();
     const identities = this.identities();
 
     const aliasEmail = alias?.email?.toLowerCase().trim();
     const seen = new Set<string>();
     const options: LinuxForwardOption[] = [];
 
-    const add = (address: string | undefined, isPrimary: boolean): void => {
+    const add = (address: string | null | undefined, isPrimary: boolean): void => {
       const value = address?.toLowerCase().trim();
       if (!value || value === aliasEmail || seen.has(value)) return;
       seen.add(value);
@@ -97,7 +97,7 @@ export class ProfileLinuxEmailComponent {
       options.push({ label: isPrimary ? `${address} (Primary)` : address!, value });
     };
 
-    add(emails?.primary_email, true);
+    add(alias?.primaryEmail, true);
     for (const identity of identities) {
       if (identity.type === 'email' && identity.displayState === 'verified') add(identity.value, false);
     }
@@ -121,17 +121,11 @@ export class ProfileLinuxEmailComponent {
     return this.forwardOptions().some((option) => option.value !== saved);
   });
 
-  // True only on a failed getUserEmails() fetch, not a genuine lack of a primary
-  // email — a successful /api/profile/emails response always has a non-empty
-  // primary_email (server-side fallback), so `emails === null` here only ever
-  // means the request errored (see initData's catchError).
-  public emailsLoadFailed = computed((): boolean => this.data().emails === null);
-
   // Public methods
 
   public purchase(): void {
     if (!isPlatformBrowser(this.platformId)) return;
-    const url = this.data().alias?.purchaseUrl;
+    const url = this.data()?.purchaseUrl;
     if (url) {
       window.open(url, '_blank', 'noopener');
     }
@@ -232,19 +226,21 @@ export class ProfileLinuxEmailComponent {
     });
   }
 
-  private initData(): Signal<LinuxEmailData> {
+  private initData(): Signal<LinuxAliasData | null> {
     return toSignal(
       this.refresh.pipe(
         switchMap(() => {
           this.loading.set(true);
-          return forkJoin({
-            alias: this.userService
-              .getLinuxAlias()
-              .pipe(catchError(() => of<LinuxAliasData | null>({ state: 'service_unavailable', domain: '', alias: null, email: null, forwardTo: null }))),
-            emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
-          }).pipe(
-            tap(({ alias, emails }) => {
-              this.applyFormDefaults(alias, emails);
+          // Single server call: getLinuxAlias reads user_emails.read server-side and
+          // returns the primary email inline, so the tab no longer makes a second
+          // getUserEmails() round-trip for the same data. If it fails, the emails read
+          // failed too, so service_unavailable (whole-tab retry) is the right state.
+          return this.userService.getLinuxAlias().pipe(
+            catchError(() =>
+              of<LinuxAliasData | null>({ state: 'service_unavailable', domain: '', alias: null, email: null, forwardTo: null, primaryEmail: null })
+            ),
+            tap((alias) => {
+              this.applyFormDefaults(alias);
               this.maybeReauthForForward(alias);
               this.maybeShowForwardRecoveryToast(alias);
             }),
@@ -252,7 +248,7 @@ export class ProfileLinuxEmailComponent {
           );
         })
       ),
-      { initialValue: { alias: null, emails: null } }
+      { initialValue: null }
     );
   }
 
@@ -300,8 +296,8 @@ export class ProfileLinuxEmailComponent {
   }
 
   /** Default the forward selection to the current target (if any) or the primary email. */
-  private applyFormDefaults(alias: LinuxAliasData | null, emails: EmailManagementData | null): void {
-    const primary = (emails?.primary_email ?? '').toLowerCase().trim();
+  private applyFormDefaults(alias: LinuxAliasData | null): void {
+    const primary = (alias?.primaryEmail ?? '').toLowerCase().trim();
 
     if (alias?.state === 'claimed') {
       // Select only a real forward target. When it hasn't loaded (re-auth pending, or the

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -567,6 +567,12 @@ export class ProfileController {
         return;
       }
 
+      // Match GET /api/profile/emails (see getEmails): fall back to the session OIDC
+      // email when auth-service omits a primary, so accounts in that gap keep their
+      // primary forward option and claim-form default instead of seeing "no verified email".
+      const sessionEmail = getEffectiveEmail(req) ?? undefined;
+      const primaryEmail = emails.primary_email || sessionEmail || null;
+
       const suffix = `@${domain}`;
       // Scan alternate emails first; also cover the edge case where the claimed alias is the
       // user's primary email, which would otherwise be missed and read as unclaimed.
@@ -609,7 +615,7 @@ export class ProfileController {
           alias,
           email,
           forwardTo: forward?.target_email ?? null,
-          primaryEmail: emails.primary_email ?? null,
+          primaryEmail,
           ...(forwardAuthRequired
             ? {
                 forwardAuthRequired: true,
@@ -633,7 +639,7 @@ export class ProfileController {
       const state = purchased ? 'purchased_unclaimed' : 'not_purchased';
 
       logger.success(req, 'get_linux_alias', startTime, { state });
-      res.json(this.linuxAliasState(state, domain, emails.primary_email ?? null));
+      res.json(this.linuxAliasState(state, domain, primaryEmail));
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -609,6 +609,7 @@ export class ProfileController {
           alias,
           email,
           forwardTo: forward?.target_email ?? null,
+          primaryEmail: emails.primary_email ?? null,
           ...(forwardAuthRequired
             ? {
                 forwardAuthRequired: true,
@@ -632,7 +633,7 @@ export class ProfileController {
       const state = purchased ? 'purchased_unclaimed' : 'not_purchased';
 
       logger.success(req, 'get_linux_alias', startTime, { state });
-      res.json(this.linuxAliasState(state, domain));
+      res.json(this.linuxAliasState(state, domain, emails.primary_email ?? null));
     } catch (error) {
       next(error);
     }
@@ -719,7 +720,11 @@ export class ProfileController {
       }
 
       logger.success(req, 'claim_linux_alias', startTime, { domain });
-      res.status(200).json({ state: 'claimed', domain, alias, email, forwardTo: forward.target_email ?? forwardTo } satisfies LinuxAliasData);
+      // primaryEmail is null here: this handler doesn't read user_emails, and the client
+      // refetches via getLinuxAlias() after a successful claim rather than consuming this body.
+      res
+        .status(200)
+        .json({ state: 'claimed', domain, alias, email, forwardTo: forward.target_email ?? forwardTo, primaryEmail: null } satisfies LinuxAliasData);
     } catch (error) {
       next(error);
     }
@@ -2243,13 +2248,18 @@ export class ProfileController {
   }
 
   /** Build a LinuxAliasData for a non-claimed state (no alias/forward yet). */
-  private linuxAliasState(state: 'not_purchased' | 'purchased_unclaimed' | 'service_unavailable', domain: string): LinuxAliasData {
+  private linuxAliasState(
+    state: 'not_purchased' | 'purchased_unclaimed' | 'service_unavailable',
+    domain: string,
+    primaryEmail: string | null = null
+  ): LinuxAliasData {
     return {
       state,
       domain,
       alias: null,
       email: null,
       forwardTo: null,
+      primaryEmail,
       ...(state === 'not_purchased' ? { purchaseUrl: PURCHASE_LINUX_URL } : {}),
     };
   }

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -3,8 +3,6 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import type { EmailManagementData } from './user-profile.interface';
-
 /**
  * Linux.com (vanity) email alias forwarding.
  *
@@ -22,12 +20,6 @@ import type { EmailManagementData } from './user-profile.interface';
 /** The four states the Linux.com email tab can render. */
 export type LinuxAliasState = 'not_purchased' | 'purchased_unclaimed' | 'claimed' | 'service_unavailable';
 
-/** Aggregate data the Linux.com email tab component renders from. */
-export interface LinuxEmailData {
-  alias: LinuxAliasData | null;
-  emails: EmailManagementData | null;
-}
-
 /** Aggregate state returned by `GET /api/profile/linux-email`. */
 export interface LinuxAliasData {
   state: LinuxAliasState;
@@ -39,6 +31,14 @@ export interface LinuxAliasData {
   email: string | null;
   /** Current forwarding destination, or null when not yet set / not readable without re-auth. */
   forwardTo: string | null;
+  /**
+   * The user's primary verified email, read server-side from the same
+   * `user_emails.read` this endpoint already makes. Lets the tab default the
+   * forward selection and build forward options without a second client fetch.
+   * Null in `service_unavailable` (emails could not be read) or when the account
+   * has no primary email.
+   */
+  primaryEmail: string | null;
   /** membership-ui CTA URL, present only in the `not_purchased` state. */
   purchaseUrl?: string;
   /**


### PR DESCRIPTION
## Summary

- The Linux.com email tab read `user_emails.read` twice per load — once server-side inside `getLinuxAlias`, and again from the client via `getUserEmails` in a `forkJoin`. `getLinuxAlias` already has the emails, so it now returns the primary email inline as `LinuxAliasData.primaryEmail` and the client drops the second round-trip.
- Because the emails read now shares the alias call's failure path, the standalone per-form "emails failed" retry state folds into the whole-tab `service_unavailable` retry. Template branches and E2E specs are updated to match.
- Removes the now-unused `LinuxEmailData` interface.

Part of LFXV2-1663 (PR #857 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)