### PR TITLE
fix(meetings): create toObservable in injection context

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -1300,6 +1300,9 @@ export class MeetingJoinComponent implements OnInit {
     // doesn't block the pageview forever. Sub-projects whose parent doesn't land in time record
     // project_* correctly and leave foundation_* empty (see buildPageviewContext callsite below).
     const PARENT_FETCH_TIMEOUT_MS = 2000;
+    // Created here (injection context) rather than inside the switchMap below — toObservable()
+    // calls inject() internally and throws NG0203 when invoked from an async stream callback.
+    const parentProject$ = toObservable(this.parentProject);
     toObservable(this.project)
       .pipe(
         filter((p): p is Partial<Project> => !!p?.slug),
@@ -1308,7 +1311,7 @@ export class MeetingJoinComponent implements OnInit {
             return of({ project, parent: null as Project | null });
           }
           return merge(
-            toObservable(this.parentProject).pipe(
+            parentProject$.pipe(
               filter((parent): parent is Project => !!parent),
               map((parent) => ({ project, parent: parent as Project | null }))
             ),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -1303,25 +1303,29 @@ export class MeetingJoinComponent implements OnInit {
     // Created here (injection context) rather than inside the switchMap below — toObservable()
     // calls inject() internally and throws NG0203 when invoked from an async stream callback.
     const parentProject$ = toObservable(this.parentProject);
-    toObservable(this.project)
-      .pipe(
-        filter((p): p is Partial<Project> => !!p?.slug),
-        switchMap((project) => {
-          if (!project.parent_uid) {
-            return of({ project, parent: null as Project | null });
-          }
-          return merge(
-            parentProject$.pipe(
-              filter((parent): parent is Project => !!parent),
-              map((parent) => ({ project, parent: parent as Project | null }))
-            ),
-            timer(PARENT_FETCH_TIMEOUT_MS).pipe(map(() => ({ project, parent: null as Project | null })))
-          );
-        }),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(({ project, parent }) => {
+    const pageviewContext$ = toObservable(this.project).pipe(
+      filter((p): p is Partial<Project> => !!p?.slug),
+      switchMap((project) => {
+        if (!project.parent_uid) {
+          return of({ project, parent: null as Project | null });
+        }
+        return merge(
+          parentProject$.pipe(
+            filter((parent): parent is Project => !!parent),
+            map((parent) => ({ project, parent: parent as Project | null }))
+          ),
+          timer(PARENT_FETCH_TIMEOUT_MS).pipe(map(() => ({ project, parent: null as Project | null })))
+        );
+      }),
+      take(1)
+    );
+    // trackPage() silently drops calls made before the Plausible script executes, and this route's
+    // pageview is deferred to this component — hold the single emission until the script is ready
+    // instead of losing the pageview when project context resolves faster than the script loads.
+    const analyticsReady$ = toObservable(this.plausibleService.ready).pipe(filter(Boolean));
+    combineLatest([pageviewContext$, analyticsReady$])
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(([{ project, parent }]) => {
         const isTopLevel = !project.parent_uid;
         this.plausibleService.trackPage(
           PlausibleService.buildPageviewContext({

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, DestroyRef, inject, Injectable } from '@angular/core';
+import { afterNextRender, DestroyRef, inject, Injectable, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
@@ -29,8 +29,11 @@ export class PlausibleService {
   private static readonly deferredPageviewPattern = /^\/meetings\/\d+(-\d{13})?$/;
 
   private scriptLoaded = false;
-  private analyticsReady = false;
+  private readonly analyticsReady = signal(false);
   private impersonating = false;
+
+  /** True once the Plausible script has executed. Owners of deferred pageviews (deferredPageviewPattern routes) must gate on this before calling trackPage() — calls made earlier are silently dropped. */
+  public readonly ready = this.analyticsReady.asReadonly();
 
   /**
    * Enable or disable analytics suppression for the current session.
@@ -57,7 +60,7 @@ export class PlausibleService {
 
   // Auto-prepends sanitized path/url/title — callers only supply context.
   public trackPage(context?: PlausiblePageviewContext): void {
-    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !window.plausible) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady() || !window.plausible) {
       return;
     }
 
@@ -98,7 +101,7 @@ export class PlausibleService {
    * @param properties Event properties
    */
   public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
-    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !window.plausible) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady() || !window.plausible) {
       return;
     }
 
@@ -145,7 +148,7 @@ export class PlausibleService {
       // analyticsReady is gated on the real script loading — onload fires
       // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
-        this.analyticsReady = true;
+        this.analyticsReady.set(true);
         if (PlausibleService.deferredPageviewPattern.test(window.location.pathname)) {
           return;
         }


### PR DESCRIPTION
## Summary

Fixes the production `NG0203` error tracked in [Datadog](https://app.datadoghq.com/error-tracking/issue/a2bb2f98-6bcb-11f1-86a8-da7ad0900002) — ~1,970 occurrences in the last 30 days, 100% on the public meeting join page (`/meetings/:id`).

**Root cause:** `initializePublicMeetingPageviewTracking()` created `toObservable(this.parentProject)` inside a `switchMap` callback. That callback runs asynchronously when the project signal emits — outside Angular's injection context — and `toObservable()` without an `{injector}` option calls `inject(Injector)` internally, throwing `NG0203`. The failing branch only executes when the project has a `parent_uid`, so the error fired on every public meeting page view for a **sub-project** and never for top-level projects (confirmed by de-minifying the production stack trace to this exact call).

**Impact beyond the error noise:** the unhandled throw killed the tracking stream, so the Plausible pageview event silently never fired for sub-project meetings (since #709).

**Fix:** hoist the `toObservable(this.parentProject)` creation out of the `switchMap` into the constructor-time injection context. Replay semantics are equivalent — signals have no history, so the shared `ReplaySubject(1)`-backed observable emits the same latest value a per-callback creation would have.

## Ticket

[LFXV2-2839](https://linuxfoundation.atlassian.net/browse/LFXV2-2839)

## Testing

- `yarn check-types`, `yarn lint`, `yarn build` all pass (build exercises the SSR bundle)
- Post-commit review pass returned clean, including verification of effect-lifetime / replay semantics of the eager hoist

[LFXV2-2839]: https://linuxfoundation.atlassian.net/browse/LFXV2-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ