### PR TITLE
feat(create): rebuild picker as lazy direct-grant tree + search

### DIFF
--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -5,14 +5,15 @@
  * Create Quick-Link E2E — smoke set.
  *
  * Exercises the rail "Create" button → type popover → target-picker dialog (LFXV2-2838 rebuild).
- * Rail visibility is driven by CreatePermissionService, which now probes
- * `GET /api/create-picker/tree` (direct-grant projects/committees only) instead of the old
- * full `GET /api/projects` pull. The eligible targets are the authenticated test user's real
- * direct grants, so these tests assert structure/behavior rather than specific project names,
- * and skip entirely when the user has no create permission (the button is hidden).
+ * The rail button and its menu are unconditional — `CreatePermissionService` no longer gates
+ * either on any eligibility probe, since a probe that could say "no" would hide the button (or
+ * empty the menu behind it) for exactly the inherited-writer/committee-only users this rebuild
+ * exists to serve. The create-target picker's own fail-closed empty state is the real signal for
+ * "nothing to create here" now, so `skipWhenNoCreatePermission` opens the Meeting picker itself
+ * and skips only if that empty state is what renders — never the button's own visibility.
  *
  * Coverage map:
- * - S1: rail "Create" button renders for a create-capable user
+ * - S1: rail "Create" button renders (unconditional; a basic smoke check that the button exists at all)
  * - S2: clicking it opens a popover listing the six artifact types, in grouped order, with descriptions
  * - S3: picking a type opens the dialog (header + target picker) with Continue disabled,
  *       and picking a direct-grant tree row enables Continue
@@ -42,8 +43,9 @@
  * Prerequisites:
  * - Dev server reachable at the Playwright baseURL
  * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
- * - The test user must hold a direct grant on at least one project or committee for S1–S3 to
- *   run; otherwise the suite skips (no create permission → no button, by design).
+ * - The test user must hold a direct grant on, or be search-reachable to, at least one project or
+ *   committee for the suite to run past `beforeEach`; otherwise it skips (see
+ *   `skipWhenNoCreatePermission`).
  *
  * Note: this suite stops at the dialog boundary. It does not assert the post-Continue
  * create page — that path is enforced by each route's writerGuard.
@@ -69,12 +71,22 @@ function skipWhenAuthMissing(page: Page): void {
   }
 }
 
-// Skip when the test user has no create permission — the button is intentionally absent.
+// Skip when the test user has no writable target at all. The rail button and its menu are now
+// unconditional by design (CreatePermissionService no longer gates on any eligibility probe —
+// the picker's own empty state is the real signal), so this opens the Meeting picker itself and
+// skips only if neither a tree row nor a real target ever renders — just the empty state.
 async function skipWhenNoCreatePermission(page: Page): Promise<void> {
-  const trigger = page.getByTestId('create-rail-button');
-  const visible = await trigger.isVisible().catch(() => false);
-  if (!visible) {
-    test.skip(true, 'Test user holds no direct-grant project or committee — button hidden by design.');
+  await openDialogForType(page, 'meeting');
+
+  const firstNode = pickerResults(page).locator('[data-testid^="create-target-node-"]').first();
+  const emptyState = page.getByTestId('create-target-empty-state');
+  await expect(firstNode.or(emptyState)).toBeVisible({ timeout: 10_000 });
+
+  const isEmpty = await emptyState.isVisible().catch(() => false);
+  await page.getByTestId('create-artifact-cancel-button').click();
+
+  if (isEmpty) {
+    test.skip(true, 'Test user holds no direct-grant or search-reachable project/committee.');
   }
 }
 
@@ -103,16 +115,11 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
-    // Give the direct-grant probe a moment to resolve before gating.
-    await page
-      .getByTestId('create-rail-button')
-      .waitFor({ state: 'visible', timeout: RAIL_TIMEOUT })
-      .catch(() => undefined);
     await skipWhenNoCreatePermission(page);
   });
 
-  // S1 — rail button renders for a create-capable user
-  test('S1: the rail "Create" button is visible for a create-capable user', async ({ page }) => {
+  // S1 — rail button renders (basic smoke check; visibility is unconditional by design)
+  test('S1: the rail "Create" button is visible', async ({ page }) => {
     await expect(page.getByTestId('create-rail-button')).toBeVisible({ timeout: RAIL_TIMEOUT });
   });
 

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -4,30 +4,46 @@
 /**
  * Create Quick-Link E2E — smoke set.
  *
- * Exercises the rail "Create" button → type popover → project-selection dialog.
- * Visibility is driven by CreatePermissionService, which derives create
- * capability from the project `writer` grant returned by GET /api/projects. The
- * eligible projects are therefore the authenticated test user's real grants, so
- * these tests assert structure/behavior rather than specific project names, and
- * skip entirely when the user has no create permission (the button is hidden).
+ * Exercises the rail "Create" button → type popover → target-picker dialog (LFXV2-2838 rebuild).
+ * Rail visibility is driven by CreatePermissionService, which now probes
+ * `GET /api/create-picker/tree` (direct-grant projects/committees only) instead of the old
+ * full `GET /api/projects` pull. The eligible targets are the authenticated test user's real
+ * direct grants, so these tests assert structure/behavior rather than specific project names,
+ * and skip entirely when the user has no create permission (the button is hidden).
  *
  * Coverage map:
  * - S1: rail "Create" button renders for a create-capable user
  * - S2: clicking it opens a popover listing the six artifact types, in grouped order, with descriptions
- * - S3: picking a type opens the dialog (header + project selector) with Continue disabled,
- *       and choosing an eligible project via the selector enables Continue
- * - S4: the dialog's project selector reuses the sidebar pattern (search + All/Foundations/Projects
- *       tabs) and renders a selectable list. Writer-scoping of that list is guaranteed by the dialog
- *       feeding the curated `creatableProjects` (verified in production-code review), not asserted here.
- * - S5: a single eligible project is auto-selected on open (Continue enabled without a pick); with
- *       multiple eligible projects nothing is pre-selected and Continue stays gated until the user picks
- * - S6: Continue routes into the create flow — lands on the lens-prefixed create URL carrying ?project=<slug>
+ * - S3: picking a type opens the dialog (header + target picker) with Continue disabled,
+ *       and picking a direct-grant tree row enables Continue
+ * - S4: the picker's default view is the direct-grant tree (search input + at least one
+ *       selectable row) — replaces the old project-selector's search + All/Foundations/Projects
+ *       tabs, which this rebuild removes from the create path entirely
+ * - S5: Continue starts disabled on open and stays disabled until an explicit pick is made — the
+ *       old "auto-select the sole eligible project" behavior is intentionally dropped: the tree
+ *       no longer knows the full eligible set upfront (that was the enumeration this ticket
+ *       removes), so there is nothing to safely auto-select
+ * - S6: Continue routes into the create flow — lands on the lens-prefixed create URL carrying
+ *       ?project=<slug>. `setContextLens()` replaces `setLens()`'s persona-gated alignment but
+ *       preserves the same external URL-prefix contract, so this assertion is unchanged
+ * - S7: typing a nonsense search term (≥2 chars) surfaces the fail-closed empty state — no
+ *       post-selection permission error is possible because the empty state renders before any
+ *       row could be picked
+ * - S8: typing a real search term switches the picker from the tree view to search results
+ *
+ * What this suite does NOT attempt: a deterministic "inherited-writer reachable only via search"
+ * or "committee target selectable for meeting but not newsletter" scenario. Both require a
+ * fixture user with a specific, known grant shape (direct grants on some resources but not
+ * others) that this suite's single real `TEST_USERNAME`/`TEST_PASSWORD` account cannot
+ * guarantee — consistent with this file's existing real-API, name-agnostic approach, it asserts
+ * on picker *shape* (search works, empty state fails closed, tree vs. search toggle) rather than
+ * a specific grant fixture it doesn't control.
  *
  * Prerequisites:
  * - Dev server reachable at the Playwright baseURL
  * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
- * - The test user must hold `writer` on at least one project for S1–S3 to run;
- *   otherwise the suite skips (no create permission → no button, by design).
+ * - The test user must hold a direct grant on at least one project or committee for S1–S3 to
+ *   run; otherwise the suite skips (no create permission → no button, by design).
  *
  * Note: this suite stops at the dialog boundary. It does not assert the post-Continue
  * create page — that path is enforced by each route's writerGuard.
@@ -58,7 +74,7 @@ async function skipWhenNoCreatePermission(page: Page): Promise<void> {
   const trigger = page.getByTestId('create-rail-button');
   const visible = await trigger.isVisible().catch(() => false);
   if (!visible) {
-    test.skip(true, 'Test user holds `writer` on no project — button hidden by design.');
+    test.skip(true, 'Test user holds no direct-grant project or committee — button hidden by design.');
   }
 }
 
@@ -79,11 +95,15 @@ function continueButton(page: Page): Locator {
   return page.getByTestId('create-artifact-continue-button').locator('button');
 }
 
+function pickerResults(page: Page): Locator {
+  return page.getByTestId('create-target-results');
+}
+
 test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
-    // Give writer-driven visibility a moment to resolve before gating.
+    // Give the direct-grant probe a moment to resolve before gating.
     await page
       .getByTestId('create-rail-button')
       .waitFor({ state: 'visible', timeout: RAIL_TIMEOUT })
@@ -117,91 +137,76 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     await expect(page.getByTestId('create-menu-option-meeting')).toContainText('Schedule a recurring or one-time meeting');
   });
 
-  // S3 — picking a project via the selector enables Continue. (On-open enabled/disabled state is S5's
-  // job; asserting "disabled on open" here would be wrong for a single-eligible-project account, where
-  // the dialog auto-selects and Continue is already enabled.)
-  test('S3: picking "Meeting" opens the dialog and choosing a project enables Continue', async ({ page }) => {
+  // S3 — picking a direct-grant tree row enables Continue
+  test('S3: picking "Meeting" opens the dialog and picking a tree row enables Continue', async ({ page }) => {
     await openDialogForType(page, 'meeting');
 
-    // Open the reused project-selector (same UI as the sidebar). Scope the trigger to the dialog —
-    // the same `project-selector` testid is emitted by the sidebar's instance in project/foundation lens.
-    const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
-    const panel = page.getByTestId('project-selector-panel');
-    await expect(panel).toBeVisible({ timeout: 5_000 });
-    const firstItem = panel.locator('[data-testid^="lens-item-"]').first();
-    await expect(firstItem).toBeVisible({ timeout: 5_000 });
-    await firstItem.click();
+    const firstNode = pickerResults(page).locator('[data-testid^="create-target-node-"]').first();
+    await expect(firstNode).toBeVisible({ timeout: 10_000 });
+    await firstNode.click();
 
     await expect(continueButton(page)).toBeEnabled();
   });
 
-  // S4 — the project selector reuses the sidebar pattern (search + tabs) and renders the writer-scoped list
-  test('S4: the project selector reuses the search + tabs pattern and renders selectable projects', async ({ page }) => {
+  // S4 — the default view is the direct-grant tree: search input + at least one selectable row
+  test('S4: the picker opens on the direct-grant tree with a search input and selectable rows', async ({ page }) => {
     await openDialogForType(page, 'meeting');
 
-    // Scope the trigger to the dialog — the sidebar renders the same `project-selector` testid in project/foundation lens.
-    const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
-    const panel = page.getByTestId('project-selector-panel');
-    await expect(panel).toBeVisible({ timeout: 5_000 });
-
-    // Familiar sidebar pattern: search input + All/Foundations/Projects tabs.
-    await expect(panel.getByTestId('project-search-input')).toBeVisible();
-    await expect(panel.getByRole('button', { name: 'All', exact: true })).toBeVisible();
-    await expect(panel.getByRole('button', { name: 'Foundations', exact: true })).toBeVisible();
-    await expect(panel.getByRole('button', { name: 'Projects', exact: true })).toBeVisible();
-
-    // The list is the dialog's writer-scoped `creatableProjects` (fed via the selector's curated `items`
-    // input), never the view-scoped nav catalog. Assert on the selector's contract — a non-empty set of
-    // selectable lens items — rather than hardcoding prod catalog names: this suite is real-API and
-    // name-agnostic (see file docstring + testing-best-practices "assert on shape, not fixtures").
-    await expect(panel.locator('[data-testid^="lens-item-"]').first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('create-target-search-input')).toBeVisible();
+    await expect(pickerResults(page).locator('[data-testid^="create-target-node-"]').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  // S5 — auto-select single: a lone eligible project is pre-selected so Continue is enabled without a pick
-  test('S5: a single eligible project is auto-selected; multiple require an explicit pick', async ({ page }) => {
+  // S5 — no auto-select: Continue starts disabled and stays disabled until an explicit pick
+  test('S5: Continue starts disabled and requires an explicit pick — no auto-select', async ({ page }) => {
     await openDialogForType(page, 'meeting');
-    const dialog = page.getByTestId('create-artifact-dialog');
-    const trigger = dialog.getByTestId('project-selector');
 
-    // Count eligible options, then toggle the panel closed via the trigger (Escape could close the dialog).
-    await trigger.click();
-    const panel = page.getByTestId('project-selector-panel');
-    await expect(panel).toBeVisible({ timeout: 5_000 });
-    const itemCount = await panel.locator('[data-testid^="lens-item-"]').count();
-    await trigger.click();
-    await expect(panel).toBeHidden();
+    await expect(continueButton(page)).toBeDisabled();
 
-    if (itemCount === 1) {
-      // Auto-selected on open — no manual pick needed.
-      await expect(continueButton(page)).toBeEnabled();
-    } else {
-      // Multiple options: nothing pre-selected, Continue gated until the user picks.
-      await expect(continueButton(page)).toBeDisabled();
-    }
+    const firstNode = pickerResults(page).locator('[data-testid^="create-target-node-"]').first();
+    await expect(firstNode).toBeVisible({ timeout: 10_000 });
+    await firstNode.click();
+
+    await expect(continueButton(page)).toBeEnabled();
   });
 
-  // S6 — Continue exercises the create-navigation path: lands on the lens-prefixed create URL carrying ?project=<slug>
-  test('S6: Continue navigates to the create page carrying the selected project slug', async ({ page }) => {
+  // S6 — Continue exercises the create-navigation path: lands on the lens-prefixed create URL
+  test('S6: Continue navigates to the lens-prefixed create page carrying ?project=', async ({ page }) => {
     await openDialogForType(page, 'meeting');
-    const dialog = page.getByTestId('create-artifact-dialog');
-    await dialog.getByTestId('project-selector').click();
-    const panel = page.getByTestId('project-selector-panel');
-    await expect(panel).toBeVisible({ timeout: 5_000 });
 
-    // Capture the picked project's slug from its data-testid (`lens-item-<slug>`).
-    const firstItem = panel.locator('[data-testid^="lens-item-"]').first();
-    await expect(firstItem).toBeVisible({ timeout: 5_000 });
-    const slug = (await firstItem.getAttribute('data-testid'))?.replace('lens-item-', '') ?? '';
-    expect(slug).not.toBe('');
-    await firstItem.click();
+    const firstNode = pickerResults(page).locator('[data-testid^="create-target-node-"]').first();
+    await expect(firstNode).toBeVisible({ timeout: 10_000 });
+    await firstNode.click();
 
     await continueButton(page).click();
 
-    // onContinue aligns the lens then navigates; lensRedirectGuard forwards to the lens-prefixed mount,
-    // preserving ?project=. Require the lens prefix explicitly (foundation|project) — a bare
-    // /meetings/create would mean setLens/lensRedirectGuard didn't run, so it must NOT match.
-    await expect(page).toHaveURL(new RegExp(`/(foundation|project)/meetings/create\\?.*project=${slug}`), { timeout: 15_000 });
+    // onContinue calls setContextLens() then navigates; lensRedirectGuard-equivalent prefixing is
+    // preserved by construction (setContextLens aligns the same underlying signal setLens did).
+    // Require the lens prefix explicitly (foundation|project) — a bare /meetings/create would mean
+    // the alignment didn't happen, so it must NOT match.
+    await expect(page).toHaveURL(/\/(foundation|project)\/meetings\/create\?.*project=/, { timeout: 15_000 });
+  });
+
+  // S7 — fail-closed empty state: a nonsense search term surfaces "no matches", not an error
+  test('S7: an unmatched search term shows the fail-closed empty state', async ({ page }) => {
+    await openDialogForType(page, 'meeting');
+
+    await page.getByTestId('create-target-search-input').fill('zzzznonexistentqueryzzzz');
+    await expect(page.getByTestId('create-target-empty-state')).toBeVisible({ timeout: 10_000 });
+    // No row could have been picked, so Continue never becomes enabled from this state.
+    await expect(continueButton(page)).toBeDisabled();
+  });
+
+  // S8 — typing ≥2 chars switches the picker from the tree to search results
+  test('S8: typing a search term switches the picker from tree to search results', async ({ page }) => {
+    await openDialogForType(page, 'meeting');
+
+    const searchInput = page.getByTestId('create-target-search-input');
+    await searchInput.fill('a');
+    // Single char: still the tree, not search — a tree node row is still identifiable.
+    await searchInput.fill('an');
+    // ≥2 chars: search mode. Either a result row or the empty state renders, never both absent.
+    await expect(pickerResults(page).locator('[data-testid^="create-target-search-result-"], [data-testid="create-target-empty-state"]').first()).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -31,21 +31,28 @@
  *       post-selection permission error is possible because the empty state renders before any
  *       row could be picked
  * - S8: typing a real search term switches the picker from the tree view to search results
+ * - S9: (separate describe block, own beforeEach — no shared skipWhenNoCreatePermission gate)
+ *       when the direct-grant tree is empty for the test account, a real search must still surface
+ *       a writable target — the exact inherited-writer/search-fallback path this rebuild exists
+ *       for. Self-skips (not the whole suite) if this account isn't currently in the
+ *       empty-tree/search-reachable bucket, since that shape isn't guaranteed by a single real
+ *       account — but when it is, this exercises the path directly rather than only asserting
+ *       picker shape.
  *
- * What this suite does NOT attempt: a deterministic "inherited-writer reachable only via search"
- * or "committee target selectable for meeting but not newsletter" scenario. Both require a
- * fixture user with a specific, known grant shape (direct grants on some resources but not
- * others) that this suite's single real `TEST_USERNAME`/`TEST_PASSWORD` account cannot
- * guarantee — consistent with this file's existing real-API, name-agnostic approach, it asserts
- * on picker *shape* (search works, empty state fails closed, tree vs. search toggle) rather than
- * a specific grant fixture it doesn't control.
+ * What this suite does NOT attempt: a deterministic "committee target selectable for meeting but
+ * not newsletter" scenario. That requires a fixture user with a specific, known grant shape
+ * (committee-only writer with no project grant) that this suite's single real
+ * `TEST_USERNAME`/`TEST_PASSWORD` account cannot guarantee — consistent with this file's existing
+ * real-API, name-agnostic approach, it asserts on picker *shape* (search works, empty state fails
+ * closed, tree vs. search toggle) rather than a specific grant fixture it doesn't control.
  *
  * Prerequisites:
  * - Dev server reachable at the Playwright baseURL
  * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
  * - The test user must hold a direct grant on, or be search-reachable to, at least one project or
- *   committee for the suite to run past `beforeEach`; otherwise it skips (see
- *   `skipWhenNoCreatePermission`).
+ *   committee for S1-S8 to run past `beforeEach`; otherwise they skip (see
+ *   `skipWhenNoCreatePermission`). S9 lives in its own describe block with a lighter beforeEach
+ *   and self-skips independently — see its inline comment.
  *
  * Note: this suite stops at the dialog boundary. It does not assert the post-Continue
  * create page — that path is enforced by each route's writerGuard.
@@ -220,5 +227,41 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     await expect(pickerResults(page).locator('[data-testid^="create-target-search-result-"], [data-testid="create-target-empty-state"]').first()).toBeVisible({
       timeout: 10_000,
     });
+  });
+});
+
+test.describe('Create Quick-Link — search-fallback for an inherited-writer (LFXV2-2838)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+  });
+
+  // S9 — the direct-grant tree can legitimately under-show an inherited-writer user by design;
+  // search must still surface their target. Deliberately outside the shared beforeEach above (no
+  // skipWhenNoCreatePermission gate) since it specifically needs the case that gate excludes: an
+  // empty tree.
+  test('S9: an inherited-writer with an empty direct-grant tree still finds their target via search', async ({ page }) => {
+    await openDialogForType(page, 'meeting');
+
+    const firstNode = pickerResults(page).locator('[data-testid^="create-target-node-"]').first();
+    const treeEmptyState = page.getByTestId('create-target-empty-state');
+    await expect(firstNode.or(treeEmptyState)).toBeVisible({ timeout: 10_000 });
+
+    const treeIsEmpty = await treeEmptyState.isVisible().catch(() => false);
+    if (!treeIsEmpty) {
+      test.skip(true, 'Test user has a direct-grant tree row — this test only covers the empty-tree/search-only path.');
+    }
+
+    await page.getByTestId('create-target-search-input').fill('on');
+    const searchResult = pickerResults(page).locator('[data-testid^="create-target-search-result-"]').first();
+    const searchEmptyState = page.getByTestId('create-target-empty-state');
+    await expect(searchResult.or(searchEmptyState)).toBeVisible({ timeout: 10_000 });
+
+    if (!(await searchResult.isVisible().catch(() => false))) {
+      test.skip(true, 'Test user has no search-reachable target either — cannot exercise the search-fallback path with this account.');
+    }
+
+    await searchResult.click();
+    await expect(continueButton(page)).toBeEnabled();
   });
 });

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -184,6 +184,10 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     // Require the lens prefix explicitly (foundation|project) — a bare /meetings/create would mean
     // the alignment didn't happen, so it must NOT match.
     await expect(page).toHaveURL(/\/(foundation|project)\/meetings\/create\?.*project=/, { timeout: 15_000 });
+    // The regex above matches `project=` with an empty value too — assert the param actually
+    // carries a usable slug, since an empty one is exactly what a mis-resolved target would produce.
+    const project = new URL(page.url()).searchParams.get('project');
+    expect(project).toBeTruthy();
   });
 
   // S7 — fail-closed empty state: a nonsense search term surfaces "no matches", not an error
@@ -203,6 +207,7 @@ test.describe('Create Quick-Link — rail popover + dialog smoke set', () => {
     const searchInput = page.getByTestId('create-target-search-input');
     await searchInput.fill('a');
     // Single char: still the tree, not search — a tree node row is still identifiable.
+    await expect(pickerResults(page).locator('[data-testid^="create-target-node-"]').first()).toBeVisible();
     await searchInput.fill('an');
     // ≥2 chars: search mode. Either a result row or the empty state renders, never both absent.
     await expect(pickerResults(page).locator('[data-testid^="create-target-search-result-"], [data-testid="create-target-empty-state"]').first()).toBeVisible({

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -19,7 +19,11 @@
       Select Foundation/Project/Group
       <span class="text-red-500">*</span>
     </label>
-    <lfx-create-target-picker [artifactType]="artifact.type" (targetSelected)="onTargetSelected($event)" data-testid="create-artifact-target-picker" />
+    <lfx-create-target-picker
+      [artifactType]="artifact.type"
+      [selectedTarget]="selectedTarget()"
+      (targetSelected)="onTargetSelected($event)"
+      data-testid="create-artifact-target-picker" />
   </div>
 
   <!-- Actions -->

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -16,7 +16,7 @@
   <!-- Target picker: lazy direct-grant tree by default, type-ahead search on ≥2 chars (LFXV2-2838) -->
   <div class="flex flex-col gap-1">
     <label class="text-sm text-gray-900">
-      Select Foundation/Project/Group
+      {{ targetLabel }}
       <span class="text-red-500">*</span>
     </label>
     <lfx-create-target-picker

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -14,18 +14,18 @@
   </div>
 
   <!-- Target picker: lazy direct-grant tree by default, type-ahead search on ≥2 chars (LFXV2-2838) -->
-  <div class="flex flex-col gap-1">
-    <label class="text-sm text-gray-900">
+  <fieldset class="flex flex-col gap-1 border-0 m-0 p-0">
+    <legend class="text-sm text-gray-900 p-0">
       {{ targetLabel }}
       <span class="text-red-500">*</span>
-    </label>
+    </legend>
     <lfx-create-target-picker
       [artifactType]="artifact.type"
       [selectedTarget]="selectedTarget()"
       (targetSelected)="onTargetSelected($event)"
       (selectionCleared)="onSelectionCleared()"
       data-testid="create-artifact-target-picker" />
-  </div>
+  </fieldset>
 
   <!-- Actions -->
   <div class="flex justify-end gap-3" data-testid="create-artifact-modal-actions">

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<form [formGroup]="form" (ngSubmit)="onContinue()" class="flex flex-col gap-4" data-testid="create-artifact-dialog">
+<div class="flex flex-col gap-4" data-testid="create-artifact-dialog">
   <!-- Header: neutral type icon + "Create <Type>" + description -->
   <div class="flex items-start gap-3" data-testid="create-artifact-summary">
     <div class="w-10 h-10 rounded-lg flex-shrink-0 flex items-center justify-center bg-gray-100 text-gray-500">
@@ -13,28 +13,24 @@
     </div>
   </div>
 
-  <!-- Foundation / project — reuses the sidebar project-selector (search + All/Foundations/Projects tabs,
-       logos, role badges). Fed the writer-scoped `selectorItems` via the curated `items` input so the list
-       is only projects the user holds `writer` on, not the view-scoped nav catalog. -->
+  <!-- Target picker: lazy direct-grant tree by default, type-ahead search on ≥2 chars (LFXV2-2838) -->
   <div class="flex flex-col gap-1">
     <label class="text-sm text-gray-900">
-      Select Foundation/Project
+      Select Foundation/Project/Group
       <span class="text-red-500">*</span>
     </label>
-    <lfx-project-selector
-      [lens]="'project'"
-      [hybridMode]="true"
-      [items]="selectorItems()"
-      [selectedProject]="selectedContext()"
-      searchPlaceholder="Search foundations and projects..."
-      emptyMessage="No foundations or projects available"
-      (itemSelected)="onItemSelected($event)"
-      data-testid="create-artifact-project-select" />
+    <lfx-create-target-picker [artifactType]="artifact.type" (targetSelected)="onTargetSelected($event)" data-testid="create-artifact-target-picker" />
   </div>
 
   <!-- Actions -->
   <div class="flex justify-end gap-3" data-testid="create-artifact-modal-actions">
     <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" type="button" (onClick)="cancel()" data-testid="create-artifact-cancel-button" />
-    <lfx-button [label]="createLabel" [disabled]="form.invalid" size="small" type="submit" data-testid="create-artifact-continue-button" />
+    <lfx-button
+      [label]="createLabel"
+      [disabled]="!canContinue()"
+      size="small"
+      type="button"
+      (onClick)="onContinue()"
+      data-testid="create-artifact-continue-button" />
   </div>
-</form>
+</div>

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.html
@@ -23,6 +23,7 @@
       [artifactType]="artifact.type"
       [selectedTarget]="selectedTarget()"
       (targetSelected)="onTargetSelected($event)"
+      (selectionCleared)="onSelectionCleared()"
       data-testid="create-artifact-target-picker" />
   </div>
 

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
@@ -2,21 +2,26 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, signal, Signal, WritableSignal } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
+import { CreateTargetPickerComponent } from '@components/create-target-picker/create-target-picker.component';
 import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
-import { CreatableArtifactConfig, CreatableArtifactType, CreatableProject, LensItem, ProjectContext } from '@lfx-one/shared/interfaces';
-import { CreatePermissionService } from '@services/create-permission.service';
+import { CreatableArtifactConfig, CreatableArtifactType, CreatePickerNode, ProjectContext } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
+/**
+ * Create-flow target picker dialog (LFXV2-2838 rebuild). Resolves the create target explicitly
+ * from the picker's selection — a pre-authorized project or committee row (direct-grant tree or
+ * batch-access-checked search result) — rather than curating a writer-scoped project list and
+ * gating navigation on whether the current persona happens to hold a matching lens. There is no
+ * "you don't have access" dead end here: every row the picker renders already passed an access
+ * check, so a selection is always safe to act on.
+ */
 @Component({
   selector: 'lfx-create-artifact-dialog',
-  imports: [ReactiveFormsModule, ProjectSelectorComponent, ButtonComponent],
+  imports: [CreateTargetPickerComponent, ButtonComponent],
   templateUrl: './create-artifact-dialog.component.html',
 })
 export class CreateArtifactDialogComponent {
@@ -24,108 +29,48 @@ export class CreateArtifactDialogComponent {
   private readonly config = inject(DynamicDialogConfig);
   private readonly router = inject(Router);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly createPermissionService = inject(CreatePermissionService);
   private readonly lensService = inject(LensService);
-  private readonly messageService = inject(MessageService);
 
   // The artifact type is chosen in the rail popover and handed to the dialog as data;
-  // this dialog only resolves the project/foundation for that fixed type.
+  // this dialog only resolves the project/committee target for that fixed type.
   protected readonly artifact: CreatableArtifactConfig = this.resolveArtifact();
 
   // Header + primary CTA copy, e.g. "Create Meeting".
   protected readonly createLabel = `Create ${this.artifact.label}`;
 
-  protected readonly form = new FormGroup({
-    project: new FormControl<string | null>(null, { validators: [Validators.required] }),
-  });
+  protected readonly selectedTarget: WritableSignal<CreatePickerNode | null> = signal<CreatePickerNode | null>(null);
+  protected readonly canContinue: Signal<boolean> = computed(() => this.selectedTarget() !== null);
 
-  // The picked project — drives the selector's trigger label/checkmark. Set on itemSelected.
-  protected readonly selectedContext: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
-
-  // Reactive by reference: the rail button only renders once this list is non-empty, so the
-  // dialog always opens populated — but reading the signal keeps it correct if it widens
-  // (e.g. persona data resolving and unlocking another lens) while the dialog is open.
-  protected readonly projectOptions: Signal<CreatableProject[]> = this.createPermissionService.creatableProjects;
-
-  // Writer-scoped options mapped to the selector's `LensItem` shape. Feeding this as the selector's
-  // curated `items` input keeps the list scoped to projects the user holds `writer` on — never the
-  // view-scoped NavigationService catalog the sidebar selector pulls by default.
-  protected readonly selectorItems: Signal<LensItem[]> = computed(() =>
-    this.projectOptions().map((project) => ({
-      uid: project.uid,
-      slug: project.slug,
-      name: project.name,
-      logoUrl: project.logoUrl ?? null,
-      isFoundation: project.isFoundation,
-    }))
-  );
-
-  public constructor() {
-    // Auto-select when the user can create on exactly one project/foundation: pre-fill the choice so the
-    // dialog opens with Continue enabled and the picker just shows the locked-in row — no redundant
-    // open-and-pick for a list of one. The rail button only renders once the list is non-empty, so this
-    // reflects the state the dialog opened in; if it later widens (persona data resolving), the user can
-    // still change the selection via the selector.
-    const options = this.projectOptions();
-    if (options.length === 1) {
-      this.applySelection(options[0]);
-    }
-  }
-
-  /** Bridge the selector's `itemSelected` output into the form control that gates the Continue CTA. */
-  public onItemSelected(item: LensItem): void {
-    this.applySelection(this.projectOptions().find((option) => option.uid === item.uid) ?? null);
+  public onTargetSelected(node: CreatePickerNode): void {
+    this.selectedTarget.set(node);
   }
 
   public onContinue(): void {
-    const projectUid = this.form.controls.project.value;
-    if (!projectUid) {
+    const target = this.selectedTarget();
+    if (!target) {
       return;
     }
 
-    // The options are a live signal, so the selection can disappear mid-dialog if the list
-    // narrows (e.g. a persona refresh dropping a lens) while the form control keeps the old uid.
-    const project = this.projectOptions().find((option) => option.uid === projectUid);
-    if (!project) {
-      this.failWith('That project is no longer available. Please choose another.');
-      return;
-    }
+    // Aligns `activeContext`'s lens-gated slot and the route prefix to the picked target's kind,
+    // WITHOUT the persona-allowed-lens rejection `setLens()` applies elsewhere — the picker
+    // already proved access to this specific target, so gating on the persona's lens set here
+    // would only reject legitimate, already-authorized picks. See LensService.setContextLens.
+    this.lensService.setContextLens(target.isFoundation ? 'foundation' : 'project');
 
-    const context: ProjectContext = this.toContext(project);
-
-    // `activeContext` is lens-gated: under `me`/`org` it reads the slot matching the user's
-    // *persona*, not the kind picked here, so the create page would resolve the other slot.
-    // Aligning the lens first makes it read the slot seeded below.
-    //
-    // This should now always succeed: the options are exactly the user's `writer` grants, and
-    // `getAllowedLensIds` admits any lens they hold `writer` within (LFXV2-2754), so the lens
-    // for a listed project is available by construction. It previously failed for real users —
-    // the lens came from persona alone, which a writer grant does not imply — which is the bug
-    // this path was fixed for. Kept as a defensive bail because the alternative on an
-    // unexpected refusal is creating against a stale project, which `writerGuard`'s ED
-    // fast-path would not catch.
-    if (!this.lensService.setLens(project.isFoundation ? 'foundation' : 'project')) {
-      console.error('Cannot align lens to the selected project; aborting create navigation.', {
-        slug: project.slug,
-        isFoundation: project.isFoundation,
-      });
-      this.failWith(`You don't have access to create in ${project.name}.`);
-      return;
-    }
-
-    // Seed the slot matching the selection's kind. `syncUrl: false` because the default rewrites
-    // the *current* page's history entry via replaceState — the dialog is global to the rail, so
-    // that would re-point whatever page the user opened it from. `router.navigate` carries the
-    // slug to the destination instead.
-    if (project.isFoundation) {
-      this.projectContextService.setFoundation(context, false);
+    // `syncUrl: false` because the default rewrites the *current* page's history entry via
+    // replaceState — the dialog is global to the rail, so that would re-point whatever page the
+    // user opened it from. `router.navigate` carries the slug (and committee_uid) to the
+    // destination instead.
+    if (target.kind === 'project') {
+      const context: ProjectContext = { uid: target.uid, name: target.name, slug: target.slug };
+      this.setContext(target.isFoundation, context);
+      this.router.navigate([this.artifact.createRoute], { queryParams: { project: target.slug } });
     } else {
-      this.projectContextService.setProject(context, false);
+      const context: ProjectContext = { uid: target.projectUid, name: target.projectName, slug: target.projectSlug };
+      this.setContext(target.isFoundation, context);
+      this.router.navigate([this.artifact.createRoute], { queryParams: { project: target.projectSlug, committee_uid: target.uid } });
     }
 
-    // The slug keeps writerGuard authoritative on the chosen project and lets
-    // projectQueryParamGuard re-seed real project data on the lens-prefixed mounts.
-    this.router.navigate([this.artifact.createRoute], { queryParams: { project: project.slug } });
     this.dialogRef.close(true);
   }
 
@@ -133,22 +78,12 @@ export class CreateArtifactDialogComponent {
     this.dialogRef.close(false);
   }
 
-  /** Set (or clear) the current selection — drives the selector's display and the Continue-gating control. */
-  private applySelection(project: CreatableProject | null): void {
-    this.selectedContext.set(project ? this.toContext(project) : null);
-    this.form.controls.project.setValue(project?.uid ?? null);
-    this.form.controls.project.markAsTouched();
-  }
-
-  /** Project a writer-scoped `CreatableProject` down to the `ProjectContext` the context service stores. */
-  private toContext(project: CreatableProject): ProjectContext {
-    return { uid: project.uid, name: project.name, slug: project.slug, parent_uid: project.parent_uid, logoUrl: project.logoUrl };
-  }
-
-  /** Surface a dead-end to the user and close, rather than leaving the CTA silently inert. */
-  private failWith(detail: string): void {
-    this.messageService.add({ severity: 'error', summary: `Cannot create ${this.artifact.label}`, detail });
-    this.dialogRef.close(false);
+  private setContext(isFoundation: boolean, context: ProjectContext): void {
+    if (isFoundation) {
+      this.projectContextService.setFoundation(context, false);
+    } else {
+      this.projectContextService.setProject(context, false);
+    }
   }
 
   private resolveArtifact(): CreatableArtifactConfig {

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, signal, Signal, WritableSignal } from '@an
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CreateTargetPickerComponent } from '@components/create-target-picker/create-target-picker.component';
-import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
+import { COMMITTEE_WRITE_ARTIFACT_TYPES, CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
 import { CreatableArtifactConfig, CreatableArtifactType, CreatePickerNode, ProjectContext } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -37,6 +37,12 @@ export class CreateArtifactDialogComponent {
 
   // Header + primary CTA copy, e.g. "Create Meeting".
   protected readonly createLabel = `Create ${this.artifact.label}`;
+
+  // Only meeting/survey/vote allow a committee-scoped writer to create against them — the picker
+  // label shouldn't promise "Group" as an option for types that can't actually target one.
+  protected readonly targetLabel = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(this.artifact.type)
+    ? 'Select Foundation/Project/Group'
+    : 'Select Foundation/Project';
 
   protected readonly selectedTarget: WritableSignal<CreatePickerNode | null> = signal<CreatePickerNode | null>(null);
   protected readonly canContinue: Signal<boolean> = computed(() => this.selectedTarget() !== null);

--- a/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-artifact-dialog/create-artifact-dialog.component.ts
@@ -51,6 +51,13 @@ export class CreateArtifactDialogComponent {
     this.selectedTarget.set(node);
   }
 
+  // The picker's active result set just changed out from under the current pick (new search term,
+  // or a switch between tree/search view) — clear it so Continue can't fire on a row that's no
+  // longer visible or selectable.
+  public onSelectionCleared(): void {
+    this.selectedTarget.set(null);
+  }
+
   public onContinue(): void {
     const target = this.selectedTarget();
     if (!target) {

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
@@ -7,7 +7,7 @@
     <input
       [formControl]="searchControl"
       type="text"
-      placeholder="Search projects and groups..."
+      [placeholder]="searchPlaceholder()"
       class="pl-10 h-9 w-full text-sm rounded-lg border border-gray-200 focus:!ring-1 focus:!ring-blue-500 focus:!outline-none"
       data-testid="create-target-search-input" />
   </div>
@@ -55,9 +55,17 @@
     @if (isEmpty()) {
       <div class="text-center py-8 text-gray-500 text-sm" data-testid="create-target-empty-state">
         @if (isSearching()) {
-          No projects or groups you can create in match "{{ searchTerm() }}".
+          @if (supportsCommitteeTarget()) {
+            No projects or groups you can create in match "{{ searchTerm() }}".
+          } @else {
+            No projects you can create in match "{{ searchTerm() }}".
+          }
         } @else {
-          Nothing here yet — try searching for a project or group.
+          @if (supportsCommitteeTarget()) {
+            Nothing here yet — try searching for a project or group.
+          } @else {
+            Nothing here yet — try searching for a project.
+          }
         }
       </div>
     }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
@@ -1,0 +1,72 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-2" data-testid="create-target-picker">
+  <div class="relative">
+    <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"></i>
+    <input
+      [formControl]="searchControl"
+      type="text"
+      placeholder="Search projects and groups..."
+      class="pl-10 h-9 w-full text-sm rounded-lg border border-gray-200 focus:!ring-1 focus:!ring-blue-500 focus:!outline-none"
+      data-testid="create-target-search-input" />
+  </div>
+
+  <div class="max-h-[320px] overflow-y-auto flex flex-col" data-testid="create-target-results">
+    @if (isSearching()) {
+      <!-- Search results — flat, no expand affordance (independent matches, not a tree). -->
+      @for (project of activeResult().projects; track project.uid) {
+        <button
+          type="button"
+          class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
+          [class.bg-blue-50]="selectedKey() === 'project:' + project.uid"
+          [class.hover:bg-gray-100]="selectedKey() !== 'project:' + project.uid"
+          (click)="onNodeSelected(project)"
+          [attr.data-testid]="'create-target-search-result-' + project.uid">
+          <i class="fa-light fa-diagram-project text-gray-400 shrink-0" aria-hidden="true"></i>
+          <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ project.name }}</span>
+        </button>
+      }
+      @for (committee of activeResult().committees; track committee.uid) {
+        <button
+          type="button"
+          class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
+          [class.bg-blue-50]="selectedKey() === 'committee:' + committee.uid"
+          [class.hover:bg-gray-100]="selectedKey() !== 'committee:' + committee.uid"
+          (click)="onNodeSelected(committee)"
+          [attr.data-testid]="'create-target-search-result-' + committee.uid">
+          <i class="fa-light fa-people-group text-gray-400 shrink-0" aria-hidden="true"></i>
+          <span class="flex-1 min-w-0 truncate text-sm text-gray-900">
+            {{ committee.name }}
+            <span class="text-xs text-gray-400">— {{ committee.projectName }}</span>
+          </span>
+        </button>
+      }
+    } @else {
+      <!-- Default view: the user's direct-grant tree, lazy fan-out on expand. -->
+      @for (project of activeResult().projects; track project.uid) {
+        <lfx-create-target-tree-node [node]="project" [artifactType]="artifactType()" [selectedKey]="selectedKey()" (nodeSelected)="onNodeSelected($event)" />
+      }
+      @for (committee of activeResult().committees; track committee.uid) {
+        <lfx-create-target-tree-node [node]="committee" [artifactType]="artifactType()" [selectedKey]="selectedKey()" (nodeSelected)="onNodeSelected($event)" />
+      }
+    }
+
+    @if (isEmpty()) {
+      <div class="text-center py-8 text-gray-500 text-sm" data-testid="create-target-empty-state">
+        @if (isSearching()) {
+          No projects or groups you can create in match "{{ searchTerm() }}".
+        } @else {
+          Nothing here yet — try searching for a project or group.
+        }
+      </div>
+    }
+
+    @if (!loaded()) {
+      <div class="flex items-center justify-center py-3 text-gray-500 text-sm gap-2">
+        <i class="fa-light fa-spinner fa-spin"></i>
+        <span>Loading...</span>
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
@@ -3,6 +3,12 @@
 
 <div class="flex flex-col gap-2" data-testid="create-target-picker">
   <div class="relative">
+    <!-- Not the lfx-input-text wrapper: it renders `data-test` (via `dataTest()`), not
+         `data-testid` — this repo's e2e suite selects exclusively via `data-testid`
+         (getByTestId), and the wrapper's `<ng-container>` root has nowhere for a raw
+         `data-testid` attribute placed on the host tag to fall through to. Converting would
+         silently break every `getByTestId('create-target-search-input')` selector in
+         create-quick-link.spec.ts (S4, S7, S8, S9). -->
     <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" aria-hidden="true"></i>
     <input
       [formControl]="searchControl"

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.html
@@ -3,52 +3,64 @@
 
 <div class="flex flex-col gap-2" data-testid="create-target-picker">
   <div class="relative">
-    <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"></i>
+    <i class="fa-light fa-search absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" aria-hidden="true"></i>
     <input
       [formControl]="searchControl"
       type="text"
       [placeholder]="searchPlaceholder()"
+      [attr.aria-label]="searchPlaceholder()"
       class="pl-10 h-9 w-full text-sm rounded-lg border border-gray-200 focus:!ring-1 focus:!ring-blue-500 focus:!outline-none"
       data-testid="create-target-search-input" />
   </div>
 
   <div class="max-h-[320px] overflow-y-auto flex flex-col" data-testid="create-target-results">
-    @if (isSearching()) {
-      <!-- Search results — flat, no expand affordance (independent matches, not a tree). -->
-      @for (project of activeResult().projects; track project.uid) {
-        <button
-          type="button"
-          class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
-          [class.bg-blue-50]="selectedKey() === 'project:' + project.uid"
-          [class.hover:bg-gray-100]="selectedKey() !== 'project:' + project.uid"
-          (click)="onNodeSelected(project)"
-          [attr.data-testid]="'create-target-search-result-' + project.uid">
-          <i class="fa-light fa-diagram-project text-gray-400 shrink-0" aria-hidden="true"></i>
-          <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ project.name }}</span>
-        </button>
-      }
-      @for (committee of activeResult().committees; track committee.uid) {
-        <button
-          type="button"
-          class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
-          [class.bg-blue-50]="selectedKey() === 'committee:' + committee.uid"
-          [class.hover:bg-gray-100]="selectedKey() !== 'committee:' + committee.uid"
-          (click)="onNodeSelected(committee)"
-          [attr.data-testid]="'create-target-search-result-' + committee.uid">
-          <i class="fa-light fa-people-group text-gray-400 shrink-0" aria-hidden="true"></i>
-          <span class="flex-1 min-w-0 truncate text-sm text-gray-900">
-            {{ committee.name }}
-            <span class="text-xs text-gray-400">— {{ committee.projectName }}</span>
-          </span>
-        </button>
-      }
-    } @else {
-      <!-- Default view: the user's direct-grant tree, lazy fan-out on expand. -->
-      @for (project of activeResult().projects; track project.uid) {
-        <lfx-create-target-tree-node [node]="project" [artifactType]="artifactType()" [selectedKey]="selectedKey()" (nodeSelected)="onNodeSelected($event)" />
-      }
-      @for (committee of activeResult().committees; track committee.uid) {
-        <lfx-create-target-tree-node [node]="committee" [artifactType]="artifactType()" [selectedKey]="selectedKey()" (nodeSelected)="onNodeSelected($event)" />
+    <!-- Only render rows once the active view has actually loaded — otherwise the previous
+         result set stays visible (and clickable) through the search debounce + in-flight
+         request, letting a user pick a stale row that no longer matches what they typed. -->
+    @if (loaded()) {
+      @if (isSearching()) {
+        <!-- Search results — flat, no expand affordance (independent matches, not a tree). -->
+        @for (project of activeResult().projects; track project.uid) {
+          <button
+            type="button"
+            class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
+            [class.bg-blue-50]="selectedKey() === 'project:' + project.uid"
+            [class.hover:bg-gray-100]="selectedKey() !== 'project:' + project.uid"
+            [attr.aria-pressed]="selectedKey() === 'project:' + project.uid"
+            (click)="onNodeSelected(project)"
+            [attr.data-testid]="'create-target-search-result-' + project.uid">
+            <i class="fa-light fa-diagram-project text-gray-400 shrink-0" aria-hidden="true"></i>
+            <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ project.name }}</span>
+          </button>
+        }
+        @for (committee of activeResult().committees; track committee.uid) {
+          <button
+            type="button"
+            class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
+            [class.bg-blue-50]="selectedKey() === 'committee:' + committee.uid"
+            [class.hover:bg-gray-100]="selectedKey() !== 'committee:' + committee.uid"
+            [attr.aria-pressed]="selectedKey() === 'committee:' + committee.uid"
+            (click)="onNodeSelected(committee)"
+            [attr.data-testid]="'create-target-search-result-' + committee.uid">
+            <i class="fa-light fa-people-group text-gray-400 shrink-0" aria-hidden="true"></i>
+            <span class="flex-1 min-w-0 truncate text-sm text-gray-900">
+              {{ committee.name }}
+              <span class="text-xs text-gray-400">— {{ committee.projectName }}</span>
+            </span>
+          </button>
+        }
+      } @else {
+        <!-- Default view: the user's direct-grant tree, lazy fan-out on expand. -->
+        @for (project of activeResult().projects; track project.uid) {
+          <lfx-create-target-tree-node [node]="project" [artifactType]="artifactType()" [selectedKey]="selectedKey()" (nodeSelected)="onNodeSelected($event)" />
+        }
+        @for (committee of activeResult().committees; track committee.uid) {
+          <lfx-create-target-tree-node
+            [node]="committee"
+            [artifactType]="artifactType()"
+            [selectedKey]="selectedKey()"
+            (nodeSelected)="onNodeSelected($event)" />
+        }
       }
     }
 

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -36,7 +36,7 @@ export class CreateTargetPickerComponent {
 
   protected readonly searchControl = new FormControl<string>('');
 
-  /** Whether this artifact type allows a committee-scoped writer to create against it — drives the search placeholder copy. */
+  /** Whether this artifact type allows a committee-scoped writer to create against it — drives the search placeholder and empty-state copy. */
   protected readonly supportsCommitteeTarget: Signal<boolean> = computed(() => COMMITTEE_WRITE_ARTIFACT_TYPES.includes(this.artifactType()));
   protected readonly searchPlaceholder: Signal<string> = computed(() =>
     this.supportsCommitteeTarget() ? 'Search projects and groups...' : 'Search projects...'

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -1,0 +1,98 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
+import { CreateTargetPickerService } from '@services/create-target-picker.service';
+import { catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
+
+import { CreateTargetTreeNodeComponent } from './create-target-tree-node.component';
+
+const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
+const MIN_SEARCH_LENGTH = 2;
+
+/**
+ * Create-flow target picker (LFXV2-2838): a lazy direct-grant tree by default, switching to
+ * type-ahead search (≥2 chars) whose results are batch-access-checked per page. Replaces the
+ * writer-scoped `project-selector` embed the create dialog used previously — this component
+ * never pulls the full project list, and it renders committee rows too where the artifact type
+ * allows a committee-scoped writer to create against them.
+ */
+@Component({
+  selector: 'lfx-create-target-picker',
+  imports: [ReactiveFormsModule, CreateTargetTreeNodeComponent],
+  templateUrl: './create-target-picker.component.html',
+})
+export class CreateTargetPickerComponent {
+  private readonly pickerService = inject(CreateTargetPickerService);
+
+  public readonly artifactType = input.required<CreatableArtifactType>();
+  public readonly selectedTarget = input<CreatePickerNode | null>(null);
+
+  public readonly targetSelected = output<CreatePickerNode>();
+
+  protected readonly searchControl = new FormControl<string>('');
+
+  protected readonly searchTerm = this.initSearchTerm();
+  protected readonly isSearching: Signal<boolean> = computed(() => (this.searchTerm() ?? '').trim().length >= MIN_SEARCH_LENGTH);
+
+  private readonly treeLoadedSignal: WritableSignal<boolean> = signal(false);
+  private readonly searchLoadedSignal: WritableSignal<boolean> = signal(false);
+
+  protected readonly treeResult: Signal<CreatePickerResultSet> = this.initTreeResult();
+  protected readonly searchResult: Signal<CreatePickerResultSet> = this.initSearchResult();
+  protected readonly treeLoaded: Signal<boolean> = this.treeLoadedSignal.asReadonly();
+  protected readonly searchLoaded: Signal<boolean> = this.searchLoadedSignal.asReadonly();
+
+  protected readonly selectedKey: Signal<string | null> = computed(() => {
+    const target = this.selectedTarget();
+    return target ? `${target.kind}:${target.uid}` : null;
+  });
+
+  protected readonly activeResult: Signal<CreatePickerResultSet> = computed(() => (this.isSearching() ? this.searchResult() : this.treeResult()));
+  protected readonly loaded: Signal<boolean> = computed(() => (this.isSearching() ? this.searchLoaded() : this.treeLoaded()));
+  protected readonly isEmpty: Signal<boolean> = computed(() => {
+    const result = this.activeResult();
+    return this.loaded() && result.projects.length === 0 && result.committees.length === 0;
+  });
+
+  protected onNodeSelected(node: CreatePickerNode): void {
+    this.targetSelected.emit(node);
+  }
+
+  private initSearchTerm() {
+    return toSignal(this.searchControl.valueChanges.pipe(startWith(''), distinctUntilChanged()), { initialValue: '' });
+  }
+
+  private initTreeResult(): Signal<CreatePickerResultSet> {
+    return toSignal(
+      toObservable(this.artifactType).pipe(
+        switchMap((artifactType) => this.pickerService.getTree(artifactType)),
+        tap(() => this.treeLoadedSignal.set(true))
+      ),
+      { initialValue: EMPTY_RESULT }
+    );
+  }
+
+  private initSearchResult(): Signal<CreatePickerResultSet> {
+    return toSignal(
+      this.searchControl.valueChanges.pipe(
+        startWith(''),
+        distinctUntilChanged(),
+        tap(() => this.searchLoadedSignal.set(false)),
+        debounceTime(300),
+        switchMap((term) => {
+          const trimmed = (term ?? '').trim();
+          if (trimmed.length < MIN_SEARCH_LENGTH) {
+            return of(EMPTY_RESULT);
+          }
+          return this.pickerService.search(trimmed, this.artifactType()).pipe(catchError(() => of(EMPTY_RESULT)));
+        }),
+        tap(() => this.searchLoadedSignal.set(true))
+      ),
+      { initialValue: EMPTY_RESULT }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -7,11 +7,12 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { COMMITTEE_WRITE_ARTIFACT_TYPES, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
-import { debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
+import { distinctUntilChanged, of, startWith, switchMap, tap, timer } from 'rxjs';
 
 import { CreateTargetTreeNodeComponent } from './create-target-tree-node.component';
 
 const MIN_SEARCH_LENGTH = 2;
+const SEARCH_DEBOUNCE_MS = 300;
 
 /**
  * Create-flow target picker (LFXV2-2838): a lazy direct-grant tree by default, switching to
@@ -97,15 +98,24 @@ export class CreateTargetPickerComponent {
         startWith(''),
         distinctUntilChanged(),
         tap(() => this.searchLoadedSignal.set(false)),
-        debounceTime(300),
-        switchMap((term) => {
-          const trimmed = (term ?? '').trim();
-          if (trimmed.length < MIN_SEARCH_LENGTH) {
-            return of(EMPTY_CREATE_PICKER_RESULT);
-          }
-          // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_CREATE_PICKER_RESULT.
-          return this.pickerService.search(trimmed, this.artifactType());
-        }),
+        // The debounce lives INSIDE switchMap's inner observable (not as its own operator before
+        // it) so a new keystroke cancels it immediately, whether the prior term is still waiting
+        // out its debounce window or already has a request in flight — otherwise a slow request
+        // for a stale term could resolve after the user has moved on to a new term but before the
+        // new term's own debounce fires, briefly showing/selecting results for a query that's no
+        // longer on screen.
+        switchMap((term) =>
+          timer(SEARCH_DEBOUNCE_MS).pipe(
+            switchMap(() => {
+              const trimmed = (term ?? '').trim();
+              if (trimmed.length < MIN_SEARCH_LENGTH) {
+                return of(EMPTY_CREATE_PICKER_RESULT);
+              }
+              // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_CREATE_PICKER_RESULT.
+              return this.pickerService.search(trimmed, this.artifactType());
+            })
+          )
+        ),
         tap(() => this.searchLoadedSignal.set(true))
       ),
       { initialValue: EMPTY_CREATE_PICKER_RESULT }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -4,14 +4,13 @@
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { COMMITTEE_WRITE_ARTIFACT_TYPES } from '@lfx-one/shared/constants';
+import { COMMITTEE_WRITE_ARTIFACT_TYPES, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
 import { debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
 
 import { CreateTargetTreeNodeComponent } from './create-target-tree-node.component';
 
-const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
 const MIN_SEARCH_LENGTH = 2;
 
 /**
@@ -79,7 +78,7 @@ export class CreateTargetPickerComponent {
         switchMap((artifactType) => this.pickerService.getTree(artifactType)),
         tap(() => this.treeLoadedSignal.set(true))
       ),
-      { initialValue: EMPTY_RESULT }
+      { initialValue: EMPTY_CREATE_PICKER_RESULT }
     );
   }
 
@@ -93,14 +92,14 @@ export class CreateTargetPickerComponent {
         switchMap((term) => {
           const trimmed = (term ?? '').trim();
           if (trimmed.length < MIN_SEARCH_LENGTH) {
-            return of(EMPTY_RESULT);
+            return of(EMPTY_CREATE_PICKER_RESULT);
           }
-          // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_RESULT.
+          // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_CREATE_PICKER_RESULT.
           return this.pickerService.search(trimmed, this.artifactType());
         }),
         tap(() => this.searchLoadedSignal.set(true))
       ),
-      { initialValue: EMPTY_RESULT }
+      { initialValue: EMPTY_CREATE_PICKER_RESULT }
     );
   }
 }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -4,14 +4,13 @@
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Component, computed, DestroyRef, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { COMMITTEE_WRITE_ARTIFACT_TYPES, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
+import { COMMITTEE_WRITE_ARTIFACT_TYPES, CREATE_PICKER_MIN_SEARCH_LENGTH, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
-import { distinctUntilChanged, of, startWith, switchMap, tap, timer } from 'rxjs';
+import { distinctUntilChanged, filter, map, of, pairwise, startWith, switchMap, tap, timer } from 'rxjs';
 
 import { CreateTargetTreeNodeComponent } from './create-target-tree-node.component';
 
-const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_MS = 300;
 
 /**
@@ -34,9 +33,12 @@ export class CreateTargetPickerComponent {
   public readonly selectedTarget = input<CreatePickerNode | null>(null);
 
   public readonly targetSelected = output<CreatePickerNode>();
-  // Emitted whenever the search term changes — the caller's `selectedTarget` may no longer be part
-  // of the view this produces (tree vs. search, or a different search term entirely), so a stale
-  // pick must not stay selectable/continuable. See create-artifact-dialog's canContinue.
+  // Emitted whenever the active view changes in a way that can invalidate the caller's
+  // `selectedTarget` — entering search, changing the search term while already searching, or
+  // leaving search back to the tree. NOT emitted for a keystroke that stays under
+  // CREATE_PICKER_MIN_SEARCH_LENGTH while already under it — the tree view (and whatever was selected in it)
+  // hasn't changed, so clearing there would drop a still-valid, still-visible tree selection.
+  // See create-artifact-dialog's canContinue.
   public readonly selectionCleared = output<void>();
 
   protected readonly searchControl = new FormControl<string>('');
@@ -48,7 +50,7 @@ export class CreateTargetPickerComponent {
   );
 
   protected readonly searchTerm = this.initSearchTerm();
-  protected readonly isSearching: Signal<boolean> = computed(() => (this.searchTerm() ?? '').trim().length >= MIN_SEARCH_LENGTH);
+  protected readonly isSearching: Signal<boolean> = computed(() => (this.searchTerm() ?? '').trim().length >= CREATE_PICKER_MIN_SEARCH_LENGTH);
 
   private readonly treeLoadedSignal: WritableSignal<boolean> = signal(false);
   private readonly searchLoadedSignal: WritableSignal<boolean> = signal(false);
@@ -71,7 +73,15 @@ export class CreateTargetPickerComponent {
   });
 
   public constructor() {
-    this.searchControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.selectionCleared.emit());
+    this.searchControl.valueChanges
+      .pipe(
+        startWith(''),
+        map((term) => (term ?? '').trim().length >= CREATE_PICKER_MIN_SEARCH_LENGTH),
+        pairwise(),
+        filter(([wasSearching, isSearchingNow]) => wasSearching || isSearchingNow),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.selectionCleared.emit());
   }
 
   protected onNodeSelected(node: CreatePickerNode): void {
@@ -108,7 +118,7 @@ export class CreateTargetPickerComponent {
           timer(SEARCH_DEBOUNCE_MS).pipe(
             switchMap(() => {
               const trimmed = (term ?? '').trim();
-              if (trimmed.length < MIN_SEARCH_LENGTH) {
+              if (trimmed.length < CREATE_PICKER_MIN_SEARCH_LENGTH) {
                 return of(EMPTY_CREATE_PICKER_RESULT);
               }
               // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_CREATE_PICKER_RESULT.

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -4,6 +4,7 @@
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { COMMITTEE_WRITE_ARTIFACT_TYPES } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
 import { debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
@@ -34,6 +35,12 @@ export class CreateTargetPickerComponent {
   public readonly targetSelected = output<CreatePickerNode>();
 
   protected readonly searchControl = new FormControl<string>('');
+
+  /** Whether this artifact type allows a committee-scoped writer to create against it — drives the search placeholder copy. */
+  protected readonly supportsCommitteeTarget: Signal<boolean> = computed(() => COMMITTEE_WRITE_ARTIFACT_TYPES.includes(this.artifactType()));
+  protected readonly searchPlaceholder: Signal<string> = computed(() =>
+    this.supportsCommitteeTarget() ? 'Search projects and groups...' : 'Search projects...'
+  );
 
   protected readonly searchTerm = this.initSearchTerm();
   protected readonly isSearching: Signal<boolean> = computed(() => (this.searchTerm() ?? '').trim().length >= MIN_SEARCH_LENGTH);

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { COMMITTEE_WRITE_ARTIFACT_TYPES, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
@@ -27,11 +27,16 @@ const MIN_SEARCH_LENGTH = 2;
 })
 export class CreateTargetPickerComponent {
   private readonly pickerService = inject(CreateTargetPickerService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly artifactType = input.required<CreatableArtifactType>();
   public readonly selectedTarget = input<CreatePickerNode | null>(null);
 
   public readonly targetSelected = output<CreatePickerNode>();
+  // Emitted whenever the search term changes — the caller's `selectedTarget` may no longer be part
+  // of the view this produces (tree vs. search, or a different search term entirely), so a stale
+  // pick must not stay selectable/continuable. See create-artifact-dialog's canContinue.
+  public readonly selectionCleared = output<void>();
 
   protected readonly searchControl = new FormControl<string>('');
 
@@ -63,6 +68,10 @@ export class CreateTargetPickerComponent {
     const result = this.activeResult();
     return this.loaded() && result.projects.length === 0 && result.committees.length === 0;
   });
+
+  public constructor() {
+    this.searchControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.selectionCleared.emit());
+  }
 
   protected onNodeSelected(node: CreatePickerNode): void {
     this.targetSelected.emit(node);

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-picker.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, input, output, signal, Signal, WritableSig
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { CreatableArtifactType, CreatePickerNode, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
-import { catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
+import { debounceTime, distinctUntilChanged, of, startWith, switchMap, tap } from 'rxjs';
 
 import { CreateTargetTreeNodeComponent } from './create-target-tree-node.component';
 
@@ -88,7 +88,8 @@ export class CreateTargetPickerComponent {
           if (trimmed.length < MIN_SEARCH_LENGTH) {
             return of(EMPTY_RESULT);
           }
-          return this.pickerService.search(trimmed, this.artifactType()).pipe(catchError(() => of(EMPTY_RESULT)));
+          // No catchError here — CreateTargetPickerService.search() already fails closed to EMPTY_RESULT.
+          return this.pickerService.search(trimmed, this.artifactType());
         }),
         tap(() => this.searchLoadedSignal.set(true))
       ),

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -20,6 +20,7 @@
       [class.bg-blue-50]="isSelected()"
       [class.hover:bg-gray-100]="!isSelected()"
       (click)="select()"
+      [attr.aria-pressed]="isSelected()"
       [attr.data-testid]="'create-target-node-' + node().uid"
       [attr.data-selected]="isSelected()">
       <i [class]="icon() + ' text-gray-400 shrink-0'" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -45,7 +45,7 @@
       } @empty {
         @if (!loadingChildren()) {
           @if (loadFailed()) {
-            <p class="text-xs text-red-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">Couldn't load — collapse and re-expand to retry</p>
+            <p class="text-xs text-red-600 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">Couldn't load — collapse and re-expand to retry</p>
           } @else {
             <p class="text-xs text-gray-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">No sub-items</p>
           }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -11,7 +11,7 @@
       (click)="toggleExpand($event)"
       [attr.aria-expanded]="expanded()"
       [attr.aria-label]="(expanded() ? 'Collapse ' : 'Expand ') + label()"
-      data-testid="create-target-node-toggle">
+      data-testid="create-target-toggle">
       <i class="fa-light fa-chevron-right text-gray-400 text-xs transition-transform" [class.rotate-90]="expanded()" aria-hidden="true"></i>
     </button>
     <button

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -44,7 +44,11 @@
           (nodeSelected)="onChildSelected($event)" />
       } @empty {
         @if (!loadingChildren()) {
-          <p class="text-xs text-gray-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">No sub-items</p>
+          @if (loadFailed()) {
+            <p class="text-xs text-red-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">Couldn't load — collapse and re-expand to retry</p>
+          } @else {
+            <p class="text-xs text-gray-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">No sub-items</p>
+          }
         }
       }
 

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -2,26 +2,35 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col">
-  <button
-    type="button"
-    class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
-    [style.padding-left.rem]="0.5 + depth() * 1.25"
-    [class.bg-blue-50]="isSelected()"
-    [class.hover:bg-gray-100]="!isSelected()"
-    (click)="select()"
-    [attr.data-testid]="'create-target-node-' + node().uid"
-    [attr.data-selected]="isSelected()">
-    <span class="shrink-0 size-5 flex items-center justify-center" (click)="toggleExpand($event)" data-testid="create-target-node-toggle">
+  <div class="flex items-center gap-1" [style.padding-left.rem]="0.5 + depth() * 1.25">
+    <!-- Separate focusable control from the row's select button below — a click-handling span
+         nested inside a button is not independently keyboard-reachable. -->
+    <button
+      type="button"
+      class="shrink-0 size-6 flex items-center justify-center rounded hover:bg-gray-100"
+      (click)="toggleExpand($event)"
+      [attr.aria-expanded]="expanded()"
+      [attr.aria-label]="(expanded() ? 'Collapse ' : 'Expand ') + label()"
+      data-testid="create-target-node-toggle">
       <i class="fa-light fa-chevron-right text-gray-400 text-xs transition-transform" [class.rotate-90]="expanded()" aria-hidden="true"></i>
-    </span>
-    <i [class]="icon() + ' text-gray-400 shrink-0'" aria-hidden="true"></i>
-    <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ label() }}</span>
-    <i
-      class="fa-light fa-check text-blue-500 shrink-0 transition-opacity"
-      [class.opacity-100]="isSelected()"
-      [class.opacity-0]="!isSelected()"
-      [attr.aria-hidden]="!isSelected()"></i>
-  </button>
+    </button>
+    <button
+      type="button"
+      class="flex items-center gap-2 p-2 flex-1 min-w-0 text-left rounded-lg transition-colors"
+      [class.bg-blue-50]="isSelected()"
+      [class.hover:bg-gray-100]="!isSelected()"
+      (click)="select()"
+      [attr.data-testid]="'create-target-node-' + node().uid"
+      [attr.data-selected]="isSelected()">
+      <i [class]="icon() + ' text-gray-400 shrink-0'" aria-hidden="true"></i>
+      <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ label() }}</span>
+      <i
+        class="fa-light fa-check text-blue-500 shrink-0 transition-opacity"
+        [class.opacity-100]="isSelected()"
+        [class.opacity-0]="!isSelected()"
+        [attr.aria-hidden]="!isSelected()"></i>
+    </button>
+  </div>
 
   @if (expanded()) {
     <div class="flex flex-col">

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.html
@@ -1,0 +1,49 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col">
+  <button
+    type="button"
+    class="flex items-center gap-2 p-2 w-full text-left rounded-lg transition-colors"
+    [style.padding-left.rem]="0.5 + depth() * 1.25"
+    [class.bg-blue-50]="isSelected()"
+    [class.hover:bg-gray-100]="!isSelected()"
+    (click)="select()"
+    [attr.data-testid]="'create-target-node-' + node().uid"
+    [attr.data-selected]="isSelected()">
+    <span class="shrink-0 size-5 flex items-center justify-center" (click)="toggleExpand($event)" data-testid="create-target-node-toggle">
+      <i class="fa-light fa-chevron-right text-gray-400 text-xs transition-transform" [class.rotate-90]="expanded()" aria-hidden="true"></i>
+    </span>
+    <i [class]="icon() + ' text-gray-400 shrink-0'" aria-hidden="true"></i>
+    <span class="flex-1 min-w-0 truncate text-sm text-gray-900">{{ label() }}</span>
+    <i
+      class="fa-light fa-check text-blue-500 shrink-0 transition-opacity"
+      [class.opacity-100]="isSelected()"
+      [class.opacity-0]="!isSelected()"
+      [attr.aria-hidden]="!isSelected()"></i>
+  </button>
+
+  @if (expanded()) {
+    <div class="flex flex-col">
+      @for (child of children(); track child.kind + ':' + child.uid) {
+        <lfx-create-target-tree-node
+          [node]="child"
+          [artifactType]="artifactType()"
+          [depth]="depth() + 1"
+          [selectedKey]="selectedKey()"
+          (nodeSelected)="onChildSelected($event)" />
+      } @empty {
+        @if (!loadingChildren()) {
+          <p class="text-xs text-gray-400 py-1" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">No sub-items</p>
+        }
+      }
+
+      @if (loadingChildren()) {
+        <div class="flex items-center gap-2 py-1 text-xs text-gray-400" [style.padding-left.rem]="0.5 + (depth() + 1) * 1.25">
+          <i class="fa-light fa-spinner fa-spin"></i>
+          <span>Loading...</span>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CreatableArtifactType, CreatePickerNode } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
 
@@ -18,6 +19,7 @@ import { CreateTargetPickerService } from '@services/create-target-picker.servic
 })
 export class CreateTargetTreeNodeComponent {
   private readonly pickerService = inject(CreateTargetPickerService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly node = input.required<CreatePickerNode>();
   public readonly artifactType = input.required<CreatableArtifactType>();
@@ -59,10 +61,13 @@ export class CreateTargetTreeNodeComponent {
   private loadChildren(): void {
     this.loadingChildren.set(true);
     const target = this.node();
-    this.pickerService.getChildren(target.kind, target.uid, this.artifactType()).subscribe((result) => {
-      this.children.set([...result.projects, ...result.committees]);
-      this.loadingChildren.set(false);
-      this.childrenLoaded.set(true);
-    });
+    this.pickerService
+      .getChildren(target.kind, target.uid, this.artifactType())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.children.set([...result.projects, ...result.committees]);
+        this.loadingChildren.set(false);
+        this.childrenLoaded.set(true);
+      });
   }
 }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, DestroyRef, inject, input, output, signal, Signal,
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CreatableArtifactType, CreatePickerNode } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
+import { Subscription } from 'rxjs';
 
 /**
  * One row of the create picker's lazy direct-grant tree — recursively renders its own children
@@ -32,6 +33,11 @@ export class CreateTargetTreeNodeComponent {
   protected readonly loadingChildren: WritableSignal<boolean> = signal(false);
   protected readonly childrenLoaded: WritableSignal<boolean> = signal(false);
   protected readonly children: WritableSignal<CreatePickerNode[]> = signal<CreatePickerNode[]>([]);
+
+  // Tracks the in-flight getChildren() request so a retry (collapse + re-expand before the first
+  // one resolves) cancels it instead of racing it — otherwise a slow first response landing after
+  // a successful retry can overwrite `children` with its own (possibly empty) result.
+  private childrenSubscription?: Subscription;
 
   protected readonly key: Signal<string> = computed(() => `${this.node().kind}:${this.node().uid}`);
   protected readonly isSelected: Signal<boolean> = computed(() => this.selectedKey() === this.key());
@@ -64,8 +70,9 @@ export class CreateTargetTreeNodeComponent {
 
   private loadChildren(): void {
     this.loadingChildren.set(true);
+    this.childrenSubscription?.unsubscribe();
     const target = this.node();
-    this.pickerService
+    this.childrenSubscription = this.pickerService
       .getChildren(target.kind, target.uid, this.artifactType())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result) => {

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
@@ -45,7 +45,11 @@ export class CreateTargetTreeNodeComponent {
       return;
     }
     this.expanded.set(true);
-    if (!this.childrenLoaded()) {
+    // Retry whenever the cached list is empty, not just on the first-ever expand:
+    // CreateTargetPickerService.getChildren() fails closed to an empty result on error, so a
+    // transient failure would otherwise look identical to a genuine "no sub-items" node and never
+    // get retried without closing and reopening the whole dialog.
+    if (!this.childrenLoaded() || this.children().length === 0) {
       this.loadChildren();
     }
   }

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, output, signal, Signal, WritableSignal } from '@angular/core';
+import { CreatableArtifactType, CreatePickerNode } from '@lfx-one/shared/interfaces';
+import { CreateTargetPickerService } from '@services/create-target-picker.service';
+
+/**
+ * One row of the create picker's lazy direct-grant tree — recursively renders its own children
+ * once expanded. Both `project` and `committee` nodes can have children (subprojects +
+ * committees under a project; child committees under a committee), so this is a single
+ * self-referencing component rather than separate project/committee renderers.
+ */
+@Component({
+  selector: 'lfx-create-target-tree-node',
+  imports: [CreateTargetTreeNodeComponent],
+  templateUrl: './create-target-tree-node.component.html',
+})
+export class CreateTargetTreeNodeComponent {
+  private readonly pickerService = inject(CreateTargetPickerService);
+
+  public readonly node = input.required<CreatePickerNode>();
+  public readonly artifactType = input.required<CreatableArtifactType>();
+  public readonly depth = input(0);
+  public readonly selectedKey = input<string | null>(null);
+
+  public readonly nodeSelected = output<CreatePickerNode>();
+
+  protected readonly expanded: WritableSignal<boolean> = signal(false);
+  protected readonly loadingChildren: WritableSignal<boolean> = signal(false);
+  protected readonly childrenLoaded: WritableSignal<boolean> = signal(false);
+  protected readonly children: WritableSignal<CreatePickerNode[]> = signal<CreatePickerNode[]>([]);
+
+  protected readonly key: Signal<string> = computed(() => `${this.node().kind}:${this.node().uid}`);
+  protected readonly isSelected: Signal<boolean> = computed(() => this.selectedKey() === this.key());
+  protected readonly label: Signal<string> = computed(() => this.node().name);
+  protected readonly icon: Signal<string> = computed(() => (this.node().kind === 'project' ? 'fa-light fa-diagram-project' : 'fa-light fa-people-group'));
+
+  protected toggleExpand(event: Event): void {
+    event.stopPropagation();
+    if (this.expanded()) {
+      this.expanded.set(false);
+      return;
+    }
+    this.expanded.set(true);
+    if (!this.childrenLoaded()) {
+      this.loadChildren();
+    }
+  }
+
+  protected select(): void {
+    this.nodeSelected.emit(this.node());
+  }
+
+  protected onChildSelected(node: CreatePickerNode): void {
+    this.nodeSelected.emit(node);
+  }
+
+  private loadChildren(): void {
+    this.loadingChildren.set(true);
+    const target = this.node();
+    this.pickerService.getChildren(target.kind, target.uid, this.artifactType()).subscribe((result) => {
+      this.children.set([...result.projects, ...result.committees]);
+      this.loadingChildren.set(false);
+      this.childrenLoaded.set(true);
+    });
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
+++ b/apps/lfx-one/src/app/shared/components/create-target-picker/create-target-tree-node.component.ts
@@ -32,6 +32,9 @@ export class CreateTargetTreeNodeComponent {
   protected readonly expanded: WritableSignal<boolean> = signal(false);
   protected readonly loadingChildren: WritableSignal<boolean> = signal(false);
   protected readonly childrenLoaded: WritableSignal<boolean> = signal(false);
+  // Distinct from `children().length === 0`: a confirmed-empty leaf (successful load, zero
+  // children) must not retry on every re-expand the way a genuinely failed request should.
+  protected readonly loadFailed: WritableSignal<boolean> = signal(false);
   protected readonly children: WritableSignal<CreatePickerNode[]> = signal<CreatePickerNode[]>([]);
 
   // Tracks the in-flight getChildren() request so a retry (collapse + re-expand before the first
@@ -51,11 +54,9 @@ export class CreateTargetTreeNodeComponent {
       return;
     }
     this.expanded.set(true);
-    // Retry whenever the cached list is empty, not just on the first-ever expand:
-    // CreateTargetPickerService.getChildren() fails closed to an empty result on error, so a
-    // transient failure would otherwise look identical to a genuine "no sub-items" node and never
-    // get retried without closing and reopening the whole dialog.
-    if (!this.childrenLoaded() || this.children().length === 0) {
+    // Retry on a failed load, not on a confirmed-empty one — a real leaf (successfully loaded,
+    // zero children) must not refetch on every re-expand the way a transient failure should.
+    if (!this.childrenLoaded() || this.loadFailed()) {
       this.loadChildren();
     }
   }
@@ -70,15 +71,23 @@ export class CreateTargetTreeNodeComponent {
 
   private loadChildren(): void {
     this.loadingChildren.set(true);
+    this.loadFailed.set(false);
     this.childrenSubscription?.unsubscribe();
     const target = this.node();
     this.childrenSubscription = this.pickerService
       .getChildren(target.kind, target.uid, this.artifactType())
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((result) => {
-        this.children.set([...result.projects, ...result.committees]);
-        this.loadingChildren.set(false);
-        this.childrenLoaded.set(true);
+      .subscribe({
+        next: (result) => {
+          this.children.set([...result.projects, ...result.committees]);
+          this.loadingChildren.set(false);
+          this.childrenLoaded.set(true);
+        },
+        error: (error) => {
+          console.error('Failed to load create-picker children:', error);
+          this.loadingChildren.set(false);
+          this.loadFailed.set(true);
+        },
       });
   }
 }

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -1,5 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
+import { COMMITTEE_WRITE_FEATURES } from '@lfx-one/shared/constants';
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { catchError, map, Observable, of, switchMap } from 'rxjs';
@@ -63,7 +64,7 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const writeFeature: string | undefined = route.data?.['writeFeature'];
   const deniedUrl = router.createUrlTree([overviewPath], { queryParams: { project: slug, _notice: writeFeature ?? 'access' } });
   const deny = () => deniedUrl;
-  const supportsCommitteeWriter = writeFeature != null && ['meetings', 'surveys', 'votes'].includes(writeFeature);
+  const supportsCommitteeWriter = writeFeature != null && COMMITTEE_WRITE_FEATURES.includes(writeFeature);
 
   // Committee writers can create meetings, surveys, and votes associated with
   // their committee. Only applicable when committee_uid is in the route query params.

--- a/apps/lfx-one/src/app/shared/services/create-permission.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-permission.service.ts
@@ -3,34 +3,33 @@
 
 import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
+import { CREATABLE_ARTIFACTS, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { CreateTargetPickerService } from '@services/create-target-picker.service';
 
-const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
-
 /**
- * Decides whether the rail "Create" quick-link (and which artifact types) is offered to the
- * current user — LFXV2-2838.
+ * Decides which artifact types the rail "Create" quick-link offers — LFXV2-2838.
  *
- * Sourced from the create picker's own `GET /api/create-picker/tree` (probed with
- * `artifactType: 'meeting'`, the broadest relation set — project writer, project
- * `meeting_coordinator`, and committee writer all included) rather than `GET /api/projects`
- * (unpaginated, batch access-checks every visible project). This used to go through
- * `WriterGrantsService.writerProjects`, which is exactly that full pull; `LensService` still
- * uses `WriterGrantsService` for its own (unrelated, general-navigation) lens-widening, but the
- * create path no longer touches it.
+ * The rail button itself is always shown (see `canShowCreateButton` below) — it does not gate on
+ * any eligibility probe. An earlier version sourced visibility from the create picker's
+ * direct-grant-only `GET /api/create-picker/tree`, but that hides the button entirely for a pure
+ * inherited-writer (a user with real, evaluated access via inheritance but zero direct FGA
+ * tuples) — exactly the class of user this ticket's picker rebuild exists to serve, since their
+ * only path to a target is the picker's search, which they could never reach if the button that
+ * opens the picker stayed hidden. The picker's own fail-closed empty state (tree and search both
+ * empty) is what communicates zero access now, same as it already does inside the dialog.
  *
- * All-or-nothing by design: a `writer`/`meeting_coordinator`/committee-writer grant is not
- * per-type, so every type is offered together once any direct-grant target exists. This probes
- * direct grants only (search isn't run here — that would mean enumerating), so it's intentionally
- * an *undershow*: a user reachable only through the picker's search (inherited writer, no direct
- * grants) won't light up this button. The create routes' `writerGuard` remains the actual
- * authority regardless of what this button advertises — it only ever narrows the affordance, it
- * never grants access.
+ * `creatableTypes` still probes `GET /api/create-picker/tree` — with `artifactType: 'newsletter'`
+ * specifically, a writer-only type (no `meeting_coordinator` or committee-writer relation
+ * included, see `COMMITTEE_WRITE_ARTIFACT_TYPES`). A `newsletter`-eligible target implies genuine
+ * project `writer`, which is valid for every one of the six creatable types — probing with
+ * `'meeting'` instead (as this service originally did) would let a `meeting_coordinator`-only or
+ * committee-writer-only user's probe succeed too, over-showing types (newsletter, mailing-list,
+ * group) they hold no grant for at all and whose own picker would come up empty. `writerGuard`
+ * remains the actual authority regardless of what this list advertises — it only ever narrows
+ * the affordance, it never grants access.
  *
- * Everything resolves to `[]` while loading and on error (the underlying service fails closed),
- * keeping the rail button hidden until eligibility is proven.
+ * Everything resolves to `[]` while loading and on error (the underlying service fails closed).
  *
  * Persona note (ED): still no ED fast-path here, unlike `writerGuard` — unchanged trade-off from
  * before this rebuild (LFXV2-2721).
@@ -42,31 +41,34 @@ export class CreatePermissionService {
   private readonly pickerService = inject(CreateTargetPickerService);
   private readonly destroyRef = inject(DestroyRef);
 
-  private readonly eligibility: WritableSignal<CreatePickerResultSet> = signal(EMPTY_RESULT);
+  private readonly writerEligibility: WritableSignal<CreatePickerResultSet> = signal(EMPTY_CREATE_PICKER_RESULT);
 
-  /** True when the user has at least one direct-grant project or committee to create against. */
-  private readonly hasEligibleTarget: Signal<boolean> = computed(() => {
-    const result = this.eligibility();
+  /** True when a writer-only probe found at least one direct-grant project or committee. */
+  private readonly hasWriterEligibleTarget: Signal<boolean> = computed(() => {
+    const result = this.writerEligibility();
     return result.projects.length > 0 || result.committees.length > 0;
   });
 
-  /** Artifact types offered to the user — all types when eligible, else none (see class doc). */
+  /** Artifact types offered to the user — all types when writer-eligible, else none (see class doc). */
   public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() =>
-    this.hasEligibleTarget() ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
+    this.hasWriterEligibleTarget() ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
   );
 
-  /** True when the user can create on at least one project or committee. */
-  public readonly canShowCreateButton: Signal<boolean> = this.hasEligibleTarget;
+  /**
+   * Always true — the rail button no longer gates on an eligibility probe (see class doc). Kept
+   * as a signal (not a plain `true`) so existing consumers don't need to change, and so a future
+   * cheap "does this user have anything at all" signal has somewhere to plug back in.
+   */
+  public readonly canShowCreateButton: Signal<boolean> = computed(() => true);
 
   public constructor() {
-    // Deferred to after the first render, mirroring the previous full-pull's SSR-safety
-    // rationale even though this probe is now cheap (direct-grant only) — any avoidable HTTP
-    // round trip during SSR still risks TTFB, so it stays off the critical render path.
+    // Deferred to after the first render — this probe is cheap (direct-grant only), but any
+    // avoidable HTTP round trip during SSR still risks TTFB, so it stays off the critical render path.
     afterNextRender(() => {
       this.pickerService
-        .getTree('meeting')
+        .getTree('newsletter')
         .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe((result) => this.eligibility.set(result));
+        .subscribe((result) => this.writerEligibility.set(result));
     });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/create-permission.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-permission.service.ts
@@ -1,76 +1,72 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { computed, inject, Injectable, Signal } from '@angular/core';
+import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
-import { CreatableArtifactType, CreatableProject } from '@lfx-one/shared/interfaces';
-import { WriterGrantsService } from '@services/writer-grants.service';
+import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
+import { CreateTargetPickerService } from '@services/create-target-picker.service';
+
+const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
 
 /**
- * Decides whether the rail "Create" quick-link (and which artifact types) is
- * offered to the current user, and which projects/foundations they may target.
+ * Decides whether the rail "Create" quick-link (and which artifact types) is offered to the
+ * current user — LFXV2-2838.
  *
- * Eligibility is the project `writer` grant, and nothing else — the same signal
- * `writerGuard` enforces. `GET /api/projects` batch access-checks every visible
- * project and returns `writer` per project, so this reflects real per-project
- * authorization rather than inferring it from a persona.
+ * Sourced from the create picker's own `GET /api/create-picker/tree` (probed with
+ * `artifactType: 'meeting'`, the broadest relation set — project writer, project
+ * `meeting_coordinator`, and committee writer all included) rather than `GET /api/projects`
+ * (unpaginated, batch access-checks every visible project). This used to go through
+ * `WriterGrantsService.writerProjects`, which is exactly that full pull; `LensService` still
+ * uses `WriterGrantsService` for its own (unrelated, general-navigation) lens-widening, but the
+ * create path no longer touches it.
  *
- * This list was previously intersected with the lenses the user's persona holds,
- * on the reasoning that `ProjectContextService.activeContext` is lens-gated so an
- * unreachable lens would dead-end at "Create". That was true, but it made the wrong
- * side give way: it silently hid projects the user provably administers. A user
- * holding `writer` on 81 foundations while detecting as `contributor` could target
- * none of them (LFXV2-2754). The lens is now derived from the grant instead —
- * `LensService.getAllowedLensIds` admits any lens the user holds `writer` within —
- * so alignment succeeds for exactly the projects listed here and the intersection
- * is redundant. Do not reintroduce a persona-derived filter on this list; persona
- * and `writer` are independent, and `writer` is the one that confers authority.
+ * All-or-nothing by design: a `writer`/`meeting_coordinator`/committee-writer grant is not
+ * per-type, so every type is offered together once any direct-grant target exists. This probes
+ * direct grants only (search isn't run here — that would mean enumerating), so it's intentionally
+ * an *undershow*: a user reachable only through the picker's search (inherited writer, no direct
+ * grants) won't light up this button. The create routes' `writerGuard` remains the actual
+ * authority regardless of what this button advertises — it only ever narrows the affordance, it
+ * never grants access.
  *
- * Everything resolves to `[]` while loading and on error, keeping the rail button
- * hidden until eligibility is proven — fail closed. The error half of that relies on
- * `ProjectService.getProjects()` catching internally and emitting `[]`.
+ * Everything resolves to `[]` while loading and on error (the underlying service fails closed),
+ * keeping the rail button hidden until eligibility is proven.
  *
- * Granularity note: `writer` is not the whole story upstream. Meetings are broader
- * (`meeting_coordinator` and committee-writer also qualify), so users holding only
- * those roles are still under-shown — they source no project `writer` at all, so the
- * client cannot see them. This is a UX affordance only — the create routes'
- * `writerGuard` remains authoritative for non-ED personas, so the button never grants
- * access, it only advertises it. A `GET /api/projects/creatable` endpoint encoding the
- * per-type grants (LFXV2-2753) is what closes that remaining gap.
- *
- * Persona note (ED): gating is purely the FGA `writer` relation, with NO ED fast-path —
- * unlike `writerGuard`, which synchronously allows the `executive-director` persona
- * because an ED is not reliably granted a per-project `writer` relation. So an ED whose
- * `GET /api/projects` returns no `writer: true` project sees no "Create" shortcut at all.
- * This is an accepted trade-off (LFXV2-2721): the shortcut is deliberately a writer-scoped
- * affordance, and EDs still create through the in-page flows, which carry their own ED
- * fast-path. Reinstating the button for those EDs would mean sourcing their foundations
- * from persona/lens data — the writer-scoped list is empty for them — which loosens the
- * writer filter this feature is scoped to; out of scope here by design.
+ * Persona note (ED): still no ED fast-path here, unlike `writerGuard` — unchanged trade-off from
+ * before this rebuild (LFXV2-2721).
  */
 @Injectable({
   providedIn: 'root',
 })
 export class CreatePermissionService {
-  private readonly writerGrantsService = inject(WriterGrantsService);
+  private readonly pickerService = inject(CreateTargetPickerService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  /** Projects the user may create on — exactly those they hold `writer` on (see class doc). */
-  public readonly creatableProjects: Signal<CreatableProject[]> = this.writerGrantsService.writerProjects;
+  private readonly eligibility: WritableSignal<CreatePickerResultSet> = signal(EMPTY_RESULT);
 
-  /**
-   * Artifact types offered to the user — all types when they can create anywhere, else none.
-   *
-   * All-or-nothing by design: a `writer` grant is not per-type, so every type is offered together.
-   * A new `CREATABLE_ARTIFACTS` entry therefore inherits visibility for free — it does NOT get
-   * independent gating. Do not assume adding a type here narrows who sees it. The per-type
-   * intersection this feeds (`lens-switcher`'s `creatableArtifacts` filter) is consequently a
-   * no-op today; it exists so the switcher stays correct if a future `GET /api/projects/creatable`
-   * endpoint makes this list a genuine per-type subset (see class doc).
-   */
+  /** True when the user has at least one direct-grant project or committee to create against. */
+  private readonly hasEligibleTarget: Signal<boolean> = computed(() => {
+    const result = this.eligibility();
+    return result.projects.length > 0 || result.committees.length > 0;
+  });
+
+  /** Artifact types offered to the user — all types when eligible, else none (see class doc). */
   public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() =>
-    this.creatableProjects().length > 0 ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
+    this.hasEligibleTarget() ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
   );
 
-  /** True when the user can create on at least one project. */
-  public readonly canShowCreateButton: Signal<boolean> = computed(() => this.creatableProjects().length > 0);
+  /** True when the user can create on at least one project or committee. */
+  public readonly canShowCreateButton: Signal<boolean> = this.hasEligibleTarget;
+
+  public constructor() {
+    // Deferred to after the first render, mirroring the previous full-pull's SSR-safety
+    // rationale even though this probe is now cheap (direct-grant only) — any avoidable HTTP
+    // round trip during SSR still risks TTFB, so it stays off the critical render path.
+    afterNextRender(() => {
+      this.pickerService
+        .getTree('meeting')
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.eligibility.set(result));
+    });
+  }
 }

--- a/apps/lfx-one/src/app/shared/services/create-permission.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-permission.service.ts
@@ -1,74 +1,34 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CREATABLE_ARTIFACTS, EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
-import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
-import { CreateTargetPickerService } from '@services/create-target-picker.service';
+import { computed, Injectable, Signal } from '@angular/core';
+import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
+import { CreatableArtifactType } from '@lfx-one/shared/interfaces';
 
 /**
  * Decides which artifact types the rail "Create" quick-link offers — LFXV2-2838.
  *
- * The rail button itself is always shown (see `canShowCreateButton` below) — it does not gate on
- * any eligibility probe. An earlier version sourced visibility from the create picker's
- * direct-grant-only `GET /api/create-picker/tree`, but that hides the button entirely for a pure
- * inherited-writer (a user with real, evaluated access via inheritance but zero direct FGA
- * tuples) — exactly the class of user this ticket's picker rebuild exists to serve, since their
- * only path to a target is the picker's search, which they could never reach if the button that
- * opens the picker stayed hidden. The picker's own fail-closed empty state (tree and search both
- * empty) is what communicates zero access now, same as it already does inside the dialog.
+ * Both signals below are unconditional: neither the rail button nor its menu gates on any
+ * eligibility probe anymore. Earlier versions of this service sourced both from the create
+ * picker's direct-grant-only `GET /api/create-picker/tree`, but that hides the button (or, once
+ * the button itself was fixed to always show, still emptied the menu behind it) for a pure
+ * inherited-writer or committee-only-grant user — exactly the class of user this ticket's picker
+ * rebuild exists to serve, since their only path to a target is the picker's own search, which
+ * they could never reach if the button — or every item in its menu — stayed hidden.
  *
- * `creatableTypes` still probes `GET /api/create-picker/tree` — with `artifactType: 'newsletter'`
- * specifically, a writer-only type (no `meeting_coordinator` or committee-writer relation
- * included, see `COMMITTEE_WRITE_ARTIFACT_TYPES`). A `newsletter`-eligible target implies genuine
- * project `writer`, which is valid for every one of the six creatable types — probing with
- * `'meeting'` instead (as this service originally did) would let a `meeting_coordinator`-only or
- * committee-writer-only user's probe succeed too, over-showing types (newsletter, mailing-list,
- * group) they hold no grant for at all and whose own picker would come up empty. `writerGuard`
- * remains the actual authority regardless of what this list advertises — it only ever narrows
- * the affordance, it never grants access.
- *
- * Everything resolves to `[]` while loading and on error (the underlying service fails closed).
- *
- * Persona note (ED): still no ED fast-path here, unlike `writerGuard` — unchanged trade-off from
- * before this rebuild (LFXV2-2721).
+ * The create-target picker's own fail-closed empty state (tree and search both empty) is what
+ * communicates zero access now, for whichever artifact type the user actually opens. `writerGuard`
+ * remains the actual authority regardless of what this menu advertises — it only ever narrows the
+ * affordance, it never grants access. There is no probe left to run, so this service has no
+ * constructor, no injected dependencies, and does no I/O.
  */
 @Injectable({
   providedIn: 'root',
 })
 export class CreatePermissionService {
-  private readonly pickerService = inject(CreateTargetPickerService);
-  private readonly destroyRef = inject(DestroyRef);
+  /** Always all six creatable types (see class doc). */
+  public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() => CREATABLE_ARTIFACTS.map((artifact) => artifact.type));
 
-  private readonly writerEligibility: WritableSignal<CreatePickerResultSet> = signal(EMPTY_CREATE_PICKER_RESULT);
-
-  /** True when a writer-only probe found at least one direct-grant project or committee. */
-  private readonly hasWriterEligibleTarget: Signal<boolean> = computed(() => {
-    const result = this.writerEligibility();
-    return result.projects.length > 0 || result.committees.length > 0;
-  });
-
-  /** Artifact types offered to the user — all types when writer-eligible, else none (see class doc). */
-  public readonly creatableTypes: Signal<CreatableArtifactType[]> = computed(() =>
-    this.hasWriterEligibleTarget() ? CREATABLE_ARTIFACTS.map((artifact) => artifact.type) : []
-  );
-
-  /**
-   * Always true — the rail button no longer gates on an eligibility probe (see class doc). Kept
-   * as a signal (not a plain `true`) so existing consumers don't need to change, and so a future
-   * cheap "does this user have anything at all" signal has somewhere to plug back in.
-   */
+  /** Always true (see class doc). */
   public readonly canShowCreateButton: Signal<boolean> = computed(() => true);
-
-  public constructor() {
-    // Deferred to after the first render — this probe is cheap (direct-grant only), but any
-    // avoidable HTTP round trip during SSR still risks TTFB, so it stays off the critical render path.
-    afterNextRender(() => {
-      this.pickerService
-        .getTree('newsletter')
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe((result) => this.writerEligibility.set(result));
-    });
-  }
 }

--- a/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
@@ -22,18 +22,33 @@ export class CreateTargetPickerService {
   /** Top-level direct-grant tree nodes for the given artifact type. */
   public getTree(artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
     const params = new HttpParams().set('artifactType', artifactType);
-    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree', { params }).pipe(
+      catchError((error) => {
+        console.error('Failed to load create-picker tree:', error);
+        return of(EMPTY_RESULT);
+      })
+    );
   }
 
   /** Lazy fan-out for one tree node. */
   public getChildren(parentType: 'project' | 'committee', parentUid: string, artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
     const params = new HttpParams().set('parentType', parentType).set('parentUid', parentUid).set('artifactType', artifactType);
-    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params }).pipe(
+      catchError((error) => {
+        console.error('Failed to load create-picker children:', error);
+        return of(EMPTY_RESULT);
+      })
+    );
   }
 
   /** Type-ahead search across both resource types. */
   public search(term: string, artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
     const params = new HttpParams().set('q', term).set('artifactType', artifactType);
-    return this.http.get<CreatePickerResultSet>('/api/create-picker/search', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/search', { params }).pipe(
+      catchError((error) => {
+        console.error('Failed to search create-picker targets:', error);
+        return of(EMPTY_RESULT);
+      })
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
@@ -1,0 +1,39 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
+import { catchError, Observable, of } from 'rxjs';
+
+const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
+
+/**
+ * Thin HTTP wrapper around the create picker's three BFF endpoints (LFXV2-2838). Every call
+ * fails closed to an empty result set rather than surfacing an error — a picker that can't load
+ * should look empty, not broken, since the create dialog has no error-recovery UI of its own.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CreateTargetPickerService {
+  private readonly http = inject(HttpClient);
+
+  /** Top-level direct-grant tree nodes for the given artifact type. */
+  public getTree(artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
+    const params = new HttpParams().set('artifactType', artifactType);
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+  }
+
+  /** Lazy fan-out for one tree node. */
+  public getChildren(parentType: 'project' | 'committee', parentUid: string, artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
+    const params = new HttpParams().set('parentType', parentType).set('parentUid', parentUid).set('artifactType', artifactType);
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+  }
+
+  /** Type-ahead search across both resource types. */
+  public search(term: string, artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
+    const params = new HttpParams().set('q', term).set('artifactType', artifactType);
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/search', { params }).pipe(catchError(() => of(EMPTY_RESULT)));
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
@@ -8,9 +8,10 @@ import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/in
 import { catchError, Observable, of } from 'rxjs';
 
 /**
- * Thin HTTP wrapper around the create picker's three BFF endpoints (LFXV2-2838). Every call
- * fails closed to an empty result set rather than surfacing an error — a picker that can't load
- * should look empty, not broken, since the create dialog has no error-recovery UI of its own.
+ * Thin HTTP wrapper around the create picker's three BFF endpoints (LFXV2-2838). `getTree()` and
+ * `search()` fail closed to an empty result set rather than surfacing an error — a picker that
+ * can't load should look empty, not broken, since the create dialog has no error-recovery UI of
+ * its own. `getChildren()` is the exception — see its own doc comment.
  */
 @Injectable({
   providedIn: 'root',

--- a/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
@@ -3,10 +3,9 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { EMPTY_CREATE_PICKER_RESULT } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerResultSet } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
-
-const EMPTY_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
 
 /**
  * Thin HTTP wrapper around the create picker's three BFF endpoints (LFXV2-2838). Every call
@@ -25,7 +24,7 @@ export class CreateTargetPickerService {
     return this.http.get<CreatePickerResultSet>('/api/create-picker/tree', { params }).pipe(
       catchError((error) => {
         console.error('Failed to load create-picker tree:', error);
-        return of(EMPTY_RESULT);
+        return of(EMPTY_CREATE_PICKER_RESULT);
       })
     );
   }
@@ -36,7 +35,7 @@ export class CreateTargetPickerService {
     return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params }).pipe(
       catchError((error) => {
         console.error('Failed to load create-picker children:', error);
-        return of(EMPTY_RESULT);
+        return of(EMPTY_CREATE_PICKER_RESULT);
       })
     );
   }
@@ -47,7 +46,7 @@ export class CreateTargetPickerService {
     return this.http.get<CreatePickerResultSet>('/api/create-picker/search', { params }).pipe(
       catchError((error) => {
         console.error('Failed to search create-picker targets:', error);
-        return of(EMPTY_RESULT);
+        return of(EMPTY_CREATE_PICKER_RESULT);
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
+++ b/apps/lfx-one/src/app/shared/services/create-target-picker.service.ts
@@ -29,15 +29,14 @@ export class CreateTargetPickerService {
     );
   }
 
-  /** Lazy fan-out for one tree node. */
+  /**
+   * Lazy fan-out for one tree node. Unlike `getTree()`/`search()`, errors are NOT swallowed here —
+   * the caller (the tree node itself) needs to tell a real failure (worth retrying on next expand)
+   * apart from a confirmed, genuinely empty result (a real leaf — must not retry indefinitely).
+   */
   public getChildren(parentType: 'project' | 'committee', parentUid: string, artifactType: CreatableArtifactType): Observable<CreatePickerResultSet> {
     const params = new HttpParams().set('parentType', parentType).set('parentUid', parentUid).set('artifactType', artifactType);
-    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params }).pipe(
-      catchError((error) => {
-        console.error('Failed to load create-picker children:', error);
-        return of(EMPTY_CREATE_PICKER_RESULT);
-      })
-    );
+    return this.http.get<CreatePickerResultSet>('/api/create-picker/tree/children', { params });
   }
 
   /** Type-ahead search across both resource types. */

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -36,6 +36,8 @@ export class LensService {
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
 
   private readonly selectedLens: WritableSignal<Lens>;
+  /** Set only by `setContextLens()`; makes `activeLens` bypass the persona-lens clamp for the create flow. Cleared by any normal `setLens()`/`switchLens()` call. */
+  private readonly contextLensOverride: WritableSignal<Lens | null> = signal(null);
 
   /** Last foundation/project lens viewed — lets the merged 'Projects' entry (hybrid personas) return to a foundation. */
   private readonly navLensSelection: WritableSignal<NavLens>;
@@ -80,6 +82,8 @@ export class LensService {
     if (!allowed.includes(lens)) {
       return false;
     }
+    // A deliberate, persona-gated switch supersedes any pending create-flow override.
+    this.contextLensOverride.set(null);
     this.applyLensSelection(lens);
     return true;
   }
@@ -94,8 +98,16 @@ export class LensService {
    * legitimate, already-authorized picks purely because the persona doesn't happen to hold a
    * matching lens. `setLens()` keeps that gate for every other caller (sidebar, lens-switcher,
    * dashboards) — this method exists so the create flow doesn't have to go through it.
+   *
+   * `applyLensSelection()` alone isn't enough: `activeLens` re-derives its value from
+   * `selectedLens` through `getAllowedLensIds()` on every read, so setting `selectedLens` without
+   * also recording an override would silently get clamped straight back to `DEFAULT_LENS` for
+   * exactly the users this method exists to unblock. `contextLensOverride` makes `activeLens`
+   * (and everything downstream of it — `lensRedirectGuard`, `ProjectContextService.activeContext`)
+   * bypass that clamp until a normal `setLens()`/`switchLens()` call clears it.
    */
   public setContextLens(lens: Lens): void {
+    this.contextLensOverride.set(lens);
     this.applyLensSelection(lens);
   }
 
@@ -112,6 +124,10 @@ export class LensService {
 
   private initActiveLens(): Signal<Lens> {
     return computed(() => {
+      const override = this.contextLensOverride();
+      if (override) {
+        return override;
+      }
       const selected = this.selectedLens();
       const allowed = this.getAllowedLensIds();
       return allowed.includes(selected) ? selected : DEFAULT_LENS;

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -80,6 +80,26 @@ export class LensService {
     if (!allowed.includes(lens)) {
       return false;
     }
+    this.applyLensSelection(lens);
+    return true;
+  }
+
+  /**
+   * Aligns `activeContext`'s lens-gated slot and the `/foundation/`/`/project/` route prefix to
+   * `lens`, without checking whether the current persona is allowed it (LFXV2-2838).
+   *
+   * Not a persona-lens switch — scoped strictly to the create picker, which has already proven
+   * access to the specific project/committee explicitly (a direct grant or a batch access-check
+   * that evaluates inherited access), so gating on `getAllowedLensIds()` here would reject
+   * legitimate, already-authorized picks purely because the persona doesn't happen to hold a
+   * matching lens. `setLens()` keeps that gate for every other caller (sidebar, lens-switcher,
+   * dashboards) — this method exists so the create flow doesn't have to go through it.
+   */
+  public setContextLens(lens: Lens): void {
+    this.applyLensSelection(lens);
+  }
+
+  private applyLensSelection(lens: Lens): void {
     if ((lens === 'foundation' || lens === 'project') && lens !== this.navLensSelection()) {
       this.navLensSelection.set(lens);
       this.persistNavLensToCookie(lens);
@@ -88,7 +108,6 @@ export class LensService {
       this.selectedLens.set(lens);
       this.persistToCookie(lens);
     }
-    return true;
   }
 
   private initActiveLens(): Signal<Lens> {

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { computed, inject, Injectable, signal, Signal, WritableSignal } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationCancel, NavigationEnd, NavigationError, NavigationSkipped, Router } from '@angular/router';
 import {
   ALL_LENSES,
   DEFAULT_LENS,
@@ -15,6 +15,7 @@ import {
 import { Lens, LensOption, NavLens } from '@lfx-one/shared/interfaces';
 import { deriveAllowedLenses } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
+import { filter, take } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
@@ -36,7 +37,13 @@ export class LensService {
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
 
   private readonly selectedLens: WritableSignal<Lens>;
-  /** Set only by `setContextLens()`; makes `activeLens` bypass the persona-lens clamp for the create flow. Cleared by any normal `setLens()`/`switchLens()` call. */
+  /**
+   * Set only by `setContextLens()`; makes `activeLens` bypass the persona-lens clamp for the
+   * create flow. Cleared by any normal `setLens()`/`switchLens()` call, or automatically once the
+   * navigation `setContextLens()` was called for concludes (see `setContextLens`) — it must not
+   * outlive that one navigation, since a committee-only writer may hold no lens capable of
+   * clearing it through the normal UI.
+   */
   private readonly contextLensOverride: WritableSignal<Lens | null> = signal(null);
 
   /** Last foundation/project lens viewed — lets the merged 'Projects' entry (hybrid personas) return to a foundation. */
@@ -105,10 +112,27 @@ export class LensService {
    * exactly the users this method exists to unblock. `contextLensOverride` makes `activeLens`
    * (and everything downstream of it — `lensRedirectGuard`, `ProjectContextService.activeContext`)
    * bypass that clamp until a normal `setLens()`/`switchLens()` call clears it.
+   *
+   * The override also self-clears once the navigation this call is for concludes (success,
+   * cancel, or error) — without that, a persona whose allowed lenses never include `lens` (e.g. a
+   * committee-only writer creating against a project/foundation target) has no normal
+   * `setLens()`/`switchLens()` call left to run, since the lens-switcher UI only offers lenses
+   * `getAllowedLensIds()` admits. Left unscoped, the override would silently stick past this one
+   * navigation and clamp every subsequent route (including lens-agnostic ones like `/profile`) to
+   * `lens` for the rest of the session.
    */
   public setContextLens(lens: Lens): void {
     this.contextLensOverride.set(lens);
     this.applyLensSelection(lens);
+    this.router.events
+      .pipe(
+        filter(
+          (event) =>
+            event instanceof NavigationEnd || event instanceof NavigationCancel || event instanceof NavigationError || event instanceof NavigationSkipped
+        ),
+        take(1)
+      )
+      .subscribe(() => this.contextLensOverride.set(null));
   }
 
   private applyLensSelection(lens: Lens): void {

--- a/apps/lfx-one/src/server/controllers/create-picker.controller.ts
+++ b/apps/lfx-one/src/server/controllers/create-picker.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
+import { CREATABLE_ARTIFACTS, CREATE_PICKER_MIN_SEARCH_LENGTH } from '@lfx-one/shared/constants';
 import { CreatableArtifactType, CreatePickerChildrenQuery } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
@@ -111,8 +111,8 @@ export class CreatePickerController {
       const artifactType = parseArtifactType(req, 'search_create_picker');
       const { q } = req.query;
 
-      if (typeof q !== 'string' || q.trim().length < 2) {
-        throw ServiceValidationError.forField('q', 'q is required and must be at least 2 characters', {
+      if (typeof q !== 'string' || q.trim().length < CREATE_PICKER_MIN_SEARCH_LENGTH) {
+        throw ServiceValidationError.forField('q', `q is required and must be at least ${CREATE_PICKER_MIN_SEARCH_LENGTH} characters`, {
           operation: 'search_create_picker',
           service: 'create_picker_controller',
           path: req.path,

--- a/apps/lfx-one/src/server/controllers/create-picker.controller.ts
+++ b/apps/lfx-one/src/server/controllers/create-picker.controller.ts
@@ -1,0 +1,128 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CreatableArtifactType } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { CreatePickerService } from '../services/create-picker.service';
+
+const VALID_ARTIFACT_TYPES: CreatableArtifactType[] = ['meeting', 'newsletter', 'vote', 'survey', 'group', 'mailing-list'];
+const VALID_PARENT_TYPES = ['project', 'committee'];
+
+function parseArtifactType(req: Request, operation: string): CreatableArtifactType {
+  const { artifactType } = req.query;
+  if (typeof artifactType !== 'string' || !VALID_ARTIFACT_TYPES.includes(artifactType as CreatableArtifactType)) {
+    throw ServiceValidationError.forField('artifactType', 'artifactType is required and must be a valid creatable artifact type', {
+      operation,
+      service: 'create_picker_controller',
+      path: req.path,
+    });
+  }
+  return artifactType as CreatableArtifactType;
+}
+
+/**
+ * Controller for the create picker's tree/search endpoints (LFXV2-2838). Backs a lazy
+ * direct-grant tree + type-ahead search — no handler here ever enumerates every project.
+ */
+export class CreatePickerController {
+  private createPickerService: CreatePickerService = new CreatePickerService();
+
+  /**
+   * GET /create-picker/tree
+   */
+  public async getTree(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_create_picker_tree', {
+      query_params: logger.sanitize(req.query as Record<string, any>),
+    });
+
+    try {
+      const artifactType = parseArtifactType(req, 'get_create_picker_tree');
+      const result = await this.createPickerService.getTree(req, artifactType);
+
+      logger.success(req, 'get_create_picker_tree', startTime, {
+        project_count: result.projects.length,
+        committee_count: result.committees.length,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /create-picker/tree/children
+   */
+  public async getChildren(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_create_picker_children', {
+      query_params: logger.sanitize(req.query as Record<string, any>),
+    });
+
+    try {
+      const artifactType = parseArtifactType(req, 'get_create_picker_children');
+      const { parentType, parentUid } = req.query;
+
+      if (typeof parentType !== 'string' || !VALID_PARENT_TYPES.includes(parentType)) {
+        throw ServiceValidationError.forField('parentType', 'parentType is required and must be "project" or "committee"', {
+          operation: 'get_create_picker_children',
+          service: 'create_picker_controller',
+          path: req.path,
+        });
+      }
+      if (typeof parentUid !== 'string' || !parentUid) {
+        throw ServiceValidationError.forField('parentUid', 'parentUid is required', {
+          operation: 'get_create_picker_children',
+          service: 'create_picker_controller',
+          path: req.path,
+        });
+      }
+
+      const result = await this.createPickerService.getChildren(req, parentType as 'project' | 'committee', parentUid, artifactType);
+
+      logger.success(req, 'get_create_picker_children', startTime, {
+        project_count: result.projects.length,
+        committee_count: result.committees.length,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /create-picker/search
+   */
+  public async search(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'search_create_picker', {
+      query_params: logger.sanitize(req.query as Record<string, any>),
+    });
+
+    try {
+      const artifactType = parseArtifactType(req, 'search_create_picker');
+      const { q } = req.query;
+
+      if (typeof q !== 'string' || q.trim().length < 2) {
+        throw ServiceValidationError.forField('q', 'q is required and must be at least 2 characters', {
+          operation: 'search_create_picker',
+          service: 'create_picker_controller',
+          path: req.path,
+        });
+      }
+
+      const result = await this.createPickerService.search(req, q.trim(), artifactType);
+
+      logger.success(req, 'search_create_picker', startTime, {
+        project_count: result.projects.length,
+        committee_count: result.committees.length,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/create-picker.controller.ts
+++ b/apps/lfx-one/src/server/controllers/create-picker.controller.ts
@@ -24,6 +24,27 @@ function parseArtifactType(req: Request, operation: string): CreatableArtifactTy
   return artifactType as CreatableArtifactType;
 }
 
+function parseChildrenQuery(req: Request, artifactType: CreatableArtifactType): CreatePickerChildrenQuery {
+  const { parentType, parentUid } = req.query;
+
+  if (typeof parentType !== 'string' || !VALID_PARENT_TYPES.includes(parentType)) {
+    throw ServiceValidationError.forField('parentType', 'parentType is required and must be "project" or "committee"', {
+      operation: 'get_create_picker_children',
+      service: 'create_picker_controller',
+      path: req.path,
+    });
+  }
+  if (typeof parentUid !== 'string' || !parentUid) {
+    throw ServiceValidationError.forField('parentUid', 'parentUid is required', {
+      operation: 'get_create_picker_children',
+      service: 'create_picker_controller',
+      path: req.path,
+    });
+  }
+
+  return { parentType: parentType as 'project' | 'committee', parentUid, artifactType };
+}
+
 /**
  * Controller for the create picker's tree/search endpoints (LFXV2-2838). Backs a lazy
  * direct-grant tree + type-ahead search — no handler here ever enumerates every project.
@@ -64,24 +85,7 @@ export class CreatePickerController {
 
     try {
       const artifactType = parseArtifactType(req, 'get_create_picker_children');
-      const { parentType, parentUid } = req.query;
-
-      if (typeof parentType !== 'string' || !VALID_PARENT_TYPES.includes(parentType)) {
-        throw ServiceValidationError.forField('parentType', 'parentType is required and must be "project" or "committee"', {
-          operation: 'get_create_picker_children',
-          service: 'create_picker_controller',
-          path: req.path,
-        });
-      }
-      if (typeof parentUid !== 'string' || !parentUid) {
-        throw ServiceValidationError.forField('parentUid', 'parentUid is required', {
-          operation: 'get_create_picker_children',
-          service: 'create_picker_controller',
-          path: req.path,
-        });
-      }
-
-      const query: CreatePickerChildrenQuery = { parentType: parentType as 'project' | 'committee', parentUid, artifactType };
+      const query = parseChildrenQuery(req, artifactType);
       const result = await this.createPickerService.getChildren(req, query.parentType, query.parentUid, query.artifactType);
 
       logger.success(req, 'get_create_picker_children', startTime, {

--- a/apps/lfx-one/src/server/controllers/create-picker.controller.ts
+++ b/apps/lfx-one/src/server/controllers/create-picker.controller.ts
@@ -1,14 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CreatableArtifactType } from '@lfx-one/shared/interfaces';
+import { CREATABLE_ARTIFACTS } from '@lfx-one/shared/constants';
+import { CreatableArtifactType, CreatePickerChildrenQuery } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { CreatePickerService } from '../services/create-picker.service';
 
-const VALID_ARTIFACT_TYPES: CreatableArtifactType[] = ['meeting', 'newsletter', 'vote', 'survey', 'group', 'mailing-list'];
+const VALID_ARTIFACT_TYPES: CreatableArtifactType[] = CREATABLE_ARTIFACTS.map((artifact) => artifact.type);
 const VALID_PARENT_TYPES = ['project', 'committee'];
 
 function parseArtifactType(req: Request, operation: string): CreatableArtifactType {
@@ -80,7 +81,8 @@ export class CreatePickerController {
         });
       }
 
-      const result = await this.createPickerService.getChildren(req, parentType as 'project' | 'committee', parentUid, artifactType);
+      const query: CreatePickerChildrenQuery = { parentType: parentType as 'project' | 'committee', parentUid, artifactType };
+      const result = await this.createPickerService.getChildren(req, query.parentType, query.parentUid, query.artifactType);
 
       logger.success(req, 'get_create_picker_children', startTime, {
         project_count: result.projects.length,

--- a/apps/lfx-one/src/server/routes/create-picker.route.ts
+++ b/apps/lfx-one/src/server/routes/create-picker.route.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { CreatePickerController } from '../controllers/create-picker.controller';
+
+const router = Router();
+
+const createPickerController = new CreatePickerController();
+
+router.get('/tree', (req, res, next) => createPickerController.getTree(req, res, next));
+router.get('/tree/children', (req, res, next) => createPickerController.getChildren(req, res, next));
+router.get('/search', (req, res, next) => createPickerController.search(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -29,6 +29,7 @@ import campaignsRouter from './routes/campaigns.route';
 import changelogRouter from './routes/changelog.route';
 import committeesRouter from './routes/committees.route';
 import copilotRouter from './routes/copilot.route';
+import createPickerRouter from './routes/create-picker.route';
 import documentsRouter from './routes/documents.route';
 import eventsRouter from './routes/events.route';
 import impersonationRouter from './routes/impersonation.route';
@@ -305,6 +306,7 @@ app.use('/public/api/projects', publicProjectsRouter);
 
 app.use('/api/projects', projectsRouter);
 app.use('/api/committees', committeesRouter);
+app.use('/api/create-picker', createPickerRouter);
 app.use('/api/mailing-lists', mailingListsRouter);
 app.use('/api/meetings', meetingsRouter);
 app.use('/api/meetups', meetupsRouter);

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -1,0 +1,96 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors meeting.service.spec.ts / session-store.service.spec.ts: the `@lfx-one/shared/*` alias
+// isn't wired into this app's vitest config, so runtime collaborators need mocking. Only
+// `AccessCheckAccessType`/`AccessCheckRequest`/etc. are imported from shared interfaces — all
+// type-only, so no mock is needed for that subpath (esbuild elides type-only imports).
+const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
+
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+}));
+
+import type { Request } from 'express';
+
+import { AccessCheckService } from './access-check.service';
+
+const req = {} as unknown as Request;
+
+describe('AccessCheckService.checkAccess', () => {
+  let service: AccessCheckService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new AccessCheckService();
+  });
+
+  it('matches results back to requests by tuple content, not array position', async () => {
+    // Upstream reorders relative to the request order it was sent in.
+    proxyRequest.mockResolvedValueOnce({
+      results: ['project:b#writer@user:alice\ttrue', 'project:a#writer@user:alice\tfalse'],
+    });
+
+    const result = await service.checkAccess(req, [
+      { resource: 'project', id: 'a', access: 'writer' },
+      { resource: 'project', id: 'b', access: 'writer' },
+    ]);
+
+    expect(result.get('a')).toBe(false);
+    expect(result.get('b')).toBe(true);
+  });
+
+  it('deduplicates identical tuples without misattributing them to different resources', async () => {
+    // Two distinct resource ids requesting the exact same relation happen to produce the same
+    // tuple string only when ids match — this checks the id is part of the matched key, not just
+    // resource+access.
+    proxyRequest.mockResolvedValueOnce({
+      results: ['committee:x#writer@user:alice\ttrue', 'committee:y#writer@user:alice\tfalse'],
+    });
+
+    const result = await service.checkAccess(req, [
+      { resource: 'committee', id: 'x', access: 'writer' },
+      { resource: 'committee', id: 'y', access: 'writer' },
+    ]);
+
+    expect(result.get('x')).toBe(true);
+    expect(result.get('y')).toBe(false);
+  });
+
+  it('fails closed when the upstream response omits a tuple entirely', async () => {
+    // Only one of two requested tuples came back — e.g. a partial/short response.
+    proxyRequest.mockResolvedValueOnce({
+      results: ['project:a#writer@user:alice\ttrue'],
+    });
+
+    const result = await service.checkAccess(req, [
+      { resource: 'project', id: 'a', access: 'writer' },
+      { resource: 'project', id: 'b', access: 'writer' },
+    ]);
+
+    expect(result.get('a')).toBe(true);
+    expect(result.get('b')).toBe(false);
+  });
+
+  it('returns an empty map without calling upstream for an empty input', async () => {
+    const result = await service.checkAccess(req, []);
+
+    expect(result.size).toBe(0);
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it('falls back to all-false on upstream error', async () => {
+    proxyRequest.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await service.checkAccess(req, [{ resource: 'project', id: 'a', access: 'writer' }]);
+
+    expect(result.get('a')).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -64,6 +64,25 @@ describe('AccessCheckService.checkAccess', () => {
     expect(result.get('y')).toBe(false);
   });
 
+  it('does not let a duplicated request tuple misalign a later distinct resource', async () => {
+    // 'a' is requested twice; upstream dedupes the repeated tuple server-side, returning only 2
+    // result lines for 3 requests. The old index-based implementation would misalign
+    // resources[1] (the duplicate 'a') against results[1] (actually resource 'b''s line),
+    // corrupting 'a' and losing 'b' entirely.
+    proxyRequest.mockResolvedValueOnce({
+      results: ['project:a#writer@user:alice\ttrue', 'project:b#writer@user:alice\tfalse'],
+    });
+
+    const result = await service.checkAccess(req, [
+      { resource: 'project', id: 'a', access: 'writer' },
+      { resource: 'project', id: 'a', access: 'writer' },
+      { resource: 'project', id: 'b', access: 'writer' },
+    ]);
+
+    expect(result.get('a')).toBe(true);
+    expect(result.get('b')).toBe(false);
+  });
+
   it('fails closed when the upstream response omits a tuple entirely', async () => {
     // Only one of two requested tuples came back — e.g. a partial/short response.
     proxyRequest.mockResolvedValueOnce({

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -54,36 +54,42 @@ export class AccessCheckService {
         requestPayload
       );
 
-      // Create result map
+      // Parse each result string into a lookup keyed by the "resource:id#access" tuple it
+      // reports on, rather than trusting positional (array-index) alignment with `resources`.
+      // The upstream response can reorder or dedupe entries, so index-based pairing can silently
+      // attribute one resource's answer to a different resource.
+      const resultByTuple = new Map<string, { hasAccess: boolean; username?: string }>();
+      for (const resultString of response.results) {
+        if (!resultString || typeof resultString !== 'string') {
+          continue;
+        }
+
+        // Format: "resource:id#access@user:username\ttrue/false"
+        const parts = resultString.split('\t');
+        if (parts.length < 2) {
+          continue;
+        }
+
+        const accessPart = parts[0];
+        const hasAccess = parts[1]?.toLowerCase() === 'true';
+        const userMatch = accessPart?.match(/@user:(.+)$/);
+        const tuple = userMatch ? accessPart.slice(0, userMatch.index) : accessPart;
+        const username = userMatch?.[1];
+
+        resultByTuple.set(tuple, { hasAccess, username });
+      }
+
+      // Map results back to resource IDs by re-deriving the same tuple each request sent
       const resultMap = new Map<string, boolean>();
       const userAccessInfo: { resourceId: string; username?: string; hasAccess: boolean }[] = [];
 
-      // Map results back to resource IDs
-      for (let i = 0; i < resources.length; i++) {
-        const resource = resources[i];
-        const resultString = response.results[i];
+      for (const resource of resources) {
+        const tuple = `${resource.resource}:${resource.id}#${resource.access}`;
+        const result = resultByTuple.get(tuple);
 
-        // Parse the result string format: "resource:id#access@user:username\ttrue/false"
-        let hasAccess = false;
-        let username: string | undefined;
-
-        if (resultString && typeof resultString === 'string') {
-          // Split by tab to get the boolean part
-          const parts = resultString.split('\t');
-          if (parts.length >= 2) {
-            hasAccess = parts[1]?.toLowerCase() === 'true';
-
-            // Extract username from the first part: "resource:id#access@user:username"
-            const accessPart = parts[0];
-            const userMatch = accessPart?.match(/@user:(.+)$/);
-            if (userMatch) {
-              username = userMatch[1];
-            }
-          }
-        }
-
-        resultMap.set(resource.id, hasAccess);
-        userAccessInfo.push({ resourceId: resource.id, username, hasAccess });
+        // Fail closed when the upstream response omits this tuple
+        resultMap.set(resource.id, result?.hasAccess ?? false);
+        userAccessInfo.push({ resourceId: resource.id, username: result?.username, hasAccess: result?.hasAccess ?? false });
       }
 
       logger.success(req, operationName, startTime, {

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Committee, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors project.service.spec.ts / meeting.service.spec.ts: the `@lfx-one/shared/*` alias isn't
+// wired into this app's vitest config, so runtime (non-type-only) imports need stubs.
+const { proxyRequest, addAccessToResources } = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  addAccessToResources: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/enums', () => ({ CommitteeMemberRole: {} }));
+vi.mock('@lfx-one/shared/utils', () => ({ invitationRequiresOrganization: vi.fn() }));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./access-check.service', () => ({
+  AccessCheckService: class {
+    public addAccessToResources = addAccessToResources;
+  },
+}));
+vi.mock('./etag.service', () => ({ ETagService: class {} }));
+vi.mock('./project.service', () => ({ ProjectService: class {} }));
+vi.mock('../utils/auth-helper', () => ({ cleanUserDisplayName: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+}));
+
+import type { Request } from 'express';
+
+import { CommitteeService } from './committee.service';
+
+const req = {} as unknown as Request;
+
+function pageOf(committees: Partial<Committee>[]): QueryServiceResponse<Committee> {
+  return { resources: committees.map((c) => ({ id: `committee:${c.uid}`, data: c as Committee })), page_token: undefined } as QueryServiceResponse<Committee>;
+}
+
+describe('CommitteeService — create picker methods', () => {
+  let service: CommitteeService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    addAccessToResources.mockReset();
+    service = new CommitteeService();
+  });
+
+  describe('getDirectGrantCommittees', () => {
+    it('queries filter_grants=direct and returns only writer-permitted committees', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a' }, { uid: 'b' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, committees: Committee[]) =>
+        Promise.resolve(committees.map((c) => ({ ...c, writer: c.uid === 'a' })))
+      );
+
+      const result = await service.getDirectGrantCommittees(req);
+
+      expect(result.map((c) => c.uid)).toEqual(['a']);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'committee', filter_grants: 'direct' });
+    });
+  });
+
+  describe('searchCreatableCommittees', () => {
+    it('queries name=<term> with a small page size and filters to writer-permitted matches', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'match-1' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, committees: Committee[]) => Promise.resolve(committees.map((c) => ({ ...c, writer: true }))));
+
+      const result = await service.searchCreatableCommittees(req, 'security');
+
+      expect(result.map((c) => c.uid)).toEqual(['match-1']);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'committee', name: 'security', page_size: 20 });
+    });
+
+    it('excludes non-writer matches even when the query service returns them', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'writer-committee' }, { uid: 'inherited-not-writer' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, committees: Committee[]) =>
+        Promise.resolve(committees.map((c) => ({ ...c, writer: c.uid === 'writer-committee' })))
+      );
+
+      const result = await service.searchCreatableCommittees(req, 'security');
+
+      expect(result.map((c) => c.uid)).toEqual(['writer-committee']);
+    });
+  });
+
+  it('never issues a type=committee query-service call without filter_grants or name', async () => {
+    proxyRequest.mockResolvedValue(pageOf([]));
+    addAccessToResources.mockImplementation((_req: Request, committees: Committee[]) => Promise.resolve(committees));
+
+    await service.getDirectGrantCommittees(req);
+    await service.searchCreatableCommittees(req, 'term');
+
+    const paramsSent = proxyRequest.mock.calls.filter((call) => call[4]?.type === 'committee').map((call) => call[4]);
+    expect(paramsSent.length).toBeGreaterThan(0);
+    for (const params of paramsSent) {
+      expect(params['filter_grants'] === 'direct' || typeof params['name'] === 'string').toBe(true);
+    }
+  });
+});

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -36,8 +36,8 @@ import { CommitteeService } from './committee.service';
 
 const req = {} as unknown as Request;
 
-function pageOf(committees: Partial<Committee>[]): QueryServiceResponse<Committee> {
-  return { resources: committees.map((c) => ({ id: `committee:${c.uid}`, data: c as Committee })), page_token: undefined } as QueryServiceResponse<Committee>;
+function pageOf(committees: Partial<Committee>[], pageToken?: string): QueryServiceResponse<Committee> {
+  return { resources: committees.map((c) => ({ id: `committee:${c.uid}`, data: c as Committee })), page_token: pageToken } as QueryServiceResponse<Committee>;
 }
 
 describe('CommitteeService — create picker methods', () => {
@@ -83,6 +83,30 @@ describe('CommitteeService — create picker methods', () => {
       const result = await service.searchCreatableCommittees(req, 'security');
 
       expect(result.map((c) => c.uid)).toEqual(['writer-committee']);
+    });
+
+    it('continues to the next page when the first page has no writer-permitted matches', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'visible-only' }], 'token-2'));
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'inherited-writer' }]));
+      addAccessToResources.mockImplementation((_req: Request, committees: Committee[]) =>
+        Promise.resolve(committees.map((c) => ({ ...c, writer: c.uid === 'inherited-writer' })))
+      );
+
+      const result = await service.searchCreatableCommittees(req, 'security');
+
+      expect(result.map((c) => c.uid)).toEqual(['inherited-writer']);
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'token-2' });
+    });
+
+    it('stops paging once the page cap is reached, even if pages remain', async () => {
+      proxyRequest.mockResolvedValue(pageOf([{ uid: 'no-match' }], 'more'));
+      addAccessToResources.mockImplementation((_req: Request, committees: Committee[]) => Promise.resolve(committees.map((c) => ({ ...c, writer: false }))));
+
+      const result = await service.searchCreatableCommittees(req, 'security');
+
+      expect(result).toEqual([]);
+      expect(proxyRequest).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -181,7 +181,9 @@ export class CommitteeService {
     committees = committees.map((committee) => ({
       ...committee,
       total_members: committee.total_members ?? 0,
-      has_mailing_list: options.skipMailingListEnrichment ? false : committeesWithMailingList.has(committee.uid),
+      // Omit rather than default to false when the lookup was skipped — false means a confirmed
+      // absence, and no lookup ran to confirm one.
+      ...(options.skipMailingListEnrichment ? {} : { has_mailing_list: committeesWithMailingList.has(committee.uid) }),
     }));
 
     // Add writer access field (used by the access filter below and consumed by the UI)

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -238,23 +238,49 @@ export class CommitteeService {
   }
 
   /**
-   * Type-ahead committee search for the create picker. A single small page, filtered to
-   * `writer === true` after the batch access-check — inherited access is evaluated here (unlike
+   * Type-ahead committee search for the create picker, filtered to `writer === true` after a
+   * per-page batch access-check — inherited access is evaluated here (unlike
    * `filter_grants=direct`), so a committee writer via inheritance is found through search even
    * when the direct-grant tree under-shows them.
+   *
+   * Keeps paging through raw name matches until either `pageSize` permitted results have been
+   * collected or upstream pages run out, bounded by a small page cap. A single unchecked page
+   * would silently miss an inherited-writer match on page 2+ behind a run of visible-but-non-writable
+   * matches on page 1 — exactly the scenario this method exists to reach.
    */
   public async searchCreatableCommittees(req: Request, searchQuery: string, pageSize: number = 20): Promise<Committee[]> {
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-      type: 'committee',
-      name: searchQuery,
-      page_size: pageSize,
-    });
-    const committees = await this.accessCheckService.addAccessToResources(
-      req,
-      resources.map((resource) => resource.data),
-      'committee'
-    );
-    return committees.filter((c) => c.writer === true);
+    // Bounds the raw-match scan (5 pages × page_size) so a generic search term can't turn this
+    // into an unbounded crawl — still vastly better than the single-page cutoff this replaces.
+    const SEARCH_PAGE_LIMIT = 5;
+    const permitted: Committee[] = [];
+    let pageToken: string | undefined;
+    let pagesFetched = 0;
+
+    do {
+      const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        {
+          type: 'committee',
+          name: searchQuery,
+          page_size: pageSize,
+          ...(pageToken && { page_token: pageToken }),
+        }
+      );
+      pagesFetched++;
+
+      const committees = await this.accessCheckService.addAccessToResources(
+        req,
+        resources.map((resource) => resource.data),
+        'committee'
+      );
+      permitted.push(...committees.filter((c) => c.writer === true));
+      pageToken = page_token;
+    } while (pageToken && permitted.length < pageSize && pagesFetched < SEARCH_PAGE_LIMIT);
+
+    return permitted.slice(0, pageSize);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -129,9 +129,13 @@ export class CommitteeService {
   }
 
   /**
-   * Fetches all committees based on query parameters
+   * Fetches all committees based on query parameters. `skipMailingListEnrichment` bypasses the
+   * batched `groupsio_mailing_list` lookup below for callers (e.g. the create picker's lazy
+   * children fan-out) that only need identity/project/writer fields and never render
+   * `has_mailing_list` — every such call otherwise paid for a query-service round trip whose
+   * result was immediately discarded.
    */
-  public async getCommittees(req: Request, query: Record<string, any> = {}): Promise<Committee[]> {
+  public async getCommittees(req: Request, query: Record<string, any> = {}, options: { skipMailingListEnrichment?: boolean } = {}): Promise<Committee[]> {
     const queryFilters = { ...query };
     delete queryFilters['page_token'];
     delete queryFilters['page_size'];
@@ -171,12 +175,13 @@ export class CommitteeService {
     // total_members is already indexed by the committee-service as part of
     // CommitteeBaseWithReadonlyAttributes — no separate per-committee count call needed.
     const committeeUids = committees.map((c) => c.uid).filter(Boolean);
-    const committeesWithMailingList = committeeUids.length > 0 ? await this.getCommitteesWithMailingList(req, committeeUids) : new Set<string>();
+    const committeesWithMailingList =
+      options.skipMailingListEnrichment || committeeUids.length === 0 ? new Set<string>() : await this.getCommitteesWithMailingList(req, committeeUids);
 
     committees = committees.map((committee) => ({
       ...committee,
       total_members: committee.total_members ?? 0,
-      has_mailing_list: committeesWithMailingList.has(committee.uid),
+      has_mailing_list: options.skipMailingListEnrichment ? false : committeesWithMailingList.has(committee.uid),
     }));
 
     // Add writer access field (used by the access filter below and consumed by the UI)

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -261,6 +261,8 @@ export class CommitteeService {
     let pageToken: string | undefined;
     let pagesFetched = 0;
 
+    logger.debug(req, 'search_creatable_committees', 'Scanning name matches for creatable committees', { page_size: pageSize, page_limit: SEARCH_PAGE_LIMIT });
+
     do {
       const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(
         req,
@@ -284,6 +286,13 @@ export class CommitteeService {
       permitted.push(...committees.filter((c) => c.writer === true));
       pageToken = page_token;
     } while (pageToken && permitted.length < pageSize && pagesFetched < SEARCH_PAGE_LIMIT);
+
+    if (pageToken && pagesFetched >= SEARCH_PAGE_LIMIT) {
+      logger.warning(req, 'search_creatable_committees', 'Hit the search page cap with more pages remaining', {
+        pages_fetched: pagesFetched,
+        permitted_count: permitted.length,
+      });
+    }
 
     return permitted.slice(0, pageSize);
   }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -218,6 +218,46 @@ export class CommitteeService {
   }
 
   /**
+   * Direct-FGA-grant committees for the create picker's default tree — NOT a full enumeration.
+   * Mirrors `ProjectService.getDirectGrantProjects`: `filter_grants=direct` narrows the
+   * query-service result set to the caller's own direct tuples before any access-check runs.
+   * Filtered to `writer === true` — this method exists for the create picker only, so the
+   * broader "public || writer || member" semantics `getCommittees` applies for its other
+   * (unscoped-listing) callers don't apply here.
+   */
+  public async getDirectGrantCommittees(req: Request): Promise<Committee[]> {
+    const resources = await fetchAllQueryResources<Committee>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'committee',
+        filter_grants: 'direct',
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+    const committees = await this.accessCheckService.addAccessToResources(req, resources, 'committee');
+    return committees.filter((c) => c.writer === true);
+  }
+
+  /**
+   * Type-ahead committee search for the create picker. A single small page, filtered to
+   * `writer === true` after the batch access-check — inherited access is evaluated here (unlike
+   * `filter_grants=direct`), so a committee writer via inheritance is found through search even
+   * when the direct-grant tree under-shows them.
+   */
+  public async searchCreatableCommittees(req: Request, searchQuery: string, pageSize: number = 20): Promise<Committee[]> {
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+      type: 'committee',
+      name: searchQuery,
+      page_size: pageSize,
+    });
+    const committees = await this.accessCheckService.addAccessToResources(
+      req,
+      resources.map((resource) => resource.data),
+      'committee'
+    );
+    return committees.filter((c) => c.writer === true);
+  }
+
+  /**
    * Fetches a single committee by ID.
    *
    * @param options.includeMembership When true, enriches the response with the caller's

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -176,13 +176,22 @@ describe('CreatePickerService', () => {
       expect(result.committees).toEqual([]);
     });
 
-    it("excludes nested sub-committees from a project node's direct committee children", async () => {
+    it("excludes nested sub-committees from a project node's direct committee children when their parent is reachable there", async () => {
       getChildProjects.mockResolvedValueOnce([]);
       getCommittees.mockResolvedValueOnce([committee('top-level', 'parent-uid'), committee('nested', 'parent-uid', 'top-level')]);
 
       const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
 
       expect(result.committees.map((c) => c.uid)).toEqual(['top-level']);
+    });
+
+    it('keeps a nested committee under the project directly when its parent committee is not writable/reachable there', async () => {
+      getChildProjects.mockResolvedValueOnce([]);
+      getCommittees.mockResolvedValueOnce([committee('nested-orphan', 'parent-uid', 'unreachable-parent')]);
+
+      const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
+
+      expect(result.committees.map((c) => c.uid)).toEqual(['nested-orphan']);
     });
 
     it('returns nothing for a committee parent when the artifact type disallows committee targets', async () => {

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -132,7 +132,7 @@ describe('CreatePickerService', () => {
 
       expect(result.projects.map((p) => p.uid)).toEqual(['child-project']);
       expect(result.committees.map((c) => c.uid)).toEqual(['project-committee']);
-      expect(getCommittees).toHaveBeenCalledWith(req, { tags: 'project_uid:parent-uid' });
+      expect(getCommittees).toHaveBeenCalledWith(req, { tags: 'project_uid:parent-uid' }, { skipMailingListEnrichment: true });
     });
 
     it('fans out a committee node into child committees only', async () => {
@@ -142,7 +142,7 @@ describe('CreatePickerService', () => {
 
       expect(result.projects).toEqual([]);
       expect(result.committees.map((c) => c.uid)).toEqual(['sub-committee']);
-      expect(getCommittees).toHaveBeenCalledWith(req, { parent: 'committee:parent-committee-uid' });
+      expect(getCommittees).toHaveBeenCalledWith(req, { parent: 'committee:parent-committee-uid' }, { skipMailingListEnrichment: true });
       expect(getChildProjects).not.toHaveBeenCalled();
     });
 

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -7,12 +7,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // exercise only CreatePickerService's own logic (relation-set selection, direct-grant
 // nesting/partitioning, node shaping), not the underlying query-service calls (covered in
 // project.service.spec.ts / committee.service.spec.ts).
-const { getDirectGrantProjects, getChildProjects, searchCreatableProjects, getProjectsByIds, enrichWithProjectData } = vi.hoisted(() => ({
+const { getDirectGrantProjects, getChildProjects, searchCreatableProjects, getProjectsByIds } = vi.hoisted(() => ({
   getDirectGrantProjects: vi.fn(),
   getChildProjects: vi.fn(),
   searchCreatableProjects: vi.fn(),
   getProjectsByIds: vi.fn(),
-  enrichWithProjectData: vi.fn(),
 }));
 const { getDirectGrantCommittees, searchCreatableCommittees, getCommittees } = vi.hoisted(() => ({
   getDirectGrantCommittees: vi.fn(),
@@ -28,7 +27,6 @@ vi.mock('./project.service', () => ({
     public getChildProjects = getChildProjects;
     public searchCreatableProjects = searchCreatableProjects;
     public getProjectsByIds = getProjectsByIds;
-    public enrichWithProjectData = enrichWithProjectData;
   },
 }));
 vi.mock('./committee.service', () => ({
@@ -61,18 +59,16 @@ describe('CreatePickerService', () => {
     getChildProjects.mockReset();
     searchCreatableProjects.mockReset();
     getProjectsByIds.mockReset();
-    enrichWithProjectData.mockReset();
     getDirectGrantCommittees.mockReset();
     searchCreatableCommittees.mockReset();
     getCommittees.mockReset();
 
-    // Default: enrichWithProjectData attaches is_foundation/project_slug/project_name per its
-    // real contract shape (keyed off project_uid).
-    enrichWithProjectData.mockImplementation((_req: Request, committees: any[]) =>
-      Promise.resolve(
-        committees.map((c) => ({ ...c, project_slug: c.project_uid, project_name: c.project_uid, is_foundation: c.project_uid === 'foundation-project' }))
-      )
-    );
+    // Default: every requested project_uid resolves — individual tests override this to exercise
+    // the "project couldn't be resolved" omission path.
+    getProjectsByIds.mockImplementation((_req: Request, uids: string[] | Set<string>) => {
+      const uidArray = Array.from(uids);
+      return Promise.resolve(new Map(uidArray.map((uid) => [uid, { uid, slug: uid, name: uid, isFoundationStub: uid === 'foundation-project' }])));
+    });
 
     service = new CreatePickerService();
   });
@@ -114,6 +110,16 @@ describe('CreatePickerService', () => {
 
       await service.getTree(req, 'vote');
       expect(getDirectGrantProjects).toHaveBeenLastCalledWith(req, false);
+    });
+
+    it('omits a committee whose project cannot be resolved, rather than emitting blank project fields', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([]);
+      getDirectGrantCommittees.mockResolvedValueOnce([committee('orphan-unresolvable', 'missing-project')]);
+      getProjectsByIds.mockResolvedValueOnce(new Map());
+
+      const result = await service.getTree(req, 'meeting');
+
+      expect(result.committees).toEqual([]);
     });
   });
 

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -36,6 +36,9 @@ vi.mock('./committee.service', () => ({
     public getCommittees = getCommittees;
   },
 }));
+vi.mock('./logger.service', () => ({
+  logger: { debug: vi.fn(), warning: vi.fn(), startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+}));
 
 import type { Request } from 'express';
 

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -43,12 +43,12 @@ import { CreatePickerService } from './create-picker.service';
 
 const req = {} as unknown as Request;
 
-function project(uid: string, isFoundation = false) {
-  return { uid, name: uid, slug: uid, isFoundationStub: isFoundation };
+function project(uid: string, isFoundation = false, parentUid = '') {
+  return { uid, name: uid, slug: uid, isFoundationStub: isFoundation, parent_uid: parentUid };
 }
 
-function committee(uid: string, projectUid: string) {
-  return { uid, name: uid, project_uid: projectUid, writer: true };
+function committee(uid: string, projectUid: string, parentUid?: string) {
+  return { uid, name: uid, project_uid: projectUid, parent_uid: parentUid, writer: true };
 }
 
 describe('CreatePickerService', () => {
@@ -121,6 +121,27 @@ describe('CreatePickerService', () => {
 
       expect(result.committees).toEqual([]);
     });
+
+    it('excludes a direct-grant child project from the root when its parent project is also directly granted', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([project('parent-proj'), project('child-proj', false, 'parent-proj')]);
+      getDirectGrantCommittees.mockResolvedValueOnce([]);
+
+      const result = await service.getTree(req, 'meeting');
+
+      expect(result.projects.map((p) => p.uid)).toEqual(['parent-proj']);
+    });
+
+    it('excludes a direct-grant sub-committee from the root when its parent committee is also directly granted', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([]);
+      getDirectGrantCommittees.mockResolvedValueOnce([
+        committee('parent-committee', 'unrelated-project'),
+        committee('sub-committee', 'unrelated-project', 'parent-committee'),
+      ]);
+
+      const result = await service.getTree(req, 'meeting');
+
+      expect(result.committees.map((c) => c.uid)).toEqual(['parent-committee']);
+    });
   });
 
   describe('getChildren', () => {
@@ -153,6 +174,15 @@ describe('CreatePickerService', () => {
       const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
 
       expect(result.committees).toEqual([]);
+    });
+
+    it("excludes nested sub-committees from a project node's direct committee children", async () => {
+      getChildProjects.mockResolvedValueOnce([]);
+      getCommittees.mockResolvedValueOnce([committee('top-level', 'parent-uid'), committee('nested', 'parent-uid', 'top-level')]);
+
+      const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
+
+      expect(result.committees.map((c) => c.uid)).toEqual(['top-level']);
     });
 
     it('returns nothing for a committee parent when the artifact type disallows committee targets', async () => {

--- a/apps/lfx-one/src/server/services/create-picker.service.spec.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.spec.ts
@@ -1,0 +1,171 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// This layer composes ProjectService/CommitteeService — both mocked wholesale so these tests
+// exercise only CreatePickerService's own logic (relation-set selection, direct-grant
+// nesting/partitioning, node shaping), not the underlying query-service calls (covered in
+// project.service.spec.ts / committee.service.spec.ts).
+const { getDirectGrantProjects, getChildProjects, searchCreatableProjects, getProjectsByIds, enrichWithProjectData } = vi.hoisted(() => ({
+  getDirectGrantProjects: vi.fn(),
+  getChildProjects: vi.fn(),
+  searchCreatableProjects: vi.fn(),
+  getProjectsByIds: vi.fn(),
+  enrichWithProjectData: vi.fn(),
+}));
+const { getDirectGrantCommittees, searchCreatableCommittees, getCommittees } = vi.hoisted(() => ({
+  getDirectGrantCommittees: vi.fn(),
+  searchCreatableCommittees: vi.fn(),
+  getCommittees: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/constants', () => ({ COMMITTEE_WRITE_ARTIFACT_TYPES: ['meeting', 'survey', 'vote'] }));
+vi.mock('@lfx-one/shared/utils', () => ({ computeIsFoundation: (project: any) => !!project?.isFoundationStub }));
+vi.mock('./project.service', () => ({
+  ProjectService: class {
+    public getDirectGrantProjects = getDirectGrantProjects;
+    public getChildProjects = getChildProjects;
+    public searchCreatableProjects = searchCreatableProjects;
+    public getProjectsByIds = getProjectsByIds;
+    public enrichWithProjectData = enrichWithProjectData;
+  },
+}));
+vi.mock('./committee.service', () => ({
+  CommitteeService: class {
+    public getDirectGrantCommittees = getDirectGrantCommittees;
+    public searchCreatableCommittees = searchCreatableCommittees;
+    public getCommittees = getCommittees;
+  },
+}));
+
+import type { Request } from 'express';
+
+import { CreatePickerService } from './create-picker.service';
+
+const req = {} as unknown as Request;
+
+function project(uid: string, isFoundation = false) {
+  return { uid, name: uid, slug: uid, isFoundationStub: isFoundation };
+}
+
+function committee(uid: string, projectUid: string) {
+  return { uid, name: uid, project_uid: projectUid, writer: true };
+}
+
+describe('CreatePickerService', () => {
+  let service: CreatePickerService;
+
+  beforeEach(() => {
+    getDirectGrantProjects.mockReset();
+    getChildProjects.mockReset();
+    searchCreatableProjects.mockReset();
+    getProjectsByIds.mockReset();
+    enrichWithProjectData.mockReset();
+    getDirectGrantCommittees.mockReset();
+    searchCreatableCommittees.mockReset();
+    getCommittees.mockReset();
+
+    // Default: enrichWithProjectData attaches is_foundation/project_slug/project_name per its
+    // real contract shape (keyed off project_uid).
+    enrichWithProjectData.mockImplementation((_req: Request, committees: any[]) =>
+      Promise.resolve(
+        committees.map((c) => ({ ...c, project_slug: c.project_uid, project_name: c.project_uid, is_foundation: c.project_uid === 'foundation-project' }))
+      )
+    );
+
+    service = new CreatePickerService();
+  });
+
+  describe('getTree', () => {
+    it('nests a direct-grant committee under its project instead of listing it top-level', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([project('proj-1')]);
+      getDirectGrantCommittees.mockResolvedValueOnce([committee('committee-1', 'proj-1')]);
+
+      const result = await service.getTree(req, 'meeting');
+
+      expect(result.projects.map((p) => p.uid)).toEqual(['proj-1']);
+      expect(result.committees).toEqual([]);
+    });
+
+    it('surfaces a direct-grant committee as a top-level orphan when its project has no direct grant', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([project('proj-1')]);
+      getDirectGrantCommittees.mockResolvedValueOnce([committee('orphan-committee', 'other-project')]);
+
+      const result = await service.getTree(req, 'meeting');
+
+      expect(result.committees.map((c) => c.uid)).toEqual(['orphan-committee']);
+    });
+
+    it('skips committee lookups entirely for artifact types that cannot target a committee', async () => {
+      getDirectGrantProjects.mockResolvedValueOnce([project('proj-1')]);
+
+      await service.getTree(req, 'newsletter');
+
+      expect(getDirectGrantCommittees).not.toHaveBeenCalled();
+    });
+
+    it('requests the meeting_coordinator relation only for the meeting artifact type', async () => {
+      getDirectGrantProjects.mockResolvedValue([]);
+      getDirectGrantCommittees.mockResolvedValue([]);
+
+      await service.getTree(req, 'meeting');
+      expect(getDirectGrantProjects).toHaveBeenLastCalledWith(req, true);
+
+      await service.getTree(req, 'vote');
+      expect(getDirectGrantProjects).toHaveBeenLastCalledWith(req, false);
+    });
+  });
+
+  describe('getChildren', () => {
+    it('fans out a project node into child projects and its committees', async () => {
+      getChildProjects.mockResolvedValueOnce([project('child-project')]);
+      getCommittees.mockResolvedValueOnce([committee('project-committee', 'parent-uid')]);
+
+      const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
+
+      expect(result.projects.map((p) => p.uid)).toEqual(['child-project']);
+      expect(result.committees.map((c) => c.uid)).toEqual(['project-committee']);
+      expect(getCommittees).toHaveBeenCalledWith(req, { tags: 'project_uid:parent-uid' });
+    });
+
+    it('fans out a committee node into child committees only', async () => {
+      getCommittees.mockResolvedValueOnce([committee('sub-committee', 'some-project')]);
+
+      const result = await service.getChildren(req, 'committee', 'parent-committee-uid', 'meeting');
+
+      expect(result.projects).toEqual([]);
+      expect(result.committees.map((c) => c.uid)).toEqual(['sub-committee']);
+      expect(getCommittees).toHaveBeenCalledWith(req, { parent: 'committee:parent-committee-uid' });
+      expect(getChildProjects).not.toHaveBeenCalled();
+    });
+
+    it('filters out non-writer committees returned by getCommittees', async () => {
+      getChildProjects.mockResolvedValueOnce([]);
+      getCommittees.mockResolvedValueOnce([{ ...committee('not-writer', 'parent-uid'), writer: false }]);
+
+      const result = await service.getChildren(req, 'project', 'parent-uid', 'meeting');
+
+      expect(result.committees).toEqual([]);
+    });
+
+    it('returns nothing for a committee parent when the artifact type disallows committee targets', async () => {
+      const result = await service.getChildren(req, 'committee', 'parent-uid', 'newsletter');
+
+      expect(result).toEqual({ projects: [], committees: [] });
+      expect(getCommittees).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('search', () => {
+    it('returns only permitted rows across both resource types', async () => {
+      searchCreatableProjects.mockResolvedValueOnce([project('found-project')]);
+      searchCreatableCommittees.mockResolvedValueOnce([committee('found-committee', 'some-project')]);
+
+      const result = await service.search(req, 'kubernetes', 'meeting');
+
+      expect(result.projects.map((p) => p.uid)).toEqual(['found-project']);
+      expect(result.committees.map((c) => c.uid)).toEqual(['found-committee']);
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -87,16 +87,18 @@ export class CreatePickerService {
           : Promise.resolve([]),
       ]);
 
+      const writableCommittees = projectCommittees.filter((c) => c.writer === true);
+      const writableUids = new Set(writableCommittees.map((c) => c.uid));
+      // tags=project_uid: returns every committee under the project, top-level AND nested — nest a
+      // committee under its actual parent (exclude it here) only when that parent is ALSO writable
+      // and will therefore render as an expandable row under this project. If the parent isn't
+      // writable (or isn't under this project at all), it's invisible in the tree, so surface the
+      // committee directly here instead of making it unreachable.
+      const directChildCommittees = writableCommittees.filter((c) => !c.parent_uid || !writableUids.has(c.parent_uid));
+
       return {
         projects: childProjects.map((p) => this.toProjectNode(p)),
-        committees: await this.toCommitteeNodes(
-          req,
-          // tags=project_uid: returns every committee under the project, top-level AND nested —
-          // exclude nested ones (parent_uid set) so a sub-committee doesn't render both directly
-          // under the project and again once its actual parent committee is expanded. Mirrors the
-          // existing `!parent_uid` top-level filter in committee-basic-info.component.ts.
-          projectCommittees.filter((c) => c.writer === true && !c.parent_uid)
-        ),
+        committees: await this.toCommitteeNodes(req, directChildCommittees),
       };
     }
 

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -1,0 +1,156 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { COMMITTEE_WRITE_ARTIFACT_TYPES } from '@lfx-one/shared/constants';
+import {
+  Committee,
+  CreatableArtifactType,
+  CreatePickerCommitteeNode,
+  CreatePickerProjectNode,
+  CreatePickerResultSet,
+  Project,
+} from '@lfx-one/shared/interfaces';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { Request } from 'express';
+
+import { CommitteeService } from './committee.service';
+import { ProjectService } from './project.service';
+
+/**
+ * Thin composition layer behind the create picker's three endpoints (tree, lazy children,
+ * search). Every method here delegates to `ProjectService`/`CommitteeService` methods that are
+ * each individually scoped (`filter_grants=direct`, `parent=`, `tags=`, or `name=`) — this class
+ * never issues its own unscoped query-service call. It only: (1) decides which relation set
+ * applies for a given `artifactType`, (2) partitions direct-grant committees into
+ * already-nested-under-a-listed-project vs. orphan top-level rows, and (3) shapes results into
+ * the flat `CreatePickerResultSet` the client renders.
+ */
+export class CreatePickerService {
+  private readonly projectService: ProjectService;
+  private readonly committeeService: CommitteeService;
+
+  public constructor() {
+    this.projectService = new ProjectService();
+    this.committeeService = new CommitteeService();
+  }
+
+  /**
+   * Top-level nodes for the picker's default tree: the user's direct-grant projects, plus any
+   * direct-grant committees whose associated project is NOT itself in that project set (those
+   * nest under their project client-side instead, once the client expands it).
+   */
+  public async getTree(req: Request, artifactType: CreatableArtifactType): Promise<CreatePickerResultSet> {
+    const includeMeetingCoordinator = artifactType === 'meeting';
+    const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
+
+    const [directProjects, directCommittees] = await Promise.all([
+      this.projectService.getDirectGrantProjects(req, includeMeetingCoordinator),
+      includeCommittees ? this.committeeService.getDirectGrantCommittees(req) : Promise.resolve([]),
+    ]);
+
+    const projectUids = new Set(directProjects.map((p) => p.uid));
+    const orphanCommittees = directCommittees.filter((c) => !projectUids.has(c.project_uid));
+
+    return {
+      projects: directProjects.map((p) => this.toProjectNode(p)),
+      committees: await this.toCommitteeNodes(req, orphanCommittees),
+    };
+  }
+
+  /**
+   * Lazy fan-out for one tree node: a project's child projects + its committees, or a
+   * committee's child committees. Reuses `CommitteeService.getCommittees`'s existing
+   * `tags=project_uid:` / `parent=committee:` scoped-listing support — only the writer-filter
+   * post-processing (this method's own concern, not that method's broader "public || writer ||
+   * member" semantics for its other callers) is new here.
+   */
+  public async getChildren(
+    req: Request,
+    parentType: 'project' | 'committee',
+    parentUid: string,
+    artifactType: CreatableArtifactType
+  ): Promise<CreatePickerResultSet> {
+    const includeMeetingCoordinator = artifactType === 'meeting';
+    const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
+
+    if (parentType === 'project') {
+      const [childProjects, projectCommittees] = await Promise.all([
+        this.projectService.getChildProjects(req, parentUid, includeMeetingCoordinator),
+        includeCommittees ? this.committeeService.getCommittees(req, { tags: `project_uid:${parentUid}` }) : Promise.resolve([]),
+      ]);
+
+      return {
+        projects: childProjects.map((p) => this.toProjectNode(p)),
+        committees: await this.toCommitteeNodes(
+          req,
+          projectCommittees.filter((c) => c.writer === true)
+        ),
+      };
+    }
+
+    if (!includeCommittees) {
+      return { projects: [], committees: [] };
+    }
+
+    const childCommittees = await this.committeeService.getCommittees(req, { parent: `committee:${parentUid}` });
+    return {
+      projects: [],
+      committees: await this.toCommitteeNodes(
+        req,
+        childCommittees.filter((c) => c.writer === true)
+      ),
+    };
+  }
+
+  /**
+   * Type-ahead search across both resource types. Every row here passed a batch access-check
+   * that evaluates inherited access (not just direct grants) — this is how an inherited-writer
+   * reaches a target that the direct-grant tree under-shows.
+   */
+  public async search(req: Request, term: string, artifactType: CreatableArtifactType): Promise<CreatePickerResultSet> {
+    const includeMeetingCoordinator = artifactType === 'meeting';
+    const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
+
+    const [projects, committees] = await Promise.all([
+      this.projectService.searchCreatableProjects(req, term, includeMeetingCoordinator),
+      includeCommittees ? this.committeeService.searchCreatableCommittees(req, term) : Promise.resolve([]),
+    ]);
+
+    return {
+      projects: projects.map((p) => this.toProjectNode(p)),
+      committees: await this.toCommitteeNodes(req, committees),
+    };
+  }
+
+  private toProjectNode(project: Project): CreatePickerProjectNode {
+    return {
+      kind: 'project',
+      uid: project.uid,
+      name: project.name,
+      slug: project.slug,
+      isFoundation: computeIsFoundation(project),
+    };
+  }
+
+  /**
+   * Reuses `ProjectService.enrichWithProjectData` (already used elsewhere to enrich items keyed
+   * by `project_uid`) to resolve each committee's `is_foundation`/`project_slug`/`project_name`
+   * in one deduplicated batch, rather than a bespoke lookup.
+   */
+  private async toCommitteeNodes(req: Request, committees: Committee[]): Promise<CreatePickerCommitteeNode[]> {
+    if (committees.length === 0) {
+      return [];
+    }
+
+    const enriched = await this.projectService.enrichWithProjectData(req, committees);
+    return enriched.map((c) => ({
+      kind: 'committee',
+      uid: c.uid,
+      name: c.name,
+      projectUid: c.project_uid,
+      projectSlug: c.project_slug,
+      projectName: c.project_name,
+      isFoundation: c.is_foundation,
+    }));
+  }
+}

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -14,6 +14,7 @@ import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { CommitteeService } from './committee.service';
+import { logger } from './logger.service';
 import { ProjectService } from './project.service';
 
 /**
@@ -47,6 +48,8 @@ export class CreatePickerService {
     const includeMeetingCoordinator = artifactType === 'meeting';
     const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
 
+    logger.debug(req, 'get_create_picker_tree', 'Fetching direct-grant tree', { artifact_type: artifactType, include_committees: includeCommittees });
+
     const [directProjects, directCommittees] = await Promise.all([
       this.projectService.getDirectGrantProjects(req, includeMeetingCoordinator),
       includeCommittees ? this.committeeService.getDirectGrantCommittees(req) : Promise.resolve([]),
@@ -56,6 +59,13 @@ export class CreatePickerService {
     const committeeUids = new Set(directCommittees.map((c) => c.uid));
     const rootProjects = directProjects.filter((p) => !projectUids.has(p.parent_uid));
     const orphanCommittees = directCommittees.filter((c) => !projectUids.has(c.project_uid) && !(c.parent_uid && committeeUids.has(c.parent_uid)));
+
+    logger.debug(req, 'get_create_picker_tree', 'Partitioned direct grants into root nodes', {
+      direct_project_count: directProjects.length,
+      direct_committee_count: directCommittees.length,
+      root_project_count: rootProjects.length,
+      orphan_committee_count: orphanCommittees.length,
+    });
 
     return {
       projects: rootProjects.map((p) => this.toProjectNode(p)),
@@ -78,6 +88,12 @@ export class CreatePickerService {
   ): Promise<CreatePickerResultSet> {
     const includeMeetingCoordinator = artifactType === 'meeting';
     const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
+
+    logger.debug(req, 'get_create_picker_children', 'Fetching lazy tree fan-out', {
+      parent_type: parentType,
+      parent_uid: parentUid,
+      artifact_type: artifactType,
+    });
 
     if (parentType === 'project') {
       const [childProjects, projectCommittees] = await Promise.all([
@@ -125,10 +141,17 @@ export class CreatePickerService {
     const includeMeetingCoordinator = artifactType === 'meeting';
     const includeCommittees = COMMITTEE_WRITE_ARTIFACT_TYPES.includes(artifactType);
 
+    logger.debug(req, 'search_create_picker', 'Searching creatable projects/committees', { term_length: term.length, artifact_type: artifactType });
+
     const [projects, committees] = await Promise.all([
       this.projectService.searchCreatableProjects(req, term, includeMeetingCoordinator),
       includeCommittees ? this.committeeService.searchCreatableCommittees(req, term) : Promise.resolve([]),
     ]);
+
+    logger.debug(req, 'search_create_picker', 'Search results resolved', {
+      permitted_project_count: projects.length,
+      permitted_committee_count: committees.length,
+    });
 
     return {
       projects: projects.map((p) => this.toProjectNode(p)),
@@ -162,11 +185,13 @@ export class CreatePickerService {
     const projectUids = [...new Set(committees.map((c) => c.project_uid).filter(Boolean))];
     const projectsByUid = await this.projectService.getProjectsByIds(req, projectUids);
 
-    return committees
-      .filter((c) => projectsByUid.has(c.project_uid))
-      .map((c) => {
-        const project = projectsByUid.get(c.project_uid)!;
-        return {
+    return committees.flatMap((c): CreatePickerCommitteeNode[] => {
+      const project = projectsByUid.get(c.project_uid);
+      if (!project) {
+        return [];
+      }
+      return [
+        {
           kind: 'committee',
           uid: c.uid,
           name: c.name,
@@ -174,7 +199,8 @@ export class CreatePickerService {
           projectSlug: project.slug,
           projectName: project.name,
           isFoundation: computeIsFoundation(project),
-        };
-      });
+        },
+      ];
+    });
   }
 }

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -76,7 +76,9 @@ export class CreatePickerService {
     if (parentType === 'project') {
       const [childProjects, projectCommittees] = await Promise.all([
         this.projectService.getChildProjects(req, parentUid, includeMeetingCoordinator),
-        includeCommittees ? this.committeeService.getCommittees(req, { tags: `project_uid:${parentUid}` }) : Promise.resolve([]),
+        includeCommittees
+          ? this.committeeService.getCommittees(req, { tags: `project_uid:${parentUid}` }, { skipMailingListEnrichment: true })
+          : Promise.resolve([]),
       ]);
 
       return {
@@ -92,7 +94,7 @@ export class CreatePickerService {
       return { projects: [], committees: [] };
     }
 
-    const childCommittees = await this.committeeService.getCommittees(req, { parent: `committee:${parentUid}` });
+    const childCommittees = await this.committeeService.getCommittees(req, { parent: `committee:${parentUid}` }, { skipMailingListEnrichment: true });
     return {
       projects: [],
       committees: await this.toCommitteeNodes(

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -38,6 +38,10 @@ export class CreatePickerService {
    * Top-level nodes for the picker's default tree: the user's direct-grant projects, plus any
    * direct-grant committees whose associated project is NOT itself in that project set (those
    * nest under their project client-side instead, once the client expands it).
+   *
+   * Also excludes any project/committee whose immediate parent is itself in the direct-grant set
+   * — that node already surfaces once its parent is expanded (`getChildren` re-checks it
+   * independently), so keeping it at the root too would render it twice.
    */
   public async getTree(req: Request, artifactType: CreatableArtifactType): Promise<CreatePickerResultSet> {
     const includeMeetingCoordinator = artifactType === 'meeting';
@@ -49,10 +53,12 @@ export class CreatePickerService {
     ]);
 
     const projectUids = new Set(directProjects.map((p) => p.uid));
-    const orphanCommittees = directCommittees.filter((c) => !projectUids.has(c.project_uid));
+    const committeeUids = new Set(directCommittees.map((c) => c.uid));
+    const rootProjects = directProjects.filter((p) => !projectUids.has(p.parent_uid));
+    const orphanCommittees = directCommittees.filter((c) => !projectUids.has(c.project_uid) && !(c.parent_uid && committeeUids.has(c.parent_uid)));
 
     return {
-      projects: directProjects.map((p) => this.toProjectNode(p)),
+      projects: rootProjects.map((p) => this.toProjectNode(p)),
       committees: await this.toCommitteeNodes(req, orphanCommittees),
     };
   }
@@ -85,7 +91,11 @@ export class CreatePickerService {
         projects: childProjects.map((p) => this.toProjectNode(p)),
         committees: await this.toCommitteeNodes(
           req,
-          projectCommittees.filter((c) => c.writer === true)
+          // tags=project_uid: returns every committee under the project, top-level AND nested —
+          // exclude nested ones (parent_uid set) so a sub-committee doesn't render both directly
+          // under the project and again once its actual parent committee is expanded. Mirrors the
+          // existing `!parent_uid` top-level filter in committee-basic-info.component.ts.
+          projectCommittees.filter((c) => c.writer === true && !c.parent_uid)
         ),
       };
     }

--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -133,24 +133,34 @@ export class CreatePickerService {
   }
 
   /**
-   * Reuses `ProjectService.enrichWithProjectData` (already used elsewhere to enrich items keyed
-   * by `project_uid`) to resolve each committee's `is_foundation`/`project_slug`/`project_name`
-   * in one deduplicated batch, rather than a bespoke lookup.
+   * Resolves each committee's parent project via `ProjectService.getProjectsByIds` — a true
+   * single-request-per-chunk batch (`filters_or=uid:X`), not `enrichWithProjectData`'s N
+   * individual per-project lookups. Committees whose project can't be resolved are omitted
+   * entirely rather than emitted with blank `projectSlug`/`projectName`: a picked row with an
+   * empty project slug would navigate with `?project=` empty, which `writerGuard` cannot resolve —
+   * exactly the post-selection dead end this picker is supposed to make impossible.
    */
   private async toCommitteeNodes(req: Request, committees: Committee[]): Promise<CreatePickerCommitteeNode[]> {
     if (committees.length === 0) {
       return [];
     }
 
-    const enriched = await this.projectService.enrichWithProjectData(req, committees);
-    return enriched.map((c) => ({
-      kind: 'committee',
-      uid: c.uid,
-      name: c.name,
-      projectUid: c.project_uid,
-      projectSlug: c.project_slug,
-      projectName: c.project_name,
-      isFoundation: c.is_foundation,
-    }));
+    const projectUids = [...new Set(committees.map((c) => c.project_uid).filter(Boolean))];
+    const projectsByUid = await this.projectService.getProjectsByIds(req, projectUids);
+
+    return committees
+      .filter((c) => projectsByUid.has(c.project_uid))
+      .map((c) => {
+        const project = projectsByUid.get(c.project_uid)!;
+        return {
+          kind: 'committee',
+          uid: c.uid,
+          name: c.name,
+          projectUid: c.project_uid,
+          projectSlug: project.slug,
+          projectName: project.name,
+          isFoundation: computeIsFoundation(project),
+        };
+      });
   }
 }

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -1,0 +1,166 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Project, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors meeting.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
+// vitest config, so every runtime (non-type-only) import needs a stub. `ProjectService`'s
+// constructor also builds `NatsService`/`SnowflakeService`/`ETagService` — none of the methods
+// under test here touch them, so they're stubbed to trivial classes to keep construction cheap.
+const { proxyRequest, addAccessToResources, checkAccess } = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  addAccessToResources: vi.fn(),
+  checkAccess: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/constants', () => ({
+  EVENT_GROWTH_TOP_EVENTS_LIMIT: 0,
+  getYearForRange: vi.fn(),
+  HEALTH_METRICS_RANGES: {},
+  isHealthMetricsRange: vi.fn(),
+  NATS_CONFIG: {},
+  PENDING_ACTION_SEVERITY: {},
+  PENDING_ACTION_SURVEYS_ROW_LIMIT: 0,
+  PROJECT_HEALTH_SCORE_CATEGORIES: [],
+  ROOT_PROJECT_SLUG: 'root',
+}));
+vi.mock('@lfx-one/shared/enums', () => ({}));
+vi.mock('@lfx-one/shared/utils', () => ({
+  computeIsFoundation: vi.fn(),
+  getDefaultMarketingImpactMonth: vi.fn(),
+  nullifyEmptyStrings: vi.fn(),
+  resolvePeriodRange: vi.fn(),
+}));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./access-check.service', () => ({
+  AccessCheckService: class {
+    public addAccessToResources = addAccessToResources;
+    public checkAccess = checkAccess;
+  },
+}));
+vi.mock('./nats.service', () => ({ NatsService: class {} }));
+vi.mock('./etag.service', () => ({ ETagService: class {} }));
+vi.mock('./snowflake.service', () => ({ SnowflakeService: { getInstance: () => ({}) } }));
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+}));
+
+import type { Request } from 'express';
+
+import { ProjectService } from './project.service';
+
+const req = {} as unknown as Request;
+
+function pageOf(projects: Partial<Project>[]): QueryServiceResponse<Project> {
+  return { resources: projects.map((p) => ({ id: `project:${p.uid}`, data: p as Project })), page_token: undefined } as QueryServiceResponse<Project>;
+}
+
+/** Every param object any of the three create-picker project methods sent to the query service. */
+function paramsSentTo(type: 'project'): Record<string, any>[] {
+  return proxyRequest.mock.calls.filter((call) => call[3] === 'GET' && call[2] === '/query/resources' && call[4]?.type === type).map((call) => call[4]);
+}
+
+describe('ProjectService — create picker methods', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    addAccessToResources.mockReset();
+    checkAccess.mockReset();
+    service = new ProjectService();
+  });
+
+  describe('getDirectGrantProjects', () => {
+    it('queries filter_grants=direct and returns only writer-permitted projects', async () => {
+      proxyRequest.mockResolvedValueOnce(
+        pageOf([
+          { uid: 'a', slug: 'a' },
+          { uid: 'b', slug: 'b' },
+        ])
+      );
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) =>
+        Promise.resolve(projects.map((p) => ({ ...p, writer: p.uid === 'a' })))
+      );
+
+      const result = await service.getDirectGrantProjects(req);
+
+      expect(result.map((p) => p.uid)).toEqual(['a']);
+      expect(proxyRequest).toHaveBeenCalledTimes(1);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', filter_grants: 'direct' });
+    });
+
+    it('excludes the ROOT pseudo-project', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'root', slug: 'root' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+
+      const result = await service.getDirectGrantProjects(req);
+
+      expect(result).toEqual([]);
+      expect(addAccessToResources).not.toHaveBeenCalled();
+    });
+
+    it('OR-includes meeting_coordinator when requested, without re-checking existing writers', async () => {
+      proxyRequest.mockResolvedValueOnce(
+        pageOf([
+          { uid: 'a', slug: 'a' },
+          { uid: 'b', slug: 'b' },
+        ])
+      );
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) =>
+        Promise.resolve(projects.map((p) => ({ ...p, writer: p.uid === 'a' })))
+      );
+      checkAccess.mockResolvedValueOnce(new Map([['b', true]]));
+
+      const result = await service.getDirectGrantProjects(req, true);
+
+      expect(result.map((p) => p.uid).sort()).toEqual(['a', 'b']);
+      // Only the non-writer ('b') needed the extra round trip.
+      expect(checkAccess).toHaveBeenCalledTimes(1);
+      expect(checkAccess.mock.calls[0][1]).toEqual([{ resource: 'project', id: 'b', access: 'meeting_coordinator' }]);
+    });
+  });
+
+  describe('getChildProjects', () => {
+    it('queries parent=project:<uid> and filters to writer-permitted children', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'child-1', slug: 'child-1' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+
+      const result = await service.getChildProjects(req, 'parent-uid');
+
+      expect(result.map((p) => p.uid)).toEqual(['child-1']);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', parent: 'project:parent-uid' });
+    });
+  });
+
+  describe('searchCreatableProjects', () => {
+    it('queries name=<term> with a small page size and filters to writer-permitted matches', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'match-1', slug: 'match-1' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+
+      const result = await service.searchCreatableProjects(req, 'kubernetes');
+
+      expect(result.map((p) => p.uid)).toEqual(['match-1']);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', name: 'kubernetes', page_size: 20 });
+    });
+  });
+
+  it('never issues a type=project query-service call without filter_grants, parent, or name', async () => {
+    proxyRequest.mockResolvedValue(pageOf([]));
+    addAccessToResources.mockImplementation((_req: Request, projects: Project[]) => Promise.resolve(projects));
+
+    await service.getDirectGrantProjects(req);
+    await service.getChildProjects(req, 'uid-1');
+    await service.searchCreatableProjects(req, 'term');
+
+    const calls = paramsSentTo('project');
+    expect(calls.length).toBeGreaterThan(0);
+    for (const params of calls) {
+      expect(params['filter_grants'] === 'direct' || typeof params['parent'] === 'string' || typeof params['name'] === 'string').toBe(true);
+    }
+  });
+});

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -56,8 +56,8 @@ import { ProjectService } from './project.service';
 
 const req = {} as unknown as Request;
 
-function pageOf(projects: Partial<Project>[]): QueryServiceResponse<Project> {
-  return { resources: projects.map((p) => ({ id: `project:${p.uid}`, data: p as Project })), page_token: undefined } as QueryServiceResponse<Project>;
+function pageOf(projects: Partial<Project>[], pageToken?: string): QueryServiceResponse<Project> {
+  return { resources: projects.map((p) => ({ id: `project:${p.uid}`, data: p as Project })), page_token: pageToken } as QueryServiceResponse<Project>;
 }
 
 /** Every param object any of the three create-picker project methods sent to the query service. */
@@ -146,6 +146,32 @@ describe('ProjectService — create picker methods', () => {
 
       expect(result.map((p) => p.uid)).toEqual(['match-1']);
       expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', name: 'kubernetes', page_size: 20 });
+    });
+
+    it('continues to the next page when the first page has no writer-permitted matches', async () => {
+      // Page 1: visible-but-non-writable matches only. Page 2: the actual inherited-writer match.
+      // A single-page search would return [] here even though a real target exists.
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'visible-only', slug: 'visible-only' }], 'token-2'));
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'inherited-writer', slug: 'inherited-writer' }]));
+      addAccessToResources.mockImplementation((_req: Request, projects: Project[]) =>
+        Promise.resolve(projects.map((p) => ({ ...p, writer: p.uid === 'inherited-writer' })))
+      );
+
+      const result = await service.searchCreatableProjects(req, 'kubernetes');
+
+      expect(result.map((p) => p.uid)).toEqual(['inherited-writer']);
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'token-2' });
+    });
+
+    it('stops paging once the page cap is reached, even if pages remain', async () => {
+      proxyRequest.mockResolvedValue(pageOf([{ uid: 'no-match', slug: 'no-match' }], 'more'));
+      addAccessToResources.mockImplementation((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: false }))));
+
+      const result = await service.searchCreatableProjects(req, 'kubernetes');
+
+      expect(result).toEqual([]);
+      expect(proxyRequest).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -398,12 +398,18 @@ export class ProjectService {
   }
 
   /**
-   * Type-ahead project search for the create picker. A single small page (`page_size`, no
-   * pagination loop) batch-access-checked to the relevant relation — inherited access is
-   * evaluated here (unlike `filter_grants=direct`), so a writer via inheritance is found through
-   * search even when the direct-grant tree under-shows them. Distinct from `searchProjects`
-   * (unpaginated, unchecked, used by the header's public project search) — different consumer,
-   * different contract, kept separate rather than overloading that method's semantics.
+   * Type-ahead project search for the create picker. Batch-access-checked to the relevant
+   * relation per page — inherited access is evaluated here (unlike `filter_grants=direct`), so a
+   * writer via inheritance is found through search even when the direct-grant tree under-shows
+   * them. Distinct from `searchProjects` (unpaginated, unchecked, used by the header's public
+   * project search) — different consumer, different contract, kept separate rather than
+   * overloading that method's semantics.
+   *
+   * Keeps paging through raw name matches — not just the first page — until either `pageSize`
+   * permitted results have been collected or upstream pages run out, bounded by a small page
+   * cap. A single unchecked page would silently miss an inherited-writer match that happens to
+   * land on page 2+ behind a run of visible-but-non-writable matches on page 1 — exactly the
+   * scenario this method exists to reach.
    */
   public async searchCreatableProjects(
     req: Request,
@@ -411,13 +417,35 @@ export class ProjectService {
     includeMeetingCoordinator: boolean = false,
     pageSize: number = 20
   ): Promise<Project[]> {
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-      type: 'project',
-      name: searchQuery,
-      page_size: pageSize,
-    });
-    const filtered = resources.map((resource) => resource.data).filter((p) => p.slug !== ROOT_PROJECT_SLUG);
-    return this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
+    // Bounds the raw-match scan (5 pages × page_size) so a generic search term can't turn this
+    // into an unbounded crawl — still vastly better than the single-page cutoff this replaces.
+    const SEARCH_PAGE_LIMIT = 5;
+    const permitted: Project[] = [];
+    let pageToken: string | undefined;
+    let pagesFetched = 0;
+
+    do {
+      const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        {
+          type: 'project',
+          name: searchQuery,
+          page_size: pageSize,
+          ...(pageToken && { page_token: pageToken }),
+        }
+      );
+      pagesFetched++;
+
+      const filtered = resources.map((resource) => resource.data).filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+      const page = await this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
+      permitted.push(...page);
+      pageToken = page_token;
+    } while (pageToken && permitted.length < pageSize && pagesFetched < SEARCH_PAGE_LIMIT);
+
+    return permitted.slice(0, pageSize);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -121,7 +121,7 @@ import {
   WebActivitiesSummaryResponse,
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
-import type { PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
+import type { AccessCheckRequest, PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
@@ -360,6 +360,64 @@ export class ProjectService {
 
     // ROOT is an administrative pseudo-project — exclude from search results.
     return resources.map((resource) => resource.data).filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+  }
+
+  /**
+   * Direct-FGA-grant projects for the create picker's default tree — NOT a full enumeration.
+   * `filter_grants=direct` narrows the query-service result set to resources the caller holds a
+   * direct OpenFGA tuple on, before any of our own access-check runs. Small by construction (a
+   * user's own direct grants), unlike `getProjects`'s unscoped pull.
+   */
+  public async getDirectGrantProjects(req: Request, includeMeetingCoordinator: boolean = false): Promise<Project[]> {
+    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'project',
+        filter_grants: 'direct',
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+    const filtered = resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+    return this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
+  }
+
+  /**
+   * Child projects of a parent (foundation or project), for the create picker's lazy tree
+   * fan-out. Reuses the same `parent=project:<uid>` query-service filter as
+   * `getFoundationProjectUids`, but returns full access-checked `Project` rows instead of bare UIDs.
+   */
+  public async getChildProjects(req: Request, parentUid: string, includeMeetingCoordinator: boolean = false): Promise<Project[]> {
+    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'project',
+        parent: `project:${parentUid}`,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+    const filtered = resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+    return this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
+  }
+
+  /**
+   * Type-ahead project search for the create picker. A single small page (`page_size`, no
+   * pagination loop) batch-access-checked to the relevant relation — inherited access is
+   * evaluated here (unlike `filter_grants=direct`), so a writer via inheritance is found through
+   * search even when the direct-grant tree under-shows them. Distinct from `searchProjects`
+   * (unpaginated, unchecked, used by the header's public project search) — different consumer,
+   * different contract, kept separate rather than overloading that method's semantics.
+   */
+  public async searchCreatableProjects(
+    req: Request,
+    searchQuery: string,
+    includeMeetingCoordinator: boolean = false,
+    pageSize: number = 20
+  ): Promise<Project[]> {
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+      type: 'project',
+      name: searchQuery,
+      page_size: pageSize,
+    });
+    const filtered = resources.map((resource) => resource.data).filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+    return this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
   }
 
   /**
@@ -6928,5 +6986,31 @@ export class ProjectService {
     const prev = all.find((m) => m.month === prevStr);
     if (!prev || prev.followers === 0) return null;
     return Math.round(((current.followers - prev.followers) / prev.followers) * 1000) / 10;
+  }
+
+  /**
+   * Shared writer/`meeting_coordinator` filtering for `getDirectGrantProjects`,
+   * `getChildProjects`, and `searchCreatableProjects`. Mirrors `getProjectById`'s "skip
+   * meeting_coordinator check for writers" shortcut, batched: only non-writers get the extra
+   * `meeting_coordinator` check when it's requested at all.
+   */
+  private async filterToCreatableProjects(req: Request, projects: Project[], includeMeetingCoordinator: boolean): Promise<Project[]> {
+    if (projects.length === 0) {
+      return projects;
+    }
+
+    const writerChecked = await this.accessCheckService.addAccessToResources(req, projects, 'project');
+    if (!includeMeetingCoordinator) {
+      return writerChecked.filter((p) => p.writer === true);
+    }
+
+    const nonWriters = writerChecked.filter((p) => p.writer !== true);
+    if (nonWriters.length === 0) {
+      return writerChecked.filter((p) => p.writer === true);
+    }
+
+    const coordinatorChecks: AccessCheckRequest[] = nonWriters.map((p) => ({ resource: 'project', id: p.uid, access: 'meeting_coordinator' }));
+    const coordinatorResults = await this.accessCheckService.checkAccess(req, coordinatorChecks);
+    return writerChecked.filter((p) => p.writer === true || coordinatorResults.get(p.uid) === true);
   }
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -427,6 +427,8 @@ export class ProjectService {
     let pageToken: string | undefined;
     let pagesFetched = 0;
 
+    logger.debug(req, 'search_creatable_projects', 'Scanning name matches for creatable projects', { page_size: pageSize, page_limit: SEARCH_PAGE_LIMIT });
+
     do {
       const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(
         req,
@@ -447,6 +449,13 @@ export class ProjectService {
       permitted.push(...page);
       pageToken = page_token;
     } while (pageToken && permitted.length < pageSize && pagesFetched < SEARCH_PAGE_LIMIT);
+
+    if (pageToken && pagesFetched >= SEARCH_PAGE_LIMIT) {
+      logger.warning(req, 'search_creatable_projects', 'Hit the search page cap with more pages remaining', {
+        pages_fetched: pagesFetched,
+        permitted_count: permitted.length,
+      });
+    }
 
     return permitted.slice(0, pageSize);
   }

--- a/packages/shared/src/constants/create-artifact.constants.ts
+++ b/packages/shared/src/constants/create-artifact.constants.ts
@@ -76,7 +76,8 @@ export const COMMITTEE_WRITE_ARTIFACT_TYPES: CreatableArtifactType[] = ['meeting
 
 /**
  * Same set as `COMMITTEE_WRITE_ARTIFACT_TYPES`, spelled in the plural `writeFeature` vocabulary
- * that route `data` blocks and `writerGuard` already use. Kept as the single source of truth so
+ * that route `data` blocks and `writerGuard` already use. Derived (every entry here is a regular
+ * "+s" plural of its `COMMITTEE_WRITE_ARTIFACT_TYPES` counterpart) rather than hand-maintained, so
  * the guard and the create-picker backend can't drift apart on which types allow a committee target.
  */
-export const COMMITTEE_WRITE_FEATURES: readonly string[] = ['meetings', 'surveys', 'votes'];
+export const COMMITTEE_WRITE_FEATURES: readonly string[] = COMMITTEE_WRITE_ARTIFACT_TYPES.map((type) => `${type}s`);

--- a/packages/shared/src/constants/create-artifact.constants.ts
+++ b/packages/shared/src/constants/create-artifact.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CreatableArtifactConfig } from '../interfaces/create-artifact.interface';
+import { CreatableArtifactConfig, CreatableArtifactType } from '../interfaces/create-artifact.interface';
 
 /**
  * Type-selection entries for the rail "Create" quick-link menu + dialog. Array
@@ -64,3 +64,19 @@ export const CREATABLE_ARTIFACTS: CreatableArtifactConfig[] = [
     group: 'organize',
   },
 ];
+
+/**
+ * Artifact types (singular `CreatableArtifactType` form) that a committee writer — not just a
+ * project writer — may create against, provided a `committee_uid` is carried into the flow. Must
+ * stay in sync with `COMMITTEE_WRITE_FEATURES` below, which mirrors the same set in the plural
+ * `data.writeFeature` route-config vocabulary already used by `meetings.routes.ts`,
+ * `surveys.routes.ts`, and `votes.routes.ts`.
+ */
+export const COMMITTEE_WRITE_ARTIFACT_TYPES: CreatableArtifactType[] = ['meeting', 'survey', 'vote'];
+
+/**
+ * Same set as `COMMITTEE_WRITE_ARTIFACT_TYPES`, spelled in the plural `writeFeature` vocabulary
+ * that route `data` blocks and `writerGuard` already use. Kept as the single source of truth so
+ * the guard and the create-picker backend can't drift apart on which types allow a committee target.
+ */
+export const COMMITTEE_WRITE_FEATURES: readonly string[] = ['meetings', 'surveys', 'votes'];

--- a/packages/shared/src/constants/create-picker.constants.ts
+++ b/packages/shared/src/constants/create-picker.constants.ts
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CreatePickerResultSet } from '../interfaces/create-picker.interface';
+
+/**
+ * Shared empty-result fallback for the create picker's BFF wrapper (`CreateTargetPickerService`)
+ * and its consumers (`CreateTargetPickerComponent`, `CreatePermissionService`) — a single source
+ * of truth instead of three identical local literals, so a future shape change to
+ * `CreatePickerResultSet` can't leave one copy stale.
+ */
+export const EMPTY_CREATE_PICKER_RESULT: CreatePickerResultSet = { projects: [], committees: [] };

--- a/packages/shared/src/constants/create-picker.constants.ts
+++ b/packages/shared/src/constants/create-picker.constants.ts
@@ -10,3 +10,12 @@ import { CreatePickerResultSet } from '../interfaces/create-picker.interface';
  * `CreatePickerResultSet` can't leave one copy stale.
  */
 export const EMPTY_CREATE_PICKER_RESULT: CreatePickerResultSet = { projects: [], committees: [] };
+
+/**
+ * Minimum trimmed query length before the create picker switches from its default tree to a real
+ * search request. Shared by `CreateTargetPickerComponent` (UI gate) and
+ * `create-picker.controller.ts` (BFF validation) so the two can't drift — a client/server mismatch
+ * here would mean the UI either issues requests the server rejects or suppresses terms the server
+ * would have accepted.
+ */
+export const CREATE_PICKER_MIN_SEARCH_LENGTH = 2;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -83,3 +83,4 @@ export * from './project-context.constants';
 export * from './project-staff.constants';
 export * from './org-lens-project-detail.constants';
 export * from './create-artifact.constants';
+export * from './create-picker.constants';

--- a/packages/shared/src/interfaces/create-picker.interface.ts
+++ b/packages/shared/src/interfaces/create-picker.interface.ts
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CreatableArtifactType } from './create-artifact.interface';
+
+/**
+ * A selectable project row in the create picker's tree/search results.
+ */
+export interface CreatePickerProjectNode {
+  kind: 'project';
+  uid: string;
+  name: string;
+  slug: string;
+  /** Drives `setFoundation()` vs `setProject()` and the `/foundation/` vs `/project/` route prefix. */
+  isFoundation: boolean;
+}
+
+/**
+ * A selectable committee row in the create picker's tree/search results. Only present when the
+ * requested `artifactType` allows a committee-scoped writer to create against it (see
+ * `COMMITTEE_WRITE_ARTIFACT_TYPES`).
+ */
+export interface CreatePickerCommitteeNode {
+  kind: 'committee';
+  uid: string;
+  name: string;
+  projectUid: string;
+  /** For the `?project=<slug>` query param and search-result breadcrumbs. */
+  projectSlug: string;
+  projectName: string;
+  /** Resolved from the committee's own associated project — see `CreatePickerProjectNode.isFoundation`. */
+  isFoundation: boolean;
+}
+
+export type CreatePickerNode = CreatePickerProjectNode | CreatePickerCommitteeNode;
+
+/**
+ * Shared response shape for all three create-picker endpoints (top-level tree, lazy children,
+ * and search) — always a flat pair of project/committee rows, never pre-nested. The client owns
+ * tree structure (which rows are whose children) via `CreatePickerCommitteeNode.projectUid` and
+ * the request that fetched them.
+ */
+export interface CreatePickerResultSet {
+  projects: CreatePickerProjectNode[];
+  committees: CreatePickerCommitteeNode[];
+}
+
+export interface CreatePickerChildrenQuery {
+  parentType: 'project' | 'committee';
+  parentUid: string;
+  artifactType: CreatableArtifactType;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -269,3 +269,4 @@ export * from './entity-project-context.interface';
 
 // Create artifact quick-link interfaces (rail "Create" button + dialog)
 export * from './create-artifact.interface';
+export * from './create-picker.interface';


### PR DESCRIPTION
## Summary

LFXV2-2838 — rebuilds the create-flow target picker to stop enumerating every project.

- Replaces the full `GET /api/projects` pull (1,305 rows) with a lazy direct-grant tree (`filter_grants=direct`) plus type-ahead search, whose pages are batch access-checked per artifact type — inherited-writer users now reach targets through search even when the tree under-shows them.
- New composed BFF endpoints: `GET /api/create-picker/{tree,tree/children,search}`, built entirely from existing `ProjectService`/`CommitteeService`/`AccessCheckService` primitives (`filter_grants`, `parent`, `tags`, `name`) — no new upstream platform calls.
- Fixes a real bug in `AccessCheckService.checkAccess`: batch results were matched to requests by array position; now matched by their own `resource:id#access` tuple, so upstream reordering/dedup can no longer misattribute a result to the wrong resource.
- New `lfx-create-target-picker` component (tree + search) replaces the writer-scoped `project-selector` embed in the create dialog. The dialog resolves its target explicitly (project or committee) instead of curating a writer-scoped project list.
- `LensService.setContextLens()` — a narrow, always-succeeding alignment method used only by the create dialog, replacing `setLens()`'s persona-gated rejection (the picker has already proven access to the specific target it renders, so gating on persona-held lenses there only produced false negatives).

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] New Vitest specs: `access-check.service.spec.ts`, `project.service.spec.ts`, `committee.service.spec.ts`, `create-picker.service.spec.ts` — including a spy assertion that no new call path issues an unscoped `type=project`/`type=committee` query
- [x] `create-quick-link.spec.ts` e2e updated for the new tree/search picker UI
- [x] Manually tested end-to-end against prod data in the `ss-2838` worktree: tree load, lazy fan-out, row selection, committee→meeting creation (lands on lens-prefixed URL carrying both `?project=` and `&committee_uid=`), type-gating (committees correctly absent for non-meeting/survey/vote types), search reaching projects outside the default tree, and the fail-closed empty state
- [x] Post-commit reviewer trio (general + Self Serve conventions + learnings) clean on the final commit
- [ ] Integration worktree validation (this PR is draft until that passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)