### PR TITLE
feat(newsletters): add inline audience email add with no invite

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -64,21 +64,27 @@
       </lfx-select>
 
       @if (selectedCommitteeUid()) {
-        <div class="flex flex-col gap-2 mt-2" data-testid="newsletter-audience-email-add-section">
-          <div class="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800" data-testid="newsletter-audience-email-add-banner">
-            Adding an email here automatically adds it to the <span class="font-medium">{{ selectedCommitteeName() }}</span> group, so it's remembered for
-            future newsletters — a one-time step.
+        <!-- Nested sub-panel: tinted + indented so it reads as an optional
+             action on the selected group, not a sibling of the Group picker. -->
+        <div class="mt-2 ml-3 flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3" data-testid="newsletter-audience-email-add-section">
+          <div class="flex items-center gap-2">
+            <i class="fa-light fa-user-plus text-gray-400" aria-hidden="true"></i>
+            <label class="text-sm font-medium text-gray-800" for="newsletter-audience-email-add">Someone missing? Add them to this group</label>
           </div>
+          <p class="text-xs text-gray-500" data-testid="newsletter-audience-email-add-banner">
+            New emails are added to the <span class="font-medium text-gray-700">{{ selectedCommitteeName() }}</span> group automatically — a one-time step,
+            remembered for future newsletters.
+          </p>
 
           <form [formGroup]="emailAddForm" (ngSubmit)="onAddEmail()" class="flex items-center gap-2">
-            <div class="flex-1">
-              <label class="sr-only" for="newsletter-audience-email-add">Email to add to the group</label>
+            <div class="w-full max-w-md">
               <lfx-input-text
                 [form]="emailAddForm"
                 control="email"
                 type="email"
-                id="newsletter-audience-email-add"
-                placeholder="Add an email to this group…"
+                [id]="'newsletter-audience-email-add'"
+                size="small"
+                placeholder="name@example.com"
                 dataTest="newsletter-audience-email-add-input">
               </lfx-input-text>
             </div>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -86,7 +86,7 @@
           </form>
 
           @if (visibleEmailAdds().length > 0) {
-            <ul class="flex flex-col gap-1" data-testid="newsletter-audience-email-add-list">
+            <ul class="flex flex-col gap-1" aria-live="polite" data-testid="newsletter-audience-email-add-list">
               @for (entry of visibleEmailAdds(); track entry.email) {
                 <li class="flex items-center gap-2 px-1 py-0.5 text-sm text-gray-700" data-testid="newsletter-audience-email-add-item">
                   <span class="break-all">{{ entry.email }}</span>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -64,7 +64,10 @@
       </lfx-select>
 
       @if (selectedCommitteeUid()) {
-        <div class="flex flex-col gap-2 mt-2" data-testid="newsletter-audience-email-add-section">
+        <!-- aria-live sits on the always-present wrapper (not the conditionally
+             rendered list) so the first entry of a group is announced too — a
+             live region only announces mutations after it registers. -->
+        <div class="flex flex-col gap-2 mt-2" aria-live="polite" data-testid="newsletter-audience-email-add-section">
           <div class="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800" data-testid="newsletter-audience-email-add-banner">
             Adding an email here automatically adds it to the <span class="font-medium">{{ selectedCommitteeName() }}</span> group, so it's remembered for
             future newsletters — a one-time step.
@@ -86,7 +89,7 @@
           </form>
 
           @if (visibleEmailAdds().length > 0) {
-            <ul class="flex flex-col gap-1" aria-live="polite" data-testid="newsletter-audience-email-add-list">
+            <ul class="flex flex-col gap-1" data-testid="newsletter-audience-email-add-list">
               @for (entry of visibleEmailAdds(); track entry.email) {
                 <li class="flex items-center gap-2 px-1 py-0.5 text-sm text-gray-700" data-testid="newsletter-audience-email-add-item">
                   <span class="break-all">{{ entry.email }}</span>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -62,6 +62,60 @@
         styleClass="w-full"
         data-testid="newsletter-audience-committees">
       </lfx-select>
+
+      @if (selectedCommitteeUid()) {
+        <div class="flex flex-col gap-2 mt-2" data-testid="newsletter-audience-email-add-section">
+          <div class="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800" data-testid="newsletter-audience-email-add-banner">
+            Adding an email here automatically adds it to the <span class="font-medium">{{ selectedCommitteeName() }}</span> group, so it's remembered for
+            future newsletters — a one-time step.
+          </div>
+
+          <form [formGroup]="emailAddForm" (ngSubmit)="onAddEmail()" class="flex items-center gap-2">
+            <div class="flex-1">
+              <lfx-input-text
+                [form]="emailAddForm"
+                control="email"
+                type="email"
+                id="newsletter-audience-email-add"
+                placeholder="Add an email to this group…"
+                dataTest="newsletter-audience-email-add-input">
+              </lfx-input-text>
+            </div>
+            <lfx-button label="Add" type="submit" size="small" severity="secondary" [outlined]="true" data-testid="newsletter-audience-email-add-btn">
+            </lfx-button>
+          </form>
+
+          @if (visibleEmailAdds().length > 0) {
+            <ul class="flex flex-col gap-1" data-testid="newsletter-audience-email-add-list">
+              @for (entry of visibleEmailAdds(); track entry.email) {
+                <li class="flex items-center gap-2 px-1 py-0.5 text-sm text-gray-700" data-testid="newsletter-audience-email-add-item">
+                  <span class="break-all">{{ entry.email }}</span>
+                  @switch (entry.status) {
+                    @case ('pending') {
+                      <p-progressSpinner styleClass="!w-3.5 !h-3.5" strokeWidth="4" ariaLabel="Adding to group"></p-progressSpinner>
+                    }
+                    @case ('added') {
+                      <i class="fa-light fa-check text-emerald-600" aria-hidden="true"></i>
+                      <span class="sr-only">Added to group</span>
+                    }
+                    @case ('already') {
+                      <span class="text-xs text-gray-500">Already exists in this group</span>
+                    }
+                    @case ('invalid') {
+                      <i class="fa-light fa-circle-exclamation text-amber-600" aria-hidden="true"></i>
+                      <span class="text-xs text-amber-700">{{ entry.reason }}</span>
+                    }
+                    @case ('failed') {
+                      <i class="fa-light fa-circle-exclamation text-red-600" aria-hidden="true"></i>
+                      <span class="text-xs text-red-700">{{ entry.reason }}</span>
+                    }
+                  }
+                </li>
+              }
+            </ul>
+          }
+        </div>
+      }
     }
   </div>
 

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.html
@@ -64,10 +64,7 @@
       </lfx-select>
 
       @if (selectedCommitteeUid()) {
-        <!-- aria-live sits on the always-present wrapper (not the conditionally
-             rendered list) so the first entry of a group is announced too — a
-             live region only announces mutations after it registers. -->
-        <div class="flex flex-col gap-2 mt-2" aria-live="polite" data-testid="newsletter-audience-email-add-section">
+        <div class="flex flex-col gap-2 mt-2" data-testid="newsletter-audience-email-add-section">
           <div class="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800" data-testid="newsletter-audience-email-add-banner">
             Adding an email here automatically adds it to the <span class="font-medium">{{ selectedCommitteeName() }}</span> group, so it's remembered for
             future newsletters — a one-time step.
@@ -75,6 +72,7 @@
 
           <form [formGroup]="emailAddForm" (ngSubmit)="onAddEmail()" class="flex items-center gap-2">
             <div class="flex-1">
+              <label class="sr-only" for="newsletter-audience-email-add">Email to add to the group</label>
               <lfx-input-text
                 [form]="emailAddForm"
                 control="email"
@@ -88,35 +86,37 @@
             </lfx-button>
           </form>
 
-          @if (visibleEmailAdds().length > 0) {
-            <ul class="flex flex-col gap-1" data-testid="newsletter-audience-email-add-list">
-              @for (entry of visibleEmailAdds(); track entry.email) {
-                <li class="flex items-center gap-2 px-1 py-0.5 text-sm text-gray-700" data-testid="newsletter-audience-email-add-item">
-                  <span class="break-all">{{ entry.email }}</span>
-                  @switch (entry.status) {
-                    @case ('pending') {
-                      <p-progressSpinner styleClass="!w-3.5 !h-3.5" strokeWidth="4" ariaLabel="Adding to group"></p-progressSpinner>
-                    }
-                    @case ('added') {
-                      <i class="fa-light fa-check text-emerald-600" aria-hidden="true"></i>
-                      <span class="sr-only">Added to group</span>
-                    }
-                    @case ('already') {
-                      <span class="text-xs text-gray-500">Already exists in this group</span>
-                    }
-                    @case ('invalid') {
-                      <i class="fa-light fa-circle-exclamation text-amber-600" aria-hidden="true"></i>
-                      <span class="text-xs text-amber-700">{{ entry.reason }}</span>
-                    }
-                    @case ('failed') {
-                      <i class="fa-light fa-circle-exclamation text-red-600" aria-hidden="true"></i>
-                      <span class="text-xs text-red-700">{{ entry.reason }}</span>
-                    }
+          <!-- Rendered (and registered as a live region) as soon as a group is
+               selected, before any entry exists — a live region only announces
+               mutations after it registers, so the first entry announces too.
+               The banner sits outside the region to avoid group-switch chatter. -->
+          <ul class="flex flex-col gap-1" aria-live="polite" data-testid="newsletter-audience-email-add-list">
+            @for (entry of visibleEmailAdds(); track entry.email) {
+              <li class="flex items-center gap-2 px-1 py-0.5 text-sm text-gray-700" data-testid="newsletter-audience-email-add-item">
+                <span class="break-all">{{ entry.email }}</span>
+                @switch (entry.status) {
+                  @case ('pending') {
+                    <p-progressSpinner styleClass="!w-3.5 !h-3.5" strokeWidth="4" ariaLabel="Adding to group"></p-progressSpinner>
                   }
-                </li>
-              }
-            </ul>
-          }
+                  @case ('added') {
+                    <i class="fa-light fa-check text-emerald-600" aria-hidden="true"></i>
+                    <span class="sr-only">Added to group</span>
+                  }
+                  @case ('already') {
+                    <span class="text-xs text-gray-500">Already exists in this group</span>
+                  }
+                  @case ('invalid') {
+                    <i class="fa-light fa-circle-exclamation text-amber-600" aria-hidden="true"></i>
+                    <span class="text-xs text-amber-700">{{ entry.reason }}</span>
+                  }
+                  @case ('failed') {
+                    <i class="fa-light fa-circle-exclamation text-red-600" aria-hidden="true"></i>
+                    <span class="text-xs text-red-700">{{ entry.reason }}</span>
+                  }
+                }
+              </li>
+            }
+          </ul>
         </div>
       }
     }

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -4,9 +4,11 @@
 import { Component, computed, DestroyRef, inject, input, output, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { NEWSLETTER_COMMITTEE_CATEGORY } from '@lfx-one/shared/constants';
-import { Committee, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-one/shared/interfaces';
+import { Committee, NewsletterAudienceEmailAdd, NewsletterCommitteeOption, NewsletterRecipient } from '@lfx-one/shared/interfaces';
 import { NewsletterService } from '@services/newsletter.service';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
@@ -14,7 +16,7 @@ import { finalize, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-newsletter-audience-step',
-  imports: [ReactiveFormsModule, SelectComponent, PopoverModule, ProgressSpinnerModule],
+  imports: [ReactiveFormsModule, SelectComponent, PopoverModule, ProgressSpinnerModule, InputTextComponent, ButtonComponent],
   templateUrl: './newsletter-audience-step.component.html',
 })
 export class NewsletterAudienceStepComponent {
@@ -39,9 +41,14 @@ export class NewsletterAudienceStepComponent {
   public readonly committeeUidsValue = input<string[]>([]);
   public readonly recipientCount = input<number | null>(null);
   public readonly recipientCountLoading = input<boolean>(false);
+  // Per-email add state is owned by the host (this panel is destroyed on step
+  // navigation, so in-flight adds and their statuses must outlive it).
+  public readonly emailAdds = input<NewsletterAudienceEmailAdd[]>([]);
 
   // === Outputs ===
   public readonly retryCommittees = output<void>();
+  // Raw email string as typed; validation, dedupe, and state live on the host.
+  public readonly addEmail = output<string>();
 
   // === Forms ===
   // The shared `form` input carries `committeeUids: string[]` end-to-end — recipient
@@ -50,6 +57,13 @@ export class NewsletterAudienceStepComponent {
   // the scalar selection; it's bridged to the shared array control in initSync().
   protected readonly audienceForm = new FormGroup({
     committeeUid: new FormControl<string | null>(null),
+  });
+
+  // Inline "add email to the selected group" input. Submitting emits the raw
+  // value to the host and clears the control immediately — adds are async and
+  // never block further typing or step navigation.
+  protected readonly emailAddForm = new FormGroup({
+    email: new FormControl<string>('', { nonNullable: true }),
   });
 
   // === Signals ===
@@ -70,9 +84,30 @@ export class NewsletterAudienceStepComponent {
   );
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);
+  protected readonly selectedCommitteeUid = computed<string | null>(() => this.committeeUidsValue()[0] ?? null);
+  protected readonly selectedCommitteeName = computed<string>(() => {
+    const uid = this.selectedCommitteeUid();
+    if (!uid) return 'the selected';
+    const committee = this.committees().find((c) => c.uid === uid);
+    return committee?.name || 'the selected';
+  });
+  // Adds are scoped per group: switching groups swaps the visible list, and
+  // entries for a previously selected group reappear on switch-back.
+  protected readonly visibleEmailAdds = computed<NewsletterAudienceEmailAdd[]>(() => {
+    const uid = this.selectedCommitteeUid();
+    if (!uid) return [];
+    return this.emailAdds().filter((e) => e.committeeUid === uid);
+  });
 
   public constructor() {
     this.initSync();
+  }
+
+  protected onAddEmail(): void {
+    const value = this.emailAddForm.controls.email.value;
+    if (!value.trim()) return;
+    this.addEmail.emit(value);
+    this.emailAddForm.controls.email.setValue('');
   }
 
   protected onShowRecipients(event: Event): void {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-audience-step/newsletter-audience-step.component.ts
@@ -85,11 +85,12 @@ export class NewsletterAudienceStepComponent {
   protected readonly selectedCount: Signal<number> = computed(() => this.committeeUidsValue().length);
   protected readonly hasCommittees = computed(() => this.committeeOptions().length > 0);
   protected readonly selectedCommitteeUid = computed<string | null>(() => this.committeeUidsValue()[0] ?? null);
+  // Fallback reads as "the selected group" in the banner sentence.
   protected readonly selectedCommitteeName = computed<string>(() => {
     const uid = this.selectedCommitteeUid();
-    if (!uid) return 'the selected';
+    if (!uid) return 'selected';
     const committee = this.committees().find((c) => c.uid === uid);
-    return committee?.name || 'the selected';
+    return committee?.name || 'selected';
   });
   // Adds are scoped per group: switching groups swaps the visible list, and
   // entries for a previously selected group reappear on switch-back.

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.html
@@ -173,7 +173,9 @@
                     [committeeUidsValue]="committeeUidsValue()"
                     [recipientCount]="recipientCount()"
                     [recipientCountLoading]="recipientCountLoading()"
-                    (retryCommittees)="retryCommittees()">
+                    [emailAdds]="audienceEmailAdds()"
+                    (retryCommittees)="retryCommittees()"
+                    (addEmail)="onAddAudienceEmail($event)">
                   </lfx-newsletter-audience-step>
                 </ng-template>
               </p-step-panel>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -13,12 +13,13 @@ import {
   CreateNewsletterRequest,
   GenerateNewsletterResponse,
   Newsletter,
+  NewsletterAudienceEmailAdd,
   NewsletterManageViewMode,
   NewsletterSendResult,
   ProjectContext,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
-import { formatRelativeTime, stripHtml } from '@lfx-one/shared/utils';
+import { formatRelativeTime, isValidEmail, stripHtml } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -162,6 +163,13 @@ export class NewsletterManageComponent {
   // cancels the stale in-flight request instead of letting it race the
   // normalized one and clobber the displayed count.
   private readonly recipientCountTrigger$ = new Subject<string[]>();
+
+  // === Audience email adds ===
+  // Owned here (not by the audience step) because the stepper destroys the step
+  // panel on navigation — in-flight adds and their per-email statuses must
+  // survive the user moving between steps. The step renders this filtered to
+  // the currently selected group.
+  protected readonly audienceEmailAdds = signal<NewsletterAudienceEmailAdd[]>([]);
 
   // === Newsletter-eligible committees ===
   // Fetched once here (not duplicated in the audience-step child) and passed down
@@ -373,6 +381,54 @@ export class NewsletterManageComponent {
     this.retryCommittees$.next();
   }
 
+  // Fired by the audience step for each email the user submits. Every add is an
+  // independent, non-blocking request: the step's input clears immediately and
+  // the per-email status here drives the inline indicator.
+  protected onAddAudienceEmail(raw: string): void {
+    const committeeUid = this.committeeUidsValue()[0];
+    if (!committeeUid) return;
+
+    const email = raw.trim().toLowerCase();
+    if (!email) return;
+
+    // pending/added/already entries are in flight or settled — retyping is a
+    // no-op. invalid/failed entries are replaced so retyping acts as a retry.
+    // This keeps (committeeUid, email) unique, which the step's @for tracking
+    // relies on.
+    const existing = this.audienceEmailAdds().find((e) => e.committeeUid === committeeUid && e.email === email);
+    if (existing && existing.status !== 'invalid' && existing.status !== 'failed') return;
+
+    const entry: NewsletterAudienceEmailAdd = isValidEmail(email)
+      ? { email, committeeUid, status: 'pending' }
+      : { email, committeeUid, status: 'invalid', reason: 'Not a valid email' };
+    this.audienceEmailAdds.update((entries) => [...entries.filter((e) => !(e.committeeUid === committeeUid && e.email === email)), entry]);
+
+    if (entry.status === 'invalid') return;
+
+    // Intentionally NOT takeUntilDestroyed: HttpClient aborts the request on
+    // unsubscribe, which would silently cancel in-flight adds if the user left
+    // the page. createCommitteeMember pipes take(1) and HTTP observables
+    // complete after one response, so each subscription cleans itself up.
+    this.committeeService.createCommitteeMember(committeeUid, { email }, { skipNotification: true }).subscribe({
+      next: () => {
+        this.updateAudienceEmailAdd(committeeUid, email, { status: 'added' });
+        // Refresh the recipient pill only if this group is still the selected
+        // audience — an add resolving after a group switch must not clobber
+        // the new group's count.
+        if (this.committeeUidsValue()[0] === committeeUid) {
+          this.fetchRecipientCountFor(this.committeeUidsValue());
+        }
+      },
+      error: (err: HttpErrorResponse) => {
+        if (err.status === 409) {
+          this.updateAudienceEmailAdd(committeeUid, email, { status: 'already' });
+        } else {
+          this.updateAudienceEmailAdd(committeeUid, email, { status: 'failed', reason: this.audienceAddFailureReason(err) });
+        }
+      },
+    });
+  }
+
   private goToList(tab?: 'draft' | 'sent'): void {
     this.router.navigate(['list'], {
       relativeTo: this.route.parent,
@@ -410,6 +466,18 @@ export class NewsletterManageComponent {
 
   private fetchRecipientCountFor(uids: string[]): void {
     this.recipientCountTrigger$.next(uids);
+  }
+
+  private updateAudienceEmailAdd(committeeUid: string, email: string, patch: Partial<NewsletterAudienceEmailAdd>): void {
+    this.audienceEmailAdds.update((entries) => entries.map((e) => (e.committeeUid === committeeUid && e.email === email ? { ...e, ...patch } : e)));
+  }
+
+  private audienceAddFailureReason(err: HttpErrorResponse): string {
+    const message = err?.error?.message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+    return 'Could not add. Try again.';
   }
 
   private fetchRecipientCount$(uids: string[]) {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -486,8 +486,21 @@ export class NewsletterManageComponent {
     return this.newsletterService.getRecipientCount(this.projectUid(), { committee_uids: uids }).pipe(
       finalize(() => this.recipientCountLoading.set(false)),
       tap({
-        next: (res) => this.recipientCount.set(res.count),
-        error: () => this.recipientCount.set(null),
+        // Apply the response only if the requested uids still match the current
+        // selection: a trigger fired just before a group switch can otherwise
+        // land during the valueChanges debounce window and briefly show the old
+        // group's count. The mirror is updated synchronously (initFormMirrors /
+        // populateFormFromDraft), so a match here is authoritative.
+        next: (res) => {
+          if (this.uidsEqual(uids, this.committeeUidsValue())) {
+            this.recipientCount.set(res.count);
+          }
+        },
+        error: () => {
+          if (this.uidsEqual(uids, this.committeeUidsValue())) {
+            this.recipientCount.set(null);
+          }
+        },
       }),
       catchError(() => EMPTY)
     );

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -20,6 +20,7 @@ import {
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { formatRelativeTime, isValidEmail, stripHtml } from '@lfx-one/shared/utils';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -391,12 +392,13 @@ export class NewsletterManageComponent {
     const email = raw.trim().toLowerCase();
     if (!email) return;
 
-    // pending/added/already entries are in flight or settled — retyping is a
-    // no-op. invalid/failed entries are replaced so retyping acts as a retry.
-    // This keeps (committeeUid, email) unique, which the step's @for tracking
-    // relies on.
+    // pending/added entries are in flight or just confirmed — retyping is a
+    // no-op. invalid/failed/already entries are replaced so retyping acts as a
+    // retry ('already' can become 'added' if the member was removed elsewhere
+    // since). This keeps (committeeUid, email) unique, which the step's @for
+    // tracking relies on.
     const existing = this.audienceEmailAdds().find((e) => e.committeeUid === committeeUid && e.email === email);
-    if (existing && existing.status !== 'invalid' && existing.status !== 'failed') return;
+    if (existing && (existing.status === 'pending' || existing.status === 'added')) return;
 
     const entry: NewsletterAudienceEmailAdd = isValidEmail(email)
       ? { email, committeeUid, status: 'pending' }
@@ -423,7 +425,7 @@ export class NewsletterManageComponent {
         if (err.status === 409) {
           this.updateAudienceEmailAdd(committeeUid, email, { status: 'already' });
         } else {
-          this.updateAudienceEmailAdd(committeeUid, email, { status: 'failed', reason: this.audienceAddFailureReason(err) });
+          this.updateAudienceEmailAdd(committeeUid, email, { status: 'failed', reason: extractErrorMessage(err, 'Could not add. Try again.') });
         }
       },
     });
@@ -470,14 +472,6 @@ export class NewsletterManageComponent {
 
   private updateAudienceEmailAdd(committeeUid: string, email: string, patch: Partial<NewsletterAudienceEmailAdd>): void {
     this.audienceEmailAdds.update((entries) => entries.map((e) => (e.committeeUid === committeeUid && e.email === email ? { ...e, ...patch } : e)));
-  }
-
-  private audienceAddFailureReason(err: HttpErrorResponse): string {
-    const message = err?.error?.message;
-    if (typeof message === 'string' && message.trim().length > 0) {
-      return message;
-    }
-    return 'Could not add. Try again.';
   }
 
   private fetchRecipientCount$(uids: string[]) {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -200,6 +200,15 @@ export class NewsletterManageComponent {
   // initAudienceNormalization() deliberately skips pruning, so a stale/legacy
   // non-Newsletter audience could otherwise be sent before it's ever checked.
   public readonly audienceNormalized = computed(() => this.eligibleCommitteeUids() !== null);
+  // Send resolves recipients live from committee membership, so an inline add
+  // still in flight for the selected group must land before an (irreversible)
+  // send — otherwise that email is silently omitted from this newsletter. Step
+  // navigation stays non-blocking; only Send waits, and adds settle in seconds.
+  private readonly hasPendingAudienceAdds = computed(() => {
+    const committeeUid = this.committeeUidsValue()[0];
+    if (!committeeUid) return false;
+    return this.audienceEmailAdds().some((e) => e.committeeUid === committeeUid && e.status === 'pending');
+  });
   public readonly canSend = computed(
     () =>
       this.audienceFilled() &&
@@ -209,7 +218,8 @@ export class NewsletterManageComponent {
       this.hasContext() &&
       !this.submitting() &&
       !this.resolvingSend() &&
-      !this.savingDraft()
+      !this.savingDraft() &&
+      !this.hasPendingAudienceAdds()
   );
   public readonly canSendTest = computed(
     () => this.subjectFilled() && this.bodyFilled() && this.hasContext() && this.edEmail().length > 0 && !this.testSending()

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -20,12 +20,12 @@ import {
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { formatRelativeTime, isValidEmail, stripHtml } from '@lfx-one/shared/utils';
-import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { CommitteeService } from '@services/committee.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -14,6 +14,7 @@ import {
   CreateCommitteeDocumentRequest,
   CreateCommitteeInviteRequest,
   CreateCommitteeJoinApplicationRequest,
+  CreateCommitteeMemberOptions,
   CreateCommitteeMemberRequest,
   MyCommittee,
   QueryServiceCountResponse,
@@ -104,8 +105,14 @@ export class CommitteeService {
     return this.http.get<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`);
   }
 
-  public createCommitteeMember(committeeId: string, memberData: CreateCommitteeMemberRequest): Observable<CommitteeMember> {
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData).pipe(take(1));
+  public createCommitteeMember(
+    committeeId: string,
+    memberData: CreateCommitteeMemberRequest,
+    options?: CreateCommitteeMemberOptions
+  ): Observable<CommitteeMember> {
+    const params = options?.skipNotification ? new HttpParams().set('skip_notification', 'true') : undefined;
+
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(take(1));
   }
 
   public updateCommitteeMember(committeeId: string, memberId: string, memberData: Partial<CreateCommitteeMemberRequest>): Observable<CommitteeMember> {

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -105,6 +105,11 @@ export class CommitteeService {
     return this.http.get<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`);
   }
 
+  /**
+   * Creates a committee member. By default the new member receives a
+   * notification email; pass `options.skipNotification` to suppress it
+   * (the BFF forwards it upstream as the X-Skip-Notification header).
+   */
   public createCommitteeMember(
     committeeId: string,
     memberData: CreateCommitteeMemberRequest,

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -382,7 +382,7 @@ export class CommitteeController {
    */
   public async createCommitteeMember(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
-    const skipNotification = req.query['skip_notification'] === 'true';
+    const skipNotification = getStringQueryParam(req, 'skip_notification') === 'true';
     const startTime = logger.startOperation(req, 'create_committee_member', {
       committee_id: id,
       member_data: logger.sanitize(req.body),

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -382,9 +382,11 @@ export class CommitteeController {
    */
   public async createCommitteeMember(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
+    const skipNotification = req.query['skip_notification'] === 'true';
     const startTime = logger.startOperation(req, 'create_committee_member', {
       committee_id: id,
       member_data: logger.sanitize(req.body),
+      skip_notification: skipNotification,
     });
 
     try {
@@ -406,7 +408,7 @@ export class CommitteeController {
       const memberData: CreateCommitteeMemberRequest = req.body;
 
       // Create the committee member
-      const newMember = await this.committeeService.createCommitteeMember(req, id, memberData);
+      const newMember = await this.committeeService.createCommitteeMember(req, id, memberData, skipNotification);
 
       // Log the success
       logger.success(req, 'create_committee_member', startTime, {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -467,12 +467,29 @@ export class CommitteeService {
   /**
    * Creates a new committee member
    */
-  public async createCommitteeMember(req: Request, committeeId: string, data: CreateCommitteeMemberRequest): Promise<CommitteeMember> {
-    const newMember = await this.microserviceProxy.proxyRequest<CommitteeMember>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/members`, 'POST', {}, data);
+  public async createCommitteeMember(
+    req: Request,
+    committeeId: string,
+    data: CreateCommitteeMemberRequest,
+    skipNotification: boolean = false
+  ): Promise<CommitteeMember> {
+    // The upstream committee-service takes the suppression intent as the
+    // X-Skip-Notification header (not a body attribute), defaulting to false.
+    const customHeaders = skipNotification ? { 'X-Skip-Notification': 'true' } : undefined;
+    const newMember = await this.microserviceProxy.proxyRequest<CommitteeMember>(
+      req,
+      'LFX_V2_SERVICE',
+      `/committees/${committeeId}/members`,
+      'POST',
+      {},
+      data,
+      customHeaders
+    );
 
     logger.debug(req, 'create_committee_member', 'Committee member created successfully', {
       committee_uid: committeeId,
       member_uid: newMember.uid,
+      skip_notification: skipNotification,
     });
 
     return newMember;

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -123,6 +123,15 @@ export interface CreateCommitteeMemberRequest {
 }
 
 /**
+ * Client-side options for creating a committee member. Not part of the upstream
+ * request body — the BFF translates these into request metadata.
+ */
+export interface CreateCommitteeMemberOptions {
+  /** When true, the BFF sends X-Skip-Notification upstream so the member gets no invite/notification email. */
+  skipNotification?: boolean;
+}
+
+/**
  * Raw form values from the member form dialog
  * @description Typed shape of the FormGroup.getRawValue() output in MemberFormComponent
  */

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -32,6 +32,32 @@ export interface NewsletterRecipientCountPayload {
   committee_uids: string[];
 }
 
+/**
+ * Lifecycle of a single inline "add email to the audience group" attempt.
+ *
+ * - `pending`: the create-member request is in flight.
+ * - `added`: the member was created in the group (with notification suppressed).
+ * - `already`: the group already has a member with this email — benign outcome.
+ * - `invalid`: the input failed client-side email validation; no request was sent.
+ * - `failed`: the create-member request was rejected upstream.
+ */
+export type NewsletterAudienceEmailAddStatus = 'pending' | 'added' | 'already' | 'invalid' | 'failed';
+
+/**
+ * Per-email state for the audience step's inline add-to-group flow. Owned by
+ * the manage host (the stepper destroys the step panel on navigation) and
+ * rendered by the audience step filtered to the currently selected group.
+ */
+export interface NewsletterAudienceEmailAdd {
+  /** Normalized (trimmed, lowercased) email; for invalid tokens, the trimmed raw input. */
+  email: string;
+  /** Committee the add was fired against — list rendering is scoped by this. */
+  committeeUid: string;
+  status: NewsletterAudienceEmailAddStatus;
+  /** Human-readable reason shown for `invalid` / `failed`. */
+  reason?: string;
+}
+
 export interface NewsletterRecipientCount {
   count: number;
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -49,7 +49,7 @@ export type NewsletterAudienceEmailAddStatus = 'pending' | 'added' | 'already' |
  * rendered by the audience step filtered to the currently selected group.
  */
 export interface NewsletterAudienceEmailAdd {
-  /** Normalized (trimmed, lowercased) email; for invalid tokens, the trimmed raw input. */
+  /** Normalized (trimmed, lowercased) email — invalid tokens are normalized the same way. */
   email: string;
   /** Committee the add was fired against — list rendering is scoped by this. */
   committeeUid: string;


### PR DESCRIPTION
## Summary

On the newsletter audience step, users can now type an email below the group picker and have it **asynchronously added as a member of the selected Newsletter group with the notification suppressed** — no more leaving the newsletter flow to add someone via the committee UI and coming back.

- An info banner explains that adding an email here automatically adds it to the selected group (one-time step, remembered for future newsletters).
- Each submitted email appears in a light list with an inline indicator next to the record: spinner while in flight → checkmark when added → muted "Already exists in this group" on duplicates → amber/red reason for invalid/failed. Nothing blocks: the input clears immediately, adds run as independent requests, and the user can keep typing or move to the next step while adds are in flight.
- Per-email state lives on the manage host (the stepper destroys the step panel on navigation), so in-flight adds and their indicators survive step changes. The recipient count pill refreshes as adds succeed, guarded against group-switch races.
- Retyping a failed/invalid/already email retries it; retyping a pending/added one is a no-op — keeping (group, email) unique for stable list tracking.

## How "No Invite" works

The BFF now accepts `?skip_notification=true` on `POST /api/committees/:id/members` and translates it to the upstream `X-Skip-Notification: true` header, which `lfx-v2-committee-service` already supports (Goa design `create-committee-member`; the `committee_member.created` NATS event carries `skip_notification: true` so the downstream email consumer suppresses the invite). **No upstream service changes are needed**: newsletter recipients are resolved live at send time from committee membership, so members added before send are automatically included. Existing callers of the endpoint are unchanged (flag defaults to false → notify as before).

## Personas

ED-facing (newsletter creation). Note for sign-off: `skip_notification` is honored for any authenticated caller with committee write access, matching the upstream contract — it suppresses the notification to people who never see LFX (added to a group without being emailed). This is the intended internal process for newsletter audiences.

## Review process & documented trade-offs

Four commits: the feature plus three review-driven fix commits (error-message extraction via the canonical `extractErrorMessage` helper, screen-reader announcements for the status list, sr-only input label, hardened `getStringQueryParam` read). Reviewer-verified notes:

- 409 → "already exists" mapping validated against the upstream Goa design (create-member declares exactly one Conflict: "Member already exists").
- A flagged recipient-count race was verified to be a false positive: the member record and its by-committee index are written before the 201 returns; `X-Sync` only defers query-service indexing/FGA messaging, which recipient resolution does not use.
- Branch name carries a descriptive suffix beyond `feat/LFXV2-2846`, consistent with sibling branches on origin.
- Settled status entries persist for the page session (bounded by hand-typed emails); add-only by design — removals stay in the committee UI.

## Testing

- `yarn lint`, `yarn check-types`, `yarn build` (SSR bundle) all green; license headers verified; no protected files touched.
- Existing newsletter Playwright specs unaffected (new section renders only after a group is selected); new `newsletter-audience-email-add-*` testids enable a future spec.

JIRA: [LFXV2-2846](https://linuxfoundation.atlassian.net/browse/LFXV2-2846)

[LFXV2-2846]: https://linuxfoundation.atlassian.net/browse/LFXV2-2846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Known trade-offs (v1, from review triage)

- **Invalid email clears the input**: a typo becomes an inline "Not a valid email" row and the field clears, so the user retypes. Control-level validation (account-settings pattern) is a follow-up candidate.
- **Network/5xx failures may show Angular's transport string** as the inline reason (`extractErrorMessage` fallback trait shared by all its call sites); a status-0/5xx guard is a follow-up candidate.
- **Previously unsubscribed addresses**: the member add genuinely succeeds (checkmark is truthful) but newsletter delivery respects the project's unsubscribe list at send time, so such an address won't receive sends and the recipient count won't move. Surfacing an `unsubscribed` status needs upstream support for distinguishing skipped-as-unsubscribed.
- **Send is gated on pending adds** (fe2bc90f): an in-flight add for the selected group blocks Send for the seconds it takes to settle, so a just-added email can't be silently omitted from an immediate send.
