### PR TITLE
feat(org-lens): paginate and server-search project leaderboards

### DIFF
--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -110,11 +110,10 @@ test.describe('Org Project Detail — leaderboards', () => {
     // page-independent (it keys off the first rendered rank, not a hardcoded 1), so a genuine ordering
     // regression surfaces on the rank assertion rather than being masked by a viewing-row precondition.
     //
-    // Precondition for the viewing-row checks below: the test project returns a single page of orgs
-    // (<= the paginator page size), so the viewing org always renders on this page. If a future fixture
-    // pushed the viewing org past page 1 the viewing-row checks would need to step the paginator first;
-    // the rank-order guard above would still hold unchanged. The custom message keeps that failure mode
-    // legible instead of opaque.
+    // The viewing org is no longer pinned and the list is the full multi-page ranked set, so the
+    // viewing row may land on a later page. The viewing-row rank check below is therefore conditional:
+    // asserted only when that row happens to render on this first page; otherwise the page-independent
+    // rank-order guard above is the coverage.
     for (const board of ['technical', 'ecosystem'] as const) {
       const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
       const count = await rows.count();
@@ -134,8 +133,9 @@ test.describe('Org Project Detail — leaderboards', () => {
         expect(ranks[i]).toBe(ranks[0] + i);
       }
 
-      expect(viewingIndex, `viewing-org row expected on the first ${board} page for this fixture (rank <= page size)`).toBeGreaterThanOrEqual(0);
-      expect(ranks[viewingIndex]).toBe(ranks[0] + viewingIndex);
+      if (viewingIndex >= 0) {
+        expect(ranks[viewingIndex]).toBe(ranks[0] + viewingIndex);
+      }
     }
   });
 

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -261,16 +261,26 @@ test.describe('Org Project Detail — leaderboards', () => {
 
     // Searching for that org (paginator resets to page 0 on a new query) must still find it — proving
     // the search spans the whole ranked set, not just the current page — and its true rank is preserved.
-    const searchRequest = page.waitForRequest((request) => {
-      const url = new URL(request.url());
-      return url.pathname.endsWith('/leaderboard/technical') && (url.searchParams.get('search') ?? '').length > 0;
+    // Wait for the OK page-0 search RESPONSE (not just the outgoing request): the board swaps in
+    // skeleton rows while the debounced reload is in flight, so a request-only wait can assert before
+    // the result is applied.
+    const searchResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        url.pathname.endsWith('/leaderboard/technical') &&
+        (url.searchParams.get('search') ?? '').length > 0 &&
+        url.searchParams.get('page') === '0' &&
+        response.status() === 200
+      );
     });
     await page.locator('[data-test="project-detail-search-technical"]').fill(targetName);
-    await searchRequest;
+    await searchResponse;
 
+    // The row carrying the target name only renders once the skeletons clear and the real result is
+    // applied, so this locator implicitly waits past the loading state before we assert the rank.
     const match = page.locator(`${TECH_BOARD} tbody tr`, { hasText: targetName }).first();
     await expect(match).toBeVisible();
-    await expect(match.locator('td').first()).toHaveText(String(targetRank));
+    await expect.poll(async () => (await match.locator('td').first().innerText()).trim()).toBe(String(targetRank));
   });
 });
 

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -140,32 +140,59 @@ test.describe('Org Project Detail — leaderboards', () => {
   });
 
   test('activity count mode also renders boards in rank order with the viewing org not pinned', async ({ page }) => {
-    // buildBoard() drops the pin in the Activity Count branch too, sorting by warehouse rank ascending
-    // (rows with no warehouse rank sort last and render a positional `i + 1` fallback). So each row's
-    // rank is non-decreasing versus the previous row EXCEPT for a trailing fallback row, whose rank
-    // equals its 1-based position. A viewing row pinned out of order would satisfy neither condition.
-    // We assert only the rendered rank order — not the viewing row's presence — because unpinning
-    // explicitly allows the viewing org to fall onto a later paginator page. Both boards load
-    // independently, so await each table before reading its rows to avoid a race.
+    // The Activity Count branch drops the pin too, ordering by warehouse rank ascending with
+    // unknown-rank rows sorting last and rendering an explicit '—' (never a positional fallback). We
+    // assert only the rendered rank order — not the viewing row's presence — because unpinning
+    // explicitly allows the viewing org to fall onto a later paginator page.
+    //
+    // Switching metric triggers a fresh server reload that swaps in skeleton rows, so wait for the
+    // activity page-0 response of BOTH boards (not just the tables, which are already on screen from
+    // the influence load) and for the skeletons to clear — otherwise the assertion could run against
+    // empty skeleton text or stale influence ranks and still pass.
+    const activityLoaded = (['technical', 'ecosystem'] as const).map((board) =>
+      page.waitForResponse(
+        (response) => {
+          const url = new URL(response.url());
+          return (
+            url.pathname.endsWith(`/leaderboard/${board}`) &&
+            url.searchParams.get('metric') === 'activity' &&
+            url.searchParams.get('page') === '0' &&
+            response.status() === 200
+          );
+        },
+        { timeout: DATA_LOAD_TIMEOUT }
+      )
+    );
     await page.getByTestId('project-detail-metric-activity').click();
     await expect(page).toHaveURL(/metric=activity/);
-    await expect(page.getByTestId('project-detail-leaderboard-technical-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await expect(page.getByTestId('project-detail-leaderboard-ecosystem-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await Promise.all(activityLoaded);
 
     for (const board of ['technical', 'ecosystem'] as const) {
       const rows = page.locator(`[data-testid="project-detail-leaderboard-${board}"] tbody tr`);
+      // Wait past the skeleton reload: the first row's rank cell resolves to a real value (a number or '—').
+      await expect.poll(async () => (await rows.first().locator('td').first().innerText()).trim()).not.toBe('');
       const count = await rows.count();
       expect(count).toBeGreaterThan(0);
 
-      const ranks: number[] = [];
+      const rankTexts: string[] = [];
       for (let i = 0; i < count; i++) {
-        ranks.push(Number((await rows.nth(i).locator('td').first().innerText()).trim()));
+        rankTexts.push((await rows.nth(i).locator('td').first().innerText()).trim());
       }
 
-      for (let i = 1; i < ranks.length; i++) {
-        const nonDecreasing = ranks[i] >= ranks[i - 1];
-        const positionalFallback = ranks[i] === i + 1;
-        expect(nonDecreasing || positionalFallback).toBe(true);
+      // Numeric warehouse ranks come first and must be non-decreasing; unknown-rank rows render '—' and
+      // sort last, so once one appears every later row is '—' too. No positional fallback is allowed.
+      let seenUnknown = false;
+      let prev = -Infinity;
+      for (const text of rankTexts) {
+        if (text === '—') {
+          seenUnknown = true;
+          continue;
+        }
+        expect(seenUnknown, `numeric rank "${text}" must not appear after an unknown '—' row`).toBe(false);
+        const rank = Number(text);
+        expect(Number.isFinite(rank)).toBe(true);
+        expect(rank).toBeGreaterThanOrEqual(prev);
+        prev = rank;
       }
     }
   });

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -8,7 +8,7 @@
  * - data-testid resolution smoke test (breadcrumb, hero, tabs, card groups, trend)
  * - tab strip switching (click + keyboard) with ?tab= URL persistence
  * - leaderboard ranking, score/metric toggles with ?metric= persistence,
- *   Activity Count hiding the band tags, and Show more pagination
+ *   Activity Count hiding the band tags, and server-side pagination + search over the full ranked set
  * - not-found (404) panel for an unknown slug
  *
  * Prerequisites:
@@ -188,11 +188,85 @@ test.describe('Org Project Detail — leaderboards', () => {
     await expect(page.getByRole('columnheader', { name: 'Total contributions' }).first()).toBeVisible();
   });
 
-  test('search filters a board to matching organizations', async ({ page }) => {
-    await page.locator('[data-test="project-detail-search-technical"]').fill('Google');
-    const rows = page.locator('[data-testid="project-detail-leaderboard-technical"] tbody tr');
-    await expect(rows).toHaveCount(1);
-    await expect(rows.first()).toContainText('Google');
+  // The leaderboard boards are now server-paginated + server-searched over the FULL ranked org set
+  // (no top-10 cap). These specs exercise that contract against live data: `k8s` has hundreds of
+  // ranked orgs, so the technical board spans many pages. Assertions key off the OUTGOING request
+  // params (page / pageSize / search) rather than exact row contents, so they stay stable as the
+  // underlying warehouse data shifts. Requires the uncapped platinum leaderboard model in the target
+  // environment (shipped by the lf-dbt side of LFXV2-2815).
+  const TECH_BOARD = '[data-testid="project-detail-leaderboard-technical"]';
+
+  /** Parse the "Showing X to Y of Z" paginator report into its total (Z). */
+  async function boardTotal(page: import('@playwright/test').Page): Promise<number> {
+    const report = await page.locator(`${TECH_BOARD} .p-paginator-current`).innerText();
+    return Number(report.replace(/,/g, '').match(/of\s+(\d+)/)?.[1] ?? '0');
+  }
+
+  test('paginates to organizations ranked beyond the first page (full list, not top-10)', async ({ page }) => {
+    const rows = page.locator(`${TECH_BOARD} tbody tr`);
+
+    // Full list — the paginator total exceeds ten (the legacy cap), and the first page starts at rank 1.
+    expect(await boardTotal(page), 'k8s technical board should expose more than ten ranked orgs').toBeGreaterThan(10);
+    expect(Number((await rows.first().locator('td').first().innerText()).trim())).toBe(1);
+
+    // Advancing the paginator asks the server for page index 1 (a real lazy load, not a client slice).
+    const pageRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith('/leaderboard/technical') && url.searchParams.get('page') === '1';
+    });
+    await page.locator(`${TECH_BOARD} button[aria-label="Next Page"]`).first().click();
+    await pageRequest;
+
+    // The first row on page 2 continues the ascending rank sequence past position ten.
+    await expect.poll(async () => Number((await rows.first().locator('td').first().innerText()).trim())).toBeGreaterThan(10);
+  });
+
+  test('changing the page size re-pages the full ranked set from the server', async ({ page }) => {
+    const rows = page.locator(`${TECH_BOARD} tbody tr`);
+    await expect(rows).toHaveCount(10); // default page size
+    const totalBefore = await boardTotal(page);
+
+    // Selecting a larger page size issues a fresh server request at pageSize=25 (total is unchanged).
+    const sizeRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith('/leaderboard/technical') && url.searchParams.get('pageSize') === '25';
+    });
+    await page.locator(`${TECH_BOARD} .p-paginator-rpp-dropdown`).click();
+    await page.getByRole('option', { name: '25', exact: true }).click();
+    await sizeRequest;
+
+    await expect.poll(async () => rows.count()).toBeGreaterThan(10);
+    expect(await boardTotal(page), 'total row count is unchanged by page size').toBe(totalBefore);
+  });
+
+  test('server-side search finds an organization ranked beyond the first page at its true rank', async ({ page }) => {
+    const rows = page.locator(`${TECH_BOARD} tbody tr`);
+    expect(await boardTotal(page), 'this spec needs a project whose full list spans multiple pages').toBeGreaterThan(10);
+
+    // Step to page 2 and capture an org that ranks past position ten.
+    const pageRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith('/leaderboard/technical') && url.searchParams.get('page') === '1';
+    });
+    await page.locator(`${TECH_BOARD} button[aria-label="Next Page"]`).first().click();
+    await pageRequest;
+    await expect.poll(async () => Number((await rows.first().locator('td').first().innerText()).trim())).toBeGreaterThan(10);
+
+    const targetRank = Number((await rows.first().locator('td').first().innerText()).trim());
+    const targetName = (await rows.first().locator('td').nth(1).locator('span.text-gray-900').innerText()).trim();
+
+    // Searching for that org (paginator resets to page 0 on a new query) must still find it — proving
+    // the search spans the whole ranked set, not just the current page — and its true rank is preserved.
+    const searchRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith('/leaderboard/technical') && (url.searchParams.get('search') ?? '').length > 0;
+    });
+    await page.locator('[data-test="project-detail-search-technical"]').fill(targetName);
+    await searchRequest;
+
+    const match = page.locator(`${TECH_BOARD} tbody tr`, { hasText: targetName }).first();
+    await expect(match).toBeVisible();
+    await expect(match.locator('td').first()).toHaveText(String(targetRank));
   });
 });
 

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -227,14 +227,18 @@ test.describe('Org Project Detail — leaderboards', () => {
     const totalBefore = await boardTotal(page);
 
     // Selecting a larger page size issues a fresh server request at pageSize=25 (total is unchanged).
-    const sizeRequest = page.waitForRequest((request) => {
-      const url = new URL(request.url());
-      return url.pathname.endsWith('/leaderboard/technical') && url.searchParams.get('pageSize') === '25';
+    // Wait for the RESPONSE (not just the request) so we assert against rendered data, not the loading skeletons.
+    const sizeResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname.endsWith('/leaderboard/technical') && url.searchParams.get('pageSize') === '25' && response.ok();
     });
     await page.locator(`${TECH_BOARD} .p-paginator-rpp-dropdown`).click();
     await page.getByRole('option', { name: '25', exact: true }).click();
-    await sizeRequest;
+    await sizeResponse;
 
+    // Poll on a real rendered rank first (skeleton rows carry no rank text → NaN), so the row count
+    // below is asserted against the resolved page rather than the 25 loading skeletons.
+    await expect.poll(async () => Number((await rows.first().locator('td').first().innerText()).trim())).toBeGreaterThanOrEqual(1);
     await expect.poll(async () => rows.count()).toBeGreaterThan(10);
     expect(await boardTotal(page), 'total row count is unchanged by page size').toBe(totalBefore);
   });

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -264,8 +264,10 @@ test.describe('Org Projects', () => {
     await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await page.getByTestId('org-projects-add-project').click();
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
+    // Single search affordance: no standalone search input in the dialog — search lives inside the multi-select's own filter.
+    await expect(page.getByRole('dialog', { name: 'Add project(s)' }).getByRole('searchbox')).toHaveCount(0);
     await page.getByTestId('org-projects-add-projects-select').click();
-    await page.getByRole('searchbox', { name: 'Search and select projects' }).fill('ku');
+    await page.getByPlaceholder('Search and select projects').fill('ku');
 
     await expect(page.getByText('Kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await page.waitForTimeout(500);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -365,7 +365,7 @@
                           class="border-b border-gray-100"
                           [class.bg-blue-50]="row.isViewingOrg"
                           [attr.data-testid]="row.isViewingOrg ? 'project-detail-leaderboard-technical-viewing-row' : null">
-                          <td class="px-3 py-3.5 text-gray-500">{{ row.rank }}</td>
+                          <td class="px-3 py-3.5 text-gray-500">{{ row.rank ?? '—' }}</td>
                           <td class="px-3 py-3.5">
                             <div class="flex items-center gap-2.5">
                               @if (row.orgLogoUrl) {
@@ -494,7 +494,7 @@
                           class="border-b border-gray-100"
                           [class.bg-blue-50]="row.isViewingOrg"
                           [attr.data-testid]="row.isViewingOrg ? 'project-detail-leaderboard-ecosystem-viewing-row' : null">
-                          <td class="px-3 py-3.5 text-gray-500">{{ row.rank }}</td>
+                          <td class="px-3 py-3.5 text-gray-500">{{ row.rank ?? '—' }}</td>
                           <td class="px-3 py-3.5">
                             <div class="flex items-center gap-2.5">
                               @if (row.orgLogoUrl) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -293,7 +293,7 @@
                     dataTest="project-detail-search-technical" />
                 </div>
               </div>
-              @switch (techBoardState().status) {
+              @switch (techBoard().status) {
                 @case ('loading') {
                   <div class="flex flex-col gap-2" data-testid="project-detail-leaderboard-technical-loading">
                     @for (slot of [1, 2, 3, 4, 5, 6]; track slot) {
@@ -313,26 +313,51 @@
                   </lfx-empty-state>
                 }
                 @default {
-                  @if (technicalBoard().length === 0) {
+                  @if (techBoard().total === 0 && !techBoard().loading) {
                     <p class="py-8 text-center text-sm text-gray-500" data-testid="project-detail-leaderboard-technical-empty">
                       {{ techSearchHasQuery() ? 'No organizations match your search.' : 'No ranked organizations for this project yet.' }}
                     </p>
                   } @else {
                     <lfx-table
-                      [value]="technicalBoard()"
+                      [value]="techBoard().rows"
+                      [lazy]="true"
+                      [lazyLoadOnInit]="false"
                       [paginator]="true"
-                      [rows]="10"
+                      [rows]="techBoard().rowsPerPage"
+                      [first]="techBoard().first"
+                      [totalRecords]="techBoard().total"
+                      [loading]="techBoard().loading"
+                      [skeletonRows]="techBoard().rowsPerPage"
                       [rowsPerPageOptions]="[10, 25, 50]"
+                      [pageLinks]="3"
                       [showCurrentPageReport]="true"
                       [showFirstLastIcon]="false"
                       currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
                       paginatorPosition="bottom"
+                      (onLazyLoad)="onTechnicalBoardLazyLoad($event)"
                       data-testid="project-detail-leaderboard-technical-table">
                       <ng-template #header>
                         <tr class="border-b border-gray-200 text-left text-xs font-medium text-gray-500">
                           <th scope="col" class="w-12 px-3 py-3">#</th>
                           <th scope="col" class="px-3 py-3">Organization</th>
                           <th scope="col" class="whitespace-nowrap px-3 py-3 text-right">{{ technicalColumnLabel() }}</th>
+                        </tr>
+                      </ng-template>
+                      <!-- Skeleton row mirrors the real row's structure + px-3 py-3.5 padding so each -->
+                      <!-- placeholder equals a loaded row's height; with skeletonRows=rowsPerPage the -->
+                      <!-- shimmer fills the card at any page size, so height stays fixed across pages. -->
+                      <ng-template #loadingbody>
+                        <tr class="border-b border-gray-100">
+                          <td class="px-3 py-3.5"><p-skeleton width="1rem" height="1rem" /></td>
+                          <td class="px-3 py-3.5">
+                            <div class="flex items-center gap-2.5">
+                              <p-skeleton shape="circle" size="1.75rem" />
+                              <p-skeleton width="8rem" height="0.875rem" />
+                            </div>
+                          </td>
+                          <td class="px-3 py-3.5">
+                            <div class="flex justify-end"><p-skeleton width="4.5rem" height="1.5rem" /></div>
+                          </td>
                         </tr>
                       </ng-template>
                       <ng-template #body let-row>
@@ -397,7 +422,7 @@
                     dataTest="project-detail-search-ecosystem" />
                 </div>
               </div>
-              @switch (ecoBoardState().status) {
+              @switch (ecoBoard().status) {
                 @case ('loading') {
                   <div class="flex flex-col gap-2" data-testid="project-detail-leaderboard-ecosystem-loading">
                     @for (slot of [1, 2, 3, 4, 5, 6]; track slot) {
@@ -417,26 +442,51 @@
                   </lfx-empty-state>
                 }
                 @default {
-                  @if (ecosystemBoard().length === 0) {
+                  @if (ecoBoard().total === 0 && !ecoBoard().loading) {
                     <p class="py-8 text-center text-sm text-gray-500" data-testid="project-detail-leaderboard-ecosystem-empty">
                       {{ ecoSearchHasQuery() ? 'No organizations match your search.' : 'No ranked organizations for this project yet.' }}
                     </p>
                   } @else {
                     <lfx-table
-                      [value]="ecosystemBoard()"
+                      [value]="ecoBoard().rows"
+                      [lazy]="true"
+                      [lazyLoadOnInit]="false"
                       [paginator]="true"
-                      [rows]="10"
+                      [rows]="ecoBoard().rowsPerPage"
+                      [first]="ecoBoard().first"
+                      [totalRecords]="ecoBoard().total"
+                      [loading]="ecoBoard().loading"
+                      [skeletonRows]="ecoBoard().rowsPerPage"
                       [rowsPerPageOptions]="[10, 25, 50]"
+                      [pageLinks]="3"
                       [showCurrentPageReport]="true"
                       [showFirstLastIcon]="false"
                       currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
                       paginatorPosition="bottom"
+                      (onLazyLoad)="onEcosystemBoardLazyLoad($event)"
                       data-testid="project-detail-leaderboard-ecosystem-table">
                       <ng-template #header>
                         <tr class="border-b border-gray-200 text-left text-xs font-medium text-gray-500">
                           <th scope="col" class="w-12 px-3 py-3">#</th>
                           <th scope="col" class="px-3 py-3">Organization</th>
                           <th scope="col" class="whitespace-nowrap px-3 py-3 text-right">{{ ecosystemColumnLabel() }}</th>
+                        </tr>
+                      </ng-template>
+                      <!-- Skeleton row mirrors the real row's structure + px-3 py-3.5 padding so each -->
+                      <!-- placeholder equals a loaded row's height; with skeletonRows=rowsPerPage the -->
+                      <!-- shimmer fills the card at any page size, so height stays fixed across pages. -->
+                      <ng-template #loadingbody>
+                        <tr class="border-b border-gray-100">
+                          <td class="px-3 py-3.5"><p-skeleton width="1rem" height="1rem" /></td>
+                          <td class="px-3 py-3.5">
+                            <div class="flex items-center gap-2.5">
+                              <p-skeleton shape="circle" size="1.75rem" />
+                              <p-skeleton width="8rem" height="0.875rem" />
+                            </div>
+                          </td>
+                          <td class="px-3 py-3.5">
+                            <div class="flex justify-end"><p-skeleton width="4.5rem" height="1.5rem" /></div>
+                          </td>
                         </tr>
                       </ng-template>
                       <ng-template #body let-row>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -39,18 +39,20 @@ import {
 } from '@lfx-one/shared/constants';
 import type {
   BlockState,
+  BoardDisplayRow,
+  BoardRenderState,
   HeroState,
   InfluenceCardVm,
   LeaderboardDimension,
   OrgLensCardDetailRow,
   OrgLensCardDetailSection,
   OrgLensInfluenceBlock,
-  OrgLensLeaderboardBlock,
   OrgLensLeaderboardMetric,
   OrgLensLeaderboardTimeRange,
   OrgLensProjectBand,
   OrgLensProjectDetailTab,
   OrgLensProjectInfluenceCard,
+  OrgLensProjectLeaderboardRow,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
 import { parseLocalDateString } from '@lfx-one/shared/utils';
@@ -106,8 +108,15 @@ export class OrgProjectDetailComponent {
   private readonly heroRetry = signal(0);
   private readonly influenceRetry = signal(0);
   private readonly trendRetry = signal(0);
-  private readonly techRetry = signal(0);
-  private readonly ecoRetry = signal(0);
+
+  // B7/B8 leaderboard boards — now server-paginated + server-searched. Each board holds its own
+  // page render state (rows, total, paginator position, in-flight overlay) and is driven imperatively
+  // (mirroring the roster drawer) so pagination keeps the prior rows visible under a loading overlay.
+  protected readonly techBoard = signal<BoardRenderState>(this.emptyBoardState());
+  protected readonly ecoBoard = signal<BoardRenderState>(this.emptyBoardState());
+  // Monotonic request tokens so a superseded board fetch (newer page / filter) is ignored on arrival.
+  private techBoardToken = 0;
+  private ecoBoardToken = 0;
 
   protected readonly techArrows = signal({ left: false, right: false });
   protected readonly ecoArrows = signal({ left: false, right: false });
@@ -158,6 +167,7 @@ export class OrgProjectDetailComponent {
     distinctUntilChanged()
   );
   private readonly range$ = toObservable(this.timeRange).pipe(distinctUntilChanged());
+  private readonly metric$ = toObservable(this.metric).pipe(distinctUntilChanged());
   private readonly influenceActivated$ = toObservable(this.activeTab).pipe(
     map((tab) => tab === 'pd-influence'),
     scan((seen, active) => seen || active, false),
@@ -175,18 +185,6 @@ export class OrgProjectDetailComponent {
     initialValue: { status: 'loading', data: null } as BlockState<OrgLensInfluenceBlock>,
   });
   protected readonly trendState = toSignal(this.buildTrendState(), { initialValue: { status: 'loading', data: null } as BlockState<OrgLensTrendBlock> });
-  protected readonly techBoardState = toSignal(
-    this.buildBoardState((uid, name, slug, range) => this.detailService.getTechnicalBoard(uid, name, slug, range), this.techRetry),
-    {
-      initialValue: { status: 'loading', data: null } as BlockState<OrgLensLeaderboardBlock>,
-    }
-  );
-  protected readonly ecoBoardState = toSignal(
-    this.buildBoardState((uid, name, slug, range) => this.detailService.getEcosystemBoard(uid, name, slug, range), this.ecoRetry),
-    {
-      initialValue: { status: 'loading', data: null } as BlockState<OrgLensLeaderboardBlock>,
-    }
-  );
 
   // Hero presentation — derived from the hero block.
   protected readonly hero = computed(() => this.heroState().data?.hero ?? null);
@@ -251,8 +249,6 @@ export class OrgProjectDetailComponent {
   protected readonly ecoSearch = signal('');
   protected readonly techSearchHasQuery = computed(() => this.techSearch().trim().length > 0);
   protected readonly ecoSearchHasQuery = computed(() => this.ecoSearch().trim().length > 0);
-  protected readonly technicalBoard = computed(() => this.buildBoard('technical', this.techSearch()));
-  protected readonly ecosystemBoard = computed(() => this.buildBoard('ecosystem', this.ecoSearch()));
 
   // Stacked area trend chart — top-10 companies + "All others" stacked by combined influence score,
   // built from the real per-org monthly series on the wire.
@@ -276,6 +272,27 @@ export class OrgProjectDetailComponent {
     combineLatest([this.orgUid$, this.slug$])
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => this.resetLeaderboardSearch());
+
+    // Board reload driver — org / slug / range / metric changes re-request BOTH boards at page 0,
+    // once the Leaderboards tab has been activated (lazy on first activation). Superseded requests
+    // are dropped by the per-board request token, so a burst of changes yields one applied result.
+    combineLatest([this.orgUid$, this.slug$, this.range$, this.metric$, this.leaderboardsActivated$])
+      .pipe(
+        filter(([, , , , activated]) => activated),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => {
+        this.reloadBoard('technical');
+        this.reloadBoard('ecosystem');
+      });
+
+    // Server-side search — a debounced query change re-requests only that board at page 0.
+    toObservable(this.techSearch)
+      .pipe(distinctUntilChanged(), skip(1), takeUntilDestroyed())
+      .subscribe(() => this.reloadBoard('technical'));
+    toObservable(this.ecoSearch)
+      .pipe(distinctUntilChanged(), skip(1), takeUntilDestroyed())
+      .subscribe(() => this.reloadBoard('ecosystem'));
 
     // Refresh horizontal scroll arrows when the Our-Influence cards change.
     toObservable(
@@ -337,11 +354,20 @@ export class OrgProjectDetailComponent {
   }
 
   protected retryTechnicalBoard(): void {
-    this.techRetry.update((v) => v + 1);
+    this.reloadBoard('technical');
   }
 
   protected retryEcosystemBoard(): void {
-    this.ecoRetry.update((v) => v + 1);
+    this.reloadBoard('ecosystem');
+  }
+
+  /** lfx-table lazy-load callback for a board — fetch the requested page / page size server-side. */
+  protected onTechnicalBoardLazyLoad(event: { first?: number; rows?: number }): void {
+    this.onBoardLazyLoad('technical', event);
+  }
+
+  protected onEcosystemBoardLazyLoad(event: { first?: number; rows?: number }): void {
+    this.onBoardLazyLoad('ecosystem', event);
   }
 
   protected retryDrawer(): void {
@@ -522,76 +548,110 @@ export class OrgProjectDetailComponent {
     return raw && PD_VALID_TIME_RANGES.has(raw) ? (raw as OrgLensLeaderboardTimeRange) : PD_DEFAULT_TIME_RANGE;
   }
 
+  private emptyBoardState(): BoardRenderState {
+    return { status: 'loading', rows: [], total: 0, first: 0, rowsPerPage: 10, loading: false };
+  }
+
+  private boardSignal(dimension: LeaderboardDimension) {
+    return dimension === 'technical' ? this.techBoard : this.ecoBoard;
+  }
+
+  /** Reset a board to the first page and (re)fetch it — used on org / slug / range / metric / search change. */
+  private reloadBoard(dimension: LeaderboardDimension): void {
+    this.loadBoardPage(dimension, 0, this.boardSignal(dimension)().rowsPerPage);
+  }
+
+  /** Paginator lazy-load handler — fetch the requested page / page size for one board. */
+  private onBoardLazyLoad(dimension: LeaderboardDimension, event: { first?: number; rows?: number }): void {
+    const current = this.boardSignal(dimension)();
+    const rowsPerPage = event.rows && event.rows > 0 ? event.rows : current.rowsPerPage;
+    const first = event.first ?? 0;
+    // Ignore the paginator echoing the page the programmatic reset already fetched.
+    if (first === current.first && rowsPerPage === current.rowsPerPage && current.status !== 'loading') return;
+    this.loadBoardPage(dimension, first, rowsPerPage);
+  }
+
   /**
-   * Rank one board's dimension (technical / ecosystem), then apply the search filter. Reads from that
-   * board's own block so each board paints as soon as its own fetch resolves. Returns all matching
-   * rows — the paginator handles slicing.
+   * Fetch one server-paginated, server-searched page of a board and apply it, unless a newer request
+   * has superseded this one (token guard). Keeps the prior rows visible under a loading overlay while
+   * the page is in flight, so pagination never flashes a skeleton.
    */
-  private buildBoard(dimension: LeaderboardDimension, search: string) {
-    const block = dimension === 'technical' ? this.techBoardState().data : this.ecoBoardState().data;
-    const isActivity = this.metric() === 'activity';
-    if (dimension === 'ecosystem' && !isActivity && this.isNonLfProject()) {
-      return [];
-    }
-    const sourceRows = isActivity ? (block?.activity ?? []) : (block?.influence ?? []);
+  private loadBoardPage(dimension: LeaderboardDimension, first: number, rowsPerPage: number): void {
+    const uid = this.accountContext.selectedAccount()?.uid;
+    const slug = this.projectSlug();
+    if (!uid || !slug) return;
 
-    if (isActivity) {
-      const ranked = [...sourceRows]
-        .sort((a, b) => (a.warehouseRank ?? Number.MAX_SAFE_INTEGER) - (b.warehouseRank ?? Number.MAX_SAFE_INTEGER))
-        .map((row, i) => {
-          const activity = dimension === 'technical' ? row.activityCount.contributions : row.activityCount.collaborations;
-          const activityPct = dimension === 'technical' ? row.activityCount.contributionsPct : row.activityCount.collaborationsPct;
-          return {
-            // Prefer the warehouse RANK; fall back to positional order so a missing rank never renders as "#0".
-            rank: row.warehouseRank ?? i + 1,
-            orgName: row.orgName,
-            orgLogoUrl: row.orgLogoUrl,
-            initials: this.initialsFor(row.orgName),
-            activityLabel: `${activity.toLocaleString('en-US')} - ${Math.round(activityPct)}%`,
-            bandLabel: '',
-            bandSeverity: 'secondary' as const,
-            isViewingOrg: row.isViewingOrg,
-          };
-        });
-      const query = search.trim().toLowerCase();
-      return query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked;
-    }
+    const range = this.timeRange();
+    const metric = this.metric();
+    const isActivity = metric === 'activity';
+    const search = (dimension === 'technical' ? this.techSearch() : this.ecoSearch()).trim();
+    const page = rowsPerPage > 0 ? Math.floor(first / rowsPerPage) : 0;
 
-    const valued = sourceRows.map((row) => {
-      // Each board ranks its own dimension: technical → contribution totals, ecosystem → collaboration totals.
-      const activity = dimension === 'technical' ? row.activityCount.contributions : row.activityCount.collaborations;
-      const activityPct = dimension === 'technical' ? row.activityCount.contributionsPct : row.activityCount.collaborationsPct;
-      return {
-        row,
-        level: row.levels[dimension],
-        activity,
-        activityPct,
-        sortKey: isActivity ? activity : row.scores[dimension],
-      };
+    const boardState = this.boardSignal(dimension);
+    const token = dimension === 'technical' ? ++this.techBoardToken : ++this.ecoBoardToken;
+
+    boardState.update((s) => ({ ...s, first, rowsPerPage, loading: true, status: s.status === 'ready' ? 'ready' : 'loading' }));
+
+    const fetch =
+      dimension === 'technical'
+        ? this.detailService.getTechnicalBoard(uid, this.orgName(), slug, range, metric, page, rowsPerPage, search)
+        : this.detailService.getEcosystemBoard(uid, this.orgName(), slug, range, metric, page, rowsPerPage, search);
+
+    fetch.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (result) => {
+        if (this.isBoardRequestStale(dimension, token)) return;
+        const rows = this.toDisplayRows(result?.rows ?? [], dimension, isActivity, first);
+        boardState.set({ status: 'ready', rows, total: result?.total ?? 0, first, rowsPerPage, loading: false });
+      },
+      error: (err: unknown) => {
+        console.error('[OrgProjectDetail] failed to load leaderboard board', err);
+        if (this.isBoardRequestStale(dimension, token)) return;
+        boardState.set({ status: 'error', rows: [], total: 0, first, rowsPerPage, loading: false });
+      },
     });
-    valued.sort((a, b) => b.sortKey - a.sortKey || a.row.orgName.localeCompare(b.row.orgName));
-    const ranked = valued.map((entry, i) => {
-      // Bands are precomputed per-org warehouse tiers (Silent/Participating/Contributing/Leading).
-      // Non-LF is a project-level classification, not a per-org band — it is surfaced once at the
-      // board/section level (ecosystemBoardNonLfMarker), never stamped on an individual org chip.
-      // A row with no mapped tier renders a blank chip.
-      const bandMeta = entry.level ? PD_BAND_TAG[entry.level] : null;
-      const activityLabel = isActivity
-        ? `${entry.activity.toLocaleString('en-US')} - ${Math.round(entry.activityPct)}%`
-        : entry.activity.toLocaleString('en-US');
+  }
+
+  private isBoardRequestStale(dimension: LeaderboardDimension, token: number): boolean {
+    return token !== (dimension === 'technical' ? this.techBoardToken : this.ecoBoardToken);
+  }
+
+  /**
+   * Map a server page of ranked rows to the board's display rows. Rows arrive pre-ranked and
+   * pre-paged, so the rank is read straight from the warehouse (falling back to the page offset only
+   * if a rank is somehow absent) — the client never re-derives rank from row position.
+   */
+  private toDisplayRows(rows: OrgLensProjectLeaderboardRow[], dimension: LeaderboardDimension, isActivity: boolean, first: number): BoardDisplayRow[] {
+    return rows.map((row, i) => {
+      const rank = row.warehouseRank ?? first + i + 1;
+      if (isActivity) {
+        const activity = dimension === 'technical' ? row.activityCount.contributions : row.activityCount.collaborations;
+        const activityPct = dimension === 'technical' ? row.activityCount.contributionsPct : row.activityCount.collaborationsPct;
+        return {
+          rank,
+          orgName: row.orgName,
+          orgLogoUrl: row.orgLogoUrl,
+          initials: this.initialsFor(row.orgName),
+          activityLabel: `${activity.toLocaleString('en-US')} - ${Math.round(activityPct)}%`,
+          bandLabel: '',
+          bandSeverity: 'secondary',
+          isViewingOrg: row.isViewingOrg,
+        };
+      }
+      // Bands are precomputed per-org warehouse tiers; Non-LF is surfaced once at the board level
+      // (ecosystemBoardNonLfMarker), never stamped on an individual org chip.
+      const level = row.levels[dimension];
+      const bandMeta = level ? PD_BAND_TAG[level] : null;
       return {
-        rank: i + 1,
-        orgName: entry.row.orgName,
-        orgLogoUrl: entry.row.orgLogoUrl,
-        initials: this.initialsFor(entry.row.orgName),
-        activityLabel,
+        rank,
+        orgName: row.orgName,
+        orgLogoUrl: row.orgLogoUrl,
+        initials: this.initialsFor(row.orgName),
+        activityLabel: '',
         bandLabel: bandMeta?.label ?? '',
-        bandSeverity: bandMeta?.severity ?? ('secondary' as const),
-        isViewingOrg: entry.row.isViewingOrg,
+        bandSeverity: bandMeta?.severity ?? 'secondary',
+        isViewingOrg: row.isViewingOrg,
       };
     });
-    const query = search.trim().toLowerCase();
-    return query ? ranked.filter((r) => r.orgName.toLowerCase().includes(query)) : ranked;
   }
 
   private initActiveTab(): OrgLensProjectDetailTab {
@@ -645,30 +705,6 @@ export class OrgProjectDetailComponent {
           catchError((err: unknown): Observable<BlockState<OrgLensTrendBlock>> => {
             console.error('[OrgProjectDetail] failed to load influence trend', err);
             return of<BlockState<OrgLensTrendBlock>>({ status: 'error', data: null });
-          })
-        )
-      )
-    );
-  }
-
-  /**
-   * B7/B8 — Leaderboard board stream (one dimension). Lazy on first pd-leaderboards activation and
-   * re-fetches on range change. Both boards use this builder with their own fetch + retry, so they
-   * fetch independently and in parallel — whichever lands first paints first.
-   */
-  private buildBoardState(
-    fetch: (uid: string, name: string, slug: string, range: OrgLensLeaderboardTimeRange) => Observable<OrgLensLeaderboardBlock | null>,
-    retry: Signal<number>
-  ): Observable<BlockState<OrgLensLeaderboardBlock>> {
-    return combineLatest([this.orgUid$, this.slug$, this.range$, this.leaderboardsActivated$, toObservable(retry)]).pipe(
-      filter(([, , , activated]) => activated),
-      switchMap(([uid, slug, range]) =>
-        fetch(uid, this.orgName(), slug, range).pipe(
-          map((block): BlockState<OrgLensLeaderboardBlock> => (block ? { status: 'ready', data: block } : { status: 'empty', data: null })),
-          startWith<BlockState<OrgLensLeaderboardBlock>>({ status: 'loading', data: null }),
-          catchError((err: unknown): Observable<BlockState<OrgLensLeaderboardBlock>> => {
-            console.error('[OrgProjectDetail] failed to load leaderboard board', err);
-            return of<BlockState<OrgLensLeaderboardBlock>>({ status: 'error', data: null });
           })
         )
       )

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -487,7 +487,10 @@ export class OrgProjectDetailComponent {
   }
 
   private resetLeaderboardSearch(): void {
-    this.searchForm.reset({ technical: '', ecosystem: '' }, { emitEvent: false });
+    // Emit the reset so the empty value flows through the same debounced valueChanges pipe: debounceTime
+    // keeps only the latest value, so a keystroke typed just before an org/slug change is superseded by
+    // this '' and can't fire a stale server search after the input is already cleared.
+    this.searchForm.reset({ technical: '', ecosystem: '' });
     this.techSearch.set('');
     this.ecoSearch.set('');
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -603,7 +603,7 @@ export class OrgProjectDetailComponent {
     fetch.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (result) => {
         if (this.isBoardRequestStale(dimension, token)) return;
-        const rows = this.toDisplayRows(result?.rows ?? [], dimension, isActivity, first);
+        const rows = this.toDisplayRows(result?.rows ?? [], dimension, isActivity);
         boardState.set({ status: 'ready', rows, total: result?.total ?? 0, first, rowsPerPage, loading: false });
       },
       error: (err: unknown) => {
@@ -620,12 +620,14 @@ export class OrgProjectDetailComponent {
 
   /**
    * Map a server page of ranked rows to the board's display rows. Rows arrive pre-ranked and
-   * pre-paged, so the rank is read straight from the warehouse (falling back to the page offset only
-   * if a rank is somehow absent) — the client never re-derives rank from row position.
+   * pre-paged, so the rank is read straight from the warehouse; when a warehouse rank is genuinely
+   * absent (nullable activity rank) the row keeps a null rank and the template renders an explicit
+   * unknown marker — the client never re-derives rank from row position (a page offset would show a
+   * misleading "#1" for an unranked org, especially after search resets the paginator to page 0).
    */
-  private toDisplayRows(rows: OrgLensProjectLeaderboardRow[], dimension: LeaderboardDimension, isActivity: boolean, first: number): BoardDisplayRow[] {
-    return rows.map((row, i) => {
-      const rank = row.warehouseRank ?? first + i + 1;
+  private toDisplayRows(rows: OrgLensProjectLeaderboardRow[], dimension: LeaderboardDimension, isActivity: boolean): BoardDisplayRow[] {
+    return rows.map((row) => {
+      const rank = row.warehouseRank ?? null;
       if (isActivity) {
         const activity = dimension === 'technical' ? row.activityCount.contributions : row.activityCount.collaborations;
         const activityPct = dimension === 'technical' ? row.activityCount.contributionsPct : row.activityCount.collaborationsPct;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -538,6 +538,7 @@
       optionValue="value"
       optionImage="logoUrl"
       [filter]="true"
+      [resetFilterOnHide]="true"
       filterPlaceHolder="Search and select projects"
       placeholder="Search and select projects"
       styleClass="w-full"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -539,6 +539,7 @@
       optionImage="logoUrl"
       [filter]="true"
       [resetFilterOnHide]="true"
+      filterBy="label,value"
       filterPlaceHolder="Search and select projects"
       placeholder="Search and select projects"
       styleClass="w-full"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -530,14 +530,6 @@
       <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
       <span>This will be shared across all users in your company.</span>
     </div>
-    <lfx-input-text
-      [form]="addProjectsForm"
-      control="search"
-      type="search"
-      placeholder="Search and select projects"
-      size="small"
-      styleClass="w-full"
-      [dataTest]="'org-projects-add-projects-search'" />
     <lfx-multi-select
       [form]="addProjectsForm"
       control="projects"
@@ -545,11 +537,13 @@
       optionLabel="label"
       optionValue="value"
       optionImage="logoUrl"
-      [filter]="false"
+      [filter]="true"
+      filterPlaceHolder="Search and select projects"
       placeholder="Search and select projects"
       styleClass="w-full"
       panelStyleClass="org-projects-add-projects-select-panel"
       scrollHeight="16rem"
+      (filterChange)="onAddProjectsFilter($event)"
       data-testid="org-projects-add-projects-select" />
     @if (addProjectsSearchLoading()) {
       <div class="flex items-center gap-2 text-sm text-gray-500" data-testid="org-projects-add-projects-loading">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -308,7 +308,15 @@ export class OrgProjectsComponent {
     if (!this.canAddProjects()) {
       return;
     }
-    this.addProjectsForm.setValue({ projects: [] }, { emitEvent: false });
+    // Cancel any debounced search still pending from a previous session so it can't land
+    // after — and overwrite — this fresh empty search when the dialog is quickly reopened.
+    if (this.addableProjectsSearchDebounceTimer) {
+      clearTimeout(this.addableProjectsSearchDebounceTimer);
+      this.addableProjectsSearchDebounceTimer = null;
+    }
+    // Emit the reset (no emitEvent:false) so the derived form-value signal — and the
+    // selected count / confirm button / empty state that read it — clear immediately.
+    this.addProjectsForm.setValue({ projects: [] });
     this.addProjectsSearchQuery.set('');
     this.addableProjectOptions.set([]);
     this.selectedAddableProjectOptions.set([]);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -614,7 +614,12 @@ export class OrgProjectsComponent {
     this.addProjectsSearchError.set(false);
     try {
       const excludeSlugs = [...new Set(this.selectedWorkspace()?.projectSlugs ?? [])];
-      const { results } = await firstValueFrom(this.projectsService.searchProjects(account.uid, trimmed, excludeSlugs));
+      // Send the raw (un-trimmed) filter text so the server's substring match stays identical to the
+      // PrimeNG multi-select's client-side filter (which matches the raw box text). If the server
+      // trimmed but the client did not, a stray leading/trailing space would let the client hide rows
+      // the API already returned, leaving the panel misleadingly empty. `trimmed` is used only for the
+      // min-length gate above.
+      const { results } = await firstValueFrom(this.projectsService.searchProjects(account.uid, query, excludeSlugs));
       if (requestId !== this.addableProjectsSearchRequestId) {
         return;
       }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -128,13 +128,14 @@ export class OrgProjectsComponent {
   protected readonly workspaceForm = new FormGroup({
     name: new FormControl<string>('', { nonNullable: true }),
   });
-  /** Selected project slugs and search query for the "Add project(s)" dialog. */
+  /** Selected project slugs for the "Add project(s)" dialog. */
   protected readonly addProjectsForm = new FormGroup({
     projects: new FormControl<string[]>([], { nonNullable: true }),
-    search: new FormControl<string>('', { nonNullable: true }),
   });
   protected readonly addableProjectOptions = signal<AddableProjectOption[]>([]);
   private readonly selectedAddableProjectOptions = signal<AddableProjectOption[]>([]);
+  /** Current text in the "Add project(s)" multi-select filter box; drives the debounced server-side search. */
+  private readonly addProjectsSearchQuery = signal<string>('');
 
   // Writable Signals
   private readonly workspaceLoading = signal(false);
@@ -243,10 +244,6 @@ export class OrgProjectsComponent {
       this.syncSelectedAddableProjectOptions();
     });
 
-    this.addProjectsForm.controls.search.valueChanges.pipe(takeUntilDestroyed()).subscribe((query) => {
-      this.searchAddableProjects(query);
-    });
-
     this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
       this.workspaceDialogOpen.set(false);
       this.addProjectsDialogOpen.set(false);
@@ -311,7 +308,8 @@ export class OrgProjectsComponent {
     if (!this.canAddProjects()) {
       return;
     }
-    this.addProjectsForm.setValue({ projects: [], search: '' }, { emitEvent: false });
+    this.addProjectsForm.setValue({ projects: [] }, { emitEvent: false });
+    this.addProjectsSearchQuery.set('');
     this.addableProjectOptions.set([]);
     this.selectedAddableProjectOptions.set([]);
     this.addProjectsSearchError.set(false);
@@ -331,7 +329,7 @@ export class OrgProjectsComponent {
   }
 
   protected retryAddableProjectsSearch(): void {
-    void this.runAddableProjectsSearch(this.addProjectsForm.controls.search.value);
+    void this.runAddableProjectsSearch(this.addProjectsSearchQuery());
   }
 
   protected async confirmAddProjects(): Promise<void> {
@@ -561,6 +559,12 @@ export class OrgProjectsComponent {
     const metrics = project.healthMetrics.map((m) => `${m.label} ${m.value}`).join(', ');
     return `Health: ${HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)]}. ${metrics}.`;
   }
+  /** The "Add project(s)" multi-select filter box drives the debounced server-side project search. */
+  protected onAddProjectsFilter(query: string): void {
+    this.addProjectsSearchQuery.set(query);
+    this.searchAddableProjects(query);
+  }
+
   protected searchAddableProjects(query: string): void {
     if (this.addableProjectsSearchDebounceTimer) {
       clearTimeout(this.addableProjectsSearchDebounceTimer);
@@ -820,7 +824,7 @@ export class OrgProjectsComponent {
   }
 
   private initAddProjectsSearchEmptyTitle(): string {
-    const query = this.addProjectsForm.controls.search.value.trim();
+    const query = this.addProjectsSearchQuery().trim();
     if (query.length > 0 && query.length < ORG_PROJECTS_SEARCH_MIN_LENGTH) {
       return `Type at least ${ORG_PROJECTS_SEARCH_MIN_LENGTH} characters to search projects.`;
     }

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -11,6 +11,7 @@
     [showToggleAll]="showToggleAll()"
     [appendTo]="appendTo()"
     [filter]="filter()"
+    [resetFilterOnHide]="resetFilterOnHide()"
     [filterBy]="filterBy()"
     [filterPlaceHolder]="filterPlaceHolder()"
     [size]="size()"

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -23,6 +23,8 @@ export class MultiSelectComponent {
   public readonly showToggleAll = input<boolean>(true);
   public readonly appendTo = input<any>('body');
   public readonly filter = input<boolean>(true);
+  /** Clear the filter box when the overlay hides so a reopened panel never shows stale filter text. */
+  public readonly resetFilterOnHide = input<boolean>(false);
   public readonly filterBy = input<string | undefined>(undefined);
   public readonly filterPlaceHolder = input<string>('Search');
   public readonly size = input<'small' | 'large'>('small');

--- a/apps/lfx-one/src/app/shared/components/table/table.component.scss
+++ b/apps/lfx-one/src/app/shared/components/table/table.component.scss
@@ -100,11 +100,19 @@
         margin-left: auto;
         font-size: 0.875rem !important;
         color: #6b7280;
+        // Keep the "Showing X to Y of Z" report on a single line so the rpp
+        // dropdown stays clustered beside it (Dano mock: report + select as one
+        // right-aligned group) instead of the dropdown orphaning to a new line.
+        white-space: nowrap;
       }
 
       .p-paginator-rpp-dropdown {
         order: 7;
-        margin-left: 1.5rem;
+        // Dano mock spaces the report and the rows-per-page select by ~10px; the
+        // previous 1.5rem was wide enough to push the select onto its own line in
+        // the narrow half-width leaderboard cards.
+        margin-left: 0.625rem;
+        flex-shrink: 0;
       }
     }
   }

--- a/apps/lfx-one/src/app/shared/components/table/table.component.scss
+++ b/apps/lfx-one/src/app/shared/components/table/table.component.scss
@@ -100,6 +100,7 @@
         margin-left: auto;
         font-size: 0.875rem !important;
         color: #6b7280;
+
         // Keep the "Showing X to Y of Z" report on a single line so the rpp
         // dropdown stays clustered beside it (Dano mock: report + select as one
         // right-aligned group) instead of the dropdown orphaning to a new line.
@@ -108,6 +109,7 @@
 
       .p-paginator-rpp-dropdown {
         order: 7;
+
         // Dano mock spaces the report and the rows-per-page select by ~10px; the
         // previous 1.5rem was wide enough to push the select onto its own line in
         // the narrow half-width leaderboard cards.

--- a/apps/lfx-one/src/app/shared/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-project-detail.service.ts
@@ -8,7 +8,8 @@ import type {
   OrgLensCardRosterPage,
   OrgLensHeroBlock,
   OrgLensInfluenceBlock,
-  OrgLensLeaderboardBlock,
+  OrgLensLeaderboardMetric,
+  OrgLensLeaderboardPage,
   OrgLensLeaderboardTimeRange,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
@@ -54,24 +55,38 @@ export class OrgLensProjectDetailService {
     return this.blockGet<OrgLensTrendBlock>(`${this.baseUrl(orgUid, projectSlug)}/trend`, { orgName });
   }
 
-  /** B7 — Technical leaderboard board (influence rows + contribution activity rows). */
+  /** B7 — Technical leaderboard board: one server-paged, server-searched page for the active metric. */
   public getTechnicalBoard(
     orgUid: string,
     orgName: string,
     projectSlug: string,
-    range: OrgLensLeaderboardTimeRange
-  ): Observable<OrgLensLeaderboardBlock | null> {
-    return this.blockGet<OrgLensLeaderboardBlock>(`${this.baseUrl(orgUid, projectSlug)}/leaderboard/technical`, { orgName, range });
+    range: OrgLensLeaderboardTimeRange,
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Observable<OrgLensLeaderboardPage | null> {
+    return this.blockGet<OrgLensLeaderboardPage>(
+      `${this.baseUrl(orgUid, projectSlug)}/leaderboard/technical`,
+      this.boardParams(orgName, range, metric, page, pageSize, search)
+    );
   }
 
-  /** B8 — Ecosystem leaderboard board (influence rows + collaboration activity rows). */
+  /** B8 — Ecosystem leaderboard board: one server-paged, server-searched page for the active metric. */
   public getEcosystemBoard(
     orgUid: string,
     orgName: string,
     projectSlug: string,
-    range: OrgLensLeaderboardTimeRange
-  ): Observable<OrgLensLeaderboardBlock | null> {
-    return this.blockGet<OrgLensLeaderboardBlock>(`${this.baseUrl(orgUid, projectSlug)}/leaderboard/ecosystem`, { orgName, range });
+    range: OrgLensLeaderboardTimeRange,
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Observable<OrgLensLeaderboardPage | null> {
+    return this.blockGet<OrgLensLeaderboardPage>(
+      `${this.baseUrl(orgUid, projectSlug)}/leaderboard/ecosystem`,
+      this.boardParams(orgName, range, metric, page, pageSize, search)
+    );
   }
 
   /** B5 — Card detail drawer definition (+ column headers) for one card; the roster rows come from getCardRoster. */
@@ -99,6 +114,21 @@ export class OrgLensProjectDetailService {
     return this.http
       .get<OrgLensCardRosterPage>(url, { params: { orgName, range, page: String(page), pageSize: String(pageSize) } })
       .pipe(catchError((err: HttpErrorResponse) => (err.status === 404 ? of({ rows: [], total: 0 }) : throwError(() => err))));
+  }
+
+  /** Query params for a paginated board request; search is omitted when blank so the cache key stays clean. */
+  private boardParams(
+    orgName: string,
+    range: OrgLensLeaderboardTimeRange,
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Record<string, string> {
+    const params: Record<string, string> = { orgName, range, metric, page: String(page), pageSize: String(pageSize) };
+    const term = search.trim();
+    if (term.length > 0) params['search'] = term;
+    return params;
   }
 
   private baseUrl(orgUid: string, projectSlug: string): string {

--- a/apps/lfx-one/src/server/controllers/org-lens-project-detail.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-project-detail.controller.ts
@@ -3,7 +3,14 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import { FOUNDATION_ID_PATTERN, PD_DEFAULT_METRIC, PD_DEFAULT_TIME_RANGE, PD_VALID_METRICS, PD_VALID_TIME_RANGES } from '@lfx-one/shared/constants';
+import {
+  FOUNDATION_ID_PATTERN,
+  PD_DEFAULT_METRIC,
+  PD_DEFAULT_TIME_RANGE,
+  PD_MAX_SEARCH_LENGTH,
+  PD_VALID_METRICS,
+  PD_VALID_TIME_RANGES,
+} from '@lfx-one/shared/constants';
 import type { OrgLensLeaderboardMetric, OrgLensLeaderboardTimeRange } from '@lfx-one/shared/interfaces';
 
 import { ServiceValidationError } from '../errors';
@@ -185,7 +192,8 @@ export class OrgLensProjectDetailController {
     const page = this.parseNonNegativeInt(req.query['page'], 0);
     // pageSize is clamped again in the service; clamp here too so the log/signature stay honest.
     const pageSize = Math.min(this.parseNonNegativeInt(req.query['pageSize'], 10) || 10, 100);
-    const search = getStringQueryParam(req, 'search')?.trim() ?? '';
+    // Cap length before it reaches the Valkey key / leading-wildcard ILIKE term (getStringQueryParam only narrows type).
+    const search = (getStringQueryParam(req, 'search')?.trim() ?? '').slice(0, PD_MAX_SEARCH_LENGTH);
     return { metric, page, pageSize, search };
   }
 

--- a/apps/lfx-one/src/server/controllers/org-lens-project-detail.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-project-detail.controller.ts
@@ -3,11 +3,12 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import { FOUNDATION_ID_PATTERN, PD_DEFAULT_TIME_RANGE, PD_VALID_TIME_RANGES } from '@lfx-one/shared/constants';
-import type { OrgLensLeaderboardTimeRange } from '@lfx-one/shared/interfaces';
+import { FOUNDATION_ID_PATTERN, PD_DEFAULT_METRIC, PD_DEFAULT_TIME_RANGE, PD_VALID_METRICS, PD_VALID_TIME_RANGES } from '@lfx-one/shared/constants';
+import type { OrgLensLeaderboardMetric, OrgLensLeaderboardTimeRange } from '@lfx-one/shared/interfaces';
 
 import { ServiceValidationError } from '../errors';
 import { assertOrgUid } from '../helpers/org-uid.helper';
+import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { OrgLensProjectDetailService } from '../services/org-lens-project-detail.service';
 
@@ -60,11 +61,19 @@ export class OrgLensProjectDetailController {
 
   public async getTechnicalBoard(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { orgUid, projectSlug, range } = this.context(req);
-    const startTime = logger.startOperation(req, 'get_org_lens_project_detail_board_technical', { org_uid: orgUid, project_slug: projectSlug, range });
+    const { metric, page, pageSize, search } = this.boardParams(req);
+    const startTime = logger.startOperation(req, 'get_org_lens_project_detail_board_technical', {
+      org_uid: orgUid,
+      project_slug: projectSlug,
+      range,
+      metric,
+      page,
+      page_size: pageSize,
+    });
     try {
       assertOrgUid(orgUid, 'get_org_lens_project_detail_board_technical');
       this.assertProjectSlug(projectSlug, 'get_org_lens_project_detail_board_technical');
-      const block = await this.service.getTechnicalBoard(orgUid, projectSlug, range);
+      const block = await this.service.getTechnicalBoard(orgUid, projectSlug, range, metric, page, pageSize, search);
       this.sendBlock(req, res, 'get_org_lens_project_detail_board_technical', startTime, orgUid, projectSlug, block);
     } catch (error) {
       next(error);
@@ -73,11 +82,19 @@ export class OrgLensProjectDetailController {
 
   public async getEcosystemBoard(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { orgUid, projectSlug, range } = this.context(req);
-    const startTime = logger.startOperation(req, 'get_org_lens_project_detail_board_ecosystem', { org_uid: orgUid, project_slug: projectSlug, range });
+    const { metric, page, pageSize, search } = this.boardParams(req);
+    const startTime = logger.startOperation(req, 'get_org_lens_project_detail_board_ecosystem', {
+      org_uid: orgUid,
+      project_slug: projectSlug,
+      range,
+      metric,
+      page,
+      page_size: pageSize,
+    });
     try {
       assertOrgUid(orgUid, 'get_org_lens_project_detail_board_ecosystem');
       this.assertProjectSlug(projectSlug, 'get_org_lens_project_detail_board_ecosystem');
-      const block = await this.service.getEcosystemBoard(orgUid, projectSlug, range);
+      const block = await this.service.getEcosystemBoard(orgUid, projectSlug, range, metric, page, pageSize, search);
       this.sendBlock(req, res, 'get_org_lens_project_detail_board_ecosystem', startTime, orgUid, projectSlug, block);
     } catch (error) {
       next(error);
@@ -161,8 +178,19 @@ export class OrgLensProjectDetailController {
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
   }
 
+  /** Parse + validate the paginated leaderboard board query params (metric enum, clamped paging, trimmed search). */
+  private boardParams(req: Request): { metric: OrgLensLeaderboardMetric; page: number; pageSize: number; search: string } {
+    const rawMetric = getStringQueryParam(req, 'metric') ?? '';
+    const metric: OrgLensLeaderboardMetric = PD_VALID_METRICS.has(rawMetric) ? (rawMetric as OrgLensLeaderboardMetric) : PD_DEFAULT_METRIC;
+    const page = this.parseNonNegativeInt(req.query['page'], 0);
+    // pageSize is clamped again in the service; clamp here too so the log/signature stay honest.
+    const pageSize = Math.min(this.parseNonNegativeInt(req.query['pageSize'], 10) || 10, 100);
+    const search = getStringQueryParam(req, 'search')?.trim() ?? '';
+    return { metric, page, pageSize, search };
+  }
+
   private context(req: Request): { orgUid: string | undefined; projectSlug: string | undefined; range: OrgLensLeaderboardTimeRange } {
-    const rawRange = typeof req.query['range'] === 'string' ? req.query['range'] : '';
+    const rawRange = getStringQueryParam(req, 'range') ?? '';
     return {
       orgUid: req.params['orgUid'],
       projectSlug: req.params['projectSlug'],

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -145,6 +145,20 @@ export function getStringQueryParam(req: Request, name: string): string | undefi
 }
 
 /**
+ * Escapes SQL LIKE/ILIKE metacharacters in user-supplied search text so the term matches LITERALLY.
+ *
+ * `%` and `_` are LIKE wildcards; without escaping, a search for "%" matches every row (and inflates a
+ * paginated total), and "_" matches any single character. Pair the returned value with an `ESCAPE '!'`
+ * clause on the predicate, e.g. `COL ILIKE ? ESCAPE '!'` bound to `` `%${escapeSqlLikePattern(term)}%` ``.
+ * `!` is the escape character (chosen over backslash, which Snowflake also interprets inside string
+ * literals — a double-escaping footgun); the `!` itself is escaped so a literal "!" in a name (e.g.
+ * "Yahoo!") still matches. Verified against Snowflake `ILIKE … ESCAPE '!'`.
+ */
+export function escapeSqlLikePattern(term: string): string {
+  return term.replace(/[!%_]/g, (ch) => `!${ch}`);
+}
+
+/**
  * Validates and narrows a raw range string to a HealthMetricsRange.
  * Throws ServiceValidationError when the value is not in the allowed set.
  */

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -622,7 +622,7 @@ export class OrgLensProjectDetailService {
       SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
              LEVEL_COMBINED, LEVEL_TECHNICAL, LEVEL_ECOSYSTEM, DIM_RANK AS RANK
       FROM (
-        SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC, ORG_ACCOUNT_ID ASC) AS DIM_RANK
+        SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC, ORG_ORGANIZATION_ID ASC) AS DIM_RANK
         FROM ${this.leaderboardTable()}
         WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${cohort.clause}
       )
@@ -673,7 +673,10 @@ export class OrgLensProjectDetailService {
       SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
       FROM ${this.activityLeaderboardsTable()}
       WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ? AND ${cohort.clause}${searchClause}
-      ORDER BY RANK ASC NULLS LAST, ORG_ACCOUNT_ID ASC
+      -- RANK and ORG_ACCOUNT_ID are both nullable, so they are not a total order for OFFSET paging.
+      -- ORG_ORGANIZATION_ID is the activity model's unique per-row grain key (its own rank tie-break),
+      -- so it guarantees a stable order — page boundaries can't skip or duplicate rows.
+      ORDER BY RANK ASC NULLS LAST, ORG_ORGANIZATION_ID ASC
       LIMIT ${limit} OFFSET ${offset}
     `;
     const countSql = `
@@ -1199,7 +1202,9 @@ export class OrgLensProjectDetailService {
         WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ?
         -- One Salesforce account can span multiple leaderboard rows (one per crowd.dev org); pick its
         -- best-ranked row deterministically so the Our-Influence band chips never flip between requests.
-        ORDER BY RANK ASC NULLS LAST, SCORE_COMBINED DESC, ORG_NAME ASC
+        -- ORG_ORGANIZATION_ID is the unique per-row key (matches resolveViewerCohort) and breaks any
+        -- rank/score/name tie that would otherwise let the LIMIT 1 pick flip.
+        ORDER BY RANK ASC NULLS LAST, SCORE_COMBINED DESC, ORG_NAME ASC, ORG_ORGANIZATION_ID ASC
         LIMIT 1
       `,
       [slug, timeRangeType, orgUid]

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -9,7 +9,8 @@ import type {
   OrgLensCardRosterPage,
   OrgLensHeroBlock,
   OrgLensInfluenceBlock,
-  OrgLensLeaderboardBlock,
+  OrgLensLeaderboardMetric,
+  OrgLensLeaderboardPage,
   OrgLensLeaderboardTimeRange,
   OrgLensProjectBand,
   OrgLensProjectHealth,
@@ -167,10 +168,6 @@ interface LeaderboardRow {
   LEVEL_TECHNICAL: string | null;
   LEVEL_ECOSYSTEM: string | null;
   RANK: number | null;
-  ACTIVITY_CONTRIBUTIONS: number | null;
-  ACTIVITY_CONTRIBUTIONS_PCT: number | null;
-  ACTIVITY_COLLABORATIONS: number | null;
-  ACTIVITY_COLLABORATIONS_PCT: number | null;
 }
 
 /**
@@ -409,16 +406,17 @@ export class OrgLensProjectDetailService {
     const isNonLf = heroRow.IS_LF_PROJECT !== true;
     const foundationLabel = heroRow.FOUNDATION_NAME ?? 'Outside LF';
 
-    const [cardRows, sparkRows, leaderboardRows] = await Promise.all([
+    const [cardRows, sparkRows, viewing] = await Promise.all([
       this.fetchCards(orgUid, slug, timeRangeType),
       this.fetchSparklines(orgUid, slug),
-      this.fetchLeaderboard(orgUid, slug, timeRangeType).catch(() => [] as LeaderboardRow[]),
+      // Only the viewing org's own row is needed here (for the section-title band chips), so fetch
+      // that single row rather than the whole board — the board itself is now paged separately.
+      this.fetchViewingLeaderboardRow(orgUid, slug, timeRangeType).catch(() => null),
     ]);
 
     const cards = cardRows[0] ?? null;
     const sparklineIndex = this.buildSparklineIndex(sparkRows);
     const monthAxis = this.monthAxis();
-    const viewing = leaderboardRows.find((row) => row.ORG_ACCOUNT_ID === orgUid) ?? null;
 
     const block: OrgLensInfluenceBlock = {
       technical: this.buildTechnicalCards(cards, sparklineIndex, monthAxis),
@@ -455,12 +453,28 @@ export class OrgLensProjectDetailService {
     return block;
   }
 
-  public async getTechnicalBoard(orgUid: string, projectSlug: string, range: OrgLensLeaderboardTimeRange): Promise<OrgLensLeaderboardBlock | null> {
-    return this.fetchLeaderboardBlock(orgUid, projectSlug, range, 'technical');
+  public async getTechnicalBoard(
+    orgUid: string,
+    projectSlug: string,
+    range: OrgLensLeaderboardTimeRange,
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Promise<OrgLensLeaderboardPage | null> {
+    return this.fetchBoardPage(orgUid, projectSlug, range, 'technical', metric, page, pageSize, search);
   }
 
-  public async getEcosystemBoard(orgUid: string, projectSlug: string, range: OrgLensLeaderboardTimeRange): Promise<OrgLensLeaderboardBlock | null> {
-    return this.fetchLeaderboardBlock(orgUid, projectSlug, range, 'ecosystem');
+  public async getEcosystemBoard(
+    orgUid: string,
+    projectSlug: string,
+    range: OrgLensLeaderboardTimeRange,
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Promise<OrgLensLeaderboardPage | null> {
+    return this.fetchBoardPage(orgUid, projectSlug, range, 'ecosystem', metric, page, pageSize, search);
   }
 
   public async getCardDrawer(
@@ -488,17 +502,34 @@ export class OrgLensProjectDetailService {
     return section;
   }
 
-  private async fetchLeaderboardBlock(
+  /**
+   * One server-paginated, server-searched page of a leaderboard board for one dimension
+   * (technical / ecosystem) and metric (Calculated Influence / Activity Count). Ranking and paging
+   * happen in SQL over the FULL org set (no top-N cap); the viewing org is flagged per row and lands
+   * at its true rank on whatever page it falls (no top-pinning). A missing (org, slug) catalog row is
+   * the page-level 404 gate, consistent with every other block.
+   */
+  private async fetchBoardPage(
     orgUid: string,
     projectSlug: string,
     range: OrgLensLeaderboardTimeRange,
-    dimension: 'technical' | 'ecosystem'
-  ): Promise<OrgLensLeaderboardBlock | null> {
+    dimension: 'technical' | 'ecosystem',
+    metric: OrgLensLeaderboardMetric,
+    page: number,
+    pageSize: number,
+    search: string
+  ): Promise<OrgLensLeaderboardPage | null> {
     const slug = projectSlug.trim().toLowerCase();
     const timeRangeType = PD_TIME_RANGE_TYPE[range];
-    const key = buildOrgCacheKey(orgUid, `project-detail-board-${dimension}:${this.paramSignature([slug, range])}`);
+    const safeSize = Math.min(Math.max(Math.trunc(pageSize) || 0, 1), 100);
+    const safePage = Math.max(Math.trunc(page) || 0, 0);
+    const offset = safePage * safeSize;
+    const term = search.trim();
+
+    const cacheKey = `project-detail-board-${dimension}-${metric}:${this.paramSignature([slug, range, safePage, safeSize, term.toLowerCase()])}`;
+    const key = buildOrgCacheKey(orgUid, cacheKey);
     if (key !== null) {
-      const cached = await valkeyService.getJson<OrgLensLeaderboardBlock>(key, OrgLensProjectDetailService.isLeaderboardBlock);
+      const cached = await valkeyService.getJson<OrgLensLeaderboardPage>(key, OrgLensProjectDetailService.isLeaderboardPage);
       if (cached !== null) return cached;
     }
 
@@ -506,22 +537,116 @@ export class OrgLensProjectDetailService {
     if (!heroRow) return null;
     const isNonLf = heroRow.IS_LF_PROJECT !== true;
 
-    const [leaderboardRows, activityBoardRows] = await Promise.all([
-      this.fetchLeaderboard(orgUid, slug, timeRangeType),
-      this.fetchActivityLeaderboards(orgUid, slug, timeRangeType),
-    ]);
+    let block: OrgLensLeaderboardPage;
+    // Non-LF projects have no ecosystem influence, so that board is empty (the client also guards).
+    if (dimension === 'ecosystem' && metric === 'influence' && isNonLf) {
+      block = { rows: [], total: 0, isNonLfProject: isNonLf };
+    } else {
+      const { rows, total } =
+        metric === 'activity'
+          ? await this.fetchActivityBoardPage(slug, timeRangeType, dimension, orgUid, safeSize, offset, term)
+          : await this.fetchInfluenceBoardPage(slug, timeRangeType, dimension, orgUid, isNonLf, safeSize, offset, term);
+      block = { rows, total, isNonLfProject: isNonLf };
+    }
 
-    const trendByAccount = new Map<string, TrendSeries>();
-    const activityLeaderboards = this.mapActivityLeaderboards(activityBoardRows, orgUid, trendByAccount);
-    const block: OrgLensLeaderboardBlock = {
-      influence: leaderboardRows.map((row) => this.mapLeaderboardRow(row, orgUid, isNonLf, trendByAccount)),
-      activity: dimension === 'technical' ? activityLeaderboards.contributions : activityLeaderboards.collaborations,
-      isNonLfProject: isNonLf,
-    };
     if (key !== null) {
       await valkeyService.setJson(key, block, VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS);
     }
     return block;
+  }
+
+  /**
+   * A page of the Calculated Influence board for one dimension. There is no stored per-dimension
+   * rank (the warehouse combined RANK is the combined-influence order), so rank is derived here via
+   * ROW_NUMBER() over the FULL set ordered by that dimension's score. Search filters rows AFTER
+   * ranking, so a matched org keeps its true board rank (e.g. an org ranked #250 stays "#250").
+   */
+  private async fetchInfluenceBoardPage(
+    slug: string,
+    timeRangeType: string,
+    dimension: 'technical' | 'ecosystem',
+    orgUid: string,
+    isNonLf: boolean,
+    limit: number,
+    offset: number,
+    search: string
+  ): Promise<{ rows: OrgLensProjectLeaderboardRow[]; total: number }> {
+    const scoreColumn = dimension === 'technical' ? 'SCORE_TECHNICAL' : 'SCORE_ECOSYSTEM';
+    const hasSearch = search.length > 0;
+    // Bound ILIKE parameter — never string-interpolated. Numeric LIMIT/OFFSET are clamped ints.
+    const searchClause = hasSearch ? 'WHERE ORG_NAME ILIKE ?' : '';
+    const countParams = hasSearch ? [slug, timeRangeType, `%${search}%`] : [slug, timeRangeType];
+    const pageParams = [...countParams, limit, offset];
+
+    const pageSql = `
+      SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
+             LEVEL_COMBINED, LEVEL_TECHNICAL, LEVEL_ECOSYSTEM, DIM_RANK AS RANK
+      FROM (
+        SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC) AS DIM_RANK
+        FROM ${this.leaderboardTable()}
+        WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ?
+      )
+      ${searchClause}
+      ORDER BY DIM_RANK
+      LIMIT ? OFFSET ?
+    `;
+    const countSql = `
+      SELECT COUNT(*) AS N
+      FROM ${this.leaderboardTable()}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ?${hasSearch ? ' AND ORG_NAME ILIKE ?' : ''}
+    `;
+
+    const [pageResult, countResult] = await Promise.all([
+      this.snowflakeService.execute<LeaderboardRow>(pageSql, pageParams),
+      this.snowflakeService.execute<{ N: number }>(countSql, countParams),
+    ]);
+    return {
+      rows: pageResult.rows.map((row) => this.mapInfluenceRow(row, orgUid, isNonLf)),
+      total: this.num(countResult.rows[0]?.N ?? 0),
+    };
+  }
+
+  /**
+   * A page of an Activity Count board for one dimension. The gold-sourced activity model already
+   * carries rank / total / percentage over the FULL org set, so this just filters, orders by that
+   * precomputed RANK, and pages — no ranking is re-implemented. Search preserves rank as above.
+   */
+  private async fetchActivityBoardPage(
+    slug: string,
+    timeRangeType: string,
+    dimension: 'technical' | 'ecosystem',
+    orgUid: string,
+    limit: number,
+    offset: number,
+    search: string
+  ): Promise<{ rows: OrgLensProjectLeaderboardRow[]; total: number }> {
+    const boardType = dimension === 'technical' ? 'contributions' : 'collaborations';
+    const hasSearch = search.length > 0;
+    const searchClause = hasSearch ? ' AND ORG_NAME ILIKE ?' : '';
+    const params = hasSearch ? [slug, timeRangeType, boardType, `%${search}%`] : [slug, timeRangeType, boardType];
+    const pageParams = [...params, limit, offset];
+
+    const pageSql = `
+      SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
+      FROM ${this.activityLeaderboardsTable()}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
+      ORDER BY RANK ASC
+      LIMIT ? OFFSET ?
+    `;
+    const countSql = `
+      SELECT COUNT(*) AS N
+      FROM ${this.activityLeaderboardsTable()}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
+    `;
+
+    const [pageResult, countResult] = await Promise.all([
+      this.snowflakeService.execute<ActivityBoardRow>(pageSql, pageParams),
+      this.snowflakeService.execute<{ N: number }>(countSql, params),
+    ]);
+    return {
+      rows: pageResult.rows.map((row) => this.mapActivityRow(row, dimension, orgUid)),
+      total: this.num(countResult.rows[0]?.N ?? 0),
+    };
   }
 
   private async fetchHeroRow(orgUid: string, slug: string): Promise<HeroRow | null> {
@@ -1021,60 +1146,54 @@ export class OrgLensProjectDetailService {
     return series;
   }
 
-  private async fetchActivityLeaderboards(orgUid: string, slug: string, timeRangeType: string): Promise<ActivityBoardRow[]> {
-    const sql = (viewerClause: string): string => `
-      SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
-      FROM ${this.activityLeaderboardsTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${viewerClause}
-      ORDER BY BOARD_TYPE ASC, RANK ASC
-    `;
-    const orgIdResult = await this.snowflakeService.execute<{ ORG_ORGANIZATION_ID: string }>(
+  /** The viewing org's own leaderboard row (for the Our-Influence tab's band chips); null if absent. */
+  private async fetchViewingLeaderboardRow(orgUid: string, slug: string, timeRangeType: string): Promise<LeaderboardRow | null> {
+    const result = await this.snowflakeService.execute<LeaderboardRow>(
       `
-        SELECT ORG_ORGANIZATION_ID
+        SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
+               LEVEL_COMBINED, LEVEL_TECHNICAL, LEVEL_ECOSYSTEM, RANK
         FROM ${this.leaderboardTable()}
         WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ?
+        -- One Salesforce account can span multiple leaderboard rows (one per crowd.dev org); pick its
+        -- best-ranked row deterministically so the Our-Influence band chips never flip between requests.
+        ORDER BY RANK ASC NULLS LAST, SCORE_COMBINED DESC, ORG_NAME ASC
         LIMIT 1
       `,
       [slug, timeRangeType, orgUid]
     );
-    const viewerOrgId = orgIdResult.rows[0]?.ORG_ORGANIZATION_ID;
-    if (viewerOrgId) {
-      const viewer = await this.snowflakeService.execute<ActivityBoardRow>(sql('MY_ORGANIZATION_ID = ?'), [slug, timeRangeType, viewerOrgId]);
-      if (viewer.rows.length > 0) {
-        return viewer.rows;
-      }
-    }
-    const fallback = await this.snowflakeService.execute<ActivityBoardRow>(sql('MY_ORGANIZATION_ID IS NULL'), [slug, timeRangeType]);
-    return fallback.rows;
+    return result.rows[0] ?? null;
   }
 
-  private mapActivityLeaderboards(
-    rows: ActivityBoardRow[],
-    orgUid: string,
-    trendByAccount: Map<string, TrendSeries>
-  ): {
-    contributions: OrgLensProjectLeaderboardRow[];
-    collaborations: OrgLensProjectLeaderboardRow[];
-  } {
-    const contributions: OrgLensProjectLeaderboardRow[] = [];
-    const collaborations: OrgLensProjectLeaderboardRow[] = [];
-    for (const row of rows) {
-      const mapped = this.mapActivityBoardRow(row, orgUid, trendByAccount);
-      if (row.BOARD_TYPE === 'contributions') {
-        contributions.push(mapped);
-      } else if (row.BOARD_TYPE === 'collaborations') {
-        collaborations.push(mapped);
-      }
-    }
-    return { contributions, collaborations };
+  /** Map a combined-leaderboard row to a Calculated Influence board row (scores + bands + rank). */
+  private mapInfluenceRow(row: LeaderboardRow, orgUid: string, isNonLf: boolean): OrgLensProjectLeaderboardRow {
+    return {
+      orgName: row.ORG_NAME ?? '',
+      orgLogoUrl: row.ORG_LOGO_URL ?? '',
+      scores: {
+        combined: this.round1(this.num(row.SCORE_COMBINED)),
+        technical: this.round1(this.num(row.SCORE_TECHNICAL)),
+        ecosystem: this.round1(this.num(row.SCORE_ECOSYSTEM)),
+      },
+      levels: {
+        combined: this.mapBand(row.LEVEL_COMBINED) ?? 'silent',
+        technical: this.mapBand(row.LEVEL_TECHNICAL) ?? 'silent',
+        ecosystem: isNonLf ? null : (this.mapBand(row.LEVEL_ECOSYSTEM) ?? 'silent'),
+      },
+      // Calculated Influence rows carry no activity totals — Activity Count mode reads the
+      // separate activity-leaderboards model — so this is a zero placeholder the board never renders.
+      activityCount: { contributions: 0, collaborations: 0, contributionsPct: 0, collaborationsPct: 0 },
+      // Rank is the DIM_RANK computed in fetchInfluenceBoardPage; leave undefined only if RANK is
+      // somehow absent so the client never renders "#0" for a real row.
+      warehouseRank: this.numOrNull(row.RANK) === null ? undefined : Math.round(this.num(row.RANK)),
+      isViewingOrg: row.ORG_ACCOUNT_ID === orgUid,
+    };
   }
 
-  private mapActivityBoardRow(row: ActivityBoardRow, orgUid: string, trendByAccount: Map<string, TrendSeries>): OrgLensProjectLeaderboardRow {
-    const isContributions = row.BOARD_TYPE === 'contributions';
+  /** Map a gold-sourced activity board row to an Activity Count board row (total/pct + warehouse rank). */
+  private mapActivityRow(row: ActivityBoardRow, dimension: 'technical' | 'ecosystem', orgUid: string): OrgLensProjectLeaderboardRow {
+    const isContributions = dimension === 'technical';
     const total = Math.round(this.num(row.ACTIVITY_TOTAL));
     const pct = this.round1(this.num(row.ACTIVITY_PCT));
-    const series = row.ORG_ACCOUNT_ID ? (trendByAccount.get(row.ORG_ACCOUNT_ID)?.combined ?? []) : [];
-    const trendSparkline = this.trendSparkline12(series);
     return {
       orgName: row.ORG_NAME ?? '',
       orgLogoUrl: row.ORG_LOGO_URL ?? '',
@@ -1086,43 +1205,9 @@ export class OrgLensProjectDetailService {
         contributionsPct: isContributions ? pct : 0,
         collaborationsPct: isContributions ? 0 : pct,
       },
-      trendSparkline,
-      trendDeltaPct: this.yoyDelta(series),
-      // Leave undefined when the warehouse RANK is absent so the client falls back to positional
-      // order instead of rendering "#0" (num() would coerce a NULL rank to 0).
       warehouseRank: this.numOrNull(row.RANK) === null ? undefined : Math.round(this.num(row.RANK)),
       isViewingOrg: row.ORG_ACCOUNT_ID === orgUid,
     };
-  }
-
-  private async fetchLeaderboard(orgUid: string, slug: string, timeRangeType: string): Promise<LeaderboardRow[]> {
-    const sql = (viewerClause: string): string => `
-      SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
-             LEVEL_COMBINED, LEVEL_TECHNICAL, LEVEL_ECOSYSTEM, RANK,
-             ACTIVITY_CONTRIBUTIONS, ACTIVITY_CONTRIBUTIONS_PCT,
-             ACTIVITY_COLLABORATIONS, ACTIVITY_COLLABORATIONS_PCT
-      FROM ${this.leaderboardTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${viewerClause}
-      ORDER BY RANK ASC
-    `;
-    const orgIdResult = await this.snowflakeService.execute<{ ORG_ORGANIZATION_ID: string }>(
-      `
-        SELECT ORG_ORGANIZATION_ID
-        FROM ${this.leaderboardTable()}
-        WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ?
-        LIMIT 1
-      `,
-      [slug, timeRangeType, orgUid]
-    );
-    const viewerOrgId = orgIdResult.rows[0]?.ORG_ORGANIZATION_ID;
-    if (viewerOrgId) {
-      const viewer = await this.snowflakeService.execute<LeaderboardRow>(sql('MY_ORGANIZATION_ID = ?'), [slug, timeRangeType, viewerOrgId]);
-      if (viewer.rows.length > 0) {
-        return viewer.rows;
-      }
-    }
-    const fallback = await this.snowflakeService.execute<LeaderboardRow>(sql('MY_ORGANIZATION_ID IS NULL'), [slug, timeRangeType]);
-    return fallback.rows;
   }
 
   private mapHero(row: HeroRow, slug: string, foundationLabel: string): OrgLensProjectHero {
@@ -1315,49 +1400,6 @@ export class OrgLensProjectDetailService {
     return { key, label, scopeLabel, sparkline, projectSparkline, caption };
   }
 
-  private mapLeaderboardRow(row: LeaderboardRow, orgUid: string, isNonLf: boolean, trendByAccount: Map<string, TrendSeries>): OrgLensProjectLeaderboardRow {
-    const series = row.ORG_ACCOUNT_ID ? (trendByAccount.get(row.ORG_ACCOUNT_ID)?.combined ?? []) : [];
-    return {
-      orgName: row.ORG_NAME ?? '',
-      orgLogoUrl: row.ORG_LOGO_URL ?? '',
-      scores: {
-        combined: this.round1(this.num(row.SCORE_COMBINED)),
-        technical: this.round1(this.num(row.SCORE_TECHNICAL)),
-        ecosystem: this.round1(this.num(row.SCORE_ECOSYSTEM)),
-      },
-      levels: {
-        combined: this.mapBand(row.LEVEL_COMBINED) ?? 'silent',
-        technical: this.mapBand(row.LEVEL_TECHNICAL) ?? 'silent',
-        ecosystem: isNonLf ? null : (this.mapBand(row.LEVEL_ECOSYSTEM) ?? 'silent'),
-      },
-      activityCount: {
-        contributions: Math.round(this.num(row.ACTIVITY_CONTRIBUTIONS)),
-        collaborations: Math.round(this.num(row.ACTIVITY_COLLABORATIONS)),
-        contributionsPct: this.round1(this.num(row.ACTIVITY_CONTRIBUTIONS_PCT)),
-        collaborationsPct: this.round1(this.num(row.ACTIVITY_COLLABORATIONS_PCT)),
-      },
-      trendSparkline: this.trendSparkline12(series),
-      trendDeltaPct: this.yoyDelta(series),
-      isViewingOrg: row.ORG_ACCOUNT_ID === orgUid,
-    };
-  }
-
-  // Per §DN7 the leaderboard trend column is a fixed trailing-12-month series paired with a
-  // 1-year delta — independent of the ?range= toggle (which scopes scores/activity counts, not
-  // this sparkline). Always take the last 12 monthly points (oldest → newest).
-  private trendSparkline12(series: number[]): number[] {
-    return series.slice(-12);
-  }
-
-  /** Year-over-year delta as a signed fraction from a monthly combined series (last vs 12 months prior). */
-  private yoyDelta(series: number[]): number {
-    if (series.length < 13) return 0;
-    const last = series[series.length - 1];
-    const prior = series[series.length - 13];
-    if (prior === 0) return 0;
-    return Math.round(((last - prior) / prior) * 1000) / 1000;
-  }
-
   /** Precomputed warehouse level string → wire band tier. */
   private mapBand(level: string | null): OrgLensProjectBand | null {
     switch ((level ?? '').toLowerCase()) {
@@ -1541,10 +1583,10 @@ export class OrgLensProjectDetailService {
     return Array.isArray((value as OrgLensTrendBlock).trend);
   }
 
-  private static isLeaderboardBlock(value: unknown): value is OrgLensLeaderboardBlock {
+  private static isLeaderboardPage(value: unknown): value is OrgLensLeaderboardPage {
     if (value === null || typeof value !== 'object') return false;
-    const candidate = value as OrgLensLeaderboardBlock;
-    return Array.isArray(candidate.influence) && Array.isArray(candidate.activity) && typeof candidate.isNonLfProject === 'boolean';
+    const candidate = value as OrgLensLeaderboardPage;
+    return Array.isArray(candidate.rows) && typeof candidate.total === 'number' && typeof candidate.isNonLfProject === 'boolean';
   }
 
   private static isCardDetailSection(value: unknown): value is OrgLensCardDetailSection {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -581,7 +581,9 @@ export class OrgLensProjectDetailService {
     // Bound ILIKE parameter — never string-interpolated. Numeric LIMIT/OFFSET are clamped ints.
     const searchClause = hasSearch ? 'WHERE ORG_NAME ILIKE ?' : '';
     const countParams = hasSearch ? [slug, timeRangeType, `%${search}%`] : [slug, timeRangeType];
-    const pageParams = [...countParams, limit, offset];
+    // Snowflake rejects bind placeholders in LIMIT/OFFSET, so the already-clamped integers are
+    // interpolated as literals (matching every other paginated Snowflake query in this service).
+    const pageParams = countParams;
 
     const pageSql = `
       SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
@@ -593,7 +595,7 @@ export class OrgLensProjectDetailService {
       )
       ${searchClause}
       ORDER BY DIM_RANK
-      LIMIT ? OFFSET ?
+      LIMIT ${limit} OFFSET ${offset}
     `;
     const countSql = `
       SELECT COUNT(*) AS N
@@ -629,14 +631,15 @@ export class OrgLensProjectDetailService {
     const hasSearch = search.length > 0;
     const searchClause = hasSearch ? ' AND ORG_NAME ILIKE ?' : '';
     const params = hasSearch ? [slug, timeRangeType, boardType, `%${search}%`] : [slug, timeRangeType, boardType];
-    const pageParams = [...params, limit, offset];
+    // Snowflake rejects binds in LIMIT/OFFSET; interpolate the clamped integers (see fetchInfluenceBoardPage).
+    const pageParams = params;
 
     const pageSql = `
       SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
       FROM ${this.activityLeaderboardsTable()}
       WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
-      ORDER BY RANK ASC, ORG_ACCOUNT_ID ASC
-      LIMIT ? OFFSET ?
+      ORDER BY RANK ASC NULLS LAST, ORG_ACCOUNT_ID ASC
+      LIMIT ${limit} OFFSET ${offset}
     `;
     const countSql = `
       SELECT COUNT(*) AS N

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -561,6 +561,32 @@ export class OrgLensProjectDetailService {
   }
 
   /**
+   * The leaderboard tables store one ranked cohort per viewing organization (keyed by
+   * MY_ORGANIZATION_ID) plus a generic MY_ORGANIZATION_ID IS NULL cohort. Ranking or counting across
+   * all cohorts would duplicate organizations and inflate ranks/totals, so every board page must scope
+   * to a single cohort: resolve the viewer's ORG_ORGANIZATION_ID and use their cohort when it has rows,
+   * else the NULL cohort (mirrors the pre-pagination loader). Returns the WHERE fragment plus its bind
+   * params to apply identically to the ranked/page source and the count query.
+   */
+  private async resolveViewerCohort(table: string, slug: string, timeRangeType: string, orgUid: string): Promise<{ clause: string; params: string[] }> {
+    const orgIdResult = await this.snowflakeService.execute<{ ORG_ORGANIZATION_ID: string }>(
+      `SELECT ORG_ORGANIZATION_ID FROM ${this.leaderboardTable()} WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ? LIMIT 1`,
+      [slug, timeRangeType, orgUid]
+    );
+    const viewerOrgId = orgIdResult.rows[0]?.ORG_ORGANIZATION_ID;
+    if (viewerOrgId) {
+      const viewerCount = await this.snowflakeService.execute<{ N: number }>(
+        `SELECT COUNT(*) AS N FROM ${table} WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND MY_ORGANIZATION_ID = ?`,
+        [slug, timeRangeType, viewerOrgId]
+      );
+      if (this.num(viewerCount.rows[0]?.N ?? 0) > 0) {
+        return { clause: 'MY_ORGANIZATION_ID = ?', params: [viewerOrgId] };
+      }
+    }
+    return { clause: 'MY_ORGANIZATION_ID IS NULL', params: [] };
+  }
+
+  /**
    * A page of the Calculated Influence board for one dimension. There is no stored per-dimension
    * rank (the warehouse combined RANK is the combined-influence order), so rank is derived here via
    * ROW_NUMBER() over the FULL set ordered by that dimension's score. Search filters rows AFTER
@@ -577,13 +603,14 @@ export class OrgLensProjectDetailService {
     search: string
   ): Promise<{ rows: OrgLensProjectLeaderboardRow[]; total: number }> {
     const scoreColumn = dimension === 'technical' ? 'SCORE_TECHNICAL' : 'SCORE_ECOSYSTEM';
+    const cohort = await this.resolveViewerCohort(this.leaderboardTable(), slug, timeRangeType, orgUid);
     const hasSearch = search.length > 0;
-    // Bound ILIKE parameter — never string-interpolated. Numeric LIMIT/OFFSET are clamped ints.
+    // Rank + count are scoped to the resolved viewer cohort; ORG_NAME ILIKE is a bound param. Snowflake
+    // rejects binds in LIMIT/OFFSET, so the already-clamped integers are interpolated as literals.
     const searchClause = hasSearch ? 'WHERE ORG_NAME ILIKE ?' : '';
-    const countParams = hasSearch ? [slug, timeRangeType, `%${search}%`] : [slug, timeRangeType];
-    // Snowflake rejects bind placeholders in LIMIT/OFFSET, so the already-clamped integers are
-    // interpolated as literals (matching every other paginated Snowflake query in this service).
-    const pageParams = countParams;
+    const baseParams = [slug, timeRangeType, ...cohort.params];
+    const pageParams = hasSearch ? [...baseParams, `%${search}%`] : baseParams;
+    const countParams = pageParams;
 
     const pageSql = `
       SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
@@ -591,7 +618,7 @@ export class OrgLensProjectDetailService {
       FROM (
         SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC, ORG_ACCOUNT_ID ASC) AS DIM_RANK
         FROM ${this.leaderboardTable()}
-        WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ?
+        WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${cohort.clause}
       )
       ${searchClause}
       ORDER BY DIM_RANK
@@ -600,7 +627,7 @@ export class OrgLensProjectDetailService {
     const countSql = `
       SELECT COUNT(*) AS N
       FROM ${this.leaderboardTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ?${hasSearch ? ' AND ORG_NAME ILIKE ?' : ''}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${cohort.clause}${hasSearch ? ' AND ORG_NAME ILIKE ?' : ''}
     `;
 
     const [pageResult, countResult] = await Promise.all([
@@ -628,23 +655,25 @@ export class OrgLensProjectDetailService {
     search: string
   ): Promise<{ rows: OrgLensProjectLeaderboardRow[]; total: number }> {
     const boardType = dimension === 'technical' ? 'contributions' : 'collaborations';
+    const cohort = await this.resolveViewerCohort(this.activityLeaderboardsTable(), slug, timeRangeType, orgUid);
     const hasSearch = search.length > 0;
+    // Scope to the viewer cohort; ORG_NAME ILIKE is bound. Snowflake rejects binds in LIMIT/OFFSET,
+    // so the clamped integers are interpolated as literals (see fetchInfluenceBoardPage).
     const searchClause = hasSearch ? ' AND ORG_NAME ILIKE ?' : '';
-    const params = hasSearch ? [slug, timeRangeType, boardType, `%${search}%`] : [slug, timeRangeType, boardType];
-    // Snowflake rejects binds in LIMIT/OFFSET; interpolate the clamped integers (see fetchInfluenceBoardPage).
+    const params = hasSearch ? [slug, timeRangeType, boardType, ...cohort.params, `%${search}%`] : [slug, timeRangeType, boardType, ...cohort.params];
     const pageParams = params;
 
     const pageSql = `
       SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
       FROM ${this.activityLeaderboardsTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ? AND ${cohort.clause}${searchClause}
       ORDER BY RANK ASC NULLS LAST, ORG_ACCOUNT_ID ASC
       LIMIT ${limit} OFFSET ${offset}
     `;
     const countSql = `
       SELECT COUNT(*) AS N
       FROM ${this.activityLeaderboardsTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ? AND ${cohort.clause}${searchClause}
     `;
 
     const [pageResult, countResult] = await Promise.all([

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -191,6 +191,10 @@ export class OrgLensProjectDetailService {
   // shipped component maps points to a fixed 36-month label axis by position and slices per range.
   private static readonly sparklineMonths = 36;
 
+  // Upper bound on the requested page. Guards against a huge/precision-lost query value overflowing
+  // page*size into an unsafe integer OFFSET (which Snowflake rejects → 500); leaderboards never approach it.
+  private static readonly maxBoardPage = 100_000;
+
   // Static drawer definition metadata for the 14 cards (LFXV2-1885 DN9 Phase 1): definition copy,
   // total-column semantics, table headers, project-total aggregation, and the ecosystem cards'
   // static source label. Technical cards' data source is derived from the platforms model per project.
@@ -522,7 +526,7 @@ export class OrgLensProjectDetailService {
     const slug = projectSlug.trim().toLowerCase();
     const timeRangeType = PD_TIME_RANGE_TYPE[range];
     const safeSize = Math.min(Math.max(Math.trunc(pageSize) || 0, 1), 100);
-    const safePage = Math.max(Math.trunc(page) || 0, 0);
+    const safePage = Math.min(Math.max(Math.trunc(page) || 0, 0), OrgLensProjectDetailService.maxBoardPage);
     const offset = safePage * safeSize;
     const term = search.trim();
 
@@ -538,7 +542,8 @@ export class OrgLensProjectDetailService {
     const isNonLf = heroRow.IS_LF_PROJECT !== true;
 
     let block: OrgLensLeaderboardPage;
-    // Non-LF projects have no ecosystem influence, so that board is empty (the client also guards).
+    // Non-LF projects have no ecosystem influence, so this board is empty. The server is authoritative:
+    // the client renders the "Non-LF" marker only and no longer guards this itself.
     if (dimension === 'ecosystem' && metric === 'influence' && isNonLf) {
       block = { rows: [], total: 0, isNonLfProject: isNonLf };
     } else {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -587,7 +587,7 @@ export class OrgLensProjectDetailService {
       SELECT ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SCORE_COMBINED, SCORE_TECHNICAL, SCORE_ECOSYSTEM,
              LEVEL_COMBINED, LEVEL_TECHNICAL, LEVEL_ECOSYSTEM, DIM_RANK AS RANK
       FROM (
-        SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC) AS DIM_RANK
+        SELECT *, ROW_NUMBER() OVER (ORDER BY ${scoreColumn} DESC NULLS LAST, ORG_NAME ASC, ORG_ACCOUNT_ID ASC) AS DIM_RANK
         FROM ${this.leaderboardTable()}
         WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ?
       )
@@ -635,7 +635,7 @@ export class OrgLensProjectDetailService {
       SELECT BOARD_TYPE, ORG_ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ACTIVITY_TOTAL, ACTIVITY_PCT, RANK
       FROM ${this.activityLeaderboardsTable()}
       WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND BOARD_TYPE = ?${searchClause}
-      ORDER BY RANK ASC
+      ORDER BY RANK ASC, ORG_ACCOUNT_ID ASC
       LIMIT ? OFFSET ?
     `;
     const countSql = `

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -569,8 +569,14 @@ export class OrgLensProjectDetailService {
    * params to apply identically to the ranked/page source and the count query.
    */
   private async resolveViewerCohort(table: string, slug: string, timeRangeType: string, orgUid: string): Promise<{ clause: string; params: string[] }> {
+    // One Salesforce account can map to several leaderboard rows (multiple crowd.dev orgs), so the pick
+    // must be deterministic — otherwise a per-page cohort lookup could resolve a different
+    // MY_ORGANIZATION_ID (or flip to the null cohort) on each page request and make ranks/totals/row
+    // membership disagree across pages. Order identically to fetchViewingLeaderboardRow (best-ranked
+    // row first) with ORG_ORGANIZATION_ID as a final unique tiebreak.
     const orgIdResult = await this.snowflakeService.execute<{ ORG_ORGANIZATION_ID: string }>(
-      `SELECT ORG_ORGANIZATION_ID FROM ${this.leaderboardTable()} WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ? LIMIT 1`,
+      `SELECT ORG_ORGANIZATION_ID FROM ${this.leaderboardTable()} WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ORG_ACCOUNT_ID = ?
+       ORDER BY RANK ASC NULLS LAST, SCORE_COMBINED DESC, ORG_NAME ASC, ORG_ORGANIZATION_ID ASC LIMIT 1`,
       [slug, timeRangeType, orgUid]
     );
     const viewerOrgId = orgIdResult.rows[0]?.ORG_ORGANIZATION_ID;

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -23,6 +23,7 @@ import type {
 import { buildInsightsUrl, classifyHealthScore } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
+import { escapeSqlLikePattern } from '../helpers/validation.helper';
 import { buildOrgCacheKey, valkeyService } from './valkey.service';
 import { SnowflakeService } from './snowflake.service';
 
@@ -613,9 +614,11 @@ export class OrgLensProjectDetailService {
     const hasSearch = search.length > 0;
     // Rank + count are scoped to the resolved viewer cohort; ORG_NAME ILIKE is a bound param. Snowflake
     // rejects binds in LIMIT/OFFSET, so the already-clamped integers are interpolated as literals.
-    const searchClause = hasSearch ? 'WHERE ORG_NAME ILIKE ?' : '';
+    // ESCAPE '!' + escaped term so a user-typed % or _ matches literally (never a wildcard), keeping the
+    // page and count predicates consistent with the old client-side literal-substring search.
+    const searchClause = hasSearch ? "WHERE ORG_NAME ILIKE ? ESCAPE '!'" : '';
     const baseParams = [slug, timeRangeType, ...cohort.params];
-    const pageParams = hasSearch ? [...baseParams, `%${search}%`] : baseParams;
+    const pageParams = hasSearch ? [...baseParams, `%${escapeSqlLikePattern(search)}%`] : baseParams;
     const countParams = pageParams;
 
     const pageSql = `
@@ -633,7 +636,7 @@ export class OrgLensProjectDetailService {
     const countSql = `
       SELECT COUNT(*) AS N
       FROM ${this.leaderboardTable()}
-      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${cohort.clause}${hasSearch ? ' AND ORG_NAME ILIKE ?' : ''}
+      WHERE PROJECT_SLUG = ? AND TIME_RANGE_TYPE = ? AND ${cohort.clause}${hasSearch ? " AND ORG_NAME ILIKE ? ESCAPE '!'" : ''}
     `;
 
     const [pageResult, countResult] = await Promise.all([
@@ -665,8 +668,12 @@ export class OrgLensProjectDetailService {
     const hasSearch = search.length > 0;
     // Scope to the viewer cohort; ORG_NAME ILIKE is bound. Snowflake rejects binds in LIMIT/OFFSET,
     // so the clamped integers are interpolated as literals (see fetchInfluenceBoardPage).
-    const searchClause = hasSearch ? ' AND ORG_NAME ILIKE ?' : '';
-    const params = hasSearch ? [slug, timeRangeType, boardType, ...cohort.params, `%${search}%`] : [slug, timeRangeType, boardType, ...cohort.params];
+    // ESCAPE '!' + escaped term so a user-typed % or _ matches literally; shared by the page and count
+    // predicates so the paginated total can't be inflated by wildcard interpretation.
+    const searchClause = hasSearch ? " AND ORG_NAME ILIKE ? ESCAPE '!'" : '';
+    const params = hasSearch
+      ? [slug, timeRangeType, boardType, ...cohort.params, `%${escapeSqlLikePattern(search)}%`]
+      : [slug, timeRangeType, boardType, ...cohort.params];
     const pageParams = params;
 
     const pageSql = `

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -71,7 +71,11 @@ export class OrgLensProjectsService {
     }
 
     const excluded = [...new Set(excludeSlugs.map((slug) => slug.trim().toLowerCase()).filter(Boolean))];
-    const like = `%${trimmed}%`;
+    // Match on the raw query, not the trimmed one, so this predicate is identical to the PrimeNG
+    // multi-select's client-side substring filter (which matches the raw filter-box text). Trimming
+    // here while the client filters on the raw text would let the client hide rows this query returned
+    // for a stray leading/trailing space. `trimmed` still gates whether the filter applies at all.
+    const like = `%${query}%`;
     const searchFilter = trimmed.length ? 'AND (PROJECT_NAME ILIKE ? OR PROJECT_SLUG ILIKE ?)' : '';
     const excludeFilter = excluded.length ? `AND PROJECT_SLUG NOT IN (${excluded.map(() => '?').join(', ')})` : '';
     const sql = `

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -37,6 +37,7 @@ import type { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { escapeSqlLikePattern } from '../helpers/validation.helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { SnowflakeService } from './snowflake.service';
@@ -75,8 +76,11 @@ export class OrgLensProjectsService {
     // multi-select's client-side substring filter (which matches the raw filter-box text). Trimming
     // here while the client filters on the raw text would let the client hide rows this query returned
     // for a stray leading/trailing space. `trimmed` still gates whether the filter applies at all.
-    const like = `%${query}%`;
-    const searchFilter = trimmed.length ? 'AND (PROJECT_NAME ILIKE ? OR PROJECT_SLUG ILIKE ?)' : '';
+    // Escape LIKE metacharacters + ESCAPE '!' so a typed % or _ matches literally — this also keeps the
+    // predicate identical to the PrimeNG multi-select's client-side filter, which matches % and _
+    // literally (plain substring), so the client can't hide a row the server returned.
+    const like = `%${escapeSqlLikePattern(query)}%`;
+    const searchFilter = trimmed.length ? "AND (PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!')" : '';
     const excludeFilter = excluded.length ? `AND PROJECT_SLUG NOT IN (${excluded.map(() => '?').join(', ')})` : '';
     const sql = `
       SELECT

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -18,6 +18,9 @@ export const PD_VALID_TABS: ReadonlySet<string> = new Set<OrgLensProjectDetailTa
 export const PD_DEFAULT_METRIC: OrgLensLeaderboardMetric = 'influence';
 export const PD_VALID_METRICS: ReadonlySet<string> = new Set<OrgLensLeaderboardMetric>(['influence', 'activity']);
 
+/** Max leaderboard search length the board endpoint accepts; longer input is truncated before it reaches the cache key or the `ILIKE` term. */
+export const PD_MAX_SEARCH_LENGTH = 100;
+
 export const PD_DEFAULT_TIME_RANGE: OrgLensLeaderboardTimeRange = '2y';
 export const PD_VALID_TIME_RANGES: ReadonlySet<string> = new Set<OrgLensLeaderboardTimeRange>(['1y', '2y', 'all']);
 

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -11,6 +11,8 @@
 
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
+import type { TagSeverity } from './components.interface';
+
 /** Dimension keyed by each side-by-side leaderboard. */
 export type LeaderboardDimension = 'technical' | 'ecosystem';
 
@@ -126,8 +128,8 @@ export interface OrgLensCardRosterPage {
 }
 
 /**
- * One organization row on the project leaderboard. Rank is derived client-side from the active
- * score-type / metric; the influence bands are precomputed in the warehouse and carried on the wire.
+ * One organization row on the project leaderboard. Rank is precomputed server-side over the full
+ * ranked set (see `warehouseRank`); the influence bands are precomputed in the warehouse and carried on the wire.
  */
 export interface OrgLensProjectLeaderboardRow {
   orgName: string;
@@ -144,11 +146,20 @@ export interface OrgLensProjectLeaderboardRow {
     contributionsPct: number;
     collaborationsPct: number;
   };
-  /** Trailing 12-month combined series (fixed window, not range-scoped), oldest → newest. */
-  trendSparkline: number[];
-  /** 1-year delta as a signed fraction (e.g. 0.12 = +12%). */
-  trendDeltaPct: number;
-  /** Precomputed warehouse rank for Activity Count mode boards (org-dashboard parity). */
+  /**
+   * Trailing 12-month combined series (fixed window, not range-scoped), oldest → newest.
+   * Optional: the paginated leaderboard boards do not render a per-row trend column, so board
+   * rows omit it (Decision 4) — only surfaces where a consumer renders the sparkline.
+   */
+  trendSparkline?: number[];
+  /** 1-year delta as a signed fraction (e.g. 0.12 = +12%). Optional for the same reason as trendSparkline. */
+  trendDeltaPct?: number;
+  /**
+   * The org's 1-based position on this board over the FULL ranked set, precomputed server-side
+   * (dimension score rank in Calculated Influence mode; warehouse activity rank in Activity mode).
+   * The board renders this rank directly — under server-side pagination the client no longer derives
+   * rank from row position, so a page never restarts numbering at 1.
+   */
   warehouseRank?: number;
   /** Marks the viewing org's own row — rendered at its rank-ordered position and visually highlighted (not pinned to the top). */
   isViewingOrg: boolean;
@@ -208,15 +219,41 @@ export interface OrgLensTrendBlock {
 }
 
 /**
- * B7/B8 Leaderboard block for one dimension (technical or ecosystem). Carries both the Calculated
- * Influence rows and the dimension's Activity Count rows so switching the metric toggle is a
- * client-side slice that never re-fetches. Range-scoped.
+ * B7/B8 Leaderboard board page for one dimension (technical or ecosystem) and one metric
+ * (Calculated Influence or Activity Count). The board is now paged and searched server-side over
+ * the FULL ranked organization set (no top-N cap), so each request returns just the requested page
+ * of rows plus the total matching count for the paginator. Rows arrive pre-ranked and pre-paged;
+ * the client renders them in order. Switching metric / range / search re-requests page 0.
  */
-export interface OrgLensLeaderboardBlock {
-  /** Calculated Influence rows (ranked client-side by this board's dimension). */
-  influence: OrgLensProjectLeaderboardRow[];
-  /** Activity Count rows for this board's dimension (contributions for technical, collaborations for ecosystem). */
-  activity: OrgLensProjectLeaderboardRow[];
+export interface OrgLensLeaderboardPage {
+  /** The requested page of ranked rows for this board's dimension + metric, ordered by rank. */
+  rows: OrgLensProjectLeaderboardRow[];
+  /** Total organizations on this board matching the current filter (search), across all pages. */
+  total: number;
   /** Project-level non-LF marker (ecosystem board only surfaces it). */
   isNonLfProject: boolean;
+}
+
+/** One rendered leaderboard-board row (already ranked + paged server-side). */
+export interface BoardDisplayRow {
+  rank: number;
+  orgName: string;
+  orgLogoUrl: string;
+  initials: string;
+  /** Activity Count cell text (e.g. "1,234 - 12%"); empty in Calculated Influence mode. */
+  activityLabel: string;
+  /** Band chip label for Calculated Influence mode; empty in Activity mode. */
+  bandLabel: string;
+  bandSeverity: TagSeverity;
+  isViewingOrg: boolean;
+}
+
+/** Per-board render state for a server-paginated leaderboard board. */
+export interface BoardRenderState {
+  status: OrgLensBlockStatus;
+  rows: BoardDisplayRow[];
+  total: number;
+  first: number;
+  rowsPerPage: number;
+  loading: boolean;
 }

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -236,7 +236,12 @@ export interface OrgLensLeaderboardPage {
 
 /** One rendered leaderboard-board row (already ranked + paged server-side). */
 export interface BoardDisplayRow {
-  rank: number;
+  /**
+   * True board position over the FULL ranked set, read straight from the warehouse. `null` when the
+   * warehouse rank is genuinely absent (nullable activity rank) — the board renders an explicit
+   * unknown marker rather than fabricating a position from the current page offset.
+   */
+  rank: number | null;
   orgName: string;
   orgLogoUrl: string;
   initials: string;


### PR DESCRIPTION
## Summary

- **What changed**: Org Lens Project Detail leaderboards move from a client-sliced top-10 payload to server-side pagination + server-side search over the full ranked org set. `packages/shared` swaps `OrgLensLeaderboardBlock` (`influence[]`/`activity[]`) → `OrgLensLeaderboardPage` (`{ rows, total, isNonLfProject }`) and relocates the board display/render-state interfaces into shared; the BFF `fetchBoardPage` re-ranks via uncapped `ROW_NUMBER()` (influence) / precomputed rank (activity) with bound `LIMIT ? OFFSET ?` + `COUNT(*)` + bound `ILIKE ?` search, the controller validates `metric/page/pageSize/search` via `getStringQueryParam` + enum/clamp guards, and the two `<lfx-table>` boards become `[lazy]` with real `totalRecords`/`onLazyLoad`, debounced server search, and page-0 reset on metric/range/search change. Also fixes the "Add project(s)" dialog to a single searchable multi-select (drops the redundant second search box). Adds e2e coverage for pagination beyond page 1, page-size re-page, and cross-page server search.
- **Why**: [LFXV2-2815](https://linuxfoundation.atlassian.net/browse/LFXV2-2815) — surface every organization on a project's leaderboards (not just top-10) so an org can see its true rank in the long tail; the Add-projects dialog fix restores the intended single-search design after live-data-wiring drift.

## Test plan

- [ ] `yarn build`
- [ ] `yarn lint:check`
- [ ] `yarn check-types`
- [ ] `yarn e2e` for `org-project-detail.spec.ts` + `org-projects.spec.ts`
- [ ] The leaderboard e2e's `total > 10` gate requires the uncapped platinum model ([lf-dbt #2672](https://github.com/linuxfoundation/lf-dbt/pull/2672)) live in the target env — verified locally against a prod-pointed schema (full list pages; non-LF `rust` ecosystem-influence board correctly shows the "Non-LF" marker with no list).

## Non-obvious notes

- The wire shape is a breaking change but internal to this feature only (no other consumer).
- Non-LF ecosystem *influence* returns an empty page by design (server guard in `fetchBoardPage`), so the marker shows with no list; the old client-side guard was intentionally not re-added (server is authoritative).
- Row rank is rendered from `warehouseRank`, never re-derived from page position.
- The viewing org's own band-chip row is selected deterministically (`ORDER BY RANK ASC` on its best-ranked leaderboard row) so chips do not flip when one account spans multiple org rows.


[LFXV2-2815]: https://linuxfoundation.atlassian.net/browse/LFXV2-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2815]: https://linuxfoundation.atlassian.net/browse/LFXV2-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ