### PR TITLE
fix(newsletters): remove dead code reintroduced by stale merge base

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -441,25 +441,6 @@ export class NewsletterManageComponent {
     });
   }
 
-  /** The still-missing requirements that block a draft save, for user feedback. */
-  private missingDraftRequirements(): string[] {
-    const missing: string[] = [];
-    if (!this.audienceFilled()) missing.push('an audience');
-    if (!this.subjectFilled()) missing.push('a subject');
-    // bodyPersistable, matching canSaveDraft: an emptied block layout is
-    // saveable, so the warning must not claim content is missing when only
-    // another field (e.g. audience) is.
-    if (!this.bodyPersistable()) missing.push('some newsletter content');
-    if (this.edEmail().length === 0) missing.push('a reply-to email');
-    return missing;
-  }
-
-  /** Join a list into readable prose: "a", "a and b", or "a, b, and c". */
-  private formatMissing(items: string[]): string {
-    if (items.length === 1) return items[0];
-    return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
-  }
-
   private goToList(tab?: 'draft' | 'sent'): void {
     this.router.navigate(['list'], {
       relativeTo: this.route.parent,


### PR DESCRIPTION
Fixes the release build break in run https://github.com/linuxfoundation/lfx-self-serve/actions/runs/30282716458 (`TS2339: Property 'bodyPersistable' does not exist`).

**Root cause:** PR #1198 ("dashboards: trend indicators") squash-merged from a branch cut before the #1133 revert (#1200) landed on `main`. Its squash diff against a stale merge base reintroduced two orphaned helper methods — `missingDraftRequirements` and `formatMissing` — into `newsletter-manage.component.ts`. Neither is called anywhere; `missingDraftRequirements` references `bodyPersistable()`, a signal that only existed as part of the (now-reverted) block-composer feature from #1133.

**Fix:** deletes both dead methods. Verified `yarn check-types` and `yarn workspace lfx-one-ui build:production` both pass locally.

No other files were affected by the same stale-merge-base issue (checked full diff between the revert commit and current `main` tip).

Refs: LFXV2-2386