### PR TITLE
fix(newsletters): remove dead methods referencing removed bodyPersistable

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -441,25 +441,6 @@ export class NewsletterManageComponent {
     });
   }
 
-  /** The still-missing requirements that block a draft save, for user feedback. */
-  private missingDraftRequirements(): string[] {
-    const missing: string[] = [];
-    if (!this.audienceFilled()) missing.push('an audience');
-    if (!this.subjectFilled()) missing.push('a subject');
-    // bodyPersistable, matching canSaveDraft: an emptied block layout is
-    // saveable, so the warning must not claim content is missing when only
-    // another field (e.g. audience) is.
-    if (!this.bodyPersistable()) missing.push('some newsletter content');
-    if (this.edEmail().length === 0) missing.push('a reply-to email');
-    return missing;
-  }
-
-  /** Join a list into readable prose: "a", "a and b", or "a, b, and c". */
-  private formatMissing(items: string[]): string {
-    if (items.length === 1) return items[0];
-    return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
-  }
-
   private goToList(tab?: 'draft' | 'sent'): void {
     this.router.navigate(['list'], {
       relativeTo: this.route.parent,


### PR DESCRIPTION
## Summary

- Removes two private methods (`missingDraftRequirements` and `formatMissing`) from `newsletter-manage.component.ts` that were introduced in #1196 but call `this.bodyPersistable()` — a method removed in a prior revert — causing a TS2339 build failure on `main`.

## Ticket

[LFXV2-2812](https://linuxfoundation.atlassian.net/browse/LFXV2-2812)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2812]: https://linuxfoundation.atlassian.net/browse/LFXV2-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ