### PR TITLE
feat(org-lens): meetings insights from the warehouse [LFXV2-2735]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ design/
 
 # Playwright MCP snapshot/screenshot artifacts
 .playwright-mcp
+.claude/launch.json

--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -34,22 +34,100 @@ async function seedSelectedOrgCookie(page: Page): Promise<void> {
   ]);
 }
 
-// Stub only what the org lens needs to render (personas + account context). The Org
-// Lens meetings BFF endpoints were retired (LFXV2-1902) — there is nothing
-// meetings-specific left to stub.
-async function stubOrgLensContext(page: Page): Promise<void> {
+const MOCK_KPI_SUMMARY = {
+  employeesActive: 63,
+  employeesActiveDeltaLabel: '+8% vs. prior period',
+  employeesActiveDeltaDirection: 'up',
+  meetingsAttended: 512,
+  meetingsAttendedDeltaLabel: '+12% vs. prior period',
+  meetingsAttendedDeltaDirection: 'up',
+  projectsSupported: 47,
+  projectsSupportedDeltaLabel: 'New',
+  projectsSupportedDeltaDirection: 'up',
+  foundationsSupported: 30,
+  foundationsSupportedDeltaLabel: 'No change vs. prior period',
+  foundationsSupportedDeltaDirection: 'flat',
+};
+
+const MOCK_SPEND_BREAKDOWN = {
+  byFoundation: [
+    { label: 'CNCF', pct: 62, count: 1240 },
+    { label: '12 others', pct: 38, count: 760, others: [{ label: 'OpenSSF', pct: 20 }] },
+  ],
+  byProject: [
+    { label: 'Kubernetes', pct: 55, count: 1100 },
+    { label: 'PyTorch', pct: 45, count: 900 },
+  ],
+  byMeetingType: [{ label: 'Technical', pct: 100, count: 2000 }],
+  byRole: [{ label: 'Participant', pct: 100, count: 2000 }],
+};
+
+function mockInfluenceRow(project: string, projectSlug: string): unknown {
+  return {
+    project,
+    projectSlug,
+    ecosystemInfluence: 88,
+    band: 'leading',
+    rankLabel: '#3 of 210',
+    fromAttendancePct: 15,
+    deltaLabel: '+6% YoY',
+    deltaDirection: 'up',
+    breakdown: [
+      { label: 'Collaboration Activity', pct: 30 },
+      { label: 'Meeting Attendance', pct: 15 },
+    ],
+  };
+}
+
+const MOCK_INFLUENCE_ROWS = [mockInfluenceRow('Kubernetes', 'kubernetes'), mockInfluenceRow('PyTorch', 'pytorch')];
+
+// Stub what the org lens needs to render: personas + account context, the three meetings-insights
+// endpoints (LFXV2-2735), plus role-grants/nav-items so `OrgMeetingsComponent.loaded()` /
+// `hasNoOrgAccess()` (which gate on both services) settle deterministically instead of hitting
+// environment-specific BFF responses.
+async function stubOrgLensContext(page: Page, options: { hasAccess?: boolean; spend?: unknown; influence?: unknown } = {}): Promise<void> {
+  const hasAccess = options.hasAccess ?? true;
+
+  await page.route('**/api/orgs/*/lens/meetings/kpi*', (route) => fulfillJson(route, MOCK_KPI_SUMMARY));
+  await page.route('**/api/orgs/*/lens/meetings/spend*', (route) => fulfillJson(route, options.spend ?? MOCK_SPEND_BREAKDOWN));
+  await page.route('**/api/orgs/*/lens/meetings/influence*', (route) => fulfillJson(route, options.influence ?? MOCK_INFLUENCE_ROWS));
+
   await page.route('**/api/user/personas*', (route) =>
     fulfillJson(route, {
       personas: ['contributor'],
       personaProjects: {},
       projects: [],
-      organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }],
+      organizations: hasAccess
+        ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }]
+        : [],
       isRootWriter: false,
     })
   );
 
   await page.route('**/api/analytics/org-lens-account-context*', (route) =>
-    fulfillJson(route, [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }])
+    fulfillJson(route, hasAccess ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }] : [])
+  );
+
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    fulfillJson(route, {
+      writers: hasAccess ? [MOCK_ACCOUNT_ID] : [],
+      auditors: [],
+      cascadingWriters: [],
+      cascadingAuditors: [],
+      username: 'e2e-org-meetings',
+      loaded_at: new Date().toISOString(),
+    })
+  );
+
+  await page.route('**/api/nav/org-items*', (route) =>
+    fulfillJson(route, {
+      items: hasAccess
+        ? [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: 'Red Hat, Inc.', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }]
+        : [],
+      next_page_token: null,
+      upstream_failed: false,
+      total: hasAccess ? 1 : 0,
+    })
   );
 }
 
@@ -66,44 +144,166 @@ async function gotoOrgMeetingsPage(page: Page): Promise<void> {
   }
 }
 
-test.describe('Org Meetings (retired — coming soon)', () => {
-  test('renders the coming-soon placeholder and no live meetings surface', async ({ page }) => {
+test.describe('Org Meetings insights (6a redesign)', () => {
+  test('renders the page shell with default 365-day KPI values', async ({ page }) => {
     await stubOrgLensContext(page);
     await gotoOrgMeetingsPage(page);
 
-    // Header stays for sibling-tab consistency.
     await expect(page.getByTestId('org-meetings-page')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Meetings' })).toBeVisible();
+    await expect(page.getByTestId('org-meetings-time-range')).toBeVisible();
 
-    // The coming-soon placeholder is shown.
-    const placeholder = page.getByTestId('org-meetings-coming-soon');
-    await expect(placeholder).toBeVisible();
-    await expect(placeholder.getByText('Coming soon')).toBeVisible();
-
-    // The retired live surface (KPI strip, filters, upcoming list, invitee PII panel) is gone.
-    await expect(page.getByTestId('org-meetings-kpi-strip')).toHaveCount(0);
-    await expect(page.getByTestId('org-meetings-filter-bar')).toHaveCount(0);
-    await expect(page.getByTestId('org-upcoming-meetings-list')).toHaveCount(0);
+    const kpiCards = page.getByTestId('org-meetings-kpi-cards');
+    await expect(kpiCards).toBeVisible();
+    await expect(kpiCards).toContainText('63');
+    await expect(kpiCards).toContainText('512');
+    await expect(kpiCards).toContainText('47');
+    await expect(kpiCards).toContainText('30');
   });
 
-  test('does not call the retired org-lens meetings BFF endpoints', async ({ page }) => {
+  test('renders the "where your people spend time" ranked percentage bars', async ({ page }) => {
     await stubOrgLensContext(page);
-
-    let meetingsApiHit = false;
-    await page.route('**/api/orgs/**/lens/meetings**', (route) => {
-      meetingsApiHit = true;
-      return route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
-    });
-
     await gotoOrgMeetingsPage(page);
 
-    await expect(page.getByTestId('org-meetings-coming-soon')).toBeVisible();
+    const spend = page.getByTestId('org-meetings-spend-breakdown');
+    await expect(spend).toBeVisible();
+    await expect(page.getByTestId('org-spend-bar-by-foundation')).toBeVisible();
+    await expect(page.getByTestId('org-spend-bar-by-project')).toBeVisible();
+    await expect(page.getByTestId('org-spend-bar-by-meeting-type')).toBeVisible();
+    await expect(page.getByTestId('org-spend-bar-by-role')).toBeVisible();
+    await expect(spend).toContainText('CNCF');
+  });
 
-    // Keep observing over a bounded window after the placeholder renders: a deferred/async
-    // call to the retired endpoint would resolve waitForRequest and fail this expectation,
-    // instead of slipping past an immediate check. No request within the window => the wait
-    // times out and rejects, which is the pass condition.
-    await expect(page.waitForRequest('**/api/orgs/**/lens/meetings**', { timeout: 1000 })).rejects.toThrow();
-    expect(meetingsApiHit).toBe(false);
+  test('renders the influence table with all rows collapsed by default', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgMeetingsPage(page);
+
+    const influence = page.getByTestId('org-meetings-influence');
+    await expect(influence).toBeVisible();
+
+    // All rows start collapsed, so no detail rows are rendered.
+    await expect(page.getByTestId('org-meetings-influence-row-kubernetes-detail')).toHaveCount(0);
+    await expect(page.getByTestId('org-meetings-influence-row-pytorch-detail')).toHaveCount(0);
+
+    // Expanding Kubernetes via its caret reveals the detail row.
+    await page.getByTestId('org-meetings-influence-row-kubernetes-caret').click();
+    const kubernetesDetail = page.getByTestId('org-meetings-influence-row-kubernetes-detail');
+    await expect(kubernetesDetail).toBeVisible();
+    await expect(kubernetesDetail).toContainText('Meeting Attendance');
+
+    // Expanding PyTorch via its caret reveals its detail row too.
+    await page.getByTestId('org-meetings-influence-row-pytorch-caret').click();
+    await expect(page.getByTestId('org-meetings-influence-row-pytorch-detail')).toBeVisible();
+
+    // Collapsing Kubernetes via its caret removes the detail row.
+    await page.getByTestId('org-meetings-influence-row-kubernetes-caret').click();
+    await expect(page.getByTestId('org-meetings-influence-row-kubernetes-detail')).toHaveCount(0);
+  });
+
+  test('switching time range refetches with the selected window', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgMeetingsPage(page);
+
+    // Assert on the outgoing request, not just the rendered label — both windows return the same
+    // stub, so a refetch that never fires (or sends the wrong range) is otherwise invisible.
+    const kpiRequest = page.waitForRequest((req) => req.url().includes('/lens/meetings/kpi') && req.url().includes('range=previousYear'));
+    const spendRequest = page.waitForRequest((req) => req.url().includes('/lens/meetings/spend') && req.url().includes('range=previousYear'));
+
+    await page.getByTestId('org-meetings-time-range').click();
+    await page.getByTestId('org-meetings-time-range-option-previousYear').click();
+
+    await kpiRequest;
+    await spendRequest;
+    await expect(page.getByTestId('org-meetings-time-range-label')).toHaveText('Previous year');
+    await expect(page.getByTestId('org-meetings-kpi-cards')).toBeVisible();
+  });
+
+  test('offers the unserved time ranges as unavailable and refuses to select them', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgMeetingsPage(page);
+
+    await page.getByTestId('org-meetings-time-range').click();
+
+    // "All time" and "Custom" have no warehouse window behind them. They stay focusable so keyboard
+    // users can discover that the option exists but is unavailable; select() refuses the activation.
+    // Wait for the panel to actually render before reading attributes; on a cold server the options
+    // can be in the DOM a tick before their bindings resolve, which made this assertion flaky.
+    const allTime = page.getByTestId('org-meetings-time-range-option-allTime');
+    await expect(allTime).toBeVisible();
+    await expect(allTime).toHaveAttribute('aria-disabled', 'true');
+    await expect(page.getByTestId('org-meetings-time-range-option-custom')).toHaveAttribute('aria-disabled', 'true');
+
+    // `force` only bypasses Playwright's actionability check; because the button is not natively
+    // disabled the DOM event really is dispatched, so this exercises select()'s early return rather
+    // than the browser silently swallowing the click.
+    await allTime.click({ force: true });
+    await expect(page.getByTestId('org-meetings-time-range-label')).toHaveText('Past 365 days');
+
+    // A served window must still be selectable — the guard rejects only the unavailable options.
+    await page.getByTestId('org-meetings-time-range-option-past90d').click();
+    await expect(page.getByTestId('org-meetings-time-range-label')).toHaveText('Past 90 days');
+  });
+
+  test('shows a per-section error state when the endpoints fail', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/meetings/**', (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'ROLE_GRANTS_UNAVAILABLE' }) })
+    );
+    await gotoOrgMeetingsPage(page);
+
+    await expect(page.getByTestId('org-meetings-kpi-cards-error')).toBeVisible();
+    await expect(page.getByTestId('org-meetings-spend-breakdown-error')).toBeVisible();
+    await expect(page.getByTestId('org-meetings-influence-error')).toBeVisible();
+  });
+
+  test('explains an empty influence table rather than leaving it blank', async ({ page }) => {
+    await stubOrgLensContext(page, { influence: [] });
+    await gotoOrgMeetingsPage(page);
+
+    const empty = page.getByTestId('org-meetings-influence-empty');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText('published Ecosystem Influence Score');
+  });
+
+  test('hides the meeting-type and role cards when the org is too small to aggregate', async ({ page }) => {
+    // The small-org safeguard returns empty arrays rather than omitting the keys, so an empty card
+    // would read as "attends no typed meetings" instead of "withheld".
+    await stubOrgLensContext(page, { spend: { ...MOCK_SPEND_BREAKDOWN, byMeetingType: [], byRole: [] } });
+    await gotoOrgMeetingsPage(page);
+
+    await expect(page.getByTestId('org-spend-bar-by-foundation')).toBeVisible();
+    await expect(page.getByTestId('org-spend-bar-by-meeting-type')).toHaveCount(0);
+    await expect(page.getByTestId('org-spend-bar-by-role')).toHaveCount(0);
+  });
+
+  test('renders the no-company empty state when no account is selected', async ({ page }) => {
+    // hasAccess: true seeds a direct writer grant (so hasNoOrgAccess() stays false, reaching the
+    // no-company branch instead of the no-access one), but nav-items/personas are overridden below
+    // to return zero orgs so org-navigation never auto-selects one via handlePendingSelection().
+    await stubOrgLensContext(page, { hasAccess: true });
+    await page.route('**/api/user/personas*', (route) =>
+      fulfillJson(route, { personas: ['contributor'], personaProjects: {}, projects: [], organizations: [], isRootWriter: false })
+    );
+    await page.route('**/api/nav/org-items*', (route) => fulfillJson(route, { items: [], next_page_token: null, upstream_failed: false, total: 0 }));
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto(ORG_MEETINGS_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    if (!page.url().includes('/org/meetings')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/meetings redirected away');
+    }
+
+    await expect(page.getByTestId('org-meetings-no-company-empty-state')).toBeVisible();
+    await expect(page.getByTestId('org-meetings-kpi-cards')).toHaveCount(0);
+  });
+
+  test('renders the no-access state when the caller has no org selector access', async ({ page }) => {
+    await stubOrgLensContext(page, { hasAccess: false });
+    await gotoOrgMeetingsPage(page);
+
+    await expect(page.getByTestId('org-meetings-no-access-state')).toBeVisible();
+    await expect(page.getByTestId('org-meetings-kpi-cards')).toHaveCount(0);
+    await expect(page.getByTestId('org-meetings-no-company-empty-state')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -170,7 +170,12 @@ export const routes: Routes = [
           },
           {
             path: 'meetings',
-            data: { lens: 'org', title: 'Meetings', description: 'Meetings your organization is participating in — coming soon.', icon: 'fa-light fa-video' },
+            data: {
+              lens: 'org',
+              title: 'Meetings',
+              description: "How your organization's employees engage across Linux Foundation projects.",
+              icon: 'fa-light fa-video',
+            },
             loadComponent: () => import('./modules/dashboards/org/org-meetings/org-meetings.component').then((m) => m.OrgMeetingsComponent),
           },
           {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.html
@@ -1,0 +1,184 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-4" data-testid="org-meetings-influence">
+  <div class="flex items-center gap-3">
+    <h2 class="flex shrink-0 items-center gap-2 text-base font-medium text-gray-900">
+      <i class="fa-light fa-arrow-trend-up text-lg" aria-hidden="true"></i>
+      <span>How attendance impacts project influence</span>
+      <button
+        type="button"
+        class="cursor-help text-xs text-gray-500 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+        [pTooltip]="infoTooltip"
+        tooltipPosition="top"
+        tooltipEvent="both"
+        aria-label="How attendance relates to the Ecosystem Influence Score"
+        data-testid="org-meetings-influence-info">
+        <i class="fa-light fa-circle-info" aria-hidden="true"></i>
+      </button>
+    </h2>
+    <div class="flex-1 self-center border-t border-gray-200"></div>
+  </div>
+  @if (loading()) {
+    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-meetings-influence-loading">
+      @for (i of [1, 2, 3, 4]; track i) {
+        <p-skeleton width="100%" height="1.5rem" />
+      }
+    </div>
+  } @else if (forbidden()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-influence-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-influence-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>Project influence couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!rows().length) {
+    <!-- Roughly a third of orgs with meeting activity land here, so the copy explains the scope of
+         the section rather than implying the organization has no project influence at all. -->
+    <div class="flex flex-col gap-1 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm" data-testid="org-meetings-influence-empty">
+      <span class="text-gray-900">No ecosystem influence data for your projects yet.</span>
+      <span class="text-gray-600">
+        This section covers only projects with a published Ecosystem Influence Score. Your organization's meeting activity still counts towards the totals
+        above.
+      </span>
+    </div>
+  } @else {
+    <div class="overflow-x-auto rounded-lg border border-gray-200 bg-white" data-testid="org-meetings-influence-table">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-50">
+          <tr class="border-b border-gray-200 text-left text-xs tracking-wide text-gray-500 uppercase">
+            <th class="px-4 py-2 font-medium">Project</th>
+            <th class="px-4 py-2 font-medium">Rank among companies</th>
+            <th class="px-4 py-2 font-medium">Ecosystem Influence</th>
+            <th class="px-4 py-2 font-medium">Attendance's contribution</th>
+            <!-- "Year over year", not "this period": this section ignores the time-range dropdown. -->
+            <th class="px-4 py-2 font-medium">Δ year over year</th>
+            <th class="px-4 py-2 font-medium"><span class="sr-only">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows(); track row.projectSlug) {
+            <!-- Row click is mouse-only convenience; the caret button below is the sole keyboard-operable
+               control (already has aria-expanded/aria-label). Don't add role/tabindex/keydown here —
+               that nests one interactive element inside another (the caret button). -->
+            <tr
+              class="cursor-pointer border-b border-gray-200 transition-colors hover:bg-gray-50"
+              [attr.data-testid]="'org-meetings-influence-row-' + row.projectSlug"
+              (click)="toggleExpansion(row.projectSlug)">
+              <td class="px-4 py-3 align-middle">
+                <div class="flex items-center gap-3">
+                  <button
+                    type="button"
+                    class="flex h-7 w-7 items-center justify-center rounded p-0 text-gray-500 hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                    [attr.aria-expanded]="!!expansionState()[row.projectSlug]"
+                    [attr.aria-label]="(expansionState()[row.projectSlug] ? 'Collapse ' : 'Expand ') + row.project"
+                    [attr.data-testid]="'org-meetings-influence-row-' + row.projectSlug + '-caret'"
+                    (mousedown)="$event.preventDefault()"
+                    (click)="toggleExpansion(row.projectSlug); $event.stopPropagation()">
+                    <i
+                      class="fa-light"
+                      [class.fa-chevron-down]="!expansionState()[row.projectSlug]"
+                      [class.fa-chevron-up]="!!expansionState()[row.projectSlug]"
+                      aria-hidden="true"></i>
+                  </button>
+                  <span class="font-medium text-gray-900">{{ row.project }}</span>
+                </div>
+              </td>
+              <td class="px-4 py-3 align-middle">
+                <span class="text-xs font-medium text-gray-900">{{ row.rankLabel }}</span>
+              </td>
+              <td class="px-4 py-3 align-middle">
+                <span [class]="row.bandChipClass" [attr.data-testid]="'org-meetings-influence-row-' + row.projectSlug + '-band'">
+                  <svg width="16" height="15" viewBox="0 0 16 15" aria-hidden="true" class="shrink-0">
+                    @for (bar of row.bandBars; track bar.x) {
+                      <rect [attr.x]="bar.x" [attr.y]="bar.y" [attr.width]="bandBarWidth" [attr.height]="bar.h" rx="0.5" [class]="bar.fillClass" />
+                    }
+                  </svg>
+                  {{ row.bandLabel }}
+                </span>
+              </td>
+              <td class="px-4 py-3 align-middle">
+                <div class="flex items-center gap-2.5">
+                  <div
+                    class="h-1.5 w-24 overflow-hidden rounded-full bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                    tabindex="0"
+                    role="img"
+                    [attr.aria-label]="'Bar is scaled for legibility; ' + row.fromAttendancePct + '% is the actual contribution.'"
+                    [pTooltip]="'Bar is scaled for legibility; ' + row.fromAttendancePct + '% is the actual contribution.'"
+                    tooltipPosition="top"
+                    tooltipEvent="both">
+                    <div class="h-1.5 rounded-full bg-blue-600" [style.width.%]="row.attendanceBarWidth"></div>
+                  </div>
+                  <span class="text-xs font-medium whitespace-nowrap text-gray-900">{{ row.fromAttendancePct }}% of score</span>
+                </div>
+              </td>
+              <td class="px-4 py-3 align-middle">
+                <span class="inline-flex items-center gap-1 text-xs font-medium" [class]="deltaTextClass[row.deltaDirection]">
+                  <i [class]="deltaIcon[row.deltaDirection]" aria-hidden="true"></i>
+                  {{ row.deltaLabel }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-right align-middle">
+                <!-- The Project-lens meetings page is addressed by slug via a query param, not by uid
+                   on a path segment. It renders for any authenticated user, so the link needs no
+                   per-row access hint. -->
+                <a
+                  class="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:underline"
+                  routerLink="/project/meetings"
+                  [queryParams]="{ project: row.projectSlug }"
+                  [attr.aria-label]="'View ' + row.project + ' in Projects'"
+                  (click)="$event.stopPropagation()">
+                  Projects
+                  <i class="fa-light fa-arrow-up-right" aria-hidden="true"></i>
+                </a>
+              </td>
+            </tr>
+            @if (expansionState()[row.projectSlug]) {
+              <tr class="bg-gray-50" [attr.data-testid]="'org-meetings-influence-row-' + row.projectSlug + '-detail'">
+                <td colspan="6" class="px-12 py-4">
+                  <div class="flex flex-col gap-3">
+                    <div class="flex flex-col gap-2.5">
+                      @for (segment of row.breakdown; track segment.label) {
+                        <div class="grid grid-cols-[1fr_2.5rem] items-center gap-2.5">
+                          <div class="flex flex-col gap-1">
+                            <span class="text-xs" [class]="segment.isAttendance ? 'font-medium text-gray-900' : 'text-gray-500'">{{ segment.label }}</span>
+                            <div class="h-1.5 w-full overflow-hidden rounded-full" [class]="segment.isAttendance ? 'bg-blue-100' : 'bg-gray-100'">
+                              <div
+                                class="h-1.5 rounded-full"
+                                [class]="segment.isAttendance ? 'bg-blue-600' : 'bg-gray-300'"
+                                [style.width.%]="segment.pct"></div>
+                            </div>
+                          </div>
+                          <span class="text-right text-xs font-medium" [class]="segment.isAttendance ? 'text-gray-900' : 'text-gray-500'"
+                            >{{ segment.pct }}%</span
+                          >
+                        </div>
+                      }
+                    </div>
+                    <p class="text-sm text-gray-600">
+                      {{ row.fromAttendancePct }}% of {{ row.project }}'s ecosystem influence score of {{ row.ecosystemInfluence }} comes from {{ orgName() }}'s
+                      meeting attendance.
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            }
+          }
+        </tbody>
+      </table>
+    </div>
+    <!-- This list can be shorter than the spend card's "By project" bar for the same organization,
+         because a project only appears here once it has a published influence score. Saying so
+         prevents the difference being read as missing data. -->
+    <p class="text-xs text-gray-500" data-testid="org-meetings-influence-coverage-note">
+      Only projects with a published Ecosystem Influence Score appear here, so this list may be shorter than the projects your people attend meetings for.
+    </p>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
+import {
+  BAND_CHIP_CLASS,
+  BAND_SIGNAL_FILL,
+  BAND_SIGNAL_FILL_LIGHT,
+  BAND_SIGNAL_RANK,
+  DELTA_DIRECTION_ICON,
+  DELTA_DIRECTION_TEXT_CLASS,
+  ORG_INFLUENCE_MEASURE_LABEL_MEETING_ATTENDANCE,
+  ORG_INFLUENCE_SIGNAL_BAR_GAP,
+  ORG_INFLUENCE_SIGNAL_BAR_HEIGHTS,
+  ORG_INFLUENCE_SIGNAL_BAR_WIDTH,
+  ORG_MEETINGS_ATTENDANCE_BAR_SCALE,
+  PD_BAND_TAG,
+} from '@lfx-one/shared/constants';
+import type { OrgInfluenceBandBar, OrgInfluenceDisplayRow, OrgInfluenceRow } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensMeetingsService } from '@services/org-lens-meetings.service';
+import { catchError, filter, of, switchMap, tap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-org-meetings-influence',
+  imports: [RouterLink, TooltipModule, SkeletonModule],
+  templateUrl: './org-meetings-influence.component.html',
+})
+export class OrgMeetingsInfluenceComponent {
+  // Private injections
+  private readonly accountContext = inject(AccountContextService);
+  private readonly meetingsService = inject(OrgLensMeetingsService);
+
+  // No `timeRange` input: influence is range-independent, so the surface deliberately takes no
+  // window and the section does not refetch when the dropdown changes.
+
+  // Configuration
+  protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
+  protected readonly deltaIcon = DELTA_DIRECTION_ICON;
+  protected readonly bandBarWidth = ORG_INFLUENCE_SIGNAL_BAR_WIDTH;
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  // A 403 means the caller holds no Org Lens grant on this org. The org selector admits
+  // persona-seeded organizations that carry no such grant, so this is reachable by simply
+  // picking one -- and "couldn't be loaded" would misdescribe it as a transient failure.
+  protected readonly forbidden = signal(false);
+
+  // Explanatory copy surfaced via the info-icon tooltip next to the section heading.
+  protected readonly infoTooltip =
+    "Meeting attendance is one of the signals behind each project's Ecosystem Influence Score. See the full breakdown on the Projects page.";
+
+  // Expansion state is owned here as a slug -> boolean map, mirroring the /org/overview
+  // foundations table pattern. All rows are collapsed by default.
+  protected readonly expansionState = signal<Record<string, boolean>>({});
+
+  // Selected organization's display name, used in the attendance-contribution explanatory sentence.
+  protected readonly orgName = computed(() => this.accountContext.selectedAccount()?.accountName || 'Your organization');
+
+  // Rows enriched with the qualitative band chip (label + signal-bar icon) and a breakdown of
+  // ecosystem-influence measures sorted descending, with meeting attendance highlighted so the
+  // section's subject stays visually dominant even when it isn't the largest measure.
+  private readonly fetchedRows: Signal<OrgInfluenceRow[]> = this.initFetchedRows();
+  protected readonly rows: Signal<OrgInfluenceDisplayRow[]> = this.initRows();
+
+  protected toggleExpansion(projectSlug: string): void {
+    this.expansionState.update((state) => {
+      const next = { ...state };
+      if (next[projectSlug]) {
+        delete next[projectSlug];
+      } else {
+        next[projectSlug] = true;
+      }
+      return next;
+    });
+  }
+
+  private initRows(): Signal<OrgInfluenceDisplayRow[]> {
+    return computed(() =>
+      this.fetchedRows().map((row) => ({
+        ...row,
+        bandChipClass: BAND_CHIP_CLASS[row.band],
+        bandLabel: PD_BAND_TAG[row.band].label,
+        bandBars: this.buildSignalBars(BAND_SIGNAL_RANK[row.band], BAND_SIGNAL_FILL[row.band], BAND_SIGNAL_FILL_LIGHT[row.band]),
+        // Emphasis-scaled width for the summary row's attendance bar — a distinct visual from the
+        // expanded detail row's unscaled breakdown bars, which compare nine measures against each
+        // other. Clamped so a high fromAttendancePct can't overflow past 100%. Precomputed here
+        // rather than called from the template, which would re-run it on every change detection.
+        attendanceBarWidth: Math.min(100, row.fromAttendancePct * ORG_MEETINGS_ATTENDANCE_BAR_SCALE),
+        breakdown: [...row.breakdown]
+          .sort((a, b) => b.pct - a.pct)
+          .map((segment) => ({ ...segment, isAttendance: segment.label === ORG_INFLUENCE_MEASURE_LABEL_MEETING_ATTENDANCE })),
+      }))
+    );
+  }
+
+  private initFetchedRows(): Signal<OrgInfluenceRow[]> {
+    const orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.accountId ?? ''));
+
+    return toSignal(
+      orgUid$.pipe(
+        filter((orgUid) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+          // Expansion is keyed by project slug, and two orgs can engage the same project — without
+          // this reset, a row expanded on the previous org reopens on the new one.
+          this.expansionState.set({});
+        }),
+        switchMap((orgUid) =>
+          this.meetingsService.getInfluenceRows(orgUid).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load meeting influence rows', error);
+              this.loading.set(false);
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of([] as OrgInfluenceRow[]);
+            })
+          )
+        )
+      ),
+      { initialValue: [] as OrgInfluenceRow[] }
+    );
+  }
+
+  private buildSignalBars(rank: number, fill: string, fillLight: string): OrgInfluenceBandBar[] {
+    return ORG_INFLUENCE_SIGNAL_BAR_HEIGHTS.map((h, index) => ({
+      x: index * (ORG_INFLUENCE_SIGNAL_BAR_WIDTH + ORG_INFLUENCE_SIGNAL_BAR_GAP),
+      y: 15 - h,
+      h,
+      fillClass: index < rank ? fill : fillLight,
+    }));
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-kpi-cards/org-meetings-kpi-cards.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-kpi-cards/org-meetings-kpi-cards.component.html
@@ -1,0 +1,32 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div data-testid="org-meetings-kpi-cards">
+  @if (loading()) {
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4" data-testid="org-meetings-kpi-cards-loading">
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="p-4 bg-white border border-gray-200 rounded-lg flex flex-col gap-2">
+          <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+          <p-skeleton width="3rem" height="1.75rem" />
+          <p-skeleton width="80%" height="0.75rem" />
+        </div>
+      }
+    </div>
+  } @else if (forbidden()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-kpi-cards-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-kpi-cards-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>Meeting totals couldn't be loaded. Please try again.</span>
+    </div>
+  } @else {
+    <lfx-stat-card-grid [cards]="cards()" [columns]="4" />
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-kpi-cards/org-meetings-kpi-cards.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-kpi-cards/org-meetings-kpi-cards.component.ts
@@ -1,0 +1,125 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+import { ORG_MEETINGS_KPI_ICON_CLASS } from '@lfx-one/shared/constants';
+import type { OrgMeetingsKpiSummary, OrgMeetingsSupportedTimeRange, StatCardItem } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensMeetingsService } from '@services/org-lens-meetings.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+
+/** Zeroed strip shown before the first response and after a failed one, so the layout never jumps. */
+const EMPTY_SUMMARY: OrgMeetingsKpiSummary = {
+  employeesActive: 0,
+  employeesActiveDeltaLabel: '',
+  employeesActiveDeltaDirection: 'flat',
+  meetingsAttended: 0,
+  meetingsAttendedDeltaLabel: '',
+  meetingsAttendedDeltaDirection: 'flat',
+  projectsSupported: 0,
+  projectsSupportedDeltaLabel: '',
+  projectsSupportedDeltaDirection: 'flat',
+  foundationsSupported: 0,
+  foundationsSupportedDeltaLabel: '',
+  foundationsSupportedDeltaDirection: 'flat',
+};
+
+@Component({
+  selector: 'lfx-org-meetings-kpi-cards',
+  imports: [StatCardGridComponent, SkeletonModule],
+  templateUrl: './org-meetings-kpi-cards.component.html',
+})
+export class OrgMeetingsKpiCardsComponent {
+  // Private injections
+  private readonly accountContext = inject(AccountContextService);
+  private readonly meetingsService = inject(OrgLensMeetingsService);
+
+  // Public fields from inputs
+  public readonly timeRange = input.required<OrgMeetingsSupportedTimeRange>();
+
+  // Configuration
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  // A 403 means the caller holds no Org Lens grant on this org. The org selector admits
+  // persona-seeded organizations that carry no such grant, so this is reachable by simply
+  // picking one -- and "couldn't be loaded" would misdescribe it as a transient failure.
+  protected readonly forbidden = signal(false);
+
+  // Complex computed
+  private readonly summary: Signal<OrgMeetingsKpiSummary> = this.initSummary();
+  protected readonly cards: Signal<StatCardItem[]> = this.initCards();
+
+  // Private initializers
+  private initSummary(): Signal<OrgMeetingsKpiSummary> {
+    // A string key, not an object: `selectedAccount` is rewritten in place by Snowflake enrichment
+    // and the canonical-record patch, and a fresh object with identical contents would dirty the
+    // computed and retrigger the fetch, flashing the loading state for no new data.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.timeRange()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgMeetingsSupportedTimeRange]),
+        // A cookie-restored account stub can carry a uid with the accountId still pending; fetching
+        // then would query the wrong org, so wait for the analytics id to arrive.
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap(([orgUid, range]) =>
+          this.meetingsService.getKpiSummary(orgUid, range).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load meeting KPI summary', error);
+              this.loading.set(false);
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_SUMMARY);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_SUMMARY }
+    );
+  }
+
+  private initCards(): Signal<StatCardItem[]> {
+    return computed(() => {
+      const summary = this.summary();
+      return [
+        {
+          label: 'Employees Active',
+          value: summary.employeesActive,
+          icon: 'fa-light fa-users',
+          iconContainerClass: ORG_MEETINGS_KPI_ICON_CLASS.employeesActive,
+          delta: { label: summary.employeesActiveDeltaLabel, direction: summary.employeesActiveDeltaDirection },
+        },
+        {
+          label: 'Meetings Attended',
+          value: summary.meetingsAttended,
+          icon: 'fa-light fa-video',
+          iconContainerClass: ORG_MEETINGS_KPI_ICON_CLASS.meetingsAttended,
+          delta: { label: summary.meetingsAttendedDeltaLabel, direction: summary.meetingsAttendedDeltaDirection },
+        },
+        {
+          label: 'Projects Supported',
+          value: summary.projectsSupported,
+          icon: 'fa-light fa-diagram-project',
+          iconContainerClass: ORG_MEETINGS_KPI_ICON_CLASS.projectsSupported,
+          delta: { label: summary.projectsSupportedDeltaLabel, direction: summary.projectsSupportedDeltaDirection },
+        },
+        {
+          label: 'Foundations Supported',
+          value: summary.foundationsSupported,
+          icon: 'fa-light fa-building-columns',
+          iconContainerClass: ORG_MEETINGS_KPI_ICON_CLASS.foundationsSupported,
+          delta: { label: summary.foundationsSupportedDeltaLabel, direction: summary.foundationsSupportedDeltaDirection },
+        },
+      ];
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-meetings-spend-breakdown.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-meetings-spend-breakdown.component.html
@@ -1,0 +1,57 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-4" data-testid="org-meetings-spend-breakdown">
+  <div class="flex items-center gap-3">
+    <h2 class="flex shrink-0 items-center gap-2 text-base font-medium text-gray-900">
+      <i class="fa-light fa-chart-pie text-lg" aria-hidden="true"></i>
+      <span>Where your people spend time</span>
+    </h2>
+    <div class="flex-1 self-center border-t border-gray-200"></div>
+  </div>
+  @if (loading()) {
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2" data-testid="org-meetings-spend-breakdown-loading">
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4">
+          <p-skeleton width="8rem" height="1rem" />
+          @for (row of [1, 2, 3, 4]; track row) {
+            <p-skeleton width="100%" height="0.75rem" />
+          }
+        </div>
+      }
+    </div>
+  } @else if (forbidden()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-spend-breakdown-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-meetings-spend-breakdown-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>Meeting distributions couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasAnyBreakdown()) {
+    <div class="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600" data-testid="org-meetings-spend-breakdown-empty">
+      No meeting attendance recorded for this period.
+    </div>
+  } @else {
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+      @if (showFoundation()) {
+        <lfx-org-spend-bar title="By foundation" icon="fa-light fa-people-group" [segments]="spend().byFoundation" />
+      }
+      @if (showProject()) {
+        <lfx-org-spend-bar title="By project" icon="fa-light fa-cube" [segments]="spend().byProject" />
+      }
+      @if (showMeetingType()) {
+        <lfx-org-spend-bar title="By meeting type" icon="fa-light fa-calendar" [segments]="spend().byMeetingType" />
+      }
+      @if (showRole()) {
+        <lfx-org-spend-bar title="By role" icon="fa-light fa-user-tag" [segments]="spend().byRole" />
+      }
+    </div>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-meetings-spend-breakdown.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-meetings-spend-breakdown.component.ts
@@ -1,0 +1,86 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import type { OrgMeetingsSpendBreakdown, OrgMeetingsSupportedTimeRange } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensMeetingsService } from '@services/org-lens-meetings.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+
+import { OrgSpendBarComponent } from './org-spend-bar.component';
+
+const EMPTY_SPEND: OrgMeetingsSpendBreakdown = { byFoundation: [], byProject: [], byMeetingType: [], byRole: [] };
+
+@Component({
+  selector: 'lfx-org-meetings-spend-breakdown',
+  imports: [OrgSpendBarComponent, SkeletonModule],
+  templateUrl: './org-meetings-spend-breakdown.component.html',
+})
+export class OrgMeetingsSpendBreakdownComponent {
+  // Private injections
+  private readonly accountContext = inject(AccountContextService);
+  private readonly meetingsService = inject(OrgLensMeetingsService);
+
+  // Public fields from inputs
+  public readonly timeRange = input.required<OrgMeetingsSupportedTimeRange>();
+
+  // Configuration
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  // A 403 means the caller holds no Org Lens grant on this org. The org selector admits
+  // persona-seeded organizations that carry no such grant, so this is reachable by simply
+  // picking one -- and "couldn't be loaded" would misdescribe it as a transient failure.
+  protected readonly forbidden = signal(false);
+
+  // Complex computed
+  protected readonly spend: Signal<OrgMeetingsSpendBreakdown> = this.initSpend();
+
+  // The meeting-type and role distributions are withheld for organizations with too few active
+  // employees to aggregate safely, and that suppression arrives as an empty array rather than a
+  // missing key. Rendering an empty card would imply the org attends no typed meetings, so the
+  // cards are hidden instead.
+  // Applied uniformly to all four: an empty card reads as "none of this happened" wherever it
+  // appears, so any breakdown that comes back empty is hidden rather than rendered blank.
+  protected readonly showFoundation: Signal<boolean> = computed(() => this.spend().byFoundation.length > 0);
+  protected readonly showProject: Signal<boolean> = computed(() => this.spend().byProject.length > 0);
+  protected readonly showMeetingType: Signal<boolean> = computed(() => this.spend().byMeetingType.length > 0);
+  protected readonly showRole: Signal<boolean> = computed(() => this.spend().byRole.length > 0);
+  protected readonly hasAnyBreakdown: Signal<boolean> = computed(
+    () => this.showFoundation() || this.showProject() || this.showMeetingType() || this.showRole()
+  );
+
+  // Private initializers
+  private initSpend(): Signal<OrgMeetingsSpendBreakdown> {
+    // A string key, not an object: `selectedAccount` is rewritten in place by Snowflake enrichment
+    // and the canonical-record patch, and a fresh object with identical contents would dirty the
+    // computed and retrigger the fetch, flashing the loading state for no new data.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.timeRange()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgMeetingsSupportedTimeRange]),
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap(([orgUid, range]) =>
+          this.meetingsService.getSpendBreakdown(orgUid, range).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load meeting spend breakdown', error);
+              this.loading.set(false);
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_SPEND);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_SPEND }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-spend-bar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-spend-bar.component.html
@@ -1,0 +1,64 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="rounded-xl border border-gray-200 bg-white p-4" [attr.data-testid]="'org-spend-bar-' + titleSlug()">
+  <div class="mb-3.5 flex items-center gap-2">
+    <i [class]="icon()" class="text-base text-blue-600" aria-hidden="true"></i>
+    <span class="text-sm font-medium text-gray-900">{{ title() }}</span>
+  </div>
+  <div class="flex flex-col gap-3">
+    <!-- aria-expanded is only valid on a widget role, so the row that owns the disclosure also takes
+         role="button" and explicit key handling; rows with no others bucket stay plain. -->
+    @for (segment of rows(); track segment.label) {
+      <div
+        class="relative rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+        [attr.tabindex]="segment.others?.length ? 0 : null"
+        [attr.role]="segment.others?.length ? 'button' : null"
+        [attr.aria-expanded]="segment.others?.length ? othersPopover.overlayVisible : null"
+        (click)="showOthersPopover($event, segment.others)"
+        (keydown.enter)="showOthersPopover($event, segment.others)"
+        (keydown.space)="$event.preventDefault(); showOthersPopover($event, segment.others)"
+        [class.mt-1]="segment.isOther"
+        [class.border-t]="segment.isOther"
+        [class.border-dashed]="segment.isOther"
+        [class.border-gray-200]="segment.isOther"
+        [class.pt-3]="segment.isOther"
+        (mouseenter)="showOthersPopover($event, segment.others)"
+        (mouseleave)="scheduleHideOthersPopover()"
+        (focus)="showOthersPopover($event, segment.others)"
+        (blur)="scheduleHideOthersPopover()">
+        <div class="mb-1 flex items-center justify-between gap-2.5">
+          <span class="text-xs" [class]="segment.isOther ? 'text-gray-500' : 'text-gray-900'">{{ segment.label }}</span>
+          <span class="text-xs font-medium" [class]="segment.isOther ? 'text-gray-500' : 'text-gray-900'">{{ segment.pct }}%</span>
+        </div>
+        <div class="h-1.5 w-full overflow-hidden rounded-full" [class]="segment.isOther ? 'bg-gray-100' : 'bg-blue-100'">
+          <div class="h-1.5 rounded-full" [class]="segment.isOther ? 'bg-gray-300' : 'bg-blue-600'" [style.width.%]="segment.pct"></div>
+        </div>
+      </div>
+    }
+  </div>
+  <p-popover #othersPopover appendTo="body" [attr.data-testid]="'org-spend-bar-' + titleSlug() + '-others-popover'">
+    <div class="flex flex-col gap-2" (mouseenter)="cancelHideOthersPopover()" (mouseleave)="scheduleHideOthersPopover()">
+      <p class="text-xs font-medium text-gray-500">Breakdown</p>
+      <!-- tabindex makes this the focus target PrimeNG's `focusOnShow` moves focus into, and the
+           focus/blur handlers keep the popover open while focus (not just the pointer) is inside it,
+           so keyboard users can Tab in and scroll with arrow keys instead of losing the panel on trigger blur. -->
+      <div
+        class="flex max-h-64 w-56 flex-col gap-1.5 overflow-y-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+        tabindex="0"
+        role="group"
+        aria-label="Breakdown of other values"
+        (focus)="cancelHideOthersPopover()"
+        (blur)="scheduleHideOthersPopover()">
+        @for (item of othersPopoverItems(); track item.label) {
+          <div class="flex items-center justify-between gap-2 text-xs">
+            <span class="text-gray-700">{{ item.label }}</span>
+            @if (item.pct !== undefined) {
+              <span class="font-medium text-gray-900">{{ item.pct }}%</span>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </p-popover>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-spend-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-spend-breakdown/org-spend-bar.component.ts
@@ -1,0 +1,69 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, input, signal, Signal, viewChild, WritableSignal } from '@angular/core';
+import type { OrgMeetingsSpendSegment, OrgMeetingsSpendOtherItem, OrgSpendBarSegment } from '@lfx-one/shared/interfaces';
+import { slugify } from '@lfx-one/shared/utils';
+import { Popover, PopoverModule } from 'primeng/popover';
+
+// Presentational ranked mini-bar list for "Where your people spend time" — each named item gets its
+// own bar so adjacent segments never need to be visually distinguished; the trailing "others" bucket
+// is muted and separated to avoid dominating the row. No shared wrapper exists for this pattern, so
+// it stays local to org-meetings.
+@Component({
+  selector: 'lfx-org-spend-bar',
+  imports: [PopoverModule],
+  templateUrl: './org-spend-bar.component.html',
+})
+export class OrgSpendBarComponent {
+  public readonly title = input.required<string>();
+  public readonly icon = input.required<string>();
+  public readonly segments = input.required<OrgMeetingsSpendSegment[]>();
+
+  private readonly othersPopoverRef = viewChild<Popover>('othersPopover');
+
+  protected readonly othersPopoverItems: WritableSignal<OrgMeetingsSpendOtherItem[]> = signal([]);
+
+  protected readonly titleSlug: Signal<string> = computed(() => slugify(this.title()));
+
+  protected readonly rows: Signal<OrgSpendBarSegment[]> = this.initRows();
+
+  // `appendTo="body"` detaches the popover from the triggering row, so the pointer briefly leaves
+  // the row while crossing to the popover — a same-tick `hide()` on the row's `mouseleave` would
+  // close it before the pointer arrives. Deferring the hide by a tick lets a `mouseenter` on the
+  // popover itself cancel it first. Also gives the "others" breakdown room to scroll instead of
+  // being clipped by a fixed-height, pointer-events-none tooltip.
+  private hideOthersPopoverTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  public constructor() {
+    // Navigating away mid-hover would otherwise leave the pending hide holding a destroyed component.
+    inject(DestroyRef).onDestroy(() => clearTimeout(this.hideOthersPopoverTimeoutId));
+  }
+
+  protected showOthersPopover(event: Event, items: OrgMeetingsSpendOtherItem[] | undefined): void {
+    if (!items?.length) {
+      return;
+    }
+    this.cancelHideOthersPopover();
+    this.othersPopoverItems.set(items);
+    this.othersPopoverRef()?.show(event);
+  }
+
+  protected scheduleHideOthersPopover(): void {
+    this.cancelHideOthersPopover();
+    this.hideOthersPopoverTimeoutId = setTimeout(() => this.othersPopoverRef()?.hide(), 100);
+  }
+
+  protected cancelHideOthersPopover(): void {
+    clearTimeout(this.hideOthersPopoverTimeoutId);
+  }
+
+  private initRows(): Signal<OrgSpendBarSegment[]> {
+    return computed(() =>
+      this.segments().map((segment) => ({
+        ...segment,
+        isOther: !!segment.others?.length,
+      }))
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-time-range/org-meetings-time-range.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-time-range/org-meetings-time-range.component.html
@@ -1,0 +1,47 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<button
+  type="button"
+  class="flex items-center gap-2 text-sm font-medium text-gray-900 hover:text-gray-700"
+  (click)="togglePanel($event)"
+  [attr.aria-expanded]="popover.overlayVisible"
+  data-testid="org-meetings-time-range">
+  <i class="fa-light fa-calendar text-gray-500" aria-hidden="true"></i>
+  <span data-testid="org-meetings-time-range-label">{{ selectedLabel() }}</span>
+  <i class="fa-light fa-chevron-down text-xs text-gray-400" aria-hidden="true"></i>
+</button>
+
+<p-popover #popover appendTo="body" [style]="{ width: '24rem', maxWidth: 'calc(100vw - 2rem)' }" data-testid="org-meetings-time-range-panel">
+  <div class="flex flex-col" data-testid="org-meetings-time-range-panel-body">
+    @for (group of groups(); track $index; let isFirstGroup = $first) {
+      <div class="flex flex-col py-1" [class.border-t]="!isFirstGroup" [class.border-gray-200]="!isFirstGroup">
+        <!-- aria-disabled rather than [disabled]: a disabled button leaves the tab order, so a
+             keyboard or screen-reader user would never discover that the option exists but is
+             unavailable. select() refuses the activation instead. -->
+        @for (option of group; track option.value) {
+          <button
+            type="button"
+            class="flex items-center justify-between gap-4 rounded-md px-3 py-2 text-left"
+            [class.hover:bg-gray-50]="!option.disabled"
+            [class.cursor-not-allowed]="option.disabled"
+            [class.opacity-50]="option.disabled"
+            [attr.aria-disabled]="option.disabled ? 'true' : null"
+            [attr.aria-pressed]="option.value === value()"
+            (click)="select(option)"
+            [attr.data-testid]="'org-meetings-time-range-option-' + option.value">
+            <span class="flex items-center gap-2 text-sm" [class.font-medium]="option.value === value()" [class.text-gray-900]="option.value === value()">
+              <i class="fa-light fa-check w-3.5 text-blue-500" [class.opacity-0]="option.value !== value()" aria-hidden="true"></i>
+              {{ option.label }}
+            </span>
+            @if (option.rangeLabel) {
+              <span class="text-xs whitespace-nowrap text-gray-500">{{ option.rangeLabel }}</span>
+            } @else if (option.disabled) {
+              <span class="text-xs whitespace-nowrap text-gray-400">Not available</span>
+            }
+          </button>
+        }
+      </div>
+    }
+  </div>
+</p-popover>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-time-range/org-meetings-time-range.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-time-range/org-meetings-time-range.component.ts
@@ -1,0 +1,116 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformServer } from '@angular/common';
+import { Component, computed, inject, input, makeStateKey, model, PLATFORM_ID, Signal, TransferState, viewChild } from '@angular/core';
+import { ORG_MEETINGS_TIME_RANGE_GROUPS, ORG_MEETINGS_TIME_RANGE_LABELS } from '@lfx-one/shared/constants';
+import type { OrgMeetingsTimeRange, OrgMeetingsTimeRangeOption } from '@lfx-one/shared/interfaces';
+import { formatShortDate } from '@lfx-one/shared/utils';
+import { Popover, PopoverModule } from 'primeng/popover';
+
+@Component({
+  selector: 'lfx-org-meetings-time-range',
+  imports: [PopoverModule],
+  templateUrl: './org-meetings-time-range.component.html',
+})
+export class OrgMeetingsTimeRangeComponent {
+  private readonly transferState = inject(TransferState);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // Server renders `rangeLabel`s off `Date.now()` at request time; without pinning that timestamp,
+  // the client would recompute a different `now` during hydration (different clock/tick), producing
+  // a different formatted string than what the server sent and triggering a hydration mismatch.
+  // TransferState carries the exact server timestamp to the client so both compute identical labels.
+  private readonly todayTimestampKey = makeStateKey<number>('org-meetings-time-range-today');
+
+  // Model signals for two-way binding
+  public readonly value = model.required<OrgMeetingsTimeRange>();
+
+  // Public fields from inputs
+  /** Ranges to render greyed out and refuse to select — the caller decides which windows it can serve. */
+  public readonly disabledValues = input<readonly OrgMeetingsTimeRange[]>([]);
+
+  private readonly popoverRef = viewChild<Popover>('popover');
+
+  // Complex computed
+  protected readonly groups: Signal<OrgMeetingsTimeRangeOption[][]> = this.initGroups();
+  protected readonly selectedLabel: Signal<string> = computed(() => ORG_MEETINGS_TIME_RANGE_LABELS[this.value()]);
+
+  protected select(option: OrgMeetingsTimeRangeOption): void {
+    // Guards keyboard activation too: `[disabled]` stops the click, but not every assistive path
+    // routes through it, and selecting an unserved window would surface a 400 rather than data.
+    if (option.disabled) {
+      return;
+    }
+    this.value.set(option.value);
+    this.popoverRef()?.hide();
+  }
+
+  protected togglePanel(event: Event): void {
+    this.popoverRef()?.toggle(event);
+  }
+
+  private initGroups(): Signal<OrgMeetingsTimeRangeOption[][]> {
+    return computed(() => {
+      const today = this.resolveToday();
+      const disabled = new Set<OrgMeetingsTimeRange>(this.disabledValues());
+      return ORG_MEETINGS_TIME_RANGE_GROUPS.map((group) =>
+        group.map((value) => ({
+          value,
+          label: ORG_MEETINGS_TIME_RANGE_LABELS[value],
+          rangeLabel: this.rangeLabelFor(value, today),
+          disabled: disabled.has(value),
+        }))
+      );
+    });
+  }
+
+  private resolveToday(): Date {
+    if (this.transferState.hasKey(this.todayTimestampKey)) {
+      const timestamp = this.transferState.get(this.todayTimestampKey, Date.now());
+      this.transferState.remove(this.todayTimestampKey);
+      return new Date(timestamp);
+    }
+    const now = Date.now();
+    if (isPlatformServer(this.platformId)) {
+      this.transferState.set(this.todayTimestampKey, now);
+    }
+    return new Date(now);
+  }
+
+  private rangeLabelFor(value: OrgMeetingsTimeRange, today: Date): string | null {
+    switch (value) {
+      case 'past90d':
+        return this.pastDaysLabel(today, 90);
+      case 'past180d':
+        return this.pastDaysLabel(today, 180);
+      case 'past365d':
+        return this.pastDaysLabel(today, 365);
+      case 'previousQuarter':
+        return this.previousQuarterLabel(today);
+      case 'previousYear':
+        return `${today.getUTCFullYear() - 1}`;
+      case 'previous5y':
+        return `${today.getUTCFullYear() - 5} → ${today.getUTCFullYear() - 1}`;
+      case 'previous10y':
+        return `${today.getUTCFullYear() - 10} → ${today.getUTCFullYear() - 1}`;
+      default:
+        return null;
+    }
+  }
+
+  private pastDaysLabel(today: Date, days: number): string {
+    const start = new Date(today);
+    start.setUTCDate(start.getUTCDate() - (days - 1));
+    return `${formatShortDate(start)} → Today`;
+  }
+
+  private previousQuarterLabel(today: Date): string {
+    const currentQuarterStartMonth = Math.floor(today.getUTCMonth() / 3) * 3;
+    const startMonth = currentQuarterStartMonth - 3;
+    const start = new Date(Date.UTC(today.getUTCFullYear(), startMonth, 1));
+    const end = new Date(Date.UTC(today.getUTCFullYear(), startMonth + 2, 1));
+    const monthYear = (date: Date): string => date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+    return `${monthYear(start)} → ${monthYear(end)}`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
@@ -1,15 +1,60 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
+
 <main class="container mx-auto flex flex-col gap-6 px-4 sm:px-6 lg:px-8" data-testid="org-meetings-page">
-  <header class="flex flex-col gap-1">
-    <h1 class="font-display font-light text-2xl">Meetings</h1>
-    <p class="text-sm text-gray-500">A view of the meetings your organization is participating in — coming soon.</p>
+  <header class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between" data-testid="org-meetings-header">
+    <div class="flex flex-col gap-2">
+      <h1 class="font-display font-light text-2xl" data-testid="org-meetings-title">Meetings</h1>
+      <p class="text-sm text-gray-500" data-testid="org-meetings-subtitle">How your organization's employees engage across Linux Foundation projects.</p>
+    </div>
+    <lfx-org-meetings-time-range [(value)]="timeRange" [disabledValues]="unsupportedTimeRanges" />
   </header>
 
-  <div class="flex flex-col items-center justify-center min-h-[50vh] text-center gap-6" data-testid="org-meetings-coming-soon">
-    <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
-      <i class="fa-light fa-video text-4xl text-blue-500" aria-hidden="true"></i>
-    </div>
-    <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
-  </div>
+  @if (hasNoOrgAccess()) {
+    <section
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-white py-16 text-center"
+      data-testid="org-meetings-no-access-state">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+        <i class="fa-light fa-lock text-2xl" aria-hidden="true"></i>
+      </div>
+      <h2 class="text-base font-semibold text-gray-900" data-testid="org-meetings-no-access-title">Organization Lens is not available</h2>
+      <p class="max-w-md text-sm text-gray-600" data-testid="org-meetings-no-access-description">
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+      </p>
+    </section>
+  } @else if (!loaded()) {
+    <!-- Pre-settled state — render lightweight skeletons so the page doesn't flash the no-company
+         empty-state during the race between the org-selector boot fetches and the first valid
+         selectedAccount, mirroring org-overview.component.html. -->
+    <section class="flex flex-col gap-4" data-testid="org-meetings-loading">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        @for (i of [1, 2, 3, 4]; track i) {
+          <div class="p-4 bg-white border border-gray-200 rounded-lg flex flex-col gap-2">
+            <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+            <p-skeleton width="3rem" height="1.75rem" />
+            <p-skeleton width="80%" height="0.75rem" />
+          </div>
+        }
+      </div>
+    </section>
+  } @else if (!hasCompany()) {
+    <lfx-empty-state
+      icon="fa-light fa-building"
+      title="Select a company via Impersonate to view meeting insights."
+      data-testid="org-meetings-no-company-empty-state" />
+  } @else if (!hasAnalyticsId()) {
+    <!-- A company is selected but its analytics id never resolved, so no section can load. Say so
+         rather than leaving three skeletons on screen forever. -->
+    <lfx-empty-state
+      icon="fa-light fa-triangle-exclamation"
+      title="Meeting insights aren't available for this company right now. Please try again."
+      data-testid="org-meetings-no-analytics-id-state" />
+  } @else {
+    <lfx-org-meetings-kpi-cards [timeRange]="servedTimeRange()" />
+
+    <lfx-org-meetings-spend-breakdown [timeRange]="servedTimeRange()" />
+
+    <!-- No time range: project influence is range-independent. -->
+    <lfx-org-meetings-influence />
+  }
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
@@ -1,17 +1,96 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component } from '@angular/core';
-import { TagComponent } from '@components/tag/tag.component';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { ORG_MEETINGS_DEFAULT_TIME_RANGE, ORG_MEETINGS_TIME_RANGES } from '@lfx-one/shared/constants';
+import type { OrgMeetingsSupportedTimeRange, OrgMeetingsTimeRange } from '@lfx-one/shared/interfaces';
+import { isSupportedOrgMeetingsTimeRange } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgNavigationService } from '@services/org-navigation.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
+import { PersonaService } from '@services/persona.service';
+import { SkeletonModule } from 'primeng/skeleton';
 
-// LFXV2-1902: the Org Lens meetings live list and its Snowflake-backed BFF read
-// path were retired (per-invitee PII served from the analytics lane with no
-// operational-plane check — ADR-0038). This page is now a "coming soon"
-// placeholder; the /org/meetings route and sidebar tab intentionally still
-// resolve this component.
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+
+import { OrgMeetingsInfluenceComponent } from './components/org-meetings-influence/org-meetings-influence.component';
+import { OrgMeetingsKpiCardsComponent } from './components/org-meetings-kpi-cards/org-meetings-kpi-cards.component';
+import { OrgMeetingsSpendBreakdownComponent } from './components/org-meetings-spend-breakdown/org-meetings-spend-breakdown.component';
+import { OrgMeetingsTimeRangeComponent } from './components/org-meetings-time-range/org-meetings-time-range.component';
+
+// The employee leaderboard is a per-person surface and needs its own privacy review plus a real
+// backend before it can render; it ships in a follow-up rather than sitting here unreferenced.
+
+// This page was previously retired to a "coming soon" placeholder (LFXV2-1902 / ADR-0038) after the
+// legacy implementation served per-invitee PII from the analytics lane without an operational-plane
+// check. The sections below now read real analytics, but only organization-level aggregates: the
+// endpoints expose no person, attendee, or meeting identifier, and each one gates on the caller's
+// org grant before reading anything.
 @Component({
   selector: 'lfx-org-meetings',
-  imports: [TagComponent],
+  imports: [
+    OrgMeetingsTimeRangeComponent,
+    OrgMeetingsKpiCardsComponent,
+    OrgMeetingsSpendBreakdownComponent,
+    OrgMeetingsInfluenceComponent,
+    EmptyStateComponent,
+    SkeletonModule,
+  ],
   templateUrl: './org-meetings.component.html',
 })
-export class OrgMeetingsComponent {}
+export class OrgMeetingsComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly orgNavigationService = inject(OrgNavigationService);
+  private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
+  private readonly personaService = inject(PersonaService);
+
+  // Simple WritableSignals
+  // The dropdown's model spans all nine ranges; only the seven the warehouse is built for are
+  // selectable (the rest are disabled below and rejected by the endpoints).
+  protected readonly timeRange = signal<OrgMeetingsTimeRange>(ORG_MEETINGS_DEFAULT_TIME_RANGE);
+
+  // Configuration
+  protected readonly unsupportedTimeRanges: OrgMeetingsTimeRange[] = ORG_MEETINGS_TIME_RANGES.filter((range) => !isSupportedOrgMeetingsTimeRange(range));
+
+  // Complex computed
+  // True once role grants + personas have settled and the caller genuinely has no org access —
+  // mirrors org-overview/org-projects' `hasNoOrgAccess`. Reused below so a direct writer/auditor
+  // with no persona-seeded organizations (who never triggers the nav fetch) isn't stuck waiting
+  // on `orgNavigationService.loaded()` forever.
+  protected readonly hasNoOrgAccess: Signal<boolean> = computed(
+    () => this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded() && !this.accountContext.hasOrgSelectorAccess()
+  );
+
+  // True once every fetch that can populate `selectedAccount` has settled — either the caller
+  // has no org access (short-circuits without waiting on nav), or role grants + personas +
+  // org-navigation's default-org selection have all returned. Without waiting on org-navigation
+  // too, a direct writer/auditor whose persona response has no organizations could see a one-tick
+  // flash of the no-company empty state before `/api/nav/org-items` populates `selectedAccount`.
+  // Mirrors org-projects.component.ts's `orgContextLoaded` gate.
+  protected readonly loaded: Signal<boolean> = computed(
+    () => this.hasNoOrgAccess() || (this.orgNavigationService.loaded() && this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded())
+  );
+
+  // Either identifier counts as "selected": a fresh persona seed can have `uid` but an empty
+  // `accountId` pending Snowflake enrichment, while a cookie-restored stub (account-context.service.ts)
+  // can have `uid` set with `accountId` still empty. Checking only one leaves a validly-selected
+  // company on the empty state, per the same gate in org-overview.component.ts.
+  protected readonly hasCompany: Signal<boolean> = computed(
+    () => !!this.accountContext.selectedAccount().uid || !!this.accountContext.selectedAccount().accountId
+  );
+
+  // Every section keys off the analytics account id, not the uid. A cookie-restored selection can
+  // carry a uid with the accountId still pending, and the canonical-record fetch that resolves it
+  // fails silently by design — so once the org context has settled without one, the sections would
+  // otherwise sit on their loading skeletons indefinitely with nothing on screen to say why.
+  protected readonly hasAnalyticsId: Signal<boolean> = computed(() => !!this.accountContext.selectedAccount().accountId);
+
+  // Children take the narrowed range, so "only a served window reaches the endpoint" is enforced by
+  // the type rather than by the dropdown alone. The fallback is unreachable while the unsupported
+  // options stay disabled, and exists so a future dropdown regression degrades to the default window
+  // instead of a 400.
+  protected readonly servedTimeRange: Signal<OrgMeetingsSupportedTimeRange> = computed(() => {
+    const range = this.timeRange();
+    return isSupportedOrgMeetingsTimeRange(range) ? range : ORG_MEETINGS_DEFAULT_TIME_RANGE;
+  });
+}

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-  <div class="grid w-full grid-cols-1 divide-y divide-gray-200 sm:divide-y-0 sm:divide-x" [class]="columns() === 2 ? 'sm:grid-cols-2' : 'sm:grid-cols-3'">
+  <div class="grid w-full grid-cols-1" [class]="gridColsClass() + ' ' + gridDividerClass()">
     @for (card of cards(); track card.label) {
       <div class="flex items-center gap-3 p-4" [attr.data-testid]="'stat-card-' + card.label">
         <div class="flex items-center justify-center w-11 h-11 rounded-full flex-shrink-0" [class]="card.iconContainerClass">
@@ -17,6 +17,12 @@
           <p class="text-sm font-normal text-gray-900">{{ card.label }}</p>
           @if (card.subLine) {
             <p class="text-xs text-gray-400">{{ card.subLine }}</p>
+          }
+          @if (card.delta && !loading()) {
+            <p class="flex items-center gap-1 text-xs font-medium" [class]="deltaTextClass[card.delta.direction]">
+              <i [class]="deltaIcon[card.delta.direction]" aria-hidden="true"></i>
+              {{ card.delta.label }}
+            </p>
           }
         </div>
       </div>

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
@@ -1,8 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { CardComponent } from '@components/card/card.component';
+import { DELTA_DIRECTION_ICON, DELTA_DIRECTION_TEXT_CLASS, GRID_COLS_CLASS, GRID_DIVIDER_CLASS } from '@lfx-one/shared/constants';
 import { StatCardItem } from '@lfx-one/shared/interfaces';
 
 @Component({
@@ -14,5 +15,10 @@ import { StatCardItem } from '@lfx-one/shared/interfaces';
 export class StatCardGridComponent {
   public readonly cards = input.required<StatCardItem[]>();
   public readonly loading = input<boolean>(false);
-  public readonly columns = input<2 | 3>(3);
+  public readonly columns = input<2 | 3 | 4>(3);
+
+  protected readonly gridColsClass = computed(() => GRID_COLS_CLASS[this.columns()]);
+  protected readonly gridDividerClass = computed(() => GRID_DIVIDER_CLASS[this.columns()]);
+  protected readonly deltaIcon = DELTA_DIRECTION_ICON;
+  protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
 }

--- a/apps/lfx-one/src/app/shared/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-meetings.service.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import type { OrgInfluenceRow, OrgMeetingsKpiSummary, OrgMeetingsSpendBreakdown, OrgMeetingsSupportedTimeRange } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+/** Client for the Org Lens Meetings insights endpoints (LFXV2-2735). */
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgLensMeetingsService {
+  private readonly http = inject(HttpClient);
+
+  public getKpiSummary(orgUid: string, range: OrgMeetingsSupportedTimeRange): Observable<OrgMeetingsKpiSummary> {
+    return this.http.get<OrgMeetingsKpiSummary>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/meetings/kpi`, {
+      params: new HttpParams().set('range', range),
+    });
+  }
+
+  public getSpendBreakdown(orgUid: string, range: OrgMeetingsSupportedTimeRange): Observable<OrgMeetingsSpendBreakdown> {
+    return this.http.get<OrgMeetingsSpendBreakdown>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/meetings/spend`, {
+      params: new HttpParams().set('range', range),
+    });
+  }
+
+  /** No `range` — the influence surface is range-independent, so the parameter is absent by design. */
+  public getInfluenceRows(orgUid: string): Observable<OrgInfluenceRow[]> {
+    return this.http.get<OrgInfluenceRow[]>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/meetings/influence`);
+  }
+}

--- a/apps/lfx-one/src/server/controllers/org-lens-meetings.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-meetings.controller.ts
@@ -1,0 +1,90 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { assertOrgLensRead } from '../helpers/org-lens-read-access.helper';
+import { parseOrgMeetingsRange } from '../helpers/org-meetings-range.helper';
+import { assertOrgUid } from '../helpers/org-uid.helper';
+import { logger } from '../services/logger.service';
+import { OrgLensMeetingsService } from '../services/org-lens-meetings.service';
+
+/**
+ * HTTP boundary for the Org Lens Meetings insights endpoints.
+ *
+ * Every handler runs the same prelude: validate `:orgUid`, then verify the caller's grant on that
+ * org *before* touching the cache or Snowflake. `:orgUid` is the analytics filter, not the
+ * authorization — an authenticated caller with no grant on this org must never reach the data.
+ */
+export class OrgLensMeetingsController {
+  private readonly service: OrgLensMeetingsService;
+
+  public constructor() {
+    this.service = new OrgLensMeetingsService();
+  }
+
+  public async getKpi(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_meetings_kpi';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const range = parseOrgMeetingsRange(req.query['range'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const summary = await this.service.getKpiSummary(req, orgUid, range);
+      logger.success(req, operation, startTime, { org_uid: orgUid, range });
+      this.send(res, summary);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getSpend(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_meetings_spend';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const range = parseOrgMeetingsRange(req.query['range'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const breakdown = await this.service.getSpendBreakdown(req, orgUid, range);
+      logger.success(req, operation, startTime, {
+        org_uid: orgUid,
+        range,
+        foundation_segments: breakdown.byFoundation.length,
+        project_segments: breakdown.byProject.length,
+        // Zero here is the small-org safeguard, not an error — worth seeing in telemetry.
+        meeting_type_segments: breakdown.byMeetingType.length,
+        role_segments: breakdown.byRole.length,
+      });
+      this.send(res, breakdown);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /** No `range` parameter — the influence surface is range-independent by contract. */
+  public async getInfluence(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_meetings_influence';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const rows = await this.service.getInfluenceRows(req, orgUid);
+      logger.success(req, operation, startTime, { org_uid: orgUid, rows: rows.length });
+      this.send(res, rows);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /** Sibling Org Lens convention: analytics are cached server-side in Valkey, never by the browser. */
+  private send(res: Response, body: unknown): void {
+    res.setHeader('Cache-Control', 'no-store');
+    res.json(body);
+  }
+}

--- a/apps/lfx-one/src/server/helpers/org-lens-read-access.helper.ts
+++ b/apps/lfx-one/src/server/helpers/org-lens-read-access.helper.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { logger } from '../services/logger.service';
+import { OrgRoleGrantsService } from '../services/org-role-grants.service';
+import { getEffectiveUsername } from '../utils/auth-helper';
+
+const roleGrants = new OrgRoleGrantsService();
+
+/**
+ * Read gate for Org Lens analytics that expose organization-level aggregates.
+ *
+ * `:orgUid` is the analytics filter, never the authorization (ADR-0038) — authentication alone does
+ * not establish that the caller may read *this* org's data, so the caller's grant is resolved
+ * independently. Any resolved role qualifies: writer, direct auditor, and the auditor a cascading
+ * parent grant confers on a child org are all read-equivalent here.
+ *
+ * Mirrors `OrgLensAccessService.assertCanManage` in separating "we checked and you don't have it"
+ * (403) from "we couldn't check" (503): a transient query-service outage answering 403 would tell
+ * users they lost access they still hold. Both directions fail closed, so the distinction is about
+ * the accuracy of the signal, not about safety.
+ *
+ * Must run before any cache read or Snowflake query so an ungranted caller never reaches the data.
+ */
+export async function assertOrgLensRead(req: Request, orgUid: string, operation: string): Promise<void> {
+  const forbidden = (): MicroserviceError =>
+    new MicroserviceError('You do not have access to Org Lens data for this organization.', 403, 'FORBIDDEN', {
+      operation,
+      service: 'LFX_V2_SERVICE',
+      path: '/query/resources',
+    });
+
+  const unavailable = (error?: unknown): MicroserviceError =>
+    new MicroserviceError("Couldn't verify your access to this organization right now. Please try again.", 503, 'ROLE_GRANTS_UNAVAILABLE', {
+      operation,
+      service: 'LFX_V2_SERVICE',
+      path: '/query/resources',
+      originalError: error instanceof Error ? error : undefined,
+    });
+
+  const username = getEffectiveUsername(req);
+  if (!username) {
+    throw forbidden();
+  }
+
+  let hasGrant = false;
+  let degraded = false;
+  try {
+    const { resolved, upstreamFailed } = await roleGrants.getAccessAwareOrgs(req, username);
+    // `getAccessAwareOrgs` degrades to an empty grant map on upstream failure instead of throwing,
+    // so an unverified lookup is indistinguishable from "no grants" unless this flag is checked.
+    degraded = upstreamFailed;
+    hasGrant = resolved.has(orgUid);
+    if (degraded) {
+      logger.warning(req, operation, 'Role-grants lookup degraded; cannot verify Org Lens read access', { org_uid: orgUid });
+    }
+  } catch (error) {
+    logger.warning(req, operation, 'Role-grants lookup failed; cannot verify Org Lens read access', {
+      org_uid: orgUid,
+      err: error instanceof Error ? error.message : String(error),
+    });
+    throw unavailable(error);
+  }
+
+  // Thrown after the try, not inside it, so a deliberate 403/503 isn't caught above and re-mapped
+  // to a generic "lookup failed" 503.
+  if (degraded) {
+    throw unavailable();
+  }
+  if (!hasGrant) {
+    throw forbidden();
+  }
+}

--- a/apps/lfx-one/src/server/helpers/org-meetings-range.helper.ts
+++ b/apps/lfx-one/src/server/helpers/org-meetings-range.helper.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_MEETINGS_DEFAULT_TIME_RANGE, ORG_MEETINGS_SUPPORTED_TIME_RANGES } from '@lfx-one/shared/constants';
+import type { OrgMeetingsSupportedTimeRange } from '@lfx-one/shared/interfaces';
+
+import { ServiceValidationError } from '../errors';
+
+const SUPPORTED = new Set<string>(ORG_MEETINGS_SUPPORTED_TIME_RANGES);
+
+/**
+ * Resolves the `range` query parameter to one of the seven bounded windows the warehouse is built
+ * for. An omitted parameter takes the default; anything else outside the set — including `allTime`
+ * and `custom`, which are valid members of the wider dropdown union but unbuilt for V1 — is a 400.
+ *
+ * Deliberately not a silent fallback: answering a request for `allTime` with `past365d` data would
+ * render a plausible-looking number for a window the caller did not ask for.
+ */
+export function parseOrgMeetingsRange(rawRange: unknown, operation: string): OrgMeetingsSupportedTimeRange {
+  // Only an absent parameter defaults. `?range=` is a supplied value, and answering it with the
+  // default window would be the silent fallback this function exists to avoid.
+  if (rawRange === undefined) {
+    return ORG_MEETINGS_DEFAULT_TIME_RANGE;
+  }
+  if (typeof rawRange !== 'string' || !SUPPORTED.has(rawRange)) {
+    throw ServiceValidationError.forField('range', `range must be one of: ${ORG_MEETINGS_SUPPORTED_TIME_RANGES.join(', ')}`, { operation });
+  }
+  return rawRange as OrgMeetingsSupportedTimeRange;
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -11,6 +11,7 @@ import { OrgLensDocumentsController } from '../controllers/org-lens-documents.co
 import { OrgLensEventsController } from '../controllers/org-lens-events.controller';
 import { OrgLensFoundationsController } from '../controllers/org-lens-foundations.controller';
 import { OrgLensKeyContactsController } from '../controllers/org-lens-key-contacts.controller';
+import { OrgLensMeetingsController } from '../controllers/org-lens-meetings.controller';
 import { OrgLensMembershipsController } from '../controllers/org-lens-memberships.controller';
 import { OrgLensPeopleController } from '../controllers/org-lens-people.controller';
 import { OrgLensProjectDetailController } from '../controllers/org-lens-project-detail.controller';
@@ -29,6 +30,7 @@ function buildOrgsRouter(): Router {
   const orgLensAccessController = new OrgLensAccessController();
   const orgLensTrainingController = new OrgLensTrainingController();
   const orgLensContributionsController = new OrgLensContributionsController();
+  const orgLensMeetingsController = new OrgLensMeetingsController();
   const orgLensProjectsController = new OrgLensProjectsController();
   const orgLensProjectDetailController = new OrgLensProjectDetailController();
   const orgIdentityController = new OrgIdentityController();
@@ -116,6 +118,12 @@ function buildOrgsRouter(): Router {
   // LFXV2-1897 — Trainings tab table + drill-down rosters.
   router.get('/:orgUid/lens/training/trainings/:courseId/employees', (req, res, next) => orgLensTrainingController.getTrainingEmployees(req, res, next));
   router.get('/:orgUid/lens/training/trainings', (req, res, next) => orgLensTrainingController.getOrgTrainings(req, res, next));
+
+  // LFXV2-2735 — Org Lens Meetings insights. Unlike the sibling org-lens routes these carry an
+  // org-membership read gate (`assertOrgLensRead`) inside each handler, ahead of any data access.
+  router.get('/:orgUid/lens/meetings/kpi', (req, res, next) => orgLensMeetingsController.getKpi(req, res, next));
+  router.get('/:orgUid/lens/meetings/spend', (req, res, next) => orgLensMeetingsController.getSpend(req, res, next));
+  router.get('/:orgUid/lens/meetings/influence', (req, res, next) => orgLensMeetingsController.getInfluence(req, res, next));
 
   // LFXV2-1894 — Org Lens Code Contributions page (KPI strip + repositories table + commits feed).
   router.get('/:orgUid/lens/contributions', (req, res, next) => orgLensContributionsController.getContributions(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -1,0 +1,456 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DEFAULT_LFX_ONE_PLATINUM_SCHEMA, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import type {
+  OrgInfluenceBreakdownSegment,
+  OrgInfluenceRow,
+  OrgLensProjectBand,
+  OrgMeetingsDeltaDirection,
+  OrgMeetingsInfluenceWarehouseRow,
+  OrgMeetingsKpiSummary,
+  OrgMeetingsKpiWarehouseRow,
+  OrgMeetingsSpendBreakdown,
+  OrgMeetingsSpendOtherItem,
+  OrgMeetingsSpendSegment,
+  OrgMeetingsSpendWarehouseRow,
+  OrgMeetingsSupportedTimeRange,
+} from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+import { withOrgCache } from './valkey.service';
+
+/** Bands the influence model emits; anything else degrades to the lowest band rather than breaking the chip. */
+const INFLUENCE_BANDS: readonly OrgLensProjectBand[] = ['silent', 'participating', 'contributing', 'leading'];
+
+/** Directions `TREND_DIRECTION` emits; verified exhaustive in prod, guarded anyway. */
+const TREND_DIRECTIONS: readonly OrgMeetingsDeltaDirection[] = ['up', 'down', 'flat'];
+
+const KPI_NO_CHANGE_LABEL = 'No change vs. prior period';
+const INFLUENCE_NO_CHANGE_LABEL = 'No change YoY';
+const NEW_LABEL = 'New';
+const NO_COMPARABLE_BASELINE_LABEL = 'No comparable prior period';
+
+/**
+ * Above this growth rate the prior period was too thin to be a baseline, and the ratio describes the
+ * emptiness of that window rather than the organization's activity. Only ~3.5 years of attendance
+ * history exist, so the long windows compare against a nearly-empty preceding period: prod holds 113
+ * org/window rows above this line, most with a prior of exactly 1, topping out near +115,000%.
+ *
+ * Deliberately a ceiling on the computed ratio rather than a floor on the prior count. Suppressing
+ * every small baseline would relabel ~3,090 rows to fix ~87 of them, discarding legitimate readings
+ * like "2 meetings → 3" (+50%), and would still miss the priors of 3 and 6 that also explode.
+ */
+const MAX_MEANINGFUL_DELTA_PCT = 1000;
+
+/**
+ * `PRIOR_YEAR_SCORE` is a continuous score, so an exact `=== 0` test would let a stored 1e-7 fall
+ * through to a ratio in the millions. Anything below this counts as no prior-year influence.
+ */
+const INFLUENCE_ZERO_SCORE_EPSILON = 1e-6;
+
+/** The four `BREAKDOWN_KIND` values the spend model emits; typed so a typo can't silently yield an empty card. */
+type SpendBreakdownKind = 'foundation' | 'project' | 'meeting_type' | 'role';
+
+/**
+ * A formatted delta plus which branch produced it. The influence rule needs to know whether a real
+ * percentage was rendered, and matching on the label text would silently change behaviour the next
+ * time someone edits one of the label constants.
+ */
+interface FormattedDelta {
+  kind: 'no-change' | 'runaway' | 'pct';
+  label: string;
+  direction: OrgMeetingsDeltaDirection;
+}
+
+/**
+ * Read-only Org Lens Meetings analytics over the three `ORG_LENS_MEETINGS_*` warehouse models.
+ *
+ * All three responses are functions of `(accountId, range)` alone — nothing varies per caller — so
+ * each is served through the plain org-scoped cache with no per-user key and no post-cache merge.
+ * Authorization is enforced upstream in the controller (`assertOrgLensRead`) before anything here
+ * runs, so a cache hit can never bypass the gate.
+ *
+ * Presentation lives here rather than in the warehouse: the models carry raw counts and prior-period
+ * counterparts, and this service turns them into the delta labels and rank strings the contract
+ * specifies.
+ */
+export class OrgLensMeetingsService {
+  private readonly snowflakeService = SnowflakeService.getInstance();
+
+  /** Four org-level counts with period-over-period deltas. A missing row is a quiet org, not an error. */
+  public async getKpiSummary(req: Request, accountId: string, range: OrgMeetingsSupportedTimeRange): Promise<OrgMeetingsKpiSummary> {
+    return withOrgCache(
+      accountId,
+      `meetings-kpi:${range}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        // Only logged on a miss, so the absence of this line in a trace means the cache served it —
+        // the first thing worth knowing when this page is slow.
+        logger.debug(req, 'get_org_lens_meetings_kpi', 'Cache miss; querying Snowflake', { account_id: accountId, range });
+        const sql = `
+        SELECT
+          EMPLOYEES_ACTIVE,
+          MEETINGS_ATTENDED,
+          PROJECTS_SUPPORTED,
+          FOUNDATIONS_SUPPORTED,
+          PRIOR_EMPLOYEES_ACTIVE,
+          PRIOR_MEETINGS_ATTENDED,
+          PRIOR_PROJECTS_SUPPORTED,
+          PRIOR_FOUNDATIONS_SUPPORTED
+        FROM ${this.kpiTable()}
+        WHERE ACCOUNT_ID = ? AND TIME_RANGE_TYPE = ?
+      `;
+        const result = await this.snowflakeService.execute<OrgMeetingsKpiWarehouseRow>(sql, [accountId, range]);
+        if (result.rows.length > 1) {
+          // Grain is (account_id, time_range_type); more than one row means the model regressed.
+          logger.warning(req, 'get_org_lens_meetings_kpi', 'Expected at most one KPI row for the grain', {
+            account_id: accountId,
+            range,
+            rows: result.rows.length,
+          });
+        }
+        return this.mapKpiSummary(result.rows.at(0) ?? null);
+      },
+      OrgLensMeetingsService.isKpiSummary
+    );
+  }
+
+  /** Four ranked breakdowns. An absent `BREAKDOWN_KIND` yields `[]` — that absence is how the warehouse encodes DR-003 suppression. */
+  public async getSpendBreakdown(req: Request, accountId: string, range: OrgMeetingsSupportedTimeRange): Promise<OrgMeetingsSpendBreakdown> {
+    return withOrgCache(
+      accountId,
+      `meetings-spend:${range}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_meetings_spend', 'Cache miss; querying Snowflake', { account_id: accountId, range });
+        const sql = `
+        SELECT
+          BREAKDOWN_KIND,
+          LABEL,
+          ATTENDANCE_COUNT,
+          PCT,
+          RANK,
+          IS_OTHER,
+          OTHER_ITEMS,
+          OTHER_OVERFLOW_COUNT
+        FROM ${this.spendTable()}
+        WHERE ACCOUNT_ID = ? AND TIME_RANGE_TYPE = ?
+        ORDER BY BREAKDOWN_KIND, RANK
+      `;
+        const result = await this.snowflakeService.execute<OrgMeetingsSpendWarehouseRow>(sql, [accountId, range]);
+        return this.mapSpendBreakdown(result.rows);
+      },
+      OrgLensMeetingsService.isSpendBreakdown
+    );
+  }
+
+  /** One row per project the org engages with that also has `last_2_years` influence data. Range-independent by design. */
+  public async getInfluenceRows(req: Request, accountId: string): Promise<OrgInfluenceRow[]> {
+    return withOrgCache(
+      accountId,
+      'meetings-influence',
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_meetings_influence', 'Cache miss; querying Snowflake', { account_id: accountId });
+        const sql = `
+        SELECT
+          PROJECT_SLUG,
+          PROJECT_NAME,
+          ECOSYSTEM_INFLUENCE,
+          BAND,
+          RANK,
+          RANK_TOTAL,
+          FROM_ATTENDANCE_PCT,
+          DELTA_PCT,
+          PRIOR_YEAR_SCORE,
+          TREND_DIRECTION,
+          BREAKDOWN
+        FROM ${this.influenceTable()}
+        WHERE ACCOUNT_ID = ?
+        ORDER BY ECOSYSTEM_INFLUENCE DESC, PROJECT_NAME
+      `;
+        const result = await this.snowflakeService.execute<OrgMeetingsInfluenceWarehouseRow>(sql, [accountId]);
+        // A row with no slug cannot link anywhere and would collide with any other slugless row on the
+        // template's track key, so it is dropped rather than rendered.
+        return result.rows.filter((row) => this.toLabel(row.PROJECT_SLUG).length > 0).map((row) => this.mapInfluenceRow(row));
+      },
+      OrgLensMeetingsService.isInfluenceRows
+    );
+  }
+
+  // ── mappers ──────────────────────────────────────────────────────────────────
+
+  private mapKpiSummary(row: OrgMeetingsKpiWarehouseRow | null): OrgMeetingsKpiSummary {
+    const employees = this.kpiDelta(row?.EMPLOYEES_ACTIVE, row?.PRIOR_EMPLOYEES_ACTIVE);
+    const meetings = this.kpiDelta(row?.MEETINGS_ATTENDED, row?.PRIOR_MEETINGS_ATTENDED);
+    const projects = this.kpiDelta(row?.PROJECTS_SUPPORTED, row?.PRIOR_PROJECTS_SUPPORTED);
+    const foundations = this.kpiDelta(row?.FOUNDATIONS_SUPPORTED, row?.PRIOR_FOUNDATIONS_SUPPORTED);
+
+    return {
+      employeesActive: employees.value,
+      employeesActiveDeltaLabel: employees.label,
+      employeesActiveDeltaDirection: employees.direction,
+      meetingsAttended: meetings.value,
+      meetingsAttendedDeltaLabel: meetings.label,
+      meetingsAttendedDeltaDirection: meetings.direction,
+      projectsSupported: projects.value,
+      projectsSupportedDeltaLabel: projects.label,
+      projectsSupportedDeltaDirection: projects.direction,
+      foundationsSupported: foundations.value,
+      foundationsSupportedDeltaLabel: foundations.label,
+      foundationsSupportedDeltaDirection: foundations.direction,
+    };
+  }
+
+  /**
+   * A zero prior period has no percentage to express, so it renders "New" rather than an infinite
+   * one, and a near-zero one renders a statement rather than a ratio in the tens of thousands.
+   * Whole percents match the counts' own granularity, and a change that rounds to zero is reported
+   * as no change rather than as "+0%".
+   *
+   * Only the upside needs the ceiling: a decline is bounded at -100%, so it cannot run away.
+   */
+  private kpiDelta(current: unknown, prior: unknown): { value: number; label: string; direction: OrgMeetingsDeltaDirection } {
+    const value = this.toCount(current);
+    const priorValue = this.toCount(prior);
+
+    if (priorValue === 0) {
+      return value > 0 ? { value, label: NEW_LABEL, direction: 'up' } : { value, label: KPI_NO_CHANGE_LABEL, direction: 'flat' };
+    }
+
+    const pct = Math.round(((value - priorValue) / priorValue) * 100);
+    const { label, direction } = this.formatDelta(pct, '% vs. prior period', KPI_NO_CHANGE_LABEL);
+    return { value, label, direction };
+  }
+
+  /**
+   * Shared tail of both delta rules: no change, a runaway ratio, or a signed percentage. Only the
+   * upside is bounded — a decline cannot pass -100%, so it can never run away.
+   */
+  private formatDelta(pct: number, suffix: string, noChangeLabel: string): FormattedDelta {
+    if (pct === 0) {
+      return { kind: 'no-change', label: noChangeLabel, direction: 'flat' };
+    }
+    if (pct > MAX_MEANINGFUL_DELTA_PCT) {
+      return { kind: 'runaway', label: NO_COMPARABLE_BASELINE_LABEL, direction: 'up' };
+    }
+    return { kind: 'pct', label: `${this.signed(pct)}${suffix}`, direction: pct > 0 ? 'up' : 'down' };
+  }
+
+  private mapSpendBreakdown(rows: OrgMeetingsSpendWarehouseRow[]): OrgMeetingsSpendBreakdown {
+    return {
+      byFoundation: this.segmentsOfKind(rows, 'foundation'),
+      byProject: this.segmentsOfKind(rows, 'project'),
+      byMeetingType: this.segmentsOfKind(rows, 'meeting_type'),
+      byRole: this.segmentsOfKind(rows, 'role'),
+    };
+  }
+
+  private segmentsOfKind(rows: OrgMeetingsSpendWarehouseRow[], kind: SpendBreakdownKind): OrgMeetingsSpendSegment[] {
+    return rows.filter((row) => row.BREAKDOWN_KIND === kind).map((row) => this.mapSpendSegment(row));
+  }
+
+  private mapSpendSegment(row: OrgMeetingsSpendWarehouseRow): OrgMeetingsSpendSegment {
+    const segment: OrgMeetingsSpendSegment = {
+      label: this.toLabel(row.LABEL),
+      pct: this.round1(row.PCT),
+      count: this.toCount(row.ATTENDANCE_COUNT),
+    };
+
+    if (!row.IS_OTHER) {
+      return segment;
+    }
+
+    const others = this.parseOtherItems(row.OTHER_ITEMS);
+    const overflow = this.toCount(row.OTHER_OVERFLOW_COUNT);
+    if (overflow > 0) {
+      // The overflow entities are deliberately unnamed (past the itemization cap), so the row states
+      // how many there are and carries no share of its own — `pct` is omitted rather than zeroed so
+      // the popover doesn't render a misleading "0%".
+      others.push({ label: `+${overflow} more` });
+    }
+    return { ...segment, others };
+  }
+
+  private mapInfluenceRow(row: OrgMeetingsInfluenceWarehouseRow): OrgInfluenceRow {
+    const delta = this.influenceDelta(row);
+    return {
+      project: this.toLabel(row.PROJECT_NAME),
+      projectSlug: this.toLabel(row.PROJECT_SLUG),
+      ecosystemInfluence: this.round1(row.ECOSYSTEM_INFLUENCE),
+      band: this.toBand(row.BAND),
+      rankLabel: this.rankLabel(row.RANK, row.RANK_TOTAL),
+      fromAttendancePct: this.round1(row.FROM_ATTENDANCE_PCT),
+      deltaLabel: delta.label,
+      deltaDirection: delta.direction,
+      breakdown: this.parseBreakdown(row.BREAKDOWN),
+    };
+  }
+
+  /**
+   * Mirrors the KPI rule for the same degeneracy. The zero baseline has to be read from
+   * `PRIOR_YEAR_SCORE`: `TREND_DIRECTION` cannot identify it, because its `flat` value is a ±1%
+   * deadband rather than equality and zero-baseline rows therefore split across `flat` and `up`.
+   * The raw from-zero percentage reaches five figures in prod and is never rendered.
+   */
+  private influenceDelta(row: OrgMeetingsInfluenceWarehouseRow): { label: string; direction: OrgMeetingsDeltaDirection } {
+    const value = this.toFiniteNumber(row.ECOSYSTEM_INFLUENCE);
+
+    // A missing prior score is unknown, not zero. `Number(null)` is 0 and passes `isFinite`, so the
+    // absent cases have to be excluded before the numeric check — otherwise a column that went away
+    // would relabel every row "New", which reads as a real finding rather than a defect. The
+    // direction is flat because there is no baseline to have moved from.
+    const priorScoreRaw = row.PRIOR_YEAR_SCORE === null || row.PRIOR_YEAR_SCORE === undefined ? NaN : Number(row.PRIOR_YEAR_SCORE);
+    if (!Number.isFinite(priorScoreRaw)) {
+      return { label: NO_COMPARABLE_BASELINE_LABEL, direction: 'flat' };
+    }
+
+    if (priorScoreRaw < INFLUENCE_ZERO_SCORE_EPSILON) {
+      return value > 0 ? { label: NEW_LABEL, direction: 'up' } : { label: INFLUENCE_NO_CHANGE_LABEL, direction: 'flat' };
+    }
+
+    const pct = this.round1(row.DELTA_PCT);
+    const delta = this.formatDelta(pct, '% YoY', INFLUENCE_NO_CHANGE_LABEL);
+    // The direction is the warehouse's own `trend_direction` rather than the sign of `pct` (DR-011),
+    // but only where an actual percentage was rendered.
+    return delta.kind === 'pct'
+      ? { label: delta.label, direction: this.toTrendDirection(row.TREND_DIRECTION) }
+      : { label: delta.label, direction: delta.direction };
+  }
+
+  // ── cached-entry shape guards ────────────────────────────────────────────────
+
+  // The `org-lens-sf:v1` namespace is shared by every Org Lens sub-resource, so bumping it to
+  // invalidate one response shape would discard all the others — meaning in practice it never gets
+  // bumped, and a DTO change leaves up to a TTL's worth of clients receiving the old shape. These
+  // guards degrade a stale or corrupt entry to a cache miss instead of serving it.
+
+  private static isKpiSummary(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const summary = value as Record<string, unknown>;
+    return (['employeesActive', 'meetingsAttended', 'projectsSupported', 'foundationsSupported'] as const).every(
+      (key) => typeof summary[key] === 'number' && typeof summary[`${key}DeltaLabel`] === 'string' && typeof summary[`${key}DeltaDirection`] === 'string'
+    );
+  }
+
+  private static isSpendBreakdown(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const breakdown = value as Record<string, unknown>;
+    return (['byFoundation', 'byProject', 'byMeetingType', 'byRole'] as const).every((key) => Array.isArray(breakdown[key]));
+  }
+
+  private static isInfluenceRows(value: unknown): boolean {
+    return (
+      Array.isArray(value) &&
+      value.every((row) => {
+        if (row === null || typeof row !== 'object') return false;
+        const entry = row as Record<string, unknown>;
+        return typeof entry['projectSlug'] === 'string' && typeof entry['ecosystemInfluence'] === 'number' && Array.isArray(entry['breakdown']);
+      })
+    );
+  }
+
+  // ── parsing / coercion ───────────────────────────────────────────────────────
+
+  /** Snowflake ARRAY columns arrive either pre-parsed or as JSON text depending on driver settings; accept both. */
+  private parseVariantArray(value: unknown): unknown[] {
+    if (Array.isArray(value)) return value;
+    if (typeof value === 'string') {
+      try {
+        const parsed: unknown = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Keeps only `{label, pct}` entries and drops malformed ones. This is a shape filter, not a
+   * privacy boundary: it cannot tell an aggregate label from a person's name, so a warehouse that
+   * started emitting person-derived labels would pass straight through. The actual guarantee is
+   * upstream — the models never project `person_key`, enforced by a dbt privacy test.
+   */
+  private parseLabelPctArray(value: unknown): { label: string; pct: number }[] {
+    return this.parseVariantArray(value).flatMap((item) => {
+      if (item === null || typeof item !== 'object') return [];
+      const entry = item as { label?: unknown; pct?: unknown };
+      if (typeof entry.label !== 'string') return [];
+      return [{ label: entry.label, pct: this.round1(entry.pct) }];
+    });
+  }
+
+  private parseOtherItems(value: unknown): OrgMeetingsSpendOtherItem[] {
+    return this.parseLabelPctArray(value);
+  }
+
+  private parseBreakdown(value: unknown): OrgInfluenceBreakdownSegment[] {
+    return this.parseLabelPctArray(value);
+  }
+
+  /** Empty rather than "#0 of 0" when either side is missing — a blank cell beats a wrong rank. */
+  private rankLabel(rank: unknown, rankTotal: unknown): string {
+    const position = this.toCount(rank);
+    const total = this.toCount(rankTotal);
+    return position > 0 && total > 0 ? `#${position} of ${total}` : '';
+  }
+
+  /** Warehouse text columns are non-null by contract; coerced anyway so a null can't reach a slug or a track key. */
+  private toLabel(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+  }
+
+  private toBand(value: unknown): OrgLensProjectBand {
+    const band = typeof value === 'string' ? (value.toLowerCase() as OrgLensProjectBand) : null;
+    return band && INFLUENCE_BANDS.includes(band) ? band : 'silent';
+  }
+
+  private toTrendDirection(value: unknown): OrgMeetingsDeltaDirection {
+    const direction = typeof value === 'string' ? (value.toLowerCase() as OrgMeetingsDeltaDirection) : null;
+    return direction && TREND_DIRECTIONS.includes(direction) ? direction : 'flat';
+  }
+
+  private signed(value: number): string {
+    return value > 0 ? `+${value}` : `${value}`;
+  }
+
+  private toFiniteNumber(value: unknown): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private toCount(value: unknown): number {
+    return Math.max(0, Math.round(this.toFiniteNumber(value)));
+  }
+
+  private round1(value: unknown): number {
+    return Math.round(this.toFiniteNumber(value) * 10) / 10;
+  }
+
+  // ── warehouse locations ──────────────────────────────────────────────────────
+
+  private snowflakeQualifier(value: string | undefined): string | null {
+    const trimmed = value?.trim();
+    return trimmed && /^[A-Z0-9_]+(\.[A-Z0-9_]+){1,2}$/i.test(trimmed) ? trimmed.toUpperCase() : null;
+  }
+
+  private lfxOnePlatinumSchema(): string {
+    return this.snowflakeQualifier(process.env['LFX_ONE_PLATINUM_SCHEMA']) ?? DEFAULT_LFX_ONE_PLATINUM_SCHEMA;
+  }
+
+  private kpiTable(): string {
+    return `${this.lfxOnePlatinumSchema()}.ORG_LENS_MEETINGS_KPI`;
+  }
+
+  private spendTable(): string {
+    return `${this.lfxOnePlatinumSchema()}.ORG_LENS_MEETINGS_SPEND`;
+  }
+
+  private influenceTable(): string {
+    return `${this.lfxOnePlatinumSchema()}.ORG_LENS_MEETINGS_INFLUENCE`;
+  }
+}

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -2,7 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 import typography from '@tailwindcss/typography';
-import { AVATAR_COLORS, lfxColors, lfxFontSizes } from '@lfx-one/shared';
+import {
+  AVATAR_COLORS,
+  BAND_CHIP_CLASS,
+  BAND_SIGNAL_FILL,
+  BAND_SIGNAL_FILL_LIGHT,
+  DELTA_DIRECTION_TEXT_CLASS,
+  GRID_COLS_CLASS,
+  GRID_DIVIDER_CLASS,
+  lfxColors,
+  lfxFontSizes,
+  ORG_MEETINGS_KPI_ICON_CLASS,
+} from '@lfx-one/shared';
 import PrimeUI from 'tailwindcss-primeui';
 
 /** @type {import('tailwindcss').Config} */
@@ -16,6 +27,15 @@ export default {
     // Person-avatar palette: built at runtime by avatarColorClass() from AVATAR_COLORS in
     // @lfx-one/shared (outside `content`), so it would be purged. Spread the source list to avoid drift.
     ...AVATAR_COLORS,
+    // Stat card grid columns/dividers: `GRID_COLS_CLASS`/`GRID_DIVIDER_CLASS` are defined in
+    // @lfx-one/shared (outside `content`), and their responsive/arbitrary utilities need to be
+    // scanned directly since they never appear as literal strings inside `content`.
+    ...Object.values(GRID_COLS_CLASS).flatMap((classes) => classes.split(' ')),
+    ...Object.values(GRID_DIVIDER_CLASS).flatMap((classes) => classes.split(' ')),
+    // Org Lens meetings — KPI card icon tints and delta text colors (ORG_MEETINGS_KPI_ICON_CLASS /
+    // DELTA_DIRECTION_TEXT_CLASS in @lfx-one/shared, not scanned here)
+    ...Object.values(ORG_MEETINGS_KPI_ICON_CLASS).flatMap((classes) => classes.split(' ')),
+    ...Object.values(DELTA_DIRECTION_TEXT_CLASS),
     // Meeting summary modal — dynamic section border/icon colors (applied via [ngClass])
     'border-l-blue-400',
     'border-l-emerald-400',
@@ -27,17 +47,13 @@ export default {
     'text-amber-500',
     'text-purple-500',
     'text-gray-500',
-    // Org Lens projects — influence band signal-strength bars (classes defined in @lfx-one/shared, not scanned here)
-    'fill-emerald-500',
-    'fill-blue-500',
-    'fill-amber-500',
+    // Org Lens project bands — chip + signal-bar fill classes (BAND_CHIP_CLASS / BAND_SIGNAL_FILL /
+    // BAND_SIGNAL_FILL_LIGHT in @lfx-one/shared, not scanned here)
+    ...Object.values(BAND_CHIP_CLASS).flatMap((classes) => classes.split(' ')),
+    ...Object.values(BAND_SIGNAL_FILL),
+    ...Object.values(BAND_SIGNAL_FILL_LIGHT),
+    // Org Lens projects page — separate band signal-fill map with a red "silent" tier (org-lens-projects.constants.ts, not scanned here)
     'fill-red-500',
-    'fill-gray-400',
-    'fill-gray-200',
-    // Lighter tints for the unfilled signal bars
-    'fill-emerald-200',
-    'fill-blue-200',
-    'fill-amber-200',
     'fill-red-200',
     // Org Lens projects — influence trend text/badge colors (INFLUENCE_TREND_TEXT_CLASS / INFLUENCE_TREND_ARROW_BADGE_CLASS in @lfx-one/shared, not scanned here)
     'text-emerald-600',

--- a/packages/shared/src/constants/delta-direction.constants.ts
+++ b/packages/shared/src/constants/delta-direction.constants.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { StatCardDeltaDirection } from '../interfaces/stat-card.interface';
+
+/** Arrow icon per period-over-period delta direction, shared by stat cards and org-lens trend/influence rows. */
+export const DELTA_DIRECTION_ICON: Record<StatCardDeltaDirection, string> = {
+  up: 'fa-light fa-arrow-up',
+  down: 'fa-light fa-arrow-down',
+  flat: 'fa-light fa-minus',
+};
+
+/** Text color per period-over-period delta direction, shared by stat cards and org-lens trend/influence rows. */
+export const DELTA_DIRECTION_TEXT_CLASS: Record<StatCardDeltaDirection, string> = {
+  up: 'text-emerald-700',
+  down: 'text-red-600',
+  flat: 'text-gray-500',
+};

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -84,3 +84,6 @@ export * from './project-staff.constants';
 export * from './org-lens-project-detail.constants';
 export * from './create-artifact.constants';
 export * from './create-picker.constants';
+export * from './org-meetings-insights.constants';
+export * from './delta-direction.constants';
+export * from './stat-card-grid.constants';

--- a/packages/shared/src/constants/org-meetings-insights.constants.ts
+++ b/packages/shared/src/constants/org-meetings-insights.constants.ts
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Valid values for the Org Lens Meetings time-range dropdown, in display order. */
+export const ORG_MEETINGS_TIME_RANGES = [
+  'past90d',
+  'past180d',
+  'past365d',
+  'previousQuarter',
+  'previousYear',
+  'previous5y',
+  'previous10y',
+  'allTime',
+  'custom',
+] as const;
+
+/**
+ * The bounded windows the meetings-insights warehouse models are built for, and therefore the only
+ * values the BFF endpoints accept. `allTime` and `custom` remain in `ORG_MEETINGS_TIME_RANGES` for
+ * the dropdown's shape but are rejected with 400 rather than silently defaulted, so the dropdown
+ * disables them from this single source of truth.
+ */
+export const ORG_MEETINGS_SUPPORTED_TIME_RANGES = ['past90d', 'past180d', 'past365d', 'previousQuarter', 'previousYear', 'previous5y', 'previous10y'] as const;
+
+/** Window used when the `range` query parameter is omitted. */
+export const ORG_MEETINGS_DEFAULT_TIME_RANGE = 'past365d';
+
+/** Dropdown-row labels for each time range. */
+export const ORG_MEETINGS_TIME_RANGE_LABELS: Record<(typeof ORG_MEETINGS_TIME_RANGES)[number], string> = {
+  past90d: 'Past 90 days',
+  past180d: 'Past 180 days',
+  past365d: 'Past 365 days',
+  previousQuarter: 'Previous quarter',
+  previousYear: 'Previous year',
+  previous5y: 'Previous 5 years',
+  previous10y: 'Previous 10 years',
+  allTime: 'All time',
+  custom: 'Custom',
+};
+
+/** Groups of time ranges rendered as divider-separated sections in the dropdown, matching the insights.linuxfoundation.org time selector. */
+export const ORG_MEETINGS_TIME_RANGE_GROUPS: (typeof ORG_MEETINGS_TIME_RANGES)[number][][] = [
+  ['past90d', 'past180d', 'past365d'],
+  ['previousQuarter', 'previousYear', 'previous5y', 'previous10y'],
+  ['allTime'],
+  ['custom'],
+];
+
+/** Per-card icon-tile tint, matching the /events and /org/overview stat-strip convention (varied tints rather than a single uniform blue). */
+export const ORG_MEETINGS_KPI_ICON_CLASS = {
+  employeesActive: 'bg-blue-100 text-blue-600',
+  meetingsAttended: 'bg-emerald-100 text-emerald-600',
+  projectsSupported: 'bg-violet-100 text-violet-600',
+  foundationsSupported: 'bg-amber-100 text-amber-600',
+} as const;
+
+/**
+ * Visual amplification factor for the influence table's "attendance contribution" bar. Real
+ * `fromAttendancePct` values cluster well under 50%, so the raw percentage reads as nearly empty —
+ * this scales the fill width for legibility without affecting the displayed percentage text.
+ */
+export const ORG_MEETINGS_ATTENDANCE_BAR_SCALE = 2.2;
+
+/** Signal-bar geometry for the influence accordion's band chip icon, matching the Org Lens Project Detail band chip (PR #1028): four ascending bars, filled up to the band's rank and greyed beyond it. */
+export const ORG_INFLUENCE_SIGNAL_BAR_HEIGHTS = [5, 8.3, 11.6, 15];
+export const ORG_INFLUENCE_SIGNAL_BAR_WIDTH = 2.6;
+export const ORG_INFLUENCE_SIGNAL_BAR_GAP = 1.8;
+
+/** Breakdown measure label highlighted (as the section's subject) in the influence accordion's expanded detail row. */
+export const ORG_INFLUENCE_MEASURE_LABEL_MEETING_ATTENDANCE = 'Meeting Attendance';

--- a/packages/shared/src/constants/stat-card-grid.constants.ts
+++ b/packages/shared/src/constants/stat-card-grid.constants.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Tailwind grid-column classes for `lfx-stat-card-grid`, keyed by its `columns` input. */
+export const GRID_COLS_CLASS: Record<2 | 3 | 4, string> = {
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-2 lg:grid-cols-4',
+};
+
+/**
+ * Tailwind divider classes for `lfx-stat-card-grid`, keyed by its `columns` input.
+ * Columns 2 and 3 go straight from a single stacked column to a single row at `sm`, so
+ * `divide-y`/`divide-x` toggle cleanly at that breakpoint. Column 4 passes through a 2x2
+ * layout at `sm`/`md` before becoming a single row at `lg`: `nth-child(n+3)` adds the
+ * horizontal divider between rows, and `nth-child(even)` adds the vertical divider between
+ * the two cards within each row; both are cleared again at `lg`, where `divide-x` takes over
+ * for the single-row 4-column layout.
+ */
+export const GRID_DIVIDER_CLASS: Record<2 | 3 | 4, string> = {
+  2: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
+  3: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
+  // The `!` (important) modifiers are required: Tailwind's `divide-y-0` reset compiles to
+  // `:not([hidden]) ~ :not([hidden])`, whose specificity beats a plain `nth-child(...)` selector,
+  // so without `!` it silently cancels the row divider below regardless of source order. The
+  // `sm` left border is left in place (not reset) at `lg`: `lg:divide-x` needs that same left
+  // border on cards 2/4 for the single-row layout, and card 3 gets it from `divide-x` itself.
+  4: 'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x',
+};

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -270,3 +270,7 @@ export * from './entity-project-context.interface';
 // Create artifact quick-link interfaces (rail "Create" button + dialog)
 export * from './create-artifact.interface';
 export * from './create-picker.interface';
+
+// Org Lens Meetings insights (LFXV2-2735) interfaces
+export * from './org-meetings-insights.interface';
+export * from './org-meetings-insights.internal.interface';

--- a/packages/shared/src/interfaces/org-meetings-insights.interface.ts
+++ b/packages/shared/src/interfaces/org-meetings-insights.interface.ts
@@ -1,0 +1,119 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_MEETINGS_SUPPORTED_TIME_RANGES, ORG_MEETINGS_TIME_RANGES } from '../constants/org-meetings-insights.constants';
+
+import type { OrgLensProjectBand } from './org-lens-project-detail.interface';
+import type { StatCardDeltaDirection } from './stat-card.interface';
+
+/** Window over which Org Lens meeting-insights data is aggregated. */
+export type OrgMeetingsTimeRange = (typeof ORG_MEETINGS_TIME_RANGES)[number];
+
+/** The subset of `OrgMeetingsTimeRange` the BFF endpoints serve; the rest are rejected with 400. */
+export type OrgMeetingsSupportedTimeRange = (typeof ORG_MEETINGS_SUPPORTED_TIME_RANGES)[number];
+
+/** One selectable row in the `lfx-org-meetings-time-range` dropdown, with its computed date-range preview. */
+export interface OrgMeetingsTimeRangeOption {
+  value: OrgMeetingsTimeRange;
+  label: string;
+  /** e.g. "Apr 18, 2026 → Today" or "2021 → 2025"; omitted for options with no fixed preview (All time, Custom). */
+  rangeLabel: string | null;
+  /** Rendered but not selectable — the window exists in the union but has no data behind it. */
+  disabled?: boolean;
+}
+
+/** Direction of a period-over-period delta, drives arrow icon + color. Same domain as `StatCardDeltaDirection`. */
+export type OrgMeetingsDeltaDirection = StatCardDeltaDirection;
+
+/** One of the four org-level KPI totals shown at the top of the page. */
+export interface OrgMeetingsKpiSummary {
+  employeesActive: number;
+  employeesActiveDeltaLabel: string;
+  employeesActiveDeltaDirection: OrgMeetingsDeltaDirection;
+  meetingsAttended: number;
+  meetingsAttendedDeltaLabel: string;
+  meetingsAttendedDeltaDirection: OrgMeetingsDeltaDirection;
+  projectsSupported: number;
+  projectsSupportedDeltaLabel: string;
+  projectsSupportedDeltaDirection: OrgMeetingsDeltaDirection;
+  foundationsSupported: number;
+  foundationsSupportedDeltaLabel: string;
+  foundationsSupportedDeltaDirection: OrgMeetingsDeltaDirection;
+}
+
+/** One item folded into a spend-bar segment's trailing "others" bucket. */
+export interface OrgMeetingsSpendOtherItem {
+  label: string;
+  /** Omitted for the trailing "+N more" row, which counts unnamed entities and has no share of its own. */
+  pct?: number;
+}
+
+/** One ranked row of a "where time is spent" percentage-bar breakdown (each row its own full-width bar, per row `pct` — matches the `/meetings` attendance-bar pattern, not a single stacked composition). */
+export interface OrgMeetingsSpendSegment {
+  label: string;
+  pct: number;
+  count?: number;
+  /** Itemized contents of the bucket, shown on hover when this is the trailing "others" segment. */
+  others?: OrgMeetingsSpendOtherItem[];
+}
+
+/** An `OrgMeetingsSpendSegment` flagged as the trailing "others" bucket, for `lfx-org-spend-bar`. */
+export interface OrgSpendBarSegment extends OrgMeetingsSpendSegment {
+  isOther: boolean;
+}
+
+/** The four ranked percentage-bar breakdowns rendered by the "Where your people spend time" card. */
+export interface OrgMeetingsSpendBreakdown {
+  byFoundation: OrgMeetingsSpendSegment[];
+  byProject: OrgMeetingsSpendSegment[];
+  byMeetingType: OrgMeetingsSpendSegment[];
+  byRole: OrgMeetingsSpendSegment[];
+}
+
+/**
+ * One measure feeding a project's Ecosystem Influence Score, rendered as a segment of the breakdown
+ * bar. Labels/measures mirror the Org Lens Project Detail ecosystem-influence cards (PR #1028):
+ * Collaboration Activity, Meeting Attendance, Board Members, Committee Members, Event Attendance,
+ * Event Speakers, Event Sponsorships, Meetup Attendance, Certified Individuals.
+ */
+export interface OrgInfluenceBreakdownSegment {
+  label: string;
+  pct: number;
+}
+
+/** An `OrgInfluenceBreakdownSegment` flagged as the Meeting Attendance measure, for highlighting. */
+export interface OrgInfluenceBreakdownRow extends OrgInfluenceBreakdownSegment {
+  isAttendance: boolean;
+}
+
+/** One row of the "How attendance drives Ecosystem Influence" accordion. */
+export interface OrgInfluenceRow {
+  project: string;
+  projectSlug: string;
+  ecosystemInfluence: number;
+  /** Qualitative ecosystem-influence band shown (with signal-bar icon) in place of the raw score. */
+  band: OrgLensProjectBand;
+  rankLabel: string;
+  fromAttendancePct: number;
+  deltaLabel: string;
+  deltaDirection: OrgMeetingsDeltaDirection;
+  breakdown: OrgInfluenceBreakdownSegment[];
+}
+
+/** One bar of the band's signal-bar icon, positioned and filled per its rank. */
+export interface OrgInfluenceBandBar {
+  x: number;
+  y: number;
+  h: number;
+  fillClass: string;
+}
+
+/** An `OrgInfluenceRow` enriched with display-ready band chip/bar and highlighted breakdown, as rendered by the influence accordion. */
+export interface OrgInfluenceDisplayRow extends Omit<OrgInfluenceRow, 'breakdown'> {
+  bandChipClass: string;
+  bandLabel: string;
+  bandBars: OrgInfluenceBandBar[];
+  /** Emphasis-scaled, clamped fill width for the attendance bar, precomputed so the template stays declarative. */
+  attendanceBarWidth: number;
+  breakdown: OrgInfluenceBreakdownRow[];
+}

--- a/packages/shared/src/interfaces/org-meetings-insights.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-meetings-insights.internal.interface.ts
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Snowflake row shapes for the three `ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_MEETINGS_*` models —
+ * server-side only. These mirror warehouse columns, not the wire contract; the BFF maps them onto
+ * `OrgMeetingsKpiSummary` / `OrgMeetingsSpendBreakdown` / `OrgInfluenceRow`.
+ *
+ * None of these carries a person-identifying column: the models consume `person_key` inside
+ * `COUNT(DISTINCT …)` and never project it (FR-015).
+ */
+
+/** One row of `ORG_LENS_MEETINGS_KPI`, grain `(ACCOUNT_ID, TIME_RANGE_TYPE)`. */
+export interface OrgMeetingsKpiWarehouseRow {
+  EMPLOYEES_ACTIVE: number;
+  MEETINGS_ATTENDED: number;
+  PROJECTS_SUPPORTED: number;
+  FOUNDATIONS_SUPPORTED: number;
+  PRIOR_EMPLOYEES_ACTIVE: number;
+  PRIOR_MEETINGS_ATTENDED: number;
+  PRIOR_PROJECTS_SUPPORTED: number;
+  PRIOR_FOUNDATIONS_SUPPORTED: number;
+}
+
+/** One row of `ORG_LENS_MEETINGS_SPEND`, grain `(ACCOUNT_ID, TIME_RANGE_TYPE, BREAKDOWN_KIND, LABEL)`. */
+export interface OrgMeetingsSpendWarehouseRow {
+  BREAKDOWN_KIND: string;
+  LABEL: string;
+  ATTENDANCE_COUNT: number;
+  PCT: number;
+  RANK: number;
+  IS_OTHER: boolean;
+  /** `{label, pct}` objects — in-universe entities only, capped at 20. Null unless `IS_OTHER`. */
+  OTHER_ITEMS: unknown;
+  /** In-universe entities beyond the 20 itemized, rendered as the trailing "+N more" row. */
+  OTHER_OVERFLOW_COUNT: number | null;
+}
+
+/** One row of `ORG_LENS_MEETINGS_INFLUENCE`, grain `(ACCOUNT_ID, PROJECT_SLUG)` — range-independent. */
+export interface OrgMeetingsInfluenceWarehouseRow {
+  PROJECT_SLUG: string;
+  PROJECT_NAME: string;
+  ECOSYSTEM_INFLUENCE: number;
+  BAND: string;
+  RANK: number;
+  RANK_TOTAL: number;
+  FROM_ATTENDANCE_PCT: number;
+  DELTA_PCT: number;
+  /** Zero-baseline detector for the "New" delta rule; `TREND_DIRECTION` cannot identify it. */
+  PRIOR_YEAR_SCORE: number;
+  TREND_DIRECTION: string;
+  /** The nine displayed `{label, pct}` categories, renormalized to 100% and sorted descending. */
+  BREAKDOWN: unknown;
+}

--- a/packages/shared/src/interfaces/stat-card.interface.ts
+++ b/packages/shared/src/interfaces/stat-card.interface.ts
@@ -1,6 +1,16 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+/** Direction of a period-over-period delta on a stat card, drives arrow icon + color. */
+export type StatCardDeltaDirection = 'up' | 'down' | 'flat';
+
+/** Optional period-over-period delta rendered below a stat card's value. */
+export interface StatCardDelta {
+  /** Text rendered next to the delta arrow (e.g., "+8% vs. prior period"). */
+  label: string;
+  direction: StatCardDeltaDirection;
+}
+
 /**
  * A single cell in an `lfx-stat-card-grid`.
  * @description Shared shape used by dashboards that surface a row of summary
@@ -17,4 +27,6 @@ export interface StatCardItem {
   icon: string;
   /** Tailwind class string applied to the icon's rounded container (bg + text color). */
   iconContainerClass: string;
+  /** Optional period-over-period delta (e.g., "+8% vs. prior period"). */
+  delta?: StatCardDelta;
 }

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -519,3 +519,8 @@ export function formatRelativeTime(date: Date): string {
   const diffDay = Math.floor(diffMs / 86_400_000);
   return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
 }
+
+/** Short date label for range previews, e.g. "Apr 18, 2026". */
+export function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -42,3 +42,4 @@ export * from './lens.utils';
 export * from './crowdfunding.utils';
 export * from './persona.utils';
 export * from './metric-trend.utils';
+export * from './org-meetings-insights.utils';

--- a/packages/shared/src/utils/org-meetings-insights.utils.ts
+++ b/packages/shared/src/utils/org-meetings-insights.utils.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_MEETINGS_SUPPORTED_TIME_RANGES } from '../constants/org-meetings-insights.constants';
+import type { OrgMeetingsSupportedTimeRange, OrgMeetingsTimeRange } from '../interfaces/org-meetings-insights.interface';
+
+/**
+ * Narrows a dropdown time range to one the meetings endpoints actually serve.
+ *
+ * Shared so the dropdown's disabled set and the range passed to the endpoints are decided by the
+ * same rule; the two drifting apart would let a user pick a window that then 400s.
+ */
+export function isSupportedOrgMeetingsTimeRange(range: OrgMeetingsTimeRange): range is OrgMeetingsSupportedTimeRange {
+  return (ORG_MEETINGS_SUPPORTED_TIME_RANGES as readonly OrgMeetingsTimeRange[]).includes(range);
+}

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -11,6 +11,19 @@ export function isUuid(value: string): boolean {
 }
 
 /**
+ * Converts arbitrary label text into a kebab-case, testid-safe slug (lowercase,
+ * alphanumerics only, words joined by single hyphens).
+ * @param text - The label text to slugify
+ * @returns A kebab-case slug, e.g. "Meetings Attended" -> "meetings-attended"
+ */
+export function slugify(text: string): string {
+  const slug = text.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const start = slug.startsWith('-') ? 1 : 0;
+  const end = slug.endsWith('-') ? slug.length - 1 : slug.length;
+  return slug.slice(start, end);
+}
+
+/**
  * Wraps a text string into multiple lines, breaking on word boundaries.
  * Used to produce multi-line Chart.js axis labels (which accept `string[]`).
  * @param text - The label text to wrap


### PR DESCRIPTION
Rebuilds the Org Lens Meetings page on real analytics. Supersedes #1137, which held the UI components against demo constants; this PR adds the data layer behind them and wires them up.

## What's here

**Three read-only endpoints** under `/api/orgs/:orgUid/lens/meetings/{kpi,spend,influence}`, reading the `ANALYTICS.PLATINUM_LFX_ONE.ORG_LENS_MEETINGS_{KPI,SPEND,INFLUENCE}` models (shipped separately in `lf-dbt` #2673). All three responses are functions of the org and window alone, so each is served through the plain org-scoped Valkey cache with no per-caller key.

**The UI**, previously demo-only, now renders live data with per-section loading, empty and error states.

## Privacy

This page was retired to a placeholder under ADR-0038 because the legacy implementation served per-invitee PII from the analytics lane without an operational-plane check. Everything here is organization-level aggregate — no payload can carry a person identifier, attendee, meeting title or meeting id. The mapper structurally rejects anything that isn't `{label, pct}`, so a roster can't survive it even if the warehouse changed shape.

**These endpoints carry an org-membership read gate, which no sibling Org Lens route has.** Authentication alone doesn't establish that a caller may read a given org's aggregates, so `assertOrgLensRead` resolves the caller's grant before any cache or Snowflake access. It separates a verified-absent grant (403) from one that could not be verified (503) — a transient query-service outage answering 403 would tell users they'd lost access they still hold. Both directions fail closed.

Note: `OrgLensAccessService.assertCanManage`, the pattern this mirrors, has an effectively dead catch block — `getAccessAwareOrgs` returns `upstreamFailed: true` rather than throwing, so the existing write gate answers **403** during an outage. This helper checks the flag explicitly. Worth back-porting separately.

## Judgement calls worth a look

- **Delta degeneracies.** A zero prior period renders "New"; a prior period too thin to be a baseline renders "No comparable prior period" rather than a five-figure percentage. Only ~3.5 years of attendance history exist, so the longest windows compare against a nearly-empty prior period — Red Hat's default view read **+115000%** before this rule. The ceiling is on the computed ratio, not on the prior count: a floor would relabel ~3,090 rows to fix ~87 and would still miss priors of 3 and 6. Recorded as DR-019.
- **Unsupported ranges rejected, not defaulted.** `allTime` and `custom` return 400; the dropdown marks them unavailable from the same shared constant. Answering an `allTime` request with 365-day data would render a plausible number for a window nobody asked for.
- **The influence delta reads its zero baseline from `prior_year_score`**, not `trend_direction` — the latter's `flat` is a ±1% deadband, so zero-baseline rows split across `flat` and `up` (DR-015).
- **The employee leaderboard is not included.** It's a per-person surface with no backend, and its placeholder data was a roster of invented names and email addresses, which sits badly beside the privacy argument above. It ships once it has a real data source and its own privacy review.

## Verification

Verified live against dev with prod analytics. Counts reconcile exactly with independent warehouse queries (Red Hat 167/1151/77/35; The Linux Foundation 323/9097/189/82), spend percentages match and sum to 100, and the nine-category influence breakdown sums to 100 with `fromAttendancePct` equal to its Meeting Attendance entry.

Authorization matrix, live:

| Case | Result |
|---|---|
| Direct writer | 200 |
| Cascading-parent auditor | 200 |
| No grant (all three endpoints) | **403, no data** |
| Grant unverifiable (gateway unreachable) | **503 `ROLE_GRANTS_UNAVAILABLE`** |
| `allTime` / `custom` / malformed org id | 400 |

Small-org suppression confirmed on a real org: the meeting-type and role cards are hidden when the warehouse withholds those distributions.

## Notes for reviewers

- **`yarn e2e` has not been run** — it needs `TEST_USERNAME`/`TEST_PASSWORD`, so CI is the first execution of the rewritten assertions. `lint:check`, `check-types`, `format:check` and `build` all pass locally.
- **The diff is ~2,300 lines**, over the 1,000-line guideline. It's one page plus its data layer; the `stat-card-grid` widening (~90 lines) could be split out if you'd prefer.
- **The frontend service deliberately has no `catchError`.** The checklist asks for one on GETs, but the three components need the failure to propagate to render their distinct error states, and doubling up would make one of them dead code.
- **Known cosmetic issue, left deliberately:** when an org's "others" spend bucket contains only out-of-universe entities, nothing can be named, and the bucket renders with named-segment styling instead of the muted "other" treatment. Fixing it properly means adding `isOther` to the frozen contract.
- This branch temporarily carries @andrestobon's `[LFXV2-2812]` build fix so CI can go green; it drops out once that lands on main.

Made with [Cursor](https://cursor.com)

[LFXV2-2812]: https://linuxfoundation.atlassian.net/browse/LFXV2-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ