### PR TITLE
fix(committees): skip FGA pre-check for LFID invite accept flow

### DIFF
--- a/apps/lfx-one/src/app/modules/invite/invite.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite.component.ts
@@ -76,6 +76,7 @@ export class InviteComponent implements OnInit {
         committeeName: invite.committee_name,
         organization: invite.organization,
         organization_required: true,
+        fromLfidInvite: true,
       })
       .pipe(take(1))
       .subscribe({

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -441,25 +441,6 @@ export class NewsletterManageComponent {
     });
   }
 
-  /** The still-missing requirements that block a draft save, for user feedback. */
-  private missingDraftRequirements(): string[] {
-    const missing: string[] = [];
-    if (!this.audienceFilled()) missing.push('an audience');
-    if (!this.subjectFilled()) missing.push('a subject');
-    // bodyPersistable, matching canSaveDraft: an emptied block layout is
-    // saveable, so the warning must not claim content is missing when only
-    // another field (e.g. audience) is.
-    if (!this.bodyPersistable()) missing.push('some newsletter content');
-    if (this.edEmail().length === 0) missing.push('a reply-to email');
-    return missing;
-  }
-
-  /** Join a list into readable prose: "a", "a and b", or "a, b, and c". */
-  private formatMissing(items: string[]): string {
-    if (items.length === 1) return items[0];
-    return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
-  }
-
   private goToList(tab?: 'draft' | 'sent'): void {
     this.router.navigate(['list'], {
       relativeTo: this.route.parent,

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -57,7 +57,10 @@ export class InvitationAcceptFlowService {
         if (!result?.organization) {
           return EMPTY;
         }
-        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, { organization: result.organization, fromLfidInvite: context.fromLfidInvite });
+        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, {
+          organization: result.organization,
+          fromLfidInvite: context.fromLfidInvite,
+        });
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -37,7 +37,7 @@ export class InvitationAcceptFlowService {
     const requiresOrganization = invitationRequiresOrganization(context);
 
     if (!requiresOrganization) {
-      return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, undefined, context.fromLfidInvite);
+      return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, { fromLfidInvite: context.fromLfidInvite });
     }
 
     // Resolve the pre-fill org: use the invite's org when present, otherwise fall back to
@@ -57,7 +57,7 @@ export class InvitationAcceptFlowService {
         if (!result?.organization) {
           return EMPTY;
         }
-        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization, context.fromLfidInvite);
+        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, { organization: result.organization, fromLfidInvite: context.fromLfidInvite });
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -52,16 +52,19 @@ export class InvitationAcceptFlowService {
 
     return contextReady$.pipe(
       switchMap((ctx) => this.preResolveOrganization(ctx)),
-      switchMap((ctx) => from(this.openOrganizationDialog(ctx))),
-      switchMap((result) => {
-        if (!result?.organization) {
-          return EMPTY;
-        }
-        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, {
-          organization: result.organization,
-          fromLfidInvite: context.fromLfidInvite,
-        });
-      })
+      switchMap((ctx) =>
+        from(this.openOrganizationDialog(ctx)).pipe(
+          switchMap((result) => {
+            if (!result?.organization) {
+              return EMPTY;
+            }
+            return this.invitationService.acceptInvitation(ctx.committeeUid, ctx.inviteUid, {
+              organization: result.organization,
+              fromLfidInvite: ctx.fromLfidInvite,
+            });
+          })
+        )
+      )
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -37,7 +37,7 @@ export class InvitationAcceptFlowService {
     const requiresOrganization = invitationRequiresOrganization(context);
 
     if (!requiresOrganization) {
-      return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid);
+      return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, undefined, context.fromLfidInvite);
     }
 
     // Resolve the pre-fill org: use the invite's org when present, otherwise fall back to
@@ -57,7 +57,7 @@ export class InvitationAcceptFlowService {
         if (!result?.organization) {
           return EMPTY;
         }
-        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization);
+        return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, result.organization, context.fromLfidInvite);
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { PendingInvitation, AcceptCommitteeInviteRequest, CommitteeOrganizationReference } from '@lfx-one/shared/interfaces';
+import { PendingInvitation, AcceptCommitteeInviteRequest, AcceptInvitationOptions } from '@lfx-one/shared/interfaces';
 import { catchError, finalize, Observable, of, shareReplay, tap } from 'rxjs';
 
 /**
@@ -69,13 +69,9 @@ export class InvitationService {
   }
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
-  public acceptInvitation(
-    committeeUid: string,
-    inviteUid: string,
-    options?: { organization?: CommitteeOrganizationReference; fromLfidInvite?: boolean }
-  ): Observable<void> {
+  public acceptInvitation(committeeUid: string, inviteUid: string, options?: AcceptInvitationOptions): Observable<void> {
     const body: AcceptCommitteeInviteRequest = options?.organization ? { organization: options.organization } : {};
-    if (options?.fromLfidInvite) {
+    if (options?.fromLfidInvite === true) {
       body.from_lfid_invite = true;
     }
     return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, body);

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -69,9 +69,9 @@ export class InvitationService {
   }
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
-  public acceptInvitation(committeeUid: string, inviteUid: string, organization?: CommitteeOrganizationReference, fromLfidInvite?: boolean): Observable<void> {
-    const body: AcceptCommitteeInviteRequest = organization ? { organization } : {};
-    if (fromLfidInvite) {
+  public acceptInvitation(committeeUid: string, inviteUid: string, options?: { organization?: CommitteeOrganizationReference; fromLfidInvite?: boolean }): Observable<void> {
+    const body: AcceptCommitteeInviteRequest = options?.organization ? { organization: options.organization } : {};
+    if (options?.fromLfidInvite) {
       body.from_lfid_invite = true;
     }
     return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, body);

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -69,7 +69,11 @@ export class InvitationService {
   }
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
-  public acceptInvitation(committeeUid: string, inviteUid: string, options?: { organization?: CommitteeOrganizationReference; fromLfidInvite?: boolean }): Observable<void> {
+  public acceptInvitation(
+    committeeUid: string,
+    inviteUid: string,
+    options?: { organization?: CommitteeOrganizationReference; fromLfidInvite?: boolean }
+  ): Observable<void> {
     const body: AcceptCommitteeInviteRequest = options?.organization ? { organization: options.organization } : {};
     if (options?.fromLfidInvite) {
       body.from_lfid_invite = true;

--- a/apps/lfx-one/src/app/shared/services/invitation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation.service.ts
@@ -69,8 +69,11 @@ export class InvitationService {
   }
 
   /** Accepts an invitation. Upstream is invitee-authenticated; returns 204. */
-  public acceptInvitation(committeeUid: string, inviteUid: string, organization?: CommitteeOrganizationReference): Observable<void> {
+  public acceptInvitation(committeeUid: string, inviteUid: string, organization?: CommitteeOrganizationReference, fromLfidInvite?: boolean): Observable<void> {
     const body: AcceptCommitteeInviteRequest = organization ? { organization } : {};
+    if (fromLfidInvite) {
+      body.from_lfid_invite = true;
+    }
     return this.http.post<void>(`/api/committees/${encodeURIComponent(committeeUid)}/invites/${encodeURIComponent(inviteUid)}/accept`, body);
   }
 

--- a/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
@@ -1,0 +1,145 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const COMMITTEE_ID = 'a0000000-0000-0000-0000-000000000001';
+const INVITE_ID = 'b0000000-0000-0000-0000-000000000002';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { getEffectiveEmailMock, committeeSvc } = vi.hoisted(() => ({
+  getEffectiveEmailMock: vi.fn(() => 'user@example.com'),
+  committeeSvc: {
+    getPendingInviteForUser: vi.fn(),
+    acceptCommitteeInvite: vi.fn(),
+    // Stub remaining methods so the constructor doesn't fail.
+    getCommittees: vi.fn(),
+    getCommitteeById: vi.fn(),
+    getCommitteeSettings: vi.fn(),
+    getPendingCommitteeInvites: vi.fn(),
+    acceptPendingCommitteeInvitesAfterLfidAccept: vi.fn(),
+  },
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
+vi.mock('@lfx-one/shared/constants', () => ({ ALLOWED_FILE_TYPES: [] }));
+vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: {} }));
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('@lfx-one/shared/utils', () => ({ isFileTypeAllowed: vi.fn(() => true) }));
+
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock }));
+vi.mock('../services/committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return committeeSvc;
+  }),
+}));
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+vi.mock('../helpers/content-disposition.helper', () => ({ contentDispositionAttachment: vi.fn() }));
+vi.mock('../helpers/ics.helper', () => ({
+  buildVCalendar: vi.fn(),
+  fetchAllMeetingPages: vi.fn(),
+  meetingsToVEvents: vi.fn(),
+}));
+vi.mock('../helpers/validation.helper', () => ({ getStringQueryParam: vi.fn() }));
+
+import { CommitteeController } from './committee.controller';
+
+function buildReq(body: Record<string, unknown> = {}): any {
+  return { params: { id: COMMITTEE_ID, inviteId: INVITE_ID }, body, path: '/test', log: {} };
+}
+
+function buildRes(): any {
+  return { status: vi.fn().mockReturnThis(), send: vi.fn() };
+}
+
+describe('CommitteeController.acceptCommitteeInvite — from_lfid_invite flag', () => {
+  let controller: CommitteeController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new CommitteeController();
+    committeeSvc.acceptCommitteeInvite.mockResolvedValue(undefined);
+  });
+
+  describe('LFID invite path (from_lfid_invite === true)', () => {
+    it('skips getPendingInviteForUser and forwards directly to acceptCommitteeInvite', async () => {
+      const res = buildRes();
+      const next = vi.fn();
+
+      await controller.acceptCommitteeInvite(buildReq({ from_lfid_invite: true }), res, next);
+
+      expect(committeeSvc.getPendingInviteForUser).not.toHaveBeenCalled();
+      expect(committeeSvc.acceptCommitteeInvite).toHaveBeenCalledOnce();
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('propagates upstream errors via next — committee-service is the real security gate', async () => {
+      // A malicious client sending from_lfid_invite: true on an invalid invite still receives
+      // a rejection from the committee-service, which is authoritative for invite existence.
+      const upstreamError = new Error('upstream: invite not found');
+      committeeSvc.acceptCommitteeInvite.mockRejectedValue(upstreamError);
+      const next = vi.fn();
+
+      await controller.acceptCommitteeInvite(buildReq({ from_lfid_invite: true }), buildRes(), next);
+
+      expect(committeeSvc.getPendingInviteForUser).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(upstreamError);
+    });
+
+    it('treats non-boolean truthy values as the standard path (strict === true check)', async () => {
+      committeeSvc.getPendingInviteForUser.mockResolvedValue({ organization_required: false });
+
+      await controller.acceptCommitteeInvite(buildReq({ from_lfid_invite: 'true' as any }), buildRes(), vi.fn());
+
+      // A string 'true' must not bypass the pre-check — only the literal boolean true does.
+      expect(committeeSvc.getPendingInviteForUser).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('standard path (from_lfid_invite absent or false)', () => {
+    it('calls getPendingInviteForUser before forwarding to acceptCommitteeInvite', async () => {
+      committeeSvc.getPendingInviteForUser.mockResolvedValue({ organization_required: false });
+      const res = buildRes();
+      const next = vi.fn();
+
+      await controller.acceptCommitteeInvite(buildReq({}), res, next);
+
+      expect(committeeSvc.getPendingInviteForUser).toHaveBeenCalledOnce();
+      expect(committeeSvc.acceptCommitteeInvite).toHaveBeenCalledOnce();
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with 400 when no matching pending invite is found', async () => {
+      committeeSvc.getPendingInviteForUser.mockResolvedValue(null);
+      const next = vi.fn();
+
+      await controller.acceptCommitteeInvite(buildReq({}), buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          validationErrors: expect.arrayContaining([
+            expect.objectContaining({ field: 'inviteId', message: expect.stringContaining('No matching pending invite') }),
+          ]),
+        })
+      );
+      expect(committeeSvc.acceptCommitteeInvite).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -727,8 +727,12 @@ export class CommitteeController {
 
       // Skip the FGA-gated pending-invite lookup when the accept originates from the LFID invite
       // flow — the invite UID was already known from the JWT, but the FGA invitee tuple may not
-      // have propagated yet. The committee-service is authoritative for invite existence and org
-      // requirements in all cases (LFXV2-2453).
+      // have propagated yet. The committee-service is authoritative for invite existence, invitee
+      // identity, and org requirements regardless of this flag: an unauthorized accept (wrong
+      // invitee, nonexistent invite, missing org) is still rejected upstream. The BFF pre-check
+      // below is a defense-in-depth optimization for non-LFID paths, not the primary security
+      // gate. Only the literal boolean true enables this path — truthy strings or objects fall
+      // through to the standard check (LFXV2-2453).
       if (body.from_lfid_invite !== true) {
         // Determine org-required using the invite's own organization_required field — accessible
         // to the invitee via the email-scoped query index regardless of committee-viewer status.
@@ -756,9 +760,9 @@ export class CommitteeController {
           return;
         }
 
-        // Only enforce org as required when organization_required is explicitly true. When it is
-        // null/undefined (invite pre-dates committee-service v1.1), skip the mandatory check and
-        // let the upstream accept endpoint be authoritative.
+        // BFF-side optimization only — committee-service independently enforces org requirements
+        // and is the authoritative security boundary. Only enforce early when organization_required
+        // is explicitly true; null/undefined (pre-v1.1 invites) defers to upstream.
         if (pendingInvite.organization_required === true && !hasOrg) {
           next(
             ServiceValidationError.forField('organization.name', 'Organization is required for this group', {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -715,34 +715,6 @@ export class CommitteeController {
         return;
       }
 
-      // Determine org-required using the invite's own organization_required field — accessible
-      // to the invitee via the email-scoped query index regardless of committee-viewer status.
-      // This replaces the previous getCommitteeById + getCommitteeSettings fetch which failed
-      // the access check for invitees who are not yet committee viewers (LFXV2-2453).
-      const userEmail = getEffectiveEmail(req);
-      if (!userEmail) {
-        next(
-          ServiceValidationError.forField('email', 'User email not found in authentication context', {
-            operation: 'accept_committee_invite',
-            service: 'committee_controller',
-            path: req.path,
-          })
-        );
-        return;
-      }
-
-      const pendingInvite = await this.committeeService.getPendingInviteForUser(req, userEmail, id, inviteId);
-      if (!pendingInvite) {
-        next(
-          ServiceValidationError.forField('inviteId', 'No matching pending invite found for this user', {
-            operation: 'accept_committee_invite',
-            service: 'committee_controller',
-            path: req.path,
-          })
-        );
-        return;
-      }
-
       // Build an explicit allowlist payload — never forward unknown client-supplied fields upstream.
       const acceptData: AcceptCommitteeInviteRequest = {};
 
@@ -753,18 +725,50 @@ export class CommitteeController {
       // Upstream accepts "organization id OR (organization name + domain)" — treat either as present.
       const hasOrg = !!(orgName || orgId);
 
-      // Only enforce org as required when organization_required is explicitly true. When it is
-      // null/undefined (invite pre-dates committee-service v1.1), skip the mandatory check and
-      // let the upstream accept endpoint be authoritative.
-      if (pendingInvite.organization_required === true && !hasOrg) {
-        next(
-          ServiceValidationError.forField('organization.name', 'Organization is required for this group', {
-            operation: 'accept_committee_invite',
-            service: 'committee_controller',
-            path: req.path,
-          })
-        );
-        return;
+      // Skip the FGA-gated pending-invite lookup when the accept originates from the LFID invite
+      // flow — the invite UID was already known from the JWT, but the FGA invitee tuple may not
+      // have propagated yet. The committee-service is authoritative for invite existence and org
+      // requirements in all cases (LFXV2-2453).
+      if (!body.from_lfid_invite) {
+        // Determine org-required using the invite's own organization_required field — accessible
+        // to the invitee via the email-scoped query index regardless of committee-viewer status.
+        const userEmail = getEffectiveEmail(req);
+        if (!userEmail) {
+          next(
+            ServiceValidationError.forField('email', 'User email not found in authentication context', {
+              operation: 'accept_committee_invite',
+              service: 'committee_controller',
+              path: req.path,
+            })
+          );
+          return;
+        }
+
+        const pendingInvite = await this.committeeService.getPendingInviteForUser(req, userEmail, id, inviteId);
+        if (!pendingInvite) {
+          next(
+            ServiceValidationError.forField('inviteId', 'No matching pending invite found for this user', {
+              operation: 'accept_committee_invite',
+              service: 'committee_controller',
+              path: req.path,
+            })
+          );
+          return;
+        }
+
+        // Only enforce org as required when organization_required is explicitly true. When it is
+        // null/undefined (invite pre-dates committee-service v1.1), skip the mandatory check and
+        // let the upstream accept endpoint be authoritative.
+        if (pendingInvite.organization_required === true && !hasOrg) {
+          next(
+            ServiceValidationError.forField('organization.name', 'Organization is required for this group', {
+              operation: 'accept_committee_invite',
+              service: 'committee_controller',
+              path: req.path,
+            })
+          );
+          return;
+        }
       }
 
       // Always forward the organization when the user supplied one — the upstream committee-service

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -729,7 +729,7 @@ export class CommitteeController {
       // flow — the invite UID was already known from the JWT, but the FGA invitee tuple may not
       // have propagated yet. The committee-service is authoritative for invite existence and org
       // requirements in all cases (LFXV2-2453).
-      if (!body.from_lfid_invite) {
+      if (body.from_lfid_invite !== true) {
         // Determine org-required using the invite's own organization_required field — accessible
         // to the invitee via the email-scoped query index regardless of committee-viewer status.
         const userEmail = getEffectiveEmail(req);

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -227,6 +227,14 @@ export interface AcceptInviteOrganizationDialogResult {
   organization: CommitteeOrganizationReference;
 }
 
+/** Options passed to InvitationService.acceptInvitation on the client side. */
+export interface AcceptInvitationOptions {
+  /** Organization the invitee confirms on acceptance. */
+  organization?: CommitteeOrganizationReference;
+  /** True when the accept originates from the LFID invite flow — see {@link AcceptCommitteeInviteRequest.from_lfid_invite}. */
+  fromLfidInvite?: boolean;
+}
+
 /** Context needed to accept a committee invitation from any surface. */
 export interface InvitationAcceptContext {
   committeeUid: string;

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -196,9 +196,15 @@ export interface AcceptCommitteeInviteRequest {
   /** Organization the invitee confirms on acceptance */
   organization?: CommitteeOrganizationReference | null;
   /**
+   * BFF-only signal — consumed by the BFF and never forwarded to the committee-service upstream.
+   *
    * Set to true when the accept originates from the LFID invite flow where the invite UID was
-   * already known from the JWT — signals the BFF to skip the FGA-gated pending-invite pre-check,
-   * which may race against async FGA tuple propagation.
+   * already known from the JWT, signalling the BFF to skip the FGA-gated pending-invite pre-check
+   * (which races against async FGA tuple propagation). Only the literal boolean true enables the
+   * skip; any other truthy value falls through to the standard check.
+   *
+   * The committee-service remains the authoritative security boundary for invite existence,
+   * invitee identity, and org requirements regardless of this flag.
    */
   from_lfid_invite?: boolean;
 }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -195,6 +195,12 @@ export interface CreateCommitteeInviteRequest {
 export interface AcceptCommitteeInviteRequest {
   /** Organization the invitee confirms on acceptance */
   organization?: CommitteeOrganizationReference | null;
+  /**
+   * Set to true when the accept originates from the LFID invite flow where the invite UID was
+   * already known from the JWT — signals the BFF to skip the FGA-gated pending-invite pre-check,
+   * which may race against async FGA tuple propagation.
+   */
+  from_lfid_invite?: boolean;
 }
 
 /** Raw organization form values shared by invite-create and invite-accept dialogs. */
@@ -225,6 +231,8 @@ export interface InvitationAcceptContext {
   enable_voting?: boolean;
   business_email_required?: boolean;
   inviteRequiresOrganization?: boolean;
+  /** True when the context was constructed from an LFID invite JWT — skips the FGA-gated BFF pre-check. */
+  fromLfidInvite?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- The BFF's `acceptCommitteeInvite` handler called `getPendingInviteForUser` unconditionally before forwarding to the committee-service. This is a FGA-gated query-service lookup that races against async invitee tuple propagation.
- In the LFID invite flow the tuple is published by NATS after LFID accept and may not have propagated by the time the user submits the org dialog, causing a 400 before the committee-service is ever reached.
- Added a `from_lfid_invite` flag to `AcceptCommitteeInviteRequest`. When set, the BFF skips `getPendingInviteForUser` and forwards directly to the committee-service, which is authoritative for all invite validation. All other call paths (My Groups, etc.) retain the full pre-check unchanged.

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

## Test plan

- [ ] Accept an LFID committee invite for a committee with org required — org dialog appears, fill in org, click Join Group — confirm 204 and redirect to return URL
- [ ] Accept a committee invite from My Groups — confirm the existing `getPendingInviteForUser` pre-check still runs (no regression)
- [ ] Send `POST /api/committees/{id}/invites/{inviteId}/accept` without `from_lfid_invite` and with an email that has no FGA tuple — confirm 400 "No matching pending invite found" is still returned

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ