### PR TITLE
fix(profile): add support link to already-claimed identity error

### DIFF
--- a/apps/lfx-one/e2e/profile-identities-support-link.spec.ts
+++ b/apps/lfx-one/e2e/profile-identities-support-link.spec.ts
@@ -148,7 +148,10 @@ test.describe('Identity dialogs — already-claimed support link', () => {
     });
 
     test('hides the support link for an unrelated error', async ({ page }) => {
-      await mockSendCode(page, 400, UNRELATED_ERROR_MESSAGE);
+      // Same 409 status as the positive case — only the message differs. This isolates the
+      // message as the discriminator: a status-based implementation (show for any 409) would
+      // wrongly pass here, so keeping the status constant proves message-based gating.
+      await mockSendCode(page, 409, UNRELATED_ERROR_MESSAGE);
       await openEmailConnectStep(page);
       await page.getByTestId('add-account-send-code').locator('button').click();
 
@@ -179,7 +182,10 @@ test.describe('Identity dialogs — already-claimed support link', () => {
     });
 
     test('hides the support link for an unrelated error', async ({ page }) => {
-      await mockSendCode(page, 400, UNRELATED_ERROR_MESSAGE);
+      // Same 409 status as the positive case — only the message differs. This isolates the
+      // message as the discriminator: a status-based implementation (show for any 409) would
+      // wrongly pass here, so keeping the status constant proves message-based gating.
+      await mockSendCode(page, 409, UNRELATED_ERROR_MESSAGE);
       await openVerifyEmailDialog(page);
       await page.getByTestId('verify-send-code').locator('button').click();
 

--- a/apps/lfx-one/e2e/profile-identities-support-link.spec.ts
+++ b/apps/lfx-one/e2e/profile-identities-support-link.spec.ts
@@ -1,0 +1,192 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Profile identity dialogs — "contact support" link on already-claimed errors (LFXV2-2858).
+ *
+ * When adding or verifying an email identity that is already claimed by another LFID
+ * account, the add-account and verify-identity dialogs surface a "contact support"
+ * action beside the red error. The link is gated on the error *message* (via the shared
+ * isIdentityAlreadyLinkedError util, the same marker set the backend uses), NOT on the
+ * HTTP status — so these tests drive the send-code error path and vary only the message:
+ *   - already-linked message  → support link appears
+ *   - any other error message  → support link is absent
+ *
+ * Both the identity list and the email verification endpoint are mocked, so the spec is
+ * self-contained and does not depend on a seeded backend test user (unlike the sibling
+ * profile-identities-verify spec, which reads live data).
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+// Mirrors EMAIL_ALREADY_LINKED_MESSAGE in @lfx-one/shared/constants. Inlined rather than
+// imported because the shared constants barrel transitively pulls Angular runtime code,
+// which the Playwright Node test loader can't compile. The only invariant this spec relies
+// on is that the message contains an already-linked marker (matched by isIdentityAlreadyLinkedError).
+const EMAIL_ALREADY_LINKED_MESSAGE = 'This email is already linked to another account';
+
+const IDENTITIES_ROUTE = '**/api/profile/identities';
+const SEND_CODE_ROUTE = '**/api/profile/identities/email/send-code';
+const UNRELATED_ERROR_MESSAGE = 'Invalid or expired verification code. Please try again.';
+const SUPPORT_BUTTON = { name: 'contact support' } as const;
+
+// The unverified email identity the mocked list exposes; drives the verify dialog's
+// verify-btn-<id> and OTP flow.
+const UNVERIFIED_EMAIL_ID = 'idf-email-unverified';
+
+// Deterministic identities payload so the page renders without depending on a seeded
+// backend test user (the sibling profile-identities-verify spec relies on live data and
+// can't run outside that environment — this spec mocks it to stay self-contained).
+async function mockIdentities(page: Page): Promise<void> {
+  await page.route(IDENTITIES_ROUTE, (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: UNVERIFIED_EMAIL_ID,
+          platform: 'email',
+          type: 'email',
+          value: 'jdoe@company.org',
+          verified: false,
+          verifiedBy: null,
+          source: 'e2e',
+          icon: 'fa-light fa-envelope',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          displayState: 'unverified',
+          inAuth0: false,
+        },
+      ]),
+    });
+  });
+}
+
+// Neutralize the Osano consent overlay, which otherwise intercepts pointer events on the
+// dialog's provider buttons. Registered via addInitScript so it applies on every navigation
+// before page scripts (mirrors profile-edit-drawer / me-profile-nav specs).
+async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const hide = (): void => {
+      if (document.getElementById('e2e-hide-osano')) {
+        return;
+      }
+      const style = document.createElement('style');
+      style.id = 'e2e-hide-osano';
+      style.textContent = '.osano-cm-window { display: none !important; pointer-events: none !important; }';
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hide);
+    } else {
+      hide();
+    }
+  });
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — keep the test running; a failure here is useful signal, not noise.
+  }
+}
+
+// Stub the send-code endpoint with a chosen status + message. Later registrations win,
+// so a test can call this to override the beforeEach default.
+async function mockSendCode(page: Page, status: number, message: string): Promise<void> {
+  await page.route(SEND_CODE_ROUTE, (route) => {
+    if (route.request().method() !== 'POST') {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: false, error: 'send_code_failed', message }),
+    });
+  });
+}
+
+test.describe('Identity dialogs — already-claimed support link', () => {
+  test.beforeEach(async ({ page }) => {
+    await suppressCookieBanner(page);
+    await mockIdentities(page);
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('unverified-identities-section').or(page.getByTestId('verified-identities-section'))).toBeVisible({ timeout: 10000 });
+  });
+
+  test.describe('Add-account dialog', () => {
+    // Open the add-account dialog and advance to the email "connect" step.
+    async function openEmailConnectStep(page: Page): Promise<void> {
+      await page.getByTestId('add-identity-btn').locator('button').click();
+      await expect(page.getByTestId('add-account-dialog')).toBeVisible({ timeout: 5000 });
+      await page.getByTestId('provider-action-email').locator('button').click();
+      await page.getByTestId('add-account-email').locator('input').fill('claimed@example.com');
+    }
+
+    test('shows the support link when the email is already linked (409)', async ({ page }) => {
+      await mockSendCode(page, 409, EMAIL_ALREADY_LINKED_MESSAGE);
+      await openEmailConnectStep(page);
+      await page.getByTestId('add-account-send-code').locator('button').click();
+
+      const error = page.getByTestId('add-account-send-error');
+      await expect(error).toBeVisible({ timeout: 5000 });
+      await expect(error).toContainText(EMAIL_ALREADY_LINKED_MESSAGE);
+      await expect(error.getByRole('button', SUPPORT_BUTTON)).toBeVisible();
+    });
+
+    test('hides the support link for an unrelated error', async ({ page }) => {
+      await mockSendCode(page, 400, UNRELATED_ERROR_MESSAGE);
+      await openEmailConnectStep(page);
+      await page.getByTestId('add-account-send-code').locator('button').click();
+
+      const error = page.getByTestId('add-account-send-error');
+      await expect(error).toBeVisible({ timeout: 5000 });
+      await expect(error).toContainText(UNRELATED_ERROR_MESSAGE);
+      await expect(error.getByRole('button', SUPPORT_BUTTON)).toHaveCount(0);
+    });
+  });
+
+  test.describe('Verify-identity dialog', () => {
+    // The mocked list exposes a single unverified email identity; its verify button id
+    // derives from UNVERIFIED_EMAIL_ID.
+    async function openVerifyEmailDialog(page: Page): Promise<void> {
+      await page.getByTestId(`verify-btn-${UNVERIFIED_EMAIL_ID}`).locator('button').click();
+      await expect(page.getByTestId('verify-identity-dialog')).toBeVisible({ timeout: 5000 });
+    }
+
+    test('shows the support link when the email is already linked (409)', async ({ page }) => {
+      await mockSendCode(page, 409, EMAIL_ALREADY_LINKED_MESSAGE);
+      await openVerifyEmailDialog(page);
+      await page.getByTestId('verify-send-code').locator('button').click();
+
+      const error = page.getByTestId('verify-email-error');
+      await expect(error).toBeVisible({ timeout: 5000 });
+      await expect(error).toContainText(EMAIL_ALREADY_LINKED_MESSAGE);
+      await expect(error.getByRole('button', SUPPORT_BUTTON)).toBeVisible();
+    });
+
+    test('hides the support link for an unrelated error', async ({ page }) => {
+      await mockSendCode(page, 400, UNRELATED_ERROR_MESSAGE);
+      await openVerifyEmailDialog(page);
+      await page.getByTestId('verify-send-code').locator('button').click();
+
+      const error = page.getByTestId('verify-email-error');
+      await expect(error).toBeVisible({ timeout: 5000 });
+      await expect(error).toContainText(UNRELATED_ERROR_MESSAGE);
+      await expect(error.getByRole('button', SUPPORT_BUTTON)).toHaveCount(0);
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
@@ -87,7 +87,7 @@
             data-testid="add-account-otp" />
           @if (verificationError()) {
             <p class="text-center text-sm text-red-600" role="alert" data-testid="add-account-otp-error">
-              {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+              {{ verificationError() }}{{ showSupportLink() ? '. ' : '' }}
               @if (showSupportLink()) {
                 If you believe this is an error,
                 <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
@@ -100,7 +100,7 @@
 
     @if (!codeSent() && verificationError()) {
       <p class="text-sm text-red-600" role="alert" data-testid="add-account-send-error">
-        {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+        {{ verificationError() }}{{ showSupportLink() ? '. ' : '' }}
         @if (showSupportLink()) {
           If you believe this is an error,
           <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.html
@@ -86,14 +86,26 @@
             styleClass="w-full gap-3 [&_.p-inputtext]:flex-1"
             data-testid="add-account-otp" />
           @if (verificationError()) {
-            <p class="text-center text-sm text-red-600" role="alert" data-testid="add-account-otp-error">{{ verificationError() }}</p>
+            <p class="text-center text-sm text-red-600" role="alert" data-testid="add-account-otp-error">
+              {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+              @if (showSupportLink()) {
+                If you believe this is an error,
+                <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
+              }
+            </p>
           }
         </div>
       }
     </div>
 
     @if (!codeSent() && verificationError()) {
-      <p class="text-sm text-red-600" role="alert" data-testid="add-account-send-error">{{ verificationError() }}</p>
+      <p class="text-sm text-red-600" role="alert" data-testid="add-account-send-error">
+        {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+        @if (showSupportLink()) {
+          If you believe this is an error,
+          <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
+        }
+      </p>
     }
 
     @if (!codeSent()) {

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
@@ -40,9 +40,8 @@ export class AddAccountDialogComponent {
   public codeSent = signal(false);
   public verificationCode = signal('');
   public verificationError = signal('');
-  // Shows the "contact support" link whenever the visible error is an already-linked
-  // conflict — detected from the message text via the same shared util the backend uses,
-  // so it works regardless of which subscribe callback set the error.
+  // Shows "contact support" for already-linked conflicts — detected via the shared util the
+  // backend uses, so it works regardless of which subscribe callback set the error.
   public readonly showSupportLink = computed(() => isIdentityAlreadyLinkedError(this.verificationError()));
   public isVerifying = signal(false);
 

--- a/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/add-account-dialog/add-account-dialog.component.ts
@@ -1,20 +1,22 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { FormsModule, NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { IDENTITY_PROVIDER_OPTIONS } from '@lfx-one/shared/constants';
 import { AddAccountDialogData, AddAccountDialogResult, IdentityProvider, IdentityProviderOption } from '@lfx-one/shared/interfaces';
+import { isIdentityAlreadyLinkedError } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { useResendCooldown } from '@shared/utils/resend-cooldown';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputOtp } from 'primeng/inputotp';
 
 @Component({
   selector: 'lfx-add-account-dialog',
-  imports: [ButtonComponent, InputTextComponent, FormsModule, ReactiveFormsModule, InputOtp],
+  imports: [ButtonComponent, InputTextComponent, FormsModule, ReactiveFormsModule, InputOtp, OpenIntercomDirective],
   templateUrl: './add-account-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -38,6 +40,10 @@ export class AddAccountDialogComponent {
   public codeSent = signal(false);
   public verificationCode = signal('');
   public verificationError = signal('');
+  // Shows the "contact support" link whenever the visible error is an already-linked
+  // conflict — detected from the message text via the same shared util the backend uses,
+  // so it works regardless of which subscribe callback set the error.
+  public readonly showSupportLink = computed(() => isIdentityAlreadyLinkedError(this.verificationError()));
   public isVerifying = signal(false);
 
   private readonly resendCooldownUtil = useResendCooldown(this.destroyRef);

--- a/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.html
@@ -53,7 +53,13 @@
 
     @if (!codeSent()) {
       @if (verificationError()) {
-        <p class="text-sm text-red-600" data-testid="verify-email-error">{{ verificationError() }}</p>
+        <p class="text-sm text-red-600" data-testid="verify-email-error">
+          {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+          @if (showSupportLink()) {
+            If you believe this is an error,
+            <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
+          }
+        </p>
       }
     } @else {
       <div class="flex flex-col gap-2">
@@ -84,7 +90,13 @@
           styleClass="w-full gap-3 [&_.p-inputtext]:flex-1"
           data-testid="verify-otp" />
         @if (verificationError()) {
-          <p class="text-center text-sm text-red-600" data-testid="verify-email-error">{{ verificationError() }}</p>
+          <p class="text-center text-sm text-red-600" data-testid="verify-email-error">
+            {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+            @if (showSupportLink()) {
+              If you believe this is an error,
+              <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
+            }
+          </p>
         }
       </div>
 

--- a/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.html
@@ -54,7 +54,7 @@
     @if (!codeSent()) {
       @if (verificationError()) {
         <p class="text-sm text-red-600" data-testid="verify-email-error">
-          {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+          {{ verificationError() }}{{ showSupportLink() ? '. ' : '' }}
           @if (showSupportLink()) {
             If you believe this is an error,
             <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.
@@ -91,7 +91,7 @@
           data-testid="verify-otp" />
         @if (verificationError()) {
           <p class="text-center text-sm text-red-600" data-testid="verify-email-error">
-            {{ verificationError() }}{{ showSupportLink() ? '.' : '' }}
+            {{ verificationError() }}{{ showSupportLink() ? '. ' : '' }}
             @if (showSupportLink()) {
               If you believe this is an error,
               <button type="button" lfxOpenIntercom class="font-medium underline">contact support</button>.

--- a/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.ts
@@ -6,14 +6,16 @@ import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { IDENTITY_PROVIDER_LABELS } from '@lfx-one/shared/constants';
 import { ConnectedIdentityFull, VerifyIdentityDialogData } from '@lfx-one/shared/interfaces';
+import { isIdentityAlreadyLinkedError } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { useResendCooldown } from '@shared/utils/resend-cooldown';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputOtp } from 'primeng/inputotp';
 
 @Component({
   selector: 'lfx-verify-identity-dialog',
-  imports: [ButtonComponent, FormsModule, InputOtp],
+  imports: [ButtonComponent, FormsModule, InputOtp, OpenIntercomDirective],
   templateUrl: './verify-identity-dialog.component.html',
   styleUrl: './verify-identity-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,6 +33,10 @@ export class VerifyIdentityDialogComponent {
   public codeSent = signal(false);
   public verificationCode = signal('');
   public verificationError = signal('');
+  // Shows the "contact support" link whenever the visible error is an already-linked
+  // conflict — detected from the message text via the same shared util the backend uses,
+  // so it works regardless of which subscribe callback set the error.
+  public readonly showSupportLink = computed(() => isIdentityAlreadyLinkedError(this.verificationError()));
   public isSendingCode = signal(false);
   public isVerifying = signal(false);
 

--- a/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/verify-identity-dialog/verify-identity-dialog.component.ts
@@ -33,9 +33,8 @@ export class VerifyIdentityDialogComponent {
   public codeSent = signal(false);
   public verificationCode = signal('');
   public verificationError = signal('');
-  // Shows the "contact support" link whenever the visible error is an already-linked
-  // conflict — detected from the message text via the same shared util the backend uses,
-  // so it works regardless of which subscribe callback set the error.
+  // Shows "contact support" for already-linked conflicts — detected via the shared util the
+  // backend uses, so it works regardless of which subscribe callback set the error.
   public readonly showSupportLink = computed(() => isIdentityAlreadyLinkedError(this.verificationError()));
   public isSendingCode = signal(false);
   public isVerifying = signal(false);


### PR DESCRIPTION
## Summary

- When adding or verifying an email identity that's already claimed by another
  LFID account, the profile dialogs showed only red error text with no way to
  get help. This adds a "contact support" link beside that error so users can
  reach out.
- The link appears **only** for the already-claimed conflict (detected via the
  shared `isIdentityAlreadyLinkedError` util, the same marker set the backend
  uses) — not for other errors like a wrong/expired OTP.
- Reuses the existing `lfxOpenIntercom` directive (opens Intercom, falls back to
  the Jira support desk), matching the existing social-connect banner's pattern.
- Applies to both the add-account and verify-identity dialogs.

## Note

The `showSupportLink` computed and the support-link template snippet are
intentionally duplicated across the two dialogs rather than extracted into a
shared component — the snippet is small and stable, and a shared abstraction
would couple two otherwise-independent dialogs for little gain.

Fixes LFXV2-2858

🤖 Generated with Claude Code
