### PR TITLE
fix(perf): resolve lens writer summary without full project sweep

### DIFF
--- a/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
+++ b/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, input, output, Si
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MeetupsService } from '@app/shared/services/meetups.service';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { DEFAULT_MEETUP_SORT_FIELD, DEFAULT_MEETUPS_PAGE_SIZE, EMPTY_MY_MEETUPS_RESPONSE } from '@lfx-one/shared/constants';
+import { DEFAULT_MEETUP_SORT_FIELD, DEFAULT_MEETUPS_PAGE_SIZE, EMPTY_MY_MEETUPS_RESPONSE, TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
 import {
   MeetupSortChangeEvent,
   MeetupSortField,
@@ -32,7 +32,6 @@ export class MeetupsListComponent {
   private readonly meetupsService = inject(MeetupsService);
   private readonly messageService = inject(MessageService);
   private readonly transientRetryCount = 2;
-  private readonly transientRetryDelayMs = 1000;
 
   public readonly activeTab = input<MeetupTabId>('upcoming');
   public readonly community = input<string | null>(null);
@@ -138,9 +137,10 @@ export class MeetupsListComponent {
           return this.meetupsService.getMyMeetups({ isPast, offset, pageSize, community, searchQuery, role, status, sortField, sortOrder }).pipe(
             retry({
               count: this.transientRetryCount,
-              delay: (error: unknown) => (isTransientHttpError(error) ? timer(this.transientRetryDelayMs) : throwError(() => error)),
+              delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)),
             }),
-            catchError(() => {
+            catchError((error) => {
+              console.error('Failed to load meetups:', error);
               if (this.activeTab() === tabId) {
                 this.showLoadError();
               }

--- a/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
+++ b/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, input, output, Si
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MeetupsService } from '@app/shared/services/meetups.service';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { DEFAULT_MEETUP_SORT_FIELD, DEFAULT_MEETUPS_PAGE_SIZE, EMPTY_MY_MEETUPS_RESPONSE, TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
+import { DEFAULT_MEETUP_SORT_FIELD, DEFAULT_MEETUPS_PAGE_SIZE, EMPTY_MY_MEETUPS_RESPONSE } from '@lfx-one/shared/constants';
 import {
   MeetupSortChangeEvent,
   MeetupSortField,
@@ -16,9 +16,9 @@ import {
   PageChangeEvent,
 } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, retry, skip, switchMap, throwError, timer } from 'rxjs';
+import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, skip, switchMap } from 'rxjs';
 
-import { isTransientHttpError } from '@shared/utils/http-error.utils';
+import { retryTransientHttpError } from '@shared/utils/http-error.utils';
 
 import { MeetupsTableComponent } from '../meetups-table/meetups-table.component';
 
@@ -135,10 +135,7 @@ export class MeetupsListComponent {
 
           loadingSignal.set(true);
           return this.meetupsService.getMyMeetups({ isPast, offset, pageSize, community, searchQuery, role, status, sortField, sortOrder }).pipe(
-            retry({
-              count: this.transientRetryCount,
-              delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)),
-            }),
+            retryTransientHttpError(this.transientRetryCount),
             catchError((error) => {
               console.error('Failed to load meetups:', error);
               if (this.activeTab() === tabId) {

--- a/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
+++ b/apps/lfx-one/src/app/modules/meetups/meetups-dashboard/components/meetups-list/meetups-list.component.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, computed, inject, input, output, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MeetupsService } from '@app/shared/services/meetups.service';
@@ -18,6 +17,8 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, retry, skip, switchMap, throwError, timer } from 'rxjs';
+
+import { isTransientHttpError } from '@shared/utils/http-error.utils';
 
 import { MeetupsTableComponent } from '../meetups-table/meetups-table.component';
 
@@ -137,7 +138,7 @@ export class MeetupsListComponent {
           return this.meetupsService.getMyMeetups({ isPast, offset, pageSize, community, searchQuery, role, status, sortField, sortOrder }).pipe(
             retry({
               count: this.transientRetryCount,
-              delay: (error: unknown) => (this.isTransientLoadError(error) ? timer(this.transientRetryDelayMs) : throwError(() => error)),
+              delay: (error: unknown) => (isTransientHttpError(error) ? timer(this.transientRetryDelayMs) : throwError(() => error)),
             }),
             catchError(() => {
               if (this.activeTab() === tabId) {
@@ -174,9 +175,5 @@ export class MeetupsListComponent {
       summary: 'Error',
       detail: 'Failed to load meetups. Please try again.',
     });
-  }
-
-  private isTransientLoadError(error: unknown): boolean {
-    return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
   }
 }

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -25,6 +25,12 @@ export const lensRedirectGuard: CanActivateFn = (_route, state) => {
   // subsequent ones — the same URL resolving differently by timing. Accepted rather than gated on a
   // readiness signal, which would block every flat-route navigation on the grants request.
   //
+  // Since LFXV2-2857, a direct writer grant resolves this quickly (sub-second, WriterGrantsService's
+  // fast path), but an *inherited-only* grant (e.g. foundation-level writer reaching a non-foundation
+  // child with no direct tuple on it) only resolves once the idle-deferred full sweep runs — up to
+  // `IDLE_SWEEP_TIMEOUT_MS` (15s) after first paint, plus that sweep's own request latency. So the
+  // un-redirected window for that user class is meaningfully longer than a single hydration tick.
+  //
   // The un-redirected flat route is a functional page, and — crucially — the create flows on it no
   // longer resolve the wrong target while it is un-redirected: the flat write routes also run
   // `projectQueryParamGuard`, which seeds the context slot from the `?project=` param (deriving

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -27,9 +27,12 @@ export const lensRedirectGuard: CanActivateFn = (_route, state) => {
   //
   // Since LFXV2-2857, a direct writer grant resolves this quickly (sub-second, WriterGrantsService's
   // fast path), but an *inherited-only* grant (e.g. foundation-level writer reaching a non-foundation
-  // child with no direct tuple on it) only resolves once the idle-deferred full sweep runs — up to
-  // `IDLE_SWEEP_TIMEOUT_MS` (15s) after first paint, plus that sweep's own request latency. So the
-  // un-redirected window for that user class is meaningfully longer than a single hydration tick.
+  // child with no direct tuple on it) only resolves once the idle-deferred full sweep runs — and that
+  // sweep is scheduled behind three sequential budgets: up to `WRITER_SUMMARY_TIMEOUT_MS` (10s) for
+  // the fast path to settle, then `IDLE_SWEEP_MIN_DELAY_MS` (2s) before idle scheduling is even
+  // attempted, then up to `IDLE_SWEEP_TIMEOUT_MS` (15s) for it to actually fire — plus the sweep's
+  // own request latency on top of all of that. So the un-redirected window for that user class is
+  // meaningfully longer than a single hydration tick.
   //
   // The un-redirected flat route is a functional page, and — crucially — the create flows on it no
   // longer resolve the wrong target while it is un-redirected: the flat write routes also run

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -21,7 +21,10 @@ export class ProjectService {
     const cacheKey = params?.toString() || '';
     if (!this.projectsCache.has(cacheKey)) {
       const projects$ = this.http.get<Project[]>('/api/projects', { params }).pipe(
-        catchError(() => of([])),
+        catchError((error) => {
+          console.error('Failed to fetch projects:', error);
+          return of([]);
+        }),
         shareReplay(1)
       );
       this.projectsCache.set(cacheKey, projects$);

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument } from '@lfx-one/shared/interfaces';
+import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
 import { BehaviorSubject, catchError, map, Observable, of, shareReplay, take, tap } from 'rxjs';
 
 @Injectable({
@@ -27,6 +27,11 @@ export class ProjectService {
       this.projectsCache.set(cacheKey, projects$);
     }
     return this.projectsCache.get(cacheKey)!;
+  }
+
+  /** Fail-closed on error, mirroring getProjects — a transport failure must not silently widen access. */
+  public getWriterSummary(): Observable<WriterSummary> {
+    return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(catchError(() => of({ hasWriterFoundation: false, hasWriterProject: false })));
   }
 
   public getProject(slug: string, current: boolean = true, options?: { meetingCoordinator?: boolean }): Observable<Project | null> {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
-import { BehaviorSubject, catchError, map, Observable, of, shareReplay, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -20,7 +20,11 @@ export class ProjectService {
   public getProjects(params?: HttpParams): Observable<Project[]> {
     const cacheKey = params?.toString() || '';
     if (!this.projectsCache.has(cacheKey)) {
+      // One retry before the fail-closed fallback: shareReplay(1) pins whatever value lands here
+      // for the rest of the session (every caller shares this cache key), so a bare transient
+      // blip shouldn't get to permanently poison it to `[]`.
       const projects$ = this.http.get<Project[]>('/api/projects', { params }).pipe(
+        retry({ count: 1, delay: 1000 }),
         catchError((error) => {
           console.error('Failed to fetch projects:', error);
           return of([]);

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
-import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap, throwError, timer } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -20,13 +20,16 @@ export class ProjectService {
   public getProjects(params?: HttpParams): Observable<Project[]> {
     const cacheKey = params?.toString() || '';
     if (!this.projectsCache.has(cacheKey)) {
-      // One retry before the fail-closed fallback: shareReplay(1) pins whatever value lands here
-      // for the rest of the session (every caller shares this cache key), so a bare transient
-      // blip shouldn't get to permanently poison it to `[]`.
+      // shareReplay(1) pins whatever lands here for the rest of the session — every caller shares
+      // this cache key. One retry, transient errors only (matches meetups-list.component.ts's
+      // isTransientLoadError), so a session-expiry/permission 4xx fails fast instead of doubling
+      // the wait before the fallback. On failure, evict the key rather than caching `[]`: the
+      // retry only lowers how often a stuck cache happens, it can't rule it out.
       const projects$ = this.http.get<Project[]>('/api/projects', { params }).pipe(
-        retry({ count: 1, delay: 1000 }),
+        retry({ count: 1, delay: (error: unknown) => (this.isTransientLoadError(error) ? timer(1000) : throwError(() => error)) }),
         catchError((error) => {
           console.error('Failed to fetch projects:', error);
+          this.projectsCache.delete(cacheKey);
           return of([]);
         }),
         shareReplay(1)
@@ -182,5 +185,10 @@ export class ProjectService {
   public deleteProjectDocument(projectUid: string, documentId: string, documentType: 'folder' | 'link'): Observable<void> {
     const params = new HttpParams().set('type', documentType);
     return this.http.delete<void>(`/api/projects/${projectUid}/documents/${documentId}`, { params }).pipe(take(1));
+  }
+
+  /** Mirrors meetups-list.component.ts's isTransientLoadError — retry only what a beat of time could fix. */
+  private isTransientLoadError(error: unknown): boolean {
+    return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -45,15 +45,15 @@ export class ProjectService {
   /**
    * Fail-closed on error, mirroring getProjects. One retry, transient errors only — this is the
    * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
-   * set narrowed until the (much slower) deferred sweep eventually resolves it instead. A timeout
-   * doesn't retry — `TimeoutError` isn't an `HttpErrorResponse`, so `isTransientHttpError` rejects
-   * it — a stalled connection fails closed immediately rather than doubling the wait; the deferred
-   * sweep is the recovery path for that case, not a second attempt here.
+   * set narrowed until the (much slower) deferred sweep eventually resolves it instead.
    *
-   * `timeout()` sits below `retryTransientHttpError()` so it bounds the whole call (retries
-   * included) to `WRITER_SUMMARY_TIMEOUT_MS`, not just one attempt — `WriterGrantsService` only
-   * schedules its deferred sweep once this call settles, so an unbounded hang here would silently
-   * starve the sweep for the whole session.
+   * `timeout()` sits downstream of `retryTransientHttpError()` in the pipe, so it wraps the whole
+   * retried call rather than each individual attempt — a `TimeoutError` is terminal by
+   * construction (it's raised after `retry` has already passed through, never offered to
+   * `isTransientHttpError`), so a stalled connection fails closed at `WRITER_SUMMARY_TIMEOUT_MS`
+   * rather than doubling the wait with a second attempt. `WriterGrantsService` only schedules its
+   * deferred sweep once this call settles, so that bound matters: an unbounded hang here would
+   * silently starve the sweep — the recovery path for a stalled fast path — for the whole session.
    */
   public getWriterSummary(): Observable<WriterSummary> {
     return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -3,13 +3,11 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
 import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap, throwError, timer } from 'rxjs';
 
 import { isTransientHttpError } from '@shared/utils/http-error.utils';
-
-/** Matches meetups-list.component.ts's transientRetryDelayMs — same retry policy, same delay. */
-const TRANSIENT_RETRY_DELAY_MS = 1000;
 
 @Injectable({
   providedIn: 'root',

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -31,7 +31,12 @@ export class ProjectService {
 
   /** Fail-closed on error, mirroring getProjects — a transport failure must not silently widen access. */
   public getWriterSummary(): Observable<WriterSummary> {
-    return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(catchError(() => of({ hasWriterFoundation: false, hasWriterProject: false })));
+    return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(
+      catchError((error) => {
+        console.error('Failed to fetch writer summary:', error);
+        return of({ hasWriterFoundation: false, hasWriterProject: false });
+      })
+    );
   }
 
   public getProject(slug: string, current: boolean = true, options?: { meetingCoordinator?: boolean }): Observable<Project | null> {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -42,9 +42,14 @@ export class ProjectService {
     return this.projectsCache.get(cacheKey)!;
   }
 
-  /** Fail-closed on error, mirroring getProjects — a transport failure must not silently widen access. */
+  /**
+   * Fail-closed on error, mirroring getProjects. One retry, transient errors only — this is the
+   * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
+   * set narrowed until the (much slower) deferred sweep eventually resolves it instead.
+   */
   public getWriterSummary(): Observable<WriterSummary> {
     return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(
+      retry({ count: 1, delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)) }),
       catchError((error) => {
         console.error('Failed to fetch writer summary:', error);
         return of({ hasWriterFoundation: false, hasWriterProject: false });

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -45,14 +45,20 @@ export class ProjectService {
   /**
    * Fail-closed on error, mirroring getProjects. One retry, transient errors only — this is the
    * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
-   * set narrowed until the (much slower) deferred sweep eventually resolves it instead. Bounded by
-   * `WRITER_SUMMARY_TIMEOUT_MS`: `WriterGrantsService` only schedules its deferred sweep once this
-   * call settles, so an unbounded hang here would silently starve the sweep for the whole session.
+   * set narrowed until the (much slower) deferred sweep eventually resolves it instead. A timeout
+   * doesn't retry — `TimeoutError` isn't an `HttpErrorResponse`, so `isTransientHttpError` rejects
+   * it — a stalled connection fails closed immediately rather than doubling the wait; the deferred
+   * sweep is the recovery path for that case, not a second attempt here.
+   *
+   * `timeout()` sits below `retryTransientHttpError()` so it bounds the whole call (retries
+   * included) to `WRITER_SUMMARY_TIMEOUT_MS`, not just one attempt — `WriterGrantsService` only
+   * schedules its deferred sweep once this call settles, so an unbounded hang here would silently
+   * starve the sweep for the whole session.
    */
   public getWriterSummary(): Observable<WriterSummary> {
     return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(
-      timeout(WRITER_SUMMARY_TIMEOUT_MS),
       retryTransientHttpError(),
+      timeout(WRITER_SUMMARY_TIMEOUT_MS),
       catchError((error) => {
         console.error('Failed to fetch writer summary:', error);
         return of({ hasWriterFoundation: false, hasWriterProject: false });

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -47,7 +47,10 @@ export class ProjectService {
     if (!this.projectCache.has(cacheKey)) {
       const params = options?.meetingCoordinator ? new HttpParams().set('meeting_coordinator', 'true') : undefined;
       const project$ = this.http.get<Project>(`/api/projects/${slug}`, { params }).pipe(
-        catchError(() => of(null)),
+        catchError((error) => {
+          console.error('Failed to fetch project:', error);
+          return of(null);
+        }),
         shareReplay(1),
         tap((project) => {
           if (current) {
@@ -125,7 +128,12 @@ export class ProjectService {
   // ── Project Documents ─────────────────────────────────────────────────────
 
   public getProjectDocuments(projectUid: string): Observable<ProjectDocument[]> {
-    return this.http.get<ProjectDocument[]>(`/api/projects/${projectUid}/documents`).pipe(catchError(() => of([])));
+    return this.http.get<ProjectDocument[]>(`/api/projects/${projectUid}/documents`).pipe(
+      catchError((error) => {
+        console.error('Failed to fetch project documents:', error);
+        return of([]);
+      })
+    );
   }
 
   public createProjectDocument(projectUid: string, data: CreateProjectDocumentRequest): Observable<ProjectDocument> {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -47,13 +47,13 @@ export class ProjectService {
    * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
    * set narrowed until the (much slower) deferred sweep eventually resolves it instead.
    *
-   * `timeout()` sits downstream of `retryTransientHttpError()` in the pipe, so it wraps the whole
-   * retried call rather than each individual attempt — a `TimeoutError` is terminal by
-   * construction (it's raised after `retry` has already passed through, never offered to
-   * `isTransientHttpError`), so a stalled connection fails closed at `WRITER_SUMMARY_TIMEOUT_MS`
-   * rather than doubling the wait with a second attempt. `WriterGrantsService` only schedules its
-   * deferred sweep once this call settles, so that bound matters: an unbounded hang here would
-   * silently starve the sweep — the recovery path for a stalled fast path — for the whole session.
+   * `timeout()` sits downstream of `retryTransientHttpError()` in the pipe, so the attempt, the
+   * retry delay, and the retried attempt all share one `WRITER_SUMMARY_TIMEOUT_MS` budget rather
+   * than each attempt getting its own — a transient failure followed by a stalled retry still
+   * fails closed at that one bound, instead of running up to roughly twice it. `WriterGrantsService`
+   * only schedules its deferred sweep once this call settles, so that bound matters: an unbounded
+   * hang here would silently starve the sweep — the recovery path for a stalled fast path — for
+   * the whole session.
    */
   public getWriterSummary(): Observable<WriterSummary> {
     return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -1,10 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
 import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap, throwError, timer } from 'rxjs';
+
+import { isTransientHttpError } from '@shared/utils/http-error.utils';
+
+/** Matches meetups-list.component.ts's transientRetryDelayMs — same retry policy, same delay. */
+const TRANSIENT_RETRY_DELAY_MS = 1000;
 
 @Injectable({
   providedIn: 'root',
@@ -21,12 +26,12 @@ export class ProjectService {
     const cacheKey = params?.toString() || '';
     if (!this.projectsCache.has(cacheKey)) {
       // shareReplay(1) pins whatever lands here for the rest of the session — every caller shares
-      // this cache key. One retry, transient errors only (matches meetups-list.component.ts's
-      // isTransientLoadError), so a session-expiry/permission 4xx fails fast instead of doubling
-      // the wait before the fallback. On failure, evict the key rather than caching `[]`: the
-      // retry only lowers how often a stuck cache happens, it can't rule it out.
+      // this cache key. One retry, transient errors only (isTransientHttpError), so a
+      // session-expiry/permission 4xx fails fast instead of doubling the wait before the
+      // fallback. On failure, evict the key rather than caching `[]`: the retry only lowers how
+      // often a stuck cache happens, it can't rule it out.
       const projects$ = this.http.get<Project[]>('/api/projects', { params }).pipe(
-        retry({ count: 1, delay: (error: unknown) => (this.isTransientLoadError(error) ? timer(1000) : throwError(() => error)) }),
+        retry({ count: 1, delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)) }),
         catchError((error) => {
           console.error('Failed to fetch projects:', error);
           this.projectsCache.delete(cacheKey);
@@ -185,10 +190,5 @@ export class ProjectService {
   public deleteProjectDocument(projectUid: string, documentId: string, documentType: 'folder' | 'link'): Observable<void> {
     const params = new HttpParams().set('type', documentType);
     return this.http.delete<void>(`/api/projects/${projectUid}/documents/${documentId}`, { params }).pipe(take(1));
-  }
-
-  /** Mirrors meetups-list.component.ts's isTransientLoadError — retry only what a beat of time could fix. */
-  private isTransientLoadError(error: unknown): boolean {
-    return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -3,11 +3,11 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
+import { WRITER_SUMMARY_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import { CreateProjectDocumentRequest, PendingActionItem, Project, ProjectDocument, WriterSummary } from '@lfx-one/shared/interfaces';
-import { BehaviorSubject, catchError, map, Observable, of, retry, shareReplay, take, tap, throwError, timer } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of, shareReplay, take, tap, timeout } from 'rxjs';
 
-import { isTransientHttpError } from '@shared/utils/http-error.utils';
+import { retryTransientHttpError } from '@shared/utils/http-error.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -29,7 +29,7 @@ export class ProjectService {
       // fallback. On failure, evict the key rather than caching `[]`: the retry only lowers how
       // often a stuck cache happens, it can't rule it out.
       const projects$ = this.http.get<Project[]>('/api/projects', { params }).pipe(
-        retry({ count: 1, delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)) }),
+        retryTransientHttpError(),
         catchError((error) => {
           console.error('Failed to fetch projects:', error);
           this.projectsCache.delete(cacheKey);
@@ -45,11 +45,14 @@ export class ProjectService {
   /**
    * Fail-closed on error, mirroring getProjects. One retry, transient errors only — this is the
    * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
-   * set narrowed until the (much slower) deferred sweep eventually resolves it instead.
+   * set narrowed until the (much slower) deferred sweep eventually resolves it instead. Bounded by
+   * `WRITER_SUMMARY_TIMEOUT_MS`: `WriterGrantsService` only schedules its deferred sweep once this
+   * call settles, so an unbounded hang here would silently starve the sweep for the whole session.
    */
   public getWriterSummary(): Observable<WriterSummary> {
     return this.http.get<WriterSummary>('/api/projects/writer-summary').pipe(
-      retry({ count: 1, delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)) }),
+      timeout(WRITER_SUMMARY_TIMEOUT_MS),
+      retryTransientHttpError(),
       catchError((error) => {
         console.error('Failed to fetch writer summary:', error);
         return of({ hasWriterFoundation: false, hasWriterProject: false });

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -17,16 +17,20 @@ import { map } from 'rxjs';
  *
  * Two-phase, both kicked off post-hydration in `afterNextRender` (LFXV2-2857):
  *  - **Fast path** — `ProjectService.getWriterSummary()` hits a `filter_grants=direct`-scoped
- *    endpoint (sub-second). Direct grants only, so it under-reports *inherited* access (e.g. a
- *    foundation-level writer's implicit access to a non-foundation child they hold no direct
- *    tuple on).
+ *    endpoint (typically sub-second for a normal direct-grant count, though it still paginates
+ *    and access-checks server-side, so it isn't a hard bound). Direct grants only, so it
+ *    under-reports *inherited* access (e.g. a foundation-level writer's implicit access to a
+ *    non-foundation child they hold no direct tuple on).
  *  - **Deferred sweep** — the existing unscoped `ProjectService.getProjects()` (the same call
  *    that used to run here directly and block bootstrap for 11-19s), rescheduled via
  *    `requestIdleCallback` so it starts well after first paint and doesn't count toward RUM's
- *    `@view.loading_time`. Resolves inherited access. Runs every bootstrap (deliberately
- *    uncached: identity-scoped state here would need to invalidate on impersonation start/stop,
- *    both of which reload in-tab — see `docs/architecture/backend/impersonation.md` — and the
- *    idle-deferred call is cheap enough that re-running it isn't worth that risk).
+ *    `@view.loading_time`. Resolves inherited access. Server-side cost is unchanged — this only
+ *    moves it off the bootstrap-blocking path, it doesn't make the call itself cheaper. Runs
+ *    every bootstrap (deliberately uncached: identity-scoped state here would need to invalidate
+ *    on impersonation start/stop, both of which reload in-tab — see
+ *    `docs/architecture/backend/impersonation.md` — and re-running an idle-deferred call beats
+ *    that invalidation risk). Skipped entirely once both signals are already `true`, since an
+ *    OR-merge can no longer change the outcome.
  *
  * Both signals start `false` and only ever OR-merge to `true` as either call resolves — never
  * back — so the fast path, deferred sweep, and their arrival order don't matter to the consumer.
@@ -67,6 +71,11 @@ export class WriterGrantsService {
   }
 
   private runDeferredSweep(): void {
+    // Signals only ever widen — with both already true, the sweep's result can't change anything.
+    if (this.hasWriterFoundationInternal() && this.hasWriterProjectInternal()) {
+      return;
+    }
+
     this.projectService
       .getProjects()
       .pipe(map(summarizeWriterGrants), takeUntilDestroyed(this.destroyRef))
@@ -75,9 +84,11 @@ export class WriterGrantsService {
 
   private runWhenIdle(cb: () => void): void {
     if (typeof requestIdleCallback === 'function') {
-      requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
+      const id = requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
+      this.destroyRef.onDestroy(() => cancelIdleCallback(id));
     } else {
-      setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
+      const id = setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
+      this.destroyRef.onDestroy(() => clearTimeout(id));
     }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -5,7 +5,7 @@ import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal, Writab
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import { WriterSummary } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { summarizeWriterGrants } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
 import { map } from 'rxjs';
 
@@ -69,15 +69,7 @@ export class WriterGrantsService {
   private runDeferredSweep(): void {
     this.projectService
       .getProjects()
-      .pipe(
-        map(
-          (projects): WriterSummary => ({
-            hasWriterFoundation: projects.some((project) => project.writer === true && computeIsFoundation(project)),
-            hasWriterProject: projects.some((project) => project.writer === true && !computeIsFoundation(project)),
-          })
-        ),
-        takeUntilDestroyed(this.destroyRef)
-      )
+      .pipe(map(summarizeWriterGrants), takeUntilDestroyed(this.destroyRef))
       .subscribe((summary) => this.widen(summary));
   }
 

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -60,9 +60,10 @@ export class WriterGrantsService {
       this.projectService
         .getWriterSummary()
         .pipe(
-          // Schedule the deferred sweep only once the fast path has actually resolved (success or
-          // fail-closed) — scheduling it eagerly in this same tick would race the HTTP round trip,
-          // so runDeferredSweep's "skip if both already true" check would almost never see a `true`.
+          // Schedule the deferred sweep once the fast path settles — resolved, failed closed, or
+          // torn down early by destroy. Scheduling it eagerly in this same tick would instead race
+          // the HTTP round trip, so runDeferredSweep's "skip if both already true" check would
+          // almost never see a `true`. runWhenIdle itself no-ops the destroy case (see below).
           finalize(() => this.runWhenIdle(() => this.runDeferredSweep())),
           takeUntilDestroyed(this.destroyRef)
         )
@@ -89,6 +90,13 @@ export class WriterGrantsService {
   }
 
   private runWhenIdle(cb: () => void): void {
+    // Reachable from `finalize`, which also fires when destroy triggers takeUntilDestroyed's
+    // early unsubscribe — by then this.destroyRef is already destroyed (R3Injector.destroy() sets
+    // its destroyed flag before running teardown hooks), so onDestroy(...) below would throw.
+    if (this.destroyRef.destroyed) {
+      return;
+    }
+
     if (typeof requestIdleCallback === 'function') {
       const id = requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
       this.destroyRef.onDestroy(() => cancelIdleCallback(id));

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -1,31 +1,35 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, computed, DestroyRef, inject, Injectable, Signal, signal } from '@angular/core';
+import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CreatableProject, Project } from '@lfx-one/shared/interfaces';
+import { WRITER_GRANTS_SESSION_CACHE_KEY } from '@lfx-one/shared/constants';
+import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
 import { map } from 'rxjs';
 
+/** Fallback delay when `requestIdleCallback` isn't available (e.g. older Safari). */
+const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;
+
 /**
- * The user's per-project `writer` grants — the same signal `writerGuard` enforces.
+ * Whether the user holds a `writer` grant on a foundation-level and/or non-foundation project —
+ * the same authorization `writerGuard` enforces. The only consumer is {@link LensService}, which
+ * OR's these into its allowed-lens set (LFXV2-2754): a `writer` grant is authority over that
+ * project, so the lens that reaches it must be available regardless of which persona was detected.
  *
- * `GET /api/projects` batch access-checks every visible project and returns `writer` per
- * project, so this reflects real authorization rather than inferring it from a persona.
- * Owned here rather than in a consumer because two independent consumers need it and must
- * not depend on each other:
- *  - {@link LensService} widens the allowed lens set to cover projects the user can write
- *    to (LFXV2-2754) — a `writer` grant is authority over that project, so the lens that
- *    reaches it must be available regardless of which persona was detected.
- *  - {@link CreatePermissionService} scopes the create quick-link to the same grants.
+ * Two-phase, both kicked off post-hydration in `afterNextRender` (LFXV2-2857):
+ *  - **Fast path** — `ProjectService.getWriterSummary()` hits a `filter_grants=direct`-scoped
+ *    endpoint (sub-second). Direct grants only, so it under-reports *inherited* access (e.g. a
+ *    foundation-level writer's implicit access to a non-foundation child they hold no direct
+ *    tuple on).
+ *  - **Deferred sweep** — the existing unscoped `ProjectService.getProjects()` (the same call
+ *    that used to run here directly and block bootstrap for 11-19s), rescheduled via
+ *    `requestIdleCallback` so it starts well after first paint and doesn't count toward RUM's
+ *    `@view.loading_time`. Resolves inherited access; only ever OR-merges into the two signals
+ *    (widens, never narrows) and runs at most once per session (cached to `sessionStorage`).
  *
- * Dependency direction matters: this service injects only `ProjectService` (which injects
- * only `HttpClient`), so `LensService` can consume it without a cycle.
- *
- * Resolves to `[]` while loading and on error — callers fail closed. The error half relies
- * on `ProjectService.getProjects()` catching internally and emitting `[]`; a local
- * `catchError` here would be unreachable.
+ * Both signals start `false` and only ever transition to `true` within a session — never back.
  */
 @Injectable({
   providedIn: 'root',
@@ -34,51 +38,90 @@ export class WriterGrantsService {
   private readonly projectService = inject(ProjectService);
   private readonly destroyRef = inject(DestroyRef);
 
-  private readonly grants = signal<CreatableProject[]>([]);
+  private readonly hasWriterFoundationInternal: WritableSignal<boolean> = signal(false);
+  private readonly hasWriterProjectInternal: WritableSignal<boolean> = signal(false);
 
-  /** Projects the user holds `writer` on. Empty until the post-hydration fetch resolves. */
-  public readonly writerProjects: Signal<CreatableProject[]> = this.grants.asReadonly();
+  /** True once a writer-held project satisfying `computeIsFoundation` is known — fast path first, deferred sweep may widen later. */
+  public readonly hasWriterFoundation: Signal<boolean> = this.hasWriterFoundationInternal.asReadonly();
 
-  /** True once at least one writer-held project satisfies `computeIsFoundation`. */
-  public readonly hasWriterFoundation: Signal<boolean> = computed(() => this.grants().some((project) => project.isFoundation));
-
-  /** True once at least one writer-held project is a non-foundation project. */
-  public readonly hasWriterProject: Signal<boolean> = computed(() => this.grants().some((project) => !project.isFoundation));
+  /** True once a writer-held non-foundation project is known — fast path first, deferred sweep may widen later. */
+  public readonly hasWriterProject: Signal<boolean> = this.hasWriterProjectInternal.asReadonly();
 
   public constructor() {
-    // Fetch after hydration, not at construction. The endpoint paginates every visible project
-    // and batch access-checks them, so a pending task would block SSR serialization on TTFB for
-    // every page. `afterNextRender` runs browser-only, once the first render is committed, so the
-    // server and the client's first pass agree and the widened lens set lands as a normal state
-    // update rather than a hydration mismatch.
+    // Runs browser-only, once the first render is committed — see the class doc for why both
+    // calls live here rather than at construction.
     afterNextRender(() => {
+      // Apply any widening cached from an earlier bootstrap this session BEFORE either network
+      // call fires, so a repeat page load never regresses below what was already established.
+      const cached = this.readCache();
+      if (cached) {
+        this.widen(cached);
+      }
+
       this.projectService
-        .getProjects()
-        .pipe(
-          map((projects) => projects.filter((project) => project.writer === true).map(toCreatableProject)),
-          takeUntilDestroyed(this.destroyRef)
-        )
-        .subscribe((projects) => this.grants.set(projects));
+        .getWriterSummary()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((summary) => this.widen(summary));
+
+      // Only run the slow sweep once per session — a cache hit means an earlier bootstrap this
+      // session already ran it.
+      if (!cached) {
+        this.runWhenIdle(() => this.runDeferredSweep());
+      }
     });
   }
-}
 
-/**
- * Project a raw `Project` down to the fields the create picker and lens derivation need.
- *
- * `isFoundation` is computed from the project's own attributes rather than read from any
- * viewer-scoped field, so it stays correct regardless of the caller's persona — it decides both
- * which lens the project requires and which slot a selection is dispatched to.
- */
-function toCreatableProject(project: Project): CreatableProject {
-  return {
-    uid: project.uid,
-    slug: project.slug,
-    name: project.name,
-    // Derived from the project's own attributes, so it stays correct regardless of the
-    // viewer's persona — it dispatches the selection to the foundation vs project slot.
-    isFoundation: computeIsFoundation(project),
-    parent_uid: project.parent_uid,
-    logoUrl: project.logo_url,
-  };
+  /** OR-merge — only ever widens, never narrows, so the fast path, deferred sweep, and cache can land in any order. */
+  private widen(summary: WriterSummary): void {
+    if (summary.hasWriterFoundation) this.hasWriterFoundationInternal.set(true);
+    if (summary.hasWriterProject) this.hasWriterProjectInternal.set(true);
+  }
+
+  private runDeferredSweep(): void {
+    this.projectService
+      .getProjects()
+      .pipe(
+        map(
+          (projects): WriterSummary => ({
+            hasWriterFoundation: projects.some((project) => project.writer === true && computeIsFoundation(project)),
+            hasWriterProject: projects.some((project) => project.writer === true && !computeIsFoundation(project)),
+          })
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((summary) => {
+        this.widen(summary);
+        this.writeCache({ hasWriterFoundation: this.hasWriterFoundationInternal(), hasWriterProject: this.hasWriterProjectInternal() });
+      });
+  }
+
+  private runWhenIdle(cb: () => void): void {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(cb);
+    } else {
+      setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
+    }
+  }
+
+  private readCache(): WriterSummary | null {
+    try {
+      const raw = sessionStorage.getItem(WRITER_GRANTS_SESSION_CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.hasWriterFoundation === 'boolean' && typeof parsed?.hasWriterProject === 'boolean') {
+        return parsed as WriterSummary;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeCache(summary: WriterSummary): void {
+    try {
+      sessionStorage.setItem(WRITER_GRANTS_SESSION_CACHE_KEY, JSON.stringify(summary));
+    } catch {
+      /* sessionStorage unavailable/full — non-fatal, the sweep just re-runs next session */
+    }
+  }
 }

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -3,14 +3,11 @@
 
 import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { WRITER_GRANTS_SESSION_CACHE_KEY } from '@lfx-one/shared/constants';
+import { IDLE_SWEEP_FALLBACK_DELAY_MS } from '@lfx-one/shared/constants';
 import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
 import { map } from 'rxjs';
-
-/** Fallback delay when `requestIdleCallback` isn't available (e.g. older Safari). */
-const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;
 
 /**
  * Whether the user holds a `writer` grant on a foundation-level and/or non-foundation project —
@@ -26,10 +23,13 @@ const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;
  *  - **Deferred sweep** — the existing unscoped `ProjectService.getProjects()` (the same call
  *    that used to run here directly and block bootstrap for 11-19s), rescheduled via
  *    `requestIdleCallback` so it starts well after first paint and doesn't count toward RUM's
- *    `@view.loading_time`. Resolves inherited access; only ever OR-merges into the two signals
- *    (widens, never narrows) and runs at most once per session (cached to `sessionStorage`).
+ *    `@view.loading_time`. Resolves inherited access. Runs every bootstrap (deliberately
+ *    uncached: identity-scoped state here would need to invalidate on impersonation start/stop,
+ *    both of which reload in-tab — see `docs/architecture/backend/impersonation.md` — and the
+ *    idle-deferred call is cheap enough that re-running it isn't worth that risk).
  *
- * Both signals start `false` and only ever transition to `true` within a session — never back.
+ * Both signals start `false` and only ever OR-merge to `true` as either call resolves — never
+ * back — so the fast path, deferred sweep, and their arrival order don't matter to the consumer.
  */
 @Injectable({
   providedIn: 'root',
@@ -51,27 +51,16 @@ export class WriterGrantsService {
     // Runs browser-only, once the first render is committed — see the class doc for why both
     // calls live here rather than at construction.
     afterNextRender(() => {
-      // Apply any widening cached from an earlier bootstrap this session BEFORE either network
-      // call fires, so a repeat page load never regresses below what was already established.
-      const cached = this.readCache();
-      if (cached) {
-        this.widen(cached);
-      }
-
       this.projectService
         .getWriterSummary()
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((summary) => this.widen(summary));
 
-      // Only run the slow sweep once per session — a cache hit means an earlier bootstrap this
-      // session already ran it.
-      if (!cached) {
-        this.runWhenIdle(() => this.runDeferredSweep());
-      }
+      this.runWhenIdle(() => this.runDeferredSweep());
     });
   }
 
-  /** OR-merge — only ever widens, never narrows, so the fast path, deferred sweep, and cache can land in any order. */
+  /** OR-merge — only ever widens, never narrows, so the fast path and deferred sweep can land in any order. */
   private widen(summary: WriterSummary): void {
     if (summary.hasWriterFoundation) this.hasWriterFoundationInternal.set(true);
     if (summary.hasWriterProject) this.hasWriterProjectInternal.set(true);
@@ -89,39 +78,14 @@ export class WriterGrantsService {
         ),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((summary) => {
-        this.widen(summary);
-        this.writeCache({ hasWriterFoundation: this.hasWriterFoundationInternal(), hasWriterProject: this.hasWriterProjectInternal() });
-      });
+      .subscribe((summary) => this.widen(summary));
   }
 
   private runWhenIdle(cb: () => void): void {
     if (typeof requestIdleCallback === 'function') {
-      requestIdleCallback(cb);
+      requestIdleCallback(cb, { timeout: IDLE_SWEEP_FALLBACK_DELAY_MS });
     } else {
       setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
-    }
-  }
-
-  private readCache(): WriterSummary | null {
-    try {
-      const raw = sessionStorage.getItem(WRITER_GRANTS_SESSION_CACHE_KEY);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw);
-      if (typeof parsed?.hasWriterFoundation === 'boolean' && typeof parsed?.hasWriterProject === 'boolean') {
-        return parsed as WriterSummary;
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  }
-
-  private writeCache(summary: WriterSummary): void {
-    try {
-      sessionStorage.setItem(WRITER_GRANTS_SESSION_CACHE_KEY, JSON.stringify(summary));
-    } catch {
-      /* sessionStorage unavailable/full — non-fatal, the sweep just re-runs next session */
     }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -3,7 +3,7 @@
 
 import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { IDLE_SWEEP_FALLBACK_DELAY_MS } from '@lfx-one/shared/constants';
+import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
@@ -83,7 +83,7 @@ export class WriterGrantsService {
 
   private runWhenIdle(cb: () => void): void {
     if (typeof requestIdleCallback === 'function') {
-      requestIdleCallback(cb, { timeout: IDLE_SWEEP_FALLBACK_DELAY_MS });
+      requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
     } else {
       setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
     }

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -7,7 +7,7 @@ import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_TIMEOUT_MS } from '@lfx-one/sh
 import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { summarizeWriterGrants } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
-import { map } from 'rxjs';
+import { finalize, map } from 'rxjs';
 
 /**
  * Whether the user holds a `writer` grant on a foundation-level and/or non-foundation project —
@@ -15,22 +15,24 @@ import { map } from 'rxjs';
  * OR's these into its allowed-lens set (LFXV2-2754): a `writer` grant is authority over that
  * project, so the lens that reaches it must be available regardless of which persona was detected.
  *
- * Two-phase, both kicked off post-hydration in `afterNextRender` (LFXV2-2857):
+ * Two-phase, kicked off post-hydration in `afterNextRender` (LFXV2-2857):
  *  - **Fast path** — `ProjectService.getWriterSummary()` hits a `filter_grants=direct`-scoped
  *    endpoint (typically sub-second for a normal direct-grant count, though it still paginates
  *    and access-checks server-side, so it isn't a hard bound). Direct grants only, so it
  *    under-reports *inherited* access (e.g. a foundation-level writer's implicit access to a
  *    non-foundation child they hold no direct tuple on).
  *  - **Deferred sweep** — the existing unscoped `ProjectService.getProjects()` (the same call
- *    that used to run here directly and block bootstrap for 11-19s), rescheduled via
- *    `requestIdleCallback` so it starts well after first paint and doesn't count toward RUM's
- *    `@view.loading_time`. Resolves inherited access. Server-side cost is unchanged — this only
- *    moves it off the bootstrap-blocking path, it doesn't make the call itself cheaper. Runs
- *    every bootstrap (deliberately uncached: identity-scoped state here would need to invalidate
- *    on impersonation start/stop, both of which reload in-tab — see
+ *    that used to run here directly and block bootstrap for 11-19s), scheduled via
+ *    `requestIdleCallback` *after the fast path settles* (not in the same tick as it — the skip
+ *    check below needs the fast path's actual result to have a chance of firing), so it starts
+ *    well after first paint and doesn't count toward RUM's `@view.loading_time`. Resolves
+ *    inherited access. Server-side cost is unchanged — this only moves it off the
+ *    bootstrap-blocking path, it doesn't make the call itself cheaper. Runs every bootstrap
+ *    (deliberately uncached: identity-scoped state here would need to invalidate on
+ *    impersonation start/stop, both of which reload in-tab — see
  *    `docs/architecture/backend/impersonation.md` — and re-running an idle-deferred call beats
- *    that invalidation risk). Skipped entirely once both signals are already `true`, since an
- *    OR-merge can no longer change the outcome.
+ *    that invalidation risk). Skipped entirely if the fast path already resolved both signals
+ *    `true`, since an OR-merge can no longer change the outcome.
  *
  * Both signals start `false` and only ever OR-merge to `true` as either call resolves — never
  * back — so the fast path, deferred sweep, and their arrival order don't matter to the consumer.
@@ -57,10 +59,14 @@ export class WriterGrantsService {
     afterNextRender(() => {
       this.projectService
         .getWriterSummary()
-        .pipe(takeUntilDestroyed(this.destroyRef))
+        .pipe(
+          // Schedule the deferred sweep only once the fast path has actually resolved (success or
+          // fail-closed) — scheduling it eagerly in this same tick would race the HTTP round trip,
+          // so runDeferredSweep's "skip if both already true" check would almost never see a `true`.
+          finalize(() => this.runWhenIdle(() => this.runDeferredSweep())),
+          takeUntilDestroyed(this.destroyRef)
+        )
         .subscribe((summary) => this.widen(summary));
-
-      this.runWhenIdle(() => this.runDeferredSweep());
     });
   }
 

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -3,7 +3,7 @@
 
 import { afterNextRender, DestroyRef, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_TIMEOUT_MS } from '@lfx-one/shared/constants';
+import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_MIN_DELAY_MS, IDLE_SWEEP_TIMEOUT_MS } from '@lfx-one/shared/constants';
 import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { summarizeWriterGrants } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
@@ -22,11 +22,14 @@ import { finalize, map } from 'rxjs';
  *    under-reports *inherited* access (e.g. a foundation-level writer's implicit access to a
  *    non-foundation child they hold no direct tuple on).
  *  - **Deferred sweep** — the existing unscoped `ProjectService.getProjects()` (the same call
- *    that used to run here directly and block bootstrap for 11-19s), scheduled via
- *    `requestIdleCallback` *after the fast path settles* (not in the same tick as it — the skip
- *    check below needs the fast path's actual result to have a chance of firing), so it starts
- *    well after first paint and doesn't count toward RUM's `@view.loading_time`. Resolves
- *    inherited access. Server-side cost is unchanged — this only moves it off the
+ *    that used to run here directly and block bootstrap for 11-19s), scheduled *after the fast
+ *    path settles* (not in the same tick as it — the skip check below needs the fast path's
+ *    actual result to have a chance of firing), then floored by `IDLE_SWEEP_MIN_DELAY_MS` before
+ *    `requestIdleCallback` is even attempted — that API has no minimum-delay guarantee of its own
+ *    and can fire on the very next idle frame, which can land inside Datadog RUM's post-request
+ *    activity-settle window and pull the sweep's XHR back into `@view.loading_time` (see that
+ *    constant's docstring). Resolves inherited access. Server-side cost is unchanged — this only
+ *    moves it off the
  *    bootstrap-blocking path, it doesn't make the call itself cheaper. Runs every bootstrap
  *    (deliberately uncached: identity-scoped state here would need to invalidate on
  *    impersonation start/stop, both of which reload in-tab — see
@@ -98,8 +101,14 @@ export class WriterGrantsService {
     }
 
     if (typeof requestIdleCallback === 'function') {
-      const id = requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
-      this.destroyRef.onDestroy(() => cancelIdleCallback(id));
+      // requestIdleCallback has no minimum-delay guarantee of its own — floor it first so RUM's
+      // post-request activity-settle window has a chance to close before we even try scheduling
+      // (see IDLE_SWEEP_MIN_DELAY_MS's docstring). The idle-callback ceiling still applies on top.
+      const floorId = setTimeout(() => {
+        const idleId = requestIdleCallback(cb, { timeout: IDLE_SWEEP_TIMEOUT_MS });
+        this.destroyRef.onDestroy(() => cancelIdleCallback(idleId));
+      }, IDLE_SWEEP_MIN_DELAY_MS);
+      this.destroyRef.onDestroy(() => clearTimeout(floorId));
     } else {
       const id = setTimeout(cb, IDLE_SWEEP_FALLBACK_DELAY_MS);
       this.destroyRef.onDestroy(() => clearTimeout(id));

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
+import { TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
+import { MonoTypeOperatorFunction, retry, throwError, timer } from 'rxjs';
 
 /**
  * Extracts a user-friendly error message from an HttpErrorResponse.
@@ -55,4 +57,18 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
  */
 export function isTransientHttpError(error: unknown): boolean {
   return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
+}
+
+/**
+ * RxJS `retry` config shared by every transient-error retry in the app — one retry policy,
+ * defined once, so `count`/delay can't drift between call sites the way a copy-pasted
+ * `retry({...})` block can. `count` defaults to 1; pass a different value for a call site that
+ * deliberately retries more (e.g. a user-triggered list load can afford to try harder than a
+ * bootstrap-critical fetch).
+ */
+export function retryTransientHttpError<T>(count: number = 1): MonoTypeOperatorFunction<T> {
+  return retry({
+    count,
+    delay: (error: unknown) => (isTransientHttpError(error) ? timer(TRANSIENT_RETRY_DELAY_MS) : throwError(() => error)),
+  });
 }

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -47,3 +47,12 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message) return error.message;
   return fallback;
 }
+
+/**
+ * Whether an error is worth retrying — a beat of time could plausibly fix a network drop (0),
+ * rate limit (429), or upstream 5xx, but not a client error like an expired session (401) or a
+ * permission/not-found response (403/404).
+ */
+export function isTransientHttpError(error: unknown): boolean {
+  return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
+}

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -52,6 +52,26 @@ export class ProjectController {
   }
 
   /**
+   * GET /projects/writer-summary
+   */
+  public async getWriterSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_writer_summary');
+
+    try {
+      const summary = await this.projectService.getWriterSummary(req);
+
+      logger.success(req, 'get_writer_summary', startTime, {
+        has_writer_foundation: summary.hasWriterFoundation,
+        has_writer_project: summary.hasWriterProject,
+      });
+
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /projects/search
    */
   public async searchProjects(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/projects.route.ts
+++ b/apps/lfx-one/src/server/routes/projects.route.ts
@@ -16,6 +16,8 @@ router.get('/search', (req, res, next) => projectController.searchProjects(req, 
 
 router.get('/pending-action-surveys', (req, res, next) => projectController.getPendingActionSurveys(req, res, next));
 
+router.get('/writer-summary', (req, res, next) => projectController.getWriterSummary(req, res, next));
+
 router.get('/:slug', (req, res, next) => projectController.getProjectBySlug(req, res, next));
 
 router.get('/:uid/permissions', (req, res, next) => projectController.getProjectPermissions(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { ProjectFunding } from '@lfx-one/shared/enums';
 import type { Project, QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,11 +9,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // vitest config, so every runtime (non-type-only) import needs a stub. `ProjectService`'s
 // constructor also builds `NatsService`/`SnowflakeService`/`ETagService` — none of the methods
 // under test here touch them, so they're stubbed to trivial classes to keep construction cheap.
-const { proxyRequest, addAccessToResources, checkAccess, computeIsFoundation } = vi.hoisted(() => ({
+const { proxyRequest, addAccessToResources, checkAccess } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   addAccessToResources: vi.fn(),
   checkAccess: vi.fn(),
-  computeIsFoundation: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/constants', () => ({
@@ -27,23 +27,23 @@ vi.mock('@lfx-one/shared/constants', () => ({
   ROOT_PROJECT_SLUG: 'root',
 }));
 vi.mock('@lfx-one/shared/enums', () => ({}));
-vi.mock('@lfx-one/shared/utils', () => ({
-  computeIsFoundation,
-  // Real reduction logic (mirrors packages/shared's summarizeWriterGrants) over the mocked
-  // computeIsFoundation, so getWriterSummary tests can drive foundation/non-foundation outcomes
-  // via computeIsFoundation.mockReturnValue/mockImplementation as before. summarizeWriterGrants
-  // itself has its own coverage in packages/shared/src/utils/project.utils.spec.ts.
-  summarizeWriterGrants: (projects: Project[]) => {
-    const writerProjects = projects.filter((p) => p.writer === true);
-    return {
-      hasWriterFoundation: writerProjects.some((p) => computeIsFoundation(p)),
-      hasWriterProject: writerProjects.some((p) => !computeIsFoundation(p)),
-    };
-  },
-  getDefaultMarketingImpactMonth: vi.fn(),
-  nullifyEmptyStrings: vi.fn(),
-  resolvePeriodRange: vi.fn(),
-}));
+// computeIsFoundation and summarizeWriterGrants are pulled in from the REAL implementation
+// (not hand-copied) so a regression there — e.g. dropping summarizeWriterGrants's `writer ===
+// true` filter, an access-widening bug — fails these tests too, rather than only the dedicated
+// packages/shared/src/utils/project.utils.spec.ts suite. Other `@lfx-one/shared/utils` exports
+// this file doesn't touch stay stubbed.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/project.utils')>(
+    '../../../../../packages/shared/src/utils/project.utils'
+  );
+  return {
+    computeIsFoundation: actual.computeIsFoundation,
+    summarizeWriterGrants: actual.summarizeWriterGrants,
+    getDefaultMarketingImpactMonth: vi.fn(),
+    nullifyEmptyStrings: vi.fn(),
+    resolvePeriodRange: vi.fn(),
+  };
+});
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
     public proxyRequest = proxyRequest;
@@ -84,7 +84,6 @@ describe('ProjectService — create picker methods', () => {
     proxyRequest.mockReset();
     addAccessToResources.mockReset();
     checkAccess.mockReset();
-    computeIsFoundation.mockReset();
     service = new ProjectService();
   });
 
@@ -138,11 +137,19 @@ describe('ProjectService — create picker methods', () => {
     });
   });
 
+  // Membership-funded + Active + not an Internal Allocation, per the real computeIsFoundation.
+  function foundation(uid: string): Partial<Project> {
+    return { uid, slug: uid, stage: 'Active', legal_entity_type: '', funding: 'Funded' as ProjectFunding, funding_model: ['Membership'] };
+  }
+  // Missing the Membership funding model — the real computeIsFoundation returns false.
+  function nonFoundation(uid: string): Partial<Project> {
+    return { uid, slug: uid, stage: 'Active', legal_entity_type: '', funding: 'Funded' as ProjectFunding, funding_model: [] };
+  }
+
   describe('getWriterSummary', () => {
     it('returns {true, false} when the only direct-writer project is a foundation', async () => {
-      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'fdn', slug: 'fdn' }]));
+      proxyRequest.mockResolvedValueOnce(pageOf([foundation('fdn')]));
       addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
-      computeIsFoundation.mockReturnValue(true);
 
       const result = await service.getWriterSummary(req);
 
@@ -150,9 +157,8 @@ describe('ProjectService — create picker methods', () => {
     });
 
     it('returns {false, true} when the only direct-writer project is non-foundation', async () => {
-      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'proj', slug: 'proj' }]));
+      proxyRequest.mockResolvedValueOnce(pageOf([nonFoundation('proj')]));
       addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
-      computeIsFoundation.mockReturnValue(false);
 
       const result = await service.getWriterSummary(req);
 
@@ -160,14 +166,8 @@ describe('ProjectService — create picker methods', () => {
     });
 
     it('returns {true, true} when direct-writer grants span both a foundation and a non-foundation project', async () => {
-      proxyRequest.mockResolvedValueOnce(
-        pageOf([
-          { uid: 'fdn', slug: 'fdn' },
-          { uid: 'proj', slug: 'proj' },
-        ])
-      );
+      proxyRequest.mockResolvedValueOnce(pageOf([foundation('fdn'), nonFoundation('proj')]));
       addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
-      computeIsFoundation.mockImplementation((p: Project) => p.uid === 'fdn');
 
       const result = await service.getWriterSummary(req);
 
@@ -175,13 +175,12 @@ describe('ProjectService — create picker methods', () => {
     });
 
     it('returns {false, false} when the caller holds no direct writer grants', async () => {
-      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'visible-only', slug: 'visible-only' }]));
+      proxyRequest.mockResolvedValueOnce(pageOf([foundation('visible-only')]));
       addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: false }))));
 
       const result = await service.getWriterSummary(req);
 
       expect(result).toEqual({ hasWriterFoundation: false, hasWriterProject: false });
-      expect(computeIsFoundation).not.toHaveBeenCalled();
     });
 
     it('propagates upstream errors rather than resolving a fail-closed summary', async () => {

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -34,6 +34,12 @@ vi.mock('@lfx-one/shared/enums', () => ({}));
 // getWriterSummary ever calls summarizeWriterGrants); that's covered by
 // packages/shared/src/utils/project.utils.spec.ts. Other `@lfx-one/shared/utils` exports this
 // file doesn't touch stay stubbed.
+//
+// Deep-imports the single pure file rather than `vi.importActual('@lfx-one/shared/utils')`:
+// the barrel re-exports Angular-dependent utils that pull in `@angular/common`'s `PlatformLocation`,
+// which needs the Angular JIT compiler — unavailable under this plain-Node Vitest environment, so
+// importing the barrel here throws at module-load time. `project.utils.ts` itself has no such
+// dependency.
 vi.mock('@lfx-one/shared/utils', async () => {
   const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/project.utils')>(
     '../../../../../packages/shared/src/utils/project.utils'

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -29,6 +29,17 @@ vi.mock('@lfx-one/shared/constants', () => ({
 vi.mock('@lfx-one/shared/enums', () => ({}));
 vi.mock('@lfx-one/shared/utils', () => ({
   computeIsFoundation,
+  // Real reduction logic (mirrors packages/shared's summarizeWriterGrants) over the mocked
+  // computeIsFoundation, so getWriterSummary tests can drive foundation/non-foundation outcomes
+  // via computeIsFoundation.mockReturnValue/mockImplementation as before. summarizeWriterGrants
+  // itself has its own coverage in packages/shared/src/utils/project.utils.spec.ts.
+  summarizeWriterGrants: (projects: Project[]) => {
+    const writerProjects = projects.filter((p) => p.writer === true);
+    return {
+      hasWriterFoundation: writerProjects.some((p) => computeIsFoundation(p)),
+      hasWriterProject: writerProjects.some((p) => !computeIsFoundation(p)),
+    };
+  },
   getDefaultMarketingImpactMonth: vi.fn(),
   nullifyEmptyStrings: vi.fn(),
   resolvePeriodRange: vi.fn(),

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -8,10 +8,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // vitest config, so every runtime (non-type-only) import needs a stub. `ProjectService`'s
 // constructor also builds `NatsService`/`SnowflakeService`/`ETagService` — none of the methods
 // under test here touch them, so they're stubbed to trivial classes to keep construction cheap.
-const { proxyRequest, addAccessToResources, checkAccess } = vi.hoisted(() => ({
+const { proxyRequest, addAccessToResources, checkAccess, computeIsFoundation } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   addAccessToResources: vi.fn(),
   checkAccess: vi.fn(),
+  computeIsFoundation: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/constants', () => ({
@@ -27,7 +28,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
 }));
 vi.mock('@lfx-one/shared/enums', () => ({}));
 vi.mock('@lfx-one/shared/utils', () => ({
-  computeIsFoundation: vi.fn(),
+  computeIsFoundation,
   getDefaultMarketingImpactMonth: vi.fn(),
   nullifyEmptyStrings: vi.fn(),
   resolvePeriodRange: vi.fn(),
@@ -72,6 +73,7 @@ describe('ProjectService — create picker methods', () => {
     proxyRequest.mockReset();
     addAccessToResources.mockReset();
     checkAccess.mockReset();
+    computeIsFoundation.mockReset();
     service = new ProjectService();
   });
 
@@ -122,6 +124,59 @@ describe('ProjectService — create picker methods', () => {
       // Only the non-writer ('b') needed the extra round trip.
       expect(checkAccess).toHaveBeenCalledTimes(1);
       expect(checkAccess.mock.calls[0][1]).toEqual([{ resource: 'project', id: 'b', access: 'meeting_coordinator' }]);
+    });
+  });
+
+  describe('getWriterSummary', () => {
+    it('returns {true, false} when the only direct-writer project is a foundation', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'fdn', slug: 'fdn' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+      computeIsFoundation.mockReturnValue(true);
+
+      const result = await service.getWriterSummary(req);
+
+      expect(result).toEqual({ hasWriterFoundation: true, hasWriterProject: false });
+    });
+
+    it('returns {false, true} when the only direct-writer project is non-foundation', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'proj', slug: 'proj' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+      computeIsFoundation.mockReturnValue(false);
+
+      const result = await service.getWriterSummary(req);
+
+      expect(result).toEqual({ hasWriterFoundation: false, hasWriterProject: true });
+    });
+
+    it('returns {true, true} when direct-writer grants span both a foundation and a non-foundation project', async () => {
+      proxyRequest.mockResolvedValueOnce(
+        pageOf([
+          { uid: 'fdn', slug: 'fdn' },
+          { uid: 'proj', slug: 'proj' },
+        ])
+      );
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: true }))));
+      computeIsFoundation.mockImplementation((p: Project) => p.uid === 'fdn');
+
+      const result = await service.getWriterSummary(req);
+
+      expect(result).toEqual({ hasWriterFoundation: true, hasWriterProject: true });
+    });
+
+    it('returns {false, false} when the caller holds no direct writer grants', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'visible-only', slug: 'visible-only' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects.map((p) => ({ ...p, writer: false }))));
+
+      const result = await service.getWriterSummary(req);
+
+      expect(result).toEqual({ hasWriterFoundation: false, hasWriterProject: false });
+      expect(computeIsFoundation).not.toHaveBeenCalled();
+    });
+
+    it('propagates upstream errors rather than resolving a fail-closed summary', async () => {
+      proxyRequest.mockRejectedValueOnce(new Error('upstream unavailable'));
+
+      await expect(service.getWriterSummary(req)).rejects.toThrow('upstream unavailable');
     });
   });
 

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -28,10 +28,12 @@ vi.mock('@lfx-one/shared/constants', () => ({
 }));
 vi.mock('@lfx-one/shared/enums', () => ({}));
 // computeIsFoundation and summarizeWriterGrants are pulled in from the REAL implementation
-// (not hand-copied) so a regression there — e.g. dropping summarizeWriterGrants's `writer ===
-// true` filter, an access-widening bug — fails these tests too, rather than only the dedicated
-// packages/shared/src/utils/project.utils.spec.ts suite. Other `@lfx-one/shared/utils` exports
-// this file doesn't touch stay stubbed.
+// (not hand-copied) so foundation-classification drift — e.g. a change to computeIsFoundation's
+// Membership/stage rules — fails these tests too. summarizeWriterGrants's own `writer === true`
+// filter can't be exercised from here (getDirectGrantProjects has already applied it before
+// getWriterSummary ever calls summarizeWriterGrants); that's covered by
+// packages/shared/src/utils/project.utils.spec.ts. Other `@lfx-one/shared/utils` exports this
+// file doesn't touch stay stubbed.
 vi.mock('@lfx-one/shared/utils', async () => {
   const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/project.utils')>(
     '../../../../../packages/shared/src/utils/project.utils'

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -391,10 +391,17 @@ export class ProjectService {
    */
   public async getWriterSummary(req: Request): Promise<WriterSummary> {
     const projects = await this.getDirectGrantProjects(req);
-    return {
+    const summary: WriterSummary = {
       hasWriterFoundation: projects.some((p) => computeIsFoundation(p)),
       hasWriterProject: projects.some((p) => !computeIsFoundation(p)),
     };
+
+    logger.debug(req, 'get_writer_summary', 'Reduced direct-grant projects to writer summary', {
+      direct_grant_count: projects.length,
+      ...summary,
+    });
+
+    return summary;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -390,7 +390,10 @@ export class ProjectService {
    * reducer (also used by `WriterGrantsService`'s deferred sweep, so both runtimes agree on what
    * counts as a writer-held foundation/project — and `summarizeWriterGrants` filters to
    * `writer === true` itself, so this stays correct even if `getDirectGrantProjects`'s
-   * `includeMeetingCoordinator` default ever changes).
+   * `includeMeetingCoordinator` default ever changes). Not short-circuited: `getDirectGrantProjects`
+   * always fully paginates and access-checks every direct grant, even once a foundation and a
+   * non-foundation row have both already been seen — bounded by the caller's own direct-grant
+   * count, which is normally small, but not by anything this method enforces.
    */
   public async getWriterSummary(req: Request): Promise<WriterSummary> {
     const projects = await this.getDirectGrantProjects(req);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -125,7 +125,7 @@ import {
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
 import type { AccessCheckRequest, MoMDirection, PaidProjectPerformance, ResolvedPeriodRange, WriterSummary } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
+import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange, summarizeWriterGrants } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
 
@@ -386,15 +386,15 @@ export class ProjectService {
   /**
    * Boolean writer-grant summary for `WriterGrantsService`'s bootstrap fast path (LFXV2-2857).
    * Reduces `getDirectGrantProjects` (direct-tuple-only, cheap — see its docstring) instead of
-   * `getProjects`'s unscoped sweep + batch access-check. `getDirectGrantProjects` already filters
-   * to `writer === true`, so no further access-check is needed here.
+   * `getProjects`'s unscoped sweep + batch access-check, via the shared `summarizeWriterGrants`
+   * reducer (also used by `WriterGrantsService`'s deferred sweep, so both runtimes agree on what
+   * counts as a writer-held foundation/project — and `summarizeWriterGrants` filters to
+   * `writer === true` itself, so this stays correct even if `getDirectGrantProjects`'s
+   * `includeMeetingCoordinator` default ever changes).
    */
   public async getWriterSummary(req: Request): Promise<WriterSummary> {
     const projects = await this.getDirectGrantProjects(req);
-    const summary: WriterSummary = {
-      hasWriterFoundation: projects.some((p) => computeIsFoundation(p)),
-      hasWriterProject: projects.some((p) => !computeIsFoundation(p)),
-    };
+    const summary = summarizeWriterGrants(projects);
 
     logger.debug(req, 'get_writer_summary', 'Reduced direct-grant projects to writer summary', {
       direct_grant_count: projects.length,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -124,7 +124,7 @@ import {
   WebActivitiesSummaryResponse,
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
-import type { AccessCheckRequest, MoMDirection, PaidProjectPerformance, ResolvedPeriodRange } from '@lfx-one/shared/interfaces';
+import type { AccessCheckRequest, MoMDirection, PaidProjectPerformance, ResolvedPeriodRange, WriterSummary } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, getDefaultMarketingImpactMonth, nullifyEmptyStrings, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 import FormData from 'form-data';
@@ -381,6 +381,20 @@ export class ProjectService {
     );
     const filtered = resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
     return this.filterToCreatableProjects(req, filtered, includeMeetingCoordinator);
+  }
+
+  /**
+   * Boolean writer-grant summary for `WriterGrantsService`'s bootstrap fast path (LFXV2-2857).
+   * Reduces `getDirectGrantProjects` (direct-tuple-only, cheap — see its docstring) instead of
+   * `getProjects`'s unscoped sweep + batch access-check. `getDirectGrantProjects` already filters
+   * to `writer === true`, so no further access-check is needed here.
+   */
+  public async getWriterSummary(req: Request): Promise<WriterSummary> {
+    const projects = await this.getDirectGrantProjects(req);
+    return {
+      hasWriterFoundation: projects.some((p) => computeIsFoundation(p)),
+      hasWriterProject: projects.some((p) => !computeIsFoundation(p)),
+    };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -398,7 +398,6 @@ export class ProjectService {
 
     logger.debug(req, 'get_writer_summary', 'Reduced direct-grant projects to writer summary', {
       direct_grant_count: projects.length,
-      ...summary,
     });
 
     return summary;

--- a/packages/shared/src/constants/http-retry.constants.ts
+++ b/packages/shared/src/constants/http-retry.constants.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Delay (ms) before retrying a transient HTTP failure (network drop, 429, 5xx) — see
+ * `isTransientHttpError` in `apps/lfx-one/src/app/shared/utils/http-error.utils.ts`. Shared so
+ * call sites that agree on this delay (e.g. `ProjectService.getProjects`,
+ * `MeetupsListComponent`) stay in sync structurally rather than by comment. Retry *count* is a
+ * per-call-site choice and isn't part of this constant.
+ */
+export const TRANSIENT_RETRY_DELAY_MS = 1000;

--- a/packages/shared/src/constants/http-retry.constants.ts
+++ b/packages/shared/src/constants/http-retry.constants.ts
@@ -2,20 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Delay (ms) before retrying a transient HTTP failure (network drop, 429, 5xx) — see
- * `isTransientHttpError` in `apps/lfx-one/src/app/shared/utils/http-error.utils.ts`. Shared so
- * call sites that agree on this delay (e.g. `ProjectService.getProjects`,
- * `MeetupsListComponent`) stay in sync structurally rather than by comment. Retry *count* is a
- * per-call-site choice and isn't part of this constant.
+ * Delay (ms) before retrying a transient HTTP failure (network drop, 429, 5xx) — used by
+ * `retryTransientHttpError` in `apps/lfx-one/src/app/shared/utils/http-error.utils.ts`, the one
+ * retry operator every transient-error retry in the app shares (`ProjectService.getProjects`,
+ * `ProjectService.getWriterSummary`, `MeetupsListComponent`). Retry *count* is a per-call-site
+ * argument to that operator and isn't part of this constant.
  */
 export const TRANSIENT_RETRY_DELAY_MS = 1000;
-
-/**
- * Hard ceiling (ms) on `ProjectService.getWriterSummary()` — `WriterGrantsService`'s bootstrap
- * fast path (LFXV2-2857). Without a bound, a hung request never settles, which means the
- * `finalize` that schedules the deferred sweep never fires either — an indefinitely-stalled fast
- * path would silently starve the *only* other path that resolves inherited writer access for the
- * rest of the session. Generous relative to the endpoint's typical latency (sub-second) but well
- * under `IDLE_SWEEP_TIMEOUT_MS`, so there's still headroom left for the sweep afterward.
- */
-export const WRITER_SUMMARY_TIMEOUT_MS = 10000;

--- a/packages/shared/src/constants/http-retry.constants.ts
+++ b/packages/shared/src/constants/http-retry.constants.ts
@@ -9,3 +9,13 @@
  * per-call-site choice and isn't part of this constant.
  */
 export const TRANSIENT_RETRY_DELAY_MS = 1000;
+
+/**
+ * Hard ceiling (ms) on `ProjectService.getWriterSummary()` — `WriterGrantsService`'s bootstrap
+ * fast path (LFXV2-2857). Without a bound, a hung request never settles, which means the
+ * `finalize` that schedules the deferred sweep never fires either — an indefinitely-stalled fast
+ * path would silently starve the *only* other path that resolves inherited writer access for the
+ * rest of the session. Generous relative to the endpoint's typical latency (sub-second) but well
+ * under `IDLE_SWEEP_TIMEOUT_MS`, so there's still headroom left for the sweep afterward.
+ */
+export const WRITER_SUMMARY_TIMEOUT_MS = 10000;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -87,3 +87,4 @@ export * from './create-picker.constants';
 export * from './org-meetings-insights.constants';
 export * from './delta-direction.constants';
 export * from './stat-card-grid.constants';
+export * from './writer-grants.constants';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -88,3 +88,4 @@ export * from './org-meetings-insights.constants';
 export * from './delta-direction.constants';
 export * from './stat-card-grid.constants';
 export * from './writer-grants.constants';
+export * from './http-retry.constants';

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -24,3 +24,16 @@ export const IDLE_SWEEP_TIMEOUT_MS = 15000;
  * trade-off. Revisit if that browser share stops being negligible.
  */
 export const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;
+
+/**
+ * Hard ceiling (ms) on `ProjectService.getWriterSummary()` — `WriterGrantsService`'s bootstrap
+ * fast path (LFXV2-2857). Bounds the whole retried call, not a single attempt: it must wrap
+ * `retryTransientHttpError()` in the pipe (not sit upstream of it), otherwise each retry
+ * resubscribes through a fresh timeout window instead of sharing this one. Without this bound, a
+ * hung request never settles, which means the `finalize` that schedules the deferred sweep never
+ * fires either — an indefinitely-stalled fast path would silently starve the *only* other path
+ * that resolves inherited writer access for the rest of the session. Generous relative to the
+ * endpoint's typical latency (sub-second), and this budget and {@link IDLE_SWEEP_TIMEOUT_MS} are
+ * sequential, not shared — the sweep's own ceiling only starts once this one has already ended.
+ */
+export const WRITER_SUMMARY_TIMEOUT_MS = 10000;

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -16,7 +16,11 @@ export const IDLE_SWEEP_TIMEOUT_MS = 15000;
 
 /**
  * `setTimeout` delay for `WriterGrantsService`'s deferred full sweep when `requestIdleCallback`
- * isn't available (LFXV2-2857) — unlike {@link IDLE_SWEEP_TIMEOUT_MS}, this is an unconditional
- * schedule with no idle detection behind it, so it stays short rather than reusing that ceiling.
+ * isn't available (LFXV2-2857) — e.g. Safari < 16.4. Unlike {@link IDLE_SWEEP_TIMEOUT_MS}, this
+ * fires unconditionally with no idle detection behind it, so it carries the same
+ * `@view.loading_time` re-entry risk that constant's ceiling is built to avoid. Kept short
+ * anyway: this path only runs on a shrinking, already-legacy browser slice, and leaving
+ * inherited-writer-grant resolution unresolved for 15s on every bootstrap there is the worse
+ * trade-off. Revisit if that browser share stops being negligible.
  */
 export const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * sessionStorage key for the merged `WriterSummary` produced by `WriterGrantsService`'s
- * deferred full sweep (LFXV2-2857). Written once the idle-triggered sweep resolves; read back
- * on the next bootstrap in the same tab session so a repeat page load gets the widened
- * foundation/project booleans immediately, without re-paying the slow unscoped sweep — and so
- * the sweep runs at most once per session (its presence is the "already ran" guard).
+ * Bound (ms) for `WriterGrantsService`'s deferred full sweep (LFXV2-2857): passed as
+ * `requestIdleCallback`'s `timeout` so a backgrounded/busy tab can't defer it indefinitely, and
+ * as the delay for the `setTimeout` fallback when `requestIdleCallback` isn't available.
  */
-export const WRITER_GRANTS_SESSION_CACHE_KEY = 'lfx-writer-grants-summary';
+export const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -2,10 +2,25 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Floor (ms) `WriterGrantsService` waits before even attempting `requestIdleCallback` for its
+ * deferred full sweep (LFXV2-2857). `requestIdleCallback` has no minimum-delay guarantee of its
+ * own — it can fire on the very next idle frame, which can be essentially immediately after the
+ * fast path's XHR completes (processing a response typically leaves the main thread idle right
+ * away). Datadog RUM's view-activity tracking only considers a view "done loading" after a settle
+ * window with no new requests, and restarts that window when another request starts — so an
+ * unfloored `requestIdleCallback` can fire inside that window and pull the deferred sweep's XHR
+ * back into `@view.loading_time`, reproducing the exact regression this ticket fixes. This floor
+ * exists to give that window a chance to close first; `IDLE_SWEEP_TIMEOUT_MS` below is a ceiling
+ * on top of it, not a substitute for it.
+ */
+export const IDLE_SWEEP_MIN_DELAY_MS = 2000;
+
+/**
  * `requestIdleCallback`'s `timeout` for `WriterGrantsService`'s deferred full sweep
- * (LFXV2-2857) — a ceiling, not a schedule. On a genuinely idle page the sweep fires via normal
- * idle detection well before this is reached; it only bounds the worst case (a chronically
- * busy/backgrounded tab that never goes idle).
+ * (LFXV2-2857) — a ceiling, not a schedule, applied *after* {@link IDLE_SWEEP_MIN_DELAY_MS} has
+ * already elapsed. On a genuinely idle page the sweep fires via normal idle detection well before
+ * this is reached; it only bounds the worst case (a chronically busy/backgrounded tab that never
+ * goes idle).
  *
  * Deliberately generous rather than short: on a busy foreground page, "busy main thread" tends
  * to correlate with "the view is still loading" (Datadog RUM's `@view.loading_time` window is

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * sessionStorage key for the merged `WriterSummary` produced by `WriterGrantsService`'s
+ * deferred full sweep (LFXV2-2857). Written once the idle-triggered sweep resolves; read back
+ * on the next bootstrap in the same tab session so a repeat page load gets the widened
+ * foundation/project booleans immediately, without re-paying the slow unscoped sweep — and so
+ * the sweep runs at most once per session (its presence is the "already ran" guard).
+ */
+export const WRITER_GRANTS_SESSION_CACHE_KEY = 'lfx-writer-grants-summary';

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -5,5 +5,12 @@
  * Bound (ms) for `WriterGrantsService`'s deferred full sweep (LFXV2-2857): passed as
  * `requestIdleCallback`'s `timeout` so a backgrounded/busy tab can't defer it indefinitely, and
  * as the delay for the `setTimeout` fallback when `requestIdleCallback` isn't available.
+ *
+ * Deliberately generous rather than short: on a busy foreground page, "busy main thread" tends
+ * to correlate with "the view is still loading" (Datadog RUM's `@view.loading_time` window is
+ * likely still open), so a short deadline can force the sweep to fire while that window is still
+ * open — reintroducing the exact regression this ticket fixes. A long bound only changes the
+ * worst-case (chronically busy/backgrounded tab) outcome; genuinely idle pages fire the sweep via
+ * normal idle detection long before this deadline is ever reached.
  */
-export const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;
+export const IDLE_SWEEP_FALLBACK_DELAY_MS = 15000;

--- a/packages/shared/src/constants/writer-grants.constants.ts
+++ b/packages/shared/src/constants/writer-grants.constants.ts
@@ -2,15 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Bound (ms) for `WriterGrantsService`'s deferred full sweep (LFXV2-2857): passed as
- * `requestIdleCallback`'s `timeout` so a backgrounded/busy tab can't defer it indefinitely, and
- * as the delay for the `setTimeout` fallback when `requestIdleCallback` isn't available.
+ * `requestIdleCallback`'s `timeout` for `WriterGrantsService`'s deferred full sweep
+ * (LFXV2-2857) — a ceiling, not a schedule. On a genuinely idle page the sweep fires via normal
+ * idle detection well before this is reached; it only bounds the worst case (a chronically
+ * busy/backgrounded tab that never goes idle).
  *
  * Deliberately generous rather than short: on a busy foreground page, "busy main thread" tends
  * to correlate with "the view is still loading" (Datadog RUM's `@view.loading_time` window is
- * likely still open), so a short deadline can force the sweep to fire while that window is still
- * open — reintroducing the exact regression this ticket fixes. A long bound only changes the
- * worst-case (chronically busy/backgrounded tab) outcome; genuinely idle pages fire the sweep via
- * normal idle detection long before this deadline is ever reached.
+ * likely still open), so a short ceiling can force the sweep to fire while that window is still
+ * open — reintroducing the exact regression this ticket fixes.
  */
-export const IDLE_SWEEP_FALLBACK_DELAY_MS = 15000;
+export const IDLE_SWEEP_TIMEOUT_MS = 15000;
+
+/**
+ * `setTimeout` delay for `WriterGrantsService`'s deferred full sweep when `requestIdleCallback`
+ * isn't available (LFXV2-2857) — unlike {@link IDLE_SWEEP_TIMEOUT_MS}, this is an unconditional
+ * schedule with no idle detection behind it, so it stays short rather than reusing that ceiling.
+ */
+export const IDLE_SWEEP_FALLBACK_DELAY_MS = 2000;

--- a/packages/shared/src/interfaces/create-artifact.interface.ts
+++ b/packages/shared/src/interfaces/create-artifact.interface.ts
@@ -1,8 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ProjectContext } from './project.interface';
-
 /**
  * Artifact types a permitted user can create from the rail "Create" quick-link.
  * Values map 1:1 to the existing creation routes (see `CREATABLE_ARTIFACTS`).
@@ -36,19 +34,4 @@ export interface CreatableArtifactConfig {
   createRoute: string;
   /** Semantic group this entry belongs to; a change between adjacent entries draws a menu separator. */
   group: CreatableArtifactGroup;
-}
-
-/**
- * A project/foundation the current user is permitted to create a given artifact
- * type on. Extends `ProjectContext` so it can be passed straight to
- * `ProjectContextService.setProject()` / `setFoundation()` before navigation.
- */
-export interface CreatableProject extends ProjectContext {
-  /**
-   * View-only, not part of any API payload: computed client-side by `computeIsFoundation()`
-   * from the project's own attributes. True when this context is a top-level foundation,
-   * which dispatches the selection to `setFoundation()` vs `setProject()` and selects the
-   * lens to align before navigating.
-   */
-  isFoundation: boolean;
 }

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -227,3 +227,19 @@ export interface PendingSurveyRow {
   RESPONSE_TYPE: string;
   SURVEY_LINK: string;
 }
+
+/**
+ * Reduced boolean summary of the caller's DIRECT `writer` grants — whether at least one
+ * directly-writable project satisfies `computeIsFoundation`, and whether at least one does not.
+ * Powers `WriterGrantsService`'s bootstrap fast path (LFXV2-2857): produced by
+ * `ProjectService.getWriterSummary`, which reduces `getDirectGrantProjects` (a
+ * `filter_grants=direct` query-service pull, cheap) instead of `getProjects`'s unscoped
+ * pagination + batch access-check (11-19s at scale). Direct-only under-reports a foundation
+ * writer's *inherited* access to non-foundation children — `WriterGrantsService`'s deferred
+ * background sweep of `getProjects()` independently OR-merges into these two booleans to
+ * restore that coverage without blocking bootstrap.
+ */
+export interface WriterSummary {
+  hasWriterFoundation: boolean;
+  hasWriterProject: boolean;
+}

--- a/packages/shared/src/utils/project.utils.spec.ts
+++ b/packages/shared/src/utils/project.utils.spec.ts
@@ -1,0 +1,74 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { ProjectFunding } from '../enums/project-funding.enum';
+import { ProjectStage } from '../enums/project-stage.enum';
+import { Project } from '../interfaces';
+import { summarizeWriterGrants } from './project.utils';
+
+/** Builds a Project fixture, defaulting every field so tests set only what they assert on. */
+function project(partial: Partial<Project>): Project {
+  return {
+    uid: partial.uid ?? 'uid',
+    slug: partial.slug ?? 'slug',
+    description: partial.description ?? '',
+    name: partial.name ?? '',
+    writer: partial.writer,
+    public: partial.public ?? true,
+    parent_uid: partial.parent_uid ?? '',
+    stage: partial.stage ?? ProjectStage.Active,
+    category: partial.category ?? '',
+    funding: partial.funding ?? ProjectFunding.Funded,
+    funding_model: partial.funding_model ?? ['Membership'],
+    charter_url: partial.charter_url ?? '',
+    legal_entity_type: partial.legal_entity_type ?? '',
+    legal_entity_name: partial.legal_entity_name ?? '',
+    legal_parent_uid: partial.legal_parent_uid ?? '',
+    autojoin_enabled: partial.autojoin_enabled ?? false,
+    formation_date: partial.formation_date ?? '',
+    logo_url: partial.logo_url ?? '',
+    repository_url: partial.repository_url ?? '',
+    website_url: partial.website_url ?? '',
+    created_at: partial.created_at ?? '',
+    updated_at: partial.updated_at ?? '',
+    mailing_list_count: partial.mailing_list_count ?? 0,
+  };
+}
+
+// Membership-funded + Active + not an Internal Allocation, per computeIsFoundation.
+const foundation = (uid: string, writer: boolean) => project({ uid, writer, stage: ProjectStage.Active, funding_model: ['Membership'] });
+// Missing the Membership funding model — computeIsFoundation returns false.
+const nonFoundation = (uid: string, writer: boolean) => project({ uid, writer, stage: ProjectStage.Active, funding_model: [] });
+
+describe('summarizeWriterGrants', () => {
+  it('returns {true, false} when the only writer-held project is a foundation', () => {
+    expect(summarizeWriterGrants([foundation('fdn', true)])).toEqual({ hasWriterFoundation: true, hasWriterProject: false });
+  });
+
+  it('returns {false, true} when the only writer-held project is non-foundation', () => {
+    expect(summarizeWriterGrants([nonFoundation('proj', true)])).toEqual({ hasWriterFoundation: false, hasWriterProject: true });
+  });
+
+  it('returns {true, true} when writer grants span both a foundation and a non-foundation project', () => {
+    expect(summarizeWriterGrants([foundation('fdn', true), nonFoundation('proj', true)])).toEqual({
+      hasWriterFoundation: true,
+      hasWriterProject: true,
+    });
+  });
+
+  it('returns {false, false} for an empty list', () => {
+    expect(summarizeWriterGrants([])).toEqual({ hasWriterFoundation: false, hasWriterProject: false });
+  });
+
+  it('ignores projects the caller can see but is not a writer on, even if visible-only rows outnumber grants', () => {
+    const result = summarizeWriterGrants([foundation('visible-fdn', false), nonFoundation('visible-proj', false), nonFoundation('actual-grant', true)]);
+
+    expect(result).toEqual({ hasWriterFoundation: false, hasWriterProject: true });
+  });
+
+  it('treats writer as false when the field is undefined (not requested / not access-checked)', () => {
+    expect(summarizeWriterGrants([project({ uid: 'unchecked' })])).toEqual({ hasWriterFoundation: false, hasWriterProject: false });
+  });
+});

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -3,7 +3,7 @@
 
 import { ProjectFunding } from '../enums/project-funding.enum';
 import { ProjectStage } from '../enums/project-stage.enum';
-import type { EnrichedPersonaProject, LensItem, Project, ProjectContext } from '../interfaces';
+import type { EnrichedPersonaProject, LensItem, Project, ProjectContext, WriterSummary } from '../interfaces';
 
 export function toProjectContext(project: EnrichedPersonaProject): ProjectContext {
   return {
@@ -57,4 +57,21 @@ export function computeIsFoundation(project: Project | null): boolean {
     Array.isArray(project.funding_model) &&
     project.funding_model.includes('Membership')
   );
+}
+
+/**
+ * Reduces a project list to a {@link WriterSummary} — whether it contains at least one
+ * writer-held foundation, and at least one writer-held non-foundation project. Filters to
+ * `writer === true` itself so callers can't accidentally widen access by passing an
+ * un-access-checked or differently-scoped list (LFXV2-2857): both `WriterGrantsService`'s
+ * deferred sweep (client, over the unscoped `getProjects()` result) and
+ * `ProjectService.getWriterSummary` (server, over the already writer-filtered
+ * `getDirectGrantProjects()` result) call this so the two runtimes can't drift apart.
+ */
+export function summarizeWriterGrants(projects: Project[]): WriterSummary {
+  const writerProjects = projects.filter((project) => project.writer === true);
+  return {
+    hasWriterFoundation: writerProjects.some((project) => computeIsFoundation(project)),
+    hasWriterProject: writerProjects.some((project) => !computeIsFoundation(project)),
+  };
 }


### PR DESCRIPTION
## Summary

Datadog RUM showed the dashboard `/` view's avg `@view.loading_time` step from ~5s to ~10s on 2026-07-20, when `WriterGrantsService` (PR #1130) started calling `GET /api/projects` in `afterNextRender` on every bootstrap. That endpoint does an unscoped pull of every visible project plus a batch access-check (avg 11-17s, p75 ~19s), and the pending XHR counted into the view's loading time.

The only consumer of `WriterGrantsService` is `LensService.getAllowedLensIds()`, which needs just two booleans (`hasWriterFoundation`, `hasWriterProject`). This PR replaces the blocking call with a two-phase approach:

- **Fast path** — a new `GET /api/projects/writer-summary` endpoint reduces `ProjectService.getDirectGrantProjects` (the `filter_grants=direct` pattern PR #1193 already proved cheap) instead of the unscoped sweep. Bounded by a 10s timeout (`WRITER_SUMMARY_TIMEOUT_MS`) that wraps its own retry, so a stalled connection can't block indefinitely.
- **Deferred sweep** — the existing unscoped `getProjects()` call still runs, but scheduled via `requestIdleCallback` once the fast path settles, so it never blocks the bootstrap-critical path and doesn't count toward `@view.loading_time`. It resolves *inherited* writer access (e.g. a foundation-level writer's implicit access to a non-foundation child project) that the direct-grant-only fast path can't see — this preserves PR #1130's original goal of widening lens access for inherited writers, not just direct ones.

Both signals only ever widen (OR-merge), never narrow, so the two phases can resolve in any order.

## Behavior changes worth reviewer attention

- **Retry policy added to `ProjectService.getProjects()` and `.getWriterSummary()`** — one retry, transient errors only (network drop / 429 / 5xx), via a new shared `retryTransientHttpError()` operator (also adopted by `MeetupsListComponent`, deduping three previously-separate inline retry blocks). `getWriterSummary()`'s retry sits *inside* its `timeout()`, so the whole retried call — not each attempt — shares the 10s budget.
- **`getProjects()` no longer pins a failed fetch into its session-long cache.** Previously a single transient failure cached `[]` for the rest of the session for every caller sharing that cache key; failures now evict the cache entry so the next caller re-fetches.

## Known trade-offs (documented, not fixed here — out of scope for this ticket)

- **Lens-redirect timing window widened.** `lensRedirectGuard` reads `activeLens()` synchronously with no readiness gate on the async-populated writer grants (pre-existing design from LFXV2-2754). Before this change, inherited-only writer access resolved within the single ~11-19s bootstrap call; now it resolves in up to two sequential stages — up to `WRITER_SUMMARY_TIMEOUT_MS` (10s) for the fast path to settle, then up to `IDLE_SWEEP_TIMEOUT_MS` (15s) before the deferred sweep dispatches, plus that sweep's own request latency. The guard already treats this as accepted/cosmetic (the underlying write authorization is enforced elsewhere, by `writerGuard` and `projectQueryParamGuard`), and `MainLayoutComponent` re-asserts the lens once the signal widens — but the window is real and worth knowing about if this becomes a UX complaint. See the comment in `lens-redirect.guard.ts`.
- **`ProjectService.getProject()` (singular)** has the same poisoned-`shareReplay`-cache-on-transient-failure pattern that `getProjects()` (plural) had before this PR fixed it — a failed fetch pins `null` for the rest of the session for that project. Not touched here since it's a separate consumer path unrelated to the writer-grants flow; worth a follow-up ticket.
- This is the tactical fix. LFXV2-2753 (a performant permissions-list API) is the long-term fix for this class of problem.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] New server-side unit tests for `getWriterSummary` (foundation-only / project-only / both / none / upstream error propagates)
- [x] New shared-package unit tests for the `summarizeWriterGrants` reducer
- [x] Manual validation against prod-backed dev server (`/lfx-full`)
