### PR TITLE
fix(profile): prevent impersonation identity fallback to impersonator

### DIFF
--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -425,6 +425,8 @@ export class ProfileController {
         this.emailVerificationService.listIdentitiesSafe(req, userSub),
       ]);
 
+      // sessionEmail is the target's email or undefined under impersonation (never the
+      // impersonator's), so a target with no primary correctly 400s instead of leaking it.
       const primaryEmail = freshEmails?.primary_email || sessionEmail;
 
       if (!primaryEmail) {
@@ -567,9 +569,8 @@ export class ProfileController {
         return;
       }
 
-      // Match GET /api/profile/emails (see getEmails): fall back to the session OIDC
-      // email when auth-service omits a primary, so accounts in that gap keep their
-      // primary forward option and claim-form default instead of seeing "no verified email".
+      // Match GET /api/profile/emails: fall back to the effective session email when auth-service
+      // omits a primary (null under impersonation — never the impersonator's, so stays null here).
       const sessionEmail = getEffectiveEmail(req) ?? undefined;
       const primaryEmail = emails.primary_email || sessionEmail || null;
 

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -1,0 +1,77 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { describe, expect, it } from 'vitest';
+
+import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername } from './auth-helper';
+
+interface TargetUser {
+  email?: string;
+  username?: string;
+  sub?: string;
+}
+
+// Minimal Request stand-in: the helpers only read `appSession`/`oidc`, and isImpersonating()
+// needs a non-empty token, a future expiry, and an impersonationUser.
+function buildReq(opts: { impersonating?: boolean; target?: TargetUser; oidc?: Record<string, unknown> }): Request {
+  const appSession = opts.impersonating
+    ? { impersonationToken: 'imp-token', impersonationExpiresAt: Date.now() + 60_000, impersonationUser: opts.target ?? {} }
+    : {};
+  return { appSession, oidc: opts.oidc ? { user: opts.oidc } : undefined } as unknown as Request;
+}
+
+// The impersonator's own OIDC identity — present in every impersonation case to prove the
+// helpers never fall back to it when the target's stored field is empty.
+const OPERATOR_OIDC = { email: 'Operator@Example.com', nickname: 'operatornick', username: 'operatorname', sub: 'auth0|operator' };
+
+describe('getEffectiveEmail', () => {
+  it('returns the target email lowercased when impersonating', () => {
+    const req = buildReq({ impersonating: true, target: { email: 'Target@Example.com' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveEmail(req)).toBe('target@example.com');
+  });
+
+  it('returns null (never the impersonator) when the target has no stored email', () => {
+    const req = buildReq({ impersonating: true, target: { email: '' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveEmail(req)).toBeNull();
+  });
+
+  it('returns the OIDC email lowercased when not impersonating', () => {
+    const req = buildReq({ oidc: { email: 'User@Example.com' } });
+    expect(getEffectiveEmail(req)).toBe('user@example.com');
+  });
+});
+
+describe('getEffectiveUsername', () => {
+  it('returns the target username when impersonating', () => {
+    const req = buildReq({ impersonating: true, target: { username: 'targetuser' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveUsername(req)).toBe('targetuser');
+  });
+
+  it('returns null (never the impersonator) when the target has no stored username', () => {
+    const req = buildReq({ impersonating: true, target: { username: '' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveUsername(req)).toBeNull();
+  });
+
+  it('falls back to the OIDC nickname when not impersonating', () => {
+    const req = buildReq({ oidc: { nickname: 'usernick', username: 'username' } });
+    expect(getEffectiveUsername(req)).toBe('usernick');
+  });
+});
+
+describe('getEffectiveSub', () => {
+  it('returns the target sub when impersonating', () => {
+    const req = buildReq({ impersonating: true, target: { sub: 'auth0|target' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveSub(req)).toBe('auth0|target');
+  });
+
+  it('returns null (never the impersonator) when the target has no stored sub', () => {
+    const req = buildReq({ impersonating: true, target: { sub: '' }, oidc: OPERATOR_OIDC });
+    expect(getEffectiveSub(req)).toBeNull();
+  });
+
+  it('returns the OIDC sub when not impersonating', () => {
+    const req = buildReq({ oidc: { sub: 'auth0|user' } });
+    expect(getEffectiveSub(req)).toBe('auth0|user');
+  });
+});

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -56,24 +56,30 @@ export function usernameMatches(authUsername: string, storedUsername: string): b
 
 /**
  * Gets the effective email for the current request context.
- * During impersonation, returns the target user's email from the impersonation session.
- * Otherwise returns the OIDC session user's email.
+ * During impersonation, returns the target user's email from the impersonation session,
+ * or null when the target has no stored email — it never falls back to the impersonator's
+ * own OIDC email. Otherwise returns the OIDC session user's email.
  */
 export function getEffectiveEmail(req: Request): string | null {
-  if (isImpersonating(req) && req.appSession?.['impersonationUser']?.email) {
-    return (req.appSession['impersonationUser'].email as string).toLowerCase();
+  // Never fall back to the impersonator's OIDC email: the stored target email can be
+  // empty, so return null in that gap and let callers handle "no primary email".
+  if (isImpersonating(req)) {
+    return (req.appSession?.['impersonationUser']?.email as string)?.toLowerCase() || null;
   }
   return (req.oidc?.user?.['email'] as string)?.toLowerCase() || null;
 }
 
 /**
  * Gets the effective username for the current request context.
- * During impersonation, returns the target user's username from the impersonation session.
- * Otherwise returns the OIDC session user's username/nickname.
+ * During impersonation, returns the target user's username from the impersonation session,
+ * or null when the target has no stored username — it never falls back to the impersonator's
+ * own OIDC username. Otherwise returns the OIDC session user's username/nickname.
  */
 export function getEffectiveUsername(req: Request): string | null {
-  if (isImpersonating(req) && req.appSession?.['impersonationUser']?.username) {
-    return req.appSession['impersonationUser'].username as string;
+  // Never fall back to the impersonator's OIDC username: the stored target username can
+  // be empty, so return null in that gap and let callers handle the missing identity.
+  if (isImpersonating(req)) {
+    return (req.appSession?.['impersonationUser']?.username as string) || null;
   }
   // `preferred_username` is the Authelia LFID-username fallback (#912) — additive last, so Auth0
   // (nickname/username) precedence is unchanged. Mirrors `getUsernameFromAuth`.
@@ -82,7 +88,8 @@ export function getEffectiveUsername(req: Request): string | null {
 
 /**
  * Gets the effective sub (user ID) for the current request context.
- * During impersonation, returns the target user's sub from the impersonation session.
+ * During impersonation, returns the target user's sub from the impersonation session,
+ * or null when unset — it never falls back to the impersonator's own OIDC sub.
  * Otherwise returns the OIDC session user's sub.
  *
  * @deprecated Prefer getEffectiveUsername for APIs that accept the LFID username.
@@ -91,8 +98,9 @@ export function getEffectiveUsername(req: Request): string | null {
  * been migrated to accept a username.
  */
 export function getEffectiveSub(req: Request): string | null {
-  if (isImpersonating(req) && req.appSession?.['impersonationUser']?.sub) {
-    return req.appSession['impersonationUser'].sub as string;
+  // Never fall back to the impersonator's OIDC sub: return the target's sub or null.
+  if (isImpersonating(req)) {
+    return (req.appSession?.['impersonationUser']?.sub as string) || null;
   }
   return (req.oidc?.user?.['sub'] as string) || null;
 }


### PR DESCRIPTION
## Summary

- The impersonation identity helpers no longer fall back to the impersonator's own OIDC
  identity when the target's stored field is empty (auth-service omitted the claim →
  `impersonation.service` stores `''`). Under impersonation they now return the target
  value or `null`, mirroring the already-correct `getEffectiveName`:
  - `getEffectiveEmail` — was surfacing the operator's address as the target's primary.
  - `getEffectiveUsername` — feeds per-user authorization/filtering (org-lens,
    persona-detection, meeting, changelog, …); the residual fallback could leak the
    operator's identity into target-scoped reads.
  - `getEffectiveSub` — same pattern, hardened for consistency.
- Audited the two `profile.controller` read call sites: `getLinuxAlias` leaves no bogus
  "(Primary)" forward option; `getUserEmails` returns 400 on the empty gap rather than
  leaking the operator's email.
- Added `auth-helper.spec.ts` locking in the null-under-impersonation contract for all
  three helpers (target present → target; target empty → null; not impersonating → OIDC).

Part of LFXV2-1663.
