### PR TITLE
feat(groups): add public group detail page

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -436,6 +436,14 @@ export const routes: Routes = [
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
   },
+  {
+    path: 'groups/not-found',
+    loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
+  },
+  {
+    path: 'groups/:id',
+    loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
+  },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {
     path: 'invite',

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { MKTG_OS_AGENTS_ROUTE_SEGMENT } from '@lfx-one/shared/constants';
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
+import { authenticatedMatchGuard } from './shared/guards/authenticated-match.guard';
 import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
@@ -17,16 +18,6 @@ import { settingsLensRedirectGuard } from './shared/guards/settings-lens-redirec
 const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
 
 export const routes: Routes = [
-  // Public group detail — must precede the root '' route because its authenticated child
-  // 'groups' → ':id' (COMMITTEE_ROUTES) would match first and trigger authGuard.
-  {
-    path: 'groups/not-found',
-    loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
-  },
-  {
-    path: 'groups/:id',
-    loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
-  },
   {
     path: '',
     canActivate: [authGuard],
@@ -333,6 +324,7 @@ export const routes: Routes = [
       },
       {
         path: 'groups',
+        canMatch: [authenticatedMatchGuard],
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/committees/committees.routes').then((m) => m.COMMITTEE_ROUTES),
       },
@@ -445,6 +437,14 @@ export const routes: Routes = [
   {
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
+  },
+  {
+    path: 'groups/not-found',
+    loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
+  },
+  {
+    path: 'groups/:id',
+    loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
   },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -17,6 +17,16 @@ import { settingsLensRedirectGuard } from './shared/guards/settings-lens-redirec
 const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
 
 export const routes: Routes = [
+  // Public group detail — must precede the root '' route because its authenticated child
+  // 'groups' → ':id' (COMMITTEE_ROUTES) would match first and trigger authGuard.
+  {
+    path: 'groups/not-found',
+    loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
+  },
+  {
+    path: 'groups/:id',
+    loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
+  },
   {
     path: '',
     canActivate: [authGuard],
@@ -435,14 +445,6 @@ export const routes: Routes = [
   {
     path: 'meetings/:id',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
-  },
-  {
-    path: 'groups/not-found',
-    loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
-  },
-  {
-    path: 'groups/:id',
-    loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
   },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -39,6 +39,9 @@
 
         <!-- Main Group Card -->
         <lfx-card class="rounded-[12.75px] mb-6" data-testid="group-info-card">
+          <!-- Group Title -->
+          <h1 class="mb-4" data-testid="group-title">{{ group.name }}</h1>
+
           <!-- Badges Row -->
           <div class="flex items-center gap-2 flex-wrap mb-4">
             <lfx-tag [value]="group.category" severity="secondary" styleClass="tag-category" data-testid="group-badge-category"></lfx-tag>
@@ -50,12 +53,15 @@
             }
           </div>
 
-          <!-- Group Title -->
-          <h1 class="mb-4" data-testid="group-title">{{ group.name }}</h1>
-
           <!-- Context Chips (Foundation / Project) -->
           <div class="flex flex-wrap items-center gap-2 mb-4" data-testid="group-context">
-            <lfx-tag [value]="group.context.foundation_name" severity="secondary" icon="fa-light fa-landmark" data-testid="group-context-foundation"></lfx-tag>
+            @if (group.context.foundation_name && group.context.foundation_name !== 'ROOT') {
+              <lfx-tag
+                [value]="group.context.foundation_name"
+                severity="secondary"
+                icon="fa-light fa-landmark"
+                data-testid="group-context-foundation"></lfx-tag>
+            }
             @if (group.context.project_name) {
               <lfx-tag
                 [value]="group.context.project_name"

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -17,13 +17,24 @@
           </div>
           <p-skeleton width="100%" height="200px" borderRadius="12px" />
         </div>
+      } @else if (error()) {
+        <!-- Error state for unexpected failures -->
+        <lfx-card data-testid="group-error-card">
+          <div class="text-center py-12">
+            <div class="flex justify-center mb-6">
+              <div class="w-24 h-24 bg-red-50 rounded-full flex items-center justify-center">
+                <i class="fa-light fa-triangle-exclamation text-4xl text-red-400"></i>
+              </div>
+            </div>
+            <h2 class="text-lg font-semibold text-gray-900 mb-2">Something went wrong</h2>
+            <p class="text-sm text-gray-600 mb-4">We couldn't load this group. Please try again later.</p>
+          </div>
+        </lfx-card>
       } @else if (group(); as group) {
         <!-- Breadcrumb -->
         <nav class="flex items-center gap-1.5 text-sm text-gray-500 mb-4" data-testid="group-breadcrumb">
-          @if (parentProject(); as parent) {
-            <a [routerLink]="['/']" class="text-blue-500 hover:underline">{{ parent.name }}</a>
-            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
-          }
+          <span class="text-gray-500">{{ group.context.foundation_name }}</span>
+          <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
           @if (group.context.project_name) {
             <span class="text-gray-500">{{ group.context.project_name }}</span>
             <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
@@ -93,7 +104,7 @@
                       </div>
                       <div class="flex flex-col gap-0.5 min-w-0">
                         <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
-                        <span class="text-xs text-gray-500">{{ meeting.starts_at | date: 'MMM d, y · h:mm a' : meeting.timezone }}</span>
+                        <span class="text-xs text-gray-500">{{ meeting.starts_at | meetingTime: 0 : 'compact' : meeting.timezone }}</span>
                       </div>
                     </a>
                   }

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -45,7 +45,16 @@
 
         <!-- Page Header -->
         <div class="flex flex-col gap-2 mb-5" data-testid="group-header">
-          <h1 class="text-xl font-semibold text-gray-900">{{ group.name }}</h1>
+          <div class="flex items-center gap-3">
+            @if (projectLogoUrl(); as logoUrl) {
+              <img
+                [src]="logoUrl"
+                [alt]="group.context.project_name || group.context.foundation_name"
+                class="w-10 h-10 rounded-lg object-contain flex-shrink-0"
+                data-testid="group-project-logo" />
+            }
+            <h1 class="text-xl font-semibold text-gray-900">{{ group.name }}</h1>
+          </div>
           <div class="flex items-center gap-2 flex-wrap">
             <lfx-tag [value]="group.category" severity="secondary" styleClass="tag-category" data-testid="group-badge-category"></lfx-tag>
             @if (joinModeLabel(); as label) {

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -77,47 +77,23 @@
           </div>
         }
 
-        <!-- Two-column layout -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
-          <!-- Main column -->
-          <div class="md:col-span-2 flex flex-col gap-5">
+        <!-- Group info card -->
+        <lfx-card data-testid="group-info-card">
+          <div class="flex flex-col gap-5">
             <!-- About / Description -->
             @if (group.description) {
-              <lfx-card data-testid="group-about-card">
+              <div data-testid="group-about-section">
                 <h3 class="text-sm font-semibold text-gray-900 mb-3">About</h3>
                 <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
-              </lfx-card>
+              </div>
             }
 
-            <!-- Upcoming Meetings -->
-            @if (hasUpcomingMeetings()) {
-              <lfx-card data-testid="group-meetings-card">
-                <h3 class="text-sm font-semibold text-gray-900 mb-3">Upcoming Meetings</h3>
-                <div class="flex flex-col gap-3">
-                  @for (meeting of group.upcoming_meetings; track meeting.uid) {
-                    <a
-                      [routerLink]="[meeting.url]"
-                      class="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group/meeting"
-                      [attr.data-testid]="'meeting-' + meeting.uid">
-                      <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
-                        <i class="fa-light fa-video text-blue-500 text-sm"></i>
-                      </div>
-                      <div class="flex flex-col gap-0.5 min-w-0">
-                        <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
-                        <span class="text-xs text-gray-500">{{ meeting.starts_at | meetingTime: 0 : 'compact' : meeting.timezone }}</span>
-                      </div>
-                    </a>
-                  }
-                </div>
-              </lfx-card>
-            }
-          </div>
-
-          <!-- Sidebar -->
-          <div class="flex flex-col gap-5">
-            <!-- Chairs card -->
+            <!-- Leadership -->
             @if (group.chairs.length > 0) {
-              <lfx-card data-testid="group-chairs-card">
+              @if (group.description) {
+                <hr class="border-gray-200" />
+              }
+              <div data-testid="group-leadership-section">
                 <h3 class="text-sm font-semibold text-gray-900 mb-3">Leadership</h3>
                 <div class="flex flex-col gap-3">
                   @for (chair of group.chairs; track chair.name) {
@@ -137,12 +113,13 @@
                     </div>
                   }
                 </div>
-              </lfx-card>
+              </div>
             }
 
-            <!-- Links card -->
+            <!-- Links -->
             @if (hasLinks()) {
-              <lfx-card data-testid="group-links-card">
+              <hr class="border-gray-200" />
+              <div data-testid="group-links-section">
                 <h3 class="text-sm font-semibold text-gray-900 mb-3">Links</h3>
                 <div class="flex flex-col gap-2">
                   @if (group.links.website) {
@@ -186,10 +163,33 @@
                     </a>
                   }
                 </div>
-              </lfx-card>
+              </div>
             }
           </div>
-        </div>
+        </lfx-card>
+
+        <!-- Upcoming Meetings -->
+        @if (hasUpcomingMeetings()) {
+          <lfx-card data-testid="group-meetings-card">
+            <h3 class="text-sm font-semibold text-gray-900 mb-3">Upcoming Meetings</h3>
+            <div class="flex flex-col gap-3">
+              @for (meeting of group.upcoming_meetings; track meeting.uid) {
+                <a
+                  [routerLink]="[meeting.url]"
+                  class="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group/meeting"
+                  [attr.data-testid]="'meeting-' + meeting.uid">
+                  <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                    <i class="fa-light fa-video text-blue-500 text-sm"></i>
+                  </div>
+                  <div class="flex flex-col gap-0.5 min-w-0">
+                    <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
+                    <span class="text-xs text-gray-500">{{ meeting.starts_at | meetingTime: 0 : 'compact' : meeting.timezone }}</span>
+                  </div>
+                </a>
+              }
+            </div>
+          </lfx-card>
+        }
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -46,7 +46,7 @@
           <div class="flex items-center gap-2 flex-wrap mb-4">
             <lfx-tag [value]="group.category" severity="secondary" styleClass="tag-category" data-testid="group-badge-category"></lfx-tag>
             @if (joinModeLabel(); as label) {
-              <lfx-tag [value]="label" severity="secondary" [icon]="joinModeIcon()!" data-testid="group-badge-join-mode"></lfx-tag>
+              <lfx-tag [value]="label" severity="secondary" [icon]="joinModeIcon() || ''" data-testid="group-badge-join-mode"></lfx-tag>
             }
             @if (group.cadence) {
               <lfx-tag [value]="group.cadence" severity="secondary" icon="fa-light fa-repeat" data-testid="group-badge-cadence"></lfx-tag>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -9,13 +9,10 @@
       @if (loading()) {
         <!-- Skeleton loading state -->
         <div class="flex flex-col gap-4">
-          <p-skeleton width="200px" height="16px" />
-          <p-skeleton width="300px" height="28px" />
-          <div class="flex gap-2">
-            <p-skeleton width="100px" height="24px" borderRadius="6px" />
-            <p-skeleton width="120px" height="24px" borderRadius="6px" />
+          <div class="flex items-center justify-center mb-6">
+            <p-skeleton width="120px" height="56px" />
           </div>
-          <p-skeleton width="100%" height="200px" borderRadius="12px" />
+          <p-skeleton width="100%" height="400px" borderRadius="12px" />
         </div>
       } @else if (error()) {
         <!-- Error state for unexpected failures -->
@@ -31,174 +28,200 @@
           </div>
         </lfx-card>
       } @else if (group(); as group) {
-        <!-- Breadcrumb -->
-        <nav class="flex items-center gap-1.5 text-sm text-gray-500 mb-4" data-testid="group-breadcrumb">
-          @if (group.context.project_name) {
-            <span class="text-gray-500">{{ group.context.project_name }}</span>
-            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
+        <!-- Project Logo (fallback to LFX logo) -->
+        <div class="flex items-center justify-center mb-6">
+          @if (projectLogoUrl(); as logoUrl) {
+            <img [src]="logoUrl" [alt]="group.context.project_name || group.context.foundation_name" class="w-auto h-10 md:h-14" />
           } @else {
-            <span class="text-gray-500">{{ group.context.foundation_name }}</span>
-            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
+            <img src="/images/logo_lfx.svg" alt="LFX Logo" class="w-auto h-10 md:h-14" />
           }
-          <span class="text-gray-700 font-medium">{{ group.name }}</span>
-        </nav>
+        </div>
 
-        <!-- Page Header -->
-        <div class="flex flex-col gap-2 mb-5" data-testid="group-header">
-          <div class="flex items-center gap-3">
-            @if (projectLogoUrl(); as logoUrl) {
-              <img
-                [src]="logoUrl"
-                [alt]="group.context.project_name || group.context.foundation_name"
-                class="w-10 h-10 rounded-lg object-contain flex-shrink-0"
-                data-testid="group-project-logo" />
-            }
-            <h1 class="text-xl font-semibold text-gray-900">{{ group.name }}</h1>
-          </div>
-          <div class="flex items-center gap-2 flex-wrap">
+        <!-- Main Group Card -->
+        <lfx-card class="rounded-[12.75px] mb-6" data-testid="group-info-card">
+          <!-- Badges Row -->
+          <div class="flex items-center gap-2 flex-wrap mb-4">
             <lfx-tag [value]="group.category" severity="secondary" styleClass="tag-category" data-testid="group-badge-category"></lfx-tag>
             @if (joinModeLabel(); as label) {
               <lfx-tag [value]="label" severity="secondary" [icon]="joinModeIcon()!" data-testid="group-badge-join-mode"></lfx-tag>
             }
-            @if (group.total_members > 0) {
-              <span class="text-sm text-gray-500">{{ group.total_members }} {{ group.total_members === 1 ? 'member' : 'members' }}</span>
+            @if (group.cadence) {
+              <lfx-tag [value]="group.cadence" severity="secondary" icon="fa-light fa-repeat" data-testid="group-badge-cadence"></lfx-tag>
             }
           </div>
-          @if (group.cadence) {
-            <div class="flex items-center gap-1.5 text-sm text-gray-500" data-testid="group-cadence">
-              <i class="fa-light fa-calendar-clock text-gray-400"></i>
-              <span>{{ group.cadence }}</span>
+
+          <!-- Group Title -->
+          <h1 class="mb-4" data-testid="group-title">{{ group.name }}</h1>
+
+          <!-- Context Chips (Foundation / Project) -->
+          <div class="flex flex-wrap items-center gap-2 mb-4" data-testid="group-context">
+            <lfx-tag
+              [value]="group.context.foundation_name"
+              severity="secondary"
+              icon="fa-light fa-landmark"
+              data-testid="group-context-foundation"></lfx-tag>
+            @if (group.context.project_name) {
+              <lfx-tag
+                [value]="group.context.project_name"
+                severity="secondary"
+                icon="fa-light fa-cube"
+                styleClass="!text-teal-700 !bg-teal-50 !border-teal-200"
+                data-testid="group-context-project"></lfx-tag>
+            }
+          </div>
+
+          <!-- Member Count -->
+          @if (group.total_members > 0) {
+            <div class="flex items-center gap-1.5 text-sm text-gray-500 mb-4" data-testid="group-member-count">
+              <i class="fa-light fa-users text-gray-400"></i>
+              <span>{{ group.total_members }} {{ group.total_members === 1 ? 'member' : 'members' }}</span>
             </div>
           }
-        </div>
 
-        <!-- Member status banner (authenticated members) -->
-        @if (group.is_member) {
-          <div
-            class="bg-emerald-50 border border-emerald-200 rounded-xl px-5 py-3 mb-4 flex items-center gap-2.5 text-sm text-emerald-800"
-            data-testid="member-status-banner">
-            <i class="fa-light fa-circle-check"></i>
-            <span>You are {{ memberRoleLabel() }} of this group.</span>
-          </div>
-        }
-
-        <!-- Visitor hero banner (unauthenticated) -->
-        @if (!authenticated()) {
-          <div class="bg-gradient-to-br from-blue-50 to-sky-50 border border-blue-200 rounded-xl py-7 px-6 mb-5 text-center" data-testid="visitor-hero-banner">
-            <h2 class="text-lg font-semibold text-gray-900 mb-2">Join {{ group.name }}</h2>
-            <p class="text-sm text-gray-600 mb-4 max-w-lg mx-auto">
-              Sign in with your LFX account to join this group, subscribe to updates, and participate in meetings.
-            </p>
-            <lfx-button label="Sign In to Join" icon="fa-light fa-right-to-bracket" (onClick)="navigateToLogin()" data-testid="visitor-join-cta"></lfx-button>
-          </div>
-        }
-
-        <!-- Group info card (only when at least one section has content) -->
-        @if (hasInfoContent()) {
-          <lfx-card data-testid="group-info-card">
-            <div class="flex flex-col gap-5">
-              <!-- About / Description -->
-              @if (group.description) {
-                <div data-testid="group-about-section">
-                  <h3 class="text-sm font-semibold text-gray-900 mb-3">About</h3>
-                  <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
-                </div>
-              }
-
-              <!-- Leadership -->
-              @if (group.chairs.length > 0) {
-                @if (group.description) {
-                  <hr class="border-gray-200" />
-                }
-                <div data-testid="group-leadership-section">
-                  <h3 class="text-sm font-semibold text-gray-900 mb-3">Leadership</h3>
-                  <div class="flex flex-col gap-3">
-                    @for (chair of group.chairs; track chair.name) {
-                      <div class="flex items-center gap-2.5">
-                        <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
-                          <span class="text-xs font-medium text-gray-600">{{ chair.name | slice: 0 : 2 | uppercase }}</span>
-                        </div>
-                        <div class="flex flex-col min-w-0">
-                          <span class="text-sm font-medium text-gray-900 truncate">{{ chair.name }}</span>
-                          <span class="text-xs text-gray-500 truncate">
-                            {{ chair.role }}
-                            @if (chair.organization) {
-                              <span> · {{ chair.organization }}</span>
-                            }
-                          </span>
-                        </div>
-                      </div>
-                    }
-                  </div>
-                </div>
-              }
-
-              <!-- Links -->
-              @if (hasLinks()) {
-                @if (group.description || group.chairs.length > 0) {
-                  <hr class="border-gray-200" />
-                }
-                <div data-testid="group-links-section">
-                  <h3 class="text-sm font-semibold text-gray-900 mb-3">Links</h3>
-                  <div class="flex flex-col gap-2">
-                    @if (group.links.website) {
-                      <a
-                        [href]="group.links.website"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                        <i class="fa-light fa-globe w-4 text-center text-gray-400"></i>
-                        <span>Website</span>
-                      </a>
-                    }
-                    @if (group.links.mailing_list) {
-                      <a
-                        [href]="group.links.mailing_list"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                        <i class="fa-light fa-envelope w-4 text-center text-gray-400"></i>
-                        <span>Mailing List</span>
-                      </a>
-                    }
-                    @if (group.links.calendar) {
-                      <button
-                        type="button"
-                        (click)="openCalendarSubscribe()"
-                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline cursor-pointer bg-transparent border-none p-0">
-                        <i class="fa-light fa-calendar w-4 text-center text-gray-400"></i>
-                        <span>Subscribe to Calendar</span>
-                      </button>
-                    }
-                  </div>
-                </div>
-              }
+          <!-- Member status banner (authenticated members) -->
+          @if (group.is_member) {
+            <div
+              class="bg-emerald-50 border border-emerald-200 rounded px-3 py-2 mb-4 flex items-center gap-2.5 text-sm text-emerald-800"
+              data-testid="member-status-banner">
+              <i class="fa-light fa-circle-check"></i>
+              <span>You are {{ memberRoleLabel() }} of this group.</span>
             </div>
-          </lfx-card>
-        }
+          }
 
-        <!-- Upcoming Meetings -->
-        @if (hasUpcomingMeetings()) {
-          <lfx-card data-testid="group-meetings-card">
-            <h3 class="text-sm font-semibold text-gray-900 mb-3">Upcoming Meetings</h3>
-            <div class="flex flex-col gap-3">
-              @for (meeting of group.upcoming_meetings; track meeting.uid) {
-                <a
-                  [routerLink]="[meeting.url]"
-                  class="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group/meeting"
-                  [attr.data-testid]="'meeting-' + meeting.uid">
-                  <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
-                    <i class="fa-light fa-video text-blue-500 text-sm"></i>
-                  </div>
-                  <div class="flex flex-col gap-0.5 min-w-0">
-                    <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
-                    <span class="text-xs text-gray-500">{{ meeting.starts_at | meetingTime: 0 : 'compact' : meeting.timezone }}</span>
-                  </div>
-                </a>
-              }
+          <!-- About / Description -->
+          @if (group.description) {
+            <hr class="border-gray-200 my-4" />
+            <div data-testid="group-about-section">
+              <div class="flex items-center gap-2 mb-3">
+                <i class="fa-light fa-info-circle text-gray-500 text-xs"></i>
+                <h3 class="text-gray-600 text-sm font-normal">About</h3>
+              </div>
+              <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
             </div>
-          </lfx-card>
-        }
+          }
+
+          <!-- Leadership -->
+          @if (group.chairs.length > 0) {
+            <hr class="border-gray-200 my-4" />
+            <div data-testid="group-leadership-section">
+              <div class="flex items-center gap-2 mb-3">
+                <i class="fa-light fa-user-crown text-gray-500 text-xs"></i>
+                <h3 class="text-gray-600 text-sm font-normal">Leadership</h3>
+              </div>
+              <div class="flex flex-col gap-3">
+                @for (chair of group.chairs; track chair.name) {
+                  <div class="flex items-center gap-2.5">
+                    <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                      <span class="text-xs font-medium text-gray-600">{{ chair.name | slice: 0 : 2 | uppercase }}</span>
+                    </div>
+                    <div class="flex flex-col min-w-0">
+                      <span class="text-sm font-medium text-gray-900 truncate">{{ chair.name }}</span>
+                      <span class="text-xs text-gray-500 truncate">
+                        {{ chair.role }}
+                        @if (chair.organization) {
+                          <span> · {{ chair.organization }}</span>
+                        }
+                      </span>
+                    </div>
+                  </div>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Links -->
+          @if (hasLinks()) {
+            <hr class="border-gray-200 my-4" />
+            <div data-testid="group-links-section">
+              <div class="flex items-center gap-2 mb-3">
+                <i class="fa-light fa-link text-gray-500 text-xs"></i>
+                <h3 class="text-gray-600 text-sm font-normal">Links</h3>
+              </div>
+              <div class="flex flex-col gap-2">
+                @if (group.links.website) {
+                  <a
+                    [href]="group.links.website"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                    <i class="fa-light fa-globe w-4 text-center text-gray-400"></i>
+                    <span>Website</span>
+                  </a>
+                }
+                @if (group.links.mailing_list) {
+                  <a
+                    [href]="group.links.mailing_list"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                    <i class="fa-light fa-envelope w-4 text-center text-gray-400"></i>
+                    <span>Mailing List</span>
+                  </a>
+                }
+                @if (group.links.calendar) {
+                  <button
+                    type="button"
+                    (click)="openCalendarSubscribe()"
+                    class="flex items-center gap-2 text-sm text-blue-500 hover:underline cursor-pointer bg-transparent border-none p-0">
+                    <i class="fa-light fa-calendar w-4 text-center text-gray-400"></i>
+                    <span>Subscribe to Calendar</span>
+                  </button>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Upcoming Meetings -->
+          @if (hasUpcomingMeetings()) {
+            <hr class="border-gray-200 my-4" />
+            <div data-testid="group-meetings-section">
+              <div class="flex items-center gap-2 mb-3">
+                <i class="fa-light fa-calendar text-gray-500 text-xs"></i>
+                <h3 class="text-gray-600 text-sm font-normal">Upcoming Meetings</h3>
+              </div>
+              <div class="flex flex-col gap-3">
+                @for (meeting of group.upcoming_meetings; track meeting.uid) {
+                  <a
+                    [routerLink]="[meeting.url]"
+                    class="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group/meeting"
+                    [attr.data-testid]="'meeting-' + meeting.uid">
+                    <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                      <i class="fa-light fa-video text-blue-500 text-sm"></i>
+                    </div>
+                    <div class="flex flex-col gap-0.5 min-w-0">
+                      <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
+                      <span class="text-xs text-gray-500">{{ meeting.starts_at | meetingTime: 0 : 'compact' : meeting.timezone }}</span>
+                    </div>
+                  </a>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Sign In Section (unauthenticated visitors) -->
+          @if (!authenticated()) {
+            <hr class="border-gray-200 my-4" />
+
+            <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center justify-between gap-3" data-testid="visitor-sign-in-banner">
+              <div class="flex items-center gap-3">
+                <i class="fa-light fa-arrow-right-to-bracket text-blue-600 text-2xl"></i>
+                <div>
+                  <p class="font-semibold text-sm text-blue-900">Sign in with your LFX account</p>
+                  <p class="text-xs text-gray-600">Join this group, subscribe to updates, and participate in meetings</p>
+                </div>
+              </div>
+              <lfx-button
+                class="w-full md:w-auto"
+                styleClass="w-full md:w-auto"
+                size="small"
+                label="Sign In"
+                icon="fa-light fa-arrow-right-to-bracket"
+                severity="info"
+                (onClick)="navigateToLogin()"
+                data-testid="visitor-sign-in-cta"></lfx-button>
+            </div>
+          }
+        </lfx-card>
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -33,10 +33,11 @@
       } @else if (group(); as group) {
         <!-- Breadcrumb -->
         <nav class="flex items-center gap-1.5 text-sm text-gray-500 mb-4" data-testid="group-breadcrumb">
-          <span class="text-gray-500">{{ group.context.foundation_name }}</span>
-          <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
           @if (group.context.project_name) {
             <span class="text-gray-500">{{ group.context.project_name }}</span>
+            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
+          } @else {
+            <span class="text-gray-500">{{ group.context.foundation_name }}</span>
             <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
           }
           <span class="text-gray-700 font-medium">{{ group.name }}</span>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -1,0 +1,185 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-header></lfx-header>
+
+<div class="bg-gray-50 min-h-screen">
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-[960px] mx-auto flex flex-col">
+      @if (loading()) {
+        <!-- Skeleton loading state -->
+        <div class="flex flex-col gap-4">
+          <p-skeleton width="200px" height="16px" />
+          <p-skeleton width="300px" height="28px" />
+          <div class="flex gap-2">
+            <p-skeleton width="100px" height="24px" borderRadius="6px" />
+            <p-skeleton width="120px" height="24px" borderRadius="6px" />
+          </div>
+          <p-skeleton width="100%" height="200px" borderRadius="12px" />
+        </div>
+      } @else if (group(); as group) {
+        <!-- Breadcrumb -->
+        <nav class="flex items-center gap-1.5 text-sm text-gray-500 mb-4" data-testid="group-breadcrumb">
+          @if (parentProject(); as parent) {
+            <a [routerLink]="['/']" class="text-blue-500 hover:underline">{{ parent.name }}</a>
+            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
+          }
+          @if (group.context.project_name) {
+            <span class="text-gray-500">{{ group.context.project_name }}</span>
+            <i class="fa-light fa-chevron-right text-xs text-gray-400"></i>
+          }
+          <span class="text-gray-700 font-medium">{{ group.name }}</span>
+        </nav>
+
+        <!-- Page Header -->
+        <div class="flex flex-col gap-2 mb-5" data-testid="group-header">
+          <h1 class="text-xl font-semibold text-gray-900">{{ group.name }}</h1>
+          <div class="flex items-center gap-2 flex-wrap">
+            <lfx-tag [value]="group.category" severity="secondary" styleClass="tag-category" data-testid="group-badge-category"></lfx-tag>
+            @if (joinModeLabel(); as label) {
+              <lfx-tag [value]="label" severity="secondary" [icon]="joinModeIcon()!" data-testid="group-badge-join-mode"></lfx-tag>
+            }
+            @if (group.total_members > 0) {
+              <span class="text-sm text-gray-500">{{ group.total_members }} {{ group.total_members === 1 ? 'member' : 'members' }}</span>
+            }
+          </div>
+        </div>
+
+        <!-- Member status banner (authenticated members) -->
+        @if (group.is_member) {
+          <div
+            class="bg-emerald-50 border border-emerald-200 rounded-xl px-5 py-3 mb-4 flex items-center gap-2.5 text-sm text-emerald-800"
+            data-testid="member-status-banner">
+            <i class="fa-light fa-circle-check"></i>
+            <span>You are {{ memberRoleLabel() }} of this group.</span>
+          </div>
+        }
+
+        <!-- Visitor hero banner (unauthenticated) -->
+        @if (!authenticated()) {
+          <div class="bg-gradient-to-br from-blue-50 to-sky-50 border border-blue-200 rounded-xl py-7 px-6 mb-5 text-center" data-testid="visitor-hero-banner">
+            <h2 class="text-lg font-semibold text-gray-900 mb-2">Join {{ group.name }}</h2>
+            <p class="text-sm text-gray-600 mb-4 max-w-lg mx-auto">
+              Sign in with your LFX account to join this group, subscribe to updates, and participate in meetings.
+            </p>
+            <lfx-button label="Sign In to Join" icon="fa-light fa-right-to-bracket" (onClick)="navigateToLogin()" data-testid="visitor-join-cta"></lfx-button>
+          </div>
+        }
+
+        <!-- Two-column layout -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
+          <!-- Main column -->
+          <div class="md:col-span-2 flex flex-col gap-5">
+            <!-- About / Description -->
+            @if (group.description) {
+              <lfx-card data-testid="group-about-card">
+                <h3 class="text-sm font-semibold text-gray-900 mb-3">About</h3>
+                <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
+              </lfx-card>
+            }
+
+            <!-- Upcoming Meetings -->
+            @if (hasUpcomingMeetings()) {
+              <lfx-card data-testid="group-meetings-card">
+                <h3 class="text-sm font-semibold text-gray-900 mb-3">Upcoming Meetings</h3>
+                <div class="flex flex-col gap-3">
+                  @for (meeting of group.upcoming_meetings; track meeting.uid) {
+                    <a
+                      [routerLink]="[meeting.url]"
+                      class="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group/meeting"
+                      [attr.data-testid]="'meeting-' + meeting.uid">
+                      <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <i class="fa-light fa-video text-blue-500 text-sm"></i>
+                      </div>
+                      <div class="flex flex-col gap-0.5 min-w-0">
+                        <span class="text-sm font-medium text-gray-900 group-hover/meeting:text-blue-600 truncate">{{ meeting.title }}</span>
+                        <span class="text-xs text-gray-500">{{ meeting.starts_at | date: 'MMM d, y · h:mm a' : meeting.timezone }}</span>
+                      </div>
+                    </a>
+                  }
+                </div>
+              </lfx-card>
+            }
+          </div>
+
+          <!-- Sidebar -->
+          <div class="flex flex-col gap-5">
+            <!-- Chairs card -->
+            @if (group.chairs.length > 0) {
+              <lfx-card data-testid="group-chairs-card">
+                <h3 class="text-sm font-semibold text-gray-900 mb-3">Leadership</h3>
+                <div class="flex flex-col gap-3">
+                  @for (chair of group.chairs; track chair.name) {
+                    <div class="flex items-center gap-2.5">
+                      <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                        <span class="text-xs font-medium text-gray-600">{{ chair.name | slice: 0 : 2 | uppercase }}</span>
+                      </div>
+                      <div class="flex flex-col min-w-0">
+                        <span class="text-sm font-medium text-gray-900 truncate">{{ chair.name }}</span>
+                        <span class="text-xs text-gray-500 truncate">
+                          {{ chair.role }}
+                          @if (chair.organization) {
+                            <span> · {{ chair.organization }}</span>
+                          }
+                        </span>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </lfx-card>
+            }
+
+            <!-- Links card -->
+            @if (hasLinks()) {
+              <lfx-card data-testid="group-links-card">
+                <h3 class="text-sm font-semibold text-gray-900 mb-3">Links</h3>
+                <div class="flex flex-col gap-2">
+                  @if (group.links.website) {
+                    <a
+                      [href]="group.links.website"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                      <i class="fa-light fa-globe w-4 text-center text-gray-400"></i>
+                      <span>Website</span>
+                    </a>
+                  }
+                  @if (group.links.mailing_list) {
+                    <a
+                      [href]="group.links.mailing_list"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                      <i class="fa-light fa-envelope w-4 text-center text-gray-400"></i>
+                      <span>Mailing List</span>
+                    </a>
+                  }
+                  @if (group.links.chat_channel) {
+                    <a
+                      [href]="group.links.chat_channel"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                      <i class="fa-light fa-message w-4 text-center text-gray-400"></i>
+                      <span>Chat Channel</span>
+                    </a>
+                  }
+                  @if (group.links.calendar) {
+                    <a
+                      [href]="group.links.calendar"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                      <i class="fa-light fa-calendar w-4 text-center text-gray-400"></i>
+                      <span>Subscribe to Calendar</span>
+                    </a>
+                  }
+                </div>
+              </lfx-card>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -55,11 +55,7 @@
 
           <!-- Context Chips (Foundation / Project) -->
           <div class="flex flex-wrap items-center gap-2 mb-4" data-testid="group-context">
-            <lfx-tag
-              [value]="group.context.foundation_name"
-              severity="secondary"
-              icon="fa-light fa-landmark"
-              data-testid="group-context-foundation"></lfx-tag>
+            <lfx-tag [value]="group.context.foundation_name" severity="secondary" icon="fa-light fa-landmark" data-testid="group-context-foundation"></lfx-tag>
             @if (group.context.project_name) {
               <lfx-tag
                 [value]="group.context.project_name"
@@ -202,7 +198,9 @@
           @if (!authenticated()) {
             <hr class="border-gray-200 my-4" />
 
-            <div class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center justify-between gap-3" data-testid="visitor-sign-in-banner">
+            <div
+              class="bg-blue-50 border border-blue-500/50 rounded px-3 py-2 flex flex-wrap items-center justify-between gap-3"
+              data-testid="visitor-sign-in-banner">
               <div class="flex items-center gap-3">
                 <i class="fa-light fa-arrow-right-to-bracket text-blue-600 text-2xl"></i>
                 <div>

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -78,96 +78,89 @@
           </div>
         }
 
-        <!-- Group info card -->
-        <lfx-card data-testid="group-info-card">
-          <div class="flex flex-col gap-5">
-            <!-- About / Description -->
-            @if (group.description) {
-              <div data-testid="group-about-section">
-                <h3 class="text-sm font-semibold text-gray-900 mb-3">About</h3>
-                <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
-              </div>
-            }
-
-            <!-- Leadership -->
-            @if (group.chairs.length > 0) {
+        <!-- Group info card (only when at least one section has content) -->
+        @if (hasInfoContent()) {
+          <lfx-card data-testid="group-info-card">
+            <div class="flex flex-col gap-5">
+              <!-- About / Description -->
               @if (group.description) {
-                <hr class="border-gray-200" />
+                <div data-testid="group-about-section">
+                  <h3 class="text-sm font-semibold text-gray-900 mb-3">About</h3>
+                  <lfx-expandable-text [maxHeight]="200">{{ group.description }}</lfx-expandable-text>
+                </div>
               }
-              <div data-testid="group-leadership-section">
-                <h3 class="text-sm font-semibold text-gray-900 mb-3">Leadership</h3>
-                <div class="flex flex-col gap-3">
-                  @for (chair of group.chairs; track chair.name) {
-                    <div class="flex items-center gap-2.5">
-                      <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
-                        <span class="text-xs font-medium text-gray-600">{{ chair.name | slice: 0 : 2 | uppercase }}</span>
-                      </div>
-                      <div class="flex flex-col min-w-0">
-                        <span class="text-sm font-medium text-gray-900 truncate">{{ chair.name }}</span>
-                        <span class="text-xs text-gray-500 truncate">
-                          {{ chair.role }}
-                          @if (chair.organization) {
-                            <span> · {{ chair.organization }}</span>
-                          }
-                        </span>
-                      </div>
-                    </div>
-                  }
-                </div>
-              </div>
-            }
 
-            <!-- Links -->
-            @if (hasLinks()) {
-              <hr class="border-gray-200" />
-              <div data-testid="group-links-section">
-                <h3 class="text-sm font-semibold text-gray-900 mb-3">Links</h3>
-                <div class="flex flex-col gap-2">
-                  @if (group.links.website) {
-                    <a
-                      [href]="group.links.website"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                      <i class="fa-light fa-globe w-4 text-center text-gray-400"></i>
-                      <span>Website</span>
-                    </a>
-                  }
-                  @if (group.links.mailing_list) {
-                    <a
-                      [href]="group.links.mailing_list"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                      <i class="fa-light fa-envelope w-4 text-center text-gray-400"></i>
-                      <span>Mailing List</span>
-                    </a>
-                  }
-                  @if (group.links.chat_channel) {
-                    <a
-                      [href]="group.links.chat_channel"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                      <i class="fa-light fa-message w-4 text-center text-gray-400"></i>
-                      <span>Chat Channel</span>
-                    </a>
-                  }
-                  @if (group.links.calendar) {
-                    <a
-                      [href]="group.links.calendar"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
-                      <i class="fa-light fa-calendar w-4 text-center text-gray-400"></i>
-                      <span>Subscribe to Calendar</span>
-                    </a>
-                  }
+              <!-- Leadership -->
+              @if (group.chairs.length > 0) {
+                @if (group.description) {
+                  <hr class="border-gray-200" />
+                }
+                <div data-testid="group-leadership-section">
+                  <h3 class="text-sm font-semibold text-gray-900 mb-3">Leadership</h3>
+                  <div class="flex flex-col gap-3">
+                    @for (chair of group.chairs; track chair.name) {
+                      <div class="flex items-center gap-2.5">
+                        <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                          <span class="text-xs font-medium text-gray-600">{{ chair.name | slice: 0 : 2 | uppercase }}</span>
+                        </div>
+                        <div class="flex flex-col min-w-0">
+                          <span class="text-sm font-medium text-gray-900 truncate">{{ chair.name }}</span>
+                          <span class="text-xs text-gray-500 truncate">
+                            {{ chair.role }}
+                            @if (chair.organization) {
+                              <span> · {{ chair.organization }}</span>
+                            }
+                          </span>
+                        </div>
+                      </div>
+                    }
+                  </div>
                 </div>
-              </div>
-            }
-          </div>
-        </lfx-card>
+              }
+
+              <!-- Links -->
+              @if (hasLinks()) {
+                @if (group.description || group.chairs.length > 0) {
+                  <hr class="border-gray-200" />
+                }
+                <div data-testid="group-links-section">
+                  <h3 class="text-sm font-semibold text-gray-900 mb-3">Links</h3>
+                  <div class="flex flex-col gap-2">
+                    @if (group.links.website) {
+                      <a
+                        [href]="group.links.website"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                        <i class="fa-light fa-globe w-4 text-center text-gray-400"></i>
+                        <span>Website</span>
+                      </a>
+                    }
+                    @if (group.links.mailing_list) {
+                      <a
+                        [href]="group.links.mailing_list"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline">
+                        <i class="fa-light fa-envelope w-4 text-center text-gray-400"></i>
+                        <span>Mailing List</span>
+                      </a>
+                    }
+                    @if (group.links.calendar) {
+                      <button
+                        type="button"
+                        (click)="openCalendarSubscribe()"
+                        class="flex items-center gap-2 text-sm text-blue-500 hover:underline cursor-pointer bg-transparent border-none p-0">
+                        <i class="fa-light fa-calendar w-4 text-center text-gray-400"></i>
+                        <span>Subscribe to Calendar</span>
+                      </button>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          </lfx-card>
+        }
 
         <!-- Upcoming Meetings -->
         @if (hasUpcomingMeetings()) {

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.html
@@ -55,6 +55,12 @@
               <span class="text-sm text-gray-500">{{ group.total_members }} {{ group.total_members === 1 ? 'member' : 'members' }}</span>
             }
           </div>
+          @if (group.cadence) {
+            <div class="flex items-center gap-1.5 text-sm text-gray-500" data-testid="group-cadence">
+              <i class="fa-light fa-calendar-clock text-gray-400"></i>
+              <span>{{ group.cadence }}</span>
+            </div>
+          }
         </div>
 
         <!-- Member status banner (authenticated members) -->

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -79,11 +79,6 @@ export class GroupDetailComponent {
 
   protected readonly hasUpcomingMeetings = computed(() => (this.group()?.upcoming_meetings?.length ?? 0) > 0);
 
-  protected readonly hasInfoContent = computed(() => {
-    const g = this.group();
-    return !!(g?.description || g?.chairs.length || this.hasLinks());
-  });
-
   protected readonly projectLogoUrl = computed(() => {
     const ctx = this.group()?.context;
     return ctx?.project_logo_url || ctx?.foundation_logo_url || null;

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -1,0 +1,135 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe, isPlatformBrowser, SlicePipe, UpperCasePipe } from '@angular/common';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ExpandableTextComponent } from '@components/expandable-text/expandable-text.component';
+import { HeaderComponent } from '@components/header/header.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
+import { PublicGroupDetail, Project } from '@lfx-one/shared/interfaces';
+import { GroupService } from '@services/group.service';
+import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-group-detail',
+  imports: [
+    DatePipe,
+    SlicePipe,
+    UpperCasePipe,
+    RouterLink,
+    ButtonComponent,
+    CardComponent,
+    ExpandableTextComponent,
+    HeaderComponent,
+    TagComponent,
+    SkeletonModule,
+  ],
+  templateUrl: './group-detail.component.html',
+})
+export class GroupDetailComponent {
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly groupService = inject(GroupService);
+  private readonly projectService = inject(ProjectService);
+  protected readonly userService = inject(UserService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  protected readonly authenticated = this.userService.authenticated;
+  protected readonly loading = signal(true);
+
+  protected readonly group: Signal<PublicGroupDetail | null> = this.initGroup();
+  protected readonly parentProject: Signal<Project | null> = this.initParentProject();
+
+  protected readonly joinModeLabel = computed(() => {
+    const mode = this.group()?.join_mode;
+    return mode ? JOIN_MODE_LABELS[mode] : null;
+  });
+
+  protected readonly joinModeIcon = computed(() => {
+    const mode = this.group()?.join_mode;
+    switch (mode) {
+      case 'open':
+        return 'fa-light fa-door-open';
+      case 'application':
+        return 'fa-light fa-file-lines';
+      case 'invite_only':
+        return 'fa-light fa-envelope';
+      case 'closed':
+        return 'fa-light fa-lock';
+      default:
+        return null;
+    }
+  });
+
+  protected readonly hasLinks = computed(() => {
+    const links = this.group()?.links;
+    return !!(links?.website || links?.mailing_list || links?.chat_channel || links?.calendar);
+  });
+
+  protected readonly hasUpcomingMeetings = computed(() => (this.group()?.upcoming_meetings?.length ?? 0) > 0);
+
+  protected readonly memberRoleLabel = computed(() => {
+    const role = this.group()?.my_role;
+    if (role === 'Chair' || role === 'Vice Chair') {
+      return `a ${role.toLowerCase()}`;
+    }
+    return 'a member';
+  });
+
+  protected navigateToLogin(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`;
+    }
+  }
+
+  private initGroup(): Signal<PublicGroupDetail | null> {
+    return toSignal(
+      this.activatedRoute.paramMap.pipe(
+        map((params) => params.get('id')),
+        filter((id): id is string => !!id),
+        distinctUntilChanged(),
+        switchMap((id) => {
+          this.loading.set(true);
+          return this.groupService.getPublicGroup(id).pipe(
+            catchError((error) => {
+              if ([404, 403, 400].includes(error.status)) {
+                this.router.navigate(['/groups/not-found']);
+              }
+              this.loading.set(false);
+              return of(null);
+            })
+          );
+        }),
+        map((group) => {
+          this.loading.set(false);
+          return group;
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initParentProject(): Signal<Project | null> {
+    return toSignal(
+      toObservable(this.group).pipe(
+        map((g) => g?.context.foundation_slug ?? null),
+        distinctUntilChanged(),
+        switchMap((slug) => {
+          if (!slug) return of(null);
+          return this.projectService.getProject(slug, false).pipe(catchError(() => of(null)));
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -84,6 +84,11 @@ export class GroupDetailComponent {
     return !!(g?.description || g?.chairs.length || this.hasLinks());
   });
 
+  protected readonly projectLogoUrl = computed(() => {
+    const ctx = this.group()?.context;
+    return ctx?.project_logo_url || ctx?.foundation_logo_url || null;
+  });
+
   protected readonly memberRoleLabel = computed(() => {
     const role = this.group()?.my_role;
     if (role === 'Chair' || role === 'Vice Chair') {
@@ -125,7 +130,9 @@ export class GroupDetailComponent {
           this.error.set(false);
           return this.groupService.getPublicGroup(id).pipe(
             catchError((err) => {
-              if ([400, 403, 404].includes(err.status)) {
+              if (err.status === 403) {
+                this.router.navigate(['/groups/not-found'], { queryParams: { reason: 'private' } });
+              } else if ([400, 404].includes(err.status)) {
                 this.router.navigate(['/groups/not-found']);
               } else {
                 this.error.set(true);

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -42,7 +42,7 @@ export class GroupDetailComponent {
   private readonly router = inject(Router);
   private readonly groupService = inject(GroupService);
   private readonly dialogService = inject(DialogService);
-  protected readonly userService = inject(UserService);
+  private readonly userService = inject(UserService);
   private readonly platformId = inject(PLATFORM_ID);
 
   protected readonly authenticated = this.userService.authenticated;
@@ -138,7 +138,9 @@ export class GroupDetailComponent {
           );
         }),
         map((group) => {
-          this.loading.set(false);
+          if (group) {
+            this.loading.set(false);
+          }
           return group;
         })
       ),

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -12,9 +12,11 @@ import { HeaderComponent } from '@components/header/header.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
 import { PublicGroupDetail } from '@lfx-one/shared/interfaces';
+import { IcalSubscribeDialogComponent } from '@modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { GroupService } from '@services/group.service';
 import { UserService } from '@services/user.service';
+import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rxjs';
 
@@ -32,12 +34,14 @@ import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rx
     MeetingTimePipe,
     SkeletonModule,
   ],
+  providers: [DialogService],
   templateUrl: './group-detail.component.html',
 })
 export class GroupDetailComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly groupService = inject(GroupService);
+  private readonly dialogService = inject(DialogService);
   protected readonly userService = inject(UserService);
   private readonly platformId = inject(PLATFORM_ID);
 
@@ -70,10 +74,15 @@ export class GroupDetailComponent {
 
   protected readonly hasLinks = computed(() => {
     const links = this.group()?.links;
-    return !!(links?.website || links?.mailing_list || links?.chat_channel || links?.calendar);
+    return !!(links?.website || links?.mailing_list || links?.calendar);
   });
 
   protected readonly hasUpcomingMeetings = computed(() => (this.group()?.upcoming_meetings?.length ?? 0) > 0);
+
+  protected readonly hasInfoContent = computed(() => {
+    const g = this.group();
+    return !!(g?.description || g?.chairs.length || this.hasLinks());
+  });
 
   protected readonly memberRoleLabel = computed(() => {
     const role = this.group()?.my_role;
@@ -87,6 +96,22 @@ export class GroupDetailComponent {
     if (isPlatformBrowser(this.platformId)) {
       window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`;
     }
+  }
+
+  protected openCalendarSubscribe(): void {
+    const g = this.group();
+    if (!g?.links.calendar) {
+      return;
+    }
+    const feedUrl = isPlatformBrowser(this.platformId) ? `${window.location.origin}${g.links.calendar}` : g.links.calendar;
+    this.dialogService.open(IcalSubscribeDialogComponent, {
+      header: `Subscribe — ${g.name}`,
+      width: '480px',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { feedUrl, name: g.name },
+    });
   }
 
   private initGroup(): Signal<PublicGroupDetail | null> {

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, isPlatformBrowser, SlicePipe, UpperCasePipe } from '@angular/common';
-import { Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { isPlatformBrowser, SlicePipe, UpperCasePipe } from '@angular/common';
+import { Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -11,9 +11,9 @@ import { ExpandableTextComponent } from '@components/expandable-text/expandable-
 import { HeaderComponent } from '@components/header/header.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
-import { PublicGroupDetail, Project } from '@lfx-one/shared/interfaces';
+import { PublicGroupDetail } from '@lfx-one/shared/interfaces';
+import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { GroupService } from '@services/group.service';
-import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rxjs';
@@ -21,7 +21,6 @@ import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rx
 @Component({
   selector: 'lfx-group-detail',
   imports: [
-    DatePipe,
     SlicePipe,
     UpperCasePipe,
     RouterLink,
@@ -30,6 +29,7 @@ import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rx
     ExpandableTextComponent,
     HeaderComponent,
     TagComponent,
+    MeetingTimePipe,
     SkeletonModule,
   ],
   templateUrl: './group-detail.component.html',
@@ -38,16 +38,14 @@ export class GroupDetailComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly groupService = inject(GroupService);
-  private readonly projectService = inject(ProjectService);
   protected readonly userService = inject(UserService);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
 
   protected readonly authenticated = this.userService.authenticated;
   protected readonly loading = signal(true);
+  protected readonly error = signal(false);
 
   protected readonly group: Signal<PublicGroupDetail | null> = this.initGroup();
-  protected readonly parentProject: Signal<Project | null> = this.initParentProject();
 
   protected readonly joinModeLabel = computed(() => {
     const mode = this.group()?.join_mode;
@@ -99,10 +97,13 @@ export class GroupDetailComponent {
         distinctUntilChanged(),
         switchMap((id) => {
           this.loading.set(true);
+          this.error.set(false);
           return this.groupService.getPublicGroup(id).pipe(
-            catchError((error) => {
-              if ([404, 403, 400].includes(error.status)) {
+            catchError((err) => {
+              if ([400, 403, 404].includes(err.status)) {
                 this.router.navigate(['/groups/not-found']);
+              } else {
+                this.error.set(true);
               }
               this.loading.set(false);
               return of(null);
@@ -113,21 +114,6 @@ export class GroupDetailComponent {
           this.loading.set(false);
           return group;
         })
-      ),
-      { initialValue: null }
-    );
-  }
-
-  private initParentProject(): Signal<Project | null> {
-    return toSignal(
-      toObservable(this.group).pipe(
-        map((g) => g?.context.foundation_slug ?? null),
-        distinctUntilChanged(),
-        switchMap((slug) => {
-          if (!slug) return of(null);
-          return this.projectService.getProject(slug, false).pipe(catchError(() => of(null)));
-        }),
-        takeUntilDestroyed(this.destroyRef)
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.html
@@ -8,14 +8,14 @@
         <div class="text-center py-12">
           <div class="flex justify-center mb-6">
             <div class="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center">
-              <i class="fa-light fa-users-slash text-4xl text-gray-400"></i>
+              <i [class]="icon() + ' text-4xl text-gray-400'"></i>
             </div>
           </div>
 
-          <h1 class="mb-3" data-testid="error-title">Group Not Found</h1>
+          <h1 class="mb-3" data-testid="error-title">{{ title() }}</h1>
 
           <p class="text-gray-600 mb-6 max-w-lg mx-auto" data-testid="error-description">
-            We couldn't find the group you're looking for. It may have been removed or the link may be incorrect.
+            {{ description() }}
           </p>
 
           <div class="flex sm:items-center flex-col sm:flex-row gap-6 justify-center">

--- a/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.html
+++ b/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.html
@@ -1,0 +1,41 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="bg-gray-50">
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-4xl mx-auto">
+      <lfx-card class="mb-6" data-testid="group-not-found-card">
+        <div class="text-center py-12">
+          <div class="flex justify-center mb-6">
+            <div class="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center">
+              <i class="fa-light fa-users-slash text-4xl text-gray-400"></i>
+            </div>
+          </div>
+
+          <h1 class="mb-3" data-testid="error-title">Group Not Found</h1>
+
+          <p class="text-gray-600 mb-6 max-w-lg mx-auto" data-testid="error-description">
+            We couldn't find the group you're looking for. It may have been removed or the link may be incorrect.
+          </p>
+
+          <div class="flex sm:items-center flex-col sm:flex-row gap-6 justify-center">
+            <lfx-button routerLink="/" class="flex items-center" size="small" data-testid="go-home-button">
+              <i class="fa-light fa-home mr-2"></i>
+              <span>Go to Dashboard</span>
+            </lfx-button>
+
+            <lfx-button
+              lfxOpenIntercom
+              class="flex items-center"
+              data-testid="contact-support-button"
+              icon="fa-light fa-life-ring"
+              label="Contact Support"
+              size="small"
+              severity="secondary">
+            </lfx-button>
+          </div>
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
+
+@Component({
+  selector: 'lfx-group-not-found',
+  imports: [RouterLink, ButtonComponent, CardComponent, OpenIntercomDirective],
+  templateUrl: './group-not-found.component.html',
+})
+export class GroupNotFoundComponent {}

--- a/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-not-found/group-not-found.component.ts
@@ -1,15 +1,29 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'lfx-group-not-found',
   imports: [RouterLink, ButtonComponent, CardComponent, OpenIntercomDirective],
   templateUrl: './group-not-found.component.html',
 })
-export class GroupNotFoundComponent {}
+export class GroupNotFoundComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly isPrivate = toSignal(this.route.queryParamMap.pipe(map((params) => params.get('reason') === 'private')), { initialValue: false });
+
+  protected readonly icon = computed(() => (this.isPrivate() ? 'fa-light fa-lock' : 'fa-light fa-users-slash'));
+  protected readonly title = computed(() => (this.isPrivate() ? 'Private Group' : 'Group Not Found'));
+  protected readonly description = computed(() =>
+    this.isPrivate()
+      ? 'This group is private and can only be accessed by its members. If you believe you should have access, please contact the group administrator or sign in.'
+      : "We couldn't find the group you're looking for. It may have been removed or the link may be incorrect."
+  );
+}

--- a/apps/lfx-one/src/app/shared/guards/authenticated-match.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/authenticated-match.guard.ts
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, makeStateKey, PLATFORM_ID, REQUEST_CONTEXT, TransferState } from '@angular/core';
+import { CanMatchFn } from '@angular/router';
+import { AuthContext } from '@lfx-one/shared/interfaces';
+
+/**
+ * CanMatch guard that returns true only when the user is authenticated.
+ *
+ * Used on the authenticated `groups` child route so that unauthenticated users
+ * skip it during route matching, allowing Angular to fall through to the public
+ * group detail route instead of hitting authGuard and redirecting to login.
+ *
+ * Reads auth state from TransferState (browser) or REQUEST_CONTEXT (SSR) —
+ * both are populated before route matching runs, unlike UserService.authenticated
+ * which is set in AppComponent's constructor after routing begins.
+ */
+export const authenticatedMatchGuard: CanMatchFn = () => {
+  const platformId = inject(PLATFORM_ID);
+
+  if (!isPlatformBrowser(platformId)) {
+    const reqContext = inject(REQUEST_CONTEXT, { optional: true }) as { auth?: AuthContext } | null;
+    return reqContext?.auth?.authenticated ?? false;
+  }
+
+  const transferState = inject(TransferState);
+  const auth = transferState.get(makeStateKey<AuthContext>('auth'), {
+    authenticated: false,
+    user: null,
+    persona: null,
+    organizations: [],
+  });
+  return auth.authenticated;
+};

--- a/apps/lfx-one/src/app/shared/services/group.service.ts
+++ b/apps/lfx-one/src/app/shared/services/group.service.ts
@@ -4,18 +4,13 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { PublicGroupDetail } from '@lfx-one/shared/interfaces';
-import { Observable, catchError, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class GroupService {
   private readonly http = inject(HttpClient);
 
   public getPublicGroup(groupUid: string): Observable<PublicGroupDetail> {
-    return this.http.get<PublicGroupDetail>(`/public/api/groups/${groupUid}`).pipe(
-      catchError((error) => {
-        console.error(`Failed to load public group ${groupUid}:`, error);
-        return throwError(() => error);
-      })
-    );
+    return this.http.get<PublicGroupDetail>(`/public/api/groups/${groupUid}`);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/group.service.ts
+++ b/apps/lfx-one/src/app/shared/services/group.service.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { PublicGroupDetail } from '@lfx-one/shared/interfaces';
+import { Observable, catchError, throwError } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class GroupService {
+  private readonly http = inject(HttpClient);
+
+  public getPublicGroup(groupUid: string): Observable<PublicGroupDetail> {
+    return this.http.get<PublicGroupDetail>(`/public/api/groups/${groupUid}`).pipe(
+      catchError((error) => {
+        console.error(`Failed to load public group ${groupUid}:`, error);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -1,9 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CommitteeMemberRole, CommitteeMemberVisibility } from '@lfx-one/shared/enums';
-import { CommitteeMember, PublicGroupContext, PublicGroupDetail, PublicGroupLinks, PublicGroupMeeting, PublicGroupMember } from '@lfx-one/shared/interfaces';
-import { MeetingVisibility } from '@lfx-one/shared/enums';
+import { CommitteeMemberRole, CommitteeMemberVisibility, MeetingVisibility } from '@lfx-one/shared/enums';
+import {
+  CommitteeMember,
+  GroupsIOMailingList,
+  PublicGroupContext,
+  PublicGroupDetail,
+  PublicGroupLinks,
+  PublicGroupMeeting,
+  PublicGroupMember,
+  QueryServiceResponse,
+} from '@lfx-one/shared/interfaces';
+import { buildCommitteeCadenceSummary } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
@@ -11,6 +20,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
 import { MeetingService } from '../services/meeting.service';
+import { MicroserviceProxyService } from '../services/microservice-proxy.service';
 import { ProjectService } from '../services/project.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
@@ -20,6 +30,7 @@ const CHAIR_ROLES = new Set<string>([CommitteeMemberRole.CHAIR, CommitteeMemberR
 export class PublicGroupsController {
   private committeeService: CommitteeService = new CommitteeService();
   private meetingService: MeetingService = new MeetingService();
+  private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
   private projectService: ProjectService = new ProjectService();
 
   public async getPublicGroupById(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -47,11 +58,19 @@ export class PublicGroupsController {
         });
       }
 
-      const [members, project, meetingsResponse] = await Promise.all([
+      const [members, project, meetingsResponse, mailingListsResponse] = await Promise.all([
         this.committeeService.getCommitteeMembers(req, id),
         this.projectService.getProjectById(req, committee.project_uid, false),
         this.meetingService.getMeetings(req, { tags: `committee_uid:${id}` }, 'v1_meeting', false),
+        this.microserviceProxy
+          .proxyRequest<QueryServiceResponse<GroupsIOMailingList>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'groupsio_mailing_list',
+            tags: `committee_uid:${id}`,
+          })
+          .catch(() => ({ resources: [] })),
       ]);
+
+      const hasPublicMailingList = mailingListsResponse.resources.some((r) => r.data.public);
 
       const chairs =
         committee.member_visibility === CommitteeMemberVisibility.HIDDEN
@@ -98,14 +117,19 @@ export class PublicGroupsController {
         }),
       };
 
-      const mailingList = committee.mailing_list;
-      const normalizedMailingList = mailingList && !mailingList.startsWith('http') && mailingList.includes('@') ? `mailto:${mailingList}` : mailingList;
+      let mailingListLink: string | undefined;
+      if (hasPublicMailingList && committee.mailing_list) {
+        const ml = committee.mailing_list;
+        mailingListLink = !ml.startsWith('http') && ml.includes('@') ? `mailto:${ml}` : ml;
+      }
 
       const links: PublicGroupLinks = {
         website: committee.website,
-        mailing_list: normalizedMailingList,
+        mailing_list: mailingListLink,
         calendar: committee.calendar?.public ? `/public/api/committees/${id}/calendar.ics` : undefined,
       };
+
+      const cadence = buildCommitteeCadenceSummary(meetingsResponse.data);
 
       const detail: PublicGroupDetail = {
         uid: committee.uid,
@@ -118,6 +142,7 @@ export class PublicGroupsController {
         chairs,
         links,
         upcoming_meetings: upcomingMeetings,
+        cadence: cadence !== 'No recurring meetings scheduled' ? cadence : undefined,
         calendar_url: links.calendar ?? undefined,
         member_visibility: committee.member_visibility!,
       };

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -15,7 +15,7 @@ import {
 import { buildCommitteeCadenceSummary } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
-import { ResourceNotFoundError } from '../errors';
+import { AuthorizationError } from '../errors';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
@@ -51,10 +51,11 @@ export class PublicGroupsController {
       const committee = await this.committeeService.getCommitteeById(req, id);
 
       if (!committee.public) {
-        throw new ResourceNotFoundError('Group', id, {
+        throw new AuthorizationError('This group is private', {
           operation: 'get_public_group_by_id',
           service: 'public_groups_controller',
           path: `/committees/${id}`,
+          code: 'GROUP_PRIVATE',
         });
       }
 
@@ -110,10 +111,12 @@ export class PublicGroupsController {
         foundation_uid: parentProject?.uid || project?.uid || committee.project_uid,
         foundation_name: parentProject?.name || project?.name || '',
         foundation_slug: parentProject?.slug || project?.slug || '',
+        foundation_logo_url: parentProject?.logo_url || project?.logo_url || undefined,
         ...(project?.parent_uid && {
           project_uid: project.uid,
           project_name: project.name,
           project_slug: project.slug,
+          project_logo_url: project.logo_url || undefined,
         }),
       };
 

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -32,6 +32,7 @@ export class PublicGroupsController {
       }
 
       const originalToken = req.bearerToken;
+      // M2M token required: public endpoint has no user session; app credentials needed for upstream calls
       const m2mToken = await generateM2MToken(req);
       req.bearerToken = m2mToken;
 

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -12,6 +12,7 @@ import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
 import { MeetingService } from '../services/meeting.service';
 import { ProjectService } from '../services/project.service';
+import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 const CHAIR_ROLES = new Set<string>([CommitteeMemberRole.CHAIR, CommitteeMemberRole.VICE_CHAIR]);
@@ -62,8 +63,10 @@ export class PublicGroupsController {
           })
         );
 
+      const now = new Date().toISOString();
       const upcomingMeetings = meetingsResponse.data
-        .filter((m) => m.visibility === MeetingVisibility.PUBLIC)
+        .filter((m) => m.visibility === MeetingVisibility.PUBLIC && m.start_time >= now)
+        .sort((a, b) => a.start_time.localeCompare(b.start_time))
         .slice(0, 5)
         .map(
           (m): PublicGroupMeeting => ({
@@ -92,9 +95,12 @@ export class PublicGroupsController {
         }),
       };
 
+      const mailingList = committee.mailing_list;
+      const normalizedMailingList = mailingList && !mailingList.startsWith('http') && mailingList.includes('@') ? `mailto:${mailingList}` : mailingList;
+
       const links: PublicGroupLinks = {
         website: committee.website,
-        mailing_list: committee.mailing_list,
+        mailing_list: normalizedMailingList,
         chat_channel: committee.chat_channel,
         calendar: committee.calendar?.public ? `/public/api/committees/${id}/calendar.ics` : undefined,
       };
@@ -118,8 +124,10 @@ export class PublicGroupsController {
       if (isAuthenticated && originalToken !== undefined) {
         req.bearerToken = originalToken;
         try {
+          const callerEmail = getEffectiveEmail(req);
+          const callerUsername = getEffectiveUsername(req);
           const callerMembership = members.find(
-            (m: CommitteeMember) => m.email === req.oidc?.user?.['email'] || m.username === req.oidc?.user?.['preferred_username']
+            (m: CommitteeMember) => (callerEmail && m.email?.toLowerCase() === callerEmail) || (callerUsername && m.username && m.username === callerUsername)
           );
           if (callerMembership) {
             detail.is_member = true;

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CommitteeMemberRole } from '@lfx-one/shared/enums';
+import { CommitteeMemberRole, CommitteeMemberVisibility } from '@lfx-one/shared/enums';
 import { CommitteeMember, PublicGroupContext, PublicGroupDetail, PublicGroupLinks, PublicGroupMeeting, PublicGroupMember } from '@lfx-one/shared/interfaces';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import { NextFunction, Request, Response } from 'express';
@@ -53,15 +53,18 @@ export class PublicGroupsController {
         this.meetingService.getMeetings(req, { tags: `committee_uid:${id}` }, 'v1_meeting', false),
       ]);
 
-      const chairs = members
-        .filter((m: CommitteeMember) => m.role?.name && CHAIR_ROLES.has(m.role.name))
-        .map(
-          (m: CommitteeMember): PublicGroupMember => ({
-            name: `${m.first_name} ${m.last_name}`.trim(),
-            organization: m.organization?.name,
-            role: m.role?.name,
-          })
-        );
+      const chairs =
+        committee.member_visibility === CommitteeMemberVisibility.HIDDEN
+          ? []
+          : members
+              .filter((m: CommitteeMember) => m.role?.name && CHAIR_ROLES.has(m.role.name))
+              .map(
+                (m: CommitteeMember): PublicGroupMember => ({
+                  name: `${m.first_name} ${m.last_name}`.trim(),
+                  organization: m.organization?.name,
+                  role: m.role?.name,
+                })
+              );
 
       const now = new Date().toISOString();
       const upcomingMeetings = meetingsResponse.data
@@ -101,7 +104,6 @@ export class PublicGroupsController {
       const links: PublicGroupLinks = {
         website: committee.website,
         mailing_list: normalizedMailingList,
-        chat_channel: committee.chat_channel,
         calendar: committee.calendar?.public ? `/public/api/committees/${id}/calendar.ics` : undefined,
       };
 

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -1,0 +1,145 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CommitteeMemberRole } from '@lfx-one/shared/enums';
+import { CommitteeMember, PublicGroupContext, PublicGroupDetail, PublicGroupLinks, PublicGroupMeeting, PublicGroupMember } from '@lfx-one/shared/interfaces';
+import { MeetingVisibility } from '@lfx-one/shared/enums';
+import { NextFunction, Request, Response } from 'express';
+
+import { ResourceNotFoundError } from '../errors';
+import { validateUidParameter } from '../helpers/validation.helper';
+import { logger } from '../services/logger.service';
+import { CommitteeService } from '../services/committee.service';
+import { MeetingService } from '../services/meeting.service';
+import { ProjectService } from '../services/project.service';
+import { generateM2MToken } from '../utils/m2m-token.util';
+
+const CHAIR_ROLES = new Set<string>([CommitteeMemberRole.CHAIR, CommitteeMemberRole.VICE_CHAIR]);
+
+export class PublicGroupsController {
+  private committeeService: CommitteeService = new CommitteeService();
+  private meetingService: MeetingService = new MeetingService();
+  private projectService: ProjectService = new ProjectService();
+
+  public async getPublicGroupById(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id } = req.params;
+
+    const startTime = logger.startOperation(req, 'get_public_group_by_id', { group_uid: id });
+
+    try {
+      if (!validateUidParameter(id, req, next, { operation: 'get_public_group_by_id', service: 'public_groups_controller' })) {
+        return;
+      }
+
+      const originalToken = req.bearerToken;
+      const m2mToken = await generateM2MToken(req);
+      req.bearerToken = m2mToken;
+
+      const committee = await this.committeeService.getCommitteeById(req, id);
+
+      if (!committee.public) {
+        throw new ResourceNotFoundError('Group', id, {
+          operation: 'get_public_group_by_id',
+          service: 'public_groups_controller',
+          path: `/committees/${id}`,
+        });
+      }
+
+      const [members, project, meetingsResponse] = await Promise.all([
+        this.committeeService.getCommitteeMembers(req, id),
+        this.projectService.getProjectById(req, committee.project_uid, false),
+        this.meetingService.getMeetings(req, { tags: `committee_uid:${id}` }, 'v1_meeting', false),
+      ]);
+
+      const chairs = members
+        .filter((m: CommitteeMember) => m.role?.name && CHAIR_ROLES.has(m.role.name))
+        .map(
+          (m: CommitteeMember): PublicGroupMember => ({
+            name: `${m.first_name} ${m.last_name}`.trim(),
+            organization: m.organization?.name,
+            role: m.role?.name,
+          })
+        );
+
+      const upcomingMeetings = meetingsResponse.data
+        .filter((m) => m.visibility === MeetingVisibility.PUBLIC)
+        .slice(0, 5)
+        .map(
+          (m): PublicGroupMeeting => ({
+            uid: m.id,
+            title: m.title,
+            starts_at: m.start_time,
+            timezone: m.timezone,
+            url: `/meetings/${m.id}`,
+          })
+        );
+
+      let parentProject = project;
+      if (project?.parent_uid) {
+        parentProject = await this.projectService.getProjectById(req, project.parent_uid, false);
+      }
+
+      const context: PublicGroupContext = {
+        scope: project?.parent_uid ? 'project' : 'foundation',
+        foundation_uid: parentProject?.uid || project?.uid || committee.project_uid,
+        foundation_name: parentProject?.name || project?.name || '',
+        foundation_slug: parentProject?.slug || project?.slug || '',
+        ...(project?.parent_uid && {
+          project_uid: project.uid,
+          project_name: project.name,
+          project_slug: project.slug,
+        }),
+      };
+
+      const links: PublicGroupLinks = {
+        website: committee.website,
+        mailing_list: committee.mailing_list,
+        chat_channel: committee.chat_channel,
+        calendar: committee.calendar?.public ? `/public/api/committees/${id}/calendar.ics` : undefined,
+      };
+
+      const detail: PublicGroupDetail = {
+        uid: committee.uid,
+        name: committee.name,
+        description: committee.description ?? undefined,
+        category: committee.category,
+        join_mode: committee.join_mode,
+        total_members: committee.total_members ?? members.length,
+        context,
+        chairs,
+        links,
+        upcoming_meetings: upcomingMeetings,
+        calendar_url: links.calendar ?? undefined,
+        member_visibility: committee.member_visibility!,
+      };
+
+      const isAuthenticated = req.oidc?.isAuthenticated();
+      if (isAuthenticated && originalToken !== undefined) {
+        req.bearerToken = originalToken;
+        try {
+          const callerMembership = members.find(
+            (m: CommitteeMember) => m.email === req.oidc?.user?.['email'] || m.username === req.oidc?.user?.['preferred_username']
+          );
+          if (callerMembership) {
+            detail.is_member = true;
+            detail.my_role = callerMembership.role?.name || 'Member';
+          }
+        } catch {
+          logger.debug(req, 'get_public_group_by_id', 'Failed to resolve caller membership', { group_uid: id });
+        }
+        req.bearerToken = m2mToken;
+      }
+
+      logger.success(req, 'get_public_group_by_id', startTime, {
+        group_uid: id,
+        group_name: committee.name,
+        chairs_count: chairs.length,
+        meetings_count: upcomingMeetings.length,
+      });
+
+      res.json(detail);
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CommitteeMemberRole, CommitteeMemberVisibility, MeetingVisibility } from '@lfx-one/shared/enums';
+import { CHAIR_ROLES } from '@lfx-one/shared/constants';
+import { CommitteeMemberVisibility, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   CommitteeMember,
   GroupsIOMailingList,
@@ -24,8 +25,6 @@ import { MicroserviceProxyService } from '../services/microservice-proxy.service
 import { ProjectService } from '../services/project.service';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
-
-const CHAIR_ROLES = new Set<string>([CommitteeMemberRole.CHAIR, CommitteeMemberRole.VICE_CHAIR]);
 
 export class PublicGroupsController {
   private committeeService: CommitteeService = new CommitteeService();
@@ -73,8 +72,9 @@ export class PublicGroupsController {
 
       const hasPublicMailingList = mailingListsResponse.resources.some((r) => r.data.public);
 
+      const visibility = committee.member_visibility || CommitteeMemberVisibility.HIDDEN;
       const chairs =
-        committee.member_visibility === CommitteeMemberVisibility.HIDDEN
+        visibility === CommitteeMemberVisibility.HIDDEN
           ? []
           : members
               .filter((m: CommitteeMember) => m.role?.name && CHAIR_ROLES.has(m.role.name))
@@ -123,7 +123,7 @@ export class PublicGroupsController {
       let mailingListLink: string | undefined;
       if (hasPublicMailingList && committee.mailing_list) {
         const ml = committee.mailing_list;
-        mailingListLink = !ml.startsWith('http') && ml.includes('@') ? `mailto:${ml}` : ml;
+        mailingListLink = !ml.startsWith('http') && !ml.startsWith('mailto:') && ml.includes('@') ? `mailto:${ml}` : ml;
       }
 
       const links: PublicGroupLinks = {
@@ -132,7 +132,8 @@ export class PublicGroupsController {
         calendar: committee.calendar?.public ? `/public/api/committees/${id}/calendar.ics` : undefined,
       };
 
-      const cadence = buildCommitteeCadenceSummary(meetingsResponse.data);
+      const publicMeetings = meetingsResponse.data.filter((m) => m.visibility === MeetingVisibility.PUBLIC);
+      const cadence = buildCommitteeCadenceSummary(publicMeetings);
 
       const detail: PublicGroupDetail = {
         uid: committee.uid,
@@ -140,14 +141,14 @@ export class PublicGroupsController {
         description: committee.description ?? undefined,
         category: committee.category,
         join_mode: committee.join_mode,
-        total_members: committee.total_members ?? members.length,
+        total_members: committee.total_members,
         context,
         chairs,
         links,
         upcoming_meetings: upcomingMeetings,
         cadence: cadence !== 'No recurring meetings scheduled' ? cadence : undefined,
         calendar_url: links.calendar ?? undefined,
-        member_visibility: committee.member_visibility!,
+        member_visibility: visibility,
       };
 
       const isAuthenticated = req.oidc?.isAuthenticated();

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -29,6 +29,9 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // Public meeting join - no authentication required
   { pattern: '/meetings/', type: 'ssr', auth: 'optional' },
 
+  // Public group detail - anonymous access with optional auth for membership enrichment
+  { pattern: '/groups/', type: 'ssr', auth: 'optional' },
+
   // Flow C callback via /passwordless/callback — needs session auth but no bearer token
   { pattern: '/passwordless/callback', type: 'ssr', auth: 'required', tokenRequired: false },
 

--- a/apps/lfx-one/src/server/routes/public-groups.route.ts
+++ b/apps/lfx-one/src/server/routes/public-groups.route.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { PublicGroupsController } from '../controllers/public-groups.controller';
+
+const router = Router();
+const publicGroupsController = new PublicGroupsController();
+
+router.get('/:id', (req, res, next) => publicGroupsController.getPublicGroupById(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -45,6 +45,7 @@ import personaRouter from './routes/persona.route';
 import profileRouter from './routes/profile.route';
 import projectsRouter from './routes/projects.route';
 import publicCommitteesRouter from './routes/public-committees.route';
+import publicGroupsRouter from './routes/public-groups.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
 import publicProjectsRouter from './routes/public-projects.route';
 import rewardsRouter from './routes/rewards.route';
@@ -304,6 +305,7 @@ app.use('/login', authRateLimiter);
 
 app.use('/public/api/meetings', publicMeetingsRouter);
 app.use('/public/api/committees', publicCommitteesRouter);
+app.use('/public/api/groups', publicGroupsRouter);
 app.use('/public/api/projects', publicProjectsRouter);
 
 app.use('/api/projects', projectsRouter);

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -274,8 +274,9 @@ if (sessionStoreEnabled) {
 
 app.use(auth(authConfig));
 
-// Meeting join pages are optional-auth; silent login picks up any existing SSO session.
+// Public pages are optional-auth; silent login picks up any existing SSO session.
 app.use('/meetings/', attemptSilentLogin());
+app.use('/groups/', attemptSilentLogin());
 
 app.use('/login', (req: Request, res: Response) => {
   if (req.oidc?.isAuthenticated() && !req.oidc?.accessToken?.isExpired()) {

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -241,6 +241,8 @@ export const MEMBER_ROLES = [
   { label: 'None', value: CommitteeMemberRole.NONE },
 ];
 
+export const CHAIR_ROLES = new Set<string>([CommitteeMemberRole.CHAIR, CommitteeMemberRole.VICE_CHAIR]);
+
 /**
  * Available voting status types for committee members
  * @description Defines the voting rights and status of committee members

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -124,6 +124,9 @@ export * from './public-committee.interface';
 // Groups dashboard engagement-stats rollup (LFXV2-1711)
 export * from './groups-engagement-stats.interface';
 
+// Public group interfaces
+export * from './public-group.interface';
+
 // Lens interfaces
 export * from './lens.interface';
 

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -33,9 +33,11 @@ export interface PublicGroupContext {
   foundation_uid: string;
   foundation_name: string;
   foundation_slug: string;
+  foundation_logo_url?: string;
   project_uid?: string;
   project_name?: string;
   project_slug?: string;
+  project_logo_url?: string;
 }
 
 export interface PublicGroupDetail {

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -53,7 +53,7 @@ export interface PublicGroupDetail {
   upcoming_meetings: PublicGroupMeeting[];
   cadence?: string;
   calendar_url?: string;
-  member_visibility: CommitteeMemberVisibility;
+  member_visibility?: CommitteeMemberVisibility;
   is_member?: boolean;
   my_role?: string;
 }

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -25,7 +25,6 @@ export interface PublicGroupMeeting {
 export interface PublicGroupLinks {
   website?: string | null;
   mailing_list?: string | null;
-  chat_channel?: string | null;
   calendar?: string | null;
 }
 

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -49,6 +49,7 @@ export interface PublicGroupDetail {
   chairs: PublicGroupMember[];
   links: PublicGroupLinks;
   upcoming_meetings: PublicGroupMeeting[];
+  cadence?: string;
   calendar_url?: string;
   member_visibility: CommitteeMemberVisibility;
   is_member?: boolean;

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -1,0 +1,57 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CommitteeMemberVisibility } from '../enums/committee.enum';
+
+import { JoinMode } from './committee.interface';
+
+export interface PublicGroupMember {
+  name: string;
+  organization?: string;
+  role?: string;
+  profile_url?: string;
+  avatar_url?: string;
+}
+
+export interface PublicGroupMeeting {
+  uid: string;
+  title: string;
+  starts_at: string;
+  ends_at?: string;
+  timezone?: string;
+  url?: string;
+}
+
+export interface PublicGroupLinks {
+  website?: string | null;
+  mailing_list?: string | null;
+  chat_channel?: string | null;
+  calendar?: string | null;
+}
+
+export interface PublicGroupContext {
+  scope: 'foundation' | 'project';
+  foundation_uid: string;
+  foundation_name: string;
+  foundation_slug: string;
+  project_uid?: string;
+  project_name?: string;
+  project_slug?: string;
+}
+
+export interface PublicGroupDetail {
+  uid: string;
+  name: string;
+  description?: string;
+  category: string;
+  join_mode?: JoinMode;
+  total_members: number;
+  context: PublicGroupContext;
+  chairs: PublicGroupMember[];
+  links: PublicGroupLinks;
+  upcoming_meetings: PublicGroupMeeting[];
+  calendar_url?: string;
+  member_visibility: CommitteeMemberVisibility;
+  is_member?: boolean;
+  my_role?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18847,21 +18847,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18847,21 +18847,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
+  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add a public-facing group detail page at `/groups/:id` that works without authentication, following the existing `/meetings/:id` pattern
- New backend API at `GET /public/api/groups/:id` using M2M token pattern for upstream calls
- Shared `PublicGroupDetail` interface and supporting types in `@lfx-one/shared/interfaces`

LFXV2-2009

## What's included

**Backend:**
- `public-groups.controller.ts` — fetches committee, members (chairs/vice-chairs), upcoming public meetings, project context; enriches with caller membership if authenticated
- `public-groups.route.ts` — simple router for `GET /:id`
- Route mounted in `server.ts` at `/public/api/groups`
- Privacy contract enforced: private groups return 403 (`GROUP_PRIVATE`), hidden member visibility suppresses chairs, private mailing lists excluded from links
- Cadence summary computed server-side via `buildCommitteeCadenceSummary`
- Project/foundation logo URLs included in context

**Frontend:**
- `GroupDetailComponent` — public group page with breadcrumb, header badges (category, join mode), visitor hero banner with sign-in CTA, member status banner, project logo, cadence display, calendar subscribe dialog
- `GroupNotFoundComponent` — distinct pages for not-found (404) vs private groups (403, lock icon + "Private Group" message)
- `GroupService` — Angular service calling the public API
- `authenticatedMatchGuard` — `canMatch` guard to resolve route collision between public/authenticated group routes
- Public routes added outside `authGuard` in `app.routes.ts`

**Shared:**
- `PublicGroupDetail`, `PublicGroupContext`, `PublicGroupLinks`, `PublicGroupMember`, `PublicGroupMeeting` interfaces
- `cadence`, `foundation_logo_url`, `project_logo_url` fields

## Review feedback addressed

- Privacy contract: chairs hidden when `member_visibility === 'hidden'`, mailing list link only shown when Groups.IO entity has `public: true`
- ROOT removed from breadcrumb
- Private groups show distinct "Private Group" page with lock icon instead of generic 404
- Project/foundation logo displayed next to group name
- Cadence summary ("Weekly on Monday · 60 min · Zoom") shown below header
- Calendar link replaced with subscribe dialog (Google Calendar / Outlook / webcal)
- Chat channel link removed (channels hidden for non-members)
- Info card hidden when empty (no description, no chairs, no links)

## Not in this PR

- **Slug-based URLs** (`/groups/:slug`): Committees don't have a `slug` field — only `project_slug` from parent project. Needs upstream backend work in committee-service to generate and persist slugs. Should be tracked as a separate story.
- **Breadcrumb navigation links**: Requires foundation/project directory pages to exist first

## Protected files

- `apps/lfx-one/src/server/server.ts` — Added public groups route registration following the existing pattern for public meetings/committees endpoints. Changes are additive (import + route mount) and follow established architecture.
- `apps/lfx-one/src/app/app.routes.ts` — Added 2 public routes (`groups/not-found`, `groups/:id`) outside the authGuard block, following the `/meetings/:id` pattern. Added `canMatch: [authenticatedMatchGuard]` to the authenticated groups route to resolve collision.

## Test plan

- [ ] Navigate to `/groups/<valid-public-group-uid>` unauthenticated — page renders with visitor view (hero banner, sign-in CTA, project logo, cadence)
- [ ] Navigate to `/groups/<valid-public-group-uid>` authenticated — page shows membership context if member
- [ ] Navigate to `/groups/<private-group-uid>` — shows "Private Group" page with lock icon
- [ ] Navigate to `/groups/invalid-uid` — shows "Group Not Found" page
- [ ] Verify breadcrumb shows project/foundation context
- [ ] Verify upcoming meetings list links to `/meetings/:id`
- [ ] Click "Subscribe to Calendar" — dialog opens with Google/Outlook/webcal options
- [ ] Verify mailing list link only appears when Groups.IO list is public
- [ ] Verify chairs hidden when committee has `member_visibility: hidden`
- [ ] Test on mobile viewport — responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)