### PR TITLE
test(profile): cover linux alias load-failure and clarify jsdoc

### DIFF
--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -234,4 +234,22 @@ test.describe('Linux.com email — service unavailable', () => {
     await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
     await expect(page.getByTestId('linux-email-claimed-panel')).not.toBeAttached();
   });
+
+  test('renders the retry panel when the alias request itself fails (client catchError)', async ({ page }) => {
+    // Distinct from the 200-body service_unavailable case above: the GET itself returns 502,
+    // so the component's own catchError synthesizes the service_unavailable retry state.
+    await stubIdentities(page);
+    await page.route('**/api/profile/linux-email', (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'Bad gateway' }) });
+    });
+
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
+    await expect(page.getByTestId('linux-email-claimed-panel')).not.toBeAttached();
+  });
 });

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -32,11 +32,12 @@ export interface LinuxAliasData {
   /** Current forwarding destination, or null when not yet set / not readable without re-auth. */
   forwardTo: string | null;
   /**
-   * The user's primary verified email, read server-side from the same
-   * `user_emails.read` this endpoint already makes. Lets the tab default the
-   * forward selection and build forward options without a second client fetch.
-   * Null in `service_unavailable` (emails could not be read) or when the account
-   * has no primary email.
+   * The user's primary email as resolved by auth-service, read server-side from
+   * the same `user_emails.read` this endpoint already makes (falling back to the
+   * session OIDC email when auth-service omits a primary, so it is not guaranteed
+   * verified). Lets the tab default the forward selection and build forward options
+   * without a second client fetch. Null in `service_unavailable` (emails could not
+   * be read) or when the account has no primary email.
    */
   primaryEmail: string | null;
   /** membership-ui CTA URL, present only in the `not_purchased` state. */


### PR DESCRIPTION
## Summary

- Reworded the `primaryEmail` JSDoc in `linux-email.interface.ts` — it can fall back to
  the session OIDC email, so it is not guaranteed "verified"; the docstring no longer
  claims otherwise.
- Added an e2e test covering the client-side `catchError` in the Linux.com tab: when the
  `GET /api/profile/linux-email` request itself fails (502), the component synthesizes the
  `service_unavailable` state and renders the whole-tab retry panel. The existing test only
  covered the server-driven 200-body path.

Part of LFXV2-1663.
