### PR TITLE
fix(meetings): normalize RSVP occurrence_id seconds vs. milliseconds

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -23,6 +23,7 @@ import {
 import {
   compareMeetingPeopleByHostThenName,
   filterPastMeetingParticipants,
+  getCurrentOrNextOccurrence,
   getPastMeetingResourceId,
   markFormControlsAsTouched,
   resolveMeetingBaseCount,
@@ -295,10 +296,16 @@ export class MeetingRegistrantsDisplayComponent {
             filter((refresh) => refresh && !this.pastMeeting() && !this.externallyManaged()),
             switchMap(() => {
               this.internalLoading.set(true);
+              // Resolve RSVPs against the occurrence the card / drawer is representing, so a
+              // per-occurrence `single` RSVP doesn't shadow the series-wide `all` RSVP on
+              // unrelated occurrences. Falls back to newest RSVP when no occurrence is
+              // available (non-recurring meetings). See LFXV2-2864.
+              const meeting = this.meeting() as Meeting;
+              const occurrenceId = getCurrentOrNextOccurrence(meeting)?.occurrence_id;
               // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views
               const registrantsObservable = useMyEndpoint
-                ? this.meetingService.getMyMeetingRegistrants(this.meeting().id, true)
-                : this.meetingService.getMeetingRegistrants(this.meeting().id, true);
+                ? this.meetingService.getMyMeetingRegistrants(meeting.id, true, occurrenceId)
+                : this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId);
 
               return registrantsObservable.pipe(
                 catchError(() => of([])),

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -92,7 +92,11 @@ export class MeetingRsvpDetailsComponent {
           }
           // Me lens (backend counts not populated) — one call for both registrants + RSVPs inline.
           if (!this.hasBackendRegistrantCounts(meeting)) {
-            return this.meetingService.getMeetingRegistrants(meeting.id, true).pipe(
+            // Resolve RSVPs against the target occurrence so a `single` decline for a
+            // future date doesn't overwrite the current occurrence's per-registrant
+            // chip (LFXV2-2864).
+            const occurrenceId = this.currentOccurrence()?.occurrence_id;
+            return this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId).pipe(
               map((registrants) => ({
                 registrants,
                 rsvps: registrants.map((r) => r.rsvp).filter((r): r is MeetingRsvp => r != null),

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -7,6 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ButtonComponent } from '@components/button/button.component';
 import {
   calculateRsvpCounts,
+  countRegistrantAttendance,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
@@ -155,6 +156,19 @@ export class MeetingRsvpDetailsComponent {
 
   private initializeRsvpCounts(): Signal<RsvpCounts> {
     return computed(() => {
+      // Me lens: registrants are already hydrated with their occurrence-applicable
+      // RSVP by the BFF. Tally via the registrant-aware counter so
+      // `invite_accepted` (series-level Google Calendar invite state) falls back
+      // in the same cases the guest chip does — keeps "N of M attending" in sync
+      // with the drawer's per-registrant chips (LFXV2-2864).
+      const registrants = this.registrants();
+      if (registrants.length > 0) {
+        return countRegistrantAttendance(registrants);
+      }
+      // Non-Me lens: no registrant array available (detail page — counts come off
+      // meeting.individual_registrants_count). Fall back to RSVP-only tallying;
+      // `invite_accepted` fallback is unreachable without registrants but the
+      // typical detail-page case has explicit RSVPs anyway.
       const rsvps = this.rsvps();
       const occurrence = this.currentOccurrence();
       return calculateRsvpCounts(occurrence, rsvps);

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -153,8 +153,7 @@ export class MeetingRsvpDetailsComponent {
     return computed(() => {
       const rsvps = this.rsvps();
       const occurrence = this.currentOccurrence();
-      const meeting = this.meeting();
-      return calculateRsvpCounts(occurrence, rsvps, meeting.start_time);
+      return calculateRsvpCounts(occurrence, rsvps);
     });
   }
 

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -345,13 +345,19 @@ export class MeetingService {
     );
   }
 
-  public getMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false): Observable<MeetingRegistrant[]> {
-    const params = new HttpParams().set('include_rsvp', includeRsvp.toString());
+  public getMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Observable<MeetingRegistrant[]> {
+    let params = new HttpParams().set('include_rsvp', includeRsvp.toString());
+    if (occurrenceId) {
+      params = params.set('occurrence_id', occurrenceId);
+    }
     return this.http.get<MeetingRegistrant[]>(`/api/meetings/${meetingUid}/registrants`, { params });
   }
 
-  public getMyMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false): Observable<MeetingRegistrant[]> {
-    const params = new HttpParams().set('include_rsvp', includeRsvp.toString());
+  public getMyMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Observable<MeetingRegistrant[]> {
+    let params = new HttpParams().set('include_rsvp', includeRsvp.toString());
+    if (occurrenceId) {
+      params = params.set('occurrence_id', occurrenceId);
+    }
     return this.http.get<MeetingRegistrant[]>(`/api/meetings/${meetingUid}/my-meeting-registrants`, { params }).pipe(
       catchError((error) => {
         console.error(`Failed to load my registrants for meeting ${meetingUid}:`, error);

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -371,12 +371,14 @@ export class MeetingController {
    */
   public async getMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const { include_rsvp } = req.query;
+    const { include_rsvp, occurrence_id } = req.query;
     const includeRsvp = include_rsvp === 'true';
+    const occurrenceId = typeof occurrence_id === 'string' && occurrence_id.length > 0 ? occurrence_id : undefined;
 
     const startTime = logger.startOperation(req, 'get_meeting_registrants', {
       meeting_id: uid,
       include_rsvp: includeRsvp,
+      occurrence_id: occurrenceId,
     });
 
     try {
@@ -391,7 +393,7 @@ export class MeetingController {
       }
 
       // Get the meeting registrants
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp);
+      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
 
       logger.success(req, 'get_meeting_registrants', startTime, {
         meeting_id: uid,
@@ -414,12 +416,14 @@ export class MeetingController {
    */
   public async getMyMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const { include_rsvp } = req.query;
+    const { include_rsvp, occurrence_id } = req.query;
     const includeRsvp = include_rsvp === 'true';
+    const occurrenceId = typeof occurrence_id === 'string' && occurrence_id.length > 0 ? occurrence_id : undefined;
 
     const startTime = logger.startOperation(req, 'get_my_meeting_registrants', {
       meeting_id: uid,
       include_rsvp: includeRsvp,
+      occurrence_id: occurrenceId,
     });
 
     try {
@@ -535,7 +539,7 @@ export class MeetingController {
         has_m2m_token: !!m2mToken,
       });
 
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp);
+      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
 
       logger.debug(req, 'get_my_meeting_registrants', 'Fetched all registrants, enriching committee data', {
         meeting_id: uid,

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1196,9 +1196,10 @@ export class MeetingService {
 
       // Delegate to the shared scope resolver so this endpoint and
       // `calculateRsvpCounts` stay in lockstep. It normalises seconds ↔ ms on
-      // occurrence_id (LFXV2-2864) and honours single > this_and_following > all
-      // in newest-first order — replacing the previous strict-equality match
-      // which never fired for occurrence-scoped rows and the arbitrary
+      // occurrence_id (LFXV2-2864) and walks the user's RSVPs newest-first,
+      // returning the first one applicable to the target occurrence (see
+      // resolver docs) — replacing the previous strict-equality match which
+      // never fired for occurrence-scoped rows and the arbitrary
       // `userRsvps[0]` fallback which surfaced order-dependent wrong answers.
       return selectApplicableRsvp(occurrenceId, userRsvps);
     } catch (error) {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -41,6 +41,7 @@ import {
   getPastMeetingTranscriptUrl,
   mapITXResponseToMeetingRsvp,
   normalizeIndexedMeetingAiSummary,
+  selectApplicableRsvp,
   selectPrimaryPastMeetingSummary,
 } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -1193,20 +1194,13 @@ export class MeetingService {
       const allRsvps = await this.getMeetingRsvps(req, meetingUid);
       const userRsvps = allRsvps.filter((rsvp) => registrantIds.has(rsvp.registrant_id));
 
-      if (occurrenceId) {
-        // First try to find an occurrence-specific RSVP (takes precedence)
-        const occurrenceRsvp = userRsvps.find((rsvp) => rsvp.occurrence_id === occurrenceId);
-        if (occurrenceRsvp) {
-          return occurrenceRsvp;
-        }
-
-        // Fall back to meeting-level RSVP (no occurrence_id means RSVP for all occurrences)
-        const meetingRsvp = userRsvps.find((rsvp) => !rsvp.occurrence_id);
-        return meetingRsvp || null;
-      }
-
-      // No occurrence specified - return any RSVP for this user
-      return userRsvps[0] || null;
+      // Delegate to the shared scope resolver so this endpoint and
+      // `calculateRsvpCounts` stay in lockstep. It normalises seconds ↔ ms on
+      // occurrence_id (LFXV2-2864) and honours single > this_and_following > all
+      // in newest-first order — replacing the previous strict-equality match
+      // which never fired for occurrence-scoped rows and the arbitrary
+      // `userRsvps[0]` fallback which surfaced order-dependent wrong answers.
+      return selectApplicableRsvp(occurrenceId, userRsvps);
     } catch (error) {
       logger.warning(req, 'get_meeting_rsvp_for_current_user', 'Failed to fetch user RSVP, returning null', {
         meeting_id: meetingUid,

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -493,10 +493,20 @@ export class MeetingService {
   }
 
   /**
-   * Fetches all registrants for a meeting
-   * @param includeRsvp - If true, includes RSVP status for each registrant
+   * Fetches all registrants for a meeting.
+   * @param includeRsvp - If true, includes RSVP status for each registrant.
+   * @param occurrenceId - Optional occurrence id (seconds or ms) whose RSVP each
+   *   registrant should be resolved against. Pass the id of the occurrence the
+   *   caller is rendering; when omitted, each registrant's most recent RSVP is
+   *   returned regardless of scope — correct only for non-recurring meetings or
+   *   aggregate views. See LFXV2-2864 for the seconds↔ms unit mismatch.
    */
-  public async getMeetingRegistrants(req: Request, meetingUid: string, includeRsvp: boolean = false): Promise<MeetingRegistrant[]> {
+  public async getMeetingRegistrants(
+    req: Request,
+    meetingUid: string,
+    includeRsvp: boolean = false,
+    occurrenceId?: string
+  ): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
     const params: Record<string, any> = {
@@ -513,12 +523,12 @@ export class MeetingService {
       })
     );
 
-    // If include_rsvp is true, fetch RSVP data and attach to registrants
+    // If include_rsvp is true, fetch RSVP data and attach to registrants.
     if (includeRsvp) {
       try {
         const rsvps = await this.getMeetingRsvps(req, meetingUid);
 
-        // Group RSVPs by registrant_id for lookup
+        // Group RSVPs by registrant_id for lookup.
         const rsvpsByRegistrant = new Map<string, MeetingRsvp[]>();
         for (const rsvp of rsvps) {
           const key = rsvp.registrant_id;
@@ -528,21 +538,17 @@ export class MeetingService {
           rsvpsByRegistrant.get(key)!.push(rsvp);
         }
 
-        // Attach most recent RSVP to each registrant by uid
+        // Resolve the applicable RSVP per registrant against the caller's occurrence.
+        // Delegating to the shared resolver keeps this endpoint aligned with the
+        // detail-page BFF (`getMeetingRsvpForCurrentUser`) and the counts calculator
+        // (`calculateRsvpCounts`) — a newer `single` decline no longer shadows an
+        // older `all` accept on unrelated occurrences (LFXV2-2864).
         registrants = registrants.map((registrant) => {
           const registrantRsvps = rsvpsByRegistrant.get(registrant.uid);
           if (!registrantRsvps || registrantRsvps.length === 0) {
             return { ...registrant, rsvp: null };
           }
-
-          // Sort by most recent modification and pick the first
-          const sorted = [...registrantRsvps].sort((a, b) => {
-            const dateA = new Date(a.modified_at || a.created_at).getTime();
-            const dateB = new Date(b.modified_at || b.created_at).getTime();
-            return dateB - dateA;
-          });
-
-          return { ...registrant, rsvp: sorted[0] };
+          return { ...registrant, rsvp: selectApplicableRsvp(occurrenceId, registrantRsvps) };
         });
       } catch (error) {
         logger.warning(req, 'get_meeting_registrants', 'Failed to fetch RSVPs for registrants, returning registrants without RSVP data', {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -501,12 +501,7 @@ export class MeetingService {
    *   returned regardless of scope — correct only for non-recurring meetings or
    *   aggregate views. See LFXV2-2864 for the seconds↔ms unit mismatch.
    */
-  public async getMeetingRegistrants(
-    req: Request,
-    meetingUid: string,
-    includeRsvp: boolean = false,
-    occurrenceId?: string
-  ): Promise<MeetingRegistrant[]> {
+  public async getMeetingRegistrants(req: Request, meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
     const params: Record<string, any> = {

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -34,7 +34,14 @@ import {
   UserPullRequestsRow,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { buildInvitationActions, getCurrentOrNextOccurrence, hasMeetingEnded, normalizeIndexedMeetingAiSummary, parseToInt } from '@lfx-one/shared/utils';
+import {
+  buildInvitationActions,
+  getCurrentOrNextOccurrence,
+  hasMeetingEnded,
+  normalizeIndexedMeetingAiSummary,
+  parseToInt,
+  selectApplicableRsvp,
+} from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { MicroserviceError, ResourceNotFoundError } from '../errors';
@@ -499,24 +506,32 @@ export class UserService {
             this.fetchUserActiveRegistrantIdentities(req, email, username),
           ]);
 
-          // Strongest-response-wins (accepted/declined beats maybe beats nothing) — same logic as
-          // `transformMissingRsvpsToActions`. Drop RSVPs whose `registrant_id` isn't in the active
-          // set; otherwise stale RSVPs from removed registrations would falsely mark meetings as
-          // "responded".
-          const rsvpByMeeting = new Map<string, MeetingRsvp>();
+          // Group all RSVPs per meeting so recurring series can be resolved against the
+          // occurrence the card is actually representing. Drop RSVPs whose `registrant_id` isn't
+          // in the active set; otherwise stale RSVPs from removed registrations would falsely
+          // mark meetings as "responded".
+          const rsvpsByMeeting = new Map<string, MeetingRsvp[]>();
           for (const rsvp of userRsvps) {
             if (!rsvp.meeting_id) continue;
             if (!rsvp.registrant_id || !activeRegistrants.uids.has(rsvp.registrant_id)) continue;
-            const existing = rsvpByMeeting.get(rsvp.meeting_id);
-            if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
-              rsvpByMeeting.set(rsvp.meeting_id, rsvp);
-            }
+            const list = rsvpsByMeeting.get(rsvp.meeting_id);
+            if (list) list.push(rsvp);
+            else rsvpsByMeeting.set(rsvp.meeting_id, [rsvp]);
           }
 
+          // Resolve each meeting's `my_rsvp` against its current/next occurrence via the shared
+          // resolver — same scope/precedence rules and seconds↔ms `occurrence_id` normalization
+          // used on the detail page. Non-recurring meetings resolve identically to before (no
+          // occurrence_id → single `all`-scoped row wins).
           for (const meeting of normalizedMeetings) {
-            if (meeting.id) {
-              meeting.my_rsvp = rsvpByMeeting.get(meeting.id) ?? null;
+            if (!meeting.id) continue;
+            const meetingRsvps = rsvpsByMeeting.get(meeting.id);
+            if (!meetingRsvps || meetingRsvps.length === 0) {
+              meeting.my_rsvp = null;
+              continue;
             }
+            const occurrence = getCurrentOrNextOccurrence(meeting);
+            meeting.my_rsvp = selectApplicableRsvp(occurrence?.occurrence_id, meetingRsvps);
           }
         } catch (error) {
           logger.warning(req, 'get_user_meetings', 'RSVP enrichment failed, continuing without my_rsvp', {

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -523,6 +523,13 @@ export class UserService {
           // resolver — same scope/precedence rules and seconds↔ms `occurrence_id` normalization
           // used on the detail page. Non-recurring meetings resolve identically to before (no
           // occurrence_id → single `all`-scoped row wins).
+          //
+          // Fall back to the newest RSVP for the series when the per-occurrence resolver returns
+          // null (e.g. the user's only RSVP is a `single`-scope row for a non-current/next
+          // occurrence). Keeps `!m.my_rsvp` a reliable "no RSVP recorded for the series at all"
+          // signal for the dashboard's Pending RSVP filter (meetings-dashboard.component.ts) and
+          // aligns it with `transformMissingRsvpsToActions`, which suppresses the Set RSVP action
+          // whenever *any* active-registrant RSVP exists.
           for (const meeting of normalizedMeetings) {
             if (!meeting.id) continue;
             const meetingRsvps = rsvpsByMeeting.get(meeting.id);
@@ -531,7 +538,8 @@ export class UserService {
               continue;
             }
             const occurrence = getCurrentOrNextOccurrence(meeting);
-            meeting.my_rsvp = selectApplicableRsvp(occurrence?.occurrence_id, meetingRsvps);
+            const applicable = selectApplicableRsvp(occurrence?.occurrence_id, meetingRsvps);
+            meeting.my_rsvp = applicable ?? selectApplicableRsvp(undefined, meetingRsvps);
           }
         } catch (error) {
           logger.warning(req, 'get_user_meetings', 'RSVP enrichment failed, continuing without my_rsvp', {

--- a/packages/shared/src/utils/rsvp-calculator.util.spec.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.spec.ts
@@ -1,0 +1,325 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for the shared RSVP scope resolver (LFXV2-2864).
+//
+// These tests pin the exact production state of meeting `92442170146` at the time
+// LFXV2-2864 was reported: Connie Krueger held a base `all` accept, a
+// `this_and_following` accept anchored at Jul 21 UTC, and a single-occurrence
+// decline for Aug 11 UTC (= Aug 12 in her local tz). Under the pre-fix strict
+// equality on `occurrence_id`, the ITX endpoint's seconds-encoded ids never matched
+// the RSVP records' millisecond-encoded ids, so the single decline was invisible
+// and the "Your RSVP" chip fell through to whichever RSVP happened to come first
+// in the query-service response.
+//
+// Data source: LFXV2-2864 Jira comment (Investigation notes — meeting 92442170146).
+// All identifiers below are the ACTUAL production ids Connie owns; they are already
+// posted publicly on the Jira ticket, so echoing them here keeps the fixture
+// verifiable against real state rather than a synthetic reduction that could
+// silently drift from the bug's real shape.
+
+import { describe, expect, it } from 'vitest';
+
+import { MeetingRsvp } from '../interfaces';
+import { isSameOccurrenceId, occurrenceIdToMs, selectApplicableRsvp } from './rsvp-calculator.util';
+
+/**
+ * Build a MeetingRsvp with just the fields the resolver reads. Any other required
+ * fields on the interface are cast on — the resolver never looks at them.
+ */
+function rsvp(overrides: Partial<MeetingRsvp>): MeetingRsvp {
+  return {
+    id: overrides.id || 'rsvp-1',
+    meeting_id: overrides.meeting_id || '92442170146',
+    registrant_id: overrides.registrant_id || '1e1322f3-d21e-42b9-8c9d-80cc7aa9f5f9',
+    username: '',
+    email: 'ckrueger@linuxfoundation.org',
+    response_type: overrides.response_type || 'accepted',
+    scope: overrides.scope || 'all',
+    occurrence_id: overrides.occurrence_id,
+    created_at: overrides.created_at || '2026-07-10T20:40:37Z',
+    modified_at: overrides.modified_at,
+    updated_at: overrides.updated_at,
+    meeting_and_occurrence_id: overrides.meeting_and_occurrence_id,
+    ...overrides,
+  } as MeetingRsvp;
+}
+
+/**
+ * Connie's real 3 RSVPs on meeting `92442170146`, as fetched from OpenSearch.
+ * The full data breakdown lives on LFXV2-2864.
+ */
+const CONNIE_BASE_ALL_ACCEPT = rsvp({
+  id: 'b7d3a81d-0c52-481f-8274-29099773ea2f',
+  response_type: 'accepted',
+  scope: 'all',
+  occurrence_id: undefined,
+  meeting_and_occurrence_id: '92442170146',
+  created_at: '2026-07-10T20:40:37Z',
+  modified_at: '2026-07-10T20:40:37Z',
+});
+
+const CONNIE_TAF_JUL_21_ACCEPT = rsvp({
+  id: '67d85cd7-bba2-4880-9307-2b873a648de9',
+  response_type: 'accepted',
+  scope: 'this_and_following',
+  occurrence_id: '1784642400000', // Jul 21 14:00 UTC (ms)
+  meeting_and_occurrence_id: '92442170146-1784642400000',
+  created_at: '2026-07-21T02:17:23Z',
+  modified_at: '2026-07-21T02:17:23Z',
+});
+
+const CONNIE_SINGLE_AUG_11_DECLINE = rsvp({
+  id: 'ea7dc865-f5ba-4ff3-8957-ec9b36109cbc',
+  response_type: 'declined',
+  scope: 'single',
+  occurrence_id: '1786456800000', // Aug 11 14:00 UTC (ms)
+  meeting_and_occurrence_id: '92442170146-1786456800000',
+  created_at: '2026-07-27T21:43:07Z',
+  modified_at: '2026-07-27T21:43:07Z',
+});
+
+const CONNIES_RSVPS = [CONNIE_BASE_ALL_ACCEPT, CONNIE_TAF_JUL_21_ACCEPT, CONNIE_SINGLE_AUG_11_DECLINE];
+
+// The meeting-service occurrence calculator emits occurrence_id in Unix SECONDS
+// (10 digits), matching what /itx/meetings/{id} returns to the frontend. These
+// are the ids the resolver will actually receive from the caller — Connie's
+// RSVPs store their occurrence_id as MILLISECONDS (13 digits) so we intentionally
+// mix units to reproduce the wire reality.
+const OCC_JUL_28_SECONDS = '1785247200';
+const OCC_AUG_04_SECONDS = '1785852000';
+const OCC_AUG_11_SECONDS = '1786456800';
+const OCC_AUG_18_SECONDS = '1787061600';
+const OCC_JUL_14_SECONDS = '1784037600';
+
+describe('occurrenceIdToMs', () => {
+  it('leaves ms-encoded ids alone', () => {
+    expect(occurrenceIdToMs('1786456800000')).toBe(1786456800000);
+  });
+
+  it('widens seconds-encoded ids into ms', () => {
+    expect(occurrenceIdToMs('1786456800')).toBe(1786456800 * 1000);
+  });
+
+  it('returns null for nullish / empty / unparseable input', () => {
+    expect(occurrenceIdToMs(null)).toBeNull();
+    expect(occurrenceIdToMs(undefined)).toBeNull();
+    expect(occurrenceIdToMs('')).toBeNull();
+    expect(occurrenceIdToMs('not-a-number')).toBeNull();
+    expect(occurrenceIdToMs('0')).toBeNull();
+    expect(occurrenceIdToMs('-1')).toBeNull();
+  });
+});
+
+describe('isSameOccurrenceId', () => {
+  it('matches identical seconds strings', () => {
+    expect(isSameOccurrenceId('1786456800', '1786456800')).toBe(true);
+  });
+
+  it('matches identical ms strings', () => {
+    expect(isSameOccurrenceId('1786456800000', '1786456800000')).toBe(true);
+  });
+
+  it('matches seconds against ms for the same instant (the LFXV2-2864 case)', () => {
+    expect(isSameOccurrenceId('1786456800', '1786456800000')).toBe(true);
+    expect(isSameOccurrenceId('1786456800000', '1786456800')).toBe(true);
+  });
+
+  it('does not match different instants regardless of unit', () => {
+    expect(isSameOccurrenceId('1786456800', '1785247200000')).toBe(false); // Aug 11 sec vs Jul 28 ms
+    expect(isSameOccurrenceId('1786456800000', '1785247200')).toBe(false); // Aug 11 ms vs Jul 28 sec
+  });
+
+  it('returns false when either side is nullish', () => {
+    expect(isSameOccurrenceId(null, '1786456800000')).toBe(false);
+    expect(isSameOccurrenceId('1786456800000', undefined)).toBe(false);
+    expect(isSameOccurrenceId(undefined, undefined)).toBe(false);
+    expect(isSameOccurrenceId('', '1786456800000')).toBe(false);
+  });
+});
+
+describe('selectApplicableRsvp — Connie Krueger (LFXV2-2864)', () => {
+  it('returns declined for the Aug 11 occurrence (her single decline in ms) when the caller passes seconds', () => {
+    // Pre-fix: strict equality failed ("1786456800000" !== "1786456800"),
+    // resolver walked past the single decline, returned the older T&F accept.
+    // Post-fix: the resolver normalises both sides to ms and matches.
+    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, CONNIES_RSVPS);
+    expect(result?.id).toBe(CONNIE_SINGLE_AUG_11_DECLINE.id);
+    expect(result?.response_type).toBe('declined');
+  });
+
+  it('returns accepted for Jul 28 (single decline does NOT apply, T&F does)', () => {
+    // Sanity check on the shape of the bug the ticket describes: a single-occurrence
+    // decline must not bleed onto other occurrences. Jul 28 is after the T&F anchor
+    // (Jul 21) so the T&F accept wins over the base `all`.
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, CONNIES_RSVPS);
+    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    expect(result?.response_type).toBe('accepted');
+  });
+
+  it('returns accepted for Aug 4 (T&F applies, single decline for Aug 11 does not)', () => {
+    const result = selectApplicableRsvp(OCC_AUG_04_SECONDS, CONNIES_RSVPS);
+    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    expect(result?.response_type).toBe('accepted');
+  });
+
+  it('returns accepted for Aug 18 (post-decline occurrence — T&F still applies)', () => {
+    const result = selectApplicableRsvp(OCC_AUG_18_SECONDS, CONNIES_RSVPS);
+    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    expect(result?.response_type).toBe('accepted');
+  });
+
+  it('returns the base `all` accept for Jul 14 (pre-T&F-anchor occurrence)', () => {
+    // Anchor is Jul 21; Jul 14 is before it, so T&F does not apply. Single decline
+    // is for Aug 11 only. Only the base `all` remains — this is the historical
+    // "declined by association" trap the old T&F comparison-against-created_at
+    // could fall into, since created_at (Jul 21T02:17) is also after Jul 14.
+    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, CONNIES_RSVPS);
+    expect(result?.id).toBe(CONNIE_BASE_ALL_ACCEPT.id);
+    expect(result?.response_type).toBe('accepted');
+  });
+});
+
+describe('selectApplicableRsvp — scope precedence and edges', () => {
+  const meetingId = 'meeting-1';
+  const registrantId = 'reg-1';
+
+  it('returns null for an empty RSVP list', () => {
+    expect(selectApplicableRsvp('1786456800', [])).toBeNull();
+  });
+
+  it('returns the most recent RSVP when no occurrence is provided (non-recurring or aggregate view)', () => {
+    const older = rsvp({
+      id: 'older',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'all',
+      response_type: 'accepted',
+      occurrence_id: undefined,
+      modified_at: '2026-01-01T00:00:00Z',
+    });
+    const newer = rsvp({
+      id: 'newer',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'all',
+      response_type: 'declined',
+      occurrence_id: undefined,
+      modified_at: '2026-06-01T00:00:00Z',
+    });
+
+    const result = selectApplicableRsvp(undefined, [older, newer]);
+    expect(result?.id).toBe('newer');
+  });
+
+  it('picks a fresher this_and_following over an older `all` for a covered occurrence', () => {
+    // Regression guard: original three-tier "check all first, then single, then T&F"
+    // ordering would surface the `all` RSVP even after the user had explicitly
+    // overridden it via a T&F starting at or before the target occurrence.
+    const staleAllDecline = rsvp({
+      id: 'stale-all',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'all',
+      response_type: 'declined',
+      occurrence_id: undefined,
+      modified_at: '2026-01-01T00:00:00Z',
+    });
+    const freshTafAccept = rsvp({
+      id: 'fresh-taf',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'this_and_following',
+      response_type: 'accepted',
+      occurrence_id: OCC_JUL_28_SECONDS, // anchor exactly on target
+      modified_at: '2026-07-27T00:00:00Z',
+    });
+
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, [staleAllDecline, freshTafAccept]);
+    expect(result?.id).toBe('fresh-taf');
+  });
+
+  it('does not apply a this_and_following whose anchor is after the target occurrence', () => {
+    const futureTaf = rsvp({
+      id: 'future-taf',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'this_and_following',
+      response_type: 'declined',
+      occurrence_id: OCC_AUG_11_SECONDS, // anchored Aug 11
+      modified_at: '2026-08-11T00:00:00Z',
+    });
+    const baseAllAccept = rsvp({
+      id: 'base-all',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'all',
+      response_type: 'accepted',
+      occurrence_id: undefined,
+      modified_at: '2026-01-01T00:00:00Z',
+    });
+
+    // Target is Jul 28 — before the T&F anchor at Aug 11 — so T&F must not apply.
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, [futureTaf, baseAllAccept]);
+    expect(result?.id).toBe('base-all');
+    expect(result?.response_type).toBe('accepted');
+  });
+
+  it('gates this_and_following by anchor time rather than created_at (LFXV2-2864 T&F subtlety)', () => {
+    // Row was WRITTEN long before the anchor occurrence (retroactive sync) — the
+    // pre-fix `created_at <= occurrenceDate` check would have wrongly applied it
+    // to a Jul 14 occurrence. The correct semantic is anchor-vs-target.
+    const retroactiveTaf = rsvp({
+      id: 'retro-taf',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'this_and_following',
+      response_type: 'declined',
+      occurrence_id: OCC_AUG_11_SECONDS, // anchor Aug 11
+      created_at: '2026-06-01T00:00:00Z', // WRITTEN before Jul 14 target
+      modified_at: '2026-06-01T00:00:00Z',
+    });
+
+    // Target Jul 14 is before the Aug 11 anchor → T&F does not apply → null.
+    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, [retroactiveTaf]);
+    expect(result).toBeNull();
+  });
+
+  it('matches single-scope RSVPs across seconds/ms boundaries symmetrically', () => {
+    const singleDeclineMs = rsvp({
+      id: 'single-ms',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'single',
+      response_type: 'declined',
+      occurrence_id: '1786456800000',
+      modified_at: '2026-07-27T21:43:07Z',
+    });
+    const singleDeclineSeconds = rsvp({
+      id: 'single-sec',
+      meeting_id: 'meeting-2',
+      registrant_id: registrantId,
+      scope: 'single',
+      response_type: 'declined',
+      occurrence_id: '1786456800',
+      modified_at: '2026-07-27T21:43:07Z',
+    });
+
+    // Caller passes seconds against a ms-stored RSVP: matches.
+    expect(selectApplicableRsvp('1786456800', [singleDeclineMs])?.id).toBe('single-ms');
+    // Caller passes ms against a seconds-stored RSVP: matches.
+    expect(selectApplicableRsvp('1786456800000', [singleDeclineSeconds])?.id).toBe('single-sec');
+  });
+
+  it('skips a this_and_following RSVP that has no anchor (malformed data)', () => {
+    const malformed = rsvp({
+      id: 'malformed',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'this_and_following',
+      response_type: 'declined',
+      occurrence_id: undefined,
+    });
+    expect(selectApplicableRsvp(OCC_JUL_28_SECONDS, [malformed])).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/rsvp-calculator.util.spec.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.spec.ts
@@ -78,13 +78,13 @@ const SINGLE_AUG_11_DECLINE = rsvp({
   modified_at: '2026-07-27T21:43:07Z',
 });
 
-const PROD_FINGERPRINT_RSVPS = [BASE_ALL_ACCEPT, TAF_JUL_21_ACCEPT, SINGLE_AUG_11_DECLINE];
+const MIXED_UNIT_RSVPS = [BASE_ALL_ACCEPT, TAF_JUL_21_ACCEPT, SINGLE_AUG_11_DECLINE];
 
 // The meeting-service occurrence calculator emits occurrence_id in Unix SECONDS
 // (10 digits), matching what /itx/meetings/{id} returns to the frontend. These
-// are the ids the resolver will actually receive from the caller — Connie's
-// RSVPs store their occurrence_id as MILLISECONDS (13 digits) so we intentionally
-// mix units to reproduce the wire reality.
+// are the ids the resolver will actually receive from the caller — the affected
+// user's RSVPs store their occurrence_id as MILLISECONDS (13 digits) so we
+// intentionally mix units to reproduce the wire reality.
 const OCC_JUL_28_SECONDS = '1785247200';
 const OCC_AUG_04_SECONDS = '1785852000';
 const OCC_AUG_11_SECONDS = '1786456800';
@@ -151,7 +151,7 @@ describe('selectApplicableRsvp — LFXV2-2864 prod fingerprint', () => {
     // Pre-fix: strict equality failed ("1786456800000" !== "1786456800"),
     // resolver walked past the single decline, returned the older T&F accept.
     // Post-fix: the resolver normalises both sides to ms and matches.
-    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, PROD_FINGERPRINT_RSVPS);
+    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, MIXED_UNIT_RSVPS);
     expect(result?.id).toBe(SINGLE_AUG_11_DECLINE.id);
     expect(result?.response_type).toBe('declined');
   });
@@ -160,19 +160,19 @@ describe('selectApplicableRsvp — LFXV2-2864 prod fingerprint', () => {
     // Sanity check on the shape of the bug the ticket describes: a single-occurrence
     // decline must not bleed onto other occurrences. Jul 28 is after the T&F anchor
     // (Jul 21) so the T&F accept wins over the base `all`.
-    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, PROD_FINGERPRINT_RSVPS);
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, MIXED_UNIT_RSVPS);
     expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 
   it('returns accepted for Aug 4 (T&F applies, single decline for Aug 11 does not)', () => {
-    const result = selectApplicableRsvp(OCC_AUG_04_SECONDS, PROD_FINGERPRINT_RSVPS);
+    const result = selectApplicableRsvp(OCC_AUG_04_SECONDS, MIXED_UNIT_RSVPS);
     expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 
   it('returns accepted for Aug 18 (post-decline occurrence — T&F still applies)', () => {
-    const result = selectApplicableRsvp(OCC_AUG_18_SECONDS, PROD_FINGERPRINT_RSVPS);
+    const result = selectApplicableRsvp(OCC_AUG_18_SECONDS, MIXED_UNIT_RSVPS);
     expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
@@ -182,7 +182,7 @@ describe('selectApplicableRsvp — LFXV2-2864 prod fingerprint', () => {
     // is for Aug 11 only. Only the base `all` remains — this is the historical
     // "declined by association" trap the old T&F comparison-against-created_at
     // could fall into, since created_at (Jul 21T02:17) is also after Jul 14.
-    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, PROD_FINGERPRINT_RSVPS);
+    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, MIXED_UNIT_RSVPS);
     expect(result?.id).toBe(BASE_ALL_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
@@ -358,6 +358,64 @@ describe('selectApplicableRsvp — scope precedence and edges', () => {
       occurrence_id: undefined,
     });
     expect(selectApplicableRsvp(OCC_JUL_28_SECONDS, [malformed])).toBeNull();
+  });
+
+  it('matches a single-scope RSVP that carries only the composite key (empty occurrence_id)', () => {
+    // Defensive fallback for a query-service shape we can't fully prove from
+    // code: every known write path sets `occurrence_id` directly, but if a
+    // `single`-scope row ever arrives with only the `meeting_and_occurrence_id`
+    // composite populated, the resolver must still match on the composite's
+    // suffix — otherwise the chip silently degrades to the invite_accepted
+    // fallback and we reintroduce LFXV2-2864.
+    const compositeOnly = rsvp({
+      id: 'composite-only',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'single',
+      response_type: 'declined',
+      occurrence_id: '',
+      meeting_and_occurrence_id: `${meetingId}-1786456800000`,
+      modified_at: '2026-07-27T21:43:07Z',
+    });
+    // Caller supplies seconds; composite suffix is ms. Fallback + unit
+    // normalisation must both fire to match.
+    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, [compositeOnly]);
+    expect(result?.id).toBe('composite-only');
+    expect(result?.response_type).toBe('declined');
+  });
+
+  it('gates a this_and_following anchor from the composite suffix when occurrence_id is empty', () => {
+    // Same fallback for T&F: the anchor lives in the composite suffix. Rows
+    // anchored after the target must still be excluded, and rows anchored
+    // at/before the target must apply.
+    const compositeTafPostAnchor = rsvp({
+      id: 'composite-taf-post',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'this_and_following',
+      response_type: 'declined',
+      occurrence_id: '',
+      meeting_and_occurrence_id: `${meetingId}-1786456800000`, // anchor Aug 11 ms
+      modified_at: '2026-08-11T00:00:00Z',
+    });
+    // Jul 28 target is before the Aug 11 anchor → does not apply.
+    expect(selectApplicableRsvp(OCC_JUL_28_SECONDS, [compositeTafPostAnchor])).toBeNull();
+    // Aug 18 target is after the anchor → applies.
+    expect(selectApplicableRsvp(OCC_AUG_18_SECONDS, [compositeTafPostAnchor])?.id).toBe('composite-taf-post');
+  });
+
+  it('does not match when neither occurrence_id nor composite carry a usable id', () => {
+    const noOccurrenceIdentifiers = rsvp({
+      id: 'no-ids',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'single',
+      response_type: 'declined',
+      occurrence_id: '',
+      meeting_and_occurrence_id: `${meetingId}-`, // trailing dash, no suffix
+      modified_at: '2026-07-27T21:43:07Z',
+    });
+    expect(selectApplicableRsvp(OCC_AUG_11_SECONDS, [noOccurrenceIdentifiers])).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/rsvp-calculator.util.spec.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.spec.ts
@@ -20,7 +20,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { MeetingRsvp } from '../interfaces';
-import { isSameOccurrenceId, occurrenceIdToMs, selectApplicableRsvp } from './rsvp-calculator.util';
+import { countRegistrantAttendance, getRegistrantAttendanceStatus, isSameOccurrenceId, occurrenceIdToMs, selectApplicableRsvp } from './rsvp-calculator.util';
 
 /**
  * Build a MeetingRsvp with just the fields the resolver reads. Any other required
@@ -358,5 +358,74 @@ describe('selectApplicableRsvp — scope precedence and edges', () => {
       occurrence_id: undefined,
     });
     expect(selectApplicableRsvp(OCC_JUL_28_SECONDS, [malformed])).toBeNull();
+  });
+});
+
+describe('getRegistrantAttendanceStatus', () => {
+  it('returns accepted when the RSVP is accepted', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'accepted' }, invite_accepted: null })).toBe('accepted');
+  });
+
+  it('returns declined when the RSVP is declined', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'declined' }, invite_accepted: null })).toBe('declined');
+  });
+
+  it('returns maybe when the RSVP is maybe', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'maybe' }, invite_accepted: null })).toBe('maybe');
+  });
+
+  it('falls back to invite_accepted=true when there is no applicable RSVP', () => {
+    // The exact LFXV2-2864 shape: single-scope decline for a future occurrence
+    // resolves to `rsvp: null` on today's occurrence, but the calendar invite
+    // itself was accepted. The chip renders "accepted"; counts must agree.
+    expect(getRegistrantAttendanceStatus({ rsvp: null, invite_accepted: true })).toBe('accepted');
+    expect(getRegistrantAttendanceStatus({ rsvp: undefined, invite_accepted: true })).toBe('accepted');
+  });
+
+  it('falls back to invite_accepted=false when there is no applicable RSVP', () => {
+    // Inverse of the case above: Google Calendar decline sets invite_accepted=false
+    // on the registrant, and the resulting single-scope decline may not apply to
+    // the currently-rendered occurrence. Chip shows declined; counts must too.
+    expect(getRegistrantAttendanceStatus({ rsvp: null, invite_accepted: false })).toBe('declined');
+    expect(getRegistrantAttendanceStatus({ rsvp: undefined, invite_accepted: false })).toBe('declined');
+  });
+
+  it('returns pending when both RSVP and invite_accepted are absent', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: null, invite_accepted: null })).toBe('pending');
+    expect(getRegistrantAttendanceStatus({})).toBe('pending');
+  });
+
+  it('prefers RSVP response over invite_accepted (deliberate action wins)', () => {
+    // Declining series-wide via calendar then explicitly accepting a single
+    // occurrence via LFX RSVP: the deliberate per-occurrence action wins.
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'accepted' }, invite_accepted: false })).toBe('accepted');
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'declined' }, invite_accepted: true })).toBe('declined');
+  });
+});
+
+describe('countRegistrantAttendance', () => {
+  it('returns zeros for an empty registrant list', () => {
+    expect(countRegistrantAttendance([])).toEqual({ accepted: 0, declined: 0, maybe: 0, total: 0 });
+  });
+
+  it('counts each registrant into exactly one bucket, including pending in total', () => {
+    const registrants = [
+      { rsvp: { response_type: 'accepted' }, invite_accepted: null },
+      { rsvp: { response_type: 'declined' }, invite_accepted: null },
+      { rsvp: { response_type: 'maybe' }, invite_accepted: null },
+      { rsvp: null, invite_accepted: null }, // pending — no info at all
+    ];
+    expect(countRegistrantAttendance(registrants)).toEqual({ accepted: 1, declined: 1, maybe: 1, total: 4 });
+  });
+
+  it('honours invite_accepted fallback for registrants with no applicable RSVP', () => {
+    // Reproduces the meeting-card list-view bug (LFXV2-2864): guest chip shows 1
+    // declined because invite_accepted=false, but pre-fix counts stayed at 0/0/0.
+    const registrants = [
+      { rsvp: null, invite_accepted: false }, // Google Calendar decline, no matching RSVP
+      { rsvp: null, invite_accepted: true }, // Google Calendar accept, no matching RSVP
+      { rsvp: { response_type: 'declined' }, invite_accepted: null }, // Explicit LFX decline
+    ];
+    expect(countRegistrantAttendance(registrants)).toEqual({ accepted: 1, declined: 2, maybe: 0, total: 3 });
   });
 });

--- a/packages/shared/src/utils/rsvp-calculator.util.spec.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.spec.ts
@@ -3,20 +3,19 @@
 
 // Unit tests for the shared RSVP scope resolver (LFXV2-2864).
 //
-// These tests pin the exact production state of meeting `92442170146` at the time
-// LFXV2-2864 was reported: Connie Krueger held a base `all` accept, a
+// These tests pin the exact shape of the production state observed at the time
+// LFXV2-2864 was reported: the affected user held a base `all` accept, a
 // `this_and_following` accept anchored at Jul 21 UTC, and a single-occurrence
-// decline for Aug 11 UTC (= Aug 12 in her local tz). Under the pre-fix strict
-// equality on `occurrence_id`, the ITX endpoint's seconds-encoded ids never matched
-// the RSVP records' millisecond-encoded ids, so the single decline was invisible
-// and the "Your RSVP" chip fell through to whichever RSVP happened to come first
-// in the query-service response.
+// decline for Aug 11 UTC (= Aug 12 in their local tz). Under the pre-fix strict
+// equality on `occurrence_id`, the ITX endpoint's seconds-encoded ids never
+// matched the RSVP records' millisecond-encoded ids, so the single decline was
+// invisible and the "Your RSVP" chip fell through to whichever RSVP happened to
+// come first in the query-service response.
 //
-// Data source: LFXV2-2864 Jira comment (Investigation notes — meeting 92442170146).
-// All identifiers below are the ACTUAL production ids Connie owns; they are already
-// posted publicly on the Jira ticket, so echoing them here keeps the fixture
-// verifiable against real state rather than a synthetic reduction that could
-// silently drift from the bug's real shape.
+// Identifiers below are synthetic (`series-1`, `reg-1`, `rsvp-N`,
+// `user@example.com`); the value comes from the response-type + scope +
+// occurrence_id + timestamp arrangement, not from any specific meeting or user.
+// See LFXV2-2864 for the original data breakdown.
 
 import { describe, expect, it } from 'vitest';
 
@@ -30,10 +29,10 @@ import { isSameOccurrenceId, occurrenceIdToMs, selectApplicableRsvp } from './rs
 function rsvp(overrides: Partial<MeetingRsvp>): MeetingRsvp {
   return {
     id: overrides.id || 'rsvp-1',
-    meeting_id: overrides.meeting_id || '92442170146',
-    registrant_id: overrides.registrant_id || '1e1322f3-d21e-42b9-8c9d-80cc7aa9f5f9',
+    meeting_id: overrides.meeting_id || 'series-1',
+    registrant_id: overrides.registrant_id || 'reg-1',
     username: '',
-    email: 'ckrueger@linuxfoundation.org',
+    email: 'user@example.com',
     response_type: overrides.response_type || 'accepted',
     scope: overrides.scope || 'all',
     occurrence_id: overrides.occurrence_id,
@@ -46,40 +45,40 @@ function rsvp(overrides: Partial<MeetingRsvp>): MeetingRsvp {
 }
 
 /**
- * Connie's real 3 RSVPs on meeting `92442170146`, as fetched from OpenSearch.
- * The full data breakdown lives on LFXV2-2864.
+ * Synthetic reproduction of the 3-RSVP prod fingerprint from LFXV2-2864:
+ * base `all` accept + Jul-21 T&F accept + Aug-11 `single` decline.
  */
-const CONNIE_BASE_ALL_ACCEPT = rsvp({
-  id: 'b7d3a81d-0c52-481f-8274-29099773ea2f',
+const BASE_ALL_ACCEPT = rsvp({
+  id: 'rsvp-1',
   response_type: 'accepted',
   scope: 'all',
   occurrence_id: undefined,
-  meeting_and_occurrence_id: '92442170146',
+  meeting_and_occurrence_id: 'series-1',
   created_at: '2026-07-10T20:40:37Z',
   modified_at: '2026-07-10T20:40:37Z',
 });
 
-const CONNIE_TAF_JUL_21_ACCEPT = rsvp({
-  id: '67d85cd7-bba2-4880-9307-2b873a648de9',
+const TAF_JUL_21_ACCEPT = rsvp({
+  id: 'rsvp-2',
   response_type: 'accepted',
   scope: 'this_and_following',
   occurrence_id: '1784642400000', // Jul 21 14:00 UTC (ms)
-  meeting_and_occurrence_id: '92442170146-1784642400000',
+  meeting_and_occurrence_id: 'series-1-1784642400000',
   created_at: '2026-07-21T02:17:23Z',
   modified_at: '2026-07-21T02:17:23Z',
 });
 
-const CONNIE_SINGLE_AUG_11_DECLINE = rsvp({
-  id: 'ea7dc865-f5ba-4ff3-8957-ec9b36109cbc',
+const SINGLE_AUG_11_DECLINE = rsvp({
+  id: 'rsvp-3',
   response_type: 'declined',
   scope: 'single',
   occurrence_id: '1786456800000', // Aug 11 14:00 UTC (ms)
-  meeting_and_occurrence_id: '92442170146-1786456800000',
+  meeting_and_occurrence_id: 'series-1-1786456800000',
   created_at: '2026-07-27T21:43:07Z',
   modified_at: '2026-07-27T21:43:07Z',
 });
 
-const CONNIES_RSVPS = [CONNIE_BASE_ALL_ACCEPT, CONNIE_TAF_JUL_21_ACCEPT, CONNIE_SINGLE_AUG_11_DECLINE];
+const PROD_FINGERPRINT_RSVPS = [BASE_ALL_ACCEPT, TAF_JUL_21_ACCEPT, SINGLE_AUG_11_DECLINE];
 
 // The meeting-service occurrence calculator emits occurrence_id in Unix SECONDS
 // (10 digits), matching what /itx/meetings/{id} returns to the frontend. These
@@ -136,15 +135,24 @@ describe('isSameOccurrenceId', () => {
     expect(isSameOccurrenceId(undefined, undefined)).toBe(false);
     expect(isSameOccurrenceId('', '1786456800000')).toBe(false);
   });
+
+  it('returns false for equal-but-malformed strings (no string fast-path)', () => {
+    // Both sides go through occurrenceIdToMs — malformed equal strings must not
+    // shortcut to `true` via reference equality; that would let a malformed
+    // single-occurrence RSVP falsely match its own bogus occurrence_id.
+    expect(isSameOccurrenceId('0', '0')).toBe(false);
+    expect(isSameOccurrenceId('not-a-number', 'not-a-number')).toBe(false);
+    expect(isSameOccurrenceId('-1', '-1')).toBe(false);
+  });
 });
 
-describe('selectApplicableRsvp — Connie Krueger (LFXV2-2864)', () => {
-  it('returns declined for the Aug 11 occurrence (her single decline in ms) when the caller passes seconds', () => {
+describe('selectApplicableRsvp — LFXV2-2864 prod fingerprint', () => {
+  it('returns declined for the Aug 11 occurrence (single decline in ms) when the caller passes seconds', () => {
     // Pre-fix: strict equality failed ("1786456800000" !== "1786456800"),
     // resolver walked past the single decline, returned the older T&F accept.
     // Post-fix: the resolver normalises both sides to ms and matches.
-    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, CONNIES_RSVPS);
-    expect(result?.id).toBe(CONNIE_SINGLE_AUG_11_DECLINE.id);
+    const result = selectApplicableRsvp(OCC_AUG_11_SECONDS, PROD_FINGERPRINT_RSVPS);
+    expect(result?.id).toBe(SINGLE_AUG_11_DECLINE.id);
     expect(result?.response_type).toBe('declined');
   });
 
@@ -152,20 +160,20 @@ describe('selectApplicableRsvp — Connie Krueger (LFXV2-2864)', () => {
     // Sanity check on the shape of the bug the ticket describes: a single-occurrence
     // decline must not bleed onto other occurrences. Jul 28 is after the T&F anchor
     // (Jul 21) so the T&F accept wins over the base `all`.
-    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, CONNIES_RSVPS);
-    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, PROD_FINGERPRINT_RSVPS);
+    expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 
   it('returns accepted for Aug 4 (T&F applies, single decline for Aug 11 does not)', () => {
-    const result = selectApplicableRsvp(OCC_AUG_04_SECONDS, CONNIES_RSVPS);
-    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    const result = selectApplicableRsvp(OCC_AUG_04_SECONDS, PROD_FINGERPRINT_RSVPS);
+    expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 
   it('returns accepted for Aug 18 (post-decline occurrence — T&F still applies)', () => {
-    const result = selectApplicableRsvp(OCC_AUG_18_SECONDS, CONNIES_RSVPS);
-    expect(result?.id).toBe(CONNIE_TAF_JUL_21_ACCEPT.id);
+    const result = selectApplicableRsvp(OCC_AUG_18_SECONDS, PROD_FINGERPRINT_RSVPS);
+    expect(result?.id).toBe(TAF_JUL_21_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 
@@ -174,8 +182,8 @@ describe('selectApplicableRsvp — Connie Krueger (LFXV2-2864)', () => {
     // is for Aug 11 only. Only the base `all` remains — this is the historical
     // "declined by association" trap the old T&F comparison-against-created_at
     // could fall into, since created_at (Jul 21T02:17) is also after Jul 14.
-    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, CONNIES_RSVPS);
-    expect(result?.id).toBe(CONNIE_BASE_ALL_ACCEPT.id);
+    const result = selectApplicableRsvp(OCC_JUL_14_SECONDS, PROD_FINGERPRINT_RSVPS);
+    expect(result?.id).toBe(BASE_ALL_ACCEPT.id);
     expect(result?.response_type).toBe('accepted');
   });
 });
@@ -210,6 +218,35 @@ describe('selectApplicableRsvp — scope precedence and edges', () => {
 
     const result = selectApplicableRsvp(undefined, [older, newer]);
     expect(result?.id).toBe('newer');
+  });
+
+  it('picks a fresher `all` over an older matching `single` for the same occurrence', () => {
+    // Regression guard for the "newest applicable wins" semantic: if a user
+    // previously declined a specific occurrence via `single` and then re-accepted
+    // the entire series via `all`, the newer series-wide answer must win — the
+    // resolver is not a strict single > all hierarchy.
+    const olderSingleDecline = rsvp({
+      id: 'older-single',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'single',
+      response_type: 'declined',
+      occurrence_id: OCC_JUL_28_SECONDS,
+      modified_at: '2026-06-01T00:00:00Z',
+    });
+    const newerAllAccept = rsvp({
+      id: 'newer-all',
+      meeting_id: meetingId,
+      registrant_id: registrantId,
+      scope: 'all',
+      response_type: 'accepted',
+      occurrence_id: undefined,
+      modified_at: '2026-07-01T00:00:00Z',
+    });
+
+    const result = selectApplicableRsvp(OCC_JUL_28_SECONDS, [olderSingleDecline, newerAllAccept]);
+    expect(result?.id).toBe('newer-all');
+    expect(result?.response_type).toBe('accepted');
   });
 
   it('picks a fresher this_and_following over an older `all` for a covered occurrence', () => {

--- a/packages/shared/src/utils/rsvp-calculator.util.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.ts
@@ -21,20 +21,26 @@ import { ITXMeetingResponseResult, MeetingOccurrence, MeetingRsvp, RsvpCounts } 
  * as "cannot compare" and skip the RSVP rather than pretend equality.
  */
 export function occurrenceIdToMs(occurrenceId: string | null | undefined): number | null {
-  if (!occurrenceId) return null;
+  if (typeof occurrenceId !== 'string' || occurrenceId.length === 0) return null;
   const n = Number(occurrenceId);
   if (!Number.isFinite(n) || n <= 0) return null;
-  return occurrenceId.length <= 10 ? n * 1000 : n;
+  // Values below 1e12 ms (~Sep 2001) are Unix seconds; at/above are already ms.
+  // Magnitude cutoff is unit-correct regardless of string formatting (padded zeros,
+  // scientific notation) and avoids reading .length on a potentially-tainted value.
+  return n < 1e12 ? n * 1000 : n;
 }
 
 /**
  * Compare two `occurrence_id` strings while treating seconds and milliseconds as
  * the same instant. Prefer this over `===` anywhere an occurrence-side id may be
  * compared against an rsvp-side id (LFXV2-2864).
+ *
+ * Both sides go through `occurrenceIdToMs`, so malformed inputs (empty strings,
+ * `"0"`, non-numeric) resolve to `null` and the comparison returns `false` —
+ * callers must treat a malformed RSVP as unmatched rather than accidentally
+ * equal via a string fast-path.
  */
 export function isSameOccurrenceId(a: string | null | undefined, b: string | null | undefined): boolean {
-  if (!a || !b) return false;
-  if (a === b) return true;
   const am = occurrenceIdToMs(a);
   const bm = occurrenceIdToMs(b);
   return am !== null && bm !== null && am === bm;
@@ -49,15 +55,19 @@ export function isSameOccurrenceId(a: string | null | undefined, b: string | nul
  * both were silently wrong for the same unit-mismatch reason — consolidating
  * here keeps them from drifting apart again.
  *
- * Precedence (newest RSVP wins within each scope):
- * 1. `single` scope whose `occurrence_id` matches this occurrence (unit-normalised).
- * 2. `this_and_following` scope whose anchor (`rsvp.occurrence_id`) is at or
- *    before this occurrence's start.
- * 3. `all` scope (series-wide).
+ * Algorithm: walk the user's RSVPs newest-first (by `modified_at` → `updated_at`
+ * → `created_at`) and return the first one that is applicable to `occurrenceId`.
+ * Applicability by scope:
+ * - `all`: always applicable (series-wide).
+ * - `single`: applicable iff `rsvp.occurrence_id` matches (unit-normalised).
+ * - `this_and_following`: applicable iff the anchor occurrence (encoded in
+ *   `rsvp.occurrence_id`) is at or before `occurrenceId`'s start.
  *
- * The scopes are interleaved in a single "most recent applicable" walk rather
- * than checked in strict tiers so a fresh `this_and_following` correctly
- * overrides an older `all` for future occurrences.
+ * This is a "newest applicable wins" resolver, **not** a strict scope hierarchy —
+ * a newer `all` will beat an older matching `single`, and a newer `single`
+ * beats an older `this_and_following` on that specific occurrence. That mirrors
+ * how Google Calendar / Zoom themselves resolve overlapping responses: the most
+ * recent action the user took is the one that stands.
  *
  * @param occurrenceId Occurrence id in either seconds or milliseconds; nullish
  *   means the caller has no per-occurrence context (non-recurring meeting or
@@ -111,15 +121,17 @@ export function selectApplicableRsvp(occurrenceId: string | null | undefined, us
 }
 
 /**
- * Calculate RSVP counts for a specific occurrence
- * Takes into account RSVP scope (single, all, this_and_following) and uses the most recent RSVP per user
+ * Calculate RSVP counts for a specific occurrence.
+ *
+ * Groups RSVPs by registrant, resolves each user's applicable RSVP for the
+ * occurrence via {@link selectApplicableRsvp} (scope-aware, unit-normalised),
+ * and tallies the resulting `response_type` values.
  *
  * @param occurrence - The meeting occurrence to calculate for (or null for non-recurring meetings)
  * @param allRsvps - All RSVPs for the meeting
- * @param _meetingStartTime - Reserved for future use (kept for API compatibility)
  * @returns Object with accepted, declined, maybe, and total counts
  */
-export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsvps: MeetingRsvp[], _meetingStartTime?: string): RsvpCounts {
+export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsvps: MeetingRsvp[]): RsvpCounts {
   if (allRsvps.length === 0) {
     return { accepted: 0, declined: 0, maybe: 0, total: 0 };
   }

--- a/packages/shared/src/utils/rsvp-calculator.util.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.ts
@@ -47,6 +47,30 @@ export function isSameOccurrenceId(a: string | null | undefined, b: string | nul
 }
 
 /**
+ * Return the effective occurrence id for a per-occurrence RSVP row, preferring
+ * `rsvp.occurrence_id` and falling back to the suffix of the
+ * `meeting_and_occurrence_id` composite (`${meeting_id}-${occurrence_id_ms}`)
+ * when the direct field is empty.
+ *
+ * Every known write path (`mapITXResponseToMeetingRsvp` and the meeting-service
+ * registrant handler) populates `occurrence_id` directly, but the query-service
+ * `v1_meeting_rsvp` shape isn't provable from code — this defensive fallback
+ * prevents a `single`/`this_and_following` row with only the composite from
+ * silently dropping and degrading the chip to the `invite_accepted` fallback
+ * (LFXV2-2864).
+ */
+function getRsvpOccurrenceId(rsvp: Pick<MeetingRsvp, 'occurrence_id' | 'meeting_and_occurrence_id'>): string | null {
+  const direct = rsvp.occurrence_id;
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+  const composite = rsvp.meeting_and_occurrence_id;
+  if (typeof composite !== 'string' || composite.length === 0) return null;
+  const idx = composite.lastIndexOf('-');
+  if (idx < 0 || idx === composite.length - 1) return null;
+  const suffix = composite.slice(idx + 1);
+  return suffix.length > 0 ? suffix : null;
+}
+
+/**
  * Pick the single RSVP that applies to a given occurrence for one user.
  *
  * Shared between the frontend counts calculator (`calculateRsvpCounts` → per-user
@@ -96,7 +120,7 @@ export function selectApplicableRsvp(occurrenceId: string | null | undefined, us
     }
 
     if (rsvp.scope === 'single') {
-      if (isSameOccurrenceId(rsvp.occurrence_id, occurrenceId)) {
+      if (isSameOccurrenceId(getRsvpOccurrenceId(rsvp), occurrenceId)) {
         return rsvp;
       }
       continue;
@@ -104,11 +128,13 @@ export function selectApplicableRsvp(occurrenceId: string | null | undefined, us
 
     if (rsvp.scope === 'this_and_following') {
       // The anchor is the specific occurrence at which the T&F starts applying,
-      // encoded in `rsvp.occurrence_id`. Comparing against `rsvp.created_at` (the
-      // previous behaviour) drifts whenever the row was written before or after
-      // the anchor date — e.g. a retroactive T&F or a delayed sync. The anchor
-      // itself is the correct semantic gate.
-      const anchorMs = occurrenceIdToMs(rsvp.occurrence_id);
+      // encoded in `rsvp.occurrence_id` (falling back to the composite suffix
+      // when the direct field is empty — see `getRsvpOccurrenceId`).
+      // Comparing against `rsvp.created_at` (the previous behaviour) drifts
+      // whenever the row was written before or after the anchor date — e.g.
+      // a retroactive T&F or a delayed sync. The anchor itself is the correct
+      // semantic gate.
+      const anchorMs = occurrenceIdToMs(getRsvpOccurrenceId(rsvp));
       if (anchorMs === null || occurrenceMs === null) continue;
       if (anchorMs <= occurrenceMs) {
         return rsvp;

--- a/packages/shared/src/utils/rsvp-calculator.util.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.ts
@@ -4,20 +4,126 @@
 import { ITXMeetingResponseResult, MeetingOccurrence, MeetingRsvp, RsvpCounts } from '../interfaces/meeting.interface';
 
 /**
+ * Convert an `occurrence_id` string into a millisecond epoch, regardless of the
+ * unit the caller happens to hold.
+ *
+ * Two units live in the LFX system for the same instant (see LFXV2-2864):
+ * - Zoom / ITX `/itx/meetings/{id}` occurrences and the meeting-service
+ *   `occurrence_calculator.go` output emit **Unix seconds** (10 digits).
+ * - `v1_meeting_rsvp` and `v1_past_meeting` records (and every
+ *   `meeting_and_occurrence_id` composite) store **Unix milliseconds** (13 digits).
+ *
+ * Any string equality between an occurrence-side id and an rsvp-side id will fail
+ * unless one is normalised first. Normalisation policy: always widen to ms so the
+ * result is directly comparable to `Date.getTime()`.
+ *
+ * Returns `null` when the input is empty or unparseable; callers must treat that
+ * as "cannot compare" and skip the RSVP rather than pretend equality.
+ */
+export function occurrenceIdToMs(occurrenceId: string | null | undefined): number | null {
+  if (!occurrenceId) return null;
+  const n = Number(occurrenceId);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return occurrenceId.length <= 10 ? n * 1000 : n;
+}
+
+/**
+ * Compare two `occurrence_id` strings while treating seconds and milliseconds as
+ * the same instant. Prefer this over `===` anywhere an occurrence-side id may be
+ * compared against an rsvp-side id (LFXV2-2864).
+ */
+export function isSameOccurrenceId(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const am = occurrenceIdToMs(a);
+  const bm = occurrenceIdToMs(b);
+  return am !== null && bm !== null && am === bm;
+}
+
+/**
+ * Pick the single RSVP that applies to a given occurrence for one user.
+ *
+ * Shared between the frontend counts calculator (`calculateRsvpCounts` → per-user
+ * grouping) and the BFF single-user lookup (`getMeetingRsvpForCurrentUser`). Both
+ * paths were previously doing their own string-equality on `occurrence_id` and
+ * both were silently wrong for the same unit-mismatch reason — consolidating
+ * here keeps them from drifting apart again.
+ *
+ * Precedence (newest RSVP wins within each scope):
+ * 1. `single` scope whose `occurrence_id` matches this occurrence (unit-normalised).
+ * 2. `this_and_following` scope whose anchor (`rsvp.occurrence_id`) is at or
+ *    before this occurrence's start.
+ * 3. `all` scope (series-wide).
+ *
+ * The scopes are interleaved in a single "most recent applicable" walk rather
+ * than checked in strict tiers so a fresh `this_and_following` correctly
+ * overrides an older `all` for future occurrences.
+ *
+ * @param occurrenceId Occurrence id in either seconds or milliseconds; nullish
+ *   means the caller has no per-occurrence context (non-recurring meeting or
+ *   aggregate view) — most recent RSVP wins.
+ * @param userRsvps All RSVPs from a single user for this meeting.
+ */
+export function selectApplicableRsvp(occurrenceId: string | null | undefined, userRsvps: MeetingRsvp[]): MeetingRsvp | null {
+  if (userRsvps.length === 0) return null;
+
+  // API sends `modified_at`; older payloads fall back through `updated_at` then `created_at`.
+  const sortedRsvps = [...userRsvps].sort((a, b) => {
+    const dateA = new Date(a.modified_at || a.updated_at || a.created_at).getTime();
+    const dateB = new Date(b.modified_at || b.updated_at || b.created_at).getTime();
+    return dateB - dateA;
+  });
+
+  if (!occurrenceId) {
+    return sortedRsvps[0] || null;
+  }
+
+  const occurrenceMs = occurrenceIdToMs(occurrenceId);
+
+  for (const rsvp of sortedRsvps) {
+    if (rsvp.scope === 'all') {
+      return rsvp;
+    }
+
+    if (rsvp.scope === 'single') {
+      if (isSameOccurrenceId(rsvp.occurrence_id, occurrenceId)) {
+        return rsvp;
+      }
+      continue;
+    }
+
+    if (rsvp.scope === 'this_and_following') {
+      // The anchor is the specific occurrence at which the T&F starts applying,
+      // encoded in `rsvp.occurrence_id`. Comparing against `rsvp.created_at` (the
+      // previous behaviour) drifts whenever the row was written before or after
+      // the anchor date — e.g. a retroactive T&F or a delayed sync. The anchor
+      // itself is the correct semantic gate.
+      const anchorMs = occurrenceIdToMs(rsvp.occurrence_id);
+      if (anchorMs === null || occurrenceMs === null) continue;
+      if (anchorMs <= occurrenceMs) {
+        return rsvp;
+      }
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Calculate RSVP counts for a specific occurrence
  * Takes into account RSVP scope (single, all, this_and_following) and uses the most recent RSVP per user
  *
  * @param occurrence - The meeting occurrence to calculate for (or null for non-recurring meetings)
  * @param allRsvps - All RSVPs for the meeting
- * @param meetingStartTime - The meeting start time (for non-recurring meetings)
+ * @param _meetingStartTime - Reserved for future use (kept for API compatibility)
  * @returns Object with accepted, declined, maybe, and total counts
  */
-export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsvps: MeetingRsvp[], meetingStartTime?: string): RsvpCounts {
+export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsvps: MeetingRsvp[], _meetingStartTime?: string): RsvpCounts {
   if (allRsvps.length === 0) {
     return { accepted: 0, declined: 0, maybe: 0, total: 0 };
   }
 
-  // Group RSVPs by registrant_id to handle multiple RSVPs from the same user
   const rsvpsByRegistrant = new Map<string, MeetingRsvp[]>();
 
   for (const rsvp of allRsvps) {
@@ -28,17 +134,15 @@ export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsv
     rsvpsByRegistrant.get(key)!.push(rsvp);
   }
 
-  // For each user, determine which RSVP applies to this occurrence
   const applicableRsvps: MeetingRsvp[] = [];
 
   for (const userRsvps of rsvpsByRegistrant.values()) {
-    const applicableRsvp = getApplicableRsvp(occurrence, userRsvps, meetingStartTime);
+    const applicableRsvp = selectApplicableRsvp(occurrence?.occurrence_id, userRsvps);
     if (applicableRsvp) {
       applicableRsvps.push(applicableRsvp);
     }
   }
 
-  // Count responses
   const counts: RsvpCounts = {
     accepted: 0,
     declined: 0,
@@ -57,71 +161,6 @@ export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsv
   }
 
   return counts;
-}
-
-/**
- * Get the applicable RSVP for a user given an occurrence
- * Uses the most recent RSVP that applies to the occurrence
- *
- * @param occurrence - The occurrence to check (or null for non-recurring meetings)
- * @param userRsvps - All RSVPs from a single user for this meeting
- * @param meetingStartTime - The meeting start time (for non-recurring meetings)
- * @returns The most recent applicable RSVP, or null if none apply
- */
-function getApplicableRsvp(occurrence: MeetingOccurrence | null, userRsvps: MeetingRsvp[], meetingStartTime?: string): MeetingRsvp | null {
-  // Sort RSVPs by most recent modification (API sends modified_at, fallback to updated_at then created_at)
-  const sortedRsvps = [...userRsvps].sort((a, b) => {
-    const dateA = new Date(a.modified_at || a.updated_at || a.created_at).getTime();
-    const dateB = new Date(b.modified_at || b.updated_at || b.created_at).getTime();
-    return dateB - dateA; // Descending order (newest first)
-  });
-
-  // For non-recurring meetings, return the most recent RSVP
-  if (!occurrence) {
-    return sortedRsvps[0] || null;
-  }
-
-  const occurrenceId = occurrence.occurrence_id;
-  const occurrenceDate = new Date(occurrence.start_time);
-  // Build the expected meeting_and_occurrence_id for this occurrence (e.g., "95156357074_1707321600000")
-  const meetingAndOccurrenceId = occurrenceId ? `${sortedRsvps[0]?.meeting_id}_${occurrenceId}` : null;
-
-  // Check each RSVP from newest to oldest (most recent wins)
-  // Return the first RSVP that applies to this occurrence
-  for (const rsvp of sortedRsvps) {
-    // Check if this RSVP applies to the current occurrence
-    if (rsvp.scope === 'all') {
-      // 'all' scope applies to all occurrences
-      return rsvp;
-    }
-
-    // Check for 'single' scope — match by occurrence_id or meeting_and_occurrence_id
-    if (rsvp.scope === 'single' && occurrenceId) {
-      const rsvpOccurrenceId = rsvp.occurrence_id || '';
-      const matchesOccurrenceId = rsvpOccurrenceId === occurrenceId || rsvpOccurrenceId === String(occurrenceId);
-      const matchesMeetingAndOccurrenceId = meetingAndOccurrenceId && rsvp.meeting_and_occurrence_id === meetingAndOccurrenceId;
-
-      if (matchesOccurrenceId || matchesMeetingAndOccurrenceId) {
-        return rsvp;
-      }
-      // If neither matches, this RSVP doesn't apply to this occurrence
-      continue;
-    }
-
-    if (rsvp.scope === 'this_and_following') {
-      // 'this_and_following' scope applies to this occurrence and all future ones
-      // Check if this RSVP was created before or at the time of this occurrence
-      const rsvpDate = new Date(rsvp.created_at);
-      if (rsvpDate <= occurrenceDate) {
-        return rsvp;
-      }
-      // If created after this occurrence, it doesn't apply
-      continue;
-    }
-  }
-
-  // No applicable RSVP found
-  return null;
 }
 
 /**

--- a/packages/shared/src/utils/rsvp-calculator.util.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.ts
@@ -175,6 +175,63 @@ export function calculateRsvpCounts(occurrence: MeetingOccurrence | null, allRsv
   return counts;
 }
 
+export type RegistrantAttendanceStatus = 'accepted' | 'declined' | 'maybe' | 'pending';
+
+/**
+ * Combined attendance status for a single registrant, mirroring the meeting-card
+ * / guest-drawer chip logic and the meetings-dashboard RSVP filter:
+ *
+ * - An explicit RSVP `response_type` (accepted / declined / maybe) is authoritative.
+ * - When there is no RSVP response — either the registrant has no RSVP at all,
+ *   or none of their RSVPs are applicable to the target occurrence — fall back
+ *   to `invite_accepted` (the series-level Google Calendar / Zoom invite state).
+ * - Otherwise pending.
+ *
+ * The caller is responsible for pre-resolving the passed-in `rsvp` (typically
+ * via {@link selectApplicableRsvp} against the target occurrence) — this helper
+ * doesn't know about scopes.
+ */
+export function getRegistrantAttendanceStatus(registrant: {
+  rsvp?: { response_type?: string | null } | null;
+  invite_accepted?: boolean | null;
+}): RegistrantAttendanceStatus {
+  const rsvpResponse = registrant.rsvp?.response_type;
+  if (rsvpResponse === 'accepted' || rsvpResponse === 'declined' || rsvpResponse === 'maybe') {
+    return rsvpResponse;
+  }
+  if (registrant.invite_accepted === true) return 'accepted';
+  if (registrant.invite_accepted === false) return 'declined';
+  return 'pending';
+}
+
+/**
+ * Tally attendance across a list of registrants using the same combined
+ * semantics as {@link getRegistrantAttendanceStatus} (RSVP + `invite_accepted`
+ * fallback). Use this instead of {@link calculateRsvpCounts} when the caller
+ * has registrants in hand — otherwise a registrant with no applicable RSVP
+ * but `invite_accepted === false` is invisible to the count even though their
+ * chip renders as "declined" (LFXV2-2864).
+ *
+ * The caller must pre-resolve each registrant's `.rsvp` to the one applicable
+ * to the target occurrence — the BFF's occurrence-aware
+ * `getMeetingRegistrants(uid, includeRsvp, occurrenceId)` does that server-side.
+ *
+ * `total` counts every registrant (accepted + declined + maybe + pending), so
+ * the denominator matches the meeting's invited count.
+ */
+export function countRegistrantAttendance(
+  registrants: ReadonlyArray<{ rsvp?: { response_type?: string | null } | null; invite_accepted?: boolean | null }>
+): RsvpCounts {
+  const counts: RsvpCounts = { accepted: 0, declined: 0, maybe: 0, total: registrants.length };
+  for (const r of registrants) {
+    const status = getRegistrantAttendanceStatus(r);
+    if (status === 'accepted') counts.accepted++;
+    else if (status === 'declined') counts.declined++;
+    else if (status === 'maybe') counts.maybe++;
+  }
+  return counts;
+}
+
 /**
  * Map an ITX meeting response result to the MeetingRsvp shape used throughout the UI
  *


### PR DESCRIPTION
## Summary

- Two of our own indices encode `occurrence_id` in different units (Zoom/ITX + `occurrence_calculator.go` emit **Unix seconds**, `v1_meeting_rsvp` + `v1_past_meeting` store **Unix milliseconds**). Every `rsvp.occurrence_id === occurrenceId` comparison across that boundary silently failed for occurrence-scoped RSVPs — the calculator walked past them and the BFF's `getMeetingRsvpForCurrentUser` fell through to `userRsvps[0]`, an arbitrary sort-order pick.
- Add a shared unit-normalising resolver (`occurrenceIdToMs`, `isSameOccurrenceId`, `selectApplicableRsvp`) in `packages/shared/src/utils/rsvp-calculator.util.ts`. Both the frontend counts calculator and the BFF single-user lookup now delegate to it, so they can't drift apart again.
- Also fix the `this_and_following` branch to gate on the anchor occurrence's start time (encoded in `rsvp.occurrence_id`) rather than `rsvp.created_at`, which drifts from the anchor when the row was written retroactively or the v1→v2 sync was delayed.
- Third read site (added after Jordan flagged it on the ticket): `getUserMeetings` in `apps/lfx-one/src/server/services/user.service.ts` collapsed all of a series' RSVPs into a single `Map<meeting_id, MeetingRsvp>` entry, so per-occurrence rows overwrote each other non-deterministically. Now groups all RSVPs per meeting and delegates to `selectApplicableRsvp` against the meeting's current/next occurrence, matching the detail-page behaviour. Only user-visible impact today is the "Pending RSVP" filter chip (which stays boolean-correct), but this closes the latent pathology before it becomes visible on any per-occurrence card render.

Full data breakdown and prod fingerprint (Connie's 3-RSVP shape on meeting `92442170146`) is on the ticket comment.

## Behaviour delta (Connie's case)

| Occurrence (UTC) | Pre-fix | Post-fix |
| --- | --- | --- |
| Aug 11 14:00 (her single decline) | accepted (walked past decline, hit older T&F accept) | **declined** ✓ |
| Jul 28 / Aug 4 / Aug 18 (post-T&F-anchor) | accepted (via `!rsvp.occurrence_id` fallback — correct answer, wrong reasoning) | accepted ✓ (via T&F match) |
| Jul 14 (pre-T&F-anchor) | accepted (T&F wrongly applied because `created_at` ≤ occurrence date) | accepted ✓ (via base `all` — T&F correctly gated by anchor) |

## Test plan

- [x] `yarn --cwd packages/shared test` — 379/379 pass (the 20 new specs in `rsvp-calculator.util.spec.ts` pin Connie's exact prod state and cover the resolver's precedence + edges).
- [x] `apps/lfx-one` vitest — 122/122 pass.
- [x] `yarn build` — clean (typecheck + Angular build).
- [x] `yarn lint` — clean (unrelated pre-existing warning in `campaigns.component.ts`).
- [ ] Manual QA in staging with a recurring meeting: decline one future occurrence in Google Calendar, wait for sync, verify the "Your RSVP" chip on the meeting detail page reads `Yes` for every other occurrence and `No` only for the declined one.
- [ ] Manual QA: also verify the accepted / declined / pending counts on the dashboard card match the per-occurrence semantics.
- [ ] Manual QA: on the meetings dashboard, confirm the "Pending RSVP" filter still hides meetings where any RSVP exists for the series.

## Follow-up (separate ticket)

The write side should normalise to a single unit end-to-end so we don't need the read-side comparator forever: `occurrence_calculator.go` should call `t.UnixMilli()` instead of `t.Unix()`, and the ITX `Occurrence` proxy should widen seconds → ms on the way out. This PR is the safe short-term guard.

Made with [Cursor](https://cursor.com)