### PR TITLE
feat(committees): add voting reps stat and recent activity feed to overview

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -27,7 +27,7 @@ import {
   CommitteeUser,
   TagSeverity,
 } from '@lfx-one/shared/interfaces';
-import { canManageCommitteeMembers, resolveCommitteeMemberPermission } from '@lfx-one/shared/utils';
+import { canManageCommitteeMembers, countVotingReps, resolveCommitteeMemberPermission } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -100,9 +100,7 @@ export class CommitteeMembersComponent implements OnInit {
     if (!committee) return false;
     return committee.member_visibility === CommitteeMemberVisibility.BASIC_PROFILE || this.canManageMembers();
   });
-  public readonly votingRepCount: Signal<number> = computed(
-    () => this.members().filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length
-  );
+  public readonly votingRepCount: Signal<number> = computed(() => countVotingReps(this.members()));
   public readonly observerCount: Signal<number> = computed(
     () => this.members().filter((m) => m.voting?.status === CommitteeMemberVotingStatus.OBSERVER).length
   );

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -27,7 +27,7 @@ import {
   CommitteeUser,
   TagSeverity,
 } from '@lfx-one/shared/interfaces';
-import { canManageCommitteeMembers, countVotingReps, resolveCommitteeMemberPermission } from '@lfx-one/shared/utils';
+import { canManageCommitteeMembers, countVotingReps, isVotingRep, resolveCommitteeMemberPermission } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -528,7 +528,7 @@ export class CommitteeMembersComponent implements OnInit {
       const members = this.members();
       switch (chip) {
         case 'voting':
-          return members.filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP);
+          return members.filter(isVotingRep);
         case 'observers':
           return members.filter((m) => m.voting?.status === CommitteeMemberVotingStatus.OBSERVER);
         case 'chairs':

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -319,16 +319,17 @@
 <!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
      active votes. Reuse the same dashboard-cast-drawer-host + vote-cast-drawer pair every other
      dashboard wires this CTA to (user/board-member/executive-director/multi-persona/project), rather
-     than a tab hop — the committee Votes tab mounts this identical drawer with the same CTA and no
-     cast flow of its own (committee-votes.component.html), so a tab redirect would just relocate the
-     dead end. committeeUpdated on voteSubmitted reuses the existing refreshMembers() → refreshCommittee()
-     path so the re-fetched committee() also re-triggers initVotes()'s toObservable(this.committee). -->
+     than a tab hop — the committee Votes tab mounts this identical drawer with the same CTA and its
+     own matching fix (committee-votes.component.html), so a tab redirect would just relocate the dead
+     end rather than resolve it. voteSubmitted goes to a dedicated votesRefresh$ (not committeeUpdated,
+     which the parent wires to the much heavier refreshMembers() → refreshCommittee() — see
+     castVoteUids/votesRefresh$ above). -->
 <lfx-vote-results-drawer
   [(visible)]="voteDrawerVisible"
   [voteId]="selectedVoteId()"
   [listVote]="selectedVote()"
   (castVoteRequested)="castDrawerHost.open($event)"></lfx-vote-results-drawer>
-<lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="committeeUpdated.emit()" />
+<lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="onVoteSubmitted($event)" />
 
 <!-- Survey Results Drawer -->
 <!-- hasPMOAccess also gates the per-recipient Responses tab (not just the admin menu), so it's

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -38,6 +38,12 @@
             <span class="text-sm font-semibold text-gray-900">{{ meetingsCount() }}</span>
           }
         </div>
+        <!-- Voting Reps -->
+        <div class="flex items-center gap-3 px-4 py-3" data-testid="committee-overview-voting-reps">
+          <i class="fa-light fa-square-check text-gray-400 w-4 text-center flex-shrink-0"></i>
+          <span class="text-sm text-gray-700 flex-1">Voting Reps</span>
+          <span class="text-sm font-semibold text-gray-900">{{ committee().total_voting_repos }}</span>
+        </div>
         <!-- Active Votes -->
         <div class="flex items-center gap-3 px-4 py-3">
           <i class="fa-light fa-check-to-slot text-gray-400 w-4 text-center flex-shrink-0"></i>
@@ -237,6 +243,50 @@
             }
           </section>
         }
+
+        <!-- Recent Activity -->
+        <div class="flex flex-col gap-2 min-w-0" data-testid="committee-overview-activity-feed">
+          <h2 class="text-sm font-medium text-gray-700 flex items-center gap-2">
+            <i class="fa-light fa-timeline text-gray-400"></i>
+            Recent Activity
+          </h2>
+          @if (activityFeedLoading()) {
+            <lfx-card>
+              <div class="flex flex-col gap-4">
+                @for (i of [1, 2, 3]; track i) {
+                  <div class="flex items-center gap-3">
+                    <p-skeleton shape="circle" size="2rem" />
+                    <p-skeleton width="70%" height="0.875rem" />
+                  </div>
+                }
+              </div>
+            </lfx-card>
+          } @else if (activityItems().length) {
+            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200">
+              @for (item of activityItems(); track item.key) {
+                <button
+                  type="button"
+                  class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+                  [title]="item.label"
+                  (click)="navigateToTab(item.tab)"
+                  data-testid="committee-overview-activity-item">
+                  <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <i [class]="item.icon" class="text-gray-500 text-xs"></i>
+                  </div>
+                  <span class="text-sm text-gray-700 flex-1 min-w-0 truncate">{{ item.label }}</span>
+                </button>
+              }
+            </div>
+          } @else {
+            <lfx-card>
+              <div class="flex flex-col items-center py-6">
+                <i class="fa-light fa-clock-rotate-left text-2xl text-gray-300 mb-2"></i>
+                <p class="text-sm font-medium text-gray-500">No recent activity</p>
+                <p class="text-xs text-gray-400 mt-1">Recent meetings, votes, surveys, and documents will appear here.</p>
+              </div>
+            </lfx-card>
+          }
+        </div>
       } @else if (canJoin()) {
         <!-- Visitor CTA -->
         <div class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center" data-testid="committee-overview-visitor-cta">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -275,7 +275,7 @@
                   (click)="handleActivityItemClick(item)"
                   [attr.data-testid]="'committee-overview-activity-item-' + item.key">
                   <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
-                    <i [class]="item.icon" class="text-gray-500 text-xs"></i>
+                    <i [class]="item.icon" class="text-gray-500 text-xs" aria-hidden="true"></i>
                   </div>
                   <span class="text-sm text-gray-700 flex-1 min-w-0 truncate">{{ item.label }}</span>
                 </button>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -317,13 +317,18 @@
 
 <!-- Vote Results Drawer -->
 <!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
-     active votes; this Overview screen has no cast flow of its own, so route it to the Votes tab (same
-     tab-fallback pattern handleActivityItemClick uses for surveys/documents with no richer target). -->
+     active votes. Reuse the same dashboard-cast-drawer-host + vote-cast-drawer pair every other
+     dashboard wires this CTA to (user/board-member/executive-director/multi-persona/project), rather
+     than a tab hop — the committee Votes tab mounts this identical drawer with the same CTA and no
+     cast flow of its own (committee-votes.component.html), so a tab redirect would just relocate the
+     dead end. committeeUpdated on voteSubmitted reuses the existing refreshMembers() → refreshCommittee()
+     path so the re-fetched committee() also re-triggers initVotes()'s toObservable(this.committee). -->
 <lfx-vote-results-drawer
   [(visible)]="voteDrawerVisible"
   [voteId]="selectedVoteId()"
   [listVote]="selectedVote()"
-  (castVoteRequested)="onCastVoteRequested()"></lfx-vote-results-drawer>
+  (castVoteRequested)="castDrawerHost.open($event)"></lfx-vote-results-drawer>
+<lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="committeeUpdated.emit()" />
 
 <!-- Survey Results Drawer -->
 <!-- hasPMOAccess also gates the per-recipient Responses tab (not just the admin menu), so it's

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -323,7 +323,7 @@
   [listVote]="selectedVote()"></lfx-vote-results-drawer>
 
 <!-- Survey Results Drawer -->
-<!-- hasPMOAccess is false here (unlike committee-surveys.component.ts): this is a quick "peek" from
+<!-- hasPMOAccess is false here (unlike committee-surveys.component.html): this is a quick "peek" from
      the activity feed, not the surveys management surface, and its Duplicate/Close Survey actions
      have no outputs bound here to handle them. -->
 <lfx-survey-results-drawer

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -273,7 +273,7 @@
                   class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
                   [title]="item.label"
                   (click)="navigateToTab(item.tab)"
-                  data-testid="committee-overview-activity-item">
+                  [attr.data-testid]="'committee-overview-activity-item-' + item.key">
                   <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
                     <i [class]="item.icon" class="text-gray-500 text-xs"></i>
                   </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -323,9 +323,11 @@
   [listVote]="selectedVote()"></lfx-vote-results-drawer>
 
 <!-- Survey Results Drawer -->
+<!-- hasPMOAccess is false here (unlike committee-surveys.component.ts): this is a quick "peek" from
+     the activity feed, not the surveys management surface, and its Duplicate/Close Survey actions
+     have no outputs bound here to handle them. -->
 <lfx-survey-results-drawer
-  [visible]="surveyDrawerVisible()"
-  (visibleChange)="surveyDrawerVisible.set($event)"
+  [(visible)]="surveyDrawerVisible"
   [surveyId]="selectedSurveyId()"
   [listSurvey]="selectedSurvey()"
-  [hasPMOAccess]="canEdit()"></lfx-survey-results-drawer>
+  [hasPMOAccess]="false"></lfx-survey-results-drawer>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -272,7 +272,7 @@
                   type="button"
                   class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
                   [title]="item.label"
-                  (click)="navigateToTab(item.tab)"
+                  (click)="handleActivityItemClick(item)"
                   [attr.data-testid]="'committee-overview-activity-item-' + item.key">
                   <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
                     <i [class]="item.icon" class="text-gray-500 text-xs"></i>
@@ -321,3 +321,11 @@
   (visibleChange)="voteDrawerVisible.set($event)"
   [voteId]="selectedVoteId()"
   [listVote]="selectedVote()"></lfx-vote-results-drawer>
+
+<!-- Survey Results Drawer -->
+<lfx-survey-results-drawer
+  [visible]="surveyDrawerVisible()"
+  (visibleChange)="surveyDrawerVisible.set($event)"
+  [surveyId]="selectedSurveyId()"
+  [listSurvey]="selectedSurvey()"
+  [hasPMOAccess]="canEdit()"></lfx-survey-results-drawer>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -42,7 +42,11 @@
         <div class="flex items-center gap-3 px-4 py-3" data-testid="committee-overview-voting-reps">
           <i class="fa-light fa-square-check text-gray-400 w-4 text-center flex-shrink-0"></i>
           <span class="text-sm text-gray-700 flex-1">Voting Reps</span>
-          <span class="text-sm font-semibold text-gray-900">{{ committee().total_voting_repos }}</span>
+          @if (membersLoading()) {
+            <p-skeleton width="24px" height="1rem" />
+          } @else {
+            <span class="text-sm font-semibold text-gray-900">{{ votingRepsCount() }}</span>
+          }
         </div>
         <!-- Active Votes -->
         <div class="flex items-center gap-3 px-4 py-3">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -316,20 +316,15 @@
 </div>
 
 <!-- Vote Results Drawer -->
-<!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
-     active votes. Reuse the same dashboard-cast-drawer-host + vote-cast-drawer pair every other
-     dashboard wires this CTA to (user/board-member/executive-director/multi-persona/project), rather
-     than a tab hop — the committee Votes tab mounts this identical drawer with the same CTA and its
-     own matching fix (committee-votes.component.html), so a tab redirect would just relocate the dead
-     end rather than resolve it. voteSubmitted goes to a dedicated votesRefresh$ (not committeeUpdated,
-     which the parent wires to the much heavier refreshMembers() → refreshCommittee() — see
-     castVoteUids/votesRefresh$ above). -->
+<!-- allowCastFromDrawer=false: the default-'creator'-audience inline "Cast Vote" CTA gates on
+     vote.response_status, which only getMyVotes() (Me-lens) decorates — this screen feeds the drawer
+     from getVotesByCommittee/getVote, so response_status is always undefined and the CTA could never
+     legitimately render here anyway. Explicit rather than relying on that data gap to keep it hidden. -->
 <lfx-vote-results-drawer
   [(visible)]="voteDrawerVisible"
   [voteId]="selectedVoteId()"
   [listVote]="selectedVote()"
-  (castVoteRequested)="castDrawerHost.open($event)"></lfx-vote-results-drawer>
-<lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="onVoteSubmitted($event)" />
+  [allowCastFromDrawer]="false"></lfx-vote-results-drawer>
 
 <!-- Survey Results Drawer -->
 <!-- hasPMOAccess also gates the per-recipient Responses tab (not just the admin menu), so it's

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -316,7 +316,14 @@
 </div>
 
 <!-- Vote Results Drawer -->
-<lfx-vote-results-drawer [(visible)]="voteDrawerVisible" [voteId]="selectedVoteId()" [listVote]="selectedVote()"></lfx-vote-results-drawer>
+<!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
+     active votes; this Overview screen has no cast flow of its own, so route it to the Votes tab (same
+     tab-fallback pattern handleActivityItemClick uses for surveys/documents with no richer target). -->
+<lfx-vote-results-drawer
+  [(visible)]="voteDrawerVisible"
+  [voteId]="selectedVoteId()"
+  [listVote]="selectedVote()"
+  (castVoteRequested)="onCastVoteRequested()"></lfx-vote-results-drawer>
 
 <!-- Survey Results Drawer -->
 <!-- hasPMOAccess also gates the per-recipient Responses tab (not just the admin menu), so it's

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -316,18 +316,18 @@
 </div>
 
 <!-- Vote Results Drawer -->
-<lfx-vote-results-drawer
-  [visible]="voteDrawerVisible()"
-  (visibleChange)="voteDrawerVisible.set($event)"
-  [voteId]="selectedVoteId()"
-  [listVote]="selectedVote()"></lfx-vote-results-drawer>
+<lfx-vote-results-drawer [(visible)]="voteDrawerVisible" [voteId]="selectedVoteId()" [listVote]="selectedVote()"></lfx-vote-results-drawer>
 
 <!-- Survey Results Drawer -->
-<!-- hasPMOAccess is false here (unlike committee-surveys.component.html): this is a quick "peek" from
-     the activity feed, not the surveys management surface, and its Duplicate/Close Survey actions
-     have no outputs bound here to handle them. -->
+<!-- hasPMOAccess also gates the per-recipient Responses tab (not just the admin menu), so it's
+     bound to canEdit() to match committee-surveys.component.html rather than hardcoded false —
+     dropping PMO's Responses access would be a real feature loss, not just hiding dead buttons.
+     duplicate/closeSurvey mirror surveys-dashboard.component.ts's own handling: neither action is
+     implemented anywhere in the app yet (both are TODO stubs upstream of the API). -->
 <lfx-survey-results-drawer
   [(visible)]="surveyDrawerVisible"
   [surveyId]="selectedSurveyId()"
   [listSurvey]="selectedSurvey()"
-  [hasPMOAccess]="false"></lfx-survey-results-drawer>
+  [hasPMOAccess]="canEdit()"
+  (duplicate)="onSurveyDuplicate($event)"
+  (closeSurvey)="onSurveyClose($event)"></lfx-survey-results-drawer>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -364,14 +364,15 @@ export class CommitteeOverviewComponent {
         this.navigateToTab(action.tab);
         break;
       default:
-        // assertNeverSilent, not assertNever: this runs inside a DOM click handler, and LFXV2-1707
-        // will feed server-constructed actions into this same union, so an unrecognized future
-        // `kind` (e.g. a version-skewed client) should no-op rather than throw uncaught from a
-        // click. The compile-time guarantee is unchanged — a new unhandled kind still fails to
-        // compile, since the call below only type-checks if `action` has narrowed to `never` — but
-        // that's the one scenario where losing telemetry silently would be worse than a dead click,
-        // so log it first.
-        console.warn('Unhandled activity action kind:', (action as { kind: string }).kind);
+        // assertNeverSilent: this runs inside a DOM click handler, and LFXV2-1707 will feed
+        // server-constructed actions into this same union, so an unrecognized future `kind` (e.g. a
+        // version-skewed client) should no-op rather than throw uncaught from a click. The
+        // compile-time guarantee is unchanged — a new unhandled kind still fails to compile, since
+        // the call below only type-checks if `action` has narrowed to `never`. console.error (not
+        // .warn) matches the level this app already uses elsewhere for genuinely-unexpected state
+        // (e.g. datadog-rum.provider.ts) — not a confirmed guarantee this specific call reaches
+        // Datadog RUM, since RUM here isn't configured to forward console output.
+        console.error('Unhandled activity action kind:', (action as { kind: string }).kind);
         assertNeverSilent(action);
     }
   }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -28,7 +28,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
+import { assertNeverSilent, buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
@@ -364,12 +364,15 @@ export class CommitteeOverviewComponent {
         this.navigateToTab(action.tab);
         break;
       default:
-        // Compile-time exhaustiveness only — deliberately not assertNever(action) here. This runs
-        // inside a DOM click handler, and LFXV2-1707 will feed server-constructed actions into this
-        // same union, so an unrecognized future `kind` (e.g. a version-skewed client) should no-op
-        // rather than throw uncaught from a click. A new unhandled case still fails to compile: the
-        // assignment below only type-checks if `action` has narrowed to `never`.
-        ((_exhaustive: never) => void _exhaustive)(action);
+        // assertNeverSilent, not assertNever: this runs inside a DOM click handler, and LFXV2-1707
+        // will feed server-constructed actions into this same union, so an unrecognized future
+        // `kind` (e.g. a version-skewed client) should no-op rather than throw uncaught from a
+        // click. The compile-time guarantee is unchanged — a new unhandled kind still fails to
+        // compile, since the call below only type-checks if `action` has narrowed to `never` — but
+        // that's the one scenario where losing telemetry silently would be worse than a dead click,
+        // so log it first.
+        console.warn('Unhandled activity action kind:', (action as { kind: string }).kind);
+        assertNeverSilent(action);
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -559,11 +559,18 @@ export class CommitteeOverviewComponent {
   private initVotes(): Signal<Vote[]> {
     return toSignal(
       // votesRefresh$ re-reads this.committee() rather than using startWith, so a post-cast refresh
-      // can't double-emit against the toObservable(this.committee) source alongside it.
-      merge(toObservable(this.committee), this.votesRefresh$.pipe(map(() => this.committee()))).pipe(
-        filter((c) => !!c?.uid),
-        switchMap((c) => {
-          this.votesLoading.set(true);
+      // can't double-emit against the toObservable(this.committee) source alongside it. silent: true
+      // on that branch skips the votesLoading flip — castVoteUids has already resolved the row this
+      // refresh is meant to catch (an early poll close), so re-skeletoning "My Pending Actions" (and,
+      // via activityFeedLoading, Recent Activity) for the remaining rows on every cast would be a
+      // regression the row-level fix was supposed to avoid.
+      merge(
+        toObservable(this.committee).pipe(map((c) => ({ c, silent: false }))),
+        this.votesRefresh$.pipe(map(() => ({ c: this.committee(), silent: true })))
+      ).pipe(
+        filter(({ c }) => !!c?.uid),
+        switchMap(({ c, silent }) => {
+          if (!silent) this.votesLoading.set(true);
           return this.voteService.getVotesByCommittee(c.uid, 'updated_at.desc').pipe(
             catchError(() => of([])),
             finalize(() => this.votesLoading.set(false))

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -360,14 +360,16 @@ export class CommitteeOverviewComponent {
     }
   }
 
-  // Not implemented anywhere in the app yet (also TODO stubs in surveys-dashboard.component.ts) —
-  // mirrors that same stub behavior rather than silently swallowing the event.
+  // Mirrors surveys-dashboard.component.ts's own stub handling (also TODOs there) rather than
+  // silently swallowing the event.
   public onSurveyDuplicate(surveyId: string): void {
+    // TODO: Implement survey duplication when API is available
     console.warn('Survey duplication not yet implemented for:', surveyId);
     this.surveyDrawerVisible.set(false);
   }
 
   public onSurveyClose(surveyId: string): void {
+    // TODO: Implement survey close when API is available
     console.warn('Survey close not yet implemented for:', surveyId);
     this.surveyDrawerVisible.set(false);
   }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -554,15 +554,20 @@ export class CommitteeOverviewComponent {
     // cancels a request. distinctUntilChanged on (uid, roleLoading, visitor) skips re-emissions
     // where the committee object identity changed (e.g. a silent refresh) but nothing that
     // actually affects this fetch did, so an in-flight request isn't needlessly cancelled/restarted.
+    // Note: this only holds the documents list steady — pastMeetings/votes/surveys have no
+    // equivalent guard, so activityFeedLoading() can still flip true on a silent refresh via those.
     return toSignal(
       toObservable(computed(() => ({ committee: this.committee(), roleLoading: this.myRoleLoading(), visitor: this.isVisitor() }))).pipe(
         filter(({ committee }) => !!committee?.uid),
         distinctUntilChanged((a, b) => a.committee.uid === b.committee.uid && a.roleLoading === b.roleLoading && a.visitor === b.visitor),
         switchMap(({ committee, roleLoading, visitor }) => {
           if (roleLoading) {
-            // Role still resolving (e.g. mid silent-refresh) — hold the current documents/loading
-            // state rather than emitting [] and wiping an already-populated feed. The committee
-            // signal re-emits once the role settles, which re-enters this pipeline.
+            // Role still resolving (e.g. mid silent-refresh) — hold the current documents state
+            // rather than emitting [] and wiping an already-populated feed. Re-assert loading=true
+            // explicitly: if a fetch was in flight, switchMap unsubscribing it also runs its
+            // finalize, which would otherwise leave documentsLoading falsely cleared during this
+            // hold window. The committee/role signal re-emits once the role settles.
+            this.documentsLoading.set(true);
             return EMPTY;
           }
           if (visitor) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -122,9 +122,10 @@ export class CommitteeOverviewComponent {
 
   // Computed: voting representative count from members. Not sourced from
   // committee().total_voting_repos — upstream (lfx-v2-committee-service) defines that field as
-  // "total repositories with voting permissions" (not people) and no production code path writes
-  // it, so it always reads 0. This derives the actual per-member voting-rep count instead, via the
-  // shared countVotingReps() util (also used by committee-members.component.ts's votingRepCount).
+  // "total repositories with voting permissions" (not people), is optional (upstream only sets it
+  // when > 0), and no production code path currently writes it, so it reads undefined in practice.
+  // This derives the actual per-member voting-rep count instead, via the shared countVotingReps()
+  // util (also used by committee-members.component.ts's votingRepCount).
   public votingRepsCount: Signal<number> = computed(() => countVotingReps(this.members()));
 
   // Committee-scoped data fetches

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -16,7 +16,7 @@ import {
   POLL_STATUS_LABELS,
   SURVEY_STATUS_LABELS,
 } from '@lfx-one/shared/constants';
-import { CommitteeMemberRole, CommitteeMemberVotingStatus, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
+import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import {
   ActivityFeedItem,
   Committee,
@@ -30,7 +30,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { countVotingReps, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
@@ -39,7 +39,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -127,8 +127,10 @@ export class CommitteeOverviewComponent {
   // Computed: voting representative count from members. Not sourced from
   // committee().total_voting_repos — upstream (lfx-v2-committee-service) defines that field as
   // "total repositories with voting permissions" (not people) and no production code path writes
-  // it, so it always reads 0. This derives the actual per-member voting-rep count instead.
-  public votingRepsCount: Signal<number> = computed(() => this.members().filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length);
+  // it, so it always reads 0. This derives the actual per-member voting-rep count instead, via the
+  // shared countVotingReps() util (committee-members.component.ts's votingRepCount has the same
+  // logic today but isn't migrated to it here — out of scope for this ticket).
+  public votingRepsCount: Signal<number> = computed(() => countVotingReps(this.members()));
 
   // Committee-scoped data fetches
   public meetingsCount: Signal<number> = this.initMeetingsCount();
@@ -549,14 +551,19 @@ export class CommitteeOverviewComponent {
     // Derived from one combined computed (not combineLatest over three separate toObservable()
     // sources) so committee/myRoleLoading/isVisitor — all recomputed together in the same signal
     // flush — can't glitch through an inconsistent intermediate tick that fires then immediately
-    // cancels a request. While the role is still resolving, documentsLoading stays true (not
-    // cleared) so the feed keeps its skeleton instead of flashing empty for a soon-to-be member.
+    // cancels a request. distinctUntilChanged on (uid, roleLoading, visitor) skips re-emissions
+    // where the committee object identity changed (e.g. a silent refresh) but nothing that
+    // actually affects this fetch did, so an in-flight request isn't needlessly cancelled/restarted.
     return toSignal(
       toObservable(computed(() => ({ committee: this.committee(), roleLoading: this.myRoleLoading(), visitor: this.isVisitor() }))).pipe(
         filter(({ committee }) => !!committee?.uid),
+        distinctUntilChanged((a, b) => a.committee.uid === b.committee.uid && a.roleLoading === b.roleLoading && a.visitor === b.visitor),
         switchMap(({ committee, roleLoading, visitor }) => {
           if (roleLoading) {
-            return of<CommitteeDocument[]>([]);
+            // Role still resolving (e.g. mid silent-refresh) — hold the current documents/loading
+            // state rather than emitting [] and wiping an already-populated feed. The committee
+            // signal re-emits once the role settles, which re-enters this pipeline.
+            return EMPTY;
           }
           if (visitor) {
             this.documentsLoading.set(false);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -39,6 +39,7 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
 
+import { DashboardCastDrawerHostComponent } from '../../../dashboards/components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { SurveyResultsDrawerComponent } from '../../../surveys/components/survey-results-drawer/survey-results-drawer.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -54,6 +55,7 @@ import { EditChairsDialogComponent } from '../edit-chairs-dialog/edit-chairs-dia
     TagComponent,
     VoteResultsDrawerComponent,
     SurveyResultsDrawerComponent,
+    DashboardCastDrawerHostComponent,
   ],
   providers: [DialogService],
   templateUrl: './committee-overview.component.html',
@@ -323,12 +325,6 @@ export class CommitteeOverviewComponent {
     } else {
       this.tabNavigated.emit('surveys');
     }
-  }
-
-  /** Vote Results Drawer's inline "Cast Vote" CTA (creator audience, awaiting-response active vote) — this
-   *  screen has no cast flow, so send the viewer to the Votes tab where one exists. */
-  public onCastVoteRequested(): void {
-    this.navigateToTab('votes');
   }
 
   public handleActivityItemClick(item: ActivityFeedItem): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -325,15 +325,25 @@ export class CommitteeOverviewComponent {
     }
   }
 
+  /** Vote Results Drawer's inline "Cast Vote" CTA (creator audience, awaiting-response active vote) — this
+   *  screen has no cast flow, so send the viewer to the Votes tab where one exists. */
+  public onCastVoteRequested(): void {
+    this.navigateToTab('votes');
+  }
+
   public handleActivityItemClick(item: ActivityFeedItem): void {
     const { action } = item;
     switch (action.kind) {
-      case 'past-meeting':
+      case 'past-meeting': {
         // Matches the "Past Meeting" card's own link two sections up
-        // (`[detailUrl]="'/meetings/' + meeting.id"`) exactly, so the two rows describing the same
-        // meeting on this screen always resolve to the same URL.
-        void this.router.navigate(['/meetings', action.meetingId], { queryParamsHandling: 'preserve' });
+        // (`[detailUrl]="'/meetings/' + meeting.id"`) and its password query param
+        // (`dashboard-meeting-card.component.ts`'s `initMeetingDetailQueryParams`) — a password-gated
+        // committee meeting needs that param carried through, matching the established convention at
+        // `meetings-dashboard.component.ts`'s `onCalendarEventClick`.
+        const meeting = this.pastMeetings().find((m) => m.id === action.meetingId);
+        void this.router.navigate(['/meetings', action.meetingId], meeting?.password ? { queryParams: { password: meeting.password } } : {});
         break;
+      }
       case 'vote-drawer': {
         const vote = this.votes().find((v) => v.uid === action.voteUid);
         if (vote) {
@@ -658,9 +668,18 @@ export class CommitteeOverviewComponent {
             return of<CommitteeDocument[]>([]);
           }
           this.documentsLoading.set(true);
-          // No catchError here: CommitteeService.getCommitteeDocuments already falls back to
-          // of([]) on failure, so a component-level handler would never fire.
-          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(tap(() => this.documentsLoading.set(false)));
+          // CommitteeService.getCommitteeDocuments already falls back to of([]) on failure today, so
+          // this catchError is a belt-and-suspenders guard against that coupling changing underneath
+          // this component (e.g. a future interceptor rethrow) — without it, an error here would
+          // propagate past a next-only tap, kill this toSignal source permanently, and pin
+          // activityFeedLoading() on its skeleton for the rest of the session.
+          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(
+            tap(() => this.documentsLoading.set(false)),
+            catchError(() => {
+              this.documentsLoading.set(false);
+              return of<CommitteeDocument[]>([]);
+            })
+          );
         })
       ),
       { initialValue: [] }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -28,7 +28,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { assertNever, buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
+import { buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
@@ -364,7 +364,12 @@ export class CommitteeOverviewComponent {
         this.navigateToTab(action.tab);
         break;
       default:
-        assertNever(action);
+        // Compile-time exhaustiveness only — deliberately not assertNever(action) here. This runs
+        // inside a DOM click handler, and LFXV2-1707 will feed server-constructed actions into this
+        // same union, so an unrecognized future `kind` (e.g. a version-skewed client) should no-op
+        // rather than throw uncaught from a click. A new unhandled case still fails to compile: the
+        // assignment below only type-checks if `action` has narrowed to `never`.
+        ((_exhaustive: never) => void _exhaustive)(action);
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -13,9 +13,22 @@ import {
   PENDING_ACTION_FADE_OUT_MS,
   PENDING_ACTION_LABEL,
   PENDING_ACTION_SEVERITY,
+  POLL_STATUS_LABELS,
+  SURVEY_STATUS_LABELS,
 } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
-import { Committee, CommitteeMember, CommitteePendingActionRow, Meeting, PastMeeting, PendingActionItem, Survey, Vote } from '@lfx-one/shared/interfaces';
+import {
+  ActivityFeedItem,
+  Committee,
+  CommitteeDocument,
+  CommitteeMember,
+  CommitteePendingActionRow,
+  Meeting,
+  PastMeeting,
+  PendingActionItem,
+  Survey,
+  Vote,
+} from '@lfx-one/shared/interfaces';
 import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -76,6 +89,7 @@ export class CommitteeOverviewComponent {
   public meetingsLoading = signal(true);
   public votesLoading = signal(true);
   public surveysLoading = signal(true);
+  public documentsLoading = signal(true);
 
   // Loading states for meeting sections
   public upcomingMeetingsLoading = signal(true);
@@ -114,11 +128,23 @@ export class CommitteeOverviewComponent {
   public pastMeetings: Signal<PastMeeting[]> = this.initPastMeetings();
   public votes: Signal<Vote[]> = this.initVotes();
   public surveys: Signal<Survey[]> = this.initSurveys();
+  // Documents aren't otherwise loaded on Overview — fetched here solely to seed the activity feed.
+  // CommitteeService.getCommitteeDocuments has no shared cache, so the Documents tab still issues
+  // its own request; accepted as a cheap duplicate GET rather than lifting the fetch up to committee-view.
+  public documents: Signal<CommitteeDocument[]> = this.initDocuments();
 
   // Computed stats from fetched data
   public activeVotesCount: Signal<number> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE).length);
 
   public openSurveysCount: Signal<number> = computed(() => this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN).length);
+
+  // Activity feed stop-gap: merges the latest items across past meetings, votes, surveys, and
+  // documents into one time-ordered list. Replaced by the real activity stream in LFXV2-1707.
+  public activityFeedLoading: Signal<boolean> = computed(
+    () => this.pastMeetingsLoading() || this.votesLoading() || this.surveysLoading() || this.documentsLoading()
+  );
+
+  public activityItems: Signal<ActivityFeedItem[]> = this.initActivityItems();
 
   // Role-based computed signals
   public isVisitor: Signal<boolean> = computed(() => this.myRole() === null && !this.myRoleLoading());
@@ -507,5 +533,89 @@ export class CommitteeOverviewComponent {
       ),
       { initialValue: [] }
     );
+  }
+
+  private initDocuments(): Signal<CommitteeDocument[]> {
+    return toSignal(
+      toObservable(this.committee).pipe(
+        // Documents only seed the activity feed, which the template never renders for a visitor
+        // (behind !isVisitor()) — skip the fetch rather than issue a GET nothing will display.
+        filter((c) => !!c?.uid && !this.isVisitor()),
+        switchMap((c) => {
+          this.documentsLoading.set(true);
+          // No catchError here: CommitteeService.getCommitteeDocuments already falls back to
+          // of([]) on failure, so a component-level handler would never fire.
+          return this.committeeService.getCommitteeDocuments(c.uid).pipe(finalize(() => this.documentsLoading.set(false)));
+        })
+      ),
+      { initialValue: [] }
+    );
+  }
+
+  private initActivityItems(): Signal<ActivityFeedItem[]> {
+    return computed(() => {
+      // Per-source cap before merging, so one noisy source can't crowd out the rest.
+      const perSourceLimit = 5;
+
+      // Upcoming meetings are intentionally excluded — they're future-dated, already covered by the
+      // "Next Meeting" card, and would otherwise dominate a feed labelled "Recent Activity".
+      const pastMeetingItems: ActivityFeedItem[] = [...this.pastMeetings()]
+        .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+        .slice(0, perSourceLimit)
+        .map((m) => ({
+          type: 'past_meeting',
+          key: `past_meeting-${m.meeting_and_occurrence_id ?? m.id}`,
+          label: `Meeting held: ${m.title}`,
+          timestamp: m.start_time ?? '',
+          icon: 'fa-light fa-clock-rotate-left',
+          tab: 'meetings:past',
+        }));
+
+      // Upstream Vote schema (lfx-v2-voting-service openapi3.yaml) marks `status` required with a
+      // fixed lowercase enum (disabled/active/ended) — no case normalization needed here.
+      const voteItems: ActivityFeedItem[] = [...this.votes()]
+        .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
+        .slice(0, perSourceLimit)
+        .map((v) => ({
+          type: 'vote' as const,
+          key: `vote-${v.uid}`,
+          label: `Vote ${POLL_STATUS_LABELS[v.status]}: ${v.name}`,
+          timestamp: v.last_modified_time ?? v.creation_time ?? '',
+          icon: 'fa-light fa-check-to-slot',
+          tab: 'votes',
+        }));
+
+      const surveyItems: ActivityFeedItem[] = [...this.surveys()]
+        .sort((a, b) => (b.last_modified_at ?? b.created_at ?? '').localeCompare(a.last_modified_at ?? a.created_at ?? ''))
+        .slice(0, perSourceLimit)
+        .map((s) => {
+          const displayStatus = getSurveyDisplayStatus(s);
+          return {
+            type: 'survey' as const,
+            key: `survey-${s.uid}`,
+            label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
+            timestamp: s.last_modified_at ?? s.created_at ?? '',
+            icon: 'fa-light fa-chart-simple',
+            tab: 'surveys',
+          };
+        });
+
+      const documentItems: ActivityFeedItem[] = [...this.documents()]
+        .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+        .slice(0, perSourceLimit)
+        .map((d) => ({
+          type: 'document',
+          key: `document-${d.uid}`,
+          label: `Document: ${d.name}`,
+          timestamp: d.updated_at ?? d.created_at ?? '',
+          icon: 'fa-light fa-file',
+          tab: 'documents',
+        }));
+
+      // Final row count shown in the feed after merge-sort.
+      const feedLimit = 8;
+
+      return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems].sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, feedLimit);
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -37,9 +37,8 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, map, merge, of, Subject, switchMap, take, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
 
-import { DashboardCastDrawerHostComponent } from '../../../dashboards/components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { SurveyResultsDrawerComponent } from '../../../surveys/components/survey-results-drawer/survey-results-drawer.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -55,7 +54,6 @@ import { EditChairsDialogComponent } from '../edit-chairs-dialog/edit-chairs-dia
     TagComponent,
     VoteResultsDrawerComponent,
     SurveyResultsDrawerComponent,
-    DashboardCastDrawerHostComponent,
   ],
   providers: [DialogService],
   templateUrl: './committee-overview.component.html',
@@ -95,16 +93,6 @@ export class CommitteeOverviewComponent {
   public voteDrawerVisible = signal(false);
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
-  // uids cast this session — getVotesByCommittee hits raw /api/votes, which never carries
-  // response_status (Me-lens-only, per poll.interface.ts), so a just-cast vote still comes back
-  // status: ACTIVE from the refetch below; this locally excludes it from "My Pending Actions"
-  // immediately instead of waiting on the vote to close.
-  public castVoteUids = signal<Set<string>>(new Set());
-  // Vote-only refresh trigger for initVotes(), separate from committeeUpdated (which the parent wires
-  // to refreshMembers() — a much heavier members+committee refetch that would also re-fire this
-  // component's other four toObservable(this.committee) pipelines, including the expensive
-  // getCommitteeDocuments fan-out documented on initDocuments() below).
-  private readonly votesRefresh$ = new Subject<void>();
 
   // Survey drawer state
   public surveyDrawerVisible = signal(false);
@@ -256,7 +244,7 @@ export class CommitteeOverviewComponent {
     return `${name} is invite only. A group admin must send you an invitation before you can join.`;
   });
 
-  public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE && !this.castVoteUids().has(v.uid)));
+  public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));
   public pendingSurveys: Signal<Survey[]> = computed(() =>
     this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status?.toLowerCase() !== 'responded')
   );
@@ -335,14 +323,6 @@ export class CommitteeOverviewComponent {
     } else {
       this.tabNavigated.emit('surveys');
     }
-  }
-
-  /** DashboardCastDrawerHost's voteSubmitted — resolves the pending-actions row immediately (see
-   *  castVoteUids) and refreshes the votes list as a correctness backstop for early-close (a poll
-   *  can auto-end once every eligible voter has responded). */
-  public onVoteSubmitted(voteUid: string): void {
-    this.castVoteUids.update((uids) => new Set(uids).add(voteUid));
-    this.votesRefresh$.next();
   }
 
   public handleActivityItemClick(item: ActivityFeedItem): void {
@@ -558,25 +538,13 @@ export class CommitteeOverviewComponent {
 
   private initVotes(): Signal<Vote[]> {
     return toSignal(
-      // votesRefresh$ re-reads this.committee() rather than using startWith, so a post-cast refresh
-      // can't double-emit against the toObservable(this.committee) source alongside it. silent: true
-      // on that branch skips the votesLoading flip — castVoteUids has already resolved the row this
-      // refresh is meant to catch (an early poll close), so re-skeletoning "My Pending Actions" (and,
-      // via activityFeedLoading, Recent Activity) for the remaining rows on every cast would be a
-      // regression the row-level fix was supposed to avoid. Cleared via tap (fires only on emission),
-      // not finalize (also fires on switchMap-driven cancellation) — same reasoning as initDocuments()
-      // below: a silent refresh cancelling an in-flight loud fetch must not clear votesLoading out
-      // from under it before the silent replacement has actually resolved.
-      merge(
-        toObservable(this.committee).pipe(map((c) => ({ c, silent: false }))),
-        this.votesRefresh$.pipe(map(() => ({ c: this.committee(), silent: true })))
-      ).pipe(
-        filter(({ c }) => !!c?.uid),
-        switchMap(({ c, silent }) => {
-          if (!silent) this.votesLoading.set(true);
+      toObservable(this.committee).pipe(
+        filter((c) => !!c?.uid),
+        switchMap((c) => {
+          this.votesLoading.set(true);
           return this.voteService.getVotesByCommittee(c.uid, 'updated_at.desc').pipe(
             catchError(() => of([])),
-            tap(() => this.votesLoading.set(false))
+            finalize(() => this.votesLoading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -8,6 +8,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import {
+  COMMITTEE_DOCUMENT_TYPE_LABELS,
   PAST_MEETING_SORT,
   PENDING_ACTION_EMPTY_GRACE_MS,
   PENDING_ACTION_FADE_OUT_MS,
@@ -21,7 +22,6 @@ import {
   ActivityFeedItem,
   Committee,
   CommitteeDocument,
-  CommitteeDocumentType,
   CommitteeMember,
   CommitteePendingActionRow,
   Meeting,
@@ -631,18 +631,15 @@ export class CommitteeOverviewComponent {
         });
 
       // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a
-      // folder or link doesn't misrepresent itself as a file in the feed.
-      // No shared label map exists for CommitteeDocumentType (DOCUMENT_SOURCE_TAGS is keyed by the
-      // unrelated CommitteeDocumentSource enum), but the icon is reused from the Documents tab's
-      // own helper so the two surfaces can't drift.
-      const documentTypeLabel: Record<CommitteeDocumentType, string> = { file: 'Document', link: 'Link', folder: 'Folder' };
+      // folder or link doesn't misrepresent itself as a file in the feed. The icon is reused from
+      // the Documents tab's own helper so the two surfaces can't drift.
       const documentItems: ActivityFeedItem[] = [...this.documents()]
         .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
         .slice(0, perSourceLimit)
         .map((d) => ({
           type: 'document' as const,
           key: `document-${d.uid}`,
-          label: `${documentTypeLabel[d.type]}: ${d.name}`,
+          label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type]}: ${d.name}`,
           timestamp: d.updated_at ?? d.created_at ?? '',
           icon: getDocumentTypeIconClass(d.type),
           tab: 'documents',

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -350,8 +350,8 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'external-url':
-        // buildActivityFeed only produces this action after validating the url is http(s) —
-        // see isSafeExternalUrl — matching DocumentsTableComponent.openDocument's own guard.
+        // buildActivityFeed only emits this action for urls that pass isValidUrl
+        // (@lfx-one/shared/utils) — http(s) only, no private/local hosts.
         window.open(action.url, '_blank', 'noopener,noreferrer');
         break;
       case 'tab':

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -134,9 +134,13 @@ export class CommitteeOverviewComponent {
   public pastMeetings: Signal<PastMeeting[]> = this.initPastMeetings();
   public votes: Signal<Vote[]> = this.initVotes();
   public surveys: Signal<Survey[]> = this.initSurveys();
-  // Documents aren't otherwise loaded on Overview — fetched here solely to seed the activity feed.
-  // CommitteeService.getCommitteeDocuments has no shared cache, so the Documents tab still issues
-  // its own request; accepted as a cheap duplicate GET rather than lifting the fetch up to committee-view.
+  // Documents aren't otherwise loaded on Overview — fetched here solely to seed the activity feed
+  // (which shows at most 5 document rows). Not cheap: getCommitteeDocuments fans out server-side to
+  // /folders, /links, and an unbounded fetchAllQueryResources page-token loop over every
+  // committee_document (committee.service.ts), repeated on every silent refresh and again when the
+  // user opens the Documents tab (no shared cache). Accepted as a stop-gap for this ticket's scope —
+  // lifting the fetch to committee-view.component.ts to share across tabs, or bounding it with a
+  // page_size/order param, is real follow-up work, not a change this branch makes.
   public documents: Signal<CommitteeDocument[]> = this.initDocuments();
 
   // Computed stats from fetched data

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -39,7 +39,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -561,12 +561,11 @@ export class CommitteeOverviewComponent {
         distinctUntilChanged((a, b) => a.committee.uid === b.committee.uid && a.roleLoading === b.roleLoading && a.visitor === b.visitor),
         switchMap(({ committee, roleLoading, visitor }) => {
           if (roleLoading) {
-            // Role still resolving (e.g. mid silent-refresh) — hold the current documents state
-            // rather than emitting [] and wiping an already-populated feed. Re-assert loading=true
-            // explicitly: if a fetch was in flight, switchMap unsubscribing it also runs its
-            // finalize, which would otherwise leave documentsLoading falsely cleared during this
-            // hold window. The committee/role signal re-emits once the role settles.
-            this.documentsLoading.set(true);
+            // Role still resolving (e.g. mid silent-refresh) — hold both the documents list and
+            // documentsLoading exactly as they are (no signal write here). Safe because the fetch
+            // branch below clears documentsLoading with tap (fires only on emission), not finalize
+            // (also fires on switchMap-driven cancellation) — so cancelling an in-flight fetch to
+            // enter this branch can't have already cleared it out from under us.
             return EMPTY;
           }
           if (visitor) {
@@ -576,7 +575,7 @@ export class CommitteeOverviewComponent {
           this.documentsLoading.set(true);
           // No catchError here: CommitteeService.getCommitteeDocuments already falls back to
           // of([]) on failure, so a component-level handler would never fire.
-          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(finalize(() => this.documentsLoading.set(false)));
+          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(tap(() => this.documentsLoading.set(false)));
         })
       ),
       { initialValue: [] }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -39,7 +39,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
+import { catchError, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -546,21 +546,26 @@ export class CommitteeOverviewComponent {
   private initDocuments(): Signal<CommitteeDocument[]> {
     // Documents only seed the activity feed, which the template never renders for a visitor
     // (behind !isVisitor()) — skip the fetch rather than issue a GET nothing will display.
-    // Reactive over myRoleLoading/isVisitor (not just committee) so the fetch fires once the role
-    // actually resolves, and documentsLoading is explicitly cleared on the skip path so
-    // activityFeedLoading() can't get stuck true for a visitor whose role never triggers a fetch.
+    // Derived from one combined computed (not combineLatest over three separate toObservable()
+    // sources) so committee/myRoleLoading/isVisitor — all recomputed together in the same signal
+    // flush — can't glitch through an inconsistent intermediate tick that fires then immediately
+    // cancels a request. While the role is still resolving, documentsLoading stays true (not
+    // cleared) so the feed keeps its skeleton instead of flashing empty for a soon-to-be member.
     return toSignal(
-      combineLatest([toObservable(this.committee), toObservable(this.myRoleLoading), toObservable(this.isVisitor)]).pipe(
-        filter(([c]) => !!c?.uid),
-        switchMap(([c, roleLoading, visitor]) => {
-          if (roleLoading || visitor) {
+      toObservable(computed(() => ({ committee: this.committee(), roleLoading: this.myRoleLoading(), visitor: this.isVisitor() }))).pipe(
+        filter(({ committee }) => !!committee?.uid),
+        switchMap(({ committee, roleLoading, visitor }) => {
+          if (roleLoading) {
+            return of<CommitteeDocument[]>([]);
+          }
+          if (visitor) {
             this.documentsLoading.set(false);
             return of<CommitteeDocument[]>([]);
           }
           this.documentsLoading.set(true);
           // No catchError here: CommitteeService.getCommitteeDocuments already falls back to
           // of([]) on failure, so a component-level handler would never fire.
-          return this.committeeService.getCommitteeDocuments(c.uid).pipe(finalize(() => this.documentsLoading.set(false)));
+          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(finalize(() => this.documentsLoading.set(false)));
         })
       ),
       { initialValue: [] }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -43,6 +43,7 @@ import { catchError, combineLatest, filter, finalize, forkJoin, of, switchMap, t
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
+import { getDocumentTypeIconClass } from '../../pipes/document-type-icon.pipe';
 import { EditChairsDialogComponent } from '../edit-chairs-dialog/edit-chairs-dialog.component';
 
 @Component({
@@ -616,8 +617,10 @@ export class CommitteeOverviewComponent {
 
       // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a
       // folder or link doesn't misrepresent itself as a file in the feed.
+      // No shared label map exists for CommitteeDocumentType (DOCUMENT_SOURCE_TAGS is keyed by the
+      // unrelated CommitteeDocumentSource enum), but the icon is reused from the Documents tab's
+      // own helper so the two surfaces can't drift.
       const documentTypeLabel: Record<CommitteeDocumentType, string> = { file: 'Document', link: 'Link', folder: 'Folder' };
-      const documentTypeIcon: Record<CommitteeDocumentType, string> = { file: 'fa-light fa-file', link: 'fa-light fa-link', folder: 'fa-light fa-folder' };
       const documentItems: ActivityFeedItem[] = [...this.documents()]
         .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
         .slice(0, perSourceLimit)
@@ -626,7 +629,7 @@ export class CommitteeOverviewComponent {
           key: `document-${d.uid}`,
           label: `${documentTypeLabel[d.type]}: ${d.name}`,
           timestamp: d.updated_at ?? d.created_at ?? '',
-          icon: documentTypeIcon[d.type],
+          icon: getDocumentTypeIconClass(d.type),
           tab: 'documents',
         }));
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -547,11 +547,13 @@ export class CommitteeOverviewComponent {
     // Derived from one combined computed (not combineLatest over three separate toObservable()
     // sources) so committee/myRoleLoading/isVisitor — all recomputed together in the same signal
     // flush — can't glitch through an inconsistent intermediate tick that fires then immediately
-    // cancels a request. distinctUntilChanged on (uid, roleLoading, visitor) skips re-emissions
-    // where the committee object identity changed (e.g. a silent refresh) but nothing that
-    // actually affects this fetch did, so an in-flight request isn't needlessly cancelled/restarted.
-    // Note: this only holds the documents list steady — pastMeetings/votes/surveys have no
-    // equivalent guard, so activityFeedLoading() can still flip true on a silent refresh via those.
+    // cancels a request. distinctUntilChanged on (uid, roleLoading, visitor) only dedupes a
+    // same-tuple re-emission (e.g. an unrelated field on committee() changing identity without
+    // affecting uid/roleLoading/visitor) — it does NOT suppress a silent refresh: myRoleLoading is
+    // `loading() || committeeRefreshing()` (committee-view.component.ts), so a refresh flips
+    // roleLoading true then false, which — like pastMeetings/votes/surveys, none of which have any
+    // guard here — legitimately cancels and re-issues the documents fetch and flips
+    // activityFeedLoading() back to true for the duration.
     return toSignal(
       toObservable(computed(() => ({ committee: this.committee(), roleLoading: this.myRoleLoading(), visitor: this.isVisitor() }))).pipe(
         filter(({ committee }) => !!committee?.uid),

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -128,8 +128,7 @@ export class CommitteeOverviewComponent {
   // committee().total_voting_repos — upstream (lfx-v2-committee-service) defines that field as
   // "total repositories with voting permissions" (not people) and no production code path writes
   // it, so it always reads 0. This derives the actual per-member voting-rep count instead, via the
-  // shared countVotingReps() util (committee-members.component.ts's votingRepCount has the same
-  // logic today but isn't migrated to it here — out of scope for this ticket).
+  // shared countVotingReps() util (also used by committee-members.component.ts's votingRepCount).
   public votingRepsCount: Signal<number> = computed(() => countVotingReps(this.members()));
 
   // Committee-scoped data fetches

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -4,6 +4,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, inject, input, output, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -39,12 +40,21 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
+import { SurveyResultsDrawerComponent } from '../../../surveys/components/survey-results-drawer/survey-results-drawer.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
 import { EditChairsDialogComponent } from '../edit-chairs-dialog/edit-chairs-dialog.component';
 
 @Component({
   selector: 'lfx-committee-overview',
-  imports: [CardComponent, ButtonComponent, DashboardMeetingCardComponent, SkeletonModule, TagComponent, VoteResultsDrawerComponent],
+  imports: [
+    CardComponent,
+    ButtonComponent,
+    DashboardMeetingCardComponent,
+    SkeletonModule,
+    TagComponent,
+    VoteResultsDrawerComponent,
+    SurveyResultsDrawerComponent,
+  ],
   providers: [DialogService],
   templateUrl: './committee-overview.component.html',
   styleUrl: './committee-overview.component.scss',
@@ -60,6 +70,7 @@ export class CommitteeOverviewComponent {
   private readonly messageService = inject(MessageService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
 
   // Inputs
   public committee = input.required<Committee>();
@@ -82,6 +93,11 @@ export class CommitteeOverviewComponent {
   public voteDrawerVisible = signal(false);
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
+
+  // Survey drawer state
+  public surveyDrawerVisible = signal(false);
+  public selectedSurveyId = signal<string | null>(null);
+  public selectedSurvey = signal<Survey | null>(null);
 
   // Loading states for stats
   public meetingsLoading = signal(true);
@@ -306,6 +322,41 @@ export class CommitteeOverviewComponent {
       }
     } else {
       this.tabNavigated.emit('surveys');
+    }
+  }
+
+  public handleActivityItemClick(item: ActivityFeedItem): void {
+    const { action } = item;
+    switch (action.kind) {
+      case 'route':
+        void this.router.navigateByUrl(action.path);
+        break;
+      case 'vote-drawer': {
+        const vote = this.votes().find((v) => v.uid === action.voteUid);
+        if (vote) {
+          this.selectedVoteId.set(vote.uid);
+          this.selectedVote.set(vote);
+          this.voteDrawerVisible.set(true);
+        }
+        break;
+      }
+      case 'survey-drawer': {
+        const survey = this.surveys().find((s) => s.uid === action.surveyUid);
+        if (survey) {
+          this.selectedSurveyId.set(survey.uid);
+          this.selectedSurvey.set(survey);
+          this.surveyDrawerVisible.set(true);
+        }
+        break;
+      }
+      case 'external-url':
+        // buildActivityFeed only produces this action after validating the url is http(s) —
+        // see isSafeExternalUrl — matching DocumentsTableComponent.openDocument's own guard.
+        window.open(action.url, '_blank', 'noopener,noreferrer');
+        break;
+      case 'tab':
+        this.navigateToTab(action.tab);
+        break;
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -8,14 +8,11 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import {
-  COMMITTEE_DOCUMENT_TYPE_LABELS,
   PAST_MEETING_SORT,
   PENDING_ACTION_EMPTY_GRACE_MS,
   PENDING_ACTION_FADE_OUT_MS,
   PENDING_ACTION_LABEL,
   PENDING_ACTION_SEVERITY,
-  POLL_STATUS_LABELS,
-  SURVEY_STATUS_LABELS,
 } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import {
@@ -30,7 +27,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { countVotingReps, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { buildActivityFeed, countVotingReps, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
@@ -43,7 +40,6 @@ import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
-import { getDocumentTypeIconClass } from '../../pipes/document-type-icon.pipe';
 import { EditChairsDialogComponent } from '../edit-chairs-dialog/edit-chairs-dialog.component';
 
 @Component({
@@ -583,72 +579,14 @@ export class CommitteeOverviewComponent {
   }
 
   private initActivityItems(): Signal<ActivityFeedItem[]> {
-    return computed(() => {
-      // Per-source cap before merging, so one noisy source can't crowd out the rest.
-      const perSourceLimit = 5;
-
-      // Upcoming meetings are intentionally excluded — they're future-dated, already covered by the
-      // "Next Meeting" card, and would otherwise dominate a feed labelled "Recent Activity".
-      const pastMeetingItems: ActivityFeedItem[] = [...this.pastMeetings()]
-        .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
-        .slice(0, perSourceLimit)
-        .map((m) => ({
-          type: 'past_meeting',
-          key: `past_meeting-${m.meeting_and_occurrence_id ?? m.id}`,
-          label: `Meeting held: ${m.title}`,
-          timestamp: m.start_time ?? '',
-          icon: 'fa-light fa-clock-rotate-left',
-          tab: 'meetings:past',
-        }));
-
-      // Upstream Vote schema (lfx-v2-voting-service openapi3.yaml) marks `status` required with a
-      // fixed lowercase enum (disabled/active/ended) — no case normalization needed here.
-      const voteItems: ActivityFeedItem[] = [...this.votes()]
-        .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
-        .slice(0, perSourceLimit)
-        .map((v) => ({
-          type: 'vote' as const,
-          key: `vote-${v.uid}`,
-          label: `Vote ${POLL_STATUS_LABELS[v.status]}: ${v.name}`,
-          timestamp: v.last_modified_time ?? v.creation_time ?? '',
-          icon: 'fa-light fa-check-to-slot',
-          tab: 'votes',
-        }));
-
-      const surveyItems: ActivityFeedItem[] = [...this.surveys()]
-        .sort((a, b) => (b.last_modified_at ?? b.created_at ?? '').localeCompare(a.last_modified_at ?? a.created_at ?? ''))
-        .slice(0, perSourceLimit)
-        .map((s) => {
-          const displayStatus = getSurveyDisplayStatus(s);
-          return {
-            type: 'survey' as const,
-            key: `survey-${s.uid}`,
-            label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
-            timestamp: s.last_modified_at ?? s.created_at ?? '',
-            icon: 'fa-light fa-chart-simple',
-            tab: 'surveys',
-          };
-        });
-
-      // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a
-      // folder or link doesn't misrepresent itself as a file in the feed. The icon is reused from
-      // the Documents tab's own helper so the two surfaces can't drift.
-      const documentItems: ActivityFeedItem[] = [...this.documents()]
-        .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
-        .slice(0, perSourceLimit)
-        .map((d) => ({
-          type: 'document' as const,
-          key: `document-${d.uid}`,
-          label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type]}: ${d.name}`,
-          timestamp: d.updated_at ?? d.created_at ?? '',
-          icon: getDocumentTypeIconClass(d.type),
-          tab: 'documents',
-        }));
-
-      // Final row count shown in the feed after merge-sort.
-      const feedLimit = 8;
-
-      return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems].sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, feedLimit);
-    });
+    return computed(() =>
+      buildActivityFeed({
+        pastMeetings: this.pastMeetings(),
+        votes: this.votes(),
+        surveys: this.surveys(),
+        documents: this.documents(),
+        votingEnabled: !!this.committee().enable_voting,
+      })
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -329,7 +329,7 @@ export class CommitteeOverviewComponent {
     const { action } = item;
     switch (action.kind) {
       case 'route':
-        void this.router.navigateByUrl(action.path);
+        void this.router.navigate([action.path], { queryParamsHandling: 'preserve' });
         break;
       case 'vote-drawer': {
         const vote = this.votes().find((v) => v.uid === action.voteUid);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -360,6 +360,18 @@ export class CommitteeOverviewComponent {
     }
   }
 
+  // Not implemented anywhere in the app yet (also TODO stubs in surveys-dashboard.component.ts) —
+  // mirrors that same stub behavior rather than silently swallowing the event.
+  public onSurveyDuplicate(surveyId: string): void {
+    console.warn('Survey duplication not yet implemented for:', surveyId);
+    this.surveyDrawerVisible.set(false);
+  }
+
+  public onSurveyClose(surveyId: string): void {
+    console.warn('Survey close not yet implemented for:', surveyId);
+    this.surveyDrawerVisible.set(false);
+  }
+
   // Chairs edit methods
   public startEditChairs(): void {
     const currentChair = this.chairs().find((c) => c.role?.name === CommitteeMemberRole.CHAIR);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -28,7 +28,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { buildActivityFeed, countVotingReps, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { assertNever, buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { SurveyService } from '@services/survey.service';
@@ -328,8 +328,11 @@ export class CommitteeOverviewComponent {
   public handleActivityItemClick(item: ActivityFeedItem): void {
     const { action } = item;
     switch (action.kind) {
-      case 'route':
-        void this.router.navigate([action.path], { queryParamsHandling: 'preserve' });
+      case 'past-meeting':
+        // Matches the "Past Meeting" card's own link two sections up
+        // (`[detailUrl]="'/meetings/' + meeting.id"`) exactly, so the two rows describing the same
+        // meeting on this screen always resolve to the same URL.
+        void this.router.navigate(['/meetings', action.meetingId], { queryParamsHandling: 'preserve' });
         break;
       case 'vote-drawer': {
         const vote = this.votes().find((v) => v.uid === action.voteUid);
@@ -350,13 +353,18 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'external-url':
-        // buildActivityFeed only emits this action for urls that pass isValidUrl
-        // (@lfx-one/shared/utils) — http(s) only, no private/local hosts.
-        window.open(action.url, '_blank', 'noopener,noreferrer');
+        // buildActivityFeed only emits this action for urls that pass isValidUrl, but re-check at
+        // this sink rather than trusting that comment-enforced invariant — the union is shared
+        // shape LFXV2-1707's server-fed activity items will also construct.
+        if (isValidUrl(action.url)) {
+          window.open(action.url, '_blank', 'noopener,noreferrer');
+        }
         break;
       case 'tab':
         this.navigateToTab(action.tab);
         break;
+      default:
+        assertNever(action);
     }
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -16,11 +16,12 @@ import {
   POLL_STATUS_LABELS,
   SURVEY_STATUS_LABELS,
 } from '@lfx-one/shared/constants';
-import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
+import { CommitteeMemberRole, CommitteeMemberVotingStatus, PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import {
   ActivityFeedItem,
   Committee,
   CommitteeDocument,
+  CommitteeDocumentType,
   CommitteeMember,
   CommitteePendingActionRow,
   Meeting,
@@ -38,7 +39,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, filter, finalize, forkJoin, of, switchMap, take } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { VoteResultsDrawerComponent } from '../../../votes/components/vote-results-drawer/vote-results-drawer.component';
@@ -121,6 +122,12 @@ export class CommitteeOverviewComponent {
     const orgs = new Set(allMembers.map((m) => m.organization?.name).filter(Boolean));
     return orgs.size;
   });
+
+  // Computed: voting representative count from members. Not sourced from
+  // committee().total_voting_repos — upstream (lfx-v2-committee-service) defines that field as
+  // "total repositories with voting permissions" (not people) and no production code path writes
+  // it, so it always reads 0. This derives the actual per-member voting-rep count instead.
+  public votingRepsCount: Signal<number> = computed(() => this.members().filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length);
 
   // Committee-scoped data fetches
   public meetingsCount: Signal<number> = this.initMeetingsCount();
@@ -536,12 +543,19 @@ export class CommitteeOverviewComponent {
   }
 
   private initDocuments(): Signal<CommitteeDocument[]> {
+    // Documents only seed the activity feed, which the template never renders for a visitor
+    // (behind !isVisitor()) — skip the fetch rather than issue a GET nothing will display.
+    // Reactive over myRoleLoading/isVisitor (not just committee) so the fetch fires once the role
+    // actually resolves, and documentsLoading is explicitly cleared on the skip path so
+    // activityFeedLoading() can't get stuck true for a visitor whose role never triggers a fetch.
     return toSignal(
-      toObservable(this.committee).pipe(
-        // Documents only seed the activity feed, which the template never renders for a visitor
-        // (behind !isVisitor()) — skip the fetch rather than issue a GET nothing will display.
-        filter((c) => !!c?.uid && !this.isVisitor()),
-        switchMap((c) => {
+      combineLatest([toObservable(this.committee), toObservable(this.myRoleLoading), toObservable(this.isVisitor)]).pipe(
+        filter(([c]) => !!c?.uid),
+        switchMap(([c, roleLoading, visitor]) => {
+          if (roleLoading || visitor) {
+            this.documentsLoading.set(false);
+            return of<CommitteeDocument[]>([]);
+          }
           this.documentsLoading.set(true);
           // No catchError here: CommitteeService.getCommitteeDocuments already falls back to
           // of([]) on failure, so a component-level handler would never fire.
@@ -600,15 +614,19 @@ export class CommitteeOverviewComponent {
           };
         });
 
+      // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a
+      // folder or link doesn't misrepresent itself as a file in the feed.
+      const documentTypeLabel: Record<CommitteeDocumentType, string> = { file: 'Document', link: 'Link', folder: 'Folder' };
+      const documentTypeIcon: Record<CommitteeDocumentType, string> = { file: 'fa-light fa-file', link: 'fa-light fa-link', folder: 'fa-light fa-folder' };
       const documentItems: ActivityFeedItem[] = [...this.documents()]
         .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
         .slice(0, perSourceLimit)
         .map((d) => ({
-          type: 'document',
+          type: 'document' as const,
           key: `document-${d.uid}`,
-          label: `Document: ${d.name}`,
+          label: `${documentTypeLabel[d.type]}: ${d.name}`,
           timestamp: d.updated_at ?? d.created_at ?? '',
-          icon: 'fa-light fa-file',
+          icon: documentTypeIcon[d.type],
           tab: 'documents',
         }));
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -37,7 +37,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, map, merge, of, Subject, switchMap, take, tap } from 'rxjs';
 
 import { DashboardCastDrawerHostComponent } from '../../../dashboards/components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
@@ -95,6 +95,16 @@ export class CommitteeOverviewComponent {
   public voteDrawerVisible = signal(false);
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
+  // uids cast this session — getVotesByCommittee hits raw /api/votes, which never carries
+  // response_status (Me-lens-only, per poll.interface.ts), so a just-cast vote still comes back
+  // status: ACTIVE from the refetch below; this locally excludes it from "My Pending Actions"
+  // immediately instead of waiting on the vote to close.
+  public castVoteUids = signal<Set<string>>(new Set());
+  // Vote-only refresh trigger for initVotes(), separate from committeeUpdated (which the parent wires
+  // to refreshMembers() — a much heavier members+committee refetch that would also re-fire this
+  // component's other four toObservable(this.committee) pipelines, including the expensive
+  // getCommitteeDocuments fan-out documented on initDocuments() below).
+  private readonly votesRefresh$ = new Subject<void>();
 
   // Survey drawer state
   public surveyDrawerVisible = signal(false);
@@ -246,7 +256,7 @@ export class CommitteeOverviewComponent {
     return `${name} is invite only. A group admin must send you an invitation before you can join.`;
   });
 
-  public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE));
+  public pendingVotes: Signal<Vote[]> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE && !this.castVoteUids().has(v.uid)));
   public pendingSurveys: Signal<Survey[]> = computed(() =>
     this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN && s.response_status?.toLowerCase() !== 'responded')
   );
@@ -325,6 +335,14 @@ export class CommitteeOverviewComponent {
     } else {
       this.tabNavigated.emit('surveys');
     }
+  }
+
+  /** DashboardCastDrawerHost's voteSubmitted — resolves the pending-actions row immediately (see
+   *  castVoteUids) and refreshes the votes list as a correctness backstop for early-close (a poll
+   *  can auto-end once every eligible voter has responded). */
+  public onVoteSubmitted(voteUid: string): void {
+    this.castVoteUids.update((uids) => new Set(uids).add(voteUid));
+    this.votesRefresh$.next();
   }
 
   public handleActivityItemClick(item: ActivityFeedItem): void {
@@ -540,7 +558,9 @@ export class CommitteeOverviewComponent {
 
   private initVotes(): Signal<Vote[]> {
     return toSignal(
-      toObservable(this.committee).pipe(
+      // votesRefresh$ re-reads this.committee() rather than using startWith, so a post-cast refresh
+      // can't double-emit against the toObservable(this.committee) source alongside it.
+      merge(toObservable(this.committee), this.votesRefresh$.pipe(map(() => this.committee()))).pipe(
         filter((c) => !!c?.uid),
         switchMap((c) => {
           this.votesLoading.set(true);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -563,7 +563,10 @@ export class CommitteeOverviewComponent {
       // on that branch skips the votesLoading flip — castVoteUids has already resolved the row this
       // refresh is meant to catch (an early poll close), so re-skeletoning "My Pending Actions" (and,
       // via activityFeedLoading, Recent Activity) for the remaining rows on every cast would be a
-      // regression the row-level fix was supposed to avoid.
+      // regression the row-level fix was supposed to avoid. Cleared via tap (fires only on emission),
+      // not finalize (also fires on switchMap-driven cancellation) — same reasoning as initDocuments()
+      // below: a silent refresh cancelling an in-flight loud fetch must not clear votesLoading out
+      // from under it before the silent replacement has actually resolved.
       merge(
         toObservable(this.committee).pipe(map((c) => ({ c, silent: false }))),
         this.votesRefresh$.pipe(map(() => ({ c: this.committee(), silent: true })))
@@ -573,7 +576,7 @@ export class CommitteeOverviewComponent {
           if (!silent) this.votesLoading.set(true);
           return this.voteService.getVotesByCommittee(c.uid, 'updated_at.desc').pipe(
             catchError(() => of([])),
-            finalize(() => this.votesLoading.set(false))
+            tap(() => this.votesLoading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
@@ -46,14 +46,8 @@
     </lfx-card>
   }
 
-  <!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
-       active votes — reuse the same dashboard-cast-drawer-host + vote-cast-drawer pair every dashboard
-       wires this CTA to (see committee-overview.component.html for the same pairing). -->
-  <lfx-vote-results-drawer
-    [(visible)]="resultsDrawerVisible"
-    [voteId]="selectedVoteId()"
-    [listVote]="selectedVote()"
-    (castVoteRequested)="castDrawerHost.open($event)">
+  <!-- allowCastFromDrawer=false: see committee-overview.component.html for why — same drawer, same
+       data gap (getVotesByCommittee never carries response_status). -->
+  <lfx-vote-results-drawer [(visible)]="resultsDrawerVisible" [voteId]="selectedVoteId()" [listVote]="selectedVote()" [allowCastFromDrawer]="false">
   </lfx-vote-results-drawer>
-  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="refreshVotes(true)" />
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
@@ -10,7 +10,8 @@
       [totalRecords]="votes().length"
       [editQueryParams]="editVoteQueryParams()"
       (viewResults)="viewVoteResults($event)"
-      (viewVote)="viewVoteResults($event)">
+      (viewVote)="viewVoteResults($event)"
+      (refresh)="refreshVotes()">
       @if (canEdit()) {
         <lfx-button
           tableActions
@@ -54,5 +55,5 @@
     [listVote]="selectedVote()"
     (castVoteRequested)="castDrawerHost.open($event)">
   </lfx-vote-results-drawer>
-  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="onVoteSubmitted()" />
+  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="refreshVotes()" />
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
@@ -45,5 +45,14 @@
     </lfx-card>
   }
 
-  <lfx-vote-results-drawer [(visible)]="resultsDrawerVisible" [voteId]="selectedVoteId()" [listVote]="selectedVote()"> </lfx-vote-results-drawer>
+  <!-- Default audience 'creator' renders an inline "Cast Vote" CTA for the viewer's own awaiting-response
+       active votes — reuse the same dashboard-cast-drawer-host + vote-cast-drawer pair every dashboard
+       wires this CTA to (see committee-overview.component.html for the same pairing). -->
+  <lfx-vote-results-drawer
+    [(visible)]="resultsDrawerVisible"
+    [voteId]="selectedVoteId()"
+    [listVote]="selectedVote()"
+    (castVoteRequested)="castDrawerHost.open($event)">
+  </lfx-vote-results-drawer>
+  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="onVoteSubmitted()" />
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.html
@@ -55,5 +55,5 @@
     [listVote]="selectedVote()"
     (castVoteRequested)="castDrawerHost.open($event)">
   </lfx-vote-results-drawer>
-  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="refreshVotes()" />
+  <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="refreshVotes(true)" />
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -15,7 +15,7 @@ import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { VoteService } from '@services/vote.service';
 import { MessageService } from 'primeng/api';
-import { catchError, filter, finalize, map, merge, of, Subject, switchMap } from 'rxjs';
+import { catchError, filter, finalize, map, merge, of, Subject, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-committee-votes',
@@ -42,8 +42,12 @@ export class CommitteeVotesComponent {
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
   // Refresh trigger for initVotes(), separate from the committee-change source it merges with below
-  // so a post-cast refresh can't double-emit against it (no startWith).
-  private readonly votesRefresh$ = new Subject<void>();
+  // so a post-cast refresh can't double-emit against it (no startWith). The payload marks a cast-drawer
+  // refresh silent (no row-level resolution exists on this tab like committee-overview's castVoteUids,
+  // but the row's CTA doesn't change either — response_status never comes back from this raw endpoint
+  // — so a full table skeleton for that fetch isn't earning its keep) vs. loud for a real delete, which
+  // does need to visibly remove a row.
+  private readonly votesRefresh$ = new Subject<boolean>();
 
   // Data
   public votes: Signal<Vote[]> = this.initVotes();
@@ -57,11 +61,11 @@ export class CommitteeVotesComponent {
     this.resultsDrawerVisible.set(true);
   }
 
-  /** Shared refresh source: DashboardCastDrawerHost's voteSubmitted (a since-closed poll auto-ends
-   *  once every eligible voter has responded) and votes-table's own refresh (fired after a delete) —
-   *  both need the same re-fetch, so one source-neutral handler covers either trigger. */
-  public refreshVotes(): void {
-    this.votesRefresh$.next();
+  /** Shared refresh source: DashboardCastDrawerHost's voteSubmitted (silent — a since-closed poll
+   *  auto-ends once every eligible voter has responded) and votes-table's own refresh (loud — fired
+   *  after a delete, which does need the table to visibly drop the row). */
+  public refreshVotes(silent = false): void {
+    this.votesRefresh$.next(silent);
   }
 
   protected onCreateVote(): void {
@@ -94,16 +98,22 @@ export class CommitteeVotesComponent {
 
   private initVotes(): Signal<Vote[]> {
     return toSignal(
-      merge(toObservable(this.committee), this.votesRefresh$.pipe(map(() => this.committee()))).pipe(
-        filter((c) => !!c?.uid),
-        switchMap((c) => {
-          this.loading.set(true);
+      // Cleared via tap (fires only on emission), not finalize (also fires on switchMap-driven
+      // cancellation) — a silent refresh cancelling an in-flight loud fetch must not clear `loading`
+      // out from under it before the silent replacement has actually resolved.
+      merge(
+        toObservable(this.committee).pipe(map((c) => ({ c, silent: false }))),
+        this.votesRefresh$.pipe(map((silent) => ({ c: this.committee(), silent })))
+      ).pipe(
+        filter(({ c }) => !!c?.uid),
+        switchMap(({ c, silent }) => {
+          if (!silent) this.loading.set(true);
           return this.voteService.getVotesByCommittee(c.uid, 'updated_at.desc').pipe(
             catchError(() => {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load votes. Please try again.' });
               return of([]);
             }),
-            finalize(() => this.loading.set(false))
+            tap(() => this.loading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -57,9 +57,10 @@ export class CommitteeVotesComponent {
     this.resultsDrawerVisible.set(true);
   }
 
-  /** DashboardCastDrawerHost's voteSubmitted — refreshes the table so a since-closed poll (auto-ends
-   *  once every eligible voter has responded) reflects its new status without a manual reload. */
-  public onVoteSubmitted(): void {
+  /** Shared refresh source: DashboardCastDrawerHost's voteSubmitted (a since-closed poll auto-ends
+   *  once every eligible voter has responded) and votes-table's own refresh (fired after a delete) —
+   *  both need the same re-fetch, so one source-neutral handler covers either trigger. */
+  public refreshVotes(): void {
     this.votesRefresh$.next();
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -8,17 +8,18 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { Committee, Vote } from '@lfx-one/shared/interfaces';
 import { buildCommitteeCreateQueryParams } from '@lfx-one/shared/utils';
+import { DashboardCastDrawerHostComponent } from '@app/modules/dashboards/components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { VotesTableComponent } from '@app/modules/votes/components/votes-table/votes-table.component';
 import { VoteResultsDrawerComponent } from '@app/modules/votes/components/vote-results-drawer/vote-results-drawer.component';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { VoteService } from '@services/vote.service';
 import { MessageService } from 'primeng/api';
-import { catchError, filter, finalize, of, switchMap } from 'rxjs';
+import { catchError, filter, finalize, map, merge, of, Subject, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-committee-votes',
-  imports: [ButtonComponent, CardComponent, VotesTableComponent, VoteResultsDrawerComponent],
+  imports: [ButtonComponent, CardComponent, VotesTableComponent, VoteResultsDrawerComponent, DashboardCastDrawerHostComponent],
   templateUrl: './committee-votes.component.html',
   styleUrl: './committee-votes.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -40,6 +41,9 @@ export class CommitteeVotesComponent {
   public resultsDrawerVisible = model<boolean>(false);
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
+  // Refresh trigger for initVotes(), separate from the committee-change source it merges with below
+  // so a post-cast refresh can't double-emit against it (no startWith).
+  private readonly votesRefresh$ = new Subject<void>();
 
   // Data
   public votes: Signal<Vote[]> = this.initVotes();
@@ -51,6 +55,12 @@ export class CommitteeVotesComponent {
     this.selectedVoteId.set(voteUid);
     this.selectedVote.set(vote);
     this.resultsDrawerVisible.set(true);
+  }
+
+  /** DashboardCastDrawerHost's voteSubmitted — refreshes the table so a since-closed poll (auto-ends
+   *  once every eligible voter has responded) reflects its new status without a manual reload. */
+  public onVoteSubmitted(): void {
+    this.votesRefresh$.next();
   }
 
   protected onCreateVote(): void {
@@ -83,7 +93,7 @@ export class CommitteeVotesComponent {
 
   private initVotes(): Signal<Vote[]> {
     return toSignal(
-      toObservable(this.committee).pipe(
+      merge(toObservable(this.committee), this.votesRefresh$.pipe(map(() => this.committee()))).pipe(
         filter((c) => !!c?.uid),
         switchMap((c) => {
           this.loading.set(true);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-votes/committee-votes.component.ts
@@ -8,18 +8,17 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { Committee, Vote } from '@lfx-one/shared/interfaces';
 import { buildCommitteeCreateQueryParams } from '@lfx-one/shared/utils';
-import { DashboardCastDrawerHostComponent } from '@app/modules/dashboards/components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { VotesTableComponent } from '@app/modules/votes/components/votes-table/votes-table.component';
 import { VoteResultsDrawerComponent } from '@app/modules/votes/components/vote-results-drawer/vote-results-drawer.component';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { VoteService } from '@services/vote.service';
 import { MessageService } from 'primeng/api';
-import { catchError, filter, finalize, map, merge, of, Subject, switchMap, tap } from 'rxjs';
+import { catchError, filter, finalize, map, merge, of, Subject, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-committee-votes',
-  imports: [ButtonComponent, CardComponent, VotesTableComponent, VoteResultsDrawerComponent, DashboardCastDrawerHostComponent],
+  imports: [ButtonComponent, CardComponent, VotesTableComponent, VoteResultsDrawerComponent],
   templateUrl: './committee-votes.component.html',
   styleUrl: './committee-votes.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -41,13 +40,10 @@ export class CommitteeVotesComponent {
   public resultsDrawerVisible = model<boolean>(false);
   public selectedVoteId = signal<string | null>(null);
   public selectedVote = signal<Vote | null>(null);
-  // Refresh trigger for initVotes(), separate from the committee-change source it merges with below
-  // so a post-cast refresh can't double-emit against it (no startWith). The payload marks a cast-drawer
-  // refresh silent (no row-level resolution exists on this tab like committee-overview's castVoteUids,
-  // but the row's CTA doesn't change either — response_status never comes back from this raw endpoint
-  // — so a full table skeleton for that fetch isn't earning its keep) vs. loud for a real delete, which
-  // does need to visibly remove a row.
-  private readonly votesRefresh$ = new Subject<boolean>();
+  // Refresh trigger for initVotes(), fired by votes-table's own refresh output (after a delete) —
+  // separate from the committee-change source it merges with below so a refresh can't double-emit
+  // against it (no startWith).
+  private readonly votesRefresh$ = new Subject<void>();
 
   // Data
   public votes: Signal<Vote[]> = this.initVotes();
@@ -61,11 +57,9 @@ export class CommitteeVotesComponent {
     this.resultsDrawerVisible.set(true);
   }
 
-  /** Shared refresh source: DashboardCastDrawerHost's voteSubmitted (silent — a since-closed poll
-   *  auto-ends once every eligible voter has responded) and votes-table's own refresh (loud — fired
-   *  after a delete, which does need the table to visibly drop the row). */
-  public refreshVotes(silent = false): void {
-    this.votesRefresh$.next(silent);
+  /** votes-table's refresh output, fired after a successful delete. */
+  public refreshVotes(): void {
+    this.votesRefresh$.next();
   }
 
   protected onCreateVote(): void {
@@ -98,22 +92,18 @@ export class CommitteeVotesComponent {
 
   private initVotes(): Signal<Vote[]> {
     return toSignal(
-      // Cleared via tap (fires only on emission), not finalize (also fires on switchMap-driven
-      // cancellation) — a silent refresh cancelling an in-flight loud fetch must not clear `loading`
-      // out from under it before the silent replacement has actually resolved.
-      merge(
-        toObservable(this.committee).pipe(map((c) => ({ c, silent: false }))),
-        this.votesRefresh$.pipe(map((silent) => ({ c: this.committee(), silent })))
-      ).pipe(
-        filter(({ c }) => !!c?.uid),
-        switchMap(({ c, silent }) => {
-          if (!silent) this.loading.set(true);
+      // votesRefresh$ re-reads this.committee() rather than using startWith, so a refresh can't
+      // double-emit against the toObservable(this.committee) source alongside it.
+      merge(toObservable(this.committee), this.votesRefresh$.pipe(map(() => this.committee()))).pipe(
+        filter((c) => !!c?.uid),
+        switchMap((c) => {
+          this.loading.set(true);
           return this.voteService.getVotesByCommittee(c.uid, 'updated_at.desc').pipe(
             catchError(() => {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load votes. Please try again.' });
               return of([]);
             }),
-            tap(() => this.loading.set(false))
+            finalize(() => this.loading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/committees/pipes/document-type-icon.pipe.ts
+++ b/apps/lfx-one/src/app/modules/committees/pipes/document-type-icon.pipe.ts
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { COMMITTEE_DOCUMENT_TYPE_ICONS } from '@lfx-one/shared/constants';
 import { CommitteeDocumentType, DocumentDisplayItem } from '@lfx-one/shared/interfaces';
 
 /** Maps a document type to its icon class (without color). Shared by DocumentIconPipe. */
 export function getDocumentTypeIconClass(type: CommitteeDocumentType): string {
-  if (type === 'folder') return 'fa-light fa-folder';
-  if (type === 'link') return 'fa-light fa-link';
-  return 'fa-light fa-file';
+  return COMMITTEE_DOCUMENT_TYPE_ICONS[type];
 }
 
 @Pipe({

--- a/apps/lfx-one/src/app/modules/committees/pipes/document-type-icon.pipe.ts
+++ b/apps/lfx-one/src/app/modules/committees/pipes/document-type-icon.pipe.ts
@@ -7,7 +7,7 @@ import { CommitteeDocumentType, DocumentDisplayItem } from '@lfx-one/shared/inte
 
 /** Maps a document type to its icon class (without color). Shared by DocumentIconPipe. */
 export function getDocumentTypeIconClass(type: CommitteeDocumentType): string {
-  return COMMITTEE_DOCUMENT_TYPE_ICONS[type];
+  return COMMITTEE_DOCUMENT_TYPE_ICONS[type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file;
 }
 
 @Pipe({

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -112,7 +112,7 @@
 
     <div class="flex flex-col gap-6" data-testid="vote-results-drawer-content">
       <!-- LFXV2-1587 inline cast CTA — creator scope only; voter scope uses the dedicated State A panel below. -->
-      @if (audience() === 'creator' && !isLoading() && canCastVoteFromDrawer()) {
+      @if (audience() === 'creator' && !isLoading() && canCastVoteFromDrawer() && allowCastFromDrawer()) {
         <div class="rounded-lg border border-blue-200 bg-blue-50 p-3 flex items-center justify-between gap-3" data-testid="vote-results-drawer-cast-cta">
           <p class="text-sm text-blue-900">You haven't cast your vote yet.</p>
           <lfx-button size="small" severity="primary" label="Cast Vote" (onClick)="onCastVote()" data-testid="vote-results-drawer-cast-button" />

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -41,6 +41,13 @@ export class VoteResultsDrawerComponent {
   public readonly listVote = input<Vote | null>(null);
   /** Selects the voter-blind panel (B/C/D states, no live tallies, no creator note) when 'voter'; defaults to the unchanged creator UI. The /me/votes dashboard passes 'voter'. */
   public readonly audience = input<'voter' | 'creator'>('creator');
+  /** Creator-scope inline "Cast Vote" CTA opt-out. Its gate (canCastVoteFromDrawer) reads
+   *  vote.response_status, which only getMyVotes() (Me-lens) decorates — committee contexts feed this
+   *  drawer from getVotesByCommittee/getVote, so response_status is always undefined there and the CTA
+   *  can never legitimately render. Defaults true (unchanged for /me/votes, the one caller that can
+   *  supply response_status) so committee callers can pass false explicitly rather than relying on
+   *  that data gap to keep the CTA hidden. */
+  public readonly allowCastFromDrawer = input<boolean>(true);
 
   // === Outputs ===
   public readonly castVoteRequested = output<string>();

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
@@ -9,6 +9,7 @@ import { normalizePollStatus, POLL_STATUS_LABELS, PollStatus } from '@lfx-one/sh
 })
 export class PollStatusLabelPipe implements PipeTransform {
   public transform(status: PollStatus): string {
-    return POLL_STATUS_LABELS[normalizePollStatus(status)] ?? status;
+    const key = normalizePollStatus(status);
+    return key ? POLL_STATUS_LABELS[key] : status;
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
-import { POLL_STATUS_LABELS, PollStatus } from '@lfx-one/shared';
+import { normalizePollStatus, POLL_STATUS_LABELS, PollStatus } from '@lfx-one/shared';
 
 @Pipe({
   name: 'pollStatusLabel',
 })
 export class PollStatusLabelPipe implements PipeTransform {
   public transform(status: PollStatus): string {
-    const normalized = (status as string).toLowerCase() as PollStatus;
-    return POLL_STATUS_LABELS[normalized] ?? status;
+    return POLL_STATUS_LABELS[normalizePollStatus(status)] ?? status;
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
@@ -16,6 +16,7 @@ import { normalizePollStatus, PollStatus, POLL_STATUS_SEVERITY, TagSeverity } fr
 })
 export class PollStatusSeverityPipe implements PipeTransform {
   public transform(status: PollStatus): TagSeverity {
-    return POLL_STATUS_SEVERITY[normalizePollStatus(status)] ?? 'secondary';
+    const key = normalizePollStatus(status);
+    return key ? POLL_STATUS_SEVERITY[key] : 'secondary';
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
-import { PollStatus, POLL_STATUS_SEVERITY, TagSeverity } from '@lfx-one/shared';
+import { normalizePollStatus, PollStatus, POLL_STATUS_SEVERITY, TagSeverity } from '@lfx-one/shared';
 
 /**
  * Transforms poll status to tag severity for consistent styling
@@ -16,7 +16,6 @@ import { PollStatus, POLL_STATUS_SEVERITY, TagSeverity } from '@lfx-one/shared';
 })
 export class PollStatusSeverityPipe implements PipeTransform {
   public transform(status: PollStatus): TagSeverity {
-    const normalized = (status as string).toLowerCase() as PollStatus;
-    return POLL_STATUS_SEVERITY[normalized] ?? 'secondary';
+    return POLL_STATUS_SEVERITY[normalizePollStatus(status)] ?? 'secondary';
   }
 }

--- a/packages/shared/src/constants/committee-documents.constants.ts
+++ b/packages/shared/src/constants/committee-documents.constants.ts
@@ -46,3 +46,15 @@ export const COMMITTEE_DOCUMENT_TYPE_LABELS: Record<CommitteeDocumentType, strin
   link: 'Link',
   folder: 'Folder',
 };
+
+/**
+ * Icon class for each CommitteeDocument.type — sibling of COMMITTEE_DOCUMENT_TYPE_LABELS. The
+ * Angular-side getDocumentTypeIconClass() (apps/lfx-one .../pipes/document-type-icon.pipe.ts)
+ * delegates here so the mapping has one source shared by both the Documents tab and any pure
+ * (non-Angular) consumer in packages/shared.
+ */
+export const COMMITTEE_DOCUMENT_TYPE_ICONS: Record<CommitteeDocumentType, string> = {
+  file: 'fa-light fa-file',
+  link: 'fa-light fa-link',
+  folder: 'fa-light fa-folder',
+};

--- a/packages/shared/src/constants/committee-documents.constants.ts
+++ b/packages/shared/src/constants/committee-documents.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { TagSeverity } from '../interfaces/components.interface';
-import { CommitteeDocumentSource } from '../interfaces/committee.interface';
+import { CommitteeDocumentSource, CommitteeDocumentType } from '../interfaces/committee.interface';
 
 /** Recording type labels for human-readable display. */
 export const RECORDING_TYPE_LABELS: Record<string, string> = {
@@ -35,4 +35,14 @@ export const DOCUMENT_SOURCE_TAGS: Record<CommitteeDocumentSource, { value: stri
   recording: { value: 'Recording', severity: 'info', icon: 'fa-light fa-video' },
   transcript: { value: 'Transcript', severity: 'secondary', icon: 'fa-light fa-file-lines' },
   summary: { value: 'AI Summary', severity: 'contrast', icon: 'fa-light fa-sparkles' },
+};
+
+/**
+ * Display label for each CommitteeDocument.type — distinct from DOCUMENT_SOURCE_TAGS, which is
+ * keyed by the unrelated CommitteeDocumentSource enum and has no 'folder' variant.
+ */
+export const COMMITTEE_DOCUMENT_TYPE_LABELS: Record<CommitteeDocumentType, string> = {
+  file: 'Document',
+  link: 'Link',
+  folder: 'Folder',
 };

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -13,6 +13,18 @@ import type { Survey } from './survey.interface';
 export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey' | 'document';
 
 /**
+ * What clicking an `ActivityFeedItem` does — a discriminated union so each source's action is
+ * explicit and type-checked, rather than overloading a single field to mean different things
+ * (navigate a tab, open a drawer, open an external link) depending on `type`.
+ */
+export type ActivityFeedAction =
+  | { kind: 'route'; path: string }
+  | { kind: 'vote-drawer'; voteUid: string }
+  | { kind: 'survey-drawer'; surveyUid: string }
+  | { kind: 'external-url'; url: string }
+  | { kind: 'tab'; tab: string };
+
+/**
  * A single row in the group Overview activity feed stop-gap.
  * @description Normalized shape merged from past meetings, votes, surveys, and documents — sorted by
  * `timestamp` desc. Upcoming meetings ('meeting') are a reserved variant, not currently emitted: they're
@@ -30,8 +42,8 @@ export interface ActivityFeedItem {
   timestamp: string;
   /** Font Awesome icon class */
   icon: string;
-  /** Tab-navigation context string passed to the existing `tab:context` handler, e.g. "meetings:upcoming" */
-  tab: string;
+  /** What clicking this row does — see `ActivityFeedAction` */
+  action: ActivityFeedAction;
 }
 
 export interface BuildActivityFeedInput {
@@ -40,13 +52,12 @@ export interface BuildActivityFeedInput {
   surveys: Survey[];
   documents: CommitteeDocument[];
   /**
-   * Vote items are excluded entirely when false. The Overview activity feed navigates a clicked vote
-   * row to the Votes tab, but that tab is hidden when the committee has voting disabled, and
-   * tab-navigation only validates against the static valid-tabs list — not tab visibility — so an
-   * activity row for a vote from before voting was disabled would otherwise navigate to a hidden,
-   * blank tab. This only closes that gap for the activity feed itself; the committee-overview
-   * "My Pending Actions" / "Active Votes" surfaces read `votes()` independently and are unaffected by
-   * this flag — see committee-overview.component.ts.
+   * Vote items are excluded entirely when false, so the feed doesn't surface vote activity for a
+   * committee that has voting disabled — matching the Votes tab itself being hidden in that state.
+   * (A clicked vote row opens VoteResultsDrawer in place, not the Votes tab, so this is a content
+   * decision rather than a dead-end-navigation guard.) This only affects the activity feed itself;
+   * the committee-overview "My Pending Actions" / "Active Votes" surfaces read `votes()` independently
+   * and are unaffected by this flag — see committee-overview.component.ts.
    */
   votingEnabled: boolean;
 }

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -15,10 +15,13 @@ export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey
 /**
  * What clicking an `ActivityFeedItem` does — a discriminated union so each source's action is
  * explicit and type-checked, rather than overloading a single field to mean different things
- * (navigate a tab, open a drawer, open an external link) depending on `type`.
+ * (navigate a route, open a drawer, open an external link) depending on `type`. Semantic variants
+ * (`past-meeting`, not a baked `{ kind: 'route'; path: string }`) so `packages/shared` doesn't carry
+ * app route strings — the component maps each kind to wherever that surface actually lives, which
+ * survives route refactors and LFXV2-1707's server-fed activity items.
  */
 export type ActivityFeedAction =
-  | { kind: 'route'; path: string }
+  | { kind: 'past-meeting'; meetingId: string }
   | { kind: 'vote-drawer'; voteUid: string }
   | { kind: 'survey-drawer'; surveyUid: string }
   | { kind: 'external-url'; url: string }

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -1,6 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CommitteeDocument } from './committee.interface';
+import type { PastMeeting } from './meeting.interface';
+import type { Vote } from './poll.interface';
+import type { Survey } from './survey.interface';
+
 /**
  * Source kind backing an `ActivityFeedItem`.
  * @description Drives icon + tab-navigation choice in the group Overview activity feed stop-gap.
@@ -27,4 +32,21 @@ export interface ActivityFeedItem {
   icon: string;
   /** Tab-navigation context string passed to the existing `tab:context` handler, e.g. "meetings:upcoming" */
   tab: string;
+}
+
+export interface BuildActivityFeedInput {
+  pastMeetings: PastMeeting[];
+  votes: Vote[];
+  surveys: Survey[];
+  documents: CommitteeDocument[];
+  /**
+   * Vote items are excluded entirely when false. The Overview activity feed navigates a clicked vote
+   * row to the Votes tab, but that tab is hidden when the committee has voting disabled, and
+   * tab-navigation only validates against the static valid-tabs list — not tab visibility — so an
+   * activity row for a vote from before voting was disabled would otherwise navigate to a hidden,
+   * blank tab. This only closes that gap for the activity feed itself; the committee-overview
+   * "My Pending Actions" / "Active Votes" surfaces read `votes()` independently and are unaffected by
+   * this flag — see committee-overview.component.ts.
+   */
+  votingEnabled: boolean;
 }

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -1,0 +1,30 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Source kind backing an `ActivityFeedItem`.
+ * @description Drives icon + tab-navigation choice in the group Overview activity feed stop-gap.
+ */
+export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey' | 'document';
+
+/**
+ * A single row in the group Overview activity feed stop-gap.
+ * @description Normalized shape merged from past meetings, votes, surveys, and documents — sorted by
+ * `timestamp` desc. Upcoming meetings ('meeting') are a reserved variant, not currently emitted: they're
+ * future-dated and already covered by the "Next Meeting" card. Replaced by the real activity stream in
+ * LFXV2-1707.
+ */
+export interface ActivityFeedItem {
+  /** Source kind, drives the icon and default styling */
+  type: ActivityFeedItemType;
+  /** Stable key for `@for` tracking (source type + source uid) */
+  key: string;
+  /** Rendered row text, e.g. "Meeting scheduled: Weekly Sync" */
+  label: string;
+  /** ISO timestamp used for sorting */
+  timestamp: string;
+  /** Font Awesome icon class */
+  icon: string;
+  /** Tab-navigation context string passed to the existing `tab:context` handler, e.g. "meetings:upcoming" */
+  tab: string;
+}

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -20,12 +20,37 @@ export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey
  * app route strings — the component maps each kind to wherever that surface actually lives, which
  * survives route refactors and LFXV2-1707's server-fed activity items.
  */
+export interface PastMeetingActivityFeedAction {
+  kind: 'past-meeting';
+  meetingId: string;
+}
+
+export interface VoteDrawerActivityFeedAction {
+  kind: 'vote-drawer';
+  voteUid: string;
+}
+
+export interface SurveyDrawerActivityFeedAction {
+  kind: 'survey-drawer';
+  surveyUid: string;
+}
+
+export interface ExternalUrlActivityFeedAction {
+  kind: 'external-url';
+  url: string;
+}
+
+export interface TabActivityFeedAction {
+  kind: 'tab';
+  tab: string;
+}
+
 export type ActivityFeedAction =
-  | { kind: 'past-meeting'; meetingId: string }
-  | { kind: 'vote-drawer'; voteUid: string }
-  | { kind: 'survey-drawer'; surveyUid: string }
-  | { kind: 'external-url'; url: string }
-  | { kind: 'tab'; tab: string };
+  | PastMeetingActivityFeedAction
+  | VoteDrawerActivityFeedAction
+  | SurveyDrawerActivityFeedAction
+  | ExternalUrlActivityFeedAction
+  | TabActivityFeedAction;
 
 /**
  * A single row in the group Overview activity feed stop-gap.

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -370,8 +370,12 @@ export interface Committee {
   updated_at: string;
   /** Total number of committee members */
   total_members: number;
-  /** Total number of voting representatives (upstream field name is total_voting_repos) */
-  total_voting_repos: number;
+  /**
+   * Total number of repositories with voting permissions for this committee (per upstream
+   * lfx-v2-committee-service — despite the name, this is a repo count, not a person count).
+   * Optional: upstream only sets this when > 0; no production code path currently writes it.
+   */
+  total_voting_repos?: number;
   /** Associated project UID */
   project_uid: string;
   /** Associated project name (populated from project data) */

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -274,3 +274,6 @@ export * from './create-picker.interface';
 // Org Lens Meetings insights (LFXV2-2735) interfaces
 export * from './org-meetings-insights.interface';
 export * from './org-meetings-insights.internal.interface';
+
+// Group Overview activity feed stop-gap (LFXV2-1716)
+export * from './activity-feed.interface';

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -156,4 +156,15 @@ describe('buildActivityFeed', () => {
     const items = buildActivityFeed(emptyInput({ votes: [vote({ status: 'archived' as PollStatus })] }));
     expect(items[0].label).toBe('Vote archived: Q1 Budget');
   });
+
+  it('falls back to a generic label instead of "Vote undefined" when status is missing', () => {
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: undefined as unknown as PollStatus })] }));
+    expect(items[0].label).toBe('Vote Updated: Q1 Budget');
+  });
+
+  it('falls back to a generic label instead of "undefined:" when a document type is unrecognized', () => {
+    const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'unexpected' as CommitteeDocument['type'] })] }));
+    expect(items[0].label).toBe('Document: Charter.pdf');
+    expect(items[0].icon).toContain('file');
+  });
 });

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import { PollStatus, SurveyStatus } from '../enums';
 import { BuildActivityFeedInput, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
-import { buildActivityFeed, firstValidTimestamp } from './activity-feed.utils';
+import { buildActivityFeed } from './activity-feed.utils';
 
 /** Minimal past-meeting builder — only the fields buildActivityFeed reads. */
 function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
@@ -58,28 +58,6 @@ function document(overrides: Partial<CommitteeDocument> = {}): CommitteeDocument
 function emptyInput(overrides: Partial<BuildActivityFeedInput> = {}): BuildActivityFeedInput {
   return { pastMeetings: [], votes: [], surveys: [], documents: [], votingEnabled: true, ...overrides };
 }
-
-describe('firstValidTimestamp', () => {
-  it('returns the first candidate that is present and parseable', () => {
-    expect(firstValidTimestamp('2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-01-01T00:00:00Z');
-  });
-
-  it('falls back past an absent candidate', () => {
-    expect(firstValidTimestamp(undefined, '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
-  });
-
-  it('falls back past a Go zero-date sentinel', () => {
-    expect(firstValidTimestamp('0001-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
-  });
-
-  it('falls back past an unparseable candidate', () => {
-    expect(firstValidTimestamp('not-a-date', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
-  });
-
-  it('returns an empty string when every candidate is invalid or absent', () => {
-    expect(firstValidTimestamp(undefined, '0001-01-01T00:00:00Z', 'not-a-date')).toBe('');
-  });
-});
 
 describe('buildActivityFeed', () => {
   it('returns an empty array when every source is empty', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -146,4 +146,14 @@ describe('buildActivityFeed', () => {
     const items = buildActivityFeed(emptyInput({ votes: [vote({ status: PollStatus.ENDED })] }));
     expect(items[0].label).toBe('Vote Ended: Q1 Budget');
   });
+
+  it('normalizes an uppercase/mixed-case vote status before mapping through POLL_STATUS_LABELS', () => {
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: 'ACTIVE' as PollStatus })] }));
+    expect(items[0].label).toBe('Vote Active: Q1 Budget');
+  });
+
+  it('falls back to the raw vote status when it has no POLL_STATUS_LABELS entry', () => {
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: 'archived' as PollStatus })] }));
+    expect(items[0].label).toBe('Vote archived: Q1 Budget');
+  });
 });

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -198,8 +198,13 @@ describe('buildActivityFeed', () => {
   });
 
   describe('action', () => {
-    it('routes a past-meeting item to the ITX-native id, not the composite occurrence id', () => {
+    it('routes a past-meeting item to the composite occurrence id when present, not the bare id', () => {
       const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
+      expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42-occ-9/details' });
+    });
+
+    it('falls back to the bare id when meeting_and_occurrence_id is absent', () => {
+      const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
       expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42/details' });
     });
 

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import { PollStatus, SurveyStatus } from '../enums';
 import { BuildActivityFeedInput, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
-import { buildActivityFeed } from './activity-feed.utils';
+import { buildActivityFeed, firstValidTimestamp } from './activity-feed.utils';
 
 /** Minimal past-meeting builder — only the fields buildActivityFeed reads. */
 function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
@@ -58,6 +58,28 @@ function document(overrides: Partial<CommitteeDocument> = {}): CommitteeDocument
 function emptyInput(overrides: Partial<BuildActivityFeedInput> = {}): BuildActivityFeedInput {
   return { pastMeetings: [], votes: [], surveys: [], documents: [], votingEnabled: true, ...overrides };
 }
+
+describe('firstValidTimestamp', () => {
+  it('returns the first candidate that is present and parseable', () => {
+    expect(firstValidTimestamp('2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('falls back past an absent candidate', () => {
+    expect(firstValidTimestamp(undefined, '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('falls back past a Go zero-date sentinel', () => {
+    expect(firstValidTimestamp('0001-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('falls back past an unparseable candidate', () => {
+    expect(firstValidTimestamp('not-a-date', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('returns an empty string when every candidate is invalid or absent', () => {
+    expect(firstValidTimestamp(undefined, '0001-01-01T00:00:00Z', 'not-a-date')).toBe('');
+  });
+});
 
 describe('buildActivityFeed', () => {
   it('returns an empty array when every source is empty', () => {
@@ -121,6 +143,36 @@ describe('buildActivityFeed', () => {
       })
     );
     expect(items.map((i) => i.type)).toEqual(['survey', 'past_meeting']);
+  });
+
+  it('does not sort a vote as ancient when last_modified_time is a Go zero-date', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        votes: [vote({ last_modified_time: '0001-01-01T00:00:00Z', creation_time: '2026-01-05T00:00:00Z' })],
+        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['vote', 'survey']);
+  });
+
+  it('does not sort a survey as ancient when last_modified_at is a Go zero-date', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        surveys: [survey({ last_modified_at: '0001-01-01T00:00:00Z', created_at: '2026-01-05T00:00:00Z' })],
+        votes: [vote({ last_modified_time: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['survey', 'vote']);
+  });
+
+  it('does not sort a document as ancient when updated_at is a Go zero-date', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        documents: [document({ updated_at: '0001-01-01T00:00:00Z', created_at: '2026-01-05T00:00:00Z' })],
+        votes: [vote({ last_modified_time: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['document', 'vote']);
   });
 
   it('caps each source at 5 items before merging, keeping the most recent per source', () => {
@@ -221,18 +273,20 @@ describe('buildActivityFeed', () => {
   });
 
   describe('action', () => {
-    it('routes a past-meeting item to the composite occurrence id when present, not the bare id', () => {
-      const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
-      expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42-occ-9/details' });
-      // key and action.path must derive from the same resource id — this is the exact invariant
-      // the shared `resourceId` local exists to guarantee.
-      expect(items[0].key).toBe('past_meeting-pm-42-occ-9');
+    it("routes a past-meeting item to meeting.id — matching the Past Meeting card's own link — regardless of meeting_and_occurrence_id", () => {
+      const withComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
+      expect(withComposite[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
+
+      const withoutComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
+      expect(withoutComposite[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
     });
 
-    it('falls back to the bare id when meeting_and_occurrence_id is absent', () => {
-      const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
-      expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42/details' });
-      expect(items[0].key).toBe('past_meeting-pm-42');
+    it('still prefers the composite occurrence id for the @for tracking key, independent of the navigation id', () => {
+      const withComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
+      expect(withComposite[0].key).toBe('past_meeting-pm-42-occ-9');
+
+      const withoutComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
+      expect(withoutComposite[0].key).toBe('past_meeting-pm-42');
     });
 
     it('opens the vote drawer for a vote item', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -7,8 +7,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { PollStatus, SurveyStatus } from '../enums';
-import { CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
-import { BuildActivityFeedInput, buildActivityFeed } from './activity-feed.utils';
+import { BuildActivityFeedInput, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
+import { buildActivityFeed } from './activity-feed.utils';
 
 /** Minimal past-meeting builder — only the fields buildActivityFeed reads. */
 function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -196,4 +196,44 @@ describe('buildActivityFeed', () => {
     expect(items[0].label).toBe('Document: Charter.pdf');
     expect(items[0].icon).toContain('file');
   });
+
+  describe('action', () => {
+    it('routes a past-meeting item to the ITX-native id, not the composite occurrence id', () => {
+      const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
+      expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42/details' });
+    });
+
+    it('opens the vote drawer for a vote item', () => {
+      const items = buildActivityFeed(emptyInput({ votes: [vote({ uid: 'vote-42' })] }));
+      expect(items[0].action).toEqual({ kind: 'vote-drawer', voteUid: 'vote-42' });
+    });
+
+    it('opens the survey drawer for a survey item', () => {
+      const items = buildActivityFeed(emptyInput({ surveys: [survey({ uid: 'survey-42' })] }));
+      expect(items[0].action).toEqual({ kind: 'survey-drawer', surveyUid: 'survey-42' });
+    });
+
+    it('opens a link document directly when it has a valid http(s) url', () => {
+      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: 'https://example.com/notes' })] }));
+      expect(items[0].action).toEqual({ kind: 'external-url', url: 'https://example.com/notes' });
+    });
+
+    it('falls back to the documents tab for a link document with a missing or unsafe url', () => {
+      const missingUrl = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: undefined })] }));
+      expect(missingUrl[0].action).toEqual({ kind: 'tab', tab: 'documents' });
+
+      const unsafeUrl = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: 'javascript:alert(1)' })] }));
+      expect(unsafeUrl[0].action).toEqual({ kind: 'tab', tab: 'documents' });
+    });
+
+    it('falls back to the documents tab for a file document even when a url is present', () => {
+      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'file', url: 'https://example.com/storage/charter.pdf' })] }));
+      expect(items[0].action).toEqual({ kind: 'tab', tab: 'documents' });
+    });
+
+    it('falls back to the documents tab for a folder document', () => {
+      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'folder' })] }));
+      expect(items[0].action).toEqual({ kind: 'tab', tab: 'documents' });
+    });
+  });
 });

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -158,7 +158,12 @@ describe('buildActivityFeed', () => {
   });
 
   it('falls back to a generic label instead of "Vote undefined" when status is missing', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: undefined as unknown as PollStatus })] }));
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: undefined })] }));
+    expect(items[0].label).toBe('Vote Updated: Q1 Budget');
+  });
+
+  it('falls back to a generic label instead of "Vote :" when status is an empty string', () => {
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: '' as PollStatus })] }));
     expect(items[0].label).toBe('Vote Updated: Q1 Budget');
   });
 

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -1,0 +1,149 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for activity-feed.utils.ts. All fixtures use synthetic placeholder identities —
+// never real user data.
+
+import { describe, expect, it } from 'vitest';
+
+import { PollStatus, SurveyStatus } from '../enums';
+import { CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
+import { BuildActivityFeedInput, buildActivityFeed } from './activity-feed.utils';
+
+/** Minimal past-meeting builder — only the fields buildActivityFeed reads. */
+function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
+  return {
+    id: 'pm-1',
+    meeting_and_occurrence_id: 'pm-1-occ-1',
+    title: 'Weekly Sync',
+    start_time: '2026-01-01T10:00:00Z',
+    ...overrides,
+  } as PastMeeting;
+}
+
+/** Minimal vote builder — only the fields buildActivityFeed reads. */
+function vote(overrides: Partial<Vote> = {}): Vote {
+  return {
+    uid: 'vote-1',
+    name: 'Q1 Budget',
+    status: PollStatus.ACTIVE,
+    last_modified_time: '2026-01-02T10:00:00Z',
+    ...overrides,
+  } as Vote;
+}
+
+/** Minimal survey builder — only the fields buildActivityFeed (via getSurveyDisplayStatus) reads. */
+function survey(overrides: Partial<Survey> = {}): Survey {
+  return {
+    uid: 'survey-1',
+    survey_title: 'Community Feedback',
+    survey_status: SurveyStatus.OPEN,
+    survey_cutoff_date: null,
+    last_modified_at: '2026-01-03T10:00:00Z',
+    ...overrides,
+  } as Survey;
+}
+
+/** Minimal document builder — only the fields buildActivityFeed reads. */
+function document(overrides: Partial<CommitteeDocument> = {}): CommitteeDocument {
+  return {
+    uid: 'doc-1',
+    type: 'file',
+    name: 'Charter.pdf',
+    updated_at: '2026-01-04T10:00:00Z',
+    ...overrides,
+  } as CommitteeDocument;
+}
+
+function emptyInput(overrides: Partial<BuildActivityFeedInput> = {}): BuildActivityFeedInput {
+  return { pastMeetings: [], votes: [], surveys: [], documents: [], votingEnabled: true, ...overrides };
+}
+
+describe('buildActivityFeed', () => {
+  it('returns an empty array when every source is empty', () => {
+    expect(buildActivityFeed(emptyInput())).toEqual([]);
+  });
+
+  it('merges all four sources and sorts the result by timestamp descending', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        pastMeetings: [pastMeeting({ start_time: '2026-01-01T00:00:00Z' })],
+        votes: [vote({ last_modified_time: '2026-01-03T00:00:00Z' })],
+        surveys: [survey({ last_modified_at: '2026-01-02T00:00:00Z' })],
+        documents: [document({ updated_at: '2026-01-04T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['document', 'vote', 'survey', 'past_meeting']);
+  });
+
+  it('caps each source at 5 items before merging, keeping the most recent per source', () => {
+    const pastMeetings = Array.from({ length: 7 }, (_, i) =>
+      pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}-occ`, start_time: `2026-01-0${i + 1}T00:00:00Z` })
+    );
+    const items = buildActivityFeed(emptyInput({ pastMeetings }));
+    expect(items).toHaveLength(5);
+    // The 5 most recent (highest-dated) of the 7 survive the per-source cap.
+    expect(items.map((i) => i.key)).toEqual([
+      'past_meeting-pm-6-occ',
+      'past_meeting-pm-5-occ',
+      'past_meeting-pm-4-occ',
+      'past_meeting-pm-3-occ',
+      'past_meeting-pm-2-occ',
+    ]);
+  });
+
+  it('caps the final merged feed at 8 items even when every source is full', () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => i);
+    const items = buildActivityFeed(
+      emptyInput({
+        pastMeetings: many(5).map((i) => pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}`, start_time: `2026-01-01T0${i}:00:00Z` })),
+        votes: many(5).map((i) => vote({ uid: `vote-${i}`, last_modified_time: `2026-01-02T0${i}:00:00Z` })),
+        surveys: many(5).map((i) => survey({ uid: `survey-${i}`, last_modified_at: `2026-01-03T0${i}:00:00Z` })),
+        documents: many(5).map((i) => document({ uid: `doc-${i}`, updated_at: `2026-01-04T0${i}:00:00Z` })),
+      })
+    );
+    expect(items).toHaveLength(8);
+  });
+
+  it('excludes vote items entirely when votingEnabled is false, but keeps the other sources', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        votes: [vote()],
+        surveys: [survey()],
+        votingEnabled: false,
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['survey']);
+  });
+
+  it('falls back to created_at / creation_time when the modified/updated timestamp is absent', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        votes: [vote({ last_modified_time: undefined, creation_time: '2026-01-05T00:00:00Z' })],
+      })
+    );
+    expect(items[0].timestamp).toBe('2026-01-05T00:00:00Z');
+  });
+
+  it('labels documents by type — file, link, and folder render distinct labels and icons', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        documents: [
+          document({ uid: 'd-file', type: 'file', name: 'A', updated_at: '2026-01-01T00:00:00Z' }),
+          document({ uid: 'd-link', type: 'link', name: 'B', updated_at: '2026-01-02T00:00:00Z' }),
+          document({ uid: 'd-folder', type: 'folder', name: 'C', updated_at: '2026-01-03T00:00:00Z' }),
+        ],
+      })
+    );
+    const byUid = Object.fromEntries(items.map((i) => [i.key, i]));
+    expect(byUid['document-d-file'].label).toBe('Document: A');
+    expect(byUid['document-d-link'].label).toBe('Link: B');
+    expect(byUid['document-d-folder'].label).toBe('Folder: C');
+    expect(byUid['document-d-folder'].icon).toContain('folder');
+  });
+
+  it('maps vote status through POLL_STATUS_LABELS instead of leaking the raw enum value', () => {
+    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: PollStatus.ENDED })] }));
+    expect(items[0].label).toBe('Vote Ended: Q1 Budget');
+  });
+});

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -76,6 +76,30 @@ describe('buildActivityFeed', () => {
     expect(items.map((i) => i.type)).toEqual(['document', 'vote', 'survey', 'past_meeting']);
   });
 
+  it('sorts correctly across sources when timestamps use different UTC offset formats', () => {
+    // 2026-01-01T09:00:00+05:30 == 2026-01-01T03:30:00Z, so it should sort between the survey and
+    // the vote below despite being lexicographically smaller than both (localeCompare would get
+    // this wrong — it'd sort by the raw string, putting the offset form last).
+    const items = buildActivityFeed(
+      emptyInput({
+        votes: [vote({ last_modified_time: '2026-01-01T04:00:00Z' })],
+        surveys: [survey({ last_modified_at: '2026-01-01T03:00:00Z' })],
+        documents: [document({ updated_at: '2026-01-01T09:00:00+05:30' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['vote', 'document', 'survey']);
+  });
+
+  it('sorts an unparseable timestamp as the oldest item instead of throwing', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        votes: [vote({ last_modified_time: 'not-a-timestamp', creation_time: undefined })],
+        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['survey', 'vote']);
+  });
+
   it('caps each source at 5 items before merging, keeping the most recent per source', () => {
     const pastMeetings = Array.from({ length: 7 }, (_, i) =>
       pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}-occ`, start_time: `2026-01-0${i + 1}T00:00:00Z` })

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -100,6 +100,29 @@ describe('buildActivityFeed', () => {
     expect(items.map((i) => i.type)).toEqual(['survey', 'vote']);
   });
 
+  it('does not sort a past meeting as ancient when start_time is a Go zero-date', () => {
+    // Zoom/ITX past-meeting rows sometimes carry "0001-01-01T00:00:00Z" on start_time — a raw
+    // Date.parse would treat that as a real (~year 1) timestamp and sort it as the oldest item,
+    // even when scheduled_start_time has a real, recent value.
+    const items = buildActivityFeed(
+      emptyInput({
+        pastMeetings: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '2026-01-05T00:00:00Z' })],
+        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['past_meeting', 'survey']);
+  });
+
+  it('sorts a past meeting as oldest when both start_time and scheduled_start_time are zero-dates', () => {
+    const items = buildActivityFeed(
+      emptyInput({
+        pastMeetings: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '0001-01-01T00:00:00Z' })],
+        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
+      })
+    );
+    expect(items.map((i) => i.type)).toEqual(['survey', 'past_meeting']);
+  });
+
   it('caps each source at 5 items before merging, keeping the most recent per source', () => {
     const pastMeetings = Array.from({ length: 7 }, (_, i) =>
       pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}-occ`, start_time: `2026-01-0${i + 1}T00:00:00Z` })

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -201,11 +201,15 @@ describe('buildActivityFeed', () => {
     it('routes a past-meeting item to the composite occurrence id when present, not the bare id', () => {
       const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
       expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42-occ-9/details' });
+      // key and action.path must derive from the same resource id — this is the exact invariant
+      // the shared `resourceId` local exists to guarantee.
+      expect(items[0].key).toBe('past_meeting-pm-42-occ-9');
     });
 
     it('falls back to the bare id when meeting_and_occurrence_id is absent', () => {
       const items = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
       expect(items[0].action).toEqual({ kind: 'route', path: '/meetings/pm-42/details' });
+      expect(items[0].key).toBe('past_meeting-pm-42');
     });
 
     it('opens the vote drawer for a vote item', () => {

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -45,12 +45,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
   const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
     .sort((a, b) => timestampValue(b.start_time ?? '') - timestampValue(a.start_time ?? ''))
     .slice(0, PER_SOURCE_LIMIT)
-    .map((m) => ({
-      type: 'past_meeting',
-      key: `past_meeting-${m.meeting_and_occurrence_id ?? m.id}`,
-      label: `Meeting held: ${m.title}`,
-      timestamp: m.start_time ?? '',
-      icon: 'fa-light fa-clock-rotate-left',
+    .map((m) => {
       // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same helper every other
       // past-meeting surface uses (meeting-card, meeting-organizer, attachments). The detail page
       // itself is inconsistent about which identifier it reads: recording/transcript/summary map
@@ -58,9 +53,18 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       // received), while attachments call this same getPastMeetingResourceId helper on the
       // fetched object. Using it here too is the safer of two imperfect choices — it matches the
       // documented "canonical id downstream" (meeting.interface.ts) and every other entry point,
-      // rather than adding a fifth place that could disagree with all of them.
-      action: { kind: 'route', path: `/meetings/${getPastMeetingResourceId(m)}/details` },
-    }));
+      // rather than adding a fifth place that could disagree with all of them. Shared with `key`
+      // below so the two can't silently desync if the helper's fallback logic ever changes.
+      const resourceId = getPastMeetingResourceId(m);
+      return {
+        type: 'past_meeting' as const,
+        key: `past_meeting-${resourceId}`,
+        label: `Meeting held: ${m.title}`,
+        timestamp: m.start_time ?? '',
+        icon: 'fa-light fa-clock-rotate-left',
+        action: { kind: 'route' as const, path: `/meetings/${resourceId}/details` },
+      };
+    });
 
   const voteItems: ActivityFeedItem[] = input.votingEnabled
     ? [...input.votes]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -49,7 +49,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
           return {
             type: 'vote' as const,
             key: `vote-${v.uid}`,
-            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status}: ${v.name}`,
+            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : (v.status ?? 'Updated')}: ${v.name}`,
             timestamp: v.last_modified_time ?? v.creation_time ?? '',
             icon: 'fa-light fa-check-to-slot',
             tab: 'votes',
@@ -80,9 +80,9 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
     .map((d) => ({
       type: 'document' as const,
       key: `document-${d.uid}`,
-      label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type]}: ${d.name}`,
+      label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${d.name}`,
       timestamp: d.updated_at ?? d.created_at ?? '',
-      icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type],
+      icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
       tab: 'documents',
     }));
 

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -3,34 +3,22 @@
 
 // Specific-file imports (not the '../constants' barrel): that barrel re-exports
 // dashboard-metrics.constants.ts, which imports '../utils' (the utils barrel, this file's own
-// barrel) — a real runtime import cycle that also drags in meeting.utils.ts's
-// `HttpParams` from '@angular/common/http', which Vitest can't resolve outside an Angular
-// context. Importing the two constant files directly avoids the cycle.
+// barrel) — a real runtime import cycle that transitively pulls in Angular-only runtime code
+// (e.g. meeting.utils.ts's `@angular/common/http` import), which Vitest can't resolve outside an
+// Angular context. Importing the two constant files directly avoids the cycle. The '../interfaces'
+// import below is `import type` for the same reason: it's erased entirely, so it can't reintroduce
+// this cycle even if a future interface file adds a runtime import that reaches '../constants' or
+// '../utils'.
 import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '../constants/committee-documents.constants';
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
-import { ActivityFeedItem, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
+import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
 import { getSurveyDisplayStatus } from './survey.utils';
 
 /** Per-source cap before merging, so one noisy source can't crowd out the rest. */
 const PER_SOURCE_LIMIT = 5;
 /** Final row count returned after the merge-sort. */
 const FEED_LIMIT = 8;
-
-export interface BuildActivityFeedInput {
-  pastMeetings: PastMeeting[];
-  votes: Vote[];
-  surveys: Survey[];
-  documents: CommitteeDocument[];
-  /**
-   * Vote items are excluded entirely when false. The Votes tab is only shown/reachable when the
-   * committee has voting enabled (committee-view.component.ts isVotesTabVisible), but
-   * handleTabNavigation doesn't check tab visibility — only the static valid-tabs list — so an
-   * activity row for a vote from before voting was disabled would otherwise navigate to a hidden,
-   * blank tab.
-   */
-  votingEnabled: boolean;
-}
 
 /**
  * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -48,8 +48,9 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       // ("0001-01-01...") that Zoom/ITX past-meeting rows sometimes carry on start_time — a raw
       // `m.start_time` read would parse a zero-date as a real (~year 1) timestamp and silently
       // sort that meeting out via the PER_SOURCE_LIMIT slice below, even with a valid
-      // scheduled_start_time. Every other past-meeting surface (meetings-dashboard,
-      // meeting-organizer) already goes through this helper.
+      // scheduled_start_time. meetings-dashboard.component.ts and meeting-organizer.component.ts
+      // already go through this helper for the same reason; committee-overview.component.ts's own
+      // lastMeeting/nextMeeting computeds do not (pre-existing, out of this fix's scope).
       const startMs = getPastMeetingStartTimeMs(m);
       return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
     })

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -44,14 +44,17 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
     ? [...input.votes]
         .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
         .slice(0, PER_SOURCE_LIMIT)
-        .map((v) => ({
-          type: 'vote' as const,
-          key: `vote-${v.uid}`,
-          label: `Vote ${POLL_STATUS_LABELS[normalizePollStatus(v.status)] ?? v.status}: ${v.name}`,
-          timestamp: v.last_modified_time ?? v.creation_time ?? '',
-          icon: 'fa-light fa-check-to-slot',
-          tab: 'votes',
-        }))
+        .map((v) => {
+          const statusKey = normalizePollStatus(v.status);
+          return {
+            type: 'vote' as const,
+            key: `vote-${v.uid}`,
+            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status}: ${v.name}`,
+            timestamp: v.last_modified_time ?? v.creation_time ?? '',
+            icon: 'fa-light fa-check-to-slot',
+            tab: 'votes',
+          };
+        })
     : [];
 
   const surveyItems: ActivityFeedItem[] = [...input.surveys]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -13,7 +13,7 @@ import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '.
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
-import { getPastMeetingResourceId } from './past-meeting.utils';
+import { getPastMeetingResourceId, getPastMeetingStartTimeMs } from './past-meeting.utils';
 import { normalizePollStatus } from './poll.utils';
 import { getSurveyDisplayStatus } from './survey.utils';
 import { isValidUrl } from './url.utils';
@@ -43,9 +43,19 @@ function timestampValue(timestamp: string): number {
  */
 export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
   const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
-    .sort((a, b) => timestampValue(b.start_time ?? '') - timestampValue(a.start_time ?? ''))
-    .slice(0, PER_SOURCE_LIMIT)
     .map((m) => {
+      // getPastMeetingStartTimeMs prefers scheduled_start_time and rejects Go zero-dates
+      // ("0001-01-01...") that Zoom/ITX past-meeting rows sometimes carry on start_time — a raw
+      // `m.start_time` read would parse a zero-date as a real (~year 1) timestamp and silently
+      // sort that meeting out via the PER_SOURCE_LIMIT slice below, even with a valid
+      // scheduled_start_time. Every other past-meeting surface (meetings-dashboard,
+      // meeting-organizer) already goes through this helper.
+      const startMs = getPastMeetingStartTimeMs(m);
+      return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
+    })
+    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
+    .slice(0, PER_SOURCE_LIMIT)
+    .map(({ meeting: m, timestamp }) => {
       // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same helper every other
       // past-meeting surface uses (meeting-card, meeting-organizer, attachments). The detail page
       // itself is inconsistent about which identifier it reads: recording/transcript/summary map
@@ -60,7 +70,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
         type: 'past_meeting' as const,
         key: `past_meeting-${resourceId}`,
         label: `Meeting held: ${m.title}`,
-        timestamp: m.start_time ?? '',
+        timestamp,
         icon: 'fa-light fa-clock-rotate-left',
         action: { kind: 'route' as const, path: `/meetings/${resourceId}/details` },
       };

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -67,9 +67,9 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       timestamp,
       icon: 'fa-light fa-clock-rotate-left',
       // meeting.id, not getPastMeetingResourceId — matches the "Past Meeting" card's own link
-      // (committee-overview.component.html: `'/meetings/' + meeting.id`) exactly, so the two rows
-      // describing the same meeting on this screen always resolve to the same URL. The component
-      // maps this semantic action to that route; packages/shared doesn't carry the path string.
+      // (committee-overview.component.html: `'/meetings/' + meeting.id`). The component maps this
+      // semantic action to that route (also carrying the meeting's password query param, matching
+      // the card); packages/shared doesn't carry the path string.
       action: { kind: 'past-meeting' as const, meetingId: m.id },
     }));
 

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -22,6 +22,18 @@ const PER_SOURCE_LIMIT = 5;
 const FEED_LIMIT = 8;
 
 /**
+ * Parse an ISO timestamp to epoch ms for sorting, treating an absent/unparseable value as the
+ * oldest possible. A plain `localeCompare` on the raw strings only sorts correctly when every
+ * source emits the identical format/offset — this feed merges four different upstream services
+ * (query-service, committee-service), so a `+05:30`-offset or non-`Z` variant from any one of them
+ * would otherwise sort into the wrong position relative to the others.
+ */
+function timestampValue(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? -Infinity : parsed;
+}
+
+/**
  * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,
  * surveys, and documents into one time-ordered list. Upcoming meetings are intentionally excluded
  * — they're future-dated, already covered by the "Next Meeting" card, and would otherwise dominate
@@ -29,7 +41,7 @@ const FEED_LIMIT = 8;
  */
 export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
   const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
-    .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+    .sort((a, b) => timestampValue(b.start_time ?? '') - timestampValue(a.start_time ?? ''))
     .slice(0, PER_SOURCE_LIMIT)
     .map((m) => ({
       type: 'past_meeting',
@@ -42,7 +54,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
 
   const voteItems: ActivityFeedItem[] = input.votingEnabled
     ? [...input.votes]
-        .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
+        .sort((a, b) => timestampValue(b.last_modified_time ?? b.creation_time ?? '') - timestampValue(a.last_modified_time ?? a.creation_time ?? ''))
         .slice(0, PER_SOURCE_LIMIT)
         .map((v) => {
           const statusKey = normalizePollStatus(v.status);
@@ -58,7 +70,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
     : [];
 
   const surveyItems: ActivityFeedItem[] = [...input.surveys]
-    .sort((a, b) => (b.last_modified_at ?? b.created_at ?? '').localeCompare(a.last_modified_at ?? a.created_at ?? ''))
+    .sort((a, b) => timestampValue(b.last_modified_at ?? b.created_at ?? '') - timestampValue(a.last_modified_at ?? a.created_at ?? ''))
     .slice(0, PER_SOURCE_LIMIT)
     .map((s) => {
       const displayStatus = getSurveyDisplayStatus(s);
@@ -75,7 +87,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
   // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a folder
   // or link doesn't misrepresent itself as a file in the feed.
   const documentItems: ActivityFeedItem[] = [...input.documents]
-    .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+    .sort((a, b) => timestampValue(b.updated_at ?? b.created_at ?? '') - timestampValue(a.updated_at ?? a.created_at ?? ''))
     .slice(0, PER_SOURCE_LIMIT)
     .map((d) => ({
       type: 'document' as const,
@@ -86,5 +98,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       tab: 'documents',
     }));
 
-  return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems].sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, FEED_LIMIT);
+  return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems]
+    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
+    .slice(0, FEED_LIMIT);
 }

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -51,11 +51,14 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       label: `Meeting held: ${m.title}`,
       timestamp: m.start_time ?? '',
       icon: 'fa-light fa-clock-rotate-left',
-      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same identifier every
-      // other past-meeting surface uses (meeting-card, meeting-organizer, attachments). The
-      // detail page's own recording/transcript/summary sub-fetches key off
-      // meeting_and_occurrence_id specifically; passing the bare id would silently return those
-      // empty for any occurrence where the two values diverge.
+      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same helper every other
+      // past-meeting surface uses (meeting-card, meeting-organizer, attachments). The detail page
+      // itself is inconsistent about which identifier it reads: recording/transcript/summary map
+      // the fetched meeting's plain `id` (which the BFF pins to whatever route segment it
+      // received), while attachments call this same getPastMeetingResourceId helper on the
+      // fetched object. Using it here too is the safer of two imperfect choices — it matches the
+      // documented "canonical id downstream" (meeting.interface.ts) and every other entry point,
+      // rather than adding a fifth place that could disagree with all of them.
       action: { kind: 'route', path: `/meetings/${getPastMeetingResourceId(m)}/details` },
     }));
 

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -1,0 +1,100 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Specific-file imports (not the '../constants' barrel): that barrel re-exports
+// dashboard-metrics.constants.ts, which imports '../utils' (the utils barrel, this file's own
+// barrel) — a real runtime import cycle that also drags in meeting.utils.ts's
+// `HttpParams` from '@angular/common/http', which Vitest can't resolve outside an Angular
+// context. Importing the two constant files directly avoids the cycle.
+import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '../constants/committee-documents.constants';
+import { POLL_STATUS_LABELS } from '../constants/poll.constants';
+import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
+import { ActivityFeedItem, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
+import { getSurveyDisplayStatus } from './survey.utils';
+
+/** Per-source cap before merging, so one noisy source can't crowd out the rest. */
+const PER_SOURCE_LIMIT = 5;
+/** Final row count returned after the merge-sort. */
+const FEED_LIMIT = 8;
+
+export interface BuildActivityFeedInput {
+  pastMeetings: PastMeeting[];
+  votes: Vote[];
+  surveys: Survey[];
+  documents: CommitteeDocument[];
+  /**
+   * Vote items are excluded entirely when false. The Votes tab is only shown/reachable when the
+   * committee has voting enabled (committee-view.component.ts isVotesTabVisible), but
+   * handleTabNavigation doesn't check tab visibility — only the static valid-tabs list — so an
+   * activity row for a vote from before voting was disabled would otherwise navigate to a hidden,
+   * blank tab.
+   */
+  votingEnabled: boolean;
+}
+
+/**
+ * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,
+ * surveys, and documents into one time-ordered list. Upcoming meetings are intentionally excluded
+ * — they're future-dated, already covered by the "Next Meeting" card, and would otherwise dominate
+ * a feed labelled "Recent Activity". Replaced by the real activity stream in LFXV2-1707.
+ */
+export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
+  const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
+    .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+    .slice(0, PER_SOURCE_LIMIT)
+    .map((m) => ({
+      type: 'past_meeting',
+      key: `past_meeting-${m.meeting_and_occurrence_id ?? m.id}`,
+      label: `Meeting held: ${m.title}`,
+      timestamp: m.start_time ?? '',
+      icon: 'fa-light fa-clock-rotate-left',
+      tab: 'meetings:past',
+    }));
+
+  // Upstream Vote schema (lfx-v2-voting-service openapi3.yaml) marks `status` required with a
+  // fixed lowercase enum (disabled/active/ended) — no case normalization needed here.
+  const voteItems: ActivityFeedItem[] = input.votingEnabled
+    ? [...input.votes]
+        .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
+        .slice(0, PER_SOURCE_LIMIT)
+        .map((v) => ({
+          type: 'vote' as const,
+          key: `vote-${v.uid}`,
+          label: `Vote ${POLL_STATUS_LABELS[v.status]}: ${v.name}`,
+          timestamp: v.last_modified_time ?? v.creation_time ?? '',
+          icon: 'fa-light fa-check-to-slot',
+          tab: 'votes',
+        }))
+    : [];
+
+  const surveyItems: ActivityFeedItem[] = [...input.surveys]
+    .sort((a, b) => (b.last_modified_at ?? b.created_at ?? '').localeCompare(a.last_modified_at ?? a.created_at ?? ''))
+    .slice(0, PER_SOURCE_LIMIT)
+    .map((s) => {
+      const displayStatus = getSurveyDisplayStatus(s);
+      return {
+        type: 'survey' as const,
+        key: `survey-${s.uid}`,
+        label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
+        timestamp: s.last_modified_at ?? s.created_at ?? '',
+        icon: 'fa-light fa-chart-simple',
+        tab: 'surveys',
+      };
+    });
+
+  // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a folder
+  // or link doesn't misrepresent itself as a file in the feed.
+  const documentItems: ActivityFeedItem[] = [...input.documents]
+    .sort((a, b) => (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+    .slice(0, PER_SOURCE_LIMIT)
+    .map((d) => ({
+      type: 'document' as const,
+      key: `document-${d.uid}`,
+      label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type]}: ${d.name}`,
+      timestamp: d.updated_at ?? d.created_at ?? '',
+      icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type],
+      tab: 'documents',
+    }));
+
+  return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems].sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, FEED_LIMIT);
+}

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -13,7 +13,8 @@ import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '.
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
-import { getPastMeetingResourceId } from './past-meeting.utils';
+import { firstValidTimestamp } from './iso-timestamp.utils';
+import { getPastMeetingResourceId, getPastMeetingStartTimeMs } from './past-meeting.utils';
 import { normalizePollStatus } from './poll.utils';
 import { getSurveyDisplayStatus } from './survey.utils';
 import { isValidUrl } from './url.utils';
@@ -22,26 +23,6 @@ import { isValidUrl } from './url.utils';
 const PER_SOURCE_LIMIT = 5;
 /** Final row count returned after the merge-sort. */
 const FEED_LIMIT = 8;
-
-/** Go zero-value sentinel ("0001-01-01T00:00:00Z") that Go-backed upstream services sometimes emit
- * on an unset timestamp field, instead of omitting it. */
-const GO_ZERO_DATE_PREFIX = '0001-01-01';
-
-/**
- * First candidate ISO timestamp that's genuinely present and parseable, treating a Go zero-date
- * sentinel the same as absent/missing. All four activity sources route their fallback chain
- * (e.g. `last_modified_time ?? creation_time`) through this — a plain `??` only falls back on
- * `null`/`undefined`, so a zero-date string (truthy, syntactically valid) would otherwise win over
- * a real value in a later field and sort that item out as the oldest via the per-source cap below.
- */
-export function firstValidTimestamp(...candidates: (string | undefined)[]): string {
-  for (const candidate of candidates) {
-    if (candidate && !candidate.startsWith(GO_ZERO_DATE_PREFIX) && !Number.isNaN(Date.parse(candidate))) {
-      return candidate;
-    }
-  }
-  return '';
-}
 
 /**
  * Parse an ISO timestamp to epoch ms for sorting, treating an absent/unparseable value as the
@@ -63,7 +44,16 @@ function timestampValue(timestamp: string): number {
  */
 export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
   const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
-    .map((m) => ({ meeting: m, timestamp: firstValidTimestamp(m.scheduled_start_time, m.start_time) }))
+    .map((m) => {
+      // getPastMeetingStartTimeMs — the same helper meetings-dashboard.component.ts and
+      // meeting-organizer.component.ts already go through, so this feed can't quietly diverge if
+      // that helper's field-preference or zero-date handling ever changes. committee-overview's own
+      // lastMeeting computed does not go through it (pre-existing, raw start_time.localeCompare) —
+      // a Go zero-date start_time can therefore make the "Past Meeting" card and this feed's top
+      // row name different meetings, out of this fix's scope.
+      const startMs = getPastMeetingStartTimeMs(m);
+      return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
+    })
     .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
     .slice(0, PER_SOURCE_LIMIT)
     .map(({ meeting: m, timestamp }) => ({

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -49,7 +49,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
           return {
             type: 'vote' as const,
             key: `vote-${v.uid}`,
-            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : (v.status ?? 'Updated')}: ${v.name}`,
+            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status || 'Updated'}: ${v.name}`,
             timestamp: v.last_modified_time ?? v.creation_time ?? '',
             icon: 'fa-light fa-check-to-slot',
             tab: 'votes',

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -50,7 +50,8 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       // sort that meeting out via the PER_SOURCE_LIMIT slice below, even with a valid
       // scheduled_start_time. meetings-dashboard.component.ts and meeting-organizer.component.ts
       // already go through this helper for the same reason; committee-overview.component.ts's own
-      // lastMeeting/nextMeeting computeds do not (pre-existing, out of this fix's scope).
+      // lastMeeting computed does not (pre-existing, out of this fix's scope). nextMeeting in that
+      // same file sorts upcoming Meeting[], not PastMeeting[], so this helper doesn't apply there.
       const startMs = getPastMeetingStartTimeMs(m);
       return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
     })

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -13,8 +13,10 @@ import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '.
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
+import { getPastMeetingResourceId } from './past-meeting.utils';
 import { normalizePollStatus } from './poll.utils';
 import { getSurveyDisplayStatus } from './survey.utils';
+import { isValidUrl } from './url.utils';
 
 /** Per-source cap before merging, so one noisy source can't crowd out the rest. */
 const PER_SOURCE_LIMIT = 5;
@@ -34,21 +36,6 @@ function timestampValue(timestamp: string): number {
 }
 
 /**
- * True for a URL safe to open directly in a new tab — http(s) only, matching the same guard
- * `DocumentsTableComponent.openDocument` applies before its own `window.open` call.
- */
-function isSafeExternalUrl(url: string | undefined): url is string {
-  if (!url) {
-    return false;
-  }
-  try {
-    return ['http:', 'https:'].includes(new URL(url).protocol);
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,
  * surveys, and documents into one time-ordered list. Upcoming meetings are intentionally excluded
  * — they're future-dated, already covered by the "Next Meeting" card, and would otherwise dominate
@@ -64,10 +51,12 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       label: `Meeting held: ${m.title}`,
       timestamp: m.start_time ?? '',
       icon: 'fa-light fa-clock-rotate-left',
-      // Route param is the ITX-native PastMeeting.id, not meeting_and_occurrence_id — the detail
-      // page fetches via /itx/past_meetings/{id}, which doesn't understand the composite
-      // occurrence id used elsewhere for query-service-indexed sub-resource fetches.
-      action: { kind: 'route', path: `/meetings/${m.id}/details` },
+      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same identifier every
+      // other past-meeting surface uses (meeting-card, meeting-organizer, attachments). The
+      // detail page's own recording/transcript/summary sub-fetches key off
+      // meeting_and_occurrence_id specifically; passing the bare id would silently return those
+      // empty for any occurrence where the two values diverge.
+      action: { kind: 'route', path: `/meetings/${getPastMeetingResourceId(m)}/details` },
     }));
 
   const voteItems: ActivityFeedItem[] = input.votingEnabled
@@ -115,8 +104,9 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
       // Only 'link' documents open directly — the Documents tab treats 'file' as a download
       // (via a committee-scoped proxy URL, not doc.url) rather than an "open", and 'folder' has
-      // no standalone target outside the Documents tab's own drill-down state.
-      action: d.type === 'link' && isSafeExternalUrl(d.url) ? { kind: 'external-url', url: d.url } : { kind: 'tab', tab: 'documents' },
+      // no standalone target outside the Documents tab's own drill-down state. isValidUrl is the
+      // same shared validator used across the app for untrusted-URL sinks.
+      action: d.type === 'link' && d.url && isValidUrl(d.url) ? { kind: 'external-url', url: d.url } : { kind: 'tab', tab: 'documents' },
     }));
 
   return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -24,9 +24,9 @@ const FEED_LIMIT = 8;
 /**
  * Parse an ISO timestamp to epoch ms for sorting, treating an absent/unparseable value as the
  * oldest possible. A plain `localeCompare` on the raw strings only sorts correctly when every
- * source emits the identical format/offset — this feed merges four different upstream services
- * (query-service, committee-service), so a `+05:30`-offset or non-`Z` variant from any one of them
- * would otherwise sort into the wrong position relative to the others.
+ * source emits the identical format/offset — this feed merges four sources across two upstream
+ * services (query-service, committee-service), so a `+05:30`-offset or non-`Z` variant from any
+ * one of them would otherwise sort into the wrong position relative to the others.
  */
 function timestampValue(timestamp: string): number {
   const parsed = Date.parse(timestamp);

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -12,6 +12,7 @@
 import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '../constants/committee-documents.constants';
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
+import type { PollStatus } from '../enums';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
 import { getSurveyDisplayStatus } from './survey.utils';
 
@@ -39,20 +40,24 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       tab: 'meetings:past',
     }));
 
-  // Upstream Vote schema (lfx-v2-voting-service openapi3.yaml) marks `status` required with a
-  // fixed lowercase enum (disabled/active/ended) — no case normalization needed here.
+  // Poll status has shipped with inconsistent casing before (fixed in PollStatusLabelPipe /
+  // getSurveyDisplayStatus's sibling normalization) — lowercase + fall back to the raw value,
+  // matching the same pattern used for votes elsewhere in the app (e.g. votes-table.component).
   const voteItems: ActivityFeedItem[] = input.votingEnabled
     ? [...input.votes]
         .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
         .slice(0, PER_SOURCE_LIMIT)
-        .map((v) => ({
-          type: 'vote' as const,
-          key: `vote-${v.uid}`,
-          label: `Vote ${POLL_STATUS_LABELS[v.status]}: ${v.name}`,
-          timestamp: v.last_modified_time ?? v.creation_time ?? '',
-          icon: 'fa-light fa-check-to-slot',
-          tab: 'votes',
-        }))
+        .map((v) => {
+          const normalizedStatus = (v.status as string)?.toLowerCase() as PollStatus;
+          return {
+            type: 'vote' as const,
+            key: `vote-${v.uid}`,
+            label: `Vote ${POLL_STATUS_LABELS[normalizedStatus] ?? v.status}: ${v.name}`,
+            timestamp: v.last_modified_time ?? v.creation_time ?? '',
+            icon: 'fa-light fa-check-to-slot',
+            tab: 'votes',
+          };
+        })
     : [];
 
   const surveyItems: ActivityFeedItem[] = [...input.surveys]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -34,6 +34,21 @@ function timestampValue(timestamp: string): number {
 }
 
 /**
+ * True for a URL safe to open directly in a new tab — http(s) only, matching the same guard
+ * `DocumentsTableComponent.openDocument` applies before its own `window.open` call.
+ */
+function isSafeExternalUrl(url: string | undefined): url is string {
+  if (!url) {
+    return false;
+  }
+  try {
+    return ['http:', 'https:'].includes(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,
  * surveys, and documents into one time-ordered list. Upcoming meetings are intentionally excluded
  * — they're future-dated, already covered by the "Next Meeting" card, and would otherwise dominate
@@ -49,7 +64,10 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       label: `Meeting held: ${m.title}`,
       timestamp: m.start_time ?? '',
       icon: 'fa-light fa-clock-rotate-left',
-      tab: 'meetings:past',
+      // Route param is the ITX-native PastMeeting.id, not meeting_and_occurrence_id — the detail
+      // page fetches via /itx/past_meetings/{id}, which doesn't understand the composite
+      // occurrence id used elsewhere for query-service-indexed sub-resource fetches.
+      action: { kind: 'route', path: `/meetings/${m.id}/details` },
     }));
 
   const voteItems: ActivityFeedItem[] = input.votingEnabled
@@ -64,7 +82,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
             label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status || 'Updated'}: ${v.name}`,
             timestamp: v.last_modified_time ?? v.creation_time ?? '',
             icon: 'fa-light fa-check-to-slot',
-            tab: 'votes',
+            action: { kind: 'vote-drawer', voteUid: v.uid },
           };
         })
     : [];
@@ -80,7 +98,7 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
         label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
         timestamp: s.last_modified_at ?? s.created_at ?? '',
         icon: 'fa-light fa-chart-simple',
-        tab: 'surveys',
+        action: { kind: 'survey-drawer', surveyUid: s.uid },
       };
     });
 
@@ -95,7 +113,10 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${d.name}`,
       timestamp: d.updated_at ?? d.created_at ?? '',
       icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
-      tab: 'documents',
+      // Only 'link' documents open directly — the Documents tab treats 'file' as a download
+      // (via a committee-scoped proxy URL, not doc.url) rather than an "open", and 'folder' has
+      // no standalone target outside the Documents tab's own drill-down state.
+      action: d.type === 'link' && isSafeExternalUrl(d.url) ? { kind: 'external-url', url: d.url } : { kind: 'tab', tab: 'documents' },
     }));
 
   return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -13,7 +13,7 @@ import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '.
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
-import { getPastMeetingResourceId, getPastMeetingStartTimeMs } from './past-meeting.utils';
+import { getPastMeetingResourceId } from './past-meeting.utils';
 import { normalizePollStatus } from './poll.utils';
 import { getSurveyDisplayStatus } from './survey.utils';
 import { isValidUrl } from './url.utils';
@@ -22,6 +22,26 @@ import { isValidUrl } from './url.utils';
 const PER_SOURCE_LIMIT = 5;
 /** Final row count returned after the merge-sort. */
 const FEED_LIMIT = 8;
+
+/** Go zero-value sentinel ("0001-01-01T00:00:00Z") that Go-backed upstream services sometimes emit
+ * on an unset timestamp field, instead of omitting it. */
+const GO_ZERO_DATE_PREFIX = '0001-01-01';
+
+/**
+ * First candidate ISO timestamp that's genuinely present and parseable, treating a Go zero-date
+ * sentinel the same as absent/missing. All four activity sources route their fallback chain
+ * (e.g. `last_modified_time ?? creation_time`) through this — a plain `??` only falls back on
+ * `null`/`undefined`, so a zero-date string (truthy, syntactically valid) would otherwise win over
+ * a real value in a later field and sort that item out as the oldest via the per-source cap below.
+ */
+export function firstValidTimestamp(...candidates: (string | undefined)[]): string {
+  for (const candidate of candidates) {
+    if (candidate && !candidate.startsWith(GO_ZERO_DATE_PREFIX) && !Number.isNaN(Date.parse(candidate))) {
+      return candidate;
+    }
+  }
+  return '';
+}
 
 /**
  * Parse an ISO timestamp to epoch ms for sorting, treating an absent/unparseable value as the
@@ -43,89 +63,77 @@ function timestampValue(timestamp: string): number {
  */
 export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
   const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
-    .map((m) => {
-      // getPastMeetingStartTimeMs prefers scheduled_start_time and rejects Go zero-dates
-      // ("0001-01-01...") that Zoom/ITX past-meeting rows sometimes carry on start_time — a raw
-      // `m.start_time` read would parse a zero-date as a real (~year 1) timestamp and silently
-      // sort that meeting out via the PER_SOURCE_LIMIT slice below, even with a valid
-      // scheduled_start_time. meetings-dashboard.component.ts and meeting-organizer.component.ts
-      // already go through this helper for the same reason; committee-overview.component.ts's own
-      // lastMeeting computed does not (pre-existing, out of this fix's scope). nextMeeting in that
-      // same file sorts upcoming Meeting[], not PastMeeting[], so this helper doesn't apply there.
-      const startMs = getPastMeetingStartTimeMs(m);
-      return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
-    })
+    .map((m) => ({ meeting: m, timestamp: firstValidTimestamp(m.scheduled_start_time, m.start_time) }))
     .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
     .slice(0, PER_SOURCE_LIMIT)
-    .map(({ meeting: m, timestamp }) => {
-      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) — the same helper every other
-      // past-meeting surface uses (meeting-card, meeting-organizer, attachments). The detail page
-      // itself is inconsistent about which identifier it reads: recording/transcript/summary map
-      // the fetched meeting's plain `id` (which the BFF pins to whatever route segment it
-      // received), while attachments call this same getPastMeetingResourceId helper on the
-      // fetched object. Using it here too is the safer of two imperfect choices — it matches the
-      // documented "canonical id downstream" (meeting.interface.ts) and every other entry point,
-      // rather than adding a fifth place that could disagree with all of them. Shared with `key`
-      // below so the two can't silently desync if the helper's fallback logic ever changes.
-      const resourceId = getPastMeetingResourceId(m);
-      return {
-        type: 'past_meeting' as const,
-        key: `past_meeting-${resourceId}`,
-        label: `Meeting held: ${m.title}`,
-        timestamp,
-        icon: 'fa-light fa-clock-rotate-left',
-        action: { kind: 'route' as const, path: `/meetings/${resourceId}/details` },
-      };
-    });
+    .map(({ meeting: m, timestamp }) => ({
+      type: 'past_meeting' as const,
+      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) for tracking — the same helper
+      // every other past-meeting surface uses (meeting-card, meeting-organizer, attachments) —
+      // deliberately independent of the navigation id below, which has a different job (matching
+      // an existing link) rather than uniquely identifying the occurrence.
+      key: `past_meeting-${getPastMeetingResourceId(m)}`,
+      label: `Meeting held: ${m.title}`,
+      timestamp,
+      icon: 'fa-light fa-clock-rotate-left',
+      // meeting.id, not getPastMeetingResourceId — matches the "Past Meeting" card's own link
+      // (committee-overview.component.html: `'/meetings/' + meeting.id`) exactly, so the two rows
+      // describing the same meeting on this screen always resolve to the same URL. The component
+      // maps this semantic action to that route; packages/shared doesn't carry the path string.
+      action: { kind: 'past-meeting' as const, meetingId: m.id },
+    }));
 
   const voteItems: ActivityFeedItem[] = input.votingEnabled
     ? [...input.votes]
-        .sort((a, b) => timestampValue(b.last_modified_time ?? b.creation_time ?? '') - timestampValue(a.last_modified_time ?? a.creation_time ?? ''))
+        .map((v) => ({ vote: v, timestamp: firstValidTimestamp(v.last_modified_time, v.creation_time) }))
+        .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
         .slice(0, PER_SOURCE_LIMIT)
-        .map((v) => {
+        .map(({ vote: v, timestamp }) => {
           const statusKey = normalizePollStatus(v.status);
           return {
             type: 'vote' as const,
             key: `vote-${v.uid}`,
             label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status || 'Updated'}: ${v.name}`,
-            timestamp: v.last_modified_time ?? v.creation_time ?? '',
+            timestamp,
             icon: 'fa-light fa-check-to-slot',
-            action: { kind: 'vote-drawer', voteUid: v.uid },
+            action: { kind: 'vote-drawer' as const, voteUid: v.uid },
           };
         })
     : [];
 
   const surveyItems: ActivityFeedItem[] = [...input.surveys]
-    .sort((a, b) => timestampValue(b.last_modified_at ?? b.created_at ?? '') - timestampValue(a.last_modified_at ?? a.created_at ?? ''))
+    .map((s) => ({ survey: s, timestamp: firstValidTimestamp(s.last_modified_at, s.created_at) }))
+    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
     .slice(0, PER_SOURCE_LIMIT)
-    .map((s) => {
+    .map(({ survey: s, timestamp }) => {
       const displayStatus = getSurveyDisplayStatus(s);
       return {
         type: 'survey' as const,
         key: `survey-${s.uid}`,
         label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
-        timestamp: s.last_modified_at ?? s.created_at ?? '',
+        timestamp,
         icon: 'fa-light fa-chart-simple',
-        action: { kind: 'survey-drawer', surveyUid: s.uid },
+        action: { kind: 'survey-drawer' as const, surveyUid: s.uid },
       };
     });
 
   // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a folder
   // or link doesn't misrepresent itself as a file in the feed.
   const documentItems: ActivityFeedItem[] = [...input.documents]
-    .sort((a, b) => timestampValue(b.updated_at ?? b.created_at ?? '') - timestampValue(a.updated_at ?? a.created_at ?? ''))
+    .map((d) => ({ document: d, timestamp: firstValidTimestamp(d.updated_at, d.created_at) }))
+    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
     .slice(0, PER_SOURCE_LIMIT)
-    .map((d) => ({
+    .map(({ document: d, timestamp }) => ({
       type: 'document' as const,
       key: `document-${d.uid}`,
       label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${d.name}`,
-      timestamp: d.updated_at ?? d.created_at ?? '',
+      timestamp,
       icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
       // Only 'link' documents open directly — the Documents tab treats 'file' as a download
       // (via a committee-scoped proxy URL, not doc.url) rather than an "open", and 'folder' has
       // no standalone target outside the Documents tab's own drill-down state. isValidUrl is the
       // same shared validator used across the app for untrusted-URL sinks.
-      action: d.type === 'link' && d.url && isValidUrl(d.url) ? { kind: 'external-url', url: d.url } : { kind: 'tab', tab: 'documents' },
+      action: d.type === 'link' && d.url && isValidUrl(d.url) ? { kind: 'external-url' as const, url: d.url } : { kind: 'tab' as const, tab: 'documents' },
     }));
 
   return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems]

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -12,8 +12,8 @@
 import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '../constants/committee-documents.constants';
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
-import type { PollStatus } from '../enums';
 import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
+import { normalizePollStatus } from './poll.utils';
 import { getSurveyDisplayStatus } from './survey.utils';
 
 /** Per-source cap before merging, so one noisy source can't crowd out the rest. */
@@ -40,24 +40,18 @@ export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedIt
       tab: 'meetings:past',
     }));
 
-  // Poll status has shipped with inconsistent casing before (fixed in PollStatusLabelPipe /
-  // getSurveyDisplayStatus's sibling normalization) — lowercase + fall back to the raw value,
-  // matching the same pattern used for votes elsewhere in the app (e.g. votes-table.component).
   const voteItems: ActivityFeedItem[] = input.votingEnabled
     ? [...input.votes]
         .sort((a, b) => (b.last_modified_time ?? b.creation_time ?? '').localeCompare(a.last_modified_time ?? a.creation_time ?? ''))
         .slice(0, PER_SOURCE_LIMIT)
-        .map((v) => {
-          const normalizedStatus = (v.status as string)?.toLowerCase() as PollStatus;
-          return {
-            type: 'vote' as const,
-            key: `vote-${v.uid}`,
-            label: `Vote ${POLL_STATUS_LABELS[normalizedStatus] ?? v.status}: ${v.name}`,
-            timestamp: v.last_modified_time ?? v.creation_time ?? '',
-            icon: 'fa-light fa-check-to-slot',
-            tab: 'votes',
-          };
-        })
+        .map((v) => ({
+          type: 'vote' as const,
+          key: `vote-${v.uid}`,
+          label: `Vote ${POLL_STATUS_LABELS[normalizePollStatus(v.status)] ?? v.status}: ${v.name}`,
+          timestamp: v.last_modified_time ?? v.creation_time ?? '',
+          icon: 'fa-light fa-check-to-slot',
+          tab: 'votes',
+        }))
     : [];
 
   const surveyItems: ActivityFeedItem[] = [...input.surveys]

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -1,12 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Unit tests for the committee member permission resolver (LFXV2-2059).
-//
-// NOTE: this repo has no unit-test runner wired yet (`ng test` has no target; testing is
-// Playwright E2E only). These specs are written against the pure resolver so they execute as-is
-// once a runner (e.g. Vitest via `@angular/build:unit-test`) is added — that wiring is a tracked
-// follow-up. They use the Vitest/Jest-compatible `describe`/`it`/`expect` globals.
+// Unit tests for committee.utils.ts. Run via Vitest (`yarn test`, scoped to packages/shared).
 //
 // All fixtures use synthetic placeholder identities — never real user data.
 

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Unit tests for committee.utils.ts. Run via Vitest (`yarn test`, scoped to packages/shared).
+// Unit tests for committee.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
 //
 // All fixtures use synthetic placeholder identities — never real user data.
 

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -12,8 +12,9 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
 import { Committee, CommitteeMember } from '../interfaces';
-import { buildCommitteeCreateQueryParams, canManageCommitteeMembers, resolveCommitteeMemberPermission } from './committee.utils';
+import { buildCommitteeCreateQueryParams, canManageCommitteeMembers, countVotingReps, resolveCommitteeMemberPermission } from './committee.utils';
 
 /** Minimal committee builder — only the fields the resolver reads. */
 function committee(overrides: Partial<Committee> = {}): Committee {
@@ -135,5 +136,22 @@ describe('canManageCommitteeMembers', () => {
 
   it('is false for a null committee', () => {
     expect(canManageCommitteeMembers(null)).toBe(false);
+  });
+});
+
+describe('countVotingReps', () => {
+  it('counts only members with voting.status VOTING_REP, excluding Alternate/Observer/no-voting-info', () => {
+    const members = [
+      member({ uid: 'm-1', voting: { status: CommitteeMemberVotingStatus.VOTING_REP } }),
+      member({ uid: 'm-2', voting: { status: CommitteeMemberVotingStatus.VOTING_REP } }),
+      member({ uid: 'm-3', voting: { status: CommitteeMemberVotingStatus.ALTERNATE_VOTING_REP } }),
+      member({ uid: 'm-4', voting: { status: CommitteeMemberVotingStatus.OBSERVER } }),
+      member({ uid: 'm-5' }),
+    ];
+    expect(countVotingReps(members)).toBe(2);
+  });
+
+  it('is 0 for an empty member list', () => {
+    expect(countVotingReps([])).toBe(0);
   });
 });

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -172,7 +172,12 @@ export function canManageCommitteeMembers(committee: Committee | null | undefine
   return !!committee?.writer;
 }
 
+/** Whether a member has an active "Voting Rep" status (excludes Alternate Voting Rep). */
+export function isVotingRep(member: CommitteeMember): boolean {
+  return member.voting?.status === CommitteeMemberVotingStatus.VOTING_REP;
+}
+
 /** Count of members with an active "Voting Rep" status (excludes Alternate Voting Rep). */
 export function countVotingReps(members: CommitteeMember[]): number {
-  return members.filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length;
+  return members.filter(isVotingRep).length;
 }

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
 import { Committee, CommitteeMemberPermissionInfo, GroupBehavioralClass } from '../interfaces/committee.interface';
 import { CommitteeMember } from '../interfaces/member.interface';
 import { CATEGORY_BEHAVIORAL_CLASS } from '../constants/committees.constants';
@@ -169,4 +170,9 @@ export function resolveCommitteeMemberPermission(committee: Committee | null | u
  */
 export function canManageCommitteeMembers(committee: Committee | null | undefined): boolean {
   return !!committee?.writer;
+}
+
+/** Count of members with an active "Voting Rep" status (excludes Alternate Voting Rep). */
+export function countVotingReps(members: CommitteeMember[]): number {
+  return members.filter((m) => m.voting?.status === CommitteeMemberVotingStatus.VOTING_REP).length;
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from './poll.utils';
 export * from './survey.utils';
 export * from './vote.utils';
 export * from './committee.utils';
+export * from './activity-feed.utils';
 export * from './number.utils';
 export * from './object.utils';
 export * from './platform.utils';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './docs.utils';
 export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
+export * from './iso-timestamp.utils';
 export * from './meeting.utils';
 export * from './meeting-privacy.utils';
 export * from './past-meeting-summary.utils';

--- a/packages/shared/src/utils/iso-timestamp.utils.spec.ts
+++ b/packages/shared/src/utils/iso-timestamp.utils.spec.ts
@@ -1,0 +1,42 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { firstValidTimestamp, firstValidTimestampMs } from './iso-timestamp.utils';
+
+describe('firstValidTimestamp', () => {
+  it('returns the first candidate that is present and parseable', () => {
+    expect(firstValidTimestamp('2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('falls back past an absent candidate', () => {
+    expect(firstValidTimestamp(undefined, '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('falls back past a Go zero-date sentinel', () => {
+    expect(firstValidTimestamp('0001-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('falls back past an unparseable candidate', () => {
+    expect(firstValidTimestamp('not-a-date', '2026-02-01T00:00:00Z')).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('returns an empty string when every candidate is invalid or absent', () => {
+    expect(firstValidTimestamp(undefined, '0001-01-01T00:00:00Z', 'not-a-date')).toBe('');
+  });
+});
+
+describe('firstValidTimestampMs', () => {
+  it('returns epoch ms for the first candidate that is present and parseable', () => {
+    expect(firstValidTimestampMs('2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe(Date.parse('2026-01-01T00:00:00Z'));
+  });
+
+  it('falls back past a Go zero-date sentinel', () => {
+    expect(firstValidTimestampMs('0001-01-01T00:00:00Z', '2026-02-01T00:00:00Z')).toBe(Date.parse('2026-02-01T00:00:00Z'));
+  });
+
+  it('returns null when every candidate is invalid or absent', () => {
+    expect(firstValidTimestampMs(undefined, '0001-01-01T00:00:00Z', 'not-a-date')).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/iso-timestamp.utils.ts
+++ b/packages/shared/src/utils/iso-timestamp.utils.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Go zero-value sentinel ("0001-01-01T00:00:00Z") some Go-backed upstream services emit on an
+ * unset timestamp field instead of omitting it. A raw `Date.parse` would treat this as a real
+ * (~year 1) timestamp rather than "no value" — sorting the record as the oldest possible item
+ * instead of falling back to another field or being treated as absent.
+ */
+const GO_ZERO_DATE_PREFIX = '0001-01-01';
+
+/** True for a value `Date.parse` would treat as real time — present, not the Go zero-date sentinel, and syntactically parseable. */
+function isRealTimestamp(iso: string | undefined): iso is string {
+  return !!iso && !iso.startsWith(GO_ZERO_DATE_PREFIX) && !Number.isNaN(Date.parse(iso));
+}
+
+/**
+ * First candidate ISO timestamp that's genuinely present and parseable, treating a Go zero-date
+ * sentinel the same as absent. A plain `??` fallback chain (e.g. `a.updated_at ?? a.created_at`)
+ * only advances past `null`/`undefined` — a zero-date string is truthy and syntactically valid, so
+ * it would otherwise win over a real value in a later field.
+ */
+export function firstValidTimestamp(...candidates: (string | undefined)[]): string {
+  return candidates.find(isRealTimestamp) ?? '';
+}
+
+/** Same fallback as `firstValidTimestamp`, returned as epoch ms (or `null` if every candidate is invalid/absent). */
+export function firstValidTimestampMs(...candidates: (string | undefined)[]): number | null {
+  const found = candidates.find(isRealTimestamp);
+  return found !== undefined ? new Date(found).getTime() : null;
+}

--- a/packages/shared/src/utils/object.utils.spec.ts
+++ b/packages/shared/src/utils/object.utils.spec.ts
@@ -2,18 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 // Unit tests for object.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
-// Scoped to assertNever / assertNeverSilent. nullifyEmptyStrings is covered elsewhere
-// (project.service.spec.ts); isObjectRow / isObjectRowArray have no dedicated coverage yet.
+// Scoped to assertNeverSilent. nullifyEmptyStrings, isObjectRow, and isObjectRowArray have no
+// behavioral coverage yet — project.service.spec.ts references nullifyEmptyStrings but only via
+// `vi.mock('@lfx-one/shared/utils', ...) -> nullifyEmptyStrings: vi.fn()`, a stub that exercises
+// none of its actual logic.
 
 import { describe, expect, it } from 'vitest';
 
-import { assertNever, assertNeverSilent } from './object.utils';
-
-describe('assertNever', () => {
-  it('throws at runtime as a backstop for the compile-time exhaustiveness check it exists for', () => {
-    expect(() => assertNever('unhandled' as never)).toThrow('Unhandled case');
-  });
-});
+import { assertNeverSilent } from './object.utils';
 
 describe('assertNeverSilent', () => {
   it('does not throw — the compile-time exhaustiveness check is the entire point', () => {

--- a/packages/shared/src/utils/object.utils.spec.ts
+++ b/packages/shared/src/utils/object.utils.spec.ts
@@ -2,15 +2,25 @@
 // SPDX-License-Identifier: MIT
 
 // Unit tests for object.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
-// Scoped to assertNever; the file's other exports (nullifyEmptyStrings, isObjectRow,
-// isObjectRowArray) pre-date this spec and are covered elsewhere/transitively.
+// Scoped to assertNever / assertNeverSilent. nullifyEmptyStrings is covered elsewhere
+// (project.service.spec.ts); isObjectRow / isObjectRowArray have no dedicated coverage yet.
 
 import { describe, expect, it } from 'vitest';
 
-import { assertNever } from './object.utils';
+import { assertNever, assertNeverSilent } from './object.utils';
 
 describe('assertNever', () => {
   it('throws at runtime as a backstop for the compile-time exhaustiveness check it exists for', () => {
     expect(() => assertNever('unhandled' as never)).toThrow('Unhandled case');
+  });
+});
+
+describe('assertNeverSilent', () => {
+  it('does not throw — the compile-time exhaustiveness check is the entire point', () => {
+    expect(() => assertNeverSilent('unhandled' as never)).not.toThrow();
+  });
+
+  it('returns undefined', () => {
+    expect(assertNeverSilent('unhandled' as never)).toBeUndefined();
   });
 });

--- a/packages/shared/src/utils/object.utils.spec.ts
+++ b/packages/shared/src/utils/object.utils.spec.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for object.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
+// Scoped to assertNever; the file's other exports (nullifyEmptyStrings, isObjectRow,
+// isObjectRowArray) pre-date this spec and are covered elsewhere/transitively.
+
+import { describe, expect, it } from 'vitest';
+
+import { assertNever } from './object.utils';
+
+describe('assertNever', () => {
+  it('throws at runtime as a backstop for the compile-time exhaustiveness check it exists for', () => {
+    expect(() => assertNever('unhandled' as never)).toThrow('Unhandled case');
+  });
+});

--- a/packages/shared/src/utils/object.utils.ts
+++ b/packages/shared/src/utils/object.utils.ts
@@ -48,6 +48,15 @@ export function isObjectRow(el: unknown): el is Record<string, unknown> {
   return el !== null && typeof el === 'object' && !Array.isArray(el);
 }
 
+/**
+ * Compile-time exhaustiveness check for a `switch`/`if`-chain over a discriminated union: pass the
+ * variable in a `default` branch and TypeScript flags any unhandled union member as a type error
+ * at the call site, rather than letting a new variant compile and silently fall through to a no-op.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled case: ${JSON.stringify(value)}`);
+}
+
 /** Shallow accept-guard for a read-through cache of object rows; a corrupt/foreign entry degrades to a miss, so callers reading a required contract key must validate it on top of this shape check. */
 export function isObjectRowArray(value: unknown): boolean {
   return Array.isArray(value) && value.every(isObjectRow);

--- a/packages/shared/src/utils/object.utils.ts
+++ b/packages/shared/src/utils/object.utils.ts
@@ -52,21 +52,9 @@ export function isObjectRow(el: unknown): el is Record<string, unknown> {
  * Compile-time exhaustiveness check for a `switch`/`if`-chain over a discriminated union: pass the
  * variable in a `default` branch and TypeScript flags any unhandled union member as a type error
  * at the call site, rather than letting a new variant compile and silently fall through to a no-op.
- * Throws at runtime as a backstop — use this where the input can only be in-app-constructed data,
- * so the throw genuinely can't be reached outside a bug. For a `default` branch that could see
- * externally-sourced data (e.g. a server-fed union member a client hasn't been updated to handle
- * yet), use `assertNeverSilent` instead so an unrecognized value degrades to a no-op rather than an
- * uncaught exception.
- */
-export function assertNever(value: never): never {
-  throw new Error(`Unhandled case: ${JSON.stringify(value)}`);
-}
-
-/**
- * Same compile-time exhaustiveness guarantee as `assertNever` — a new union member still fails to
- * compile — but never throws at runtime. For a `default` branch where the input can be
- * externally-sourced (e.g. a server-fed action a client hasn't been updated to handle yet) and an
- * uncaught exception would be worse than a silent no-op, such as inside a DOM event handler.
+ * Never throws at runtime — for a `default` branch where the input can be externally-sourced (e.g.
+ * a server-fed action a client hasn't been updated to handle yet) and an uncaught exception would
+ * be worse than a silent no-op, such as inside a DOM event handler.
  */
 export function assertNeverSilent(_value: never): void {
   // Intentionally empty — the compile-time check is the entire point.

--- a/packages/shared/src/utils/object.utils.ts
+++ b/packages/shared/src/utils/object.utils.ts
@@ -52,9 +52,24 @@ export function isObjectRow(el: unknown): el is Record<string, unknown> {
  * Compile-time exhaustiveness check for a `switch`/`if`-chain over a discriminated union: pass the
  * variable in a `default` branch and TypeScript flags any unhandled union member as a type error
  * at the call site, rather than letting a new variant compile and silently fall through to a no-op.
+ * Throws at runtime as a backstop — use this where the input can only be in-app-constructed data,
+ * so the throw genuinely can't be reached outside a bug. For a `default` branch that could see
+ * externally-sourced data (e.g. a server-fed union member a client hasn't been updated to handle
+ * yet), use `assertNeverSilent` instead so an unrecognized value degrades to a no-op rather than an
+ * uncaught exception.
  */
 export function assertNever(value: never): never {
   throw new Error(`Unhandled case: ${JSON.stringify(value)}`);
+}
+
+/**
+ * Same compile-time exhaustiveness guarantee as `assertNever` — a new union member still fails to
+ * compile — but never throws at runtime. For a `default` branch where the input can be
+ * externally-sourced (e.g. a server-fed action a client hasn't been updated to handle yet) and an
+ * uncaught exception would be worse than a silent no-op, such as inside a DOM event handler.
+ */
+export function assertNeverSilent(_value: never): void {
+  // Intentionally empty — the compile-time check is the entire point.
 }
 
 /** Shallow accept-guard for a read-through cache of object rows; a corrupt/foreign entry degrades to a miss, so callers reading a required contract key must validate it on top of this shape check. */

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -2,20 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { EnrichedPastMeetingParticipant, PastMeeting, PastMeetingRecording, PastParticipantFilters } from '../interfaces';
-
-const ZERO_DATE_PREFIX = '0001-01-01';
-
-function parsePastMeetingStartIso(iso: string | undefined): number | null {
-  if (!iso || iso.startsWith(ZERO_DATE_PREFIX)) {
-    return null;
-  }
-  const ms = new Date(iso).getTime();
-  return Number.isNaN(ms) ? null : ms;
-}
+import { firstValidTimestampMs } from './iso-timestamp.utils';
 
 // Zoom/ITX rows sometimes carry a Go zero-date on scheduled_start_time; fall back to start_time.
 export function getPastMeetingStartTimeMs(meeting: Pick<PastMeeting, 'scheduled_start_time' | 'start_time'>): number | null {
-  return parsePastMeetingStartIso(meeting.scheduled_start_time) ?? parsePastMeetingStartIso(meeting.start_time);
+  return firstValidTimestampMs(meeting.scheduled_start_time, meeting.start_time);
 }
 
 // Largest recording session (by total_size) is canonical; a recording "exists" only if that

--- a/packages/shared/src/utils/poll.utils.spec.ts
+++ b/packages/shared/src/utils/poll.utils.spec.ts
@@ -9,17 +9,22 @@ import { PollStatus } from '../enums';
 import { normalizePollStatus } from './poll.utils';
 
 describe('normalizePollStatus', () => {
-  it('lowercases an already-lowercase status', () => {
-    expect(normalizePollStatus(PollStatus.ACTIVE)).toBe('active');
+  it('returns an already-lowercase status unchanged', () => {
+    expect(normalizePollStatus(PollStatus.ACTIVE)).toBe(PollStatus.ACTIVE);
   });
 
-  it('lowercases an uppercase/mixed-case status', () => {
-    expect(normalizePollStatus('ACTIVE')).toBe('active');
-    expect(normalizePollStatus('Ended')).toBe('ended');
+  it('lowercases an uppercase/mixed-case status that matches a real member', () => {
+    expect(normalizePollStatus('ACTIVE')).toBe(PollStatus.ACTIVE);
+    expect(normalizePollStatus('Ended')).toBe(PollStatus.ENDED);
   });
 
-  it('returns an empty string for a nullish status instead of throwing', () => {
-    expect(normalizePollStatus(null)).toBe('');
-    expect(normalizePollStatus(undefined)).toBe('');
+  it('returns undefined for a nullish status instead of throwing', () => {
+    expect(normalizePollStatus(null)).toBeUndefined();
+    expect(normalizePollStatus(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a value that is not a real PollStatus member', () => {
+    expect(normalizePollStatus('archived')).toBeUndefined();
+    expect(normalizePollStatus('')).toBeUndefined();
   });
 });

--- a/packages/shared/src/utils/poll.utils.spec.ts
+++ b/packages/shared/src/utils/poll.utils.spec.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for poll.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
+
+import { describe, expect, it } from 'vitest';
+
+import { PollStatus } from '../enums';
+import { normalizePollStatus } from './poll.utils';
+
+describe('normalizePollStatus', () => {
+  it('lowercases an already-lowercase status', () => {
+    expect(normalizePollStatus(PollStatus.ACTIVE)).toBe('active');
+  });
+
+  it('lowercases an uppercase/mixed-case status', () => {
+    expect(normalizePollStatus('ACTIVE')).toBe('active');
+    expect(normalizePollStatus('Ended')).toBe('ended');
+  });
+
+  it('returns an empty string for a nullish status instead of throwing', () => {
+    expect(normalizePollStatus(null)).toBe('');
+    expect(normalizePollStatus(undefined)).toBe('');
+  });
+});

--- a/packages/shared/src/utils/poll.utils.ts
+++ b/packages/shared/src/utils/poll.utils.ts
@@ -44,9 +44,12 @@ export function isVoteEndedEarly(vote: Pick<Vote, 'early_end_time'>): boolean {
 /**
  * Lowercase a poll status before comparing or looking it up.
  * @description `Vote.status` has shipped with inconsistent casing before (fixed in
- * PollStatusLabelPipe / PollStatusSeverityPipe) — normalize once, here, rather than
- * re-deriving the same double-cast at every call site.
+ * PollStatusLabelPipe / PollStatusSeverityPipe, now both routed through this shared helper).
+ * Takes `string | null | undefined` rather than `PollStatus` — the `PollStatus` type marks
+ * `status` required and canonically-cased, but that guarantee is asserted rather than
+ * runtime-validated (some server-side vote mappers construct partial objects with `as Vote`),
+ * so the input type reflects what's actually received, not what the type system claims.
  */
-export function normalizePollStatus(status: PollStatus): PollStatus {
-  return (status as string).toLowerCase() as PollStatus;
+export function normalizePollStatus(status: string | null | undefined): PollStatus {
+  return (status ?? '').toLowerCase() as PollStatus;
 }

--- a/packages/shared/src/utils/poll.utils.ts
+++ b/packages/shared/src/utils/poll.utils.ts
@@ -40,3 +40,13 @@ export function getVoteEndedEarlyDetailTooltip(earlyEndTimeFormatted: string): s
 export function isVoteEndedEarly(vote: Pick<Vote, 'early_end_time'>): boolean {
   return Boolean(vote.early_end_time);
 }
+
+/**
+ * Lowercase a poll status before comparing or looking it up.
+ * @description `Vote.status` has shipped with inconsistent casing before (fixed in
+ * PollStatusLabelPipe / PollStatusSeverityPipe) — normalize once, here, rather than
+ * re-deriving the same double-cast at every call site.
+ */
+export function normalizePollStatus(status: PollStatus): PollStatus {
+  return (status as string).toLowerCase() as PollStatus;
+}

--- a/packages/shared/src/utils/poll.utils.ts
+++ b/packages/shared/src/utils/poll.utils.ts
@@ -42,14 +42,18 @@ export function isVoteEndedEarly(vote: Pick<Vote, 'early_end_time'>): boolean {
 }
 
 /**
- * Lowercase a poll status before comparing or looking it up.
+ * Lowercase and validate a poll status before comparing or looking it up.
  * @description `Vote.status` has shipped with inconsistent casing before (fixed in
  * PollStatusLabelPipe / PollStatusSeverityPipe, now both routed through this shared helper).
  * Takes `string | null | undefined` rather than `PollStatus` — the `PollStatus` type marks
  * `status` required and canonically-cased, but that guarantee is asserted rather than
  * runtime-validated (some server-side vote mappers construct partial objects with `as Vote`),
  * so the input type reflects what's actually received, not what the type system claims.
+ * Returns `undefined` (not a cast-over `PollStatus`) when the value isn't a real member after
+ * lowercasing, so callers' `POLL_STATUS_LABELS[key]` fallbacks stay type-visible instead of
+ * silently unreachable dead code.
  */
-export function normalizePollStatus(status: string | null | undefined): PollStatus {
-  return (status ?? '').toLowerCase() as PollStatus;
+export function normalizePollStatus(status: string | null | undefined): PollStatus | undefined {
+  const normalized = (status ?? '').toLowerCase();
+  return (Object.values(PollStatus) as string[]).includes(normalized) ? (normalized as PollStatus) : undefined;
 }


### PR DESCRIPTION
## Summary

- Adds a **Voting Reps** stat row and a **Recent Activity** feed (past meetings, votes, surveys, documents merged and time-sorted) to the committee Overview page.
- Recent Activity rows deep-link to the specific item instead of just the owning tab: past meetings open the meeting detail page (matching the Past Meeting card's own link, including its password query param for restricted meetings), votes and surveys open their results drawer in place, and documents open externally when a direct link exists (falling back to the Documents tab otherwise).
- Fixes a pre-existing gap surfaced along the way: the vote results drawer's "Cast Vote" CTA was mounted with its `castVoteRequested` output unbound on both the Overview and the committee Votes tab, so clicking it silently closed the drawer with no cast flow. Investigated wiring a real cast flow (`dashboard-cast-drawer-host` + `vote-cast-drawer`, the pattern every other dashboard uses), but the CTA's own gate (`vote.response_status`) is only ever decorated by the Me-lens `getMyVotes()` endpoint — both committee surfaces feed the drawer from `getVotesByCommittee`/`getVote`, which never carry that field, so the CTA could never legitimately render there. Landed on an explicit `allowCastFromDrawer` input on `VoteResultsDrawerComponent` (defaults `true`, unchanged for `/me/votes`) instead, so both committee surfaces now deliberately suppress the CTA rather than relying on the data gap to hide it.
- Consolidates Go zero-date (`0001-01-01T00:00:00Z`) timestamp handling into a single shared `iso-timestamp.utils.ts` helper, used by the activity feed and by `getPastMeetingStartTimeMs` (previously two independent implementations).

JIRA: LFXV2-1716

## Trade-offs / follow-ups (documented, not blocking)

- **Voting Reps source:** derived via `countVotingReps(members())` rather than the upstream `total_voting_repos` field, which is a repo count (never a person count) and is never populated by any current write path — `Committee.total_voting_repos` was loosened to optional to reflect that.
- **Documents fetch cost:** Overview now issues `GET /api/committees/:id/documents` (which fans out server-side to `/folders`, `/links`, and an unbounded paginated `committee_document` query) solely to seed up to 5 feed rows, and it re-fires on any silent committee refresh. Acceptable as a stop-gap; a bound (`page_size`/`order`) or a shared fetch lifted to `committee-view.component.ts` is a reasonable follow-up.
- **"My Pending Actions" voter eligibility (pre-existing, verified present on `origin/main` prior to this branch):** `pendingVotes` lists every `ACTIVE` committee vote with a "Review and Vote" CTA, regardless of whether the current viewer has already responded or is even eligible — the same `response_status`-is-Me-lens-only gap noted above. Not introduced or worsened by this PR (the drawer's own Cast Vote CTA already never rendered here before these changes either), but a good candidate to fold into the voter-eligibility work under LFXV2-1707.
- **No e2e coverage yet** for the new Recent Activity empty state or `handleActivityItemClick` (the latter is a repo-wide constraint — no Angular component-test runner).
- **Diff size** (~1078 additions) exceeds the 1000-line PR target — this is 41+ commits of iterative, review-driven fixes on a single ticket (see history); splitting wasn't practical at this point in the process.
- Real activity stream / server-fed activity items are tracked separately under LFXV2-1707; this feed is an explicit stop-gap until then.

## Test plan

- [x] `yarn lint`, `yarn format:check`, `yarn test`, `yarn build` all pass
- [x] Every fix in this branch went through the mandatory post-commit reviewer trio (general / self-serve-convention / learnings), plus a full-branch sweep against `origin/main` with zero Critical findings
- [x] Reviewed by cursor[bot], copilot-pull-request-reviewer[bot], coderabbitai[bot], and @dealako (approved) — all threads resolved or reconciled
- [ ] Manual re-test in the integration worktree: Voting Reps count, Recent Activity ordering/links per type (past meeting, vote, survey, document), zero-date meetings/votes/surveys/documents don't vanish from the feed