### PR TITLE
fix(meetings): pass occurrence_id to Show Members registrant preload

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -104,14 +104,19 @@
 
             <!-- RSVP Status Badge Overlay -->
             <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
-              @if (registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true) {
-                <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
-              } @else if (registrant.rsvp?.response_type === 'maybe') {
-                <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
-              } @else if (registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false) {
-                <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
-              } @else {
-                <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
+              @switch (registrantAttendanceStatus(registrant)) {
+                @case ('accepted') {
+                  <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
+                }
+                @case ('maybe') {
+                  <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
+                }
+                @case ('declined') {
+                  <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
+                }
+                @default {
+                  <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
+                }
               }
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -104,7 +104,7 @@
 
             <!-- RSVP Status Badge Overlay -->
             <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
-              @switch (registrantAttendanceStatus(registrant)) {
+              @switch (registrant.attendanceStatus) {
                 @case ('accepted') {
                   <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
                 }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -29,6 +29,7 @@ import {
   resolveMeetingBaseCount,
   resolveRsvpOccurrenceId,
 } from '@lfx-one/shared/utils';
+import type { RegistrantAttendanceStatus } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -36,6 +37,8 @@ import { TooltipModule } from 'primeng/tooltip';
 import { BehaviorSubject, catchError, combineLatest, debounceTime, filter, finalize, map, of, pairwise, startWith, switchMap, take, tap } from 'rxjs';
 
 import { RegistrantFormComponent } from '../registrant-form/registrant-form.component';
+
+type RegistrantWithAttendance = MeetingRegistrant & { attendanceStatus: RegistrantAttendanceStatus };
 
 @Component({
   selector: 'lfx-meeting-registrants-display',
@@ -120,9 +123,6 @@ export class MeetingRegistrantsDisplayComponent {
     { label: 'Invited', value: 'invited' },
     { label: 'Not Invited', value: 'uninvited' },
   ];
-
-  /** Shared chip / filter semantics — see {@link getRegistrantAttendanceStatus}. */
-  protected readonly registrantAttendanceStatus = getRegistrantAttendanceStatus;
 
   // Group (Committee) filter options computed from meeting committees
   public readonly groupFilterOptions = this.initGroupFilterOptions();
@@ -436,14 +436,19 @@ export class MeetingRegistrantsDisplayComponent {
     });
   }
 
-  private initFilteredRegistrants() {
+  private initFilteredRegistrants(): Signal<RegistrantWithAttendance[]> {
     return computed(() => {
       const registrants = this.registrants();
       const query = this.searchQuery().toLowerCase().trim();
       const rsvp = this.rsvpFilter();
       const group = this.groupFilter();
 
-      return registrants.filter((registrant) => {
+      return registrants
+        .map((registrant) => ({
+          ...registrant,
+          attendanceStatus: getRegistrantAttendanceStatus(registrant),
+        }))
+        .filter((registrant) => {
         // Search filter
         const matchesSearch =
           !query ||
@@ -452,10 +457,10 @@ export class MeetingRegistrantsDisplayComponent {
           registrant.email?.toLowerCase().includes(query) ||
           registrant.org_name?.toLowerCase().includes(query);
 
-        // RSVP filter — must match chip rendering via getRegistrantAttendanceStatus
+        // RSVP filter — must match chip rendering via attendanceStatus
         let matchesRsvp = true;
         if (rsvp !== 'all') {
-          const status = getRegistrantAttendanceStatus(registrant);
+          const status = registrant.attendanceStatus;
           if (rsvp === 'yes') {
             matchesRsvp = status === 'accepted';
           } else if (rsvp === 'no') {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -23,10 +23,11 @@ import {
 import {
   compareMeetingPeopleByHostThenName,
   filterPastMeetingParticipants,
-  getCurrentOrNextOccurrence,
+  getRegistrantAttendanceStatus,
   getPastMeetingResourceId,
   markFormControlsAsTouched,
   resolveMeetingBaseCount,
+  resolveRsvpOccurrenceId,
 } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -119,6 +120,9 @@ export class MeetingRegistrantsDisplayComponent {
     { label: 'Invited', value: 'invited' },
     { label: 'Not Invited', value: 'uninvited' },
   ];
+
+  /** Shared chip / filter semantics — see {@link getRegistrantAttendanceStatus}. */
+  protected readonly registrantAttendanceStatus = getRegistrantAttendanceStatus;
 
   // Group (Committee) filter options computed from meeting committees
   public readonly groupFilterOptions = this.initGroupFilterOptions();
@@ -301,7 +305,7 @@ export class MeetingRegistrantsDisplayComponent {
               // unrelated occurrences. Falls back to newest RSVP when no occurrence is
               // available (non-recurring meetings). See LFXV2-2864.
               const meeting = this.meeting() as Meeting;
-              const occurrenceId = getCurrentOrNextOccurrence(meeting)?.occurrence_id;
+              const occurrenceId = resolveRsvpOccurrenceId(meeting);
               // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views
               const registrantsObservable = useMyEndpoint
                 ? this.meetingService.getMyMeetingRegistrants(meeting.id, true, occurrenceId)
@@ -448,20 +452,16 @@ export class MeetingRegistrantsDisplayComponent {
           registrant.email?.toLowerCase().includes(query) ||
           registrant.org_name?.toLowerCase().includes(query);
 
-        // RSVP filter (must match display logic in template)
+        // RSVP filter — must match chip rendering via getRegistrantAttendanceStatus
         let matchesRsvp = true;
         if (rsvp !== 'all') {
+          const status = getRegistrantAttendanceStatus(registrant);
           if (rsvp === 'yes') {
-            // Accepted: rsvp.response_type === 'accepted' OR invite_accepted === true
-            matchesRsvp = registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true;
+            matchesRsvp = status === 'accepted';
           } else if (rsvp === 'no') {
-            // Declined: rsvp.response_type === 'declined' OR invite_accepted === false
-            matchesRsvp = registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false;
+            matchesRsvp = status === 'declined';
           } else if (rsvp === 'pending') {
-            // Pending: NOT accepted AND NOT declined (includes maybe and no response)
-            const isAccepted = registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true;
-            const isDeclined = registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false;
-            matchesRsvp = !isAccepted && !isDeclined;
+            matchesRsvp = status === 'pending' || status === 'maybe';
           }
         }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -449,32 +449,32 @@ export class MeetingRegistrantsDisplayComponent {
           attendanceStatus: getRegistrantAttendanceStatus(registrant),
         }))
         .filter((registrant) => {
-        // Search filter
-        const matchesSearch =
-          !query ||
-          registrant.first_name?.toLowerCase().includes(query) ||
-          registrant.last_name?.toLowerCase().includes(query) ||
-          registrant.email?.toLowerCase().includes(query) ||
-          registrant.org_name?.toLowerCase().includes(query);
+          // Search filter
+          const matchesSearch =
+            !query ||
+            registrant.first_name?.toLowerCase().includes(query) ||
+            registrant.last_name?.toLowerCase().includes(query) ||
+            registrant.email?.toLowerCase().includes(query) ||
+            registrant.org_name?.toLowerCase().includes(query);
 
-        // RSVP filter — must match chip rendering via attendanceStatus
-        let matchesRsvp = true;
-        if (rsvp !== 'all') {
-          const status = registrant.attendanceStatus;
-          if (rsvp === 'yes') {
-            matchesRsvp = status === 'accepted';
-          } else if (rsvp === 'no') {
-            matchesRsvp = status === 'declined';
-          } else if (rsvp === 'pending') {
-            matchesRsvp = status === 'pending' || status === 'maybe';
+          // RSVP filter — must match chip rendering via attendanceStatus
+          let matchesRsvp = true;
+          if (rsvp !== 'all') {
+            const status = registrant.attendanceStatus;
+            if (rsvp === 'yes') {
+              matchesRsvp = status === 'accepted';
+            } else if (rsvp === 'no') {
+              matchesRsvp = status === 'declined';
+            } else if (rsvp === 'pending') {
+              matchesRsvp = status === 'pending' || status === 'maybe';
+            }
           }
-        }
 
-        // Group (Committee) filter
-        const matchesGroup = group === 'all' || registrant.committee_uid === group;
+          // Group (Committee) filter
+          const matchesGroup = group === 'all' || registrant.committee_uid === group;
 
-        return matchesSearch && matchesRsvp && matchesGroup;
-      });
+          return matchesSearch && matchesRsvp && matchesGroup;
+        });
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -97,7 +97,7 @@ export class MeetingRsvpDetailsComponent {
             // Resolve RSVPs against the target occurrence so a `single` decline for a
             // future date doesn't overwrite the current occurrence's per-registrant
             // chip (LFXV2-2864).
-            const occurrenceId = resolveRsvpOccurrenceId(meeting as Meeting, { occurrence: this.currentOccurrence() });
+            const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrence: this.currentOccurrence() });
             return this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId).pipe(
               map((registrants) => ({
                 registrants,

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -17,6 +17,7 @@ import {
   Project,
   RsvpCounts,
 } from '@lfx-one/shared';
+import { resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { UserService } from '@services/user.service';
 import { catchError, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
@@ -96,7 +97,7 @@ export class MeetingRsvpDetailsComponent {
             // Resolve RSVPs against the target occurrence so a `single` decline for a
             // future date doesn't overwrite the current occurrence's per-registrant
             // chip (LFXV2-2864).
-            const occurrenceId = this.currentOccurrence()?.occurrence_id;
+            const occurrenceId = resolveRsvpOccurrenceId(meeting as Meeting, { occurrence: this.currentOccurrence() });
             return this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId).pipe(
               map((registrants) => ({
                 registrants,

--- a/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
@@ -7,6 +7,7 @@ import { Component, computed, inject, input, InputSignal, output, OutputEmitterR
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RsvpScopeModalComponent } from '@app/modules/meetings/components/rsvp-scope-modal/rsvp-scope-modal.component';
 import { CreateMeetingRsvpRequest, Meeting, MeetingRsvp, RsvpResponse, RsvpScope, User } from '@lfx-one/shared';
+import { resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -175,7 +176,7 @@ export class RsvpButtonGroupComponent {
           if (this.disabled()) {
             return of(null);
           }
-          const occurrenceId = this.meeting().recurrence ? this.occurrenceId() : undefined;
+          const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrenceId: this.occurrenceId() });
           if (authenticated && meeting?.id) {
             return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(catchError(() => of(null)));
           }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   getActiveOccurrences,
   getCurrentOrNextOccurrence,
+  resolveRsvpOccurrenceId,
   hasMeetingEnded,
   isPastMeetingSummaryAwaitingApproval,
   Meeting,
@@ -1101,7 +1102,7 @@ export class MeetingJoinComponent implements OnInit {
           if (!authenticated || !canToggle || !meeting?.id) {
             return of(null);
           }
-          const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
+          const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrence });
           // Capture the current update revision at fetch dispatch time. If a manual update
           // bumps the counter before the server response arrives (typically because the
           // query-service hasn't indexed the new RSVP yet), the filter drops both the
@@ -1347,16 +1348,18 @@ export class MeetingJoinComponent implements OnInit {
     return toSignal(
       combineLatest([
         toObservable(this.meeting).pipe(distinctUntilChanged((a, b) => a?.id === b?.id)),
+        toObservable(this.currentOccurrence).pipe(distinctUntilChanged((a, b) => a?.occurrence_id === b?.occurrence_id)),
         toObservable(this.authenticated),
         this.registrantsRefresh$,
       ]).pipe(
-        switchMap(([meeting, authenticated]) => {
+        switchMap(([meeting, occurrence, authenticated]) => {
           if (!meeting?.id || !authenticated || !(meeting.organizer || meeting.invited) || this.isPastMeeting()) {
             return of([] as MeetingRegistrant[]);
           }
           this.registrantsLoading.set(true);
           const baseCount = (meeting.individual_registrants_count || 0) + (meeting.committee_members_count || 0);
-          return this.meetingService.getMyMeetingRegistrants(meeting.id, true).pipe(
+          const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrence });
+          return this.meetingService.getMyMeetingRegistrants(meeting.id, true, occurrenceId).pipe(
             tap((list) => {
               // Once the refetch lands, drop the optimistic pad so it doesn't double-count.
               const fetchedAdditional = Math.max(0, list.length - baseCount);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -40,6 +40,7 @@ import {
   hasMeetingEnded,
   normalizeIndexedMeetingAiSummary,
   parseToInt,
+  resolveRsvpOccurrenceId,
   selectApplicableRsvp,
 } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -537,8 +538,7 @@ export class UserService {
               meeting.my_rsvp = null;
               continue;
             }
-            const occurrence = getCurrentOrNextOccurrence(meeting);
-            const applicable = selectApplicableRsvp(occurrence?.occurrence_id, meetingRsvps);
+            const applicable = selectApplicableRsvp(resolveRsvpOccurrenceId(meeting), meetingRsvps);
             meeting.my_rsvp = applicable ?? selectApplicableRsvp(undefined, meetingRsvps);
           }
         } catch (error) {

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -6,7 +6,7 @@
 // compiler first provides that facade so the module can be imported.
 import '@angular/compiler';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { RecurrenceType } from '../enums';
 import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
@@ -135,9 +135,29 @@ describe('resolveRsvpOccurrenceId', () => {
   });
 
   it('falls back to getCurrentOrNextOccurrence when no occurrence context is supplied', () => {
-    // Both ids are valid outputs depending on clock; assert we get one of the series ids.
-    const resolved = resolveRsvpOccurrenceId(recurringMeeting);
-    expect(['1785247200', '1785852000']).toContain(resolved);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00.000Z'));
+    try {
+      const firstStart = new Date('2026-01-20T14:00:00.000Z');
+      const secondStart = new Date('2026-01-27T14:00:00.000Z');
+      const firstOccurrenceId = String(Math.floor(firstStart.getTime() / 1000));
+      const meeting = {
+        recurrence: { type: RecurrenceType.WEEKLY, repeat_interval: 1, weekly_days: '2' },
+        occurrences: [
+          { occurrence_id: firstOccurrenceId, start_time: firstStart.toISOString(), duration: 60 },
+          {
+            occurrence_id: String(Math.floor(secondStart.getTime() / 1000)),
+            start_time: secondStart.toISOString(),
+            duration: 60,
+          },
+        ],
+        cancelled_occurrences: [],
+      } as Meeting;
+
+      expect(resolveRsvpOccurrenceId(meeting)).toBe(firstOccurrenceId);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -25,6 +25,7 @@ import {
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
   resolveOccurrenceRecurrence,
+  resolveRsvpOccurrenceId,
   selectCommitteeCadenceMeeting,
   selectPrimaryPastMeetingSummary,
   sortPastMeetingsDescending,
@@ -102,6 +103,41 @@ describe('sortPastMeetingsDescending', () => {
     const merged = sortPastMeetingsDescending([...page1, ...page2]);
 
     expect(uids(merged)).toEqual(['p2-may', 'p2-mar', 'p1-feb', 'p1-jan']);
+  });
+});
+
+describe('resolveRsvpOccurrenceId', () => {
+  const recurringMeeting = {
+    recurrence: { type: RecurrenceType.WEEKLY, repeat_interval: 1, weekly_days: '2' },
+    occurrences: [
+      { occurrence_id: '1785247200', start_time: '2026-07-28T14:00:00Z', duration: 60 },
+      { occurrence_id: '1785852000', start_time: '2026-08-04T14:00:00Z', duration: 60 },
+    ],
+    cancelled_occurrences: [],
+  } as Meeting;
+
+  const nonRecurringMeeting = { recurrence: null, occurrences: [] } as unknown as Meeting;
+
+  it('returns undefined for non-recurring meetings', () => {
+    expect(resolveRsvpOccurrenceId(nonRecurringMeeting, { occurrenceId: '1785247200' })).toBeUndefined();
+  });
+
+  it('prefers an explicit occurrence id string', () => {
+    expect(resolveRsvpOccurrenceId(recurringMeeting, { occurrenceId: '1785852000' })).toBe('1785852000');
+  });
+
+  it('prefers an explicit occurrence object', () => {
+    expect(
+      resolveRsvpOccurrenceId(recurringMeeting, {
+        occurrence: { occurrence_id: '1785852000', start_time: '2026-08-04T14:00:00Z', duration: 60 } as MeetingOccurrence,
+      })
+    ).toBe('1785852000');
+  });
+
+  it('falls back to getCurrentOrNextOccurrence when no occurrence context is supplied', () => {
+    // Both ids are valid outputs depending on clock; assert we get one of the series ids.
+    const resolved = resolveRsvpOccurrenceId(recurringMeeting);
+    expect(['1785247200', '1785852000']).toContain(resolved);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -134,6 +134,15 @@ describe('resolveRsvpOccurrenceId', () => {
     ).toBe('1785852000');
   });
 
+  it('falls through empty occurrenceId to occurrence object id', () => {
+    expect(
+      resolveRsvpOccurrenceId(recurringMeeting, {
+        occurrenceId: '',
+        occurrence: { occurrence_id: '1785852000', start_time: '2026-08-04T14:00:00Z', duration: 60 } as MeetingOccurrence,
+      })
+    ).toBe('1785852000');
+  });
+
   it('falls back to getCurrentOrNextOccurrence when no occurrence context is supplied', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-15T12:00:00.000Z'));

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -341,7 +341,7 @@ export function resolveRsvpOccurrenceId(
   options?: { occurrence?: MeetingOccurrence | null; occurrenceId?: string | null }
 ): string | undefined {
   if (!meeting.recurrence) return undefined;
-  const explicitId = options?.occurrenceId ?? options?.occurrence?.occurrence_id;
+  const explicitId = options?.occurrenceId || options?.occurrence?.occurrence_id;
   if (explicitId) return explicitId;
   return getCurrentOrNextOccurrence(meeting)?.occurrence_id;
 }

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -328,6 +328,25 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
 }
 
 /**
+ * Occurrence id to pass to RSVP BFF endpoints (`getMeetingRegistrants`,
+ * `getMyMeetingRegistrants`, `getMeetingRsvpForCurrentUser`).
+ *
+ * Non-recurring meetings return `undefined` (newest / aggregate RSVP semantics).
+ * Recurring meetings prefer an explicit occurrence or id; when neither is supplied,
+ * fall back to {@link getCurrentOrNextOccurrence} so list/card surfaces that only
+ * hold the meeting payload still resolve against the current/next slot.
+ */
+export function resolveRsvpOccurrenceId(
+  meeting: Meeting,
+  options?: { occurrence?: MeetingOccurrence | null; occurrenceId?: string | null }
+): string | undefined {
+  if (!meeting.recurrence) return undefined;
+  const explicitId = options?.occurrenceId ?? options?.occurrence?.occurrence_id;
+  if (explicitId) return explicitId;
+  return getCurrentOrNextOccurrence(meeting)?.occurrence_id;
+}
+
+/**
  * Returns the recurrence that should drive the displayed cadence label for a given occurrence:
  * the occurrence's own recurrence override when present (the cadence changed at/after this
  * occurrence — LFXV2-2112), otherwise the meeting's top-level recurrence.


### PR DESCRIPTION
## Summary

- Fixes a fifth read path missed by #1219: the meeting **details page Show Members drawer** preloaded registrants via `getMyMeetingRegistrants` without `occurrence_id`, so a future `single`-scope decline appeared on every occurrence even though **Your RSVP** and the card drawer were correct.
- Adds shared `resolveRsvpOccurrenceId()` and uses it across all frontend RSVP BFF call sites so occurrence context is resolved consistently (explicit occurrence → fallback to current/next).
- Routes registrant chip + filter rendering through `getRegistrantAttendanceStatus()` so display semantics live in one place instead of being duplicated in the template and filter logic.

## Follow-up to [lfx-self-serve#1219](https://github.com/linuxfoundation/lfx-self-serve/pull/1219) (LFXV2-2864)

[lfx-self-serve#1219](https://github.com/linuxfoundation/lfx-self-serve/pull/1219) normalised RSVP `occurrence_id` seconds-vs-milliseconds handling and routed the detail-page **Your RSVP** chip, meeting-card **Show Guests** drawer, dashboard list, and guest-list BFF through the shared `selectApplicableRsvp` resolver. After that landed, manual QA on Connie's recurring meeting still showed a mismatch on the meeting **details page Show Members drawer**: it preloaded registrants without `occurrence_id`, so a `single`-scope decline for a future occurrence appeared on every occurrence even when **Your RSVP** and the card drawer were correct.

This PR closes that remaining read path by passing the viewed occurrence into the Show Members preload, centralising occurrence resolution via `resolveRsvpOccurrenceId()`, and aligning chip/filter rendering with `getRegistrantAttendanceStatus()` so all RSVP display sites stay in lockstep.

## Test plan

- [x] Recurring meeting: decline one future occurrence in Google Calendar, wait for sync
- [x] Open the **next** occurrence on the meeting details page — **Your RSVP** shows accepted
- [x] Open **Show Members** on that occurrence — organizer row shows **accepted**, not declined
- [x] Navigate to the **declined** occurrence — Show Members shows declined there only
- [x] Spot-check meeting card **Show Guests** drawer — same per-occurrence semantics, no regression