### PR TITLE
test(profile): split emails fetch guard into a method-scoped test

### DIFF
--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -45,6 +45,15 @@ async function stubIdentities(page: Page): Promise<void> {
   });
 }
 
+/** Stub the alias GET as purchased-but-unclaimed — the first-time-claim starting state. */
+async function stubUnclaimedLinuxEmail(page: Page): Promise<void> {
+  await page.route('**/api/profile/linux-email', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: PRIMARY_EMAIL };
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
 /**
  * Stub the alias GET/POST pair so the claim endpoint fails on the forward step
  * while the alias itself is left claimed upstream (mirrors the real add_alias-then-
@@ -187,21 +196,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
 
   test('shows the normal hint on a first-time claim with a single verified email', async ({ page }) => {
     await stubIdentities(page);
-
-    // Regression guard for the perf goal of this tab: the primary email now arrives inline on
-    // the linux-email response, so the tab must not make a second /api/profile/emails round-trip.
-    // Count GET hits (fulfilling so the assertion fails loudly rather than hanging if reintroduced).
-    let emailsFetchCount = 0;
-    await page.route('**/api/profile/emails', (route) => {
-      if (route.request().method() === 'GET') emailsFetchCount++;
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ primary_email: PRIMARY_EMAIL, alternate_emails: [] }) });
-    });
-
-    await page.route('**/api/profile/linux-email', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = { state: 'purchased_unclaimed', domain: DOMAIN, alias: null, email: null, forwardTo: null, primaryEmail: PRIMARY_EMAIL };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
+    await stubUnclaimedLinuxEmail(page);
 
     await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
@@ -210,6 +205,27 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-claim-forward-select')).toBeVisible();
     await expect(page.getByText('Choose one of your verified email addresses.')).toBeVisible();
+  });
+
+  test('does not make a second /api/profile/emails fetch on the Linux.com tab', async ({ page }) => {
+    // Perf regression guard: the primary email arrives inline, so the tab must not make a second
+    // /api/profile/emails round-trip. GET-scoped, fulfilled so a reintroduced fetch fails loudly.
+    await stubIdentities(page);
+
+    let emailsFetchCount = 0;
+    await page.route('**/api/profile/emails', (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      emailsFetchCount++;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ primary_email: PRIMARY_EMAIL, alternate_emails: [] }) });
+    });
+    await stubUnclaimedLinuxEmail(page);
+
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // Let the tab finish rendering before asserting no /emails fetch was made.
+    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
     expect(emailsFetchCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Split the `/api/profile/emails` zero-fetch regression guard out of the "first-time claim
  hint" test into its own test named for the regression. The hint test was carrying two
  unrelated concerns under a title mentioning only one (`testing-best-practices.md`: "group
  by screen first, then by concern").
- Method-scoped the `/api/profile/emails` stub to GET (`route.fallback()` for other methods),
  matching every other stub in the file and the method-scoped-stub guidance.
- Extracted the repeated `purchased_unclaimed` alias GET stub into a `stubUnclaimedLinuxEmail`
  helper (mirroring the existing `stubIdentities`), shared by both tests.

Part of LFXV2-1663.
