### PR TITLE
refactor(profile): narrow claim alias response type

### DIFF
--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -11,6 +11,7 @@ import {
   ProjectAffiliationPatchBody,
   CombinedProfile,
   ClaimAliasRequest,
+  ClaimAliasResponse,
   CreateUserPermissionRequest,
   DeveloperTokenInfo,
   EmailManagementData,
@@ -148,8 +149,8 @@ export class UserService {
   /**
    * Claim a Linux.com alias and set its forwarding target.
    */
-  public claimLinuxAlias(body: ClaimAliasRequest): Observable<LinuxAliasData> {
-    return this.http.post<LinuxAliasData>('/api/profile/linux-email/claim', body).pipe(take(1));
+  public claimLinuxAlias(body: ClaimAliasRequest): Observable<ClaimAliasResponse> {
+    return this.http.post<ClaimAliasResponse>('/api/profile/linux-email/claim', body).pipe(take(1));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -16,6 +16,7 @@ import {
   CdpIdentity,
   CdpWorkExperienceRequest,
   ClaimAliasRequest,
+  ClaimAliasResponse,
   CombinedProfile,
   DeveloperTokenInfo,
   EmailManagementData,
@@ -727,11 +728,7 @@ export class ProfileController {
       }
 
       logger.success(req, 'claim_linux_alias', startTime, { domain });
-      // primaryEmail is null here: this handler doesn't read user_emails, and the client
-      // refetches via getLinuxAlias() after a successful claim rather than consuming this body.
-      res
-        .status(200)
-        .json({ state: 'claimed', domain, alias, email, forwardTo: forward.target_email ?? forwardTo, primaryEmail: null } satisfies LinuxAliasData);
+      res.status(200).json({ state: 'claimed', domain, alias, email, forwardTo: forward.target_email ?? forwardTo } satisfies ClaimAliasResponse);
     } catch (error) {
       next(error);
     }

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -58,6 +58,13 @@ export interface ClaimAliasRequest {
   forwardTo: string;
 }
 
+/**
+ * Response from `POST /api/profile/linux-email/claim`. Excludes `primaryEmail`: the claim
+ * handler doesn't read user_emails, and the client refetches via the GET after a successful
+ * claim rather than consuming this body.
+ */
+export type ClaimAliasResponse = Omit<LinuxAliasData, 'primaryEmail'>;
+
 /** Body for `PUT /api/profile/linux-email/forward`. */
 export interface UpdateForwardRequest {
   forwardTo: string;


### PR DESCRIPTION
## Summary

- Added `ClaimAliasResponse = Omit<LinuxAliasData, 'primaryEmail'>` in `linux-email.interface.ts`
  and used it for `POST /api/profile/linux-email/claim` on both ends. The claim handler doesn't
  read `user_emails`, so it no longer invents a `primaryEmail: null` placeholder to satisfy the
  full `LinuxAliasData` shape, and `claimLinuxAlias()` in `user.service.ts` now returns the
  narrower type. Mirrors the existing narrow-return precedent of `updateLinuxForward`.
- No behavior change: the client already discards the claim response body and refetches via the
  GET, so nothing consumed `primaryEmail` on this path.

Part of LFXV2-1663.
